### PR TITLE
Track file index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,6 +2765,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use pep440_rs::Version;
 use puffin_normalize::PackageName;
-use pypi_types::File;
+use pypi_types::{File, IndexUrl};
 
 pub use crate::any::*;
 pub use crate::cached::*;
@@ -62,6 +62,7 @@ pub struct RegistryBuiltDist {
     pub name: PackageName,
     pub version: Version,
     pub file: File,
+    pub index: IndexUrl,
 }
 
 /// A built distribution (wheel) that exists at an arbitrary URL.
@@ -77,6 +78,7 @@ pub struct RegistrySourceDist {
     pub name: PackageName,
     pub version: Version,
     pub file: File,
+    pub index: IndexUrl,
 }
 
 /// A source distribution that exists at an arbitrary URL.
@@ -95,7 +97,7 @@ pub struct GitSourceDist {
 
 impl Dist {
     /// Create a [`Dist`] for a registry-based distribution.
-    pub fn from_registry(name: PackageName, version: Version, file: File) -> Self {
+    pub fn from_registry(name: PackageName, version: Version, file: File, index: IndexUrl) -> Self {
         if Path::new(&file.filename)
             .extension()
             .is_some_and(|ext| ext.eq_ignore_ascii_case("whl"))
@@ -104,12 +106,14 @@ impl Dist {
                 name,
                 version,
                 file,
+                index,
             }))
         } else {
             Self::Source(SourceDist::Registry(RegistrySourceDist {
                 name,
                 version,
                 file,
+                index,
             }))
         }
     }

--- a/crates/pypi-types/Cargo.toml
+++ b/crates/pypi-types/Cargo.toml
@@ -22,6 +22,7 @@ rfc2047-decoder = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 indoc = { version = "2.0.4" }

--- a/crates/pypi-types/src/index_url.rs
+++ b/crates/pypi-types/src/index_url.rs
@@ -1,0 +1,17 @@
+use url::Url;
+
+/// The url of an index, newtype'd to avoid mixing it with file urls
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct IndexUrl(Url);
+
+impl From<Url> for IndexUrl {
+    fn from(url: Url) -> Self {
+        Self(url)
+    }
+}
+
+impl From<IndexUrl> for Url {
+    fn from(index: IndexUrl) -> Self {
+        index.0
+    }
+}

--- a/crates/pypi-types/src/lib.rs
+++ b/crates/pypi-types/src/lib.rs
@@ -1,9 +1,11 @@
 pub use direct_url::{ArchiveInfo, DirectUrl, VcsInfo, VcsKind};
+pub use index_url::IndexUrl;
 pub use lenient_requirement::LenientVersionSpecifiers;
 pub use metadata::{Error, Metadata21};
 pub use simple_json::{File, SimpleJson, Yanked};
 
 mod direct_url;
+mod index_url;
 mod lenient_requirement;
 mod metadata;
 mod simple_json;


### PR DESCRIPTION
Track the index (or at least its url) where we got a file from across the source code.

Fixes #448