### PR TITLE
Move `Source` abstraction into `puffin-distribution`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,6 +2241,7 @@ dependencies = [
  "anyhow",
  "pep440_rs 0.3.12",
  "puffin-cache",
+ "puffin-git",
  "puffin-normalize",
  "puffin-package",
  "url",

--- a/crates/puffin-distribution/Cargo.toml
+++ b/crates/puffin-distribution/Cargo.toml
@@ -12,6 +12,7 @@ license = { workspace = true }
 [dependencies]
 pep440_rs = { path = "../pep440-rs" }
 puffin-cache = { path = "../puffin-cache" }
+puffin-git = { path = "../puffin-git" }
 puffin-normalize = { path = "../puffin-normalize" }
 puffin-package = { path = "../puffin-package" }
 

--- a/crates/puffin-distribution/src/lib.rs
+++ b/crates/puffin-distribution/src/lib.rs
@@ -10,6 +10,8 @@ use puffin_cache::CanonicalUrl;
 use puffin_normalize::PackageName;
 use puffin_package::pypi_types::File;
 
+pub mod source;
+
 /// A built distribution (wheel), which either exists remotely or locally.
 #[derive(Debug, Clone)]
 pub enum Distribution {

--- a/crates/puffin-distribution/src/source.rs
+++ b/crates/puffin-distribution/src/source.rs
@@ -1,15 +1,15 @@
 use std::path::PathBuf;
 
 use anyhow::{Error, Result};
-
 use url::Url;
 
-use puffin_distribution::RemoteDistributionRef;
 use puffin_git::Git;
+
+use crate::RemoteDistributionRef;
 
 /// The source of a distribution.
 #[derive(Debug)]
-pub(crate) enum Source<'a> {
+pub enum Source<'a> {
     /// The distribution is available at a URL in a registry, like PyPI.
     RegistryUrl(Url),
     /// The distribution is available at an arbitrary remote URL, like a GitHub Release.

--- a/crates/puffin-resolver/src/distribution/mod.rs
+++ b/crates/puffin-resolver/src/distribution/mod.rs
@@ -2,6 +2,5 @@ pub(crate) use source_distribution::SourceDistributionFetcher;
 pub(crate) use wheel::WheelFetcher;
 
 mod cached_wheel;
-mod source;
 mod source_distribution;
 mod wheel;

--- a/crates/puffin-resolver/src/distribution/source_distribution.rs
+++ b/crates/puffin-resolver/src/distribution/source_distribution.rs
@@ -10,13 +10,13 @@ use url::Url;
 use distribution_filename::WheelFilename;
 use platform_tags::Tags;
 use puffin_client::RegistryClient;
+use puffin_distribution::source::Source;
 use puffin_distribution::RemoteDistributionRef;
 use puffin_git::{Git, GitSource};
 use puffin_package::pypi_types::Metadata21;
 use puffin_traits::BuildContext;
 
 use crate::distribution::cached_wheel::CachedWheel;
-use crate::distribution::source::Source;
 
 const BUILT_WHEELS_CACHE: &str = "built-wheels-v0";
 


### PR DESCRIPTION
No code changes, but this will allow it to be shared between the installer and the resolver.