### PR TITLE
`cargo upgrade --incompatible`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -381,9 +381,9 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cacache"
-version = "11.7.1"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58a06fb14213c5dd9eef8c612a24a3121f91293be7ea7960d48f3ba73bdc715"
+checksum = "142316461ed3a3dfcba10417317472da5bfd0461e4d276bf7c07b330766d9490"
 dependencies = [
  "digest",
  "either",
@@ -522,7 +522,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -961,7 +961,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1198,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "http-cache"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2bfa9289247941a8b6a7e742d6df6065b7f1cb152d3d1eeaeacebfa09acde"
+checksum = "57bae69908277d47122334bf6009e514cd3d24e65d0bf2b56f1b45db6ad8864d"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1214,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "http-cache-reqwest"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e985295258eea7d8868bec254f6bb687d3410bd594c472dc8cfc4403630e2c"
+checksum = "ee5a40915f9da8f3feef6f942f9aace74393803c47bce6870f19cd2b5123f27a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
@@ -1392,12 +1392,6 @@ dependencies = [
  "unicode-width",
  "vt100",
 ]
-
-[[package]]
-name = "indoc"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "indoc"
@@ -1444,7 +1438,7 @@ dependencies = [
  "fs2",
  "fxhash",
  "goblin",
- "indoc 2.0.4",
+ "indoc",
  "mailparse",
  "once_cell",
  "platform-host",
@@ -1541,9 +1535,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libgit2-sys"
@@ -1704,7 +1698,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1906,7 +1900,7 @@ dependencies = [
 name = "pep440_rs"
 version = "0.3.12"
 dependencies = [
- "indoc 2.0.4",
+ "indoc",
  "once_cell",
  "pyo3",
  "regex",
@@ -1931,7 +1925,7 @@ dependencies = [
 name = "pep508_rs"
 version = "0.2.3"
 dependencies = [
- "indoc 2.0.4",
+ "indoc",
  "log",
  "once_cell",
  "pep440_rs 0.3.12",
@@ -1961,7 +1955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -1981,7 +1975,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2042,12 +2036,12 @@ dependencies = [
 
 [[package]]
 name = "plist"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4a0cfc5fb21a09dc6af4bf834cf10d4a32fccd9e2ea468c4b1751a097487aa"
+checksum = "e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef"
 dependencies = [
  "base64 0.21.5",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "line-wrap",
  "quick-xml",
  "serde",
@@ -2159,7 +2153,7 @@ dependencies = [
 name = "pubgrub"
 version = "0.2.1"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "log",
  "priority-queue",
  "rustc-hash",
@@ -2175,7 +2169,7 @@ dependencies = [
  "flate2",
  "fs-err",
  "gourgeist",
- "indoc 2.0.4",
+ "indoc",
  "pep508_rs",
  "platform-host",
  "platform-tags",
@@ -2417,7 +2411,7 @@ name = "puffin-normalize"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "indoc 2.0.4",
+ "indoc",
  "insta",
  "once_cell",
  "regex",
@@ -2433,7 +2427,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "fs-err",
- "indoc 2.0.4",
+ "indoc",
  "insta",
  "mailparse",
  "once_cell",
@@ -2519,12 +2513,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e681a6cfdc4adcc93b4d3cf993749a4552018ee0a9b65fc0ccfad74352c72a38"
+checksum = "04e8453b658fe480c3e70c8ed4e3d3ec33eb74988bd186561b0cc66b85c3bc4b"
 dependencies = [
  "cfg-if 1.0.0",
- "indoc 1.0.9",
+ "indoc",
  "libc",
  "memoffset",
  "parking_lot 0.12.1",
@@ -2536,9 +2530,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076c73d0bc438f7a4ef6fdd0c3bb4732149136abd952b110ac93e4edb13a6ba5"
+checksum = "a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2546,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53cee42e77ebe256066ba8aa77eff722b3bb91f3419177cf4cd0f304d3284d9"
+checksum = "214929900fd25e6604661ed9cf349727c8920d47deff196c4e28165a6ef2a96b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2556,9 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c09c2b349b6538d8a73d436ca606dab6ce0aaab4dad9e6b7bdd57a4f556c3bc3"
+checksum = "4c10808ee7250403bedb24bc30c32493e93875fef7ba3e4292226fe924f398bd"
 dependencies = [
  "arc-swap",
  "log",
@@ -2567,25 +2561,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeb4c99597e136528c6dd7d5e3de5434d1ceaf487436a3f03b2d56b6fc9efd1"
+checksum = "dac53072f717aa1bfa4db832b39de8c875b7c7af4f4a6fe93cdbf9264cf8383b"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947dc12175c254889edc0c02e399476c2f652b4b9ebd123aa655c224de259536"
+checksum = "7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424"
 dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2594,7 +2589,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0774c13ff0b8b7ebb4791c050c497aefcfe3f6a222c0829c7017161ed38391ff"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "pep440_rs 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "pep508_rs",
  "serde",
@@ -2603,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
 ]
@@ -2989,7 +2984,7 @@ checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3025,7 +3020,7 @@ checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3238,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3342,7 +3337,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3354,7 +3349,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "test-case-core",
 ]
 
@@ -3395,7 +3390,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3486,7 +3481,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3565,7 +3560,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3578,7 +3573,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3611,7 +3606,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3733,9 +3728,9 @@ checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unindent"
-version = "0.1.11"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "unscanny"
@@ -3883,7 +3878,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -3917,7 +3912,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3974,14 +3969,15 @@ checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
 dependencies = [
  "either",
  "home",
  "once_cell",
  "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4168,9 +4164,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]
@@ -4226,7 +4222,7 @@ checksum = "255c4596d41e6916ced49cfafea18727b24d67878fa180ddfd69b9df34fd1726"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ license = "MIT OR Apache-2.0"
 anyhow = { version = "1.0.75" }
 async_http_range_reader = { git = "https://github.com/baszalmstra/async_http_range_reader", ref = "4cafe5afda889d53060e0565c949d4ffd6ef3786" }
 async_zip = { version = "0.0.15", features = ["tokio", "deflate"] }
-bitflags = { version = "2.4.0" }
-cacache = { version = "11.7.1", default-features = false, features = ["tokio-runtime"] }
+bitflags = { version = "2.4.1" }
+cacache = { version = "12.0.0", default-features = false, features = ["tokio-runtime"] }
 camino = { version = "1.1.6", features = ["serde1"] }
-clap = { version = "4.4.6" }
+clap = { version = "4.4.7" }
 colored = { version = "2.0.4" }
 configparser = { version = "3.0.2" }
 csv = { version = "1.3.0" }
@@ -29,12 +29,12 @@ dirs = { version = "5.0.1" }
 flate2 = { version = "1.0.28" }
 fs-err = { version = "2.9.0" }
 fs2 = { version = "0.4.3" }
-futures = { version = "0.3.28" }
+futures = { version = "0.3.29" }
 fxhash = { version = "0.2.1" }
 glob = { version = "0.3.1" }
 goblin = { version = "0.7.1" }
 hex = { version = "0.4.3" }
-http-cache-reqwest = { version = "0.11.3" }
+http-cache-reqwest = { version = "0.12.0" }
 indicatif = { version = "0.17.7" }
 indoc = { version = "2.0.4" }
 itertools = { version = "0.11.0" }
@@ -43,38 +43,38 @@ miette = { version = "5.10.0" }
 once_cell = { version = "1.18.0" }
 petgraph = { version = "0.6.4" }
 platform-info = { version = "2.0.2" }
-plist = { version = "1.5.0" }
+plist = { version = "1.6.0" }
 pyproject-toml = { version = "0.8.0" }
 rand = { version = "0.8.5" }
 rayon = { version = "1.8.0" }
-reflink-copy = { version = "0.1.10" }
-regex = { version = "1.9.6" }
+reflink-copy = { version = "0.1.11" }
+regex = { version = "1.10.2" }
 reqwest = { version = "0.11.22", default-features = false, features = ["json", "gzip", "brotli", "stream", "rustls-tls"] }
-reqwest-middleware = { version = "0.2.3" }
+reqwest-middleware = { version = "0.2.4" }
 reqwest-retry = { version = "0.3.0" }
 rfc2047-decoder = { version = "1.0.1" }
 seahash = { version = "4.1.0" }
-serde = { version = "1.0.188" }
-serde_json = { version = "1.0.107" }
+serde = { version = "1.0.190" }
+serde_json = { version = "1.0.108" }
 sha2 = { version = "0.10.8" }
 tar = { version = "0.4.40" }
-target-lexicon = { version = "0.12.11" }
-tempfile = { version = "3.8.0" }
-thiserror = { version = "1.0.49" }
-tokio = { version = "1.16.1", features = ["rt-multi-thread"] }
-tokio-util = { version = "0.7.9", features = ["compat"] }
-toml = { version = "0.8.2" }
-toml_edit = { version = "0.20.2" }
-tracing = { version = "0.1.37" }
+target-lexicon = { version = "0.12.12" }
+tempfile = { version = "3.8.1" }
+thiserror = { version = "1.0.50" }
+tokio = { version = "1.33.0", features = ["rt-multi-thread"] }
+tokio-util = { version = "0.7.10", features = ["compat"] }
+toml = { version = "0.8.6" }
+toml_edit = { version = "0.20.7" }
+tracing = { version = "0.1.40" }
 tracing-indicatif = { version = "0.3.5" }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 tracing-tree = { version = "0.2.5" }
-unicode-width = { version = "0.1.8" }
+unicode-width = { version = "0.1.11" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.4.1" }
 waitmap = { version = "1.1.0" }
 walkdir = { version = "2.4.0" }
-which = { version = "4.4.2" }
+which = { version = "5.0.0" }
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 
 [patch.crates-io]

--- a/crates/install-wheel-rs/Cargo.toml
+++ b/crates/install-wheel-rs/Cargo.toml
@@ -32,7 +32,7 @@ mailparse = { workspace = true }
 once_cell = { workspace = true }
 platform-info = { workspace = true }
 plist = { workspace = true }
-pyo3 = { version = "0.19.2", features = ["extension-module", "abi3-py37"], optional = true }
+pyo3 = { version = "0.20.0", features = ["extension-module", "abi3-py37"], optional = true }
 rayon = { version = "1.8.0", optional = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }

--- a/crates/pep440-rs/Cargo.toml
+++ b/crates/pep440-rs/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 tracing = { workspace = true, optional = true }
 unicode-width = { workspace = true }
 
-pyo3 = { version = "0.19", optional = true, features = ["extension-module", "abi3-py37"] }
+pyo3 = { version = "0.20", optional = true, features = ["extension-module", "abi3-py37"] }
 
 [dev-dependencies]
-indoc = "2.0.1"
+indoc = "2.0.4"

--- a/crates/pep508-rs/Cargo.toml
+++ b/crates/pep508-rs/Cargo.toml
@@ -29,14 +29,14 @@ tracing = { workspace = true, features = ["log"] }
 unicode-width = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 
-pyo3 = { version = "0.19.2", optional = true, features = ["abi3", "extension-module"] }
-pyo3-log = { version = "0.8.3", optional = true }
+pyo3 = { version = "0.20.0", optional = true, features = ["abi3", "extension-module"] }
+pyo3-log = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 indoc = "2.0.4"
 log = "0.4.20"
 testing_logger = "0.1.1"
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 
 [features]
 pyo3 = ["dep:pyo3", "pep440_rs/pyo3", "pyo3-log"]

--- a/crates/puffin-cli/Cargo.toml
+++ b/crates/puffin-cli/Cargo.toml
@@ -54,7 +54,7 @@ url = { workspace = true }
 which = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = { version = "2.0.8" }
+assert_cmd = { version = "2.0.12" }
 assert_fs = { version = "1.0.13" }
 insta-cmd = { version = "0.4.0" }
 insta = { version = "1.34.0", features = ["filters"] }

--- a/crates/puffin-normalize/Cargo.toml
+++ b/crates/puffin-normalize/Cargo.toml
@@ -12,7 +12,7 @@ serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 indoc = { version = "2.0.4" }
-insta = { version = "1.33.0" }
-serde_json = { version = "1.0.107" }
-tempfile = { version = "3.8.0" }
+insta = { version = "1.34.0" }
+serde_json = { version = "1.0.108" }
+tempfile = { version = "3.8.1" }
 test-case = { version = "3.2.1" }

--- a/crates/puffin-package/Cargo.toml
+++ b/crates/puffin-package/Cargo.toml
@@ -21,7 +21,7 @@ unscanny = { workspace = true }
 
 [dev-dependencies]
 indoc = { version = "2.0.4" }
-insta = { version = "1.33.0" }
-serde_json = { version = "1.0.107" }
-tempfile = { version = "3.8.0" }
+insta = { version = "1.34.0" }
+serde_json = { version = "1.0.108" }
+tempfile = { version = "3.8.1" }
 test-case = { version = "3.2.1" }


### PR DESCRIPTION
Ran `cargo upgrade --incompatible`, seems there are no changes required.

From cacache 0.12.0:
>  BREAKING CHANGE: some signatures for copy have changed, and copy no longer automatically reflinks

`which` 5.0.0 seems to have only error message changes.