### PR TITLE
 Rename source distribution build to source build 

### DIFF
--- a/crates/puffin-build/src/lib.rs
+++ b/crates/puffin-build/src/lib.rs
@@ -97,10 +97,10 @@ impl Pep517Backend {
 
 /// Uses an [`Arc`] internally, clone freely
 #[derive(Debug, Default, Clone)]
-pub struct SourceDistributionBuildContext {
+pub struct SourceBuildContext {
     /// Cache the first resolution of `pip`, `setuptools` and `wheel` we made for setup.py (and
     /// some PEP 517) builds so we can reuse it
-    setup_py_requirements: Arc<Mutex<Option<Vec<Requirement>>>>,
+    setup_py_resolution: Arc<Mutex<Option<Vec<Requirement>>>>,
 }
 
 /// Holds the state through a series of PEP 517 frontend to backend calls or a single setup.py
@@ -108,7 +108,7 @@ pub struct SourceDistributionBuildContext {
 ///
 /// This keeps both the temp dir and the result of a potential `prepare_metadata_for_build_wheel`
 /// call which changes how we call `build_wheel`.
-pub struct SourceDistributionBuild {
+pub struct SourceBuild {
     temp_dir: TempDir,
     source_tree: PathBuf,
     /// `Some` if this is a PEP 517 build
@@ -126,25 +126,25 @@ pub struct SourceDistributionBuild {
     metadata_directory: Option<PathBuf>,
 }
 
-impl SourceDistributionBuild {
+impl SourceBuild {
     /// Create a virtual environment in which to build a source distribution, extracting the
     /// contents from an archive if necessary.
     pub async fn setup(
-        sdist: &Path,
+        source: &Path,
         subdirectory: Option<&Path>,
         interpreter_info: &InterpreterInfo,
         build_context: &impl BuildContext,
-        setup_py_requirements: SourceDistributionBuildContext,
-    ) -> Result<SourceDistributionBuild, Error> {
+        source_build_context: SourceBuildContext,
+    ) -> Result<SourceBuild, Error> {
         let temp_dir = tempdir()?;
 
         // TODO(konstin): Parse and verify filenames
-        let source_root = if fs::metadata(sdist)?.is_dir() {
-            sdist.to_path_buf()
+        let source_root = if fs::metadata(source)?.is_dir() {
+            source.to_path_buf()
         } else {
-            debug!("Unpacking for build: {}", sdist.display());
+            debug!("Unpacking for build: {}", source.display());
             let extracted = temp_dir.path().join("extracted");
-            extract_archive(sdist, &extracted)?
+            extract_archive(source, &extracted)?
         };
         let source_tree = if let Some(subdir) = subdirectory {
             source_root.join(subdir)
@@ -195,7 +195,7 @@ impl SourceDistributionBuild {
                 Requirement::from_str("setuptools").unwrap(),
                 Requirement::from_str("pip").unwrap(),
             ];
-            let mut resolution = setup_py_requirements.setup_py_requirements.lock().await;
+            let mut resolution = source_build_context.setup_py_resolution.lock().await;
             let resolved_requirements = if let Some(resolved_requirements) = &*resolution {
                 resolved_requirements.clone()
             } else {

--- a/crates/puffin-dev/src/build.rs
+++ b/crates/puffin-dev/src/build.rs
@@ -53,7 +53,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
         fs::canonicalize(venv.python_executable())?,
     );
     let wheel = build_dispatch
-        .build_source_distribution(&args.sdist, args.subdirectory.as_deref(), &wheel_dir)
+        .build_source(&args.sdist, args.subdirectory.as_deref(), &wheel_dir)
         .await?;
     Ok(wheel_dir.join(wheel))
 }

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -13,7 +13,7 @@ use tracing::{debug, instrument};
 
 use pep508_rs::Requirement;
 use platform_tags::Tags;
-use puffin_build::{SourceDistributionBuild, SourceDistributionBuildContext};
+use puffin_build::{SourceBuild, SourceBuildContext};
 use puffin_client::RegistryClient;
 use puffin_installer::{Builder, Downloader, InstallPlan, Installer, Unzipper};
 use puffin_interpreter::{InterpreterInfo, Virtualenv};
@@ -27,7 +27,7 @@ pub struct BuildDispatch {
     cache: PathBuf,
     interpreter_info: InterpreterInfo,
     base_python: PathBuf,
-    source_distribution_builder: SourceDistributionBuildContext,
+    source_build_context: SourceBuildContext,
 }
 
 impl BuildDispatch {
@@ -42,7 +42,7 @@ impl BuildDispatch {
             cache,
             interpreter_info,
             base_python,
-            source_distribution_builder: SourceDistributionBuildContext::default(),
+            source_build_context: SourceBuildContext::default(),
         }
     }
 }
@@ -223,19 +223,19 @@ impl BuildContext for BuildDispatch {
     }
 
     #[instrument(skip(self))]
-    fn build_source_distribution<'a>(
+    fn build_source<'a>(
         &'a self,
-        sdist: &'a Path,
+        source: &'a Path,
         subdirectory: Option<&'a Path>,
         wheel_dir: &'a Path,
     ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
         Box::pin(async move {
-            let builder = SourceDistributionBuild::setup(
-                sdist,
+            let builder = SourceBuild::setup(
+                source,
                 subdirectory,
                 &self.interpreter_info,
                 self,
-                self.source_distribution_builder.clone(),
+                self.source_build_context.clone(),
             )
             .await?;
             Ok(builder.build(wheel_dir)?)

--- a/crates/puffin-installer/src/builder.rs
+++ b/crates/puffin-installer/src/builder.rs
@@ -86,7 +86,7 @@ async fn build_sdist<T: BuildContext + Send + Sync>(
     // repository is used by multiple dependencies, at multiple commits, the local checkout may now
     // point to the wrong commit.
     let disk_filename = build_context
-        .build_source_distribution(
+        .build_source(
             &distribution.sdist_file,
             distribution.subdirectory.as_deref(),
             &wheel_dir,

--- a/crates/puffin-resolver/src/distribution/source_distribution.rs
+++ b/crates/puffin-resolver/src/distribution/source_distribution.rs
@@ -115,7 +115,7 @@ impl<'a, T: BuildContext> SourceDistributionFetcher<'a, T> {
         // Build the wheel.
         let disk_filename = self
             .0
-            .build_source_distribution(&sdist_file, subdirectory.as_deref(), &wheel_dir)
+            .build_source(&sdist_file, subdirectory.as_deref(), &wheel_dir)
             .await?;
 
         // Read the metadata from the wheel.

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -49,7 +49,7 @@ impl BuildContext for DummyContext {
         panic!("The test should not need to build source distributions")
     }
 
-    fn build_source_distribution<'a>(
+    fn build_source<'a>(
         &'a self,
         _sdist: &'a Path,
         _subdirectory: Option<&'a Path>,

--- a/crates/puffin-traits/src/lib.rs
+++ b/crates/puffin-traits/src/lib.rs
@@ -16,7 +16,7 @@ use puffin_interpreter::{InterpreterInfo, Virtualenv};
 /// them and then build. The installer, the resolver and the source distribution builder are each in
 /// their own crate. To avoid circular crate dependencies, this type dispatches between the three
 /// crates with its three main methods ([`BuildContext::resolve`], [`BuildContext::install`] and
-/// [`BuildContext::build_source_distribution`]).
+/// [`BuildContext::build_source`]).
 ///
 /// The overall main crate structure looks like this:
 ///
@@ -62,6 +62,7 @@ pub trait BuildContext {
         &'a self,
         requirements: &'a [Requirement],
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<Vec<Requirement>>> + Send + 'a>>;
+
     /// Install the given set of package versions into the virtual environment. The environment must
     /// use the same base python as [`BuildContext::base_python`]
     fn install<'a>(
@@ -69,12 +70,13 @@ pub trait BuildContext {
         requirements: &'a [Requirement],
         venv: &'a Virtualenv,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>>;
+
     /// Build a source distribution into a wheel from an archive.
     ///
     /// Returns the filename of the built wheel inside the given `wheel_dir`.
-    fn build_source_distribution<'a>(
+    fn build_source<'a>(
         &'a self,
-        sdist: &'a Path,
+        source: &'a Path,
         subdirectory: Option<&'a Path>,
         wheel_dir: &'a Path,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send + 'a>>;


### PR DESCRIPTION
This is less verbose and better reflects that we're building both source distributions and source trees passed into the function.