### PR TITLE
Respect existing versions in "lockfile"

### DIFF
--- a/crates/puffin-cli/src/main.rs
+++ b/crates/puffin-cli/src/main.rs
@@ -89,6 +89,10 @@ struct PipCompileArgs {
     /// Ignore the package index, instead relying on local archives and caches.
     #[clap(long, conflicts_with = "index_url", conflicts_with = "extra_index_url")]
     no_index: bool,
+
+    /// Allow package upgrades, ignoring pinned versions in the existing output file.
+    #[clap(long)]
+    upgrade: bool,
 }
 
 #[derive(Args)]
@@ -196,6 +200,7 @@ async fn main() -> ExitCode {
                 &constraints,
                 args.output_file.as_deref(),
                 args.resolution.unwrap_or_default(),
+                args.upgrade.into(),
                 index_urls,
                 cache_dir,
                 printer,

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -18,7 +18,7 @@ use puffin_installer::{
     uninstall, Downloader, Installer, PartitionedRequirements, RemoteDistribution, Unzipper,
 };
 use puffin_interpreter::{InterpreterInfo, Virtualenv};
-use puffin_resolver::{ResolutionMode, Resolver, WheelFinder};
+use puffin_resolver::{Manifest, ResolutionMode, Resolver, WheelFinder};
 use puffin_traits::BuildContext;
 use tracing::debug;
 
@@ -70,9 +70,12 @@ impl BuildContext for BuildDispatch {
                 self.interpreter_info.simple_version(),
             )?;
             let resolver = Resolver::new(
-                requirements.to_vec(),
-                Vec::default(),
-                ResolutionMode::Highest,
+                Manifest::new(
+                    requirements.to_vec(),
+                    Vec::default(),
+                    Vec::default(),
+                    ResolutionMode::default(),
+                ),
                 self.interpreter_info.markers(),
                 &tags,
                 &self.client,

--- a/crates/puffin-resolver/src/distribution.rs
+++ b/crates/puffin-resolver/src/distribution.rs
@@ -66,6 +66,19 @@ impl From<SdistFile> for DistributionFile {
     }
 }
 
+impl From<File> for DistributionFile {
+    fn from(file: File) -> Self {
+        if std::path::Path::new(file.filename.as_str())
+            .extension()
+            .map_or(false, |ext| ext.eq_ignore_ascii_case("whl"))
+        {
+            Self::Wheel(WheelFile::from(file))
+        } else {
+            Self::Sdist(SdistFile::from(file))
+        }
+    }
+}
+
 impl DistributionFile {
     pub(crate) fn filename(&self) -> &str {
         match self {

--- a/crates/puffin-resolver/src/lib.rs
+++ b/crates/puffin-resolver/src/lib.rs
@@ -1,6 +1,6 @@
 pub use error::ResolveError;
 pub use resolution::PinnedPackage;
-pub use resolver::Resolver;
+pub use resolver::{Manifest, Resolver};
 pub use selector::ResolutionMode;
 pub use source_distribution::BuiltSourceDistributionCache;
 pub use wheel_finder::{Reporter, WheelFinder};

--- a/crates/puffin-resolver/src/resolution.rs
+++ b/crates/puffin-resolver/src/resolution.rs
@@ -69,6 +69,11 @@ impl Resolution {
         self.0.into_values().map(|package| package.file)
     }
 
+    /// Return the pinned package for the given package name, if it exists.
+    pub fn get(&self, package_name: &PackageName) -> Option<&PinnedPackage> {
+        self.0.get(package_name)
+    }
+
     /// Return the number of pinned packages in this resolution.
     pub fn len(&self) -> usize {
         self.0.len()

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -16,7 +16,7 @@ use platform_host::{Arch, Os, Platform};
 use platform_tags::Tags;
 use puffin_client::RegistryClientBuilder;
 use puffin_interpreter::{InterpreterInfo, Virtualenv};
-use puffin_resolver::{ResolutionMode, Resolver};
+use puffin_resolver::{Manifest, ResolutionMode, Resolver};
 use puffin_traits::BuildContext;
 
 struct DummyContext;
@@ -66,15 +66,15 @@ async fn pylint() -> Result<()> {
 
     let requirements = vec![Requirement::from_str("pylint==2.3.0").unwrap()];
     let constraints = vec![];
-    let resolver = Resolver::new(
+    let preferences = vec![];
+    let manifest = Manifest::new(
         requirements,
         constraints,
+        preferences,
         ResolutionMode::default(),
-        &MARKERS_311,
-        &TAGS_311,
-        &client,
-        &DummyContext,
     );
+
+    let resolver = Resolver::new(manifest, &MARKERS_311, &TAGS_311, &client, &DummyContext);
     let resolution = resolver.resolve().await?;
 
     insta::assert_display_snapshot!(resolution);
@@ -90,15 +90,15 @@ async fn black() -> Result<()> {
 
     let requirements = vec![Requirement::from_str("black<=23.9.1").unwrap()];
     let constraints = vec![];
-    let resolver = Resolver::new(
+    let preferences = vec![];
+    let manifest = Manifest::new(
         requirements,
         constraints,
+        preferences,
         ResolutionMode::default(),
-        &MARKERS_311,
-        &TAGS_311,
-        &client,
-        &DummyContext,
     );
+
+    let resolver = Resolver::new(manifest, &MARKERS_311, &TAGS_311, &client, &DummyContext);
     let resolution = resolver.resolve().await?;
 
     insta::assert_display_snapshot!(resolution);
@@ -114,15 +114,15 @@ async fn black_colorama() -> Result<()> {
 
     let requirements = vec![Requirement::from_str("black[colorama]<=23.9.1").unwrap()];
     let constraints = vec![];
-    let resolver = Resolver::new(
+    let preferences = vec![];
+    let manifest = Manifest::new(
         requirements,
         constraints,
+        preferences,
         ResolutionMode::default(),
-        &MARKERS_311,
-        &TAGS_311,
-        &client,
-        &DummyContext,
     );
+
+    let resolver = Resolver::new(manifest, &MARKERS_311, &TAGS_311, &client, &DummyContext);
     let resolution = resolver.resolve().await?;
 
     insta::assert_display_snapshot!(resolution);
@@ -138,15 +138,15 @@ async fn black_python_310() -> Result<()> {
 
     let requirements = vec![Requirement::from_str("black<=23.9.1").unwrap()];
     let constraints = vec![];
-    let resolver = Resolver::new(
+    let preferences = vec![];
+    let manifest = Manifest::new(
         requirements,
         constraints,
+        preferences,
         ResolutionMode::default(),
-        &MARKERS_310,
-        &TAGS_310,
-        &client,
-        &DummyContext,
     );
+
+    let resolver = Resolver::new(manifest, &MARKERS_310, &TAGS_310, &client, &DummyContext);
     let resolution = resolver.resolve().await?;
 
     insta::assert_display_snapshot!(resolution);
@@ -164,15 +164,15 @@ async fn black_mypy_extensions() -> Result<()> {
 
     let requirements = vec![Requirement::from_str("black<=23.9.1").unwrap()];
     let constraints = vec![Requirement::from_str("mypy-extensions<1").unwrap()];
-    let resolver = Resolver::new(
+    let preferences = vec![];
+    let manifest = Manifest::new(
         requirements,
         constraints,
+        preferences,
         ResolutionMode::default(),
-        &MARKERS_311,
-        &TAGS_311,
-        &client,
-        &DummyContext,
     );
+
+    let resolver = Resolver::new(manifest, &MARKERS_311, &TAGS_311, &client, &DummyContext);
     let resolution = resolver.resolve().await?;
 
     insta::assert_display_snapshot!(resolution);
@@ -190,15 +190,15 @@ async fn black_mypy_extensions_extra() -> Result<()> {
 
     let requirements = vec![Requirement::from_str("black<=23.9.1").unwrap()];
     let constraints = vec![Requirement::from_str("mypy-extensions[extra]<1").unwrap()];
-    let resolver = Resolver::new(
+    let preferences = vec![];
+    let manifest = Manifest::new(
         requirements,
         constraints,
+        preferences,
         ResolutionMode::default(),
-        &MARKERS_311,
-        &TAGS_311,
-        &client,
-        &DummyContext,
     );
+
+    let resolver = Resolver::new(manifest, &MARKERS_311, &TAGS_311, &client, &DummyContext);
     let resolution = resolver.resolve().await?;
 
     insta::assert_display_snapshot!(resolution);
@@ -216,15 +216,15 @@ async fn black_flake8() -> Result<()> {
 
     let requirements = vec![Requirement::from_str("black<=23.9.1").unwrap()];
     let constraints = vec![Requirement::from_str("flake8<1").unwrap()];
-    let resolver = Resolver::new(
+    let preferences = vec![];
+    let manifest = Manifest::new(
         requirements,
         constraints,
+        preferences,
         ResolutionMode::default(),
-        &MARKERS_311,
-        &TAGS_311,
-        &client,
-        &DummyContext,
     );
+
+    let resolver = Resolver::new(manifest, &MARKERS_311, &TAGS_311, &client, &DummyContext);
     let resolution = resolver.resolve().await?;
 
     insta::assert_display_snapshot!(resolution);
@@ -240,15 +240,15 @@ async fn black_lowest() -> Result<()> {
 
     let requirements = vec![Requirement::from_str("black>21").unwrap()];
     let constraints = vec![];
-    let resolver = Resolver::new(
+    let preferences = vec![];
+    let manifest = Manifest::new(
         requirements,
         constraints,
+        preferences,
         ResolutionMode::Lowest,
-        &MARKERS_311,
-        &TAGS_311,
-        &client,
-        &DummyContext,
     );
+
+    let resolver = Resolver::new(manifest, &MARKERS_311, &TAGS_311, &client, &DummyContext);
     let resolution = resolver.resolve().await?;
 
     insta::assert_display_snapshot!(resolution);
@@ -264,15 +264,63 @@ async fn black_lowest_direct() -> Result<()> {
 
     let requirements = vec![Requirement::from_str("black>21").unwrap()];
     let constraints = vec![];
-    let resolver = Resolver::new(
+    let preferences = vec![];
+    let manifest = Manifest::new(
         requirements,
         constraints,
+        preferences,
         ResolutionMode::LowestDirect,
-        &MARKERS_311,
-        &TAGS_311,
-        &client,
-        &DummyContext,
     );
+
+    let resolver = Resolver::new(manifest, &MARKERS_311, &TAGS_311, &client, &DummyContext);
+    let resolution = resolver.resolve().await?;
+
+    insta::assert_display_snapshot!(resolution);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn black_respect_preference() -> Result<()> {
+    colored::control::set_override(false);
+
+    let client = RegistryClientBuilder::default().build();
+
+    let requirements = vec![Requirement::from_str("black<=23.9.1").unwrap()];
+    let constraints = vec![];
+    let preferences = vec![Requirement::from_str("black==23.9.0").unwrap()];
+    let manifest = Manifest::new(
+        requirements,
+        constraints,
+        preferences,
+        ResolutionMode::default(),
+    );
+
+    let resolver = Resolver::new(manifest, &MARKERS_311, &TAGS_311, &client, &DummyContext);
+    let resolution = resolver.resolve().await?;
+
+    insta::assert_display_snapshot!(resolution);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn black_ignore_preference() -> Result<()> {
+    colored::control::set_override(false);
+
+    let client = RegistryClientBuilder::default().build();
+
+    let requirements = vec![Requirement::from_str("black<=23.9.1").unwrap()];
+    let constraints = vec![];
+    let preferences = vec![Requirement::from_str("black==23.9.2").unwrap()];
+    let manifest = Manifest::new(
+        requirements,
+        constraints,
+        preferences,
+        ResolutionMode::default(),
+    );
+
+    let resolver = Resolver::new(manifest, &MARKERS_311, &TAGS_311, &client, &DummyContext);
     let resolution = resolver.resolve().await?;
 
     insta::assert_display_snapshot!(resolution);

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_ignore_preference.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_ignore_preference.snap
@@ -1,0 +1,16 @@
+---
+source: crates/puffin-resolver/tests/resolver.rs
+expression: resolution
+---
+black==23.9.1
+click==8.1.7
+    # via black
+mypy-extensions==1.0.0
+    # via black
+packaging==23.2
+    # via black
+pathspec==0.11.2
+    # via black
+platformdirs==3.11.0
+    # via black
+

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_respect_preference.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_respect_preference.snap
@@ -1,0 +1,16 @@
+---
+source: crates/puffin-resolver/tests/resolver.rs
+expression: resolution
+---
+black==23.9.0
+click==8.1.7
+    # via black
+mypy-extensions==1.0.0
+    # via black
+packaging==23.2
+    # via black
+pathspec==0.11.2
+    # via black
+platformdirs==3.11.0
+    # via black
+


### PR DESCRIPTION
Like `pip-compile`, we now respect existing versions from the `requirements.txt` provided via `--output-file`, unless you pass a `--upgrade` flag.

Closes #166.