### PR TITLE
Delete any directories listed in the RECORD file

### DIFF
--- a/crates/puffin-cli/tests/snapshots/pip_compile__compile_python_312.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_compile__compile_python_312.snap
@@ -8,9 +8,9 @@ info:
     - "--python-version"
     - py312
     - "--cache-dir"
-    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpbKzceW
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpOMYCx3
   env:
-    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpZkKRNz/.venv
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpPNeQK1/.venv
 ---
 success: true
 exit_code: 0
@@ -26,7 +26,7 @@ packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 
 ----- stderr -----

--- a/crates/puffin-cli/tests/snapshots/pip_compile__compile_python_37.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_compile__compile_python_37.snap
@@ -8,9 +8,9 @@ info:
     - "--python-version"
     - py37
     - "--cache-dir"
-    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpQwHoBA
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpzwzUVe
   env:
-    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmp1TmUIW/.venv
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpqFv4YL/.venv
 ---
 success: true
 exit_code: 0
@@ -28,7 +28,7 @@ packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 tomli==2.0.1
     # via black

--- a/crates/puffin-resolver/tests/snapshots/resolver__black.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black.snap
@@ -11,6 +11,6 @@ packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_colorama.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_colorama.snap
@@ -12,6 +12,6 @@ packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_flake8.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_flake8.snap
@@ -11,6 +11,6 @@ packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_ignore_preference.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_ignore_preference.snap
@@ -11,6 +11,6 @@ packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_lowest_direct.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_lowest_direct.snap
@@ -9,7 +9,7 @@ mypy-extensions==1.0.0
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 tomli==2.0.1
     # via black

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_mypy_extensions.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_mypy_extensions.snap
@@ -11,6 +11,6 @@ packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_mypy_extensions_extra.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_mypy_extensions_extra.snap
@@ -11,6 +11,6 @@ packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_python_310.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_python_310.snap
@@ -11,7 +11,7 @@ packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 tomli==2.0.1
     # via black

--- a/crates/puffin-resolver/tests/snapshots/resolver__black_respect_preference.snap
+++ b/crates/puffin-resolver/tests/snapshots/resolver__black_respect_preference.snap
@@ -11,6 +11,6 @@ packaging==23.2
     # via black
 pathspec==0.11.2
     # via black
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via black
 


### PR DESCRIPTION
## Summary

It looks like, when you install `pip`, it includes a bunch of `__pycache__` directories in the RECORD file (although these directories don't exist until you run `pip`). Our uninstaller assumed that the RECORD file only contained _files_.

Closes https://github.com/astral-sh/puffin/issues/389.
