### PR TITLE
Only fall back to copy when the first hard linking failed

### DIFF
--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -387,9 +387,13 @@ fn hardlink_wheel_files(
         } else {
             let hard_link_result = fs::hard_link(entry.path(), &out_path);
             // Once https://github.com/rust-lang/rust/issues/86442 is stable, use that
-            if first_try_hard_linking && hard_link_result.is_err() {
-                fs::copy(entry.path(), &out_path)?;
-                use_copy_fallback = true;
+            if let Err(err) = hard_link_result {
+                if first_try_hard_linking {
+                    fs::copy(entry.path(), &out_path)?;
+                    use_copy_fallback = true;
+                } else {
+                    return Err(err.into());
+                }
             }
             first_try_hard_linking = false;
         }


### PR DESCRIPTION
Hard linking might not be supported but we (afaik) can't detect this ahead of time, so we'll try hard linking the first file, if this succeeds we'll know later hard linking errors are not due to lack of os/fs support, if it fails we'll switch to copying for the rest of the install. Follow up to https://github.com/astral-sh/puffin/pull/237#discussion_r1376705137