### PR TITLE
puffin_interpreter cleanup ahead of #235

### DIFF
--- a/crates/gourgeist/src/lib.rs
+++ b/crates/gourgeist/src/lib.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 pub use interpreter::parse_python_cli;
 use platform_host::PlatformError;
-use puffin_interpreter::{InterpreterInfo, Virtualenv};
+use puffin_interpreter::{Interpreter, Virtualenv};
 
 pub use crate::bare::create_bare_venv;
 
@@ -24,10 +24,13 @@ pub enum Error {
 }
 
 /// Create a virtualenv.
-pub fn create_venv(location: &Path, info: &InterpreterInfo) -> Result<Virtualenv, Error> {
+pub fn create_venv(location: &Path, interpreter: &Interpreter) -> Result<Virtualenv, Error> {
     let location: &Utf8Path = location
         .try_into()
         .map_err(|err: FromPathError| err.into_io_error())?;
-    let paths = create_bare_venv(location, info)?;
-    Ok(Virtualenv::new_prefix(paths.root.as_std_path(), info))
+    let paths = create_bare_venv(location, interpreter)?;
+    Ok(Virtualenv::new_prefix(
+        paths.root.as_std_path(),
+        interpreter,
+    ))
 }

--- a/crates/gourgeist/src/main.rs
+++ b/crates/gourgeist/src/main.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::{fmt, EnvFilter};
 
 use gourgeist::{create_bare_venv, parse_python_cli};
 use platform_host::Platform;
-use puffin_interpreter::InterpreterInfo;
+use puffin_interpreter::Interpreter;
 
 #[derive(Parser, Debug)]
 struct Cli {
@@ -25,7 +25,7 @@ fn run() -> Result<(), gourgeist::Error> {
     let location = cli.path.unwrap_or(Utf8PathBuf::from(".venv"));
     let python = parse_python_cli(cli.python)?;
     let platform = Platform::current()?;
-    let info = InterpreterInfo::query(python.as_std_path(), platform, None).unwrap();
+    let info = Interpreter::query(python.as_std_path(), platform, None).unwrap();
     create_bare_venv(&location, &info)?;
     Ok(())
 }

--- a/crates/puffin-build/src/lib.rs
+++ b/crates/puffin-build/src/lib.rs
@@ -27,7 +27,7 @@ use tracing::{debug, instrument};
 use zip::ZipArchive;
 
 use pep508_rs::Requirement;
-use puffin_interpreter::{InterpreterInfo, Virtualenv};
+use puffin_interpreter::{Interpreter, Virtualenv};
 use puffin_traits::BuildContext;
 
 /// e.g. `pygraphviz/graphviz_wrap.c:3020:10: fatal error: graphviz/cgraph.h: No such file or directory`
@@ -220,7 +220,7 @@ impl SourceBuild {
     pub async fn setup(
         source: &Path,
         subdirectory: Option<&Path>,
-        interpreter_info: &InterpreterInfo,
+        interpreter: &Interpreter,
         build_context: &impl BuildContext,
         source_build_context: SourceBuildContext,
         package_id: &str,
@@ -250,7 +250,7 @@ impl SourceBuild {
             None
         };
 
-        let venv = gourgeist::create_venv(&temp_dir.path().join(".venv"), interpreter_info)?;
+        let venv = gourgeist::create_venv(&temp_dir.path().join(".venv"), interpreter)?;
 
         // There are packages such as DTLSSocket 0.1.16 that say
         // ```toml

--- a/crates/puffin-cli/src/commands/pip_compile.rs
+++ b/crates/puffin-cli/src/commands/pip_compile.rs
@@ -116,24 +116,24 @@ pub(crate) async fn pip_compile(
 
     debug!(
         "Using Python {} at {}",
-        venv.interpreter_info().markers().python_version,
+        venv.interpreter().markers().python_version,
         venv.python_executable().display()
     );
 
     // Determine the compatible platform tags.
     let tags = Tags::from_env(
-        venv.interpreter_info().platform(),
-        venv.interpreter_info().simple_version(),
+        venv.interpreter().platform(),
+        venv.interpreter().simple_version(),
     )?;
 
     // Determine the markers to use for resolution.
     let markers = python_version.map_or_else(
-        || Cow::Borrowed(venv.interpreter_info().markers()),
-        |python_version| Cow::Owned(python_version.markers(venv.interpreter_info().markers())),
+        || Cow::Borrowed(venv.interpreter().markers()),
+        |python_version| Cow::Owned(python_version.markers(venv.interpreter().markers())),
     );
     // Inject the fake python version if necessary
     let interpreter_info = venv
-        .interpreter_info()
+        .interpreter()
         .clone()
         .patch_markers(markers.clone().into_owned());
 

--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -105,8 +105,8 @@ pub(crate) async fn sync_requirements(
 
     // Determine the current environment markers.
     let tags = Tags::from_env(
-        venv.interpreter_info().platform(),
-        venv.interpreter_info().simple_version(),
+        venv.interpreter().platform(),
+        venv.interpreter().simple_version(),
     )?;
 
     // Instantiate a client.
@@ -129,9 +129,8 @@ pub(crate) async fn sync_requirements(
     } else {
         let start = std::time::Instant::now();
 
-        let wheel_finder =
-            puffin_resolver::DistFinder::new(&tags, &client, venv.interpreter_info())
-                .with_reporter(FinderReporter::from(printer).with_length(remote.len() as u64));
+        let wheel_finder = puffin_resolver::DistFinder::new(&tags, &client, venv.interpreter())
+            .with_reporter(FinderReporter::from(printer).with_length(remote.len() as u64));
         let resolution = wheel_finder.resolve(&remote).await?;
 
         let s = if resolution.len() == 1 { "" } else { "s" };
@@ -223,7 +222,7 @@ pub(crate) async fn sync_requirements(
         let build_dispatch = BuildDispatch::new(
             client,
             cache.to_path_buf(),
-            venv.interpreter_info().clone(),
+            venv.interpreter().clone(),
             fs::canonicalize(venv.python_executable())?,
             no_build,
         );

--- a/crates/puffin-cli/src/commands/venv.rs
+++ b/crates/puffin-cli/src/commands/venv.rs
@@ -5,9 +5,10 @@ use anyhow::Result;
 use colored::Colorize;
 use fs_err as fs;
 use miette::{Diagnostic, IntoDiagnostic};
-use platform_host::Platform;
-use puffin_interpreter::InterpreterInfo;
 use thiserror::Error;
+
+use platform_host::Platform;
+use puffin_interpreter::Interpreter;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -43,7 +44,7 @@ enum VenvError {
 
     #[error("Failed to extract Python interpreter info")]
     #[diagnostic(code(puffin::venv::interpreter))]
-    InterpreterError(#[source] anyhow::Error),
+    InterpreterError(#[source] puffin_interpreter::Error),
 
     #[error("Failed to create virtual environment")]
     #[diagnostic(code(puffin::venv::creation))]
@@ -73,8 +74,8 @@ fn venv_impl(
     };
 
     let platform = Platform::current().into_diagnostic()?;
-    let interpreter_info = InterpreterInfo::query(&base_python, platform, None)
-        .map_err(VenvError::InterpreterError)?;
+    let interpreter_info =
+        Interpreter::query(&base_python, platform, None).map_err(VenvError::InterpreterError)?;
 
     writeln!(
         printer,

--- a/crates/puffin-dev/src/build.rs
+++ b/crates/puffin-dev/src/build.rs
@@ -46,7 +46,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
     let build_dispatch = BuildDispatch::new(
         RegistryClientBuilder::new(cache_dir.path().clone()).build(),
         cache_dir.path().clone(),
-        venv.interpreter_info().clone(),
+        venv.interpreter().clone(),
         fs::canonicalize(venv.python_executable())?,
         false,
     );

--- a/crates/puffin-dev/src/resolve_cli.rs
+++ b/crates/puffin-dev/src/resolve_cli.rs
@@ -50,15 +50,15 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
     let build_dispatch = BuildDispatch::new(
         client.clone(),
         cache_dir.path().clone(),
-        venv.interpreter_info().clone(),
+        venv.interpreter().clone(),
         fs::canonicalize(venv.python_executable())?,
         args.no_build,
     );
 
     // Copied from `BuildDispatch`
     let tags = Tags::from_env(
-        venv.interpreter_info().platform(),
-        venv.interpreter_info().simple_version(),
+        venv.interpreter().platform(),
+        venv.interpreter().simple_version(),
     )?;
     let resolver = Resolver::new(
         Manifest::new(
@@ -68,7 +68,7 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
             None,
         ),
         ResolutionOptions::default(),
-        venv.interpreter_info().markers(),
+        venv.interpreter().markers(),
         &tags,
         &client,
         &build_dispatch,

--- a/crates/puffin-dev/src/resolve_many.rs
+++ b/crates/puffin-dev/src/resolve_many.rs
@@ -52,7 +52,7 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
     let build_dispatch = BuildDispatch::new(
         RegistryClientBuilder::new(cache_dir.path().clone()).build(),
         cache_dir.path().clone(),
-        venv.interpreter_info().clone(),
+        venv.interpreter().clone(),
         fs::canonicalize(venv.python_executable())?,
         args.no_build,
     );

--- a/crates/puffin-installer/src/installer.rs
+++ b/crates/puffin-installer/src/installer.rs
@@ -41,7 +41,7 @@ impl<'a> Installer<'a> {
             wheels.par_iter().try_for_each(|wheel| {
                 let location = install_wheel_rs::InstallLocation::new(
                     self.venv.root(),
-                    self.venv.interpreter_info().simple_version(),
+                    self.venv.interpreter().simple_version(),
                 );
 
                 install_wheel_rs::linker::install_wheel(

--- a/crates/puffin-interpreter/src/lib.rs
+++ b/crates/puffin-interpreter/src/lib.rs
@@ -1,6 +1,44 @@
-pub use crate::interpreter_info::InterpreterInfo;
+use std::io;
+use std::path::PathBuf;
+use std::time::SystemTimeError;
+
+use thiserror::Error;
+
+pub use crate::interpreter::Interpreter;
 pub use crate::virtual_env::Virtualenv;
 
-mod interpreter_info;
+mod interpreter;
 mod python_platform;
 mod virtual_env;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Expected {0} to be a virtual environment, but pyvenv.cfg is missing")]
+    MissingPyVenvCfg(PathBuf),
+    #[error("Your virtualenv at {0} is broken. It contains a pyvenv.cfg but no python at {1}")]
+    BrokenVenv(PathBuf, PathBuf),
+    #[error("Both VIRTUAL_ENV and CONDA_PREFIX are set. Please unset one of them.")]
+    Conflict,
+    #[error("Couldn't find a virtualenv or conda environment (Looked for VIRTUAL_ENV, CONDA_PREFIX and .venv)")]
+    NotFound,
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error("Invalid modified date on {0}")]
+    SystemTime(PathBuf, #[source] SystemTimeError),
+    #[error("Failed to query python interpreter at {interpreter}")]
+    PythonSubcommandLaunch {
+        interpreter: PathBuf,
+        #[source]
+        err: io::Error,
+    },
+    #[error("{message}:\n--- stdout:\n{stdout}\n--- stderr:\n{stderr}\n---")]
+    PythonSubcommandOutput {
+        message: String,
+        stdout: String,
+        stderr: String,
+    },
+    #[error("Failed to write to cache")]
+    Cacache(#[from] cacache::Error),
+    #[error("Failed to write to cache")]
+    Serde(#[from] serde_json::Error),
+}

--- a/crates/puffin-resolver/src/finder.rs
+++ b/crates/puffin-resolver/src/finder.rs
@@ -15,7 +15,7 @@ use pep440_rs::Version;
 use pep508_rs::{Requirement, VersionOrUrl};
 use platform_tags::{TagPriority, Tags};
 use puffin_client::RegistryClient;
-use puffin_interpreter::InterpreterInfo;
+use puffin_interpreter::Interpreter;
 use puffin_normalize::PackageName;
 use pypi_types::{File, IndexUrl, SimpleJson};
 
@@ -26,21 +26,17 @@ pub struct DistFinder<'a> {
     tags: &'a Tags,
     client: &'a RegistryClient,
     reporter: Option<Box<dyn Reporter>>,
-    interpreter_info: &'a InterpreterInfo,
+    interpreter: &'a Interpreter,
 }
 
 impl<'a> DistFinder<'a> {
     /// Initialize a new distribution finder.
-    pub fn new(
-        tags: &'a Tags,
-        client: &'a RegistryClient,
-        interpreter_info: &'a InterpreterInfo,
-    ) -> Self {
+    pub fn new(tags: &'a Tags, client: &'a RegistryClient, interpreter: &'a Interpreter) -> Self {
         Self {
             tags,
             client,
             reporter: None,
-            interpreter_info,
+            interpreter,
         }
     }
 
@@ -157,7 +153,7 @@ impl<'a> DistFinder<'a> {
                 .requires_python
                 .as_ref()
                 .map_or(true, |requires_python| {
-                    requires_python.contains(self.interpreter_info.version())
+                    requires_python.contains(self.interpreter.version())
                 })
             {
                 continue;

--- a/crates/puffin-resolver/src/resolver.rs
+++ b/crates/puffin-resolver/src/resolver.rs
@@ -552,7 +552,7 @@ impl<'a, Context: BuildContext + Send + Sync> Resolver<'a, Context> {
                         metadata,
                         &package_name,
                         self.tags,
-                        self.build_context.interpreter_info().version(),
+                        self.build_context.interpreter().version(),
                         self.exclude_newer.as_ref(),
                     );
                     self.index

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -17,7 +17,7 @@ use pep508_rs::{MarkerEnvironment, Requirement, StringVersion};
 use platform_host::{Arch, Os, Platform};
 use platform_tags::Tags;
 use puffin_client::RegistryClientBuilder;
-use puffin_interpreter::{InterpreterInfo, Virtualenv};
+use puffin_interpreter::{Interpreter, Virtualenv};
 use puffin_resolver::{
     Graph, Manifest, PreReleaseMode, ResolutionMode, ResolutionOptions, Resolver,
 };
@@ -31,7 +31,7 @@ static EXCLUDE_NEWER: Lazy<DateTime<Utc>> = Lazy::new(|| {
 });
 
 struct DummyContext {
-    interpreter_info: InterpreterInfo,
+    interpreter: Interpreter,
 }
 
 impl BuildContext for DummyContext {
@@ -39,8 +39,8 @@ impl BuildContext for DummyContext {
         panic!("The test should not need to build source distributions")
     }
 
-    fn interpreter_info(&self) -> &InterpreterInfo {
-        &self.interpreter_info
+    fn interpreter(&self) -> &Interpreter {
+        &self.interpreter
     }
 
     fn base_python(&self) -> &Path {
@@ -82,7 +82,7 @@ async fn resolve(
     let temp_dir = tempdir()?;
     let client = RegistryClientBuilder::new(temp_dir.path()).build();
     let build_context = DummyContext {
-        interpreter_info: InterpreterInfo::artificial(
+        interpreter: Interpreter::artificial(
             Platform::current()?,
             markers.clone(),
             PathBuf::from("/dev/null"),

--- a/crates/puffin-traits/src/lib.rs
+++ b/crates/puffin-traits/src/lib.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use anyhow::Result;
 
 use pep508_rs::Requirement;
-use puffin_interpreter::{InterpreterInfo, Virtualenv};
+use puffin_interpreter::{Interpreter, Virtualenv};
 
 /// Avoid cyclic crate dependencies between resolver, installer and builder.
 ///
@@ -54,7 +54,7 @@ pub trait BuildContext {
 
     /// All (potentially nested) source distribution builds use the same base python and can reuse
     /// it's metadata (e.g. wheel compatibility tags).
-    fn interpreter_info(&self) -> &InterpreterInfo;
+    fn interpreter(&self) -> &Interpreter;
 
     /// The system (or conda) python interpreter to create venvs.
     fn base_python(&self) -> &Path;


### PR DESCRIPTION
Preparing for #235, some refactoring to `puffin_interpreter`.

* Added a dedicated error type instead of anyhow
* `InterpreterInfo` -> `Interpreter`
* `detect_virtual_env` now returns an option so it can be chained for #235