### PR TITLE
Clear built wheels when remote changed

### DIFF
--- a/crates/puffin-cache/src/lib.rs
+++ b/crates/puffin-cache/src/lib.rs
@@ -91,12 +91,14 @@ impl Cache {
 pub enum CacheBucket {
     /// Downloaded remote wheel archives.
     Archives,
-    /// Metadata of a built source distribution.
+    /// Wheels built from source distributions, their extracted metadata and caching information
+    /// about the source distribution.
     ///
     /// Cache structure:
-    ///  * `<build wheel metadata cache>/pypi/foo-1.0.0.zip/metadata.json`
-    ///  * `<build wheel metadata cache>/<sha256(index-url)>/foo-1.0.0.zip/metadata.json`
-    ///  * `<build wheel metadata cache>/url/<sha256(url)>/foo-1.0.0.zip/metadata.json`
+    ///  * `<build wheel cache>/pypi/foo-1.0.0.zip/{metadata.json, foo-1.0.0-py3-none-any.whl, ...other wheels}`
+    ///  * `<build wheel cache>/<digest(index-url)>/foo-1.0.0.zip/{metadata.json, foo-1.0.0-py3-none-any.whl, ...other wheels}`
+    ///  * `<build wheel cache>/url/<digest(url)>/foo-1.0.0.zip/{metadata.json, foo-1.0.0-py3-none-any.whl, ...other wheels}`
+    ///  * `<build wheel cache>/git/<digest(url)>/<git sha>/foo-1.0.0.zip/{metadata.json, foo-1.0.0-py3-none-any.whl, ...other wheels}`
     ///
     /// But the url filename does not need to be a valid source dist filename
     /// (<https://github.com/search?q=path%3A**%2Frequirements.txt+master.zip&type=code>),
@@ -117,18 +119,21 @@ pub enum CacheBucket {
     ///
     /// ...may be cached as:
     /// ```text
-    /// built-wheel-metadata-v0
+    /// built-wheels-v0/
     /// ├── git
-    /// │   └── 5c56bc1c58c34c11
+    /// │   └── a67db8ed076e3814
     /// │       └── 843b753e9e8cb74e83cac55598719b39a4d5ef1f
-    /// │           └── metadata.json
+    /// │           ├── metadata.json
+    /// │           └── pydantic_extra_types-2.1.0-py3-none-any.whl
     /// ├── pypi
     /// │   └── django-allauth-0.51.0.tar.gz
+    /// │       ├── django_allauth-0.51.0-py3-none-any.whl
     /// │       └── metadata.json
     /// └── url
     ///     └── 6781bd6440ae72c2
     ///         └── werkzeug-3.0.1.tar.gz
-    ///             └── metadata.json
+    ///             ├── metadata.json
+    ///             └── werkzeug-3.0.1-py3-none-any.whl
     /// ```
     ///
     /// The inside of a `metadata.json`:
@@ -144,8 +149,6 @@ pub enum CacheBucket {
     ///   }
     /// }
     /// ```
-    BuiltWheelMetadata,
-    /// Wheel archives built from source distributions.
     BuiltWheels,
     /// Git repositories.
     Git,
@@ -230,7 +233,6 @@ impl CacheBucket {
     fn to_str(self) -> &'static str {
         match self {
             CacheBucket::Archives => "archives-v0",
-            CacheBucket::BuiltWheelMetadata => "built-wheel-metadata-v0",
             CacheBucket::BuiltWheels => "built-wheels-v0",
             CacheBucket::Git => "git-v0",
             CacheBucket::Interpreter => "interpreter-v0",

--- a/crates/puffin-cache/src/metadata.rs
+++ b/crates/puffin-cache/src/metadata.rs
@@ -10,9 +10,8 @@ use crate::{digest, CanonicalUrl};
 
 /// Cache wheel metadata, both from remote wheels and built from source distributions.
 ///
-/// See [`WheelMetadataCache::wheel_dir`]/[`CacheBucket::WheelMetadata`] for remote wheel metadata
-/// caching and [`WheelMetadataCache::built_wheel_dir`]/[`CacheBucket::BuiltWheelMetadata`] for
-/// built source distributions metadata caching.
+/// Use [`WheelMetadataCache::wheel_dir`] for remote wheel metadata caching and
+/// [`WheelMetadataCache::built_wheel_dir`] for built source distributions metadata caching.
 pub enum WheelMetadataCache<'a> {
     /// Either pypi or an alternative index, which we key by index url
     Index(&'a IndexUrl),
@@ -46,7 +45,7 @@ impl<'a> WheelMetadataCache<'a> {
         self.bucket()
     }
 
-    /// Metadata of a built source distribution. See [`CacheBucket::BuiltWheelMetadata`]
+    /// Metadata of a built source distribution. See [`CacheBucket::BuiltWheels`]
     pub fn built_wheel_dir(&self, filename: &str) -> PathBuf {
         self.bucket().join(filename)
     }

--- a/crates/puffin-cli/tests/pip_sync.rs
+++ b/crates/puffin-cli/tests/pip_sync.rs
@@ -555,6 +555,36 @@ fn install_sdist() -> Result<()> {
     Ok(())
 }
 
+/// Install a source distribution into a virtual environment.
+#[test]
+fn install_sdist_url() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let cache_dir = assert_fs::TempDir::new()?;
+    let venv = create_venv_py312(&temp_dir, &cache_dir);
+
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("Werkzeug @ https://files.pythonhosted.org/packages/63/69/5702e5eb897d1a144001e21d676676bcb87b88c0862f947509ea95ea54fc/Werkzeug-0.9.6.tar.gz")?;
+
+    insta::with_settings!({
+        filters => vec![
+            (r"(\d|\.)+(ms|s)", "[TIME]"),
+        ]
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-sync")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir));
+    });
+
+    check_command(&venv, "import werkzeug", &temp_dir);
+
+    Ok(())
+}
+
 /// Attempt to re-install a package into a virtual environment from a URL. The second install
 /// should be a no-op.
 #[test]

--- a/crates/puffin-cli/tests/snapshots/pip_sync__install_sdist_url.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_sync__install_sdist_url.snap
@@ -1,0 +1,23 @@
+---
+source: crates/puffin-cli/tests/pip_sync.rs
+info:
+  program: puffin
+  args:
+    - pip-sync
+    - requirements.txt
+    - "--cache-dir"
+    - /tmp/.tmptfyv49
+  env:
+    VIRTUAL_ENV: /tmp/.tmpquje1e/.venv
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+Resolved 1 package in [TIME]
+Downloaded 1 package in [TIME]
+Unzipped 1 package in [TIME]
+Installed 1 package in [TIME]
+ + werkzeug @ https://files.pythonhosted.org/packages/63/69/5702e5eb897d1a144001e21d676676bcb87b88c0862f947509ea95ea54fc/Werkzeug-0.9.6.tar.gz
+

--- a/crates/puffin-distribution/src/distribution_database.rs
+++ b/crates/puffin-distribution/src/distribution_database.rs
@@ -45,8 +45,6 @@ pub enum DistributionDatabaseError {
     Distribution(#[from] distribution_types::Error),
     #[error(transparent)]
     SourceBuild(#[from] SourceDistError),
-    #[error("Failed to build")]
-    Build(#[source] anyhow::Error),
     #[error("Git operation failed")]
     Git(#[source] anyhow::Error),
     /// Should not occur, i've only seen it when another task panicked


### PR DESCRIPTION
Remove built wheels alongside their metadata when their index source dist or url source dist changed. For git source dists, we currently don't clear the previous build but use a new directory (not sure what's right here - are there any generic cache GC approaches out there? I've seen that e.g. spotify keeps its cache at 10GB max, but i also haven't seen any reusable, well tested approaches for this). Path distributions are unchanged (#478).

I like the structure of metadata alongside the wheel for cache invalidation, i'll try to do that for `wheels-v0`/`wheel-metadata-v0` too. (The unzipped wheels afaik currently lack cache invalidation when the remote changed.) This should give is roughly the same structure for wheel and built wheels and a very similar pattern of invalidation.