### PR TITLE
Upgrade PubGrub to dev branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,6 +1967,7 @@ dependencies = [
 name = "pubgrub"
 version = "0.2.1"
 dependencies = [
+ "log",
  "rustc-hash",
  "thiserror",
 ]

--- a/crates/puffin-resolver/src/error.rs
+++ b/crates/puffin-resolver/src/error.rs
@@ -1,3 +1,4 @@
+use pubgrub::range::Range;
 use thiserror::Error;
 
 use pep508_rs::Requirement;
@@ -23,7 +24,7 @@ pub enum ResolveError {
     Join(#[from] tokio::task::JoinError),
 
     #[error(transparent)]
-    PubGrub(#[from] pubgrub::error::PubGrubError<PubGrubPackage, PubGrubVersion>),
+    PubGrub(#[from] pubgrub::error::PubGrubError<PubGrubPackage, Range<PubGrubVersion>>),
 }
 
 impl<T> From<futures::channel::mpsc::TrySendError<T>> for ResolveError {

--- a/crates/puffin-resolver/src/pubgrub/mod.rs
+++ b/crates/puffin-resolver/src/pubgrub/mod.rs
@@ -58,19 +58,19 @@ pub(crate) fn version_range(
     specifiers: Option<&pep508_rs::VersionOrUrl>,
 ) -> Result<Range<PubGrubVersion>> {
     let Some(specifiers) = specifiers else {
-        return Ok(Range::any());
+        return Ok(Range::full());
     };
 
     let pep508_rs::VersionOrUrl::VersionSpecifier(specifiers) = specifiers else {
-        return Ok(Range::any());
+        return Ok(Range::full());
     };
 
-    let mut final_range = Range::any();
+    let mut final_range = Range::full();
     for spec in specifiers.iter() {
         let spec_range =
             PubGrubSpecifier::try_from(spec)?
                 .into_iter()
-                .fold(Range::none(), |accum, range| {
+                .fold(Range::empty(), |accum, range| {
                     accum.union(&if range.end < *MAX_VERSION {
                         Range::between(range.start, range.end)
                     } else {

--- a/crates/puffin-resolver/src/pubgrub/version.rs
+++ b/crates/puffin-resolver/src/pubgrub/version.rs
@@ -37,6 +37,13 @@ impl pubgrub::version::Version for PubGrubVersion {
         self.next()
     }
 }
+
+// impl From<PubGrubVersion> for Range<PubGrubVersion> {
+//     fn from(value: PubGrubVersion) -> Self {
+//         Range::from(value)
+//     }
+// }
+
 impl<'a> From<&'a PubGrubVersion> for &'a pep440_rs::Version {
     fn from(version: &'a PubGrubVersion) -> Self {
         &version.0

--- a/vendor/pubgrub/CHANGELOG.md
+++ b/vendor/pubgrub/CHANGELOG.md
@@ -48,7 +48,7 @@ The gist of it is:
 
 #### Added
 
-- Links to code items in the code documenation.
+- Links to code items in the code documentation.
 - New `"serde"` feature that allows serializing some library types, useful for making simple reproducible bug reports.
 - New variants for `error::PubGrubError` which are `DependencyOnTheEmptySet`,
   `SelfDependency`, `ErrorChoosingPackageVersion` and `ErrorInShouldCancel`.

--- a/vendor/pubgrub/Cargo.toml
+++ b/vendor/pubgrub/Cargo.toml
@@ -23,12 +23,14 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/**", "tests/**", "examples
 thiserror = "1.0"
 rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
+log = "0.4.14" # for debug logs in tests
 
 [dev-dependencies]
 proptest = "0.10.1"
 ron = "0.6"
 varisat = "0.2.2"
 criterion = "0.3"
+env_logger = "0.9.0"
 
 [[bench]]
 name = "large_case"

--- a/vendor/pubgrub/examples/branching_error_reporting.rs
+++ b/vendor/pubgrub/examples/branching_error_reporting.rs
@@ -6,51 +6,53 @@ use pubgrub::report::{DefaultStringReporter, Reporter};
 use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::SemanticVersion;
 
+type SemVS = Range<SemanticVersion>;
+
 // https://github.com/dart-lang/pub/blob/master/doc/solver.md#branching-error-reporting
 fn main() {
-    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemVS>::new();
     #[rustfmt::skip]
     // root 1.0.0 depends on foo ^1.0.0
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![("foo", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("foo", Range::from_range_bounds((1, 0, 0)..(2, 0, 0)))],
     );
     #[rustfmt::skip]
     // foo 1.0.0 depends on a ^1.0.0 and b ^1.0.0
         dependency_provider.add_dependencies(
         "foo", (1, 0, 0),
-        vec![
-            ("a", Range::between((1, 0, 0), (2, 0, 0))),
-            ("b", Range::between((1, 0, 0), (2, 0, 0))),
+        [
+            ("a", Range::from_range_bounds((1, 0, 0)..(2, 0, 0))),
+            ("b", Range::from_range_bounds((1, 0, 0)..(2, 0, 0))),
         ],
     );
     #[rustfmt::skip]
     // foo 1.1.0 depends on x ^1.0.0 and y ^1.0.0
         dependency_provider.add_dependencies(
         "foo", (1, 1, 0),
-        vec![
-            ("x", Range::between((1, 0, 0), (2, 0, 0))),
-            ("y", Range::between((1, 0, 0), (2, 0, 0))),
+        [
+            ("x", Range::from_range_bounds((1, 0, 0)..(2, 0, 0))),
+            ("y", Range::from_range_bounds((1, 0, 0)..(2, 0, 0))),
         ],
     );
     #[rustfmt::skip]
     // a 1.0.0 depends on b ^2.0.0
         dependency_provider.add_dependencies(
         "a", (1, 0, 0),
-        vec![("b", Range::between((2, 0, 0), (3, 0, 0)))],
+        [("b", Range::from_range_bounds((2, 0, 0)..(3, 0, 0)))],
     );
     // b 1.0.0 and 2.0.0 have no dependencies.
-    dependency_provider.add_dependencies("b", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("b", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("b", (1, 0, 0), []);
+    dependency_provider.add_dependencies("b", (2, 0, 0), []);
     #[rustfmt::skip]
     // x 1.0.0 depends on y ^2.0.0.
         dependency_provider.add_dependencies(
         "x", (1, 0, 0),
-        vec![("y", Range::between((2, 0, 0), (3, 0, 0)))],
+        [("y", Range::from_range_bounds((2, 0, 0)..(3, 0, 0)))],
     );
     // y 1.0.0 and 2.0.0 have no dependencies.
-    dependency_provider.add_dependencies("y", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("y", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("y", (1, 0, 0), []);
+    dependency_provider.add_dependencies("y", (2, 0, 0), []);
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {

--- a/vendor/pubgrub/examples/doc_interface.rs
+++ b/vendor/pubgrub/examples/doc_interface.rs
@@ -4,19 +4,21 @@ use pubgrub::range::Range;
 use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::NumberVersion;
 
+type NumVS = Range<NumberVersion>;
+
 // `root` depends on `menu` and `icons`
 // `menu` depends on `dropdown`
 // `dropdown` depends on `icons`
 // `icons` has no dependency
 #[rustfmt::skip]
 fn main() {
-    let mut dependency_provider = OfflineDependencyProvider::<&str, NumberVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, NumVS>::new();
     dependency_provider.add_dependencies(
-        "root", 1, vec![("menu", Range::any()), ("icons", Range::any())],
+        "root", 1, [("menu", Range::full()), ("icons", Range::full())],
     );
-    dependency_provider.add_dependencies("menu", 1, vec![("dropdown", Range::any())]);
-    dependency_provider.add_dependencies("dropdown", 1, vec![("icons", Range::any())]);
-    dependency_provider.add_dependencies("icons", 1, vec![]);
+    dependency_provider.add_dependencies("menu", 1, [("dropdown", Range::full())]);
+    dependency_provider.add_dependencies("dropdown", 1, [("icons", Range::full())]);
+    dependency_provider.add_dependencies("icons", 1, []);
 
     // Run the algorithm.
     let solution = resolve(&dependency_provider, "root", 1);

--- a/vendor/pubgrub/examples/doc_interface_error.rs
+++ b/vendor/pubgrub/examples/doc_interface_error.rs
@@ -6,6 +6,8 @@ use pubgrub::report::{DefaultStringReporter, Reporter};
 use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::SemanticVersion;
 
+type SemVS = Range<SemanticVersion>;
+
 // `root` depends on `menu`, `icons 1.0.0` and `intl 5.0.0`
 // `menu 1.0.0` depends on `dropdown < 2.0.0`
 // `menu >= 1.1.0` depends on `dropdown >= 2.0.0`
@@ -15,59 +17,59 @@ use pubgrub::version::SemanticVersion;
 // `intl` has no dependency
 #[rustfmt::skip]
 fn main() {
-    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemVS>::new();
     // Direct dependencies: menu and icons.
-    dependency_provider.add_dependencies("root", (1, 0, 0), vec![
-        ("menu", Range::any()),
-        ("icons", Range::exact((1, 0, 0))),
-        ("intl", Range::exact((5, 0, 0))),
+    dependency_provider.add_dependencies("root", (1, 0, 0), [
+        ("menu", Range::full()),
+        ("icons", Range::singleton((1, 0, 0))),
+        ("intl", Range::singleton((5, 0, 0))),
     ]);
 
     // Dependencies of the menu lib.
-    dependency_provider.add_dependencies("menu", (1, 0, 0), vec![
-        ("dropdown", Range::strictly_lower_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 0, 0), [
+        ("dropdown", Range::from_range_bounds(..(2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 1, 0), vec![
-        ("dropdown", Range::higher_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 1, 0), [
+        ("dropdown", Range::from_range_bounds((2, 0, 0)..)),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 2, 0), vec![
-        ("dropdown", Range::higher_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 2, 0), [
+        ("dropdown", Range::from_range_bounds((2, 0, 0)..)),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 3, 0), vec![
-        ("dropdown", Range::higher_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 3, 0), [
+        ("dropdown", Range::from_range_bounds((2, 0, 0)..)),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 4, 0), vec![
-        ("dropdown", Range::higher_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 4, 0), [
+        ("dropdown", Range::from_range_bounds((2, 0, 0)..)),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 5, 0), vec![
-        ("dropdown", Range::higher_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 5, 0), [
+        ("dropdown", Range::from_range_bounds((2, 0, 0)..)),
     ]);
 
     // Dependencies of the dropdown lib.
-    dependency_provider.add_dependencies("dropdown", (1, 8, 0), vec![
-        ("intl", Range::exact((3, 0, 0))),
+    dependency_provider.add_dependencies("dropdown", (1, 8, 0), [
+        ("intl", Range::singleton((3, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 0, 0), vec![
-        ("icons", Range::exact((2, 0, 0))),
+    dependency_provider.add_dependencies("dropdown", (2, 0, 0), [
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 1, 0), vec![
-        ("icons", Range::exact((2, 0, 0))),
+    dependency_provider.add_dependencies("dropdown", (2, 1, 0), [
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 2, 0), vec![
-        ("icons", Range::exact((2, 0, 0))),
+    dependency_provider.add_dependencies("dropdown", (2, 2, 0), [
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 3, 0), vec![
-        ("icons", Range::exact((2, 0, 0))),
+    dependency_provider.add_dependencies("dropdown", (2, 3, 0), [
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
 
     // Icons have no dependencies.
-    dependency_provider.add_dependencies("icons", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("icons", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("icons", (1, 0, 0), []);
+    dependency_provider.add_dependencies("icons", (2, 0, 0), []);
 
     // Intl have no dependencies.
-    dependency_provider.add_dependencies("intl", (3, 0, 0), vec![]);
-    dependency_provider.add_dependencies("intl", (4, 0, 0), vec![]);
-    dependency_provider.add_dependencies("intl", (5, 0, 0), vec![]);
+    dependency_provider.add_dependencies("intl", (3, 0, 0), []);
+    dependency_provider.add_dependencies("intl", (4, 0, 0), []);
+    dependency_provider.add_dependencies("intl", (5, 0, 0), []);
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {

--- a/vendor/pubgrub/examples/doc_interface_semantic.rs
+++ b/vendor/pubgrub/examples/doc_interface_semantic.rs
@@ -6,6 +6,8 @@ use pubgrub::report::{DefaultStringReporter, Reporter};
 use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::SemanticVersion;
 
+type SemVS = Range<SemanticVersion>;
+
 // `root` depends on `menu` and `icons 1.0.0`
 // `menu 1.0.0` depends on `dropdown < 2.0.0`
 // `menu >= 1.1.0` depends on `dropdown >= 2.0.0`
@@ -14,51 +16,51 @@ use pubgrub::version::SemanticVersion;
 // `icons` has no dependency
 #[rustfmt::skip]
 fn main() {
-    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemVS>::new();
     // Direct dependencies: menu and icons.
-    dependency_provider.add_dependencies("root", (1, 0, 0), vec![
-        ("menu", Range::any()),
-        ("icons", Range::exact((1, 0, 0))),
+    dependency_provider.add_dependencies("root", (1, 0, 0), [
+        ("menu", Range::full()),
+        ("icons", Range::singleton((1, 0, 0))),
     ]);
 
     // Dependencies of the menu lib.
-    dependency_provider.add_dependencies("menu", (1, 0, 0), vec![
-        ("dropdown", Range::strictly_lower_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 0, 0), [
+        ("dropdown", Range::from_range_bounds(..(2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 1, 0), vec![
-        ("dropdown", Range::higher_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 1, 0), [
+        ("dropdown", Range::from_range_bounds((2, 0, 0)..)),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 2, 0), vec![
-        ("dropdown", Range::higher_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 2, 0), [
+        ("dropdown", Range::from_range_bounds((2, 0, 0)..)),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 3, 0), vec![
-        ("dropdown", Range::higher_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 3, 0), [
+        ("dropdown", Range::from_range_bounds((2, 0, 0)..)),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 4, 0), vec![
-        ("dropdown", Range::higher_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 4, 0), [
+        ("dropdown", Range::from_range_bounds((2, 0, 0)..)),
     ]);
-    dependency_provider.add_dependencies("menu", (1, 5, 0), vec![
-        ("dropdown", Range::higher_than((2, 0, 0))),
+    dependency_provider.add_dependencies("menu", (1, 5, 0), [
+        ("dropdown", Range::from_range_bounds((2, 0, 0)..)),
     ]);
 
     // Dependencies of the dropdown lib.
-    dependency_provider.add_dependencies("dropdown", (1, 8, 0), vec![]);
-    dependency_provider.add_dependencies("dropdown", (2, 0, 0), vec![
-        ("icons", Range::exact((2, 0, 0))),
+    dependency_provider.add_dependencies("dropdown", (1, 8, 0), []);
+    dependency_provider.add_dependencies("dropdown", (2, 0, 0), [
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 1, 0), vec![
-        ("icons", Range::exact((2, 0, 0))),
+    dependency_provider.add_dependencies("dropdown", (2, 1, 0), [
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 2, 0), vec![
-        ("icons", Range::exact((2, 0, 0))),
+    dependency_provider.add_dependencies("dropdown", (2, 2, 0), [
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
-    dependency_provider.add_dependencies("dropdown", (2, 3, 0), vec![
-        ("icons", Range::exact((2, 0, 0))),
+    dependency_provider.add_dependencies("dropdown", (2, 3, 0), [
+        ("icons", Range::singleton((2, 0, 0))),
     ]);
 
     // Icons has no dependency.
-    dependency_provider.add_dependencies("icons", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("icons", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("icons", (1, 0, 0), []);
+    dependency_provider.add_dependencies("icons", (2, 0, 0), []);
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {

--- a/vendor/pubgrub/examples/linear_error_reporting.rs
+++ b/vendor/pubgrub/examples/linear_error_reporting.rs
@@ -6,33 +6,35 @@ use pubgrub::report::{DefaultStringReporter, Reporter};
 use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::version::SemanticVersion;
 
+type SemVS = Range<SemanticVersion>;
+
 // https://github.com/dart-lang/pub/blob/master/doc/solver.md#linear-error-reporting
 fn main() {
-    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemVS>::new();
     #[rustfmt::skip]
     // root 1.0.0 depends on foo ^1.0.0 and baz ^1.0.0
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![
-            ("foo", Range::between((1, 0, 0), (2, 0, 0))),
-            ("baz", Range::between((1, 0, 0), (2, 0, 0))),
+        [
+            ("foo", Range::from_range_bounds((1, 0, 0)..(2, 0, 0))),
+            ("baz", Range::from_range_bounds((1, 0, 0)..(2, 0, 0))),
         ],
     );
     #[rustfmt::skip]
     // foo 1.0.0 depends on bar ^2.0.0
         dependency_provider.add_dependencies(
         "foo", (1, 0, 0),
-        vec![("bar", Range::between((2, 0, 0), (3, 0, 0)))],
+        [("bar", Range::from_range_bounds((2, 0, 0)..(3, 0, 0)))],
     );
     #[rustfmt::skip]
     // bar 2.0.0 depends on baz ^3.0.0
         dependency_provider.add_dependencies(
         "bar", (2, 0, 0),
-        vec![("baz", Range::between((3, 0, 0), (4, 0, 0)))],
+        [("baz", Range::from_range_bounds((3, 0, 0)..(4, 0, 0)))],
     );
     // baz 1.0.0 and 3.0.0 have no dependencies
-    dependency_provider.add_dependencies("baz", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("baz", (3, 0, 0), vec![]);
+    dependency_provider.add_dependencies("baz", (1, 0, 0), []);
+    dependency_provider.add_dependencies("baz", (3, 0, 0), []);
 
     // Run the algorithm.
     match resolve(&dependency_provider, "root", (1, 0, 0)) {

--- a/vendor/pubgrub/release.md
+++ b/vendor/pubgrub/release.md
@@ -1,0 +1,28 @@
+# Creation of a new release
+
+This is taking the 0.2.1 release as an example.
+
+## GitHub stuff
+
+- Checkout the prep-v0.2.1 branch
+- Update the release date in the changelog and push to the PR.
+- Squash merge the PR to the dev branch
+- Check that the merged PR is passing the tests on the dev branch
+- Pull the updated dev locally
+- Switch to the release branch
+- Merge locally dev into release in fast-forward mode, we want to keep the history of commits and the merge point.
+- `git tag -a v0.2.1 -m "v0.2.1: mostly perf improvements"`
+- (Optional) cryptographically sign the tag
+- On GitHub, edit the branch protection setting for release: uncheck include admin, and save
+- Push release to github: git push --follow-tags
+- Reset the release branch protection to include admins
+- On GitHub, create a release from that tag.
+
+## Crates.io stuff
+
+- `cargo publish --dry-run`
+- `cargo publish`
+
+## Community stuff
+
+Talk about the awesome new features of the new release online.

--- a/vendor/pubgrub/src/error.rs
+++ b/vendor/pubgrub/src/error.rs
@@ -6,14 +6,14 @@ use thiserror::Error;
 
 use crate::package::Package;
 use crate::report::DerivationTree;
-use crate::version::Version;
+use crate::version_set::VersionSet;
 
 /// Errors that may occur while solving dependencies.
 #[derive(Error, Debug)]
-pub enum PubGrubError<P: Package, V: Version> {
+pub enum PubGrubError<P: Package, VS: VersionSet> {
     /// There is no solution for this set of dependencies.
     #[error("No solution")]
-    NoSolution(DerivationTree<P, V>),
+    NoSolution(DerivationTree<P, VS>),
 
     /// Error arising when the implementer of
     /// [DependencyProvider](crate::solver::DependencyProvider)
@@ -24,7 +24,7 @@ pub enum PubGrubError<P: Package, V: Version> {
         /// Package whose dependencies we want.
         package: P,
         /// Version of the package for which we want the dependencies.
-        version: V,
+        version: VS::V,
         /// Error raised by the implementer of
         /// [DependencyProvider](crate::solver::DependencyProvider).
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -40,7 +40,7 @@ pub enum PubGrubError<P: Package, V: Version> {
         /// Package whose dependencies we want.
         package: P,
         /// Version of the package for which we want the dependencies.
-        version: V,
+        version: VS::V,
         /// The dependent package that requires us to pick from the empty set.
         dependent: P,
     },
@@ -55,7 +55,7 @@ pub enum PubGrubError<P: Package, V: Version> {
         /// Package whose dependencies we want.
         package: P,
         /// Version of the package for which we want the dependencies.
-        version: V,
+        version: VS::V,
     },
 
     /// Error arising when the implementer of

--- a/vendor/pubgrub/src/internal/arena.rs
+++ b/vendor/pubgrub/src/internal/arena.rs
@@ -55,7 +55,7 @@ impl<T> Id<T> {
     }
     fn from(n: u32) -> Self {
         Self {
-            raw: n as u32,
+            raw: n,
             _ty: PhantomData,
         }
     }

--- a/vendor/pubgrub/src/internal/mod.rs
+++ b/vendor/pubgrub/src/internal/mod.rs
@@ -2,9 +2,9 @@
 
 //! Non exposed modules.
 
-pub(crate) mod arena;
-pub(crate) mod core;
-pub(crate) mod incompatibility;
-pub(crate) mod partial_solution;
-pub(crate) mod small_map;
-pub(crate) mod small_vec;
+pub mod arena;
+pub mod core;
+pub mod incompatibility;
+pub mod partial_solution;
+pub mod small_map;
+pub mod small_vec;

--- a/vendor/pubgrub/src/internal/small_map.rs
+++ b/vendor/pubgrub/src/internal/small_map.rs
@@ -2,7 +2,7 @@ use crate::type_aliases::Map;
 use std::hash::Hash;
 
 #[derive(Debug, Clone)]
-pub(crate) enum SmallMap<K, V> {
+pub enum SmallMap<K, V> {
     Empty,
     One([(K, V); 1]),
     Two([(K, V); 2]),
@@ -10,7 +10,7 @@ pub(crate) enum SmallMap<K, V> {
 }
 
 impl<K: PartialEq + Eq + Hash, V> SmallMap<K, V> {
-    pub(crate) fn get(&self, key: &K) -> Option<&V> {
+    pub fn get(&self, key: &K) -> Option<&V> {
         match self {
             Self::Empty => None,
             Self::One([(k, v)]) if k == key => Some(v),
@@ -22,7 +22,7 @@ impl<K: PartialEq + Eq + Hash, V> SmallMap<K, V> {
         }
     }
 
-    pub(crate) fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         match self {
             Self::Empty => None,
             Self::One([(k, v)]) if k == key => Some(v),
@@ -34,7 +34,7 @@ impl<K: PartialEq + Eq + Hash, V> SmallMap<K, V> {
         }
     }
 
-    pub(crate) fn remove(&mut self, key: &K) -> Option<V> {
+    pub fn remove(&mut self, key: &K) -> Option<V> {
         let out;
         *self = match std::mem::take(self) {
             Self::Empty => {
@@ -70,7 +70,7 @@ impl<K: PartialEq + Eq + Hash, V> SmallMap<K, V> {
         out
     }
 
-    pub(crate) fn insert(&mut self, key: K, value: V) {
+    pub fn insert(&mut self, key: K, value: V) {
         *self = match std::mem::take(self) {
             Self::Empty => Self::One([(key, value)]),
             Self::One([(k, v)]) => {
@@ -108,7 +108,7 @@ impl<K: Clone + PartialEq + Eq + Hash, V: Clone> SmallMap<K, V> {
     /// apply the provided function to both values.
     /// If the result is None, remove that key from the merged map,
     /// otherwise add the content of the Some(_).
-    pub(crate) fn merge<'a>(
+    pub fn merge<'a>(
         &'a mut self,
         map_2: impl Iterator<Item = (&'a K, &'a V)>,
         f: impl Fn(&V, &V) -> Option<V>,
@@ -136,7 +136,7 @@ impl<K, V> Default for SmallMap<K, V> {
 }
 
 impl<K, V> SmallMap<K, V> {
-    pub(crate) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         match self {
             Self::Empty => 0,
             Self::One(_) => 1,
@@ -147,7 +147,7 @@ impl<K, V> SmallMap<K, V> {
 }
 
 impl<K: Eq + Hash + Clone, V: Clone> SmallMap<K, V> {
-    pub(crate) fn as_map(&self) -> Map<K, V> {
+    pub fn as_map(&self) -> Map<K, V> {
         match self {
             Self::Empty => Map::default(),
             Self::One([(k, v)]) => {
@@ -184,7 +184,7 @@ impl<'a, K: 'a, V: 'a> Iterator for IterSmallMap<'a, K, V> {
 }
 
 impl<K, V> SmallMap<K, V> {
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
         match self {
             Self::Empty => IterSmallMap::Inline([].iter()),
             Self::One(data) => IterSmallMap::Inline(data.iter()),

--- a/vendor/pubgrub/src/internal/small_vec.rs
+++ b/vendor/pubgrub/src/internal/small_vec.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
 #[derive(Clone)]
@@ -108,6 +109,13 @@ impl<T: fmt::Debug> fmt::Debug for SmallVec<T> {
     }
 }
 
+impl<T: Hash> Hash for SmallVec<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.len().hash(state);
+        Hash::hash_slice(self.as_slice(), state);
+    }
+}
+
 #[cfg(feature = "serde")]
 impl<T: serde::Serialize> serde::Serialize for SmallVec<T> {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
@@ -118,13 +126,70 @@ impl<T: serde::Serialize> serde::Serialize for SmallVec<T> {
 #[cfg(feature = "serde")]
 impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for SmallVec<T> {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let items: Vec<T> = serde::Deserialize::deserialize(d)?;
-
-        let mut v = Self::empty();
-        for item in items {
-            v.push(item);
+        struct SmallVecVisitor<T> {
+            marker: std::marker::PhantomData<T>,
         }
-        Ok(v)
+
+        impl<'de, T> serde::de::Visitor<'de> for SmallVecVisitor<T>
+        where
+            T: serde::Deserialize<'de>,
+        {
+            type Value = SmallVec<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a sequence")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut values = SmallVec::empty();
+                while let Some(value) = seq.next_element()? {
+                    values.push(value);
+                }
+                Ok(values)
+            }
+        }
+
+        let visitor = SmallVecVisitor {
+            marker: Default::default(),
+        };
+        d.deserialize_seq(visitor)
+    }
+}
+
+impl<T> IntoIterator for SmallVec<T> {
+    type Item = T;
+    type IntoIter = SmallVecIntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            SmallVec::Empty => SmallVecIntoIter::Empty,
+            SmallVec::One(a) => SmallVecIntoIter::One(IntoIterator::into_iter(a)),
+            SmallVec::Two(a) => SmallVecIntoIter::Two(IntoIterator::into_iter(a)),
+            SmallVec::Flexible(v) => SmallVecIntoIter::Flexible(IntoIterator::into_iter(v)),
+        }
+    }
+}
+
+pub enum SmallVecIntoIter<T> {
+    Empty,
+    One(<[T; 1] as IntoIterator>::IntoIter),
+    Two(<[T; 2] as IntoIterator>::IntoIter),
+    Flexible(<Vec<T> as IntoIterator>::IntoIter),
+}
+
+impl<T> Iterator for SmallVecIntoIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            SmallVecIntoIter::Empty => None,
+            SmallVecIntoIter::One(it) => it.next(),
+            SmallVecIntoIter::Two(it) => it.next(),
+            SmallVecIntoIter::Flexible(it) => it.next(),
+        }
     }
 }
 
@@ -137,11 +202,11 @@ pub mod tests {
 
     proptest! {
         #[test]
-        fn push_and_pop(comands: Vec<Option<u8>>) {
+        fn push_and_pop(commands: Vec<Option<u8>>) {
             let mut v = vec![];
             let mut sv = SmallVec::Empty;
-            for comand in comands {
-                match comand {
+            for command in commands {
+                match command {
                     Some(i) => {
                         v.push(i);
                         sv.push(i);

--- a/vendor/pubgrub/src/lib.rs
+++ b/vendor/pubgrub/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
+#![allow(clippy::all, unreachable_pub)]
+
 //! PubGrub version solving algorithm.
 //!
 //! Version solving consists in efficiently finding a set of packages and versions
@@ -49,15 +51,17 @@
 //! # use pubgrub::solver::{OfflineDependencyProvider, resolve};
 //! # use pubgrub::version::NumberVersion;
 //! # use pubgrub::range::Range;
-//! #
-//! let mut dependency_provider = OfflineDependencyProvider::<&str, NumberVersion>::new();
+//!
+//! type NumVS = Range<NumberVersion>;
+//!
+//! let mut dependency_provider = OfflineDependencyProvider::<&str, NumVS>::new();
 //!
 //! dependency_provider.add_dependencies(
-//!     "root", 1, vec![("menu", Range::any()), ("icons", Range::any())],
+//!     "root", 1, [("menu", Range::full()), ("icons", Range::full())],
 //! );
-//! dependency_provider.add_dependencies("menu", 1, vec![("dropdown", Range::any())]);
-//! dependency_provider.add_dependencies("dropdown", 1, vec![("icons", Range::any())]);
-//! dependency_provider.add_dependencies("icons", 1, vec![]);
+//! dependency_provider.add_dependencies("menu", 1, [("dropdown", Range::full())]);
+//! dependency_provider.add_dependencies("dropdown", 1, [("icons", Range::full())]);
+//! dependency_provider.add_dependencies("icons", 1, []);
 //!
 //! // Run the algorithm.
 //! let solution = resolve(&dependency_provider, "root", 1).unwrap();
@@ -84,8 +88,10 @@
 //! #
 //! # struct MyDependencyProvider;
 //! #
-//! impl DependencyProvider<String, SemanticVersion> for MyDependencyProvider {
-//!     fn choose_package_version<T: Borrow<String>, U: Borrow<Range<SemanticVersion>>>(&self,packages: impl Iterator<Item=(T, U)>) -> Result<(T, Option<SemanticVersion>), Box<dyn Error>> {
+//! type SemVS = Range<SemanticVersion>;
+//!
+//! impl DependencyProvider<String, SemVS> for MyDependencyProvider {
+//!     fn choose_package_version<T: Borrow<String>, U: Borrow<SemVS>>(&self,packages: impl Iterator<Item=(T, U)>) -> Result<(T, Option<SemanticVersion>), Box<dyn Error + Send + Sync>> {
 //!         unimplemented!()
 //!     }
 //!
@@ -93,7 +99,7 @@
 //!         &self,
 //!         package: &String,
 //!         version: &SemanticVersion,
-//!     ) -> Result<Dependencies<String, SemanticVersion>, Box<dyn Error>> {
+//!     ) -> Result<Dependencies<String, SemVS>, Box<dyn Error + Send + Sync>> {
 //!         unimplemented!()
 //!     }
 //! }
@@ -153,13 +159,13 @@
 //! [Output](crate::report::Reporter::Output) type and a single method.
 //! ```
 //! # use pubgrub::package::Package;
-//! # use pubgrub::version::Version;
+//! # use pubgrub::version_set::VersionSet;
 //! # use pubgrub::report::DerivationTree;
 //! #
-//! pub trait Reporter<P: Package, V: Version> {
+//! pub trait Reporter<P: Package, VS: VersionSet> {
 //!     type Output;
 //!
-//!     fn report(derivation_tree: &DerivationTree<P, V>) -> Self::Output;
+//!     fn report(derivation_tree: &DerivationTree<P, VS>) -> Self::Output;
 //! }
 //! ```
 //! Implementing a [Reporter](crate::report::Reporter) may involve a lot of heuristics
@@ -173,8 +179,11 @@
 //! # use pubgrub::report::{DefaultStringReporter, Reporter};
 //! # use pubgrub::error::PubGrubError;
 //! # use pubgrub::version::NumberVersion;
+//! # use pubgrub::range::Range;
 //! #
-//! # let dependency_provider = OfflineDependencyProvider::<&str, NumberVersion>::new();
+//! # type NumVS = Range<NumberVersion>;
+//! #
+//! # let dependency_provider = OfflineDependencyProvider::<&str, NumVS>::new();
 //! # let root_package = "root";
 //! # let root_version = 1;
 //! #
@@ -217,5 +226,6 @@ pub mod solver;
 pub mod term;
 pub mod type_aliases;
 pub mod version;
+pub mod version_set;
 
 mod internal;

--- a/vendor/pubgrub/src/package.rs
+++ b/vendor/pubgrub/src/package.rs
@@ -2,16 +2,16 @@
 
 //! Trait for identifying packages.
 //! Automatically implemented for traits implementing
-//! [Clone] + [Eq] + [Hash] + [Debug] + [Display](std::fmt::Display).
+//! [Clone] + [Eq] + [Hash] + [Debug] + [Display].
 
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
 /// Trait for identifying packages.
 /// Automatically implemented for types already implementing
-/// [Clone] + [Eq] + [Hash] + [Debug] + [Display](std::fmt::Display).
+/// [Clone] + [Eq] + [Hash] + [Debug] + [Display].
 pub trait Package: Clone + Eq + Hash + Debug + Display {}
 
 /// Automatically implement the Package trait for any type
-/// that already implement [Clone] + [Eq] + [Hash] + [Debug] + [Display](std::fmt::Display).
+/// that already implement [Clone] + [Eq] + [Hash] + [Debug] + [Display].
 impl<T: Clone + Eq + Hash + Debug + Display> Package for T {}

--- a/vendor/pubgrub/src/range.rs
+++ b/vendor/pubgrub/src/range.rs
@@ -7,287 +7,425 @@
 //! of the ranges building blocks.
 //!
 //! Those building blocks are:
-//!  - [none()](Range::none): the empty set
-//!  - [any()](Range::any): the set of all possible versions
-//!  - [exact(v)](Range::exact): the set containing only the version v
+//!  - [empty()](Range::empty): the empty set
+//!  - [full()](Range::full): the set of all possible versions
+//!  - [singleton(v)](Range::singleton): the set containing only the version v
 //!  - [higher_than(v)](Range::higher_than): the set defined by `v <= versions`
+//!  - [strictly_higher_than(v)](Range::strictly_higher_than): the set defined by `v < versions`
+//!  - [lower_than(v)](Range::lower_than): the set defined by `versions <= v`
 //!  - [strictly_lower_than(v)](Range::strictly_lower_than): the set defined by `versions < v`
 //!  - [between(v1, v2)](Range::between): the set defined by `v1 <= versions < v2`
+//!
+//! Ranges can be created from any type that implements [`Ord`] + [`Clone`].
+//!
+//! In order to advance the solver front, comparisons of versions sets are necessary in the algorithm.
+//! To do those comparisons between two sets S1 and S2 we use the mathematical property that S1 ⊂ S2 if and only if S1 ∩ S2 == S1.
+//! We can thus compute an intersection and evaluate an equality to answer if S1 is a subset of S2.
+//! But this means that the implementation of equality must be correct semantically.
+//! In practice, if equality is derived automatically, this means sets must have unique representations.
+//!
+//! By migrating from a custom representation for discrete sets in v0.2
+//! to a generic bounded representation for continuous sets in v0.3
+//! we are potentially breaking that assumption in two ways:
+//!
+//!  1. Minimal and maximal `Unbounded` values can be replaced by their equivalent if it exists.
+//!  2. Simplifying adjacent bounds of discrete sets cannot be detected and automated in the generic intersection code.
+//!
+//! An example for each can be given when `T` is `u32`.
+//! First, we can have both segments `S1 = (Unbounded, Included(42u32))` and `S2 = (Included(0), Included(42u32))`
+//! that represent the same segment but are structurally different.
+//! Thus, a derived equality check would answer `false` to `S1 == S2` while it's true.
+//!
+//! Second both segments `S1 = (Included(1), Included(5))` and `S2 = (Included(1), Included(3)) + (Included(4), Included(5))` are equal.
+//! But without asking the user to provide a `bump` function for discrete sets,
+//! the algorithm is not able tell that the space between the right `Included(3)` bound and the left `Included(4)` bound is empty.
+//! Thus the algorithm is not able to reduce S2 to its canonical S1 form while computing sets operations like intersections in the generic code.
+//!
+//! This is likely to lead to user facing theoretically correct but practically nonsensical ranges,
+//! like (Unbounded, Excluded(0)) or (Excluded(6), Excluded(7)).
+//! In general nonsensical inputs often lead to hard to track bugs.
+//! But as far as we can tell this should work in practice.
+//! So for now this crate only provides an implementation for continuous ranges.
+//! With the v0.3 api the user could choose to bring back the discrete implementation from v0.2, as documented in the guide.
+//! If doing so regularly fixes bugs seen by users, we will bring it back into the core library.
+//! If we do not see practical bugs, or we get a formal proof that the code cannot lead to error states, then we may remove this warning.
 
-use std::cmp::Ordering;
-use std::fmt;
+use crate::{internal::small_vec::SmallVec, version_set::VersionSet};
+use std::ops::RangeBounds;
+use std::{
+    fmt::{Debug, Display, Formatter},
+    ops::Bound::{self, Excluded, Included, Unbounded},
+};
 
-use crate::internal::small_vec::SmallVec;
-use crate::version::Version;
-
-/// A Range is a set of versions.
-#[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+/// A Range represents multiple intervals of a continuous range of monotone increasing
+/// values.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct Range<V: Version> {
+pub struct Range<V> {
     segments: SmallVec<Interval<V>>,
 }
 
-type Interval<V> = (V, Option<V>);
+type Interval<V> = (Bound<V>, Bound<V>);
 
-// Range building blocks.
-impl<V: Version> Range<V> {
+impl<V> Range<V> {
     /// Empty set of versions.
-    pub fn none() -> Self {
+    pub fn empty() -> Self {
         Self {
             segments: SmallVec::empty(),
         }
     }
 
-    /// Set of all possible versions.
-    pub fn any() -> Self {
-        Self::higher_than(V::lowest())
-    }
-
-    /// Set containing exactly one version.
-    pub fn exact(v: impl Into<V>) -> Self {
-        let v = v.into();
+    /// Set of all possible versions
+    pub fn full() -> Self {
         Self {
-            segments: SmallVec::one((v.clone(), Some(v.bump()))),
+            segments: SmallVec::one((Unbounded, Unbounded)),
         }
     }
 
-    /// Set of all versions higher or equal to some version.
+    /// Set of all versions higher or equal to some version
     pub fn higher_than(v: impl Into<V>) -> Self {
         Self {
-            segments: SmallVec::one((v.into(), None)),
+            segments: SmallVec::one((Included(v.into()), Unbounded)),
         }
     }
 
-    /// Set of all versions strictly lower than some version.
+    /// Set of all versions higher to some version
+    pub fn strictly_higher_than(v: impl Into<V>) -> Self {
+        Self {
+            segments: SmallVec::one((Excluded(v.into()), Unbounded)),
+        }
+    }
+
+    /// Set of all versions lower to some version
     pub fn strictly_lower_than(v: impl Into<V>) -> Self {
-        let v = v.into();
-        if v == V::lowest() {
-            Self::none()
-        } else {
-            Self {
-                segments: SmallVec::one((V::lowest(), Some(v))),
-            }
+        Self {
+            segments: SmallVec::one((Unbounded, Excluded(v.into()))),
         }
     }
 
-    /// Set of all versions comprised between two given versions.
-    /// The lower bound is included and the higher bound excluded.
-    /// `v1 <= v < v2`.
+    /// Set of all versions lower or equal to some version
+    pub fn lower_than(v: impl Into<V>) -> Self {
+        Self {
+            segments: SmallVec::one((Unbounded, Included(v.into()))),
+        }
+    }
+
+    /// Set of versions greater or equal to `v1` but less than `v2`.
     pub fn between(v1: impl Into<V>, v2: impl Into<V>) -> Self {
-        let v1 = v1.into();
-        let v2 = v2.into();
-        if v1 < v2 {
-            Self {
-                segments: SmallVec::one((v1, Some(v2))),
-            }
-        } else {
-            Self::none()
+        Self {
+            segments: SmallVec::one((Included(v1.into()), Excluded(v2.into()))),
         }
     }
 }
 
-// Set operations.
-impl<V: Version> Range<V> {
-    // Negate ##################################################################
+impl<V: Clone> Range<V> {
+    /// Set containing exactly one version
+    pub fn singleton(v: impl Into<V>) -> Self {
+        let v = v.into();
+        Self {
+            segments: SmallVec::one((Included(v.clone()), Included(v))),
+        }
+    }
 
-    /// Compute the complement set of versions.
-    pub fn negate(&self) -> Self {
+    /// Returns the complement of this Range.
+    pub fn complement(&self) -> Self {
         match self.segments.first() {
-            None => Self::any(), // Complement of ∅  is *
+            // Complement of ∅ is ∞
+            None => Self::full(),
+
+            // Complement of ∞ is ∅
+            Some((Unbounded, Unbounded)) => Self::empty(),
 
             // First high bound is +∞
-            Some((v, None)) => {
-                // Complement of * is ∅
-                if v == &V::lowest() {
-                    Self::none()
-                // Complement of "v <= _" is "_ < v"
-                } else {
-                    Self::strictly_lower_than(v.clone())
-                }
-            }
+            Some((Included(v), Unbounded)) => Self::strictly_lower_than(v.clone()),
+            Some((Excluded(v), Unbounded)) => Self::lower_than(v.clone()),
 
-            // First high bound is not +∞
-            Some((v1, Some(v2))) => {
-                if v1 == &V::lowest() {
-                    Self::negate_segments(v2.clone(), &self.segments[1..])
-                } else {
-                    Self::negate_segments(V::lowest(), &self.segments)
-                }
+            Some((Unbounded, Included(v))) => {
+                Self::negate_segments(Excluded(v.clone()), &self.segments[1..])
             }
+            Some((Unbounded, Excluded(v))) => {
+                Self::negate_segments(Included(v.clone()), &self.segments[1..])
+            }
+            Some((Included(_), Included(_)))
+            | Some((Included(_), Excluded(_)))
+            | Some((Excluded(_), Included(_)))
+            | Some((Excluded(_), Excluded(_))) => Self::negate_segments(Unbounded, &self.segments),
         }
     }
 
     /// Helper function performing the negation of intervals in segments.
-    /// For example:
-    ///    [ (v1, None) ] => [ (start, Some(v1)) ]
-    ///    [ (v1, Some(v2)) ] => [ (start, Some(v1)), (v2, None) ]
-    fn negate_segments(start: V, segments: &[Interval<V>]) -> Range<V> {
-        let mut complement_segments = SmallVec::empty();
-        let mut start = Some(start);
-        for (v1, maybe_v2) in segments {
-            // start.unwrap() is fine because `segments` is not exposed,
-            // and our usage guaranties that only the last segment may contain a None.
-            complement_segments.push((start.unwrap(), Some(v1.to_owned())));
-            start = maybe_v2.to_owned();
+    fn negate_segments(start: Bound<V>, segments: &[Interval<V>]) -> Self {
+        let mut complement_segments: SmallVec<Interval<V>> = SmallVec::empty();
+        let mut start = start;
+        for (v1, v2) in segments {
+            complement_segments.push((
+                start,
+                match v1 {
+                    Included(v) => Excluded(v.clone()),
+                    Excluded(v) => Included(v.clone()),
+                    Unbounded => unreachable!(),
+                },
+            ));
+            start = match v2 {
+                Included(v) => Excluded(v.clone()),
+                Excluded(v) => Included(v.clone()),
+                Unbounded => Unbounded,
+            }
         }
-        if let Some(last) = start {
-            complement_segments.push((last, None));
+        if !matches!(start, Unbounded) {
+            complement_segments.push((start, Unbounded));
         }
 
         Self {
             segments: complement_segments,
         }
     }
-
-    // Union and intersection ##################################################
-
-    /// Compute the union of two sets of versions.
-    pub fn union(&self, other: &Self) -> Self {
-        self.negate().intersection(&other.negate()).negate()
-    }
-
-    /// Compute the intersection of two sets of versions.
-    pub fn intersection(&self, other: &Self) -> Self {
-        let mut segments = SmallVec::empty();
-        let mut left_iter = self.segments.iter();
-        let mut right_iter = other.segments.iter();
-        let mut left = left_iter.next();
-        let mut right = right_iter.next();
-        loop {
-            match (left, right) {
-                // Both left and right still contain a finite interval:
-                (Some((l1, Some(l2))), Some((r1, Some(r2)))) => {
-                    if l2 <= r1 {
-                        // Intervals are disjoint, progress on the left.
-                        left = left_iter.next();
-                    } else if r2 <= l1 {
-                        // Intervals are disjoint, progress on the right.
-                        right = right_iter.next();
-                    } else {
-                        // Intervals are not disjoint.
-                        let start = l1.max(r1).to_owned();
-                        if l2 < r2 {
-                            segments.push((start, Some(l2.to_owned())));
-                            left = left_iter.next();
-                        } else {
-                            segments.push((start, Some(r2.to_owned())));
-                            right = right_iter.next();
-                        }
-                    }
-                }
-
-                // Right contains an infinite interval:
-                (Some((l1, Some(l2))), Some((r1, None))) => match l2.cmp(r1) {
-                    Ordering::Less => {
-                        left = left_iter.next();
-                    }
-                    Ordering::Equal => {
-                        for l in left_iter.cloned() {
-                            segments.push(l)
-                        }
-                        break;
-                    }
-                    Ordering::Greater => {
-                        let start = l1.max(r1).to_owned();
-                        segments.push((start, Some(l2.to_owned())));
-                        for l in left_iter.cloned() {
-                            segments.push(l)
-                        }
-                        break;
-                    }
-                },
-
-                // Left contains an infinite interval:
-                (Some((l1, None)), Some((r1, Some(r2)))) => match r2.cmp(l1) {
-                    Ordering::Less => {
-                        right = right_iter.next();
-                    }
-                    Ordering::Equal => {
-                        for r in right_iter.cloned() {
-                            segments.push(r)
-                        }
-                        break;
-                    }
-                    Ordering::Greater => {
-                        let start = l1.max(r1).to_owned();
-                        segments.push((start, Some(r2.to_owned())));
-                        for r in right_iter.cloned() {
-                            segments.push(r)
-                        }
-                        break;
-                    }
-                },
-
-                // Both sides contain an infinite interval:
-                (Some((l1, None)), Some((r1, None))) => {
-                    let start = l1.max(r1).to_owned();
-                    segments.push((start, None));
-                    break;
-                }
-
-                // Left or right has ended.
-                _ => {
-                    break;
-                }
-            }
-        }
-
-        Self { segments }
-    }
 }
 
-// Other useful functions.
-impl<V: Version> Range<V> {
-    /// Check if a range contains a given version.
-    pub fn contains(&self, version: &V) -> bool {
-        for (v1, maybe_v2) in &self.segments {
-            match maybe_v2 {
-                None => return v1 <= version,
-                Some(v2) => {
-                    if version < v1 {
-                        return false;
-                    } else if version < v2 {
-                        return true;
-                    }
-                }
+impl<V: Ord> Range<V> {
+    /// Convert to something that can be used with
+    /// [BTreeMap::range](std::collections::BTreeMap::range).
+    /// All versions contained in self, will be in the output,
+    /// but there may be versions in the output that are not contained in self.
+    /// Returns None if the range is empty.
+    pub fn bounding_range(&self) -> Option<(Bound<&V>, Bound<&V>)> {
+        self.segments.first().map(|(start, _)| {
+            let end = self
+                .segments
+                .last()
+                .expect("if there is a first element, there must be a last element");
+            (bound_as_ref(start), bound_as_ref(&end.1))
+        })
+    }
+
+    /// Returns true if the this Range contains the specified value.
+    pub fn contains(&self, v: &V) -> bool {
+        for segment in self.segments.iter() {
+            if match segment {
+                (Unbounded, Unbounded) => true,
+                (Unbounded, Included(end)) => v <= end,
+                (Unbounded, Excluded(end)) => v < end,
+                (Included(start), Unbounded) => v >= start,
+                (Included(start), Included(end)) => v >= start && v <= end,
+                (Included(start), Excluded(end)) => v >= start && v < end,
+                (Excluded(start), Unbounded) => v > start,
+                (Excluded(start), Included(end)) => v > start && v <= end,
+                (Excluded(start), Excluded(end)) => v > start && v < end,
+            } {
+                return true;
             }
         }
         false
     }
 
-    /// Return the lowest version in the range (if there is one).
-    pub fn lowest_version(&self) -> Option<V> {
-        self.segments.first().map(|(start, _)| start).cloned()
+    /// Construct a simple range from anything that impls [RangeBounds] like `v1..v2`.
+    pub fn from_range_bounds<R, IV>(bounds: R) -> Self
+    where
+        R: RangeBounds<IV>,
+        IV: Clone + Into<V>,
+    {
+        let start = match bounds.start_bound() {
+            Included(v) => Included(v.clone().into()),
+            Excluded(v) => Excluded(v.clone().into()),
+            Unbounded => Unbounded,
+        };
+        let end = match bounds.end_bound() {
+            Included(v) => Included(v.clone().into()),
+            Excluded(v) => Excluded(v.clone().into()),
+            Unbounded => Unbounded,
+        };
+        if valid_segment(&start, &end) {
+            Self {
+                segments: SmallVec::one((start, end)),
+            }
+        } else {
+            Self::empty()
+        }
+    }
+
+    fn check_invariants(self) -> Self {
+        if cfg!(debug_assertions) {
+            for p in self.segments.as_slice().windows(2) {
+                match (&p[0].1, &p[1].0) {
+                    (Included(l_end), Included(r_start)) => assert!(l_end < r_start),
+                    (Included(l_end), Excluded(r_start)) => assert!(l_end < r_start),
+                    (Excluded(l_end), Included(r_start)) => assert!(l_end < r_start),
+                    (Excluded(l_end), Excluded(r_start)) => assert!(l_end <= r_start),
+                    (_, Unbounded) => panic!(),
+                    (Unbounded, _) => panic!(),
+                }
+            }
+            for (s, e) in self.segments.iter() {
+                assert!(valid_segment(s, e));
+            }
+        }
+        self
+    }
+}
+
+/// Implementation of [`Bound::as_ref`] which is currently marked as unstable.
+fn bound_as_ref<V>(bound: &Bound<V>) -> Bound<&V> {
+    match bound {
+        Included(v) => Included(v),
+        Excluded(v) => Excluded(v),
+        Unbounded => Unbounded,
+    }
+}
+
+fn valid_segment<T: PartialOrd>(start: &Bound<T>, end: &Bound<T>) -> bool {
+    match (start, end) {
+        (Included(s), Included(e)) => s <= e,
+        (Included(s), Excluded(e)) => s < e,
+        (Excluded(s), Included(e)) => s < e,
+        (Excluded(s), Excluded(e)) => s < e,
+        (Unbounded, _) | (_, Unbounded) => true,
+    }
+}
+
+impl<V: Ord + Clone> Range<V> {
+    /// Computes the union of this `Range` and another.
+    pub fn union(&self, other: &Self) -> Self {
+        self.complement()
+            .intersection(&other.complement())
+            .complement()
+            .check_invariants()
+    }
+
+    /// Computes the intersection of two sets of versions.
+    pub fn intersection(&self, other: &Self) -> Self {
+        let mut segments: SmallVec<Interval<V>> = SmallVec::empty();
+        let mut left_iter = self.segments.iter().peekable();
+        let mut right_iter = other.segments.iter().peekable();
+
+        while let (Some((left_start, left_end)), Some((right_start, right_end))) =
+            (left_iter.peek(), right_iter.peek())
+        {
+            let start = match (left_start, right_start) {
+                (Included(l), Included(r)) => Included(std::cmp::max(l, r)),
+                (Excluded(l), Excluded(r)) => Excluded(std::cmp::max(l, r)),
+
+                (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if i <= e => Excluded(e),
+                (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if e < i => Included(i),
+                (s, Unbounded) | (Unbounded, s) => bound_as_ref(s),
+                _ => unreachable!(),
+            }
+            .cloned();
+            let end = match (left_end, right_end) {
+                (Included(l), Included(r)) => Included(std::cmp::min(l, r)),
+                (Excluded(l), Excluded(r)) => Excluded(std::cmp::min(l, r)),
+
+                (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if i >= e => Excluded(e),
+                (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if e > i => Included(i),
+                (s, Unbounded) | (Unbounded, s) => bound_as_ref(s),
+                _ => unreachable!(),
+            }
+            .cloned();
+            left_iter.next_if(|(_, e)| e == &end);
+            right_iter.next_if(|(_, e)| e == &end);
+            if valid_segment(&start, &end) {
+                segments.push((start, end))
+            }
+        }
+
+        Self { segments }.check_invariants()
+    }
+}
+
+impl<T: Debug + Display + Clone + Eq + Ord> VersionSet for Range<T> {
+    type V = T;
+
+    fn empty() -> Self {
+        Range::empty()
+    }
+
+    fn singleton(v: Self::V) -> Self {
+        Range::singleton(v)
+    }
+
+    fn complement(&self) -> Self {
+        Range::complement(self)
+    }
+
+    fn intersection(&self, other: &Self) -> Self {
+        Range::intersection(self, other)
+    }
+
+    fn contains(&self, v: &Self::V) -> bool {
+        Range::contains(self, v)
+    }
+
+    fn full() -> Self {
+        Range::full()
+    }
+
+    fn union(&self, other: &Self) -> Self {
+        Range::union(self, other)
     }
 }
 
 // REPORT ######################################################################
 
-impl<V: Version> fmt::Display for Range<V> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.segments.as_slice() {
-            [] => write!(f, "∅"),
-            [(start, None)] if start == &V::lowest() => write!(f, "∗"),
-            [(start, None)] => write!(f, "{} <= v", start),
-            [(start, Some(end))] if end == &start.bump() => write!(f, "{}", start),
-            [(start, Some(end))] if start == &V::lowest() => write!(f, "v < {}", end),
-            [(start, Some(end))] => write!(f, "{} <= v < {}", start, end),
-            more_than_one_interval => {
-                let string_intervals: Vec<_> = more_than_one_interval
-                    .iter()
-                    .map(interval_to_string)
-                    .collect();
-                write!(f, "{}", string_intervals.join("  "))
+impl<V: Display + Eq> Display for Range<V> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.segments.is_empty() {
+            write!(f, "∅")?;
+        } else {
+            for (idx, segment) in self.segments.iter().enumerate() {
+                if idx > 0 {
+                    write!(f, ", ")?;
+                }
+                match segment {
+                    (Unbounded, Unbounded) => write!(f, "*")?,
+                    (Unbounded, Included(v)) => write!(f, "<={v}")?,
+                    (Unbounded, Excluded(v)) => write!(f, "<{v}")?,
+                    (Included(v), Unbounded) => write!(f, ">={v}")?,
+                    (Included(v), Included(b)) => {
+                        if v == b {
+                            write!(f, "{v}")?
+                        } else {
+                            write!(f, ">={v},<={b}")?
+                        }
+                    }
+                    (Included(v), Excluded(b)) => write!(f, ">={v}, <{b}")?,
+                    (Excluded(v), Unbounded) => write!(f, ">{v}")?,
+                    (Excluded(v), Included(b)) => write!(f, ">{v}, <={b}")?,
+                    (Excluded(v), Excluded(b)) => write!(f, ">{v}, <{b}")?,
+                };
             }
         }
+        Ok(())
     }
 }
 
-fn interval_to_string<V: Version>((start, maybe_end): &Interval<V>) -> String {
-    match maybe_end {
-        Some(end) => format!("[ {}, {} [", start, end),
-        None => format!("[ {}, ∞ [", start),
+// SERIALIZATION ###############################################################
+
+#[cfg(feature = "serde")]
+impl<'de, V: serde::Deserialize<'de>> serde::Deserialize<'de> for Range<V> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // This enables conversion from the "old" discrete implementation of `Range` to the new
+        // bounded one.
+        //
+        // Serialization is always performed in the new format.
+        #[derive(serde::Deserialize)]
+        #[serde(untagged)]
+        enum EitherInterval<V> {
+            B(Bound<V>, Bound<V>),
+            D(V, Option<V>),
+        }
+
+        let bounds: SmallVec<EitherInterval<V>> = serde::Deserialize::deserialize(deserializer)?;
+
+        let mut segments = SmallVec::Empty;
+        for i in bounds {
+            match i {
+                EitherInterval::B(l, r) => segments.push((l, r)),
+                EitherInterval::D(l, Some(r)) => segments.push((Included(l), Excluded(r))),
+                EitherInterval::D(l, None) => segments.push((Included(l), Unbounded)),
+            }
+        }
+
+        Ok(Range { segments })
     }
 }
 
@@ -297,28 +435,74 @@ fn interval_to_string<V: Version>((start, maybe_end): &Interval<V>) -> String {
 pub mod tests {
     use proptest::prelude::*;
 
-    use crate::version::NumberVersion;
-
     use super::*;
 
-    pub fn strategy() -> impl Strategy<Value = Range<NumberVersion>> {
-        prop::collection::vec(any::<u32>(), 0..10).prop_map(|mut vec| {
-            vec.sort_unstable();
-            vec.dedup();
-            let mut pair_iter = vec.chunks_exact(2);
-            let mut segments = SmallVec::empty();
-            while let Some([v1, v2]) = pair_iter.next() {
-                segments.push((NumberVersion(*v1), Some(NumberVersion(*v2))));
-            }
-            if let [v] = pair_iter.remainder() {
-                segments.push((NumberVersion(*v), None));
-            }
-            Range { segments }
-        })
+    /// Generate version sets from a random vector of deltas between bounds.
+    /// Each bound is randomly inclusive or exclusive.
+    pub fn strategy() -> impl Strategy<Value = Range<u32>> {
+        (
+            any::<bool>(),
+            prop::collection::vec(any::<(u32, bool)>(), 1..10),
+        )
+            .prop_map(|(start_unbounded, deltas)| {
+                let mut start = if start_unbounded {
+                    Some(Unbounded)
+                } else {
+                    None
+                };
+                let mut largest: u32 = 0;
+                let mut last_bound_was_inclusive = false;
+                let mut segments = SmallVec::Empty;
+                for (delta, inclusive) in deltas {
+                    // Add the offset to the current bound
+                    largest = match largest.checked_add(delta) {
+                        Some(s) => s,
+                        None => {
+                            // Skip this offset, if it would result in a too large bound.
+                            continue;
+                        }
+                    };
+
+                    let current_bound = if inclusive {
+                        Included(largest)
+                    } else {
+                        Excluded(largest)
+                    };
+
+                    // If we already have a start bound, the next offset defines the complete range.
+                    // If we don't have a start bound, we have to generate one.
+                    if let Some(start_bound) = start.take() {
+                        // If the delta from the start bound is 0, the only authorized configuration is
+                        // Included(x), Included(x)
+                        if delta == 0 && !(matches!(start_bound, Included(_)) && inclusive) {
+                            start = Some(start_bound);
+                            continue;
+                        }
+                        last_bound_was_inclusive = inclusive;
+                        segments.push((start_bound, current_bound));
+                    } else {
+                        // If the delta from the end bound of the last range is 0 and
+                        // any of the last ending or current starting bound is inclusive,
+                        // we skip the delta because they basically overlap.
+                        if delta == 0 && (last_bound_was_inclusive || inclusive) {
+                            continue;
+                        }
+                        start = Some(current_bound);
+                    }
+                }
+
+                // If we still have a start bound, but didn't have enough deltas to complete another
+                // segment, we add an unbounded upperbound.
+                if let Some(start_bound) = start {
+                    segments.push((start_bound, Unbounded));
+                }
+
+                return Range { segments }.check_invariants();
+            })
     }
 
-    fn version_strat() -> impl Strategy<Value = NumberVersion> {
-        any::<u32>().prop_map(NumberVersion)
+    fn version_strat() -> impl Strategy<Value = u32> {
+        any::<u32>()
     }
 
     proptest! {
@@ -327,17 +511,17 @@ pub mod tests {
 
         #[test]
         fn negate_is_different(range in strategy()) {
-            assert_ne!(range.negate(), range);
+            assert_ne!(range.complement(), range);
         }
 
         #[test]
         fn double_negate_is_identity(range in strategy()) {
-            assert_eq!(range.negate().negate(), range);
+            assert_eq!(range.complement().complement(), range);
         }
 
         #[test]
         fn negate_contains_opposite(range in strategy(), version in version_strat()) {
-            assert_ne!(range.contains(&version), range.negate().contains(&version));
+            assert_ne!(range.contains(&version), range.complement().contains(&version));
         }
 
         // Testing intersection ----------------------------
@@ -349,12 +533,12 @@ pub mod tests {
 
         #[test]
         fn intersection_with_any_is_identity(range in strategy()) {
-            assert_eq!(Range::any().intersection(&range), range);
+            assert_eq!(Range::full().intersection(&range), range);
         }
 
         #[test]
         fn intersection_with_none_is_none(range in strategy()) {
-            assert_eq!(Range::none().intersection(&range), Range::none());
+            assert_eq!(Range::empty().intersection(&range), Range::empty());
         }
 
         #[test]
@@ -369,7 +553,7 @@ pub mod tests {
 
         #[test]
         fn intesection_of_complements_is_none(range in strategy()) {
-            assert_eq!(range.negate().intersection(&range), Range::none());
+            assert_eq!(range.complement().intersection(&range), Range::empty());
         }
 
         #[test]
@@ -381,7 +565,7 @@ pub mod tests {
 
         #[test]
         fn union_of_complements_is_any(range in strategy()) {
-            assert_eq!(range.negate().union(&range), Range::any());
+            assert_eq!(range.complement().union(&range), Range::full());
         }
 
         #[test]
@@ -393,17 +577,37 @@ pub mod tests {
 
         #[test]
         fn always_contains_exact(version in version_strat()) {
-            assert!(Range::exact(version).contains(&version));
+            assert!(Range::singleton(version).contains(&version));
         }
 
         #[test]
         fn contains_negation(range in strategy(), version in version_strat()) {
-            assert_ne!(range.contains(&version), range.negate().contains(&version));
+            assert_ne!(range.contains(&version), range.complement().contains(&version));
         }
 
         #[test]
         fn contains_intersection(range in strategy(), version in version_strat()) {
-            assert_eq!(range.contains(&version), range.intersection(&Range::exact(version)) != Range::none());
+            assert_eq!(range.contains(&version), range.intersection(&Range::singleton(version)) != Range::empty());
+        }
+
+        #[test]
+        fn contains_bounding_range(range in strategy(), version in version_strat()) {
+            if range.contains(&version) {
+                assert!(range.bounding_range().map(|b| b.contains(&version)).unwrap_or(false));
+            }
+        }
+
+        #[test]
+        fn from_range_bounds(range in any::<(Bound<u32>, Bound<u32>)>(), version in version_strat()) {
+            let rv: Range<_> = Range::from_range_bounds(range);
+            assert_eq!(range.contains(&version), rv.contains(&version));
+        }
+
+        #[test]
+        fn from_range_bounds_round_trip(range in any::<(Bound<u32>, Bound<u32>)>()) {
+            let rv: Range<u32> = Range::from_range_bounds(range);
+            let rv2: Range<u32> = rv.bounding_range().map(Range::from_range_bounds::<_, u32>).unwrap_or_else(Range::empty);
+            assert_eq!(rv, rv2);
         }
     }
 }

--- a/vendor/pubgrub/src/solver.rs
+++ b/vendor/pubgrub/src/solver.rs
@@ -27,8 +27,8 @@
 //!
 //! The algorithm is generic and works for any type of dependency system
 //! as long as packages (P) and versions (V) implement
-//! the [Package](crate::package::Package) and [Version](crate::version::Version) traits.
-//! [Package](crate::package::Package) is strictly equivalent and automatically generated
+//! the [Package] and [Version](crate::version::Version) traits.
+//! [Package] is strictly equivalent and automatically generated
 //! for any type that implement [Clone] + [Eq] + [Hash] + [Debug] + [Display](std::fmt::Display).
 //! [Version](crate::version::Version) simply states that versions are ordered,
 //! that there should be
@@ -44,9 +44,12 @@
 //! # use pubgrub::solver::{resolve, OfflineDependencyProvider};
 //! # use pubgrub::version::NumberVersion;
 //! # use pubgrub::error::PubGrubError;
+//! # use pubgrub::range::Range;
 //! #
-//! # fn try_main() -> Result<(), PubGrubError<&'static str, NumberVersion>> {
-//! #     let dependency_provider = OfflineDependencyProvider::<&str, NumberVersion>::new();
+//! # type NumVS = Range<NumberVersion>;
+//! #
+//! # fn try_main() -> Result<(), PubGrubError<&'static str, NumVS>> {
+//! #     let dependency_provider = OfflineDependencyProvider::<&str, NumVS>::new();
 //! #     let package = "root";
 //! #     let version = 1;
 //! let solution = resolve(&dependency_provider, package, version)?;
@@ -73,49 +76,56 @@ use crate::error::PubGrubError;
 pub use crate::internal::core::State;
 pub use crate::internal::incompatibility::Incompatibility;
 use crate::package::Package;
-use crate::range::Range;
-use crate::type_aliases::{Map, SelectedDependencies};
-use crate::version::Version;
+use crate::type_aliases::{DependencyConstraints, Map, SelectedDependencies};
+use crate::version_set::VersionSet;
+use log::{debug, info};
 
 /// Main function of the library.
 /// Finds a set of packages satisfying dependency bounds for a given package + version pair.
-pub fn resolve<P: Package, V: Version>(
-    dependency_provider: &impl DependencyProvider<P, V>,
+pub fn resolve<P: Package, VS: VersionSet>(
+    dependency_provider: &impl DependencyProvider<P, VS>,
     package: P,
-    version: impl Into<V>,
-) -> Result<SelectedDependencies<P, V>, PubGrubError<P, V>> {
+    version: impl Into<VS::V>,
+) -> Result<SelectedDependencies<P, VS::V>, PubGrubError<P, VS>> {
     let mut state = State::init(package.clone(), version.into());
-    let mut added_dependencies: Map<P, Set<V>> = Map::default();
+    let mut added_dependencies: Map<P, Set<VS::V>> = Map::default();
     let mut next = package;
     loop {
         dependency_provider
             .should_cancel()
             .map_err(|err| PubGrubError::ErrorInShouldCancel(err))?;
 
+        info!("unit_propagation: {}", &next);
         state.unit_propagation(next)?;
 
-        let potential_packages = state.partial_solution.potential_packages();
-        if potential_packages.is_none() {
-            drop(potential_packages);
-            // The borrow checker did not like using a match on potential_packages.
-            // This `if ... is_none ... drop` is a workaround.
-            // I believe this is a case where Polonius could help, when and if it lands in rustc.
+        debug!(
+            "Partial solution after unit propagation: {}",
+            state.partial_solution
+        );
+
+        let Some(potential_packages) = state.partial_solution.potential_packages() else {
             return state.partial_solution.extract_solution().ok_or_else(|| {
                 PubGrubError::Failure(
                     "How did we end up with no package to choose but no solution?".into(),
                 )
             });
-        }
+        };
+
         let decision = dependency_provider
-            .choose_package_version(potential_packages.unwrap())
+            .choose_package_version(potential_packages)
             .map_err(PubGrubError::ErrorChoosingPackageVersion)?;
+        info!("DP chose: {} @ {:?}", decision.0, decision.1);
+
         next = decision.0.clone();
 
         // Pick the next compatible version.
         let term_intersection = state
             .partial_solution
             .term_intersection_for_package(&next)
-            .expect("a package was chosen but we don't have a term.");
+            .ok_or_else(|| {
+                PubGrubError::Failure("a package was chosen but we don't have a term.".into())
+            })?;
+
         let v = match decision.1 {
             None => {
                 let inc = Incompatibility::no_versions(next.clone(), term_intersection.clone());
@@ -124,108 +134,107 @@ pub fn resolve<P: Package, V: Version>(
             }
             Some(x) => x,
         };
+
         if !term_intersection.contains(&v) {
             return Err(PubGrubError::ErrorChoosingPackageVersion(
                 "choose_package_version picked an incompatible version".into(),
             ));
         }
 
-        if added_dependencies
+        let is_new_dependency = added_dependencies
             .entry(next.clone())
             .or_default()
-            .insert(v.clone())
-        {
-            // Retrieve that package dependencies.
-            let p = &next;
-            let dependencies =
-                match dependency_provider
-                    .get_dependencies(&p, &v)
-                    .map_err(|err| PubGrubError::ErrorRetrievingDependencies {
-                        package: p.clone(),
-                        version: v.clone(),
-                        source: err,
-                    })? {
-                    Dependencies::Unknown => {
-                        state.add_incompatibility(Incompatibility::unavailable_dependencies(
-                            p.clone(),
-                            v.clone(),
-                        ));
-                        continue;
-                    }
-                    Dependencies::Known(x) => {
-                        if x.contains_key(&p) {
-                            return Err(PubGrubError::SelfDependency {
-                                package: p.clone(),
-                                version: v.clone(),
-                            });
-                        }
-                        if let Some((dependent, _)) = x.iter().find(|(_, r)| r == &&Range::none()) {
-                            return Err(PubGrubError::DependencyOnTheEmptySet {
-                                package: p.clone(),
-                                version: v.clone(),
-                                dependent: dependent.clone(),
-                            });
-                        }
-                        x
-                    }
-                };
+            .insert(v.clone());
 
-            // Add that package and version if the dependencies are not problematic.
-            let dep_incompats =
-                state.add_incompatibility_from_dependencies(p.clone(), v.clone(), &dependencies);
-
-            // TODO: I don't think this check can actually happen.
-            // We might want to put it under #[cfg(debug_assertions)].
-            if state.incompatibility_store[dep_incompats.clone()]
-                .iter()
-                .any(|incompat| state.is_terminal(incompat))
-            {
-                // For a dependency incompatibility to be terminal,
-                // it can only mean that root depend on not root?
-                return Err(PubGrubError::Failure(
-                    "Root package depends on itself at a different version?".into(),
-                ));
-            }
-            state.partial_solution.add_version(
-                p.clone(),
-                v,
-                dep_incompats,
-                &state.incompatibility_store,
-            );
-        } else {
+        if !is_new_dependency {
             // `dep_incompats` are already in `incompatibilities` so we know there are not satisfied
             // terms and can add the decision directly.
+            info!("add_decision (not first time): {} @ {}", &next, v);
             state.partial_solution.add_decision(next.clone(), v);
+            continue;
         }
+
+        // Retrieve that package dependencies.
+        let p = &next;
+        let dependencies = dependency_provider.get_dependencies(p, &v).map_err(|err| {
+            PubGrubError::ErrorRetrievingDependencies {
+                package: p.clone(),
+                version: v.clone(),
+                source: err,
+            }
+        })?;
+
+        let known_dependencies = match dependencies {
+            Dependencies::Unknown => {
+                state.add_incompatibility(Incompatibility::unavailable_dependencies(
+                    p.clone(),
+                    v.clone(),
+                ));
+                continue;
+            }
+            Dependencies::Known(x) if x.contains_key(p) => {
+                return Err(PubGrubError::SelfDependency {
+                    package: p.clone(),
+                    version: v.clone(),
+                });
+            }
+            Dependencies::Known(x) => {
+                if let Some((dependent, _)) = x.iter().find(|(_, r)| r == &&VS::empty()) {
+                    return Err(PubGrubError::DependencyOnTheEmptySet {
+                        package: p.clone(),
+                        version: v.clone(),
+                        dependent: dependent.clone(),
+                    });
+                }
+
+                x
+            }
+        };
+
+        // Add that package and version if the dependencies are not problematic.
+        let dep_incompats =
+            state.add_incompatibility_from_dependencies(p.clone(), v.clone(), &known_dependencies);
+
+        // TODO: I don't think this check can actually happen.
+        // We might want to put it under #[cfg(debug_assertions)].
+        let incompatible_self_dependency = state.incompatibility_store[dep_incompats.clone()]
+            .iter()
+            .any(|incompat| state.is_terminal(incompat));
+        if incompatible_self_dependency {
+            // For a dependency incompatibility to be terminal,
+            // it can only mean that root depend on not root?
+            return Err(PubGrubError::Failure(
+                "Root package depends on itself at a different version?".into(),
+            ));
+        }
+
+        state.partial_solution.add_version(
+            p.clone(),
+            v,
+            dep_incompats,
+            &state.incompatibility_store,
+        );
     }
 }
 
 /// An enum used by [DependencyProvider] that holds information about package dependencies.
-/// For each [Package] there is a [Range] of concrete versions it allows as a dependency.
+/// For each [Package] there is a set of versions allowed as a dependency.
 #[derive(Clone)]
-pub enum Dependencies<P: Package, V: Version> {
+pub enum Dependencies<P: Package, VS: VersionSet> {
     /// Package dependencies are unavailable.
     Unknown,
     /// Container for all available package versions.
-    Known(DependencyConstraints<P, V>),
+    Known(DependencyConstraints<P, VS>),
 }
-
-/// Subtype of [Dependencies] which holds information about
-/// all possible versions a given package can accept.
-/// There is a difference in semantics between an empty [Map<P, Range<V>>](crate::type_aliases::Map)
-/// inside [DependencyConstraints] and [Dependencies::Unknown]:
-/// the former means the package has no dependencies and it is a known fact,
-/// while the latter means they could not be fetched by [DependencyProvider].
-pub type DependencyConstraints<P, V> = Map<P, Range<V>>;
 
 /// Trait that allows the algorithm to retrieve available packages and their dependencies.
 /// An implementor needs to be supplied to the [resolve] function.
-pub trait DependencyProvider<P: Package, V: Version> {
+pub trait DependencyProvider<P: Package, VS: VersionSet> {
     /// [Decision making](https://github.com/dart-lang/pub/blob/master/doc/solver.md#decision-making)
     /// is the process of choosing the next package
     /// and version that will be appended to the partial solution.
     /// Every time such a decision must be made,
-    /// potential valid packages and version ranges are preselected by the resolver,
+    /// potential valid packages and sets of versions are preselected by the resolver,
     /// and the dependency provider must choose.
     ///
     /// The strategy employed to choose such package and version
@@ -246,18 +255,19 @@ pub trait DependencyProvider<P: Package, V: Version> {
     /// of the available versions in preference order for any package.
     ///
     /// Note: the type `T` ensures that this returns an item from the `packages` argument.
-    fn choose_package_version<T: Borrow<P>, U: Borrow<Range<V>>>(
+    #[allow(clippy::type_complexity)]
+    fn choose_package_version<T: Borrow<P>, U: Borrow<VS>>(
         &self,
         potential_packages: impl Iterator<Item = (T, U)>,
-    ) -> Result<(T, Option<V>), Box<dyn Error + Send + Sync>>;
+    ) -> Result<(T, Option<VS::V>), Box<dyn Error + Send + Sync>>;
 
     /// Retrieves the package dependencies.
     /// Return [Dependencies::Unknown] if its dependencies are unknown.
     fn get_dependencies(
         &self,
         package: &P,
-        version: &V,
-    ) -> Result<Dependencies<P, V>, Box<dyn Error + Send + Sync>>;
+        version: &VS::V,
+    ) -> Result<Dependencies<P, VS>, Box<dyn Error + Send + Sync>>;
 
     /// This is called fairly regularly during the resolution,
     /// if it returns an Err then resolution will be terminated.
@@ -276,38 +286,44 @@ pub trait DependencyProvider<P: Package, V: Version> {
 /// The helper finds the package from the `packages` argument with the fewest versions from
 /// `list_available_versions` contained in the constraints. Then takes that package and finds the
 /// first version contained in the constraints.
-pub fn choose_package_with_fewest_versions<P: Package, V: Version, T, U, I, F>(
+pub fn choose_package_with_fewest_versions<P: Package, VS: VersionSet, T, U, I, F>(
     list_available_versions: F,
     potential_packages: impl Iterator<Item = (T, U)>,
-) -> (T, Option<V>)
+) -> (T, Option<VS::V>)
 where
     T: Borrow<P>,
-    U: Borrow<Range<V>>,
-    I: Iterator<Item = V>,
+    U: Borrow<VS>,
+    I: Iterator<Item = VS::V>,
     F: Fn(&P) -> I,
 {
-    let count_valid = |(p, range): &(T, U)| {
+    let count_valid = |(p, set): &(T, U)| {
         list_available_versions(p.borrow())
-            .filter(|v| range.borrow().contains(v.borrow()))
+            .filter(|v| set.borrow().contains(v))
             .count()
     };
-    let (pkg, range) = potential_packages
+    let (pkg, set) = potential_packages
         .min_by_key(count_valid)
         .expect("potential_packages gave us an empty iterator");
-    let version =
-        list_available_versions(pkg.borrow()).find(|v| range.borrow().contains(v.borrow()));
+    let version = list_available_versions(pkg.borrow()).find(|v| set.borrow().contains(v));
     (pkg, version)
 }
 
 /// A basic implementation of [DependencyProvider].
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(bound(
+        serialize = "VS::V: serde::Serialize, VS: serde::Serialize, P: serde::Serialize",
+        deserialize = "VS::V: serde::Deserialize<'de>, VS: serde::Deserialize<'de>, P: serde::Deserialize<'de>"
+    ))
+)]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct OfflineDependencyProvider<P: Package, V: Version> {
-    dependencies: Map<P, BTreeMap<V, DependencyConstraints<P, V>>>,
+pub struct OfflineDependencyProvider<P: Package, VS: VersionSet> {
+    dependencies: Map<P, BTreeMap<VS::V, DependencyConstraints<P, VS>>>,
 }
 
-impl<P: Package, V: Version> OfflineDependencyProvider<P, V> {
+impl<P: Package, VS: VersionSet> OfflineDependencyProvider<P, VS> {
     /// Creates an empty OfflineDependencyProvider with no dependencies.
     pub fn new() -> Self {
         Self {
@@ -325,10 +341,10 @@ impl<P: Package, V: Version> OfflineDependencyProvider<P, V> {
     /// The API does not allow to add dependencies one at a time to uphold an assumption that
     /// [OfflineDependencyProvider.get_dependencies(p, v)](OfflineDependencyProvider::get_dependencies)
     /// provides all dependencies of a given package (p) and version (v) pair.
-    pub fn add_dependencies<I: IntoIterator<Item = (P, Range<V>)>>(
+    pub fn add_dependencies<I: IntoIterator<Item = (P, VS)>>(
         &mut self,
         package: P,
-        version: impl Into<V>,
+        version: impl Into<VS::V>,
         dependencies: I,
     ) {
         let package_deps = dependencies.into_iter().collect();
@@ -348,13 +364,13 @@ impl<P: Package, V: Version> OfflineDependencyProvider<P, V> {
 
     /// Lists versions of saved packages in sorted order.
     /// Returns [None] if no information is available regarding that package.
-    pub fn versions(&self, package: &P) -> Option<impl Iterator<Item = &V>> {
+    pub fn versions(&self, package: &P) -> Option<impl Iterator<Item = &VS::V>> {
         self.dependencies.get(package).map(|k| k.keys())
     }
 
     /// Lists dependencies of a given package and version.
     /// Returns [None] if no information is available regarding that package and version pair.
-    fn dependencies(&self, package: &P, version: &V) -> Option<DependencyConstraints<P, V>> {
+    fn dependencies(&self, package: &P, version: &VS::V) -> Option<DependencyConstraints<P, VS>> {
         self.dependencies.get(package)?.get(version).cloned()
     }
 }
@@ -363,11 +379,12 @@ impl<P: Package, V: Version> OfflineDependencyProvider<P, V> {
 /// contains all dependency information available in memory.
 /// Packages are picked with the fewest versions contained in the constraints first.
 /// Versions are picked with the newest versions first.
-impl<P: Package, V: Version> DependencyProvider<P, V> for OfflineDependencyProvider<P, V> {
-    fn choose_package_version<T: Borrow<P>, U: Borrow<Range<V>>>(
+impl<P: Package, VS: VersionSet> DependencyProvider<P, VS> for OfflineDependencyProvider<P, VS> {
+    #[allow(clippy::type_complexity)]
+    fn choose_package_version<T: Borrow<P>, U: Borrow<VS>>(
         &self,
         potential_packages: impl Iterator<Item = (T, U)>,
-    ) -> Result<(T, Option<V>), Box<dyn Error + Send + Sync>> {
+    ) -> Result<(T, Option<VS::V>), Box<dyn Error + Send + Sync>> {
         Ok(choose_package_with_fewest_versions(
             |p| {
                 self.dependencies
@@ -384,8 +401,8 @@ impl<P: Package, V: Version> DependencyProvider<P, V> for OfflineDependencyProvi
     fn get_dependencies(
         &self,
         package: &P,
-        version: &V,
-    ) -> Result<Dependencies<P, V>, Box<dyn Error + Send + Sync>> {
+        version: &VS::V,
+    ) -> Result<Dependencies<P, VS>, Box<dyn Error + Send + Sync>> {
         Ok(match self.dependencies(package, version) {
             None => Dependencies::Unknown,
             Some(dependencies) => Dependencies::Known(dependencies),

--- a/vendor/pubgrub/src/type_aliases.rs
+++ b/vendor/pubgrub/src/type_aliases.rs
@@ -6,5 +6,12 @@
 pub type Map<K, V> = rustc_hash::FxHashMap<K, V>;
 
 /// Concrete dependencies picked by the library during [resolve](crate::solver::resolve)
-/// from [DependencyConstraints](crate::solver::DependencyConstraints)
+/// from [DependencyConstraints].
 pub type SelectedDependencies<P, V> = Map<P, V>;
+
+/// Holds information about all possible versions a given package can accept.
+/// There is a difference in semantics between an empty map
+/// inside [DependencyConstraints] and [Dependencies::Unknown](crate::solver::Dependencies::Unknown):
+/// the former means the package has no dependency and it is a known fact,
+/// while the latter means they could not be fetched by the [DependencyProvider](crate::solver::DependencyProvider).
+pub type DependencyConstraints<P, VS> = Map<P, VS>;

--- a/vendor/pubgrub/src/version.rs
+++ b/vendor/pubgrub/src/version.rs
@@ -80,6 +80,21 @@ impl From<(u32, u32, u32)> for SemanticVersion {
     }
 }
 
+// Convert a &(major, minor, patch) into a version.
+impl From<&(u32, u32, u32)> for SemanticVersion {
+    fn from(tuple: &(u32, u32, u32)) -> Self {
+        let (major, minor, patch) = *tuple;
+        Self::new(major, minor, patch)
+    }
+}
+
+// Convert an &version into a version.
+impl From<&SemanticVersion> for SemanticVersion {
+    fn from(v: &SemanticVersion) -> Self {
+        *v
+    }
+}
+
 // Convert a version into a tuple (major, minor, patch).
 impl From<SemanticVersion> for (u32, u32, u32) {
     fn from(v: SemanticVersion) -> Self {
@@ -234,6 +249,20 @@ pub struct NumberVersion(pub u32);
 impl From<u32> for NumberVersion {
     fn from(v: u32) -> Self {
         Self(v)
+    }
+}
+
+// Convert an &usize into a version.
+impl From<&u32> for NumberVersion {
+    fn from(v: &u32) -> Self {
+        Self(*v)
+    }
+}
+
+// Convert an &version into a version.
+impl From<&NumberVersion> for NumberVersion {
+    fn from(v: &NumberVersion) -> Self {
+        *v
     }
 }
 

--- a/vendor/pubgrub/src/version_set.rs
+++ b/vendor/pubgrub/src/version_set.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! As its name suggests, the [VersionSet] trait describes sets of versions.
+//!
+//! One needs to define
+//! - the associate type for versions,
+//! - two constructors for the empty set and a singleton set,
+//! - the complement and intersection set operations,
+//! - and a function to evaluate membership of versions.
+//!
+//! Two functions are automatically derived, thanks to the mathematical properties of sets.
+//! You can overwrite those implementations, but we highly recommend that you don't,
+//! except if you are confident in a correct implementation that brings much performance gains.
+//!
+//! It is also extremely important that the `Eq` trait is correctly implemented.
+//! In particular, you can only use `#[derive(Eq, PartialEq)]` if `Eq` is strictly equivalent to the
+//! structural equality, i.e. if version sets have canonical representations.
+//! Such problems may arise if your implementations of `complement()` and `intersection()` do not
+//! return canonical representations so be careful there.
+
+use std::fmt::{Debug, Display};
+
+/// Trait describing sets of versions.
+pub trait VersionSet: Debug + Display + Clone + Eq {
+    /// Version type associated with the sets manipulated.
+    type V: Debug + Display + Clone + Ord;
+
+    // Constructors
+    /// Constructor for an empty set containing no version.
+    fn empty() -> Self;
+    /// Constructor for a set containing exactly one version.
+    fn singleton(v: Self::V) -> Self;
+
+    // Operations
+    /// Compute the complement of this set.
+    fn complement(&self) -> Self;
+    /// Compute the intersection with another set.
+    fn intersection(&self, other: &Self) -> Self;
+
+    // Membership
+    /// Evaluate membership of a version in this set.
+    fn contains(&self, v: &Self::V) -> bool;
+
+    // Automatically implemented functions ###########################
+
+    /// Constructor for the set containing all versions.
+    /// Automatically implemented as `Self::empty().complement()`.
+    fn full() -> Self {
+        Self::empty().complement()
+    }
+
+    /// Compute the union with another set.
+    /// Thanks to set properties, this is automatically implemented as:
+    /// `self.complement().intersection(&other.complement()).complement()`
+    fn union(&self, other: &Self) -> Self {
+        self.complement()
+            .intersection(&other.complement())
+            .complement()
+    }
+}

--- a/vendor/pubgrub/tests/examples.rs
+++ b/vendor/pubgrub/tests/examples.rs
@@ -5,22 +5,37 @@ use pubgrub::solver::{resolve, OfflineDependencyProvider};
 use pubgrub::type_aliases::Map;
 use pubgrub::version::{NumberVersion, SemanticVersion};
 
+type NumVS = Range<NumberVersion>;
+type SemVS = Range<SemanticVersion>;
+
+use log::LevelFilter;
+use std::io::Write;
+
+fn init_log() {
+    let _ = env_logger::builder()
+        .filter_level(LevelFilter::Trace)
+        .format(|buf, record| writeln!(buf, "{}", record.args()))
+        .is_test(true)
+        .try_init();
+}
+
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#no-conflicts
 fn no_conflict() {
-    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
+    init_log();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemVS>::new();
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![("foo", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("foo", Range::between((1, 0, 0), (2, 0, 0)))],
     );
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "foo", (1, 0, 0),
-        vec![("bar", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("bar", Range::between((1, 0, 0), (2, 0, 0)))],
     );
-    dependency_provider.add_dependencies("bar", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("bar", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("bar", (1, 0, 0), []);
+    dependency_provider.add_dependencies("bar", (2, 0, 0), []);
 
     // Run the algorithm.
     let computed_solution = resolve(&dependency_provider, "root", (1, 0, 0)).unwrap();
@@ -38,11 +53,12 @@ fn no_conflict() {
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#avoiding-conflict-during-decision-making
 fn avoiding_conflict_during_decision_making() {
-    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
+    init_log();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemVS>::new();
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![
+        [
             ("foo", Range::between((1, 0, 0), (2, 0, 0))),
             ("bar", Range::between((1, 0, 0), (2, 0, 0))),
         ],
@@ -50,12 +66,12 @@ fn avoiding_conflict_during_decision_making() {
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "foo", (1, 1, 0),
-        vec![("bar", Range::between((2, 0, 0), (3, 0, 0)))],
+        [("bar", Range::between((2, 0, 0), (3, 0, 0)))],
     );
-    dependency_provider.add_dependencies("foo", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("bar", (1, 0, 0), vec![]);
-    dependency_provider.add_dependencies("bar", (1, 1, 0), vec![]);
-    dependency_provider.add_dependencies("bar", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("foo", (1, 0, 0), []);
+    dependency_provider.add_dependencies("bar", (1, 0, 0), []);
+    dependency_provider.add_dependencies("bar", (1, 1, 0), []);
+    dependency_provider.add_dependencies("bar", (2, 0, 0), []);
 
     // Run the algorithm.
     let computed_solution = resolve(&dependency_provider, "root", (1, 0, 0)).unwrap();
@@ -73,22 +89,23 @@ fn avoiding_conflict_during_decision_making() {
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#performing-conflict-resolution
 fn conflict_resolution() {
-    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
+    init_log();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemVS>::new();
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![("foo", Range::higher_than((1, 0, 0)))],
+        [("foo", Range::higher_than((1, 0, 0)))],
     );
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "foo", (2, 0, 0),
-        vec![("bar", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("bar", Range::between((1, 0, 0), (2, 0, 0)))],
     );
-    dependency_provider.add_dependencies("foo", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("foo", (1, 0, 0), []);
     #[rustfmt::skip]
         dependency_provider.add_dependencies(
         "bar", (1, 0, 0),
-        vec![("foo", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("foo", Range::between((1, 0, 0), (2, 0, 0)))],
     );
 
     // Run the algorithm.
@@ -106,12 +123,13 @@ fn conflict_resolution() {
 #[test]
 /// https://github.com/dart-lang/pub/blob/master/doc/solver.md#conflict-resolution-with-a-partial-satisfier
 fn conflict_with_partial_satisfier() {
-    let mut dependency_provider = OfflineDependencyProvider::<&str, SemanticVersion>::new();
+    init_log();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, SemVS>::new();
     #[rustfmt::skip]
     // root 1.0.0 depends on foo ^1.0.0 and target ^2.0.0
         dependency_provider.add_dependencies(
         "root", (1, 0, 0),
-        vec![
+        [
             ("foo", Range::between((1, 0, 0), (2, 0, 0))),
             ("target", Range::between((2, 0, 0), (3, 0, 0))),
         ],
@@ -120,33 +138,33 @@ fn conflict_with_partial_satisfier() {
     // foo 1.1.0 depends on left ^1.0.0 and right ^1.0.0
         dependency_provider.add_dependencies(
         "foo", (1, 1, 0),
-        vec![
+        [
             ("left", Range::between((1, 0, 0), (2, 0, 0))),
             ("right", Range::between((1, 0, 0), (2, 0, 0))),
         ],
     );
-    dependency_provider.add_dependencies("foo", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("foo", (1, 0, 0), []);
     #[rustfmt::skip]
     // left 1.0.0 depends on shared >=1.0.0
         dependency_provider.add_dependencies(
         "left", (1, 0, 0),
-        vec![("shared", Range::higher_than((1, 0, 0)))],
+        [("shared", Range::higher_than((1, 0, 0)))],
     );
     #[rustfmt::skip]
     // right 1.0.0 depends on shared <2.0.0
         dependency_provider.add_dependencies(
         "right", (1, 0, 0),
-        vec![("shared", Range::strictly_lower_than((2, 0, 0)))],
+        [("shared", Range::strictly_lower_than((2, 0, 0)))],
     );
-    dependency_provider.add_dependencies("shared", (2, 0, 0), vec![]);
+    dependency_provider.add_dependencies("shared", (2, 0, 0), []);
     #[rustfmt::skip]
     // shared 1.0.0 depends on target ^1.0.0
         dependency_provider.add_dependencies(
         "shared", (1, 0, 0),
-        vec![("target", Range::between((1, 0, 0), (2, 0, 0)))],
+        [("target", Range::between((1, 0, 0), (2, 0, 0)))],
     );
-    dependency_provider.add_dependencies("target", (2, 0, 0), vec![]);
-    dependency_provider.add_dependencies("target", (1, 0, 0), vec![]);
+    dependency_provider.add_dependencies("target", (2, 0, 0), []);
+    dependency_provider.add_dependencies("target", (1, 0, 0), []);
 
     // Run the algorithm.
     let computed_solution = resolve(&dependency_provider, "root", (1, 0, 0)).unwrap();
@@ -171,13 +189,14 @@ fn conflict_with_partial_satisfier() {
 ///
 /// Solution: a0, b0, c0, d0
 fn double_choices() {
-    let mut dependency_provider = OfflineDependencyProvider::<&str, NumberVersion>::new();
-    dependency_provider.add_dependencies("a", 0, vec![("b", Range::any()), ("c", Range::any())]);
-    dependency_provider.add_dependencies("b", 0, vec![("d", Range::exact(0))]);
-    dependency_provider.add_dependencies("b", 1, vec![("d", Range::exact(1))]);
-    dependency_provider.add_dependencies("c", 0, vec![]);
-    dependency_provider.add_dependencies("c", 1, vec![("d", Range::exact(2))]);
-    dependency_provider.add_dependencies("d", 0, vec![]);
+    init_log();
+    let mut dependency_provider = OfflineDependencyProvider::<&str, NumVS>::new();
+    dependency_provider.add_dependencies("a", 0, [("b", Range::full()), ("c", Range::full())]);
+    dependency_provider.add_dependencies("b", 0, [("d", Range::singleton(0))]);
+    dependency_provider.add_dependencies("b", 1, [("d", Range::singleton(1))]);
+    dependency_provider.add_dependencies("c", 0, []);
+    dependency_provider.add_dependencies("c", 1, [("d", Range::singleton(2))]);
+    dependency_provider.add_dependencies("d", 0, []);
 
     // Solution.
     let mut expected_solution = Map::default();


### PR DESCRIPTION
Updates to `29c48fb9f3daa11bd02794edd55060d0b01ee705` from the `pubgrub-rs` dev branch. This lets us reduce the number of changes we've made to PubGrub itself (now, only changing visibility to export a few things from the `solver.rs` module).
