### PR TITLE
Avoid clone for `WheelMetadataCache`

### DIFF
--- a/crates/puffin-cache/src/metadata.rs
+++ b/crates/puffin-cache/src/metadata.rs
@@ -16,19 +16,19 @@ const BUILT_WHEEL_METADATA_CACHE: &str = "built-wheel-metadata-v0";
 /// See [`WheelMetadataCache::wheel_dir`] for remote wheel metadata caching and
 /// [`WheelMetadataCache::built_wheel_dir`] for caching of metadata of built source
 /// distributions.
-pub enum WheelMetadataCache {
+pub enum WheelMetadataCache<'a> {
     /// Either pypi or an alternative index, which we key by index url
-    Index(IndexUrl),
+    Index(&'a IndexUrl),
     /// A direct url dependency, which we key by url
-    Url(Url),
+    Url(&'a Url),
     /// A git dependency, which we key by repository url. We use the revision as filename.
     ///
     /// Note that this variant only exists for source distributions, wheels can't be delivered
     /// through git.
-    Git(Url),
+    Git(&'a Url),
 }
 
-impl WheelMetadataCache {
+impl<'a> WheelMetadataCache<'a> {
     fn bucket(&self) -> PathBuf {
         match self {
             WheelMetadataCache::Index(IndexUrl::Pypi) => PathBuf::from("pypi"),

--- a/crates/puffin-client/src/client.rs
+++ b/crates/puffin-client/src/client.rs
@@ -219,7 +219,7 @@ impl RegistryClient {
                 self.wheel_metadata_no_pep658(
                     &wheel.filename,
                     &wheel.url,
-                    WheelMetadataCache::Url(wheel.url.clone()),
+                    WheelMetadataCache::Url(&wheel.url),
                 )
                 .await?
             }
@@ -262,7 +262,7 @@ impl RegistryClient {
 
             let cache_dir = self
                 .cache
-                .join(WheelMetadataCache::Index(index).wheel_dir());
+                .join(WheelMetadataCache::Index(&index).wheel_dir());
             let cache_file = format!("{}.json", filename.stem());
 
             let response_callback = |response: Response| async {
@@ -278,17 +278,17 @@ impl RegistryClient {
             // If we lack PEP 658 support, try using HTTP range requests to read only the
             // `.dist-info/METADATA` file from the zip, and if that also fails, download the whole wheel
             // into the cache and read from there
-            self.wheel_metadata_no_pep658(&filename, &url, WheelMetadataCache::Index(index))
+            self.wheel_metadata_no_pep658(&filename, &url, WheelMetadataCache::Index(&index))
                 .await
         }
     }
 
     /// Get the wheel metadata if it isn't available in an index through PEP 658
-    async fn wheel_metadata_no_pep658(
+    async fn wheel_metadata_no_pep658<'data>(
         &self,
-        filename: &WheelFilename,
-        url: &Url,
-        cache_shard: WheelMetadataCache,
+        filename: &'data WheelFilename,
+        url: &'data Url,
+        cache_shard: WheelMetadataCache<'data>,
     ) -> Result<Metadata21, Error> {
         if self.no_index {
             return Err(Error::NoIndex(url.to_string()));


### PR DESCRIPTION
This doesn't need to own the underlying data which allows us to remove a number of clones.