### PR TITLE
Split resolver inputs into manifest and options

### DIFF
--- a/crates/puffin-dev/src/resolve_cli.rs
+++ b/crates/puffin-dev/src/resolve_cli.rs
@@ -16,7 +16,7 @@ use puffin_cache::{CacheArgs, CacheDir};
 use puffin_client::RegistryClientBuilder;
 use puffin_dispatch::BuildDispatch;
 use puffin_interpreter::Virtualenv;
-use puffin_resolver::{Manifest, PreReleaseMode, ResolutionMode, Resolver};
+use puffin_resolver::{Manifest, ResolutionOptions, Resolver};
 
 #[derive(ValueEnum, Default, Clone)]
 pub(crate) enum ResolveCliFormat {
@@ -61,17 +61,13 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> anyhow::Result<()> {
         venv.interpreter_info().simple_version(),
     )?;
     let resolver = Resolver::new(
-        // TODO(konstin): Split settings (for all resolutions) and inputs (only for this
-        // resolution) and attach the former to Self.
         Manifest::new(
             args.requirements.clone(),
             Vec::default(),
             Vec::default(),
-            ResolutionMode::default(),
-            PreReleaseMode::default(),
-            None, // TODO(zanieb): We may want to provide a project name here
             None,
         ),
+        ResolutionOptions::default(),
         venv.interpreter_info().markers(),
         &tags,
         &client,

--- a/crates/puffin-resolver/src/candidate_selector.rs
+++ b/crates/puffin-resolver/src/candidate_selector.rs
@@ -9,7 +9,7 @@ use crate::prerelease_mode::PreReleaseStrategy;
 use crate::pubgrub::PubGrubVersion;
 use crate::resolution_mode::ResolutionStrategy;
 use crate::version_map::VersionMap;
-use crate::Manifest;
+use crate::{Manifest, ResolutionOptions};
 
 #[derive(Debug)]
 pub(crate) struct CandidateSelector {
@@ -18,16 +18,16 @@ pub(crate) struct CandidateSelector {
     preferences: Preferences,
 }
 
-impl From<&Manifest> for CandidateSelector {
+impl CandidateSelector {
     /// Return a [`CandidateSelector`] for the given [`Manifest`].
-    fn from(manifest: &Manifest) -> Self {
+    pub(crate) fn for_resolution(manifest: &Manifest, options: ResolutionOptions) -> Self {
         Self {
             resolution_strategy: ResolutionStrategy::from_mode(
-                manifest.resolution_mode,
+                options.resolution_mode,
                 manifest.requirements.as_slice(),
             ),
             prerelease_strategy: PreReleaseStrategy::from_mode(
-                manifest.prerelease_mode,
+                options.prerelease_mode,
                 manifest.requirements.as_slice(),
             ),
             preferences: Preferences::from(manifest.preferences.as_slice()),

--- a/crates/puffin-resolver/src/lib.rs
+++ b/crates/puffin-resolver/src/lib.rs
@@ -5,6 +5,7 @@ pub use prerelease_mode::PreReleaseMode;
 pub use pubgrub::ResolutionFailureReporter;
 pub use resolution::Graph;
 pub use resolution_mode::ResolutionMode;
+pub use resolution_options::ResolutionOptions;
 pub use resolver::{BuildId, Reporter as ResolverReporter, Resolver};
 
 mod candidate_selector;
@@ -18,5 +19,6 @@ mod prerelease_mode;
 mod pubgrub;
 mod resolution;
 mod resolution_mode;
+mod resolution_options;
 mod resolver;
 mod version_map;

--- a/crates/puffin-resolver/src/manifest.rs
+++ b/crates/puffin-resolver/src/manifest.rs
@@ -1,9 +1,5 @@
-use chrono::{DateTime, Utc};
 use pep508_rs::Requirement;
 use puffin_normalize::PackageName;
-
-use crate::prerelease_mode::PreReleaseMode;
-use crate::resolution_mode::ResolutionMode;
 
 /// A manifest of requirements, constraints, and preferences.
 #[derive(Debug)]
@@ -11,10 +7,7 @@ pub struct Manifest {
     pub(crate) requirements: Vec<Requirement>,
     pub(crate) constraints: Vec<Requirement>,
     pub(crate) preferences: Vec<Requirement>,
-    pub(crate) resolution_mode: ResolutionMode,
-    pub(crate) prerelease_mode: PreReleaseMode,
     pub(crate) project: Option<PackageName>,
-    pub(crate) exclude_newer: Option<DateTime<Utc>>,
 }
 
 impl Manifest {
@@ -22,19 +15,13 @@ impl Manifest {
         requirements: Vec<Requirement>,
         constraints: Vec<Requirement>,
         preferences: Vec<Requirement>,
-        resolution_mode: ResolutionMode,
-        prerelease_mode: PreReleaseMode,
         project: Option<PackageName>,
-        exclude_newer: Option<DateTime<Utc>>,
     ) -> Self {
         Self {
             requirements,
             constraints,
             preferences,
-            resolution_mode,
-            prerelease_mode,
             project,
-            exclude_newer,
         }
     }
 }

--- a/crates/puffin-resolver/src/resolution_options.rs
+++ b/crates/puffin-resolver/src/resolution_options.rs
@@ -1,0 +1,24 @@
+use crate::{PreReleaseMode, ResolutionMode};
+use chrono::{DateTime, Utc};
+
+/// Options for resolving a manifest.
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ResolutionOptions {
+    pub(crate) resolution_mode: ResolutionMode,
+    pub(crate) prerelease_mode: PreReleaseMode,
+    pub(crate) exclude_newer: Option<DateTime<Utc>>,
+}
+
+impl ResolutionOptions {
+    pub fn new(
+        resolution_mode: ResolutionMode,
+        prerelease_mode: PreReleaseMode,
+        exclude_newer: Option<DateTime<Utc>>,
+    ) -> Self {
+        Self {
+            resolution_mode,
+            prerelease_mode,
+            exclude_newer,
+        }
+    }
+}

--- a/crates/puffin-resolver/src/resolver.rs
+++ b/crates/puffin-resolver/src/resolver.rs
@@ -40,6 +40,7 @@ use crate::pubgrub::{
 };
 use crate::resolution::Graph;
 use crate::version_map::VersionMap;
+use crate::ResolutionOptions;
 
 pub struct Resolver<'a, Context: BuildContext + Sync> {
     project: Option<PackageName>,
@@ -61,6 +62,7 @@ impl<'a, Context: BuildContext + Sync> Resolver<'a, Context> {
     /// Initialize a new resolver.
     pub fn new(
         manifest: Manifest,
+        options: ResolutionOptions,
         markers: &'a MarkerEnvironment,
         tags: &'a Tags,
         client: &'a RegistryClient,
@@ -69,7 +71,7 @@ impl<'a, Context: BuildContext + Sync> Resolver<'a, Context> {
         Self {
             index: Arc::new(Index::default()),
             locks: Arc::new(Locks::default()),
-            selector: CandidateSelector::from(&manifest),
+            selector: CandidateSelector::for_resolution(&manifest, options),
             allowed_urls: manifest
                 .requirements
                 .iter()
@@ -85,9 +87,9 @@ impl<'a, Context: BuildContext + Sync> Resolver<'a, Context> {
             project: manifest.project,
             requirements: manifest.requirements,
             constraints: manifest.constraints,
+            exclude_newer: options.exclude_newer,
             markers,
             tags,
-            exclude_newer: manifest.exclude_newer,
             client,
             build_context,
             reporter: None,

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -17,7 +17,9 @@ use platform_host::{Arch, Os, Platform};
 use platform_tags::Tags;
 use puffin_client::RegistryClientBuilder;
 use puffin_interpreter::{InterpreterInfo, Virtualenv};
-use puffin_resolver::{Graph, Manifest, PreReleaseMode, ResolutionMode, Resolver};
+use puffin_resolver::{
+    Graph, Manifest, PreReleaseMode, ResolutionMode, ResolutionOptions, Resolver,
+};
 use puffin_traits::BuildContext;
 
 struct DummyContext {
@@ -65,6 +67,7 @@ impl BuildContext for DummyContext {
 
 async fn resolve(
     manifest: Manifest,
+    options: ResolutionOptions,
     markers: &'static MarkerEnvironment,
     tags: &Tags,
 ) -> Result<Graph> {
@@ -79,7 +82,7 @@ async fn resolve(
             PathBuf::from("/dev/null"),
         ),
     };
-    let resolver = Resolver::new(manifest, markers, tags, &client, &build_context);
+    let resolver = Resolver::new(manifest, options, markers, tags, &client, &build_context);
     Ok(resolver.resolve().await?)
 }
 
@@ -91,13 +94,16 @@ async fn black() -> Result<()> {
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::default(),
-        None,
         None,
     );
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(
+        manifest,
+        ResolutionOptions::default(),
+        &MARKERS_311,
+        &TAGS_311,
+    )
+    .await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -112,13 +118,16 @@ async fn black_colorama() -> Result<()> {
         vec![Requirement::from_str("black[colorama]<=23.9.1").unwrap()],
         vec![],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::default(),
-        None,
         None,
     );
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(
+        manifest,
+        ResolutionOptions::default(),
+        &MARKERS_311,
+        &TAGS_311,
+    )
+    .await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -133,13 +142,16 @@ async fn black_python_310() -> Result<()> {
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::default(),
-        None,
         None,
     );
 
-    let resolution = resolve(manifest, &MARKERS_310, &TAGS_310).await?;
+    let resolution = resolve(
+        manifest,
+        ResolutionOptions::default(),
+        &MARKERS_310,
+        &TAGS_310,
+    )
+    .await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -156,13 +168,16 @@ async fn black_mypy_extensions() -> Result<()> {
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![Requirement::from_str("mypy-extensions<0.4.4").unwrap()],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::default(),
-        None,
         None,
     );
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(
+        manifest,
+        ResolutionOptions::default(),
+        &MARKERS_311,
+        &TAGS_311,
+    )
+    .await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -179,13 +194,16 @@ async fn black_mypy_extensions_extra() -> Result<()> {
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![Requirement::from_str("mypy-extensions[extra]<0.4.4").unwrap()],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::default(),
-        None,
         None,
     );
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(
+        manifest,
+        ResolutionOptions::default(),
+        &MARKERS_311,
+        &TAGS_311,
+    )
+    .await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -202,13 +220,16 @@ async fn black_flake8() -> Result<()> {
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![Requirement::from_str("flake8<1").unwrap()],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::default(),
-        None,
         None,
     );
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(
+        manifest,
+        ResolutionOptions::default(),
+        &MARKERS_311,
+        &TAGS_311,
+    )
+    .await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -223,13 +244,11 @@ async fn black_lowest() -> Result<()> {
         vec![Requirement::from_str("black>21").unwrap()],
         vec![],
         vec![],
-        ResolutionMode::Lowest,
-        PreReleaseMode::default(),
-        None,
         None,
     );
+    let options = ResolutionOptions::new(ResolutionMode::Lowest, PreReleaseMode::default(), None);
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(manifest, options, &MARKERS_311, &TAGS_311).await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -244,13 +263,15 @@ async fn black_lowest_direct() -> Result<()> {
         vec![Requirement::from_str("black>21").unwrap()],
         vec![],
         vec![],
+        None,
+    );
+    let options = ResolutionOptions::new(
         ResolutionMode::LowestDirect,
         PreReleaseMode::default(),
         None,
-        None,
     );
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(manifest, options, &MARKERS_311, &TAGS_311).await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -265,13 +286,16 @@ async fn black_respect_preference() -> Result<()> {
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![],
         vec![Requirement::from_str("black==23.9.0").unwrap()],
-        ResolutionMode::default(),
-        PreReleaseMode::default(),
-        None,
         None,
     );
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(
+        manifest,
+        ResolutionOptions::default(),
+        &MARKERS_311,
+        &TAGS_311,
+    )
+    .await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -286,13 +310,16 @@ async fn black_ignore_preference() -> Result<()> {
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![],
         vec![Requirement::from_str("black==23.9.2").unwrap()],
-        ResolutionMode::default(),
-        PreReleaseMode::default(),
-        None,
         None,
     );
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(
+        manifest,
+        ResolutionOptions::default(),
+        &MARKERS_311,
+        &TAGS_311,
+    )
+    .await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -307,13 +334,11 @@ async fn black_disallow_prerelease() -> Result<()> {
         vec![Requirement::from_str("black<=20.0").unwrap()],
         vec![],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::Disallow,
-        None,
         None,
     );
+    let options = ResolutionOptions::new(ResolutionMode::default(), PreReleaseMode::Disallow, None);
 
-    let err = resolve(manifest, &MARKERS_311, &TAGS_311)
+    let err = resolve(manifest, options, &MARKERS_311, &TAGS_311)
         .await
         .unwrap_err();
 
@@ -330,13 +355,12 @@ async fn black_allow_prerelease_if_necessary() -> Result<()> {
         vec![Requirement::from_str("black<=20.0").unwrap()],
         vec![],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::IfNecessary,
-        None,
         None,
     );
+    let options =
+        ResolutionOptions::new(ResolutionMode::default(), PreReleaseMode::IfNecessary, None);
 
-    let err = resolve(manifest, &MARKERS_311, &TAGS_311)
+    let err = resolve(manifest, options, &MARKERS_311, &TAGS_311)
         .await
         .unwrap_err();
 
@@ -353,13 +377,11 @@ async fn pylint_disallow_prerelease() -> Result<()> {
         vec![Requirement::from_str("pylint==2.3.0").unwrap()],
         vec![],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::Disallow,
-        None,
         None,
     );
+    let options = ResolutionOptions::new(ResolutionMode::default(), PreReleaseMode::Disallow, None);
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(manifest, options, &MARKERS_311, &TAGS_311).await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -374,13 +396,11 @@ async fn pylint_allow_prerelease() -> Result<()> {
         vec![Requirement::from_str("pylint==2.3.0").unwrap()],
         vec![],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::Allow,
-        None,
         None,
     );
+    let options = ResolutionOptions::new(ResolutionMode::default(), PreReleaseMode::Allow, None);
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(manifest, options, &MARKERS_311, &TAGS_311).await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -398,13 +418,11 @@ async fn pylint_allow_explicit_prerelease_without_marker() -> Result<()> {
         ],
         vec![],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::Explicit,
-        None,
         None,
     );
+    let options = ResolutionOptions::new(ResolutionMode::default(), PreReleaseMode::Explicit, None);
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(manifest, options, &MARKERS_311, &TAGS_311).await?;
 
     insta::assert_display_snapshot!(resolution);
 
@@ -422,13 +440,11 @@ async fn pylint_allow_explicit_prerelease_with_marker() -> Result<()> {
         ],
         vec![],
         vec![],
-        ResolutionMode::default(),
-        PreReleaseMode::Explicit,
-        None,
         None,
     );
+    let options = ResolutionOptions::new(ResolutionMode::default(), PreReleaseMode::Explicit, None);
 
-    let resolution = resolve(manifest, &MARKERS_311, &TAGS_311).await?;
+    let resolution = resolve(manifest, options, &MARKERS_311, &TAGS_311).await?;
 
     insta::assert_display_snapshot!(resolution);
 


### PR DESCRIPTION
## Summary

This is a refactor to address a TODO in the build context whereby we aren't respecting the resolution options in recursive resolutions. Now, the options are split out from the resolution _manifest_, and shared across the build context tree.