### PR TITLE
Fix rustdoc warnings

### DIFF
--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -306,7 +306,7 @@ impl<'source> FromPyObject<'source> for Version {
     }
 }
 
-/// Workaround for https://github.com/PyO3/pyo3/pull/2786
+/// Workaround for <https://github.com/PyO3/pyo3/pull/2786>
 #[cfg(feature = "pyo3")]
 #[derive(Clone, Debug)]
 #[pyclass(name = "Version")]

--- a/crates/puffin-cli/src/main.rs
+++ b/crates/puffin-cli/src/main.rs
@@ -78,7 +78,7 @@ struct PipCompileArgs {
     #[clap(short, long)]
     output_file: Option<PathBuf>,
 
-    /// The URL of the Python Package Index (default: https://pypi.org/simple).
+    /// The URL of the Python Package Index (default: <https://pypi.org/simple>).
     #[clap(long, short)]
     index_url: Option<Url>,
 
@@ -101,7 +101,7 @@ struct PipSyncArgs {
     #[clap(long, value_enum)]
     link_mode: Option<install_wheel_rs::linker::LinkMode>,
 
-    /// The URL of the Python Package Index (default: https://pypi.org/simple).
+    /// The URL of the Python Package Index (default: <https://pypi.org/simple>).
     #[clap(long, short)]
     index_url: Option<Url>,
 

--- a/crates/puffin-installer/src/installer.rs
+++ b/crates/puffin-installer/src/installer.rs
@@ -23,7 +23,7 @@ impl<'a> Installer<'a> {
         }
     }
 
-    /// Set the [`Mode`] to use for this installer.
+    /// Set the [`LinkMode`][`install_wheel_rs::linker::LinkMode`] to use for this installer.
     #[must_use]
     pub fn with_link_mode(self, link_mode: install_wheel_rs::linker::LinkMode) -> Self {
         Self { link_mode, ..self }


### PR DESCRIPTION
Changes to make `cargo doc --all --all-features` pass without warnings.