### PR TITLE
Remove `__pycache__` directories when uninstalling

### DIFF
--- a/crates/puffin-cli/tests/snapshots/pip_uninstall__uninstall.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_uninstall__uninstall.snap
@@ -1,0 +1,20 @@
+---
+source: crates/puffin-cli/tests/pip_uninstall.rs
+info:
+  program: puffin
+  args:
+    - pip-uninstall
+    - MarkupSafe
+    - "--cache-dir"
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmp2hOiz7
+  env:
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmp9AcnyS/.venv
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+Uninstalled 1 package in [TIME]
+ - markupsafe==2.1.3
+


### PR DESCRIPTION
According to the [packaging documentation](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#binary-distribution-format), "uninstallers should be smart enough to remove .pyc even if it is not mentioned in RECORD". Previously, we weren't handling this case, so if you installed via Puffin, then imported a file (to trigger bytecode compilation), then uninstalled, we'd leave spare `__pycache__` directories around.

Closes https://github.com/astral-sh/puffin/issues/395.