### PR TITLE
Add source distribution support to the `DistributionFinder`

### DIFF
--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -16,7 +16,7 @@ use puffin_installer::PartitionedRequirements;
 use puffin_interpreter::Virtualenv;
 
 use crate::commands::reporters::{
-    DownloadReporter, InstallReporter, UnzipReporter, WheelFinderReporter,
+    DownloadReporter, FinderReporter, InstallReporter, UnzipReporter,
 };
 use crate::commands::{elapsed, ExitStatus};
 use crate::index_urls::IndexUrls;
@@ -118,8 +118,8 @@ pub(crate) async fn sync_requirements(
     } else {
         let start = std::time::Instant::now();
 
-        let wheel_finder = puffin_resolver::WheelFinder::new(&tags, &client)
-            .with_reporter(WheelFinderReporter::from(printer).with_length(remote.len() as u64));
+        let wheel_finder = puffin_resolver::DistributionFinder::new(&tags, &client)
+            .with_reporter(FinderReporter::from(printer).with_length(remote.len() as u64));
         let resolution = wheel_finder.resolve(&remote).await?;
 
         let s = if resolution.len() == 1 { "" } else { "s" };

--- a/crates/puffin-cli/src/commands/reporters.rs
+++ b/crates/puffin-cli/src/commands/reporters.rs
@@ -9,11 +9,11 @@ use puffin_normalize::PackageName;
 use crate::printer::Printer;
 
 #[derive(Debug)]
-pub(crate) struct WheelFinderReporter {
+pub(crate) struct FinderReporter {
     progress: ProgressBar,
 }
 
-impl From<Printer> for WheelFinderReporter {
+impl From<Printer> for FinderReporter {
     fn from(printer: Printer) -> Self {
         let progress = ProgressBar::with_draw_target(None, printer.target());
         progress.set_style(
@@ -24,7 +24,7 @@ impl From<Printer> for WheelFinderReporter {
     }
 }
 
-impl WheelFinderReporter {
+impl FinderReporter {
     #[must_use]
     pub(crate) fn with_length(self, length: u64) -> Self {
         self.progress.set_length(length);
@@ -32,7 +32,7 @@ impl WheelFinderReporter {
     }
 }
 
-impl puffin_resolver::WheelFinderReporter for WheelFinderReporter {
+impl puffin_resolver::FinderReporter for FinderReporter {
     fn on_progress(&self, wheel: &RemoteDistribution) {
         self.progress.set_message(format!("{wheel}"));
         self.progress.inc(1);

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -17,7 +17,7 @@ use puffin_build::SourceDistributionBuilder;
 use puffin_client::RegistryClient;
 use puffin_installer::{Downloader, Installer, PartitionedRequirements, Unzipper};
 use puffin_interpreter::{InterpreterInfo, Virtualenv};
-use puffin_resolver::{Manifest, PreReleaseMode, ResolutionMode, Resolver, WheelFinder};
+use puffin_resolver::{DistributionFinder, Manifest, PreReleaseMode, ResolutionMode, Resolver};
 use puffin_traits::BuildContext;
 
 /// The main implementation of [`BuildContext`], used by the CLI, see [`BuildContext`]
@@ -122,7 +122,7 @@ impl BuildContext for BuildDispatch {
                     if remote.len() == 1 { "" } else { "s" },
                     remote.iter().map(ToString::to_string).join(", ")
                 );
-                let resolution = WheelFinder::new(&tags, &self.client)
+                let resolution = DistributionFinder::new(&tags, &self.client)
                     .resolve(&remote)
                     .await
                     .context("Failed to resolve build dependencies")?;

--- a/crates/puffin-resolver/src/lib.rs
+++ b/crates/puffin-resolver/src/lib.rs
@@ -1,20 +1,20 @@
 pub use error::ResolveError;
+pub use finder::{DistributionFinder, Reporter as FinderReporter};
 pub use manifest::Manifest;
 pub use prerelease_mode::PreReleaseMode;
 pub use pubgrub::ResolutionFailureReporter;
 pub use resolution::Graph;
 pub use resolution_mode::ResolutionMode;
 pub use resolver::{Reporter as ResolverReporter, Resolver};
-pub use wheel_finder::{Reporter as WheelFinderReporter, WheelFinder};
 
 mod candidate_selector;
 mod distribution;
 mod error;
 mod file;
+mod finder;
 mod manifest;
 mod prerelease_mode;
 mod pubgrub;
 mod resolution;
 mod resolution_mode;
 mod resolver;
-mod wheel_finder;


### PR DESCRIPTION
## Summary

This just enables the `DistributionFinder` (previously known as the `WheelFinder`) to select source distributions when there are no matching wheels for a given platform. As a reminder, the `DistributionFinder` is a simple resolver that doesn't look at any dependencies: it just takes a set of pinned packages, and finds a distribution to install to satisfy each requirement.