### PR TITLE
Add PackageName::as_dist_info_name

### DIFF
--- a/crates/install-wheel-rs/src/wheel.rs
+++ b/crates/install-wheel-rs/src/wheel.rs
@@ -1030,8 +1030,12 @@ pub fn find_dist_info(
     filename: &WheelFilename,
     archive: &mut ZipArchive<impl Read + Seek + Sized>,
 ) -> Result<String, Error> {
-    let dist_info_matcher =
-        format!("{}-{}", filename.distribution, filename.version).to_lowercase();
+    let dist_info_matcher = format!(
+        "{}-{}",
+        filename.distribution.as_dist_info_name(),
+        filename.version
+    )
+    .to_lowercase();
     let dist_infos: Vec<_> = archive
         .file_names()
         .filter_map(|name| name.split_once('/'))

--- a/crates/puffin-normalize/src/package_name.rs
+++ b/crates/puffin-normalize/src/package_name.rs
@@ -36,6 +36,13 @@ impl PackageName {
         normalized.make_ascii_lowercase();
         Self(normalized)
     }
+
+    /// Escape this name with underscores (`_`) instead of dashes (`-`)
+    ///
+    /// See: <https://packaging.python.org/en/latest/specifications/recording-installed-packages/#recording-installed-packages>
+    pub fn as_dist_info_name(&self) -> String {
+        self.0.replace('-', "_")
+    }
 }
 
 impl AsRef<str> for PackageName {


### PR DESCRIPTION
From https://packaging.python.org/en/latest/specifications/recording-installed-packages/#recording-installed-packages

> This directory is named as {name}-{version}.dist-info, with name and version fields corresponding to Core metadata specifications. Both fields must be normalized (see Package name normalization and PEP 440 for the definition of normalization for each field respectively), and replace dash (-) characters with underscore (_) characters, so the .dist-info directory always has exactly one dash (-) character in its stem, separating the name and version fields.

Matching this explanation, the dist info names don't get their own type but are an export format from the `PackageName` type.

Follow up to #278 