### PR TITLE
Perform a single Git fetch when building source distributions

### DIFF
--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -260,6 +260,18 @@ impl SourceDist {
             SourceDist::DirectUrl(_) | SourceDist::Git(_) | SourceDist::Path(_) => None,
         }
     }
+
+    #[must_use]
+    pub fn with_url(self, url: Url) -> Self {
+        match self {
+            SourceDist::DirectUrl(dist) => {
+                SourceDist::DirectUrl(DirectUrlSourceDist { url, ..dist })
+            }
+            SourceDist::Git(dist) => SourceDist::Git(GitSourceDist { url, ..dist }),
+            SourceDist::Path(dist) => SourceDist::Path(PathSourceDist { url, ..dist }),
+            dist @ SourceDist::Registry(_) => dist,
+        }
+    }
 }
 
 impl Metadata for RegistryBuiltDist {

--- a/crates/puffin-distribution/src/locks.rs
+++ b/crates/puffin-distribution/src/locks.rs
@@ -24,6 +24,8 @@ impl Locks {
     }
 }
 
+/// A file lock that is automatically released when dropped.
+#[derive(Debug)]
 pub(crate) struct LockedFile(File);
 
 impl LockedFile {
@@ -40,7 +42,7 @@ impl Drop for LockedFile {
     fn drop(&mut self) {
         if let Err(err) = self.0.file().unlock() {
             error!(
-                "Failed to unlock {}, the program might be stuck! Error: {}",
+                "Failed to unlock {}; program may be stuck: {}",
                 self.0.path().display(),
                 err
             );

--- a/crates/puffin-git/src/source.rs
+++ b/crates/puffin-git/src/source.rs
@@ -128,6 +128,7 @@ impl Fetch {
     pub fn path(&self) -> &Path {
         &self.path
     }
+
     pub fn into_git(self) -> GitUrl {
         self.git
     }


### PR DESCRIPTION
## Summary

We need to pass in the distribution with the "precise" URL to avoid refetching.

## Test Plan

Ran `cargo run -p puffin-cli -- pip-compile requirements.in --verbose` with `flask @ git+https://github.com/pallets/flask.git` and verified that we only checked out Flask once.