### PR TITLE
Remove Monotrail-specific code from `install-wheel-rs`

### DIFF
--- a/crates/gourgeist/src/packages.rs
+++ b/crates/gourgeist/src/packages.rs
@@ -51,10 +51,7 @@ pub(crate) fn install_base_packages(
     info: &InterpreterInfo,
     paths: &VenvPaths,
 ) -> Result<(), Error> {
-    let install_location = InstallLocation::Venv {
-        venv_base: location.canonicalize()?,
-        python_version: (info.major, info.minor),
-    };
+    let install_location = InstallLocation::new(location.canonicalize()?, (info.major, info.minor));
     let install_location = install_location.acquire_lock()?;
 
     // TODO: Use the json api instead
@@ -79,8 +76,6 @@ pub(crate) fn install_base_packages(
                 false,
                 false,
                 &[],
-                // Only relevant for monotrail style installation
-                "",
                 paths.interpreter.as_std_path(),
             )
             .map_err(|err| Error::InstallWheel {

--- a/crates/install-wheel-rs/src/lib.rs
+++ b/crates/install-wheel-rs/src/lib.rs
@@ -1,4 +1,4 @@
-//! Takes a wheel and installs it, either in a venv or for monotrail.
+//! Takes a wheel and installs it into a venv..
 
 use std::io;
 use std::io::{Read, Seek};

--- a/crates/install-wheel-rs/src/main.rs
+++ b/crates/install-wheel-rs/src/main.rs
@@ -31,10 +31,7 @@ struct Args {
 fn main() -> Result<(), Error> {
     let args = Args::parse();
     let venv_base = args.venv.canonicalize()?;
-    let location = InstallLocation::Venv {
-        venv_base,
-        python_version: (args.major, args.minor),
-    };
+    let location = InstallLocation::new(venv_base, (args.major, args.minor));
     let locked_dir = location.acquire_lock()?;
 
     let wheels: Vec<(PathBuf, WheelFilename)> = args
@@ -69,9 +66,7 @@ fn main() -> Result<(), Error> {
                 args.compile,
                 !args.skip_hashes,
                 &[],
-                // Only relevant for monotrail style installation
-                "",
-                location.get_python(),
+                location.python(),
             )?;
             Ok(())
         })

--- a/crates/install-wheel-rs/src/python_bindings.rs
+++ b/crates/install-wheel-rs/src/python_bindings.rs
@@ -40,10 +40,10 @@ impl LockedVenv {
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn new(py: Python, venv: PathBuf) -> PyResult<Self> {
         Ok(Self {
-            location: InstallLocation::Venv {
-                venv_base: LockedDir::acquire(&venv)?,
-                python_version: (py.version_info().major, py.version_info().minor),
-            },
+            location: InstallLocation::new(
+                LockedDir::acquire(&venv)?,
+                (py.version_info().major, py.version_info().minor),
+            ),
         })
     }
 
@@ -65,8 +65,6 @@ impl LockedVenv {
                 true,
                 true,
                 &[],
-                // unique_version can be anything since it's only used to monotrail
-                "",
                 Path::new(&sys_executable),
             )
         })?;

--- a/crates/install-wheel-rs/src/unpacked.rs
+++ b/crates/install-wheel-rs/src/unpacked.rs
@@ -34,26 +34,19 @@ pub fn install_wheel(
     let name = &filename.distribution;
     let _my_span = span!(Level::DEBUG, "install_wheel", name = name.as_str());
 
-    let InstallLocation::Venv {
-        venv_base: base_location,
-        ..
-    } = location
-    else {
-        return Err(Error::InvalidWheel(
-            "Monotrail installation is not supported yet".to_string(),
-        ));
-    };
+    let base_location = location.venv_base();
 
     // TODO(charlie): Pass this in.
     let site_packages_python = format!(
         "python{}.{}",
-        location.get_python_version().0,
-        location.get_python_version().1
+        location.python_version().0,
+        location.python_version().1
     );
     let site_packages = if cfg!(target_os = "windows") {
-        base_location.join("Lib").join("site-packages")
+        base_location.as_ref().join("Lib").join("site-packages")
     } else {
         base_location
+            .as_ref()
             .join("lib")
             .join(site_packages_python)
             .join("site-packages")
@@ -94,7 +87,7 @@ pub fn install_wheel(
     if data_dir.is_dir() {
         debug!(name = name.as_str(), "Installing data");
         install_data(
-            base_location,
+            base_location.as_ref(),
             &site_packages,
             &data_dir,
             &name,

--- a/crates/puffin-installer/src/lib.rs
+++ b/crates/puffin-installer/src/lib.rs
@@ -114,10 +114,7 @@ pub async fn install(
     );
 
     // Phase 3: Install each wheel.
-    let location = InstallLocation::Venv {
-        venv_base: python.venv().to_path_buf(),
-        python_version: python.simple_version(),
-    };
+    let location = InstallLocation::new(python.venv().to_path_buf(), python.simple_version());
     let locked_dir = location.acquire_lock()?;
 
     for wheel in wheels {


### PR DESCRIPTION
I think this isn't necessary to support in this generic crate. If we choose to adopt Monotrail-style concepts, we'll likely need to rework them anyway.