### PR TITLE
Use a custom PubGrub error type to always show resolution report

### DIFF
--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -85,7 +85,7 @@ impl BuildContext for BuildDispatch {
                 self,
             );
             let resolution_graph = resolver.resolve().await.context(
-                "No solution found when resolving build dependencies for source distribution build",
+                "No solution found when resolving build dependencies for source distribution:",
             )?;
             Ok(resolution_graph.requirements())
         })

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_allow_prerelease_if_necessary.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_allow_prerelease_if_necessary.snap
@@ -2,4 +2,4 @@
 source: crates/puffin-resolver/tests/resolver.rs
 expression: resolution
 ---
-No solution
+Because there is no version of black available matching <=20.0 and root depends on black<=20.0, version solving failed.

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_disallow_prerelease.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_disallow_prerelease.snap
@@ -2,4 +2,4 @@
 source: crates/puffin-resolver/tests/resolver.rs
 expression: err
 ---
-No solution
+Because there is no version of black available matching <=20.0 and root depends on black<=20.0, version solving failed.


### PR DESCRIPTION
Closes https://github.com/astral-sh/puffin/issues/356.

The example from the issue now renders as:

```
❯ cargo run --bin puffin-dev -q -- resolve-cli tensorflow-cpu-aws
puffin-dev failed
  Caused by: No solution found when resolving build dependencies for source distribution:
  Caused by: Because there is no available version for tensorflow-cpu-aws and root depends on tensorflow-cpu-aws, version solving failed.
```