### PR TITLE
Respect direct URLs in puffin installer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,11 +2324,13 @@ name = "puffin-distribution"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fs-err",
  "pep440_rs 0.3.12",
  "puffin-cache",
  "puffin-git",
  "puffin-normalize",
  "pypi-types",
+ "serde_json",
  "url",
 ]
 

--- a/crates/puffin-cli/tests/pip_sync.rs
+++ b/crates/puffin-cli/tests/pip_sync.rs
@@ -573,7 +573,53 @@ fn install_url() -> Result<()> {
 /// Install a package into a virtual environment from a Git repository.
 #[test]
 #[cfg(feature = "git")]
-fn install_git() -> Result<()> {
+fn install_git_commit() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let cache_dir = assert_fs::TempDir::new()?;
+    let venv = temp_dir.child(".venv");
+
+    Command::new(get_cargo_bin(BIN_NAME))
+        .arg("venv")
+        .arg(venv.as_os_str())
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .current_dir(&temp_dir)
+        .assert()
+        .success();
+    venv.assert(predicates::path::is_dir());
+
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("werkzeug @ git+https://github.com/pallets/werkzeug.git@af160e0b6b7ddd81c22f1652c728ff5ac72d5c74")?;
+
+    insta::with_settings!({
+        filters => vec![
+            (r"(\d|\.)+(ms|s)", "[TIME]"),
+        ]
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-sync")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir));
+    });
+
+    Command::new(venv.join("bin").join("python"))
+        .arg("-c")
+        .arg("import werkzeug")
+        .current_dir(&temp_dir)
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+/// Install a package into a virtual environment from a Git repository.
+#[test]
+#[cfg(feature = "git")]
+fn install_git_tag() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let cache_dir = assert_fs::TempDir::new()?;
     let venv = temp_dir.child(".venv");
@@ -682,6 +728,182 @@ fn install_sdist() -> Result<()> {
     let requirements_txt = temp_dir.child("requirements.txt");
     requirements_txt.touch()?;
     requirements_txt.write_str("Werkzeug==0.9.6")?;
+
+    insta::with_settings!({
+        filters => vec![
+            (r"(\d|\.)+(ms|s)", "[TIME]"),
+        ]
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-sync")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir));
+    });
+
+    Command::new(venv.join("bin").join("python"))
+        .arg("-c")
+        .arg("import werkzeug")
+        .current_dir(&temp_dir)
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+/// Attempt to re-install a package into a virtual environment from a URL. The second install
+/// should be a no-op.
+#[test]
+fn install_url_then_install_url() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let cache_dir = assert_fs::TempDir::new()?;
+    let venv = temp_dir.child(".venv");
+
+    Command::new(get_cargo_bin(BIN_NAME))
+        .arg("venv")
+        .arg(venv.as_os_str())
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .current_dir(&temp_dir)
+        .assert()
+        .success();
+    venv.assert(predicates::path::is_dir());
+
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("werkzeug @ https://files.pythonhosted.org/packages/ff/1d/960bb4017c68674a1cb099534840f18d3def3ce44aed12b5ed8b78e0153e/Werkzeug-2.0.0-py3-none-any.whl")?;
+
+    Command::new(get_cargo_bin(BIN_NAME))
+        .arg("pip-sync")
+        .arg("requirements.txt")
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .env("VIRTUAL_ENV", venv.as_os_str())
+        .current_dir(&temp_dir)
+        .assert()
+        .success();
+
+    insta::with_settings!({
+        filters => vec![
+            (r"(\d|\.)+(ms|s)", "[TIME]"),
+        ]
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-sync")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir));
+    });
+
+    Command::new(venv.join("bin").join("python"))
+        .arg("-c")
+        .arg("import werkzeug")
+        .current_dir(&temp_dir)
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+/// Install a package via a URL, then via a registry version. The second install _should_ remove the
+/// URL-based version, but doesn't right now.
+#[test]
+fn install_url_then_install_version() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let cache_dir = assert_fs::TempDir::new()?;
+    let venv = temp_dir.child(".venv");
+
+    Command::new(get_cargo_bin(BIN_NAME))
+        .arg("venv")
+        .arg(venv.as_os_str())
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .current_dir(&temp_dir)
+        .assert()
+        .success();
+    venv.assert(predicates::path::is_dir());
+
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("werkzeug @ https://files.pythonhosted.org/packages/ff/1d/960bb4017c68674a1cb099534840f18d3def3ce44aed12b5ed8b78e0153e/Werkzeug-2.0.0-py3-none-any.whl")?;
+
+    Command::new(get_cargo_bin(BIN_NAME))
+        .arg("pip-sync")
+        .arg("requirements.txt")
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .env("VIRTUAL_ENV", venv.as_os_str())
+        .current_dir(&temp_dir)
+        .assert()
+        .success();
+
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("werkzeug==2.0.0")?;
+
+    insta::with_settings!({
+        filters => vec![
+            (r"(\d|\.)+(ms|s)", "[TIME]"),
+        ]
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-sync")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir));
+    });
+
+    Command::new(venv.join("bin").join("python"))
+        .arg("-c")
+        .arg("import werkzeug")
+        .current_dir(&temp_dir)
+        .assert()
+        .success();
+
+    Ok(())
+}
+
+/// Install a package via a registry version, then via a direct URL version. The second install
+/// should remove the registry-based version.
+#[test]
+fn install_version_then_install_url() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let cache_dir = assert_fs::TempDir::new()?;
+    let venv = temp_dir.child(".venv");
+
+    Command::new(get_cargo_bin(BIN_NAME))
+        .arg("venv")
+        .arg(venv.as_os_str())
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .current_dir(&temp_dir)
+        .assert()
+        .success();
+    venv.assert(predicates::path::is_dir());
+
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("werkzeug==2.0.0")?;
+
+    Command::new(get_cargo_bin(BIN_NAME))
+        .arg("pip-sync")
+        .arg("requirements.txt")
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .env("VIRTUAL_ENV", venv.as_os_str())
+        .current_dir(&temp_dir)
+        .assert()
+        .success();
+
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("werkzeug @ https://files.pythonhosted.org/packages/ff/1d/960bb4017c68674a1cb099534840f18d3def3ce44aed12b5ed8b78e0153e/Werkzeug-2.0.0-py3-none-any.whl")?;
 
     insta::with_settings!({
         filters => vec![

--- a/crates/puffin-cli/tests/snapshots/pip_sync__install_git_commit.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_sync__install_git_commit.snap
@@ -6,9 +6,9 @@ info:
     - pip-sync
     - requirements.txt
     - "--cache-dir"
-    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpZNXBuT
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpMEVMlO
   env:
-    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpBYANH7/.venv
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpevmjat/.venv
 ---
 success: true
 exit_code: 0
@@ -20,5 +20,5 @@ Downloaded 1 package in [TIME]
 Built 1 package in [TIME]
 Unzipped 1 package in [TIME]
 Installed 1 package in [TIME]
- + werkzeug @ git+https://github.com/pallets/werkzeug.git@2.0.0
+ + werkzeug @ git+https://github.com/pallets/werkzeug.git@af160e0b6b7ddd81c22f1652c728ff5ac72d5c74
 

--- a/crates/puffin-cli/tests/snapshots/pip_sync__install_git_tag.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_sync__install_git_tag.snap
@@ -1,0 +1,24 @@
+---
+source: crates/puffin-cli/tests/pip_sync.rs
+info:
+  program: puffin
+  args:
+    - pip-sync
+    - requirements.txt
+    - "--cache-dir"
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpaUnvqN
+  env:
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpd1OThU/.venv
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+Resolved 1 package in [TIME]
+Downloaded 1 package in [TIME]
+Built 1 package in [TIME]
+Unzipped 1 package in [TIME]
+Installed 1 package in [TIME]
+ + werkzeug @ git+https://github.com/pallets/werkzeug.git@2.0.0
+

--- a/crates/puffin-cli/tests/snapshots/pip_sync__install_url_then_install_url.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_sync__install_url_then_install_url.snap
@@ -1,0 +1,19 @@
+---
+source: crates/puffin-cli/tests/pip_sync.rs
+info:
+  program: puffin
+  args:
+    - pip-sync
+    - requirements.txt
+    - "--cache-dir"
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmppJc9Sz
+  env:
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpf8JjJa/.venv
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+Audited 1 package in [TIME]
+

--- a/crates/puffin-cli/tests/snapshots/pip_sync__install_url_then_install_version.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_sync__install_url_then_install_version.snap
@@ -1,0 +1,19 @@
+---
+source: crates/puffin-cli/tests/pip_sync.rs
+info:
+  program: puffin
+  args:
+    - pip-sync
+    - requirements.txt
+    - "--cache-dir"
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmp83DdhQ
+  env:
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpWIocF0/.venv
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+Audited 1 package in [TIME]
+

--- a/crates/puffin-cli/tests/snapshots/pip_sync__install_version_then_install_url.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_sync__install_version_then_install_url.snap
@@ -1,0 +1,25 @@
+---
+source: crates/puffin-cli/tests/pip_sync.rs
+info:
+  program: puffin
+  args:
+    - pip-sync
+    - requirements.txt
+    - "--cache-dir"
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmp4yAvnn
+  env:
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpAIWfM9/.venv
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+Resolved 1 package in [TIME]
+Downloaded 1 package in [TIME]
+Unzipped 1 package in [TIME]
+Uninstalled 1 package in [TIME]
+Installed 1 package in [TIME]
+ - werkzeug==2.0.0
+ + werkzeug @ https://files.pythonhosted.org/packages/ff/1d/960bb4017c68674a1cb099534840f18d3def3ce44aed12b5ed8b78e0153e/Werkzeug-2.0.0-py3-none-any.whl
+

--- a/crates/puffin-distribution/Cargo.toml
+++ b/crates/puffin-distribution/Cargo.toml
@@ -17,4 +17,6 @@ puffin-normalize = { path = "../puffin-normalize" }
 pypi-types = { path = "../pypi-types" }
 
 anyhow = { workspace = true }
+fs-err = { workspace = true }
+serde_json = { workspace = true }
 url = { workspace = true }

--- a/crates/puffin-git/src/lib.rs
+++ b/crates/puffin-git/src/lib.rs
@@ -24,6 +24,29 @@ impl Git {
         self.precise = Some(precise);
         self
     }
+
+    /// Return the [`Url`] of the Git repository.
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Return the reference to the commit to use, which could be a branch, tag or revision.
+    pub fn reference(&self) -> Option<&str> {
+        match &self.reference {
+            GitReference::Branch(rev)
+            | GitReference::Tag(rev)
+            | GitReference::BranchOrTag(rev)
+            | GitReference::Ref(rev)
+            | GitReference::FullCommit(rev)
+            | GitReference::ShortCommit(rev) => Some(rev),
+            GitReference::DefaultBranch => None,
+        }
+    }
+
+    /// Return the precise commit, if known.
+    pub fn precise(&self) -> Option<git2::Oid> {
+        self.precise
+    }
 }
 
 impl TryFrom<Url> for Git {

--- a/crates/puffin-resolver/src/distribution/source_distribution.rs
+++ b/crates/puffin-resolver/src/distribution/source_distribution.rs
@@ -146,6 +146,11 @@ impl<'a, T: BuildContext> SourceDistributionFetcher<'a, T> {
             return Ok(None);
         };
 
+        // If the commit already contains a complete SHA, short-circuit.
+        if git.precise().is_some() {
+            return Ok(None);
+        }
+
         // Fetch the precise SHA of the Git reference (which could be a branch, a tag, a partial
         // commit, etc.).
         let dir = self.0.cache().join(GIT_CACHE);

--- a/crates/pypi-types/src/direct_url.rs
+++ b/crates/pypi-types/src/direct_url.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// Metadata for a distribution that was installed via a direct URL.
 ///
 /// See: <https://packaging.python.org/en/latest/specifications/direct-url-data-structure/>
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DirectUrl {
     /// The direct URL is a path to an archive. For example:
@@ -31,7 +31,7 @@ pub enum DirectUrl {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ArchiveInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -40,16 +40,17 @@ pub struct ArchiveInfo {
     pub hashes: Option<HashMap<String, String>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct VcsInfo {
     pub vcs: VcsKind,
-    pub commit_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commit_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requested_revision: Option<String>,
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum VcsKind {
     Git,

--- a/crates/pypi-types/src/lib.rs
+++ b/crates/pypi-types/src/lib.rs
@@ -1,4 +1,4 @@
-pub use direct_url::DirectUrl;
+pub use direct_url::{ArchiveInfo, DirectUrl, VcsInfo, VcsKind};
 pub use metadata::{Error, Metadata21};
 pub use simple_json::{File, SimpleJson};
 


### PR DESCRIPTION
We now write the `direct_url.json` when installing, and _skip_ installing if we find a package installed via the direct URL that the user is requesting.

A lot of TODOs, especially around cleaning up the `Source` abstraction and its relationship to `DirectUrl`. I'm gonna keep working on these today, but this works and makes the requirements clear.

Closes #332.