### PR TITLE
Allow `pip-compile` without a venv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,6 +2624,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "which",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -103,15 +103,23 @@ Puffin's `requirements.txt` files may not be portable across platforms and Pytho
 Puffin itself does not depend on Python, but it does need to locate a Python environment to (1)
 install dependencies into the environment, and (2) build source distributions.
 
-When running `pip-install` or `pip-sync`, Puffin will search for a Python environment in the
+When running `pip-sync` or `pip-install`, Puffin will search for a virtual environment in the
 following order:
 
 - An activated virtual environment based on the `VIRTUAL_ENV` environment variable.
 - An activated Conda environment based on the `CONDA_PREFIX` environment variable.
 - A virtual environment at `.venv` in the current directory, or in the nearest parent directory.
 
-If no Python environment is found, Puffin will prompt the user to create a virtual environment in
-the current directory.
+If no virtual environment is found, Puffin will prompt the user to create one in the current
+directory via `puffin venv`.
+
+When running `pip-compile`, Puffin does not _require_ a virtual environment and will search for a
+Python interpreter in the following order:
+
+- An activated virtual environment based on the `VIRTUAL_ENV` environment variable.
+- An activated Conda environment based on the `CONDA_PREFIX` environment variable.
+- A virtual environment at `.venv` in the current directory, or in the nearest parent directory.
+- The Python interpreter available as `python3` on the system path (preferring, e.g., `python3.7` if `--python-version=3.7` is specified).
 
 ### Dependency caching
 

--- a/crates/puffin-cli/src/main.rs
+++ b/crates/puffin-cli/src/main.rs
@@ -10,12 +10,12 @@ use colored::Colorize;
 use distribution_types::{IndexUrl, IndexUrls};
 use puffin_cache::{Cache, CacheArgs};
 use puffin_installer::Reinstall;
+use puffin_interpreter::PythonVersion;
 use puffin_normalize::{ExtraName, PackageName};
 use puffin_resolver::{PreReleaseMode, ResolutionMode};
 use requirements::ExtrasSpecification;
 
 use crate::commands::{extra_name_with_clap_error, ExitStatus};
-use crate::python_version::PythonVersion;
 use crate::requirements::RequirementsSource;
 
 #[cfg(target_os = "windows")]
@@ -37,7 +37,6 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 mod commands;
 mod logging;
 mod printer;
-mod python_version;
 mod requirements;
 
 #[derive(Parser)]
