### PR TITLE
Add `python3-dev` to builder.dockerfile

### DIFF
--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -6,6 +6,7 @@ FROM ubuntu:22.04
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         python3 \
+        python3-dev \
         python3-pip \
         python3-venv \
         build-essential \


### PR DESCRIPTION
Surprisingly few builds want `Python.h`, but they exist