### PR TITLE
Prefer future stream over `JoinSet` in downloader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,6 +2576,7 @@ dependencies = [
  "distribution-filename",
  "distribution-types",
  "fs-err",
+ "futures",
  "fxhash",
  "install-wheel-rs",
  "pep440_rs 0.3.12",

--- a/crates/puffin-installer/Cargo.toml
+++ b/crates/puffin-installer/Cargo.toml
@@ -26,6 +26,7 @@ pypi-types = { path = "../pypi-types" }
 
 anyhow = { workspace = true }
 fs-err = { workspace = true }
+futures = { workspace = true }
 fxhash = { workspace = true }
 rayon = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
This avoids introducing a static lifetime requirement and, in my benchmarks, is even a little faster.