### PR TITLE
Use dist info name in cache again

### DIFF
--- a/crates/puffin-distribution/src/lib.rs
+++ b/crates/puffin-distribution/src/lib.rs
@@ -145,7 +145,11 @@ impl RemoteDistribution {
             Self::Registry(name, version, _) => {
                 // https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-dist-info-directory
                 // `version` is normalized by its `ToString` impl
-                format!("{}-{}", PackageName::from(name), version)
+                format!(
+                    "{}-{}",
+                    PackageName::from(name).as_dist_info_name(),
+                    version
+                )
             }
             Self::Url(_name, url) => puffin_cache::digest(&CanonicalUrl::new(url)),
         }


### PR DESCRIPTION
Fixup for the `PackageName`/`DistInfoName` refactor that would lead to invalid cache entries