### PR TITLE
Update worker to avoid downloading entire wheel

### DIFF
--- a/workers/pypi-metadata/package-lock.json
+++ b/workers/pypi-metadata/package-lock.json
@@ -8,6 +8,7 @@
       "name": "api",
       "version": "0.0.0",
       "dependencies": {
+        "@zip.js/zip.js": "^2.7.30",
         "install": "^0.13.0",
         "jszip": "^3.10.1",
         "npm": "^10.2.1",
@@ -338,6 +339,16 @@
       "resolved": "https://registry.npmjs.org/@types/stack-trace/-/stack-trace-0.0.29.tgz",
       "integrity": "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==",
       "dev": true
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.7.30",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.30.tgz",
+      "integrity": "sha512-nhMvQCj+TF1ATBqYzFds7v+yxPBhdDYHh8J341KtC1D2UrVBUIYcYK4Jy1/GiTsxOXEiKOXSUxvPG/XR+7jMqw==",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=16.5.0"
+      }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",

--- a/workers/pypi-metadata/package.json
+++ b/workers/pypi-metadata/package.json
@@ -13,8 +13,8 @@
     "fmt": "prettier --cache -w ."
   },
   "dependencies": {
+    "@zip.js/zip.js": "^2.7.30",
     "install": "^0.13.0",
-    "jszip": "^3.10.1",
     "npm": "^10.2.1",
     "prettier": "^3.0.3"
   }


### PR DESCRIPTION
The previous solution downloaded the entire wheel in-memory. This solution reads lazily.

Closes https://github.com/astral-sh/puffin/issues/153.
