### PR TITLE
Only store compatible wheels in the resolver

### DIFF
--- a/crates/platform-tags/src/lib.rs
+++ b/crates/platform-tags/src/lib.rs
@@ -2,7 +2,7 @@ use platform_host::{Arch, Os, Platform, PlatformError};
 
 /// A set of compatible tags for a given Python version and platform, in
 /// (`python_tag`, `abi_tag`, `platform_tag`) format.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Tags(Vec<(String, String, String)>);
 
 impl Tags {

--- a/crates/puffin-resolver/src/error.rs
+++ b/crates/puffin-resolver/src/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 use pep508_rs::Requirement;
+use puffin_package::package_name::PackageName;
 
 use crate::pubgrub::package::PubGrubPackage;
 use crate::pubgrub::version::PubGrubVersion;
@@ -12,6 +13,9 @@ pub enum ResolveError {
 
     #[error("The request stream terminated unexpectedly")]
     StreamTermination,
+
+    #[error("No platform-compatible distributions found for: {0}")]
+    NoCompatibleDistributions(PackageName),
 
     #[error(transparent)]
     Client(#[from] puffin_client::PypiClientError),


### PR DESCRIPTION
Rather than constantly iterating over all files and testing their compatibility with the current platform, just store wheels we can actually consider in the solver cache.