### PR TITLE
Parallelize wheel installations with Rayon

### DIFF
--- a/crates/install-wheel-rs/src/install_location.rs
+++ b/crates/install-wheel-rs/src/install_location.rs
@@ -73,7 +73,7 @@ impl AsRef<Path> for LockedDir {
 /// We use a lockfile to prevent multiple instance writing stuff on the same time
 /// As of pip 22.0, e.g. `pip install numpy; pip install numpy; pip install numpy` will
 /// non-deterministically fail.
-pub struct InstallLocation<T: AsRef<Path>> {
+pub struct InstallLocation<T> {
     /// absolute path
     venv_base: T,
     python_version: (u8, u8),

--- a/crates/install-wheel-rs/src/wheel.rs
+++ b/crates/install-wheel-rs/src/wheel.rs
@@ -261,8 +261,8 @@ fn unpack_wheel_files<R: Read + Seek>(
     Ok(extracted_paths)
 }
 
-pub(crate) fn get_shebang(location: &InstallLocation<LockedDir>) -> String {
-    let path = location.python().display().to_string();
+pub(crate) fn get_shebang(location: &InstallLocation<impl AsRef<Path>>) -> String {
+    let path = location.python().to_string_lossy().to_string();
     let path = if cfg!(windows) {
         // https://stackoverflow.com/a/50323079
         const VERBATIM_PREFIX: &str = r"\\?\";
@@ -326,7 +326,7 @@ pub(crate) fn windows_script_launcher(launcher_python_script: &str) -> Result<Ve
 /// TODO: Test for this launcher directly in install-wheel-rs
 pub(crate) fn write_script_entrypoints(
     site_packages: &Path,
-    location: &InstallLocation<LockedDir>,
+    location: &InstallLocation<impl AsRef<Path>>,
     entrypoints: &[Script],
     record: &mut Vec<RecordEntry>,
 ) -> Result<(), Error> {
@@ -649,7 +649,7 @@ fn install_script(
     site_packages: &Path,
     record: &mut [RecordEntry],
     file: &DirEntry,
-    location: &InstallLocation<LockedDir>,
+    location: &InstallLocation<impl AsRef<Path>>,
 ) -> Result<(), Error> {
     let path = file.path();
     if !path.is_file() {
@@ -726,7 +726,7 @@ pub(crate) fn install_data(
     site_packages: &Path,
     data_dir: &Path,
     dist_name: &str,
-    location: &InstallLocation<LockedDir>,
+    location: &InstallLocation<impl AsRef<Path>>,
     console_scripts: &[Script],
     gui_scripts: &[Script],
     record: &mut [RecordEntry],


### PR DESCRIPTION
It looks like using _either_ async Rust with a `JoinSet` _or_ parallelizing a fixed threadpool with Rayon provide about a ~5% speed-up over our current serial approach:

```console
❯ hyperfine --runs 30 --warmup 5 --prepare "./target/release/puffin venv .venv" \
  "./target/release/rayon sync ./scripts/benchmarks/requirements-large.txt" \
  "./target/release/async sync ./scripts/benchmarks/requirements-large.txt" \
  "./target/release/main sync ./scripts/benchmarks/requirements-large.txt"
Benchmark 1: ./target/release/rayon sync ./scripts/benchmarks/requirements-large.txt
  Time (mean ± σ):     295.7 ms ±  16.9 ms    [User: 28.6 ms, System: 263.3 ms]
  Range (min … max):   249.2 ms … 315.9 ms    30 runs

Benchmark 2: ./target/release/async sync ./scripts/benchmarks/requirements-large.txt
  Time (mean ± σ):     296.2 ms ±  20.2 ms    [User: 36.1 ms, System: 340.1 ms]
  Range (min … max):   258.0 ms … 359.4 ms    30 runs

Benchmark 3: ./target/release/main sync ./scripts/benchmarks/requirements-large.txt
  Time (mean ± σ):     306.6 ms ±  19.5 ms    [User: 25.3 ms, System: 220.5 ms]
  Range (min … max):   269.6 ms … 332.2 ms    30 runs

Summary
  './target/release/rayon sync ./scripts/benchmarks/requirements-large.txt' ran
    1.00 ± 0.09 times faster than './target/release/async sync ./scripts/benchmarks/requirements-large.txt'
    1.04 ± 0.09 times faster than './target/release/main sync ./scripts/benchmarks/requirements-large.txt'
```

It's much easier to just parallelize with Rayon and avoid async in the underlying wheel code, so this PR takes that approach for now.
