### PR TITLE
Rename commands to `pip-sync` and `pip-compile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Puffin does not yet support:
 - Source distributions
 - VCS dependencies
 - URL dependencies
-- Uninstalling packages
 - Windows
 - ...
 
@@ -47,13 +46,13 @@ Like `pip-compile`, Puffin generates a platform-specific `requirements.txt` file
 To resolve a `requirements.in` file:
 
 ```shell
-cargo run -p puffin-cli -- compile requirements.in
+cargo run -p puffin-cli -- pip-compile requirements.in
 ```
 
 To install from a resolved `requirements.txt` file:
 
 ```shell
-cargo run -p puffin-cli -- sync requirements.txt
+cargo run -p puffin-cli -- pip-sync requirements.txt
 ```
 
 For more, see `cargo run -p puffin-cli -- --help`:

--- a/crates/puffin-cli/src/commands/mod.rs
+++ b/crates/puffin-cli/src/commands/mod.rs
@@ -3,20 +3,20 @@ use std::time::Duration;
 
 pub(crate) use add::add;
 pub(crate) use clean::clean;
-pub(crate) use compile::compile;
 pub(crate) use freeze::freeze;
+pub(crate) use pip_compile::pip_compile;
+pub(crate) use pip_sync::{pip_sync, PipSyncFlags};
 pub(crate) use remove::remove;
-pub(crate) use sync::{sync, SyncFlags};
 pub(crate) use uninstall::uninstall;
 pub(crate) use venv::venv;
 
 mod add;
 mod clean;
-mod compile;
 mod freeze;
+mod pip_compile;
+mod pip_sync;
 mod remove;
 mod reporters;
-mod sync;
 mod uninstall;
 mod venv;
 

--- a/crates/puffin-cli/src/commands/pip_compile.rs
+++ b/crates/puffin-cli/src/commands/pip_compile.rs
@@ -18,7 +18,7 @@ use crate::commands::{elapsed, ExitStatus};
 use crate::printer::Printer;
 
 /// Resolve a set of requirements into a set of pinned versions.
-pub(crate) async fn compile(
+pub(crate) async fn pip_compile(
     src: &Path,
     output_file: Option<&Path>,
     cache: Option<&Path>,

--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -24,17 +24,17 @@ use crate::printer::Printer;
 
 bitflags! {
     #[derive(Debug, Copy, Clone, Default)]
-    pub struct SyncFlags: u8 {
+    pub struct PipSyncFlags: u8 {
         /// Ignore any installed packages, forcing a re-installation.
         const IGNORE_INSTALLED = 1 << 0;
     }
 }
 
 /// Install a set of locked requirements into the current Python environment.
-pub(crate) async fn sync(
+pub(crate) async fn pip_sync(
     src: &Path,
     cache: Option<&Path>,
-    flags: SyncFlags,
+    flags: PipSyncFlags,
     mut printer: Printer,
 ) -> Result<ExitStatus> {
     // Read the `requirements.txt` from disk.
@@ -59,7 +59,7 @@ pub(crate) async fn sync(
 pub(crate) async fn sync_requirements(
     requirements: &[Requirement],
     cache: Option<&Path>,
-    flags: SyncFlags,
+    flags: PipSyncFlags,
     mut printer: Printer,
 ) -> Result<ExitStatus> {
     let start = std::time::Instant::now();
@@ -216,11 +216,11 @@ pub(crate) async fn sync_requirements(
 async fn find_uncached_requirements(
     requirements: &[Requirement],
     cache: Option<&Path>,
-    flags: SyncFlags,
+    flags: PipSyncFlags,
     python: &PythonExecutable,
 ) -> Result<(Vec<LocalDistribution>, Vec<Requirement>)> {
     // Index all the already-installed packages in site-packages.
-    let site_packages = if flags.intersects(SyncFlags::IGNORE_INSTALLED) {
+    let site_packages = if flags.intersects(PipSyncFlags::IGNORE_INSTALLED) {
         SitePackages::default()
     } else {
         SitePackages::from_executable(python).await?

--- a/crates/puffin-cli/src/main.rs
+++ b/crates/puffin-cli/src/main.rs
@@ -34,9 +34,9 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Compile a `requirements.in` file to a `requirements.txt` file.
-    Compile(CompileArgs),
+    PipCompile(PipCompileArgs),
     /// Sync dependencies from a `requirements.txt` file.
-    Sync(SyncArgs),
+    PipSync(PipSyncArgs),
     /// Clear the cache.
     Clean,
     /// Enumerate the installed packages in the current environment.
@@ -52,7 +52,7 @@ enum Commands {
 }
 
 #[derive(Args)]
-struct CompileArgs {
+struct PipCompileArgs {
     /// Output `requirements.txt` file
     #[clap(short, long)]
     output_file: Option<PathBuf>,
@@ -61,7 +61,7 @@ struct CompileArgs {
 }
 
 #[derive(Args)]
-struct SyncArgs {
+struct PipSyncArgs {
     /// Path to the `requirements.txt` file to install.
     src: PathBuf,
 
@@ -120,8 +120,8 @@ async fn main() -> ExitCode {
     let dirs = ProjectDirs::from("", "", "puffin");
 
     let result = match &cli.command {
-        Commands::Compile(args) => {
-            commands::compile(
+        Commands::PipCompile(args) => {
+            commands::pip_compile(
                 &args.src,
                 args.output_file.as_deref(),
                 dirs.as_ref()
@@ -131,16 +131,16 @@ async fn main() -> ExitCode {
             )
             .await
         }
-        Commands::Sync(args) => {
-            commands::sync(
+        Commands::PipSync(args) => {
+            commands::pip_sync(
                 &args.src,
                 dirs.as_ref()
                     .map(ProjectDirs::cache_dir)
                     .filter(|_| !cli.no_cache),
                 if args.ignore_installed {
-                    commands::SyncFlags::IGNORE_INSTALLED
+                    commands::PipSyncFlags::IGNORE_INSTALLED
                 } else {
-                    commands::SyncFlags::empty()
+                    commands::PipSyncFlags::empty()
                 },
                 printer,
             )

--- a/scripts/benchmarks/compile.sh
+++ b/scripts/benchmarks/compile.sh
@@ -16,12 +16,12 @@ TARGET=${1}
 # Resolution with a cold cache.
 ###
 hyperfine --runs 20 --warmup 3 --prepare "rm -f /tmp/requirements.txt" \
-    "./target/release/puffin --no-cache compile ${TARGET} > /tmp/requirements.txt" \
-    "./target/release/main --no-cache compile ${TARGET} > /tmp/requirements.txt"
+    "./target/release/puffin --no-cache pip-compile ${TARGET} > /tmp/requirements.txt" \
+    "./target/release/main --no-cache pip-compile ${TARGET} > /tmp/requirements.txt"
 
 ###
 # Resolution with a warm cache.
 ###
 hyperfine --runs 20 --warmup 3 --prepare "rm -f /tmp/requirements.txt" \
-    "./target/release/puffin compile ${TARGET} > /tmp/requirements.txt" \
-    "./target/release/main compile ${TARGET} > /tmp/requirements.txt"
+    "./target/release/puffin pip-compile ${TARGET} > /tmp/requirements.txt" \
+    "./target/release/main pip-compile ${TARGET} > /tmp/requirements.txt"

--- a/scripts/benchmarks/sync.sh
+++ b/scripts/benchmarks/sync.sh
@@ -17,7 +17,7 @@ TARGET=${1}
 ###
 hyperfine --runs 20 --warmup 3 \
     --prepare "virtualenv --clear .venv" \
-    "./target/release/puffin sync ${TARGET} --ignore-installed --no-cache" \
+    "./target/release/puffin pip-sync ${TARGET} --ignore-installed --no-cache" \
     --prepare "rm -rf /tmp/site-packages" \
     "pip install -r ${TARGET} --target /tmp/site-packages --ignore-installed --no-cache-dir --no-deps"
 
@@ -26,7 +26,7 @@ hyperfine --runs 20 --warmup 3 \
 ###
 hyperfine --runs 20 --warmup 3 \
     --prepare "virtualenv --clear .venv" \
-    "./target/release/puffin sync ${TARGET} --ignore-installed" \
+    "./target/release/puffin pip-sync ${TARGET} --ignore-installed" \
     --prepare "rm -rf /tmp/site-packages" \
     "pip install -r ${TARGET} --target /tmp/site-packages --ignore-installed --no-deps"
 
@@ -35,5 +35,5 @@ hyperfine --runs 20 --warmup 3 \
 ###
 hyperfine --runs 20 --warmup 3 \
     --setup "virtualenv --clear .venv && source .venv/bin/activate" \
-    "./target/release/puffin sync ${TARGET}" \
+    "./target/release/puffin pip-sync ${TARGET}" \
     "pip install -r ${TARGET} --no-deps"


### PR DESCRIPTION
To free up the rest of the interface.