### PR TITLE
Rename source distribution build to source build

### DIFF
--- a/crates/puffin-dev/src/build.rs
+++ b/crates/puffin-dev/src/build.rs
@@ -53,7 +53,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
         fs::canonicalize(venv.python_executable())?,
     );
     let wheel = build_dispatch
-        .build_source_distribution(&args.sdist, args.subdirectory.as_deref(), &wheel_dir)
+        .build_source(&args.sdist, args.subdirectory.as_deref(), &wheel_dir)
         .await?;
     Ok(wheel_dir.join(wheel))
 }

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -13,7 +13,7 @@ use tracing::{debug, instrument};
 
 use pep508_rs::Requirement;
 use platform_tags::Tags;
-use puffin_build::{SourceDistributionBuild, SourceDistributionBuildContext};
+use puffin_build::{SourceBuild, SourceBuildContext};
 use puffin_client::RegistryClient;
 use puffin_installer::{Downloader, Installer, PartitionedRequirements, Unzipper};
 use puffin_interpreter::{InterpreterInfo, Virtualenv};
@@ -27,7 +27,7 @@ pub struct BuildDispatch {
     cache: PathBuf,
     interpreter_info: InterpreterInfo,
     base_python: PathBuf,
-    source_distribution_builder: SourceDistributionBuildContext,
+    source_build_context: SourceBuildContext,
 }
 
 impl BuildDispatch {
@@ -42,7 +42,7 @@ impl BuildDispatch {
             cache,
             interpreter_info,
             base_python,
-            source_distribution_builder: SourceDistributionBuildContext::default(),
+            source_build_context: SourceBuildContext::default(),
         }
     }
 }
@@ -196,19 +196,19 @@ impl BuildContext for BuildDispatch {
     }
 
     #[instrument(skip(self))]
-    fn build_source_distribution<'a>(
+    fn build_source<'a>(
         &'a self,
-        sdist: &'a Path,
+        source: &'a Path,
         subdirectory: Option<&'a Path>,
         wheel_dir: &'a Path,
     ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
         Box::pin(async move {
-            let builder = SourceDistributionBuild::setup(
-                sdist,
+            let builder = SourceBuild::setup(
+                source,
                 subdirectory,
                 &self.interpreter_info,
                 self,
-                self.source_distribution_builder.clone(),
+                self.source_build_context.clone(),
             )
             .await?;
             Ok(builder.build(wheel_dir)?)

--- a/crates/puffin-resolver/src/distribution/source_distribution.rs
+++ b/crates/puffin-resolver/src/distribution/source_distribution.rs
@@ -111,7 +111,7 @@ impl<'a, T: BuildContext> SourceDistributionFetcher<'a, T> {
         // Build the wheel.
         let disk_filename = self
             .0
-            .build_source_distribution(&sdist_file, subdirectory.as_deref(), &wheel_dir)
+            .build_source(&sdist_file, subdirectory.as_deref(), &wheel_dir)
             .await?;
 
         // Read the metadata from the wheel.

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -49,7 +49,7 @@ impl BuildContext for DummyContext {
         panic!("The test should not need to build source distributions")
     }
 
-    fn build_source_distribution<'a>(
+    fn build_source<'a>(
         &'a self,
         _sdist: &'a Path,
         _subdirectory: Option<&'a Path>,

--- a/crates/puffin-traits/src/lib.rs
+++ b/crates/puffin-traits/src/lib.rs
@@ -16,7 +16,7 @@ use puffin_interpreter::{InterpreterInfo, Virtualenv};
 /// them and then build. The installer, the resolver and the source distribution builder are each in
 /// their own crate. To avoid circular crate dependencies, this type dispatches between the three
 /// crates with its three main methods ([`BuildContext::resolve`], [`BuildContext::install`] and
-/// [`BuildContext::build_source_distribution`]).
+/// [`BuildContext::build_source`]).
 ///
 /// The overall main crate structure looks like this:
 ///
@@ -62,6 +62,7 @@ pub trait BuildContext {
         &'a self,
         requirements: &'a [Requirement],
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<Requirement>>> + Send + 'a>>;
+
     /// Install the given set of package versions into the virtual environment. The environment must
     /// use the same base python as [`BuildContext::base_python`]
     fn install<'a>(
@@ -69,12 +70,13 @@ pub trait BuildContext {
         requirements: &'a [Requirement],
         venv: &'a Virtualenv,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
     /// Build a source distribution into a wheel from an archive.
     ///
     /// Returns the filename of the built wheel inside the given `wheel_dir`.
-    fn build_source_distribution<'a>(
+    fn build_source<'a>(
         &'a self,
-        sdist: &'a Path,
+        source: &'a Path,
         subdirectory: Option<&'a Path>,
         wheel_dir: &'a Path,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send + 'a>>;


### PR DESCRIPTION
This is less verbose and better reflects that we're building both source distributions and source trees passed into the function.