@@ -179,7 +178,7 @@ struct PipCompileArgs {
     ///
     /// If a patch version is omitted, the most recent known patch version for that minor version
     /// is assumed. For example, `3.7` is mapped to `3.7.17`.
-    #[arg(long, short, value_enum)]
+    #[arg(long, short)]
     python_version: Option<PythonVersion>,
 
     /// Try to resolve at a past time.

--- a/crates/puffin-interpreter/Cargo.toml
+++ b/crates/puffin-interpreter/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+which = { workspace = true}
 
 [dev-dependencies]
 indoc = { version = "2.0.4" }

--- a/crates/puffin-interpreter/src/lib.rs
+++ b/crates/puffin-interpreter/src/lib.rs
@@ -5,11 +5,13 @@ use std::time::SystemTimeError;
 use thiserror::Error;
 
 pub use crate::interpreter::Interpreter;
+pub use crate::python_version::PythonVersion;
 pub use crate::virtual_env::Virtualenv;
 
 mod cfg;
 mod interpreter;
 mod python_platform;
+mod python_version;
 mod virtual_env;
 
 #[derive(Debug, Error)]
@@ -20,6 +22,8 @@ pub enum Error {
     BrokenVenv(PathBuf, PathBuf),
     #[error("Both VIRTUAL_ENV and CONDA_PREFIX are set. Please unset one of them.")]
     Conflict,
+    #[error("Could not find `{0}` in PATH")]
+    WhichNotFound(String, #[source] which::Error),
     #[error("Failed to locate a virtualenv or Conda environment (checked: `VIRTUAL_ENV`, `CONDA_PREFIX`, and `.venv`). Run `puffin venv` to create a virtual environment.")]
     NotFound,
     #[error(transparent)]

--- a/crates/puffin-interpreter/src/python_version.rs
+++ b/crates/puffin-interpreter/src/python_version.rs
@@ -1,11 +1,12 @@
 use std::str::FromStr;
+
 use tracing::debug;
 
 use pep440_rs::Version;
 use pep508_rs::{MarkerEnvironment, StringVersion};
 
 #[derive(Debug, Clone)]
-pub(crate) struct PythonVersion(StringVersion);
+pub struct PythonVersion(StringVersion);
 
 impl FromStr for PythonVersion {
     type Err = String;
@@ -65,7 +66,7 @@ impl PythonVersion {
     ///
     /// The returned [`MarkerEnvironment`] will preserve the base environment's platform markers,
     /// but override its Python version markers.
-    pub(crate) fn markers(self, base: &MarkerEnvironment) -> MarkerEnvironment {
+    pub fn markers(self, base: &MarkerEnvironment) -> MarkerEnvironment {
         let mut markers = base.clone();
 
         // Ex) `implementation_version == "3.12.0"`
@@ -80,5 +81,15 @@ impl PythonVersion {
         markers.python_version = self.0;
 
         markers
+    }
+
+    /// Return the major version of this Python version.
+    pub fn major(&self) -> u64 {
+        self.0.release()[0]
+    }
+
+    /// Return the minor version of this Python version.
+    pub fn minor(&self) -> u64 {
+        self.0.release()[1]
     }
 }


### PR DESCRIPTION
The semantics are a bit unintuitive because `--python-version` is a preference when looking for a python version without a venv, but if we don't find that exact version we'll take `python3` and patch the markers. This will make more sense once we start provisioning python builds.

We can now resolve black with both python 3.8 and 3.12, with or without that python version being in scope. In the example below, `PATH=$HOME/.cargo/bin:/usr/bin` removes the pyenv builds and leaves only `python3`, which is python 3.11. 

```console
$ RUST_LOG=puffin::commands=debug cargo run --bin puffin -q -- pip-compile -v scripts/benchmarks/requirements/black.in --python-version py38
    0.004108s DEBUG puffin::commands::pip_compile Using Python 3.8 at /home/konsti/.local/bin/python3.8
Resolved 8 packages in 44ms
# This file was autogenerated by Puffin v0.0.1 via the following command:
#    puffin pip-compile -v scripts/benchmarks/requirements/black.in --python-version py38
black==23.11.0
[...]
platformdirs==4.0.0
    # via black
tomli==2.0.1
    # via black
typing-extensions==4.8.0
    # via black
$ PATH=$HOME/.cargo/bin:/usr/bin RUST_LOG=puffin::commands=debug cargo run --bin puffin -q -- pip-compile -v scripts/benchmarks/requirements/black.in --python-version py38
    0.004315s DEBUG puffin::commands::pip_compile Using Python 3.11 at /usr/bin/python3
Resolved 8 packages in 43ms
# This file was autogenerated by Puffin v0.0.1 via the following command:
#    puffin pip-compile -v scripts/benchmarks/requirements/black.in --python-version py38
black==23.11.0
[...]
platformdirs==4.0.0
    # via black
tomli==2.0.1
    # via black
typing-extensions==4.8.0
    # via black
```

```console
$ RUST_LOG=puffin::commands=debug cargo run --bin puffin -q -- pip-compile -v scripts/benchmarks/requirements/black.in --python-version py312
    0.004216s DEBUG puffin::commands::pip_compile Using Python 3.12 at /home/konsti/.local/bin/python3.12
Resolved 6 packages in 37ms
# This file was autogenerated by Puffin v0.0.1 via the following command:
#    puffin pip-compile -v scripts/benchmarks/requirements/black.in --python-version py312
black==23.11.0
[...]
platformdirs==4.0.0
    # via black
$ PATH=$HOME/.cargo/bin:/usr/bin RUST_LOG=puffin::commands=debug cargo run --bin puffin -q -- pip-compile -v scripts/benchmarks/requirements/black.in --python-version py312
    0.004190s DEBUG puffin::commands::pip_compile Using Python 3.11 at /usr/bin/python3
Resolved 6 packages in 39ms
# This file was autogenerated by Puffin v0.0.1 via the following command:
#    puffin pip-compile -v scripts/benchmarks/requirements/black.in --python-version py312
black==23.11.0
[...]
platformdirs==4.0.0
    # via black
```

Fixes #235.
