### PR TITLE
Use `anstream` to avoid writing colorized output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,6 +2334,7 @@ dependencies = [
 name = "puffin-cli"
 version = "0.0.1"
 dependencies = [
+ "anstream",
  "anyhow",
  "assert_cmd",
  "assert_fs",
@@ -2414,6 +2415,7 @@ dependencies = [
 name = "puffin-dev"
 version = "0.0.1"
 dependencies = [
+ "anstream",
  "anyhow",
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ authors = ["Astral Software Inc. <hey@astral.sh>"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
+anstream = { version = "0.6.4" }
 anyhow = { version = "1.0.75" }
 async_http_range_reader = { git = "https://github.com/baszalmstra/async_http_range_reader", rev = "8dab2c08ac864fec1df014465264f9a7c8eae905" }
 async_zip = { version = "0.0.15", features = ["tokio", "deflate"] }

--- a/crates/puffin-cli/Cargo.toml
+++ b/crates/puffin-cli/Cargo.toml
@@ -32,6 +32,7 @@ requirements-txt = { path = "../requirements-txt" }
 puffin-resolver = { path = "../puffin-resolver", features = ["clap"] }
 puffin-workspace = { path = "../puffin-workspace" }
 
+anstream = { workspace = true }
 anyhow = { workspace = true }
 bitflags = { workspace = true }
 cacache = { workspace = true }

--- a/crates/puffin-cli/src/printer.rs
+++ b/crates/puffin-cli/src/printer.rs
@@ -1,3 +1,4 @@
+use anstream::eprint;
 use indicatif::ProgressDrawTarget;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -26,7 +27,7 @@ impl std::fmt::Write for Printer {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
         match self {
             Self::Default | Self::Verbose => {
-                #[allow(clippy::print_stderr)]
+                #[allow(clippy::print_stderr, clippy::ignored_unit_patterns)]
                 {
                     eprint!("{s}");
                 }

--- a/crates/puffin-dev/Cargo.toml
+++ b/crates/puffin-dev/Cargo.toml
@@ -23,6 +23,7 @@ puffin-interpreter = { path = "../puffin-interpreter" }
 pypi-types = { path = "../pypi-types" }
 puffin-traits = { path = "../puffin-traits" }
 
+anstream = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 colored = { workspace = true }

--- a/crates/puffin-dev/src/resolve_cli.rs
+++ b/crates/puffin-dev/src/resolve_cli.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 
+use anstream::println;
 use clap::Parser;
 use directories::ProjectDirs;
 use itertools::Itertools;
@@ -46,8 +47,12 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> anyhow::Result<()> {
 
     let mut resolution = build_dispatch.resolve(&args.requirements).await?;
     resolution.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+
     // Concise format for dev
-    println!("{}", resolution.iter().map(ToString::to_string).join(" "));
+    #[allow(clippy::print_stderr, clippy::ignored_unit_patterns)]
+    {
+        println!("{}", resolution.iter().map(ToString::to_string).join(" "));
+    }
 
     Ok(())
 }


### PR DESCRIPTION
A more robust solution to avoiding colorized output by ensuring we write to `stdout` and `stderr` via the [`anstream`](https://docs.rs/anstream/latest/anstream/) crate.

Closes https://github.com/astral-sh/puffin/issues/393.
