### PR TITLE
Use absolute cache paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2353,6 +2353,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "directories",
+ "fs-err",
  "hex",
  "seahash",
  "tempfile",

--- a/crates/puffin-cache/Cargo.toml
+++ b/crates/puffin-cache/Cargo.toml
@@ -13,6 +13,7 @@ license = { workspace = true }
 [dependencies]
 clap = { workspace = true, features = ["derive"], optional = true }
 directories = { workspace = true }
+fs-err = { workspace = true }
 hex = { workspace = true }
 seahash = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/puffin-cache/src/cli.rs
+++ b/crates/puffin-cache/src/cli.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "clap")]
 
+use fs_err as fs;
 use std::io;
 use std::path::PathBuf;
 
@@ -37,6 +38,8 @@ impl TryFrom<CacheArgs> for CacheDir {
     /// 2. The specific cache directory specified by the user via `--cache-dir` or `PUFFIN_CACHE_DIR`.
     /// 3. The system-appropriate cache directory.
     /// 4. A `.puffin_cache` directory in the current working directory.
+    ///
+    /// Returns an absolute cache dir.
     fn try_from(value: CacheArgs) -> Result<Self, Self::Error> {
         let project_dirs = ProjectDirs::from("", "", "puffin");
         if value.no_cache {
@@ -48,7 +51,7 @@ impl TryFrom<CacheArgs> for CacheDir {
             })
         } else if let Some(cache_dir) = value.cache_dir {
             Ok(Self {
-                cache_dir,
+                cache_dir: fs::canonicalize(cache_dir)?,
                 temp_dir: None,
             })
         } else if let Some(project_dirs) = project_dirs {
@@ -58,7 +61,7 @@ impl TryFrom<CacheArgs> for CacheDir {
             })
         } else {
             Ok(Self {
-                cache_dir: PathBuf::from(".puffin_cache"),
+                cache_dir: fs::canonicalize(".puffin_cache")?,
                 temp_dir: None,
             })
         }


### PR DESCRIPTION
Previously, git requirements would fail when setting `--cache-dir`:

```console
$ cargo run --bin puffin -- pip-compile --cache-dir cache-all-kinds scripts/benchmarks/requirements/all-kinds.in
error: Failed to build distribution from URL: git+https://github.com/pydantic/pydantic-extra-types.git
  Caused by: Invalid path URL: cache-all-kinds/git-v0/db/b49ffcfeb6c2e9d8
  ```

The cause is using a relative and not an absolute path, which `Url` needs, the solution is to turn the cache dir into an absolute path.

This never showed up in the tests since the tests use absolute temp dirs for everything.