### PR TITLE
Refactor lenient parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,6 +2783,7 @@ dependencies = [
  "once_cell",
  "pep440_rs 0.3.12",
  "pep508_rs",
+ "puffin-macros",
  "puffin-normalize",
  "regex",
  "rfc2047-decoder",

--- a/crates/puffin-macros/Cargo.toml
+++ b/crates/puffin-macros/Cargo.toml
@@ -10,5 +10,7 @@ authors = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+colored = { workspace = true }
 fxhash = { workspace = true }
 once_cell = { workspace = true }
+tracing = { workspace = true }

--- a/crates/puffin-macros/src/lib.rs
+++ b/crates/puffin-macros/src/lib.rs
@@ -3,14 +3,20 @@ use std::sync::Mutex;
 use fxhash::FxHashSet;
 use once_cell::sync::Lazy;
 
+// macro hygiene: The user might not have direct dependencies on those crates
+#[doc(hidden)]
+pub use colored;
+#[doc(hidden)]
+pub use tracing;
+
 pub static WARNINGS: Lazy<Mutex<FxHashSet<String>>> = Lazy::new(Mutex::default);
 
 /// Warn a user once, with uniqueness determined by the content of the message.
 #[macro_export]
 macro_rules! warn_once {
     ($($arg:tt)*) => {
-        use colored::Colorize;
-        use tracing::warn;
+        use $crate::colored::Colorize;
+        use $crate::tracing::warn;
 
         if let Ok(mut states) = $crate::WARNINGS.lock() {
             let message = format!("{}", format_args!($($arg)*));

--- a/crates/pypi-types/Cargo.toml
+++ b/crates/pypi-types/Cargo.toml
@@ -13,6 +13,7 @@ license = { workspace = true }
 pep440_rs = { path = "../pep440-rs", features = ["serde"] }
 pep508_rs = { path = "../pep508-rs", features = ["serde"] }
 puffin-normalize = { path = "../puffin-normalize" }
+puffin-macros = { path = "../puffin-macros" }
 
 chrono = { workspace = true, features = ["serde"] }
 mailparse = { workspace = true }


### PR DESCRIPTION
Deduplicate lenient parsing code between version specifiers and Requirement. Use `warn_once!` since the warnings did show up multiple times in my code. Fix the macro hygiene in `warn_once!`.