### PR TITLE
Select most recent wheel, most recent sdist

### DIFF
--- a/crates/puffin-resolver/src/selector.rs
+++ b/crates/puffin-resolver/src/selector.rs
@@ -153,12 +153,15 @@ impl CandidateSelector {
                             file: file.clone(),
                         });
                     }
-                    DistributionFile::Sdist(_) => {
+                    DistributionFile::Sdist(_) if sdist.is_none() => {
                         sdist = Some(Candidate {
                             package_name: package_name.clone(),
                             version: version.clone(),
                             file: file.clone(),
                         });
+                    }
+                    DistributionFile::Sdist(_) => {
+                        // We already selected a more recent source distribution
                     }
                 }
             }

--- a/scripts/benchmarks/requirements/mst.in
+++ b/scripts/benchmarks/requirements/mst.in
@@ -1,0 +1,1 @@
+meine_stadt_transparent


### PR DESCRIPTION
Select a compatible wheel for a version, even we already found a source distribution previously.

If no wheel is found, select the most recent source distribution, not the oldest compatible one.

This fixes the resolution of `mst.in`, which i added