### PR TITLE
Skip tf-models-nightly in resolve-many dev script for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,7 @@ dependencies = [
  "puffin-client",
  "puffin-dispatch",
  "puffin-interpreter",
+ "puffin-normalize",
  "puffin-resolver",
  "puffin-traits",
  "pypi-types",

--- a/crates/puffin-dev/Cargo.toml
+++ b/crates/puffin-dev/Cargo.toml
@@ -25,6 +25,7 @@ puffin-cache = { path = "../puffin-cache", features = ["clap"] }
 puffin-client = { path = "../puffin-client" }
 puffin-dispatch = { path = "../puffin-dispatch" }
 puffin-interpreter = { path = "../puffin-interpreter" }
+puffin-normalize = { path = "../puffin-normalize" }
 puffin-resolver = { path = "../puffin-resolver" }
 pypi-types = { path = "../pypi-types" }
 puffin-traits = { path = "../puffin-traits" }


### PR DESCRIPTION
`tf-models-nightly` has pathologic backtracking behaviour, skip it for now so we can benchmark the rest.