### PR TITLE
Add `-p` base python option to venv command

### DIFF
--- a/crates/puffin-cli/src/main.rs
+++ b/crates/puffin-cli/src/main.rs
@@ -71,6 +71,11 @@ struct UninstallArgs {
 
 #[derive(Args)]
 struct VenvArgs {
+    /// The python interpreter to use for the virtual environment
+    // Short `-p` to match `virtualenv`
+    // TODO(konstin): Support e.g. `-p 3.10`
+    #[clap(short, long)]
+    python: Option<PathBuf>,
     /// The path to the virtual environment to create.
     name: PathBuf,
 }
@@ -143,7 +148,7 @@ async fn main() -> ExitCode {
             )
             .await
         }
-        Commands::Venv(args) => commands::venv(&args.name, printer).await,
+        Commands::Venv(args) => commands::venv(&args.name, args.python.as_deref(), printer).await,
     };
 
     match result {


### PR DESCRIPTION
This is the same option that `virtualenv` offers, except that we only support absolute paths atm and not e.g. `-p 3.10` (which we need to eventually).