### PR TITLE
Refactor distribution types to return `Result`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,7 @@ dependencies = [
  "pypi-types",
  "serde",
  "serde_json",
+ "thiserror",
  "url",
 ]
 
@@ -2540,6 +2541,7 @@ dependencies = [
  "fs-err",
  "install-wheel-rs",
  "platform-tags",
+ "puffin-cache",
  "puffin-client",
  "puffin-git",
  "puffin-traits",

--- a/crates/distribution-types/Cargo.toml
+++ b/crates/distribution-types/Cargo.toml
@@ -21,4 +21,5 @@ anyhow = { workspace = true }
 fs-err = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 url = { workspace = true }

--- a/crates/distribution-types/src/error.rs
+++ b/crates/distribution-types/src/error.rs
@@ -1,0 +1,10 @@
+use url::Url;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    WheelFilename(#[from] distribution_filename::WheelFilenameError),
+
+    #[error("Unable to extract filename from URL: {0}")]
+    UrlFilename(Url),
+}

--- a/crates/distribution-types/src/traits.rs
+++ b/crates/distribution-types/src/traits.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use puffin_cache::CanonicalUrl;
 use puffin_normalize::PackageName;
 
+use crate::error::Error;
 use crate::{
     AnyDist, BuiltDist, CachedDirectUrlDist, CachedDist, CachedRegistryDist, DirectUrlBuiltDist,
     DirectUrlSourceDist, Dist, GitSourceDist, InstalledDirectUrlDist, InstalledDist,
@@ -35,7 +36,7 @@ pub trait Metadata {
 
 pub trait RemoteSource {
     /// Return an appropriate filename for the distribution.
-    fn filename(&self) -> Result<&str>;
+    fn filename(&self) -> Result<&str, Error>;
 
     /// Return the size of the distribution, if known.
     fn size(&self) -> Option<usize>;

--- a/crates/puffin-client/src/client.rs
+++ b/crates/puffin-client/src/client.rs
@@ -224,10 +224,10 @@ impl RegistryClient {
             self.cached_client
                 .get_cached_with_callback(req, &cache_dir, &cache_file, response_callback)
                 .await
-        // If we lack PEP 658 support, try using HTTP range requests to read only the
-        // `.dist-info/METADATA` file from the zip, and if that also fails, download the whole wheel
-        // into the cache and read from there
         } else {
+            // If we lack PEP 658 support, try using HTTP range requests to read only the
+            // `.dist-info/METADATA` file from the zip, and if that also fails, download the whole wheel
+            // into the cache and read from there
             self.wheel_metadata_no_pep658(&filename, &url, WheelMetadataCache::Index(index))
                 .await
         }

--- a/crates/puffin-distribution/Cargo.toml
+++ b/crates/puffin-distribution/Cargo.toml
@@ -14,6 +14,7 @@ distribution-filename = { path = "../distribution-filename" }
 distribution-types = { path = "../distribution-types" }
 install-wheel-rs = { path = "../install-wheel-rs" }
 platform-tags = { path = "../platform-tags" }
+puffin-cache = { path = "../puffin-cache" }
 puffin-client = { path = "../puffin-client" }
 puffin-git = { path = "../puffin-git" }
 puffin-traits = { path = "../puffin-traits" }

--- a/crates/puffin-distribution/src/fetcher.rs
+++ b/crates/puffin-distribution/src/fetcher.rs
@@ -13,6 +13,7 @@ use distribution_filename::WheelFilename;
 use distribution_types::direct_url::{DirectArchiveUrl, DirectGitUrl};
 use distribution_types::{BuiltDist, Dist, Identifier, Metadata, RemoteSource, SourceDist};
 use platform_tags::Tags;
+use puffin_cache::metadata::WheelMetadataCache;
 use puffin_client::RegistryClient;
 use puffin_git::{GitSource, GitUrl};
 use puffin_traits::BuildContext;
@@ -74,6 +75,13 @@ impl<'a> Fetcher<'a> {
             Dist::Built(BuiltDist::Registry(wheel)) => {
                 let metadata = client
                     .wheel_metadata(wheel.index.clone(), wheel.file.clone())
+                    .await?;
+                Ok(metadata)
+            }
+            // Fetch the metadata directly from the wheel URL.
+            Dist::Built(BuiltDist::DirectUrl(wheel)) => {
+                let metadata = client
+                    .wheel_metadata_no_pep658(&wheel.filename, &wheel.url, WheelMetadataCache::Url)
                     .await?;
                 Ok(metadata)
             }

--- a/crates/puffin-resolver/src/error.rs
+++ b/crates/puffin-resolver/src/error.rs
@@ -50,6 +50,9 @@ pub enum ResolveError {
     #[error("Package `{0}` attempted to resolve via URL: {1}. URL dependencies must be expressed as direct requirements or constraints. Consider adding `{0} @ {1}` to your dependencies or constraints file.")]
     DisallowedUrl(PackageName, Url),
 
+    #[error(transparent)]
+    DistributionType(#[from] distribution_types::Error),
+
     #[error("Failed to fetch wheel metadata from: {filename}")]
     RegistryBuiltDist {
         filename: String,

--- a/crates/puffin-resolver/src/finder.rs
+++ b/crates/puffin-resolver/src/finder.rs
@@ -87,7 +87,7 @@ impl<'a> DistFinder<'a> {
                 }
                 Some(VersionOrUrl::Url(url)) => {
                     let package_name = requirement.name.clone();
-                    let package = Dist::from_url(package_name.clone(), url.clone());
+                    let package = Dist::from_url(package_name.clone(), url.clone())?;
                     resolution.insert(package_name, package);
                 }
             }


### PR DESCRIPTION
## Summary

A variety of small refactors to the distribution types crate to (1) return `Result` if we find an invalid wheel, rather than treating it as a source distribution with a `.whl` suffix, and (2) DRY up some repeated code around URLs.