### PR TITLE
Make cache non-optional in most crates

### DIFF
--- a/crates/gourgeist/src/main.rs
+++ b/crates/gourgeist/src/main.rs
@@ -26,7 +26,7 @@ fn run() -> Result<(), gourgeist::Error> {
     let location = cli.path.unwrap_or(Utf8PathBuf::from(".venv"));
     let python = parse_python_cli(cli.python)?;
     let platform = Platform::current()?;
-    let info = InterpreterInfo::query_cached(python.as_std_path(), platform, None).unwrap();
+    let info = InterpreterInfo::query(python.as_std_path(), platform, None).unwrap();
     create_venv(location, &python, &info, cli.bare)?;
 
     Ok(())

--- a/crates/puffin-cli/src/commands/clean.rs
+++ b/crates/puffin-cli/src/commands/clean.rs
@@ -9,11 +9,7 @@ use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Clear the cache.
-pub(crate) fn clean(cache: Option<&Path>, mut printer: Printer) -> Result<ExitStatus> {
-    let Some(cache) = cache else {
-        return Err(anyhow::anyhow!("No cache found"));
-    };
-
+pub(crate) fn clean(cache: &Path, mut printer: Printer) -> Result<ExitStatus> {
     if !cache.exists() {
         writeln!(printer, "No cache found at: {}", cache.display())?;
         return Ok(ExitStatus::Success);

--- a/crates/puffin-cli/src/commands/freeze.rs
+++ b/crates/puffin-cli/src/commands/freeze.rs
@@ -11,10 +11,10 @@ use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Enumerate the installed packages in the current environment.
-pub(crate) fn freeze(cache: Option<&Path>, _printer: Printer) -> Result<ExitStatus> {
+pub(crate) fn freeze(cache: &Path, _printer: Printer) -> Result<ExitStatus> {
     // Detect the current Python interpreter.
     let platform = Platform::current()?;
-    let python = Virtualenv::from_env(platform, cache)?;
+    let python = Virtualenv::from_env(platform, Some(cache))?;
     debug!(
         "Using Python interpreter: {}",
         python.python_executable().display()

--- a/crates/puffin-cli/src/commands/pip_compile.rs
+++ b/crates/puffin-cli/src/commands/pip_compile.rs
@@ -37,7 +37,7 @@ pub(crate) async fn pip_compile(
     prerelease_mode: PreReleaseMode,
     upgrade_mode: UpgradeMode,
     index_urls: Option<IndexUrls>,
-    cache: Option<&Path>,
+    cache: &Path,
     mut printer: Printer,
 ) -> Result<ExitStatus> {
     let start = std::time::Instant::now();
@@ -88,7 +88,7 @@ pub(crate) async fn pip_compile(
 
     // Detect the current Python interpreter.
     let platform = Platform::current()?;
-    let venv = Virtualenv::from_env(platform, cache)?;
+    let venv = Virtualenv::from_env(platform, Some(cache))?;
 
     debug!(
         "Using Python {} at {}",
@@ -105,7 +105,7 @@ pub(crate) async fn pip_compile(
     // Instantiate a client.
     let client = {
         let mut builder = RegistryClientBuilder::default();
-        builder = builder.cache(cache);
+        builder = builder.cache(Some(cache));
         if let Some(IndexUrls { index, extra_index }) = index_urls {
             if let Some(index) = index {
                 builder = builder.index(index);
@@ -119,7 +119,7 @@ pub(crate) async fn pip_compile(
 
     let build_dispatch = BuildDispatch::new(
         RegistryClientBuilder::default().build(),
-        cache.map(Path::to_path_buf),
+        cache.to_path_buf(),
         venv.interpreter_info().clone(),
         fs::canonicalize(venv.python_executable())?,
     );

--- a/crates/puffin-cli/src/commands/pip_uninstall.rs
+++ b/crates/puffin-cli/src/commands/pip_uninstall.rs
@@ -15,7 +15,7 @@ use crate::requirements::{ExtrasSpecification, RequirementsSource, RequirementsS
 /// Uninstall packages from the current environment.
 pub(crate) async fn pip_uninstall(
     sources: &[RequirementsSource],
-    cache: Option<&Path>,
+    cache: &Path,
     mut printer: Printer,
 ) -> Result<ExitStatus> {
     let start = std::time::Instant::now();
@@ -29,7 +29,7 @@ pub(crate) async fn pip_uninstall(
 
     // Detect the current Python interpreter.
     let platform = Platform::current()?;
-    let venv = Virtualenv::from_env(platform, cache)?;
+    let venv = Virtualenv::from_env(platform, Some(cache))?;
     debug!(
         "Using Python interpreter: {}",
         venv.python_executable().display()

--- a/crates/puffin-cli/src/commands/venv.rs
+++ b/crates/puffin-cli/src/commands/venv.rs
@@ -65,7 +65,7 @@ fn venv_impl(
     };
 
     let platform = Platform::current().into_diagnostic()?;
-    let interpreter_info = InterpreterInfo::query_cached(&base_python, platform, None)
+    let interpreter_info = InterpreterInfo::query(&base_python, platform, None)
         .map_err(VenvError::InterpreterError)?;
 
     writeln!(

--- a/crates/puffin-installer/src/plan.rs
+++ b/crates/puffin-installer/src/plan.rs
@@ -30,24 +30,15 @@ impl PartitionedRequirements {
     /// need to be downloaded, and those that should be removed.
     pub fn try_from_requirements(
         requirements: &[Requirement],
-        cache: Option<&Path>,
+        cache: &Path,
         venv: &Virtualenv,
     ) -> Result<Self> {
         // Index all the already-installed packages in site-packages.
         let mut site_packages = SitePackages::try_from_executable(venv)?;
 
         // Index all the already-downloaded wheels in the cache.
-        let registry_index = if let Some(cache) = cache {
-            RegistryIndex::try_from_directory(cache)?
-        } else {
-            RegistryIndex::default()
-        };
-
-        let url_index = if let Some(cache) = cache {
-            UrlIndex::try_from_directory(cache)?
-        } else {
-            UrlIndex::default()
-        };
+        let registry_index = RegistryIndex::try_from_directory(cache)?;
+        let url_index = UrlIndex::try_from_directory(cache)?;
 
         let mut local = vec![];
         let mut remote = vec![];

--- a/crates/puffin-interpreter/src/virtual_env.rs
+++ b/crates/puffin-interpreter/src/virtual_env.rs
@@ -21,7 +21,7 @@ impl Virtualenv {
         let platform = PythonPlatform::from(platform);
         let venv = detect_virtual_env(&platform)?;
         let executable = platform.venv_python(&venv);
-        let interpreter_info = InterpreterInfo::query_cached(&executable, platform.0, cache)?;
+        let interpreter_info = InterpreterInfo::query(&executable, platform.0, cache)?;
 
         Ok(Self {
             root: venv,
@@ -32,7 +32,7 @@ impl Virtualenv {
     pub fn from_virtualenv(platform: Platform, root: &Path, cache: Option<&Path>) -> Result<Self> {
         let platform = PythonPlatform::from(platform);
         let executable = platform.venv_python(root);
-        let interpreter_info = InterpreterInfo::query_cached(&executable, platform.0, cache)?;
+        let interpreter_info = InterpreterInfo::query(&executable, platform.0, cache)?;
 
         Ok(Self {
             root: root.to_path_buf(),

--- a/crates/puffin-resolver/src/distribution/cached_wheel.rs
+++ b/crates/puffin-resolver/src/distribution/cached_wheel.rs
@@ -25,9 +25,9 @@ impl CachedWheel {
     pub(super) fn find_in_cache(
         distribution: &RemoteDistributionRef<'_>,
         tags: &Tags,
-        cache: &Path,
+        cache: impl AsRef<Path>,
     ) -> Option<Self> {
-        let wheel_dir = cache.join(distribution.id());
+        let wheel_dir = cache.as_ref().join(distribution.id());
         let Ok(read_dir) = fs_err::read_dir(wheel_dir) else {
             return None;
         };

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -22,7 +22,7 @@ use puffin_traits::BuildContext;
 struct DummyContext;
 
 impl BuildContext for DummyContext {
-    fn cache(&self) -> Option<&Path> {
+    fn cache(&self) -> &Path {
         panic!("The test should not need to build source distributions")
     }
 

--- a/crates/puffin-traits/src/lib.rs
+++ b/crates/puffin-traits/src/lib.rs
@@ -48,7 +48,7 @@ use puffin_interpreter::{InterpreterInfo, Virtualenv};
 // TODO(konstin): Proper error types
 pub trait BuildContext {
     // TODO(konstin): Add a cache abstraction
-    fn cache(&self) -> Option<&Path>;
+    fn cache(&self) -> &Path;
 
     /// All (potentially nested) source distribution builds use the same base python and can reuse
     /// it's metadata (e.g. wheel compatibility tags).


### PR DESCRIPTION
This PR makes the cache non-optional in most of Puffin, which simplifies the code, allows us to reuse the cache within a single command (even with `--no-cache`), and also allows us to use the cache for disk storage across an invocation.

I left the cache as optional for the `Virtualenv` and `InterpreterInfo` abstractions, since those are generic enough that it seems nice to have a non-cached version, but it's kind of arbitrary.