### PR TITLE
Choose most-compatible wheel in resolver and installer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,6 +2161,7 @@ dependencies = [
 name = "platform-tags"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "fxhash",
  "platform-host",
 ]

--- a/crates/distribution-filename/src/wheel.rs
+++ b/crates/distribution-filename/src/wheel.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use url::Url;
 
 use pep440_rs::Version;
-use platform_tags::Tags;
+use platform_tags::{TagPriority, Tags};
 use puffin_normalize::{InvalidNameError, PackageName};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -120,6 +120,12 @@ impl WheelFilename {
     /// Returns `true` if the wheel is compatible with the given tags.
     pub fn is_compatible(&self, compatible_tags: &Tags) -> bool {
         compatible_tags.is_compatible(&self.python_tag, &self.abi_tag, &self.platform_tag)
+    }
+
+    /// Return the [`TagPriority`] score of the wheel with the given tags, or `None` if the wheel is
+    /// incompatible.
+    pub fn compatibility(&self, compatible_tags: &Tags) -> Option<TagPriority> {
+        compatible_tags.compatibility(&self.python_tag, &self.abi_tag, &self.platform_tag)
     }
 
     /// Get the tag for this wheel.

--- a/crates/platform-tags/Cargo.toml
+++ b/crates/platform-tags/Cargo.toml
@@ -10,5 +10,7 @@ authors = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-fxhash = { workspace = true }
 platform-host = { path = "../platform-host" }
+
+anyhow = { workspace = true }
+fxhash = { workspace = true }

--- a/crates/puffin-cli/tests/pip_compile.rs
+++ b/crates/puffin-cli/tests/pip_compile.rs
@@ -535,7 +535,6 @@ fn compile_numpy_py38() -> Result<()> {
             .arg("requirements.in")
             .arg("--cache-dir")
             .arg(cache_dir.path())
-            // Check that we select the wheel and not the sdist
             .arg("--no-build")
             .env("VIRTUAL_ENV", venv.as_os_str())
             .current_dir(&temp_dir), @r###"

--- a/crates/puffin-resolver/src/candidate_selector.rs
+++ b/crates/puffin-resolver/src/candidate_selector.rs
@@ -8,7 +8,7 @@ use crate::file::DistFile;
 use crate::prerelease_mode::PreReleaseStrategy;
 use crate::pubgrub::PubGrubVersion;
 use crate::resolution_mode::ResolutionStrategy;
-use crate::resolver::VersionMap;
+use crate::version_map::VersionMap;
 use crate::Manifest;
 
 #[derive(Debug)]

--- a/crates/puffin-resolver/src/lib.rs
+++ b/crates/puffin-resolver/src/lib.rs
@@ -19,3 +19,4 @@ mod pubgrub;
 mod resolution;
 mod resolution_mode;
 mod resolver;
+mod version_map;

--- a/crates/puffin-resolver/src/version_map.rs
+++ b/crates/puffin-resolver/src/version_map.rs
@@ -1,0 +1,121 @@
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::str::FromStr;
+
+use distribution_filename::{SourceDistFilename, WheelFilename};
+use pep440_rs::Version;
+use platform_tags::{TagPriority, Tags};
+use puffin_normalize::PackageName;
+use pypi_types::SimpleJson;
+
+use crate::file::{DistFile, SdistFile, WheelFile};
+use crate::pubgrub::PubGrubVersion;
+
+/// A map from versions to distributions.
+#[derive(Debug, Default)]
+pub(crate) struct VersionMap(BTreeMap<PubGrubVersion, ScoreDistribution>);
+
+impl VersionMap {
+    /// Initialize a [`VersionMap`] from the given metadata.
+    pub(crate) fn from_metadata(
+        metadata: SimpleJson,
+        package_name: &PackageName,
+        tags: &Tags,
+        python_version: &Version,
+    ) -> Self {
+        let mut map = BTreeMap::default();
+
+        // Group the distributions by version and kind, discarding any incompatible
+        // distributions.
+        for file in metadata.files {
+            // Only add dists compatible with the python version. This is relevant for source
+            // distributions which give no other indication of their compatibility and wheels which
+            // may be tagged `py3-none-any` but have `requires-python: ">=3.9"`.
+            // TODO(konstin): https://github.com/astral-sh/puffin/issues/406
+            if !file
+                .requires_python
+                .as_ref()
+                .map_or(true, |requires_python| {
+                    requires_python.contains(python_version)
+                })
+            {
+                continue;
+            }
+
+            // When resolving, exclude yanked files.
+            // TODO(konstin): When we fail resolving due to a dependency locked to yanked version,
+            // we should tell the user.
+            if file.yanked.is_yanked() {
+                continue;
+            }
+
+            if let Ok(filename) = WheelFilename::from_str(file.filename.as_str()) {
+                let priority = filename.compatibility(tags);
+
+                match map.entry(filename.version.into()) {
+                    Entry::Occupied(mut entry) => {
+                        match entry.get() {
+                            ScoreDistribution::Sdist(_) => {
+                                // Prefer wheels over source distributions.
+                                entry.insert(ScoreDistribution::Wheel(
+                                    DistFile::from(WheelFile(file)),
+                                    priority,
+                                ));
+                            }
+                            ScoreDistribution::Wheel(.., existing) => {
+                                // Prefer wheels with higher priority.
+                                if priority > *existing {
+                                    entry.insert(ScoreDistribution::Wheel(
+                                        DistFile::from(WheelFile(file)),
+                                        priority,
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    Entry::Vacant(entry) => {
+                        entry.insert(ScoreDistribution::Wheel(
+                            DistFile::from(WheelFile(file)),
+                            priority,
+                        ));
+                    }
+                }
+            } else if let Ok(filename) =
+                SourceDistFilename::parse(file.filename.as_str(), package_name)
+            {
+                if let Entry::Vacant(entry) = map.entry(filename.version.into()) {
+                    entry.insert(ScoreDistribution::Sdist(DistFile::from(SdistFile(file))));
+                }
+            }
+        }
+
+        Self(map)
+    }
+
+    /// Return the [`DistFile`] for the given version, if any.
+    pub(crate) fn get(&self, version: &PubGrubVersion) -> Option<&DistFile> {
+        self.0.get(version).map(|file| match file {
+            ScoreDistribution::Sdist(file) => file,
+            ScoreDistribution::Wheel(file, ..) => file,
+        })
+    }
+
+    /// Return an iterator over the versions and distributions.
+    pub(crate) fn iter(&self) -> impl DoubleEndedIterator<Item = (&PubGrubVersion, &DistFile)> {
+        self.0.iter().map(|(version, file)| {
+            (
+                version,
+                match file {
+                    ScoreDistribution::Sdist(file) => file,
+                    ScoreDistribution::Wheel(file, ..) => file,
+                },
+            )
+        })
+    }
+}
+
+#[derive(Debug)]
+enum ScoreDistribution {
+    Sdist(DistFile),
+    Wheel(DistFile, Option<TagPriority>),
+}


### PR DESCRIPTION
## Summary

This PR implements logic to sort wheels by priority, where priority is defined as preferring more "specific" wheels over less "specific" wheels. For example, in the case of Black, my machine now selects `black-23.11.0-cp311-cp311-macosx_11_0_arm64.whl`, whereas sorting by lowest priority instead gives me `black-23.11.0-py3-none-any.whl`.

As part of this change, I've also modified the resolver to fallback to using incompatible wheels when determining package metadata, if no compatible wheels are available.

The `VersionMap` was also moved out of `resolver.rs` and into its own file with a wrapper type, for clarity.

Closes https://github.com/astral-sh/puffin/issues/380.
Closes https://github.com/astral-sh/puffin/issues/421.