### PR TITLE
Check compatibility for cached unzipped wheels

### DIFF
--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -115,13 +115,13 @@ impl BuildContext for BuildDispatch {
                 venv.root().display(),
             );
 
+            let tags = Tags::from_interpreter(&self.interpreter)?;
+
             let InstallPlan {
                 local,
                 remote,
                 extraneous,
-            } = InstallPlan::try_from_requirements(requirements, &self.cache, venv)?;
-
-            let tags = Tags::from_interpreter(&self.interpreter)?;
+            } = InstallPlan::try_from_requirements(requirements, &self.cache, venv, &tags)?;
 
             // Resolve the dependencies.
             let remote = if remote.is_empty() {

--- a/crates/puffin-installer/src/url_index.rs
+++ b/crates/puffin-installer/src/url_index.rs
@@ -4,8 +4,8 @@ use fxhash::FxHashMap;
 use tracing::warn;
 use url::Url;
 
+use distribution_filename::WheelFilename;
 use distribution_types::{CachedDirectUrlDist, Identifier};
-use puffin_normalize::PackageName;
 
 use crate::cache::{CacheShard, WheelCache};
 
@@ -49,13 +49,13 @@ impl UrlIndex {
     }
 
     /// Returns a distribution from the index, if it exists.
-    pub(crate) fn get(&self, name: &PackageName, url: &Url) -> Option<CachedDirectUrlDist> {
+    pub(crate) fn get(&self, filename: WheelFilename, url: &Url) -> Option<CachedDirectUrlDist> {
         // TODO(charlie): This takes advantage of the fact that for URL dependencies, the package ID
         // and distribution ID are identical. We should either change the cache layout to use
         // distribution IDs, or implement package ID for URL.
         let path = self.0.get(&url.distribution_id())?;
         Some(CachedDirectUrlDist::from_url(
-            name.clone(),
+            filename,
             url.clone(),
             path.clone(),
         ))


### PR DESCRIPTION
**Motivation** Previously, we would install any wheel with the correct package name and version from the cache, even if it doesn't match the current python interpreter.

**Summary** The unzipped wheel cache for registries now uses the entire wheel filename over the name-version (`editables-0.5-py3-none-any.whl` over `editables-0.5`).

Built wheels are not stored in the `wheels-v0` unzipped wheels cache anymore. For each source distribution, there can be multiple built wheels (with different compatibility tags), so i argue that we need a different cache structure for them (follow up PR).

For `all-kinds.in` with

```bash
rm -rf cache-all-kinds
virtualenv --clear -p 3.12 .venv
cargo run --bin puffin -- pip-sync --cache-dir cache-all-kinds target/all-kinds.txt
```

we get:

**Before**
```
cache-all-kinds/wheels-v0/
├── registry
│   ├── annotated_types-0.6.0
│   ├── asgiref-3.7.2
│   ├── blinker-1.7.0
│   ├── certifi-2023.11.17
│   ├── cffi-1.16.0
│   ├── [...]
│   ├── tzdata-2023.3
│   ├── urllib3-2.1.0
│   └── wheel-0.42.0
└── url
    ├── 4b8be67c801a7ecb
    │   ├── flask
    │   └── flask-3.0.0.dist-info
    ├── 6781bd6440ae72c2
    │   ├── werkzeug
    │   └── werkzeug-3.0.1.dist-info
    └── a67db8ed076e3814
        ├── pydantic_extra_types
        └── pydantic_extra_types-2.1.0.dist-info

48 directories, 0 files
```

**After**

```
cache-all-kinds/wheels-v0/
├── registry
│   ├── annotated_types-0.6.0-py3-none-any.whl
│   ├── asgiref-3.7.2-py3-none-any.whl
│   ├── blinker-1.7.0-py3-none-any.whl
│   ├── certifi-2023.11.17-py3-none-any.whl
│   ├── cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
│   ├── [...]
│   ├── tzdata-2023.3-py2.py3-none-any.whl
│   ├── urllib3-2.1.0-py3-none-any.whl
│   └── wheel-0.42.0-py3-none-any.whl
└── url
    └── 4b8be67c801a7ecb
        └── flask-3.0.0-py3-none-any.whl

39 directories, 0 files
```

**Outlook** Part of #477 "Fix wheel caching". Further tasks:
* Replace the `CacheShard` with `WheelMetadataCache` which handles urls properly.
* Delete unzipped wheels when their remote wheel changed
* Store built wheels next to the `metadata.json` in the source dist directory; delete built wheels when their source dist changed (different cache bucket, but it's the same problem of fixing wheel caching) I'll make stacked PRs for those