### PR TITLE
Consistent Cargo.toml syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,14 @@ bitflags = { version = "2.4.1" }
 bytesize = { version = "1.3.0" }
 cacache = { version = "12.0.0", default-features = false, features = ["tokio-runtime"] }
 camino = { version = "1.1.6", features = ["serde1"] }
+cargo-util = { version = "0.2.6" }
+chrono = { version = "0.4.31" }
 clap = { version = "4.4.7" }
 colored = { version = "2.0.4" }
 configparser = { version = "3.0.2" }
-chrono = { version = "0.4.31" }
 csv = { version = "1.3.0" }
 data-encoding = { version = "2.4.0" }
+derivative = { version = "2.2.0" }
 directories = { version = "5.0.1" }
 dirs = { version = "5.0.1" }
 flate2 = { version = "1.0.28" }
@@ -33,6 +35,7 @@ fs-err = { version = "2.9.0" }
 fs2 = { version = "0.4.3" }
 futures = { version = "0.3.29" }
 fxhash = { version = "0.2.1" }
+git2 = { version = "0.18.1" }
 glob = { version = "0.3.1" }
 goblin = { version = "0.7.1" }
 hex = { version = "0.4.3" }
@@ -50,6 +53,8 @@ petgraph = { version = "0.6.4" }
 platform-info = { version = "2.0.2" }
 plist = { version = "1.6.0" }
 pubgrub = { git = "https://github.com/zanieb/pubgrub", rev = "725b9a8e323c9ae0727fed2d045bad64eb212167" }
+pyo3 = { version = "0.20.0" }
+pyo3-log = { version = "0.9.0"}
 pyproject-toml = { version = "0.8.0" }
 rand = { version = "0.8.5" }
 rayon = { version = "1.8.0" }
@@ -66,6 +71,7 @@ sha2 = { version = "0.10.8" }
 tar = { version = "0.4.40" }
 target-lexicon = { version = "0.12.12" }
 tempfile = { version = "3.8.1" }
+textwrap = { version = "0.15.2" }
 thiserror = { version = "1.0.50" }
 tokio = { version = "1.33.0", features = ["rt-multi-thread"] }
 tokio-util = { version = "0.7.10", features = ["compat"] }

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -20,7 +20,7 @@ path = "benches/distribution_filename.rs"
 harness = false
 
 [dependencies]
-criterion = { version = "0.5.1", default-features = false }
+distribution-filename = { path = "../distribution-filename" }
+platform-tags = { path = "../platform-tags" }
 
-distribution-filename.path = "../distribution-filename"
-platform-tags.path = "../platform-tags"
+criterion = { version = "0.5.1", default-features = false }

--- a/crates/install-wheel-rs/Cargo.toml
+++ b/crates/install-wheel-rs/Cargo.toml
@@ -35,8 +35,8 @@ mailparse = { workspace = true }
 once_cell = { workspace = true }
 platform-info = { workspace = true }
 plist = { workspace = true }
-pyo3 = { version = "0.20.0", features = ["extension-module", "abi3-py37"], optional = true }
-rayon = { version = "1.8.0", optional = true }
+pyo3 = { workspace = true, features = ["extension-module", "abi3-py37"], optional = true }
+rayon = { workspace = true, optional = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/pep440-rs/Cargo.toml
+++ b/crates/pep440-rs/Cargo.toml
@@ -18,12 +18,11 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 once_cell = { workspace = true }
+pyo3 = { workspace = true, optional = true, features = ["extension-module", "abi3-py37"] }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 tracing = { workspace = true, optional = true }
 unicode-width = { workspace = true }
-
-pyo3 = { version = "0.20", optional = true, features = ["extension-module", "abi3-py37"] }
 
 [dev-dependencies]
 indoc = "2.0.4"

--- a/crates/pep508-rs/Cargo.toml
+++ b/crates/pep508-rs/Cargo.toml
@@ -21,6 +21,8 @@ pep440_rs = { path = "../pep440-rs" }
 puffin-normalize = { path = "../puffin-normalize" }
 
 once_cell = { workspace = true }
+pyo3 = { workspace = true, optional = true, features = ["abi3", "extension-module"] }
+pyo3-log = { workspace = true, optional = true }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
@@ -28,9 +30,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 unicode-width = { workspace = true }
 url = { workspace = true, features = ["serde"] }
-
-pyo3 = { version = "0.20.0", optional = true, features = ["abi3", "extension-module"] }
-pyo3-log = { version = "0.9.0", optional = true }
 
 [dev-dependencies]
 indoc = "2.0.4"

--- a/crates/puffin-cli/Cargo.toml
+++ b/crates/puffin-cli/Cargo.toml
@@ -14,8 +14,6 @@ name = "puffin"
 path = "src/main.rs"
 
 [dependencies]
-textwrap = { version = "0.15.2" }
-
 gourgeist = { path = "../gourgeist" }
 install-wheel-rs = { path = "../install-wheel-rs", default-features = false }
 pep440_rs = { path = "../pep440-rs" }
@@ -50,6 +48,7 @@ miette = { workspace = true, features = ["fancy"] }
 pubgrub = { workspace = true }
 pyproject-toml = { workspace = true }
 tempfile = { workspace = true }
+textwrap = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }

--- a/crates/puffin-git/Cargo.toml
+++ b/crates/puffin-git/Cargo.toml
@@ -13,8 +13,8 @@ license = { workspace = true }
 puffin-cache = { path = "../puffin-cache" }
 
 anyhow = { workspace = true }
-cargo-util = { version = "0.2.6" }
-git2 = { version = "0.18.1" }
+cargo-util = { workspace = true }
+git2 = { workspace = true }
 glob = { workspace = true }
 hex = { workspace = true }
 once_cell = { workspace = true }
@@ -23,7 +23,7 @@ serde = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"] }
-tokio.workspace = true
+tokio = { workspace = true }
 
 [features]
 vendored-libgit2 = ["git2/vendored-libgit2"]

--- a/crates/puffin-resolver/Cargo.toml
+++ b/crates/puffin-resolver/Cargo.toml
@@ -47,7 +47,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 waitmap = { workspace = true }
 zip = { workspace = true }
-derivative = { version = "2.2.0" }
+derivative = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]

--- a/crates/requirements-txt/Cargo.toml
+++ b/crates/requirements-txt/Cargo.toml
@@ -23,7 +23,7 @@ tracing = { workspace = true }
 unscanny = { workspace = true }
 
 [dev-dependencies]
-anyhow = { workspace = true }
+anyhow = { version = "1.0.75" }
 indoc = { version = "2.0.4" }
 insta = { version = "1.34.0" }
 serde_json = { version = "1.0.108" }


### PR DESCRIPTION
Remove the last Cargo.toml inconsistencies, see https://github.com/astral-sh/puffin/pull/468/files/1526b3458a10bd50f64748862af9d46b202c563d#r1401083681. Now all `[dependencies]` are workspace dependencies.