### PR TITLE
Add CACHEDIR and .gitignore tags to cache directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
+name = "cachedir"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +2282,7 @@ dependencies = [
 name = "puffin-cache"
 version = "0.0.1"
 dependencies = [
+ "cachedir",
  "clap",
  "directories",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ async_http_range_reader = { git = "https://github.com/baszalmstra/async_http_ran
 async_zip = { version = "0.0.15", features = ["tokio", "deflate"] }
 bitflags = { version = "2.4.1" }
 bytesize = { version = "1.3.0" }
+cachedir = { version = "0.3.0" }
 camino = { version = "1.1.6", features = ["serde1"] }
 cargo-util = { version = "0.2.6" }
 chrono = { version = "0.4.31" }

--- a/crates/puffin-cache/Cargo.toml
+++ b/crates/puffin-cache/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 pypi-types = { path = "../pypi-types" }
 
+cachedir = { workspace = true }
 clap = { workspace = true, features = ["derive"], optional = true }
 directories = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/puffin-cache/src/cli.rs
+++ b/crates/puffin-cache/src/cli.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use directories::ProjectDirs;
-use fs_err as fs;
 
 use crate::Cache;
 
@@ -31,18 +30,14 @@ impl TryFrom<CacheArgs> for Cache {
     ///
     /// Returns an absolute cache dir.
     fn try_from(value: CacheArgs) -> Result<Self, Self::Error> {
-        let project_dirs = ProjectDirs::from("", "", "puffin");
         if value.no_cache {
-            Ok(Cache::temp()?)
+            Cache::temp()
         } else if let Some(cache_dir) = value.cache_dir {
-            fs::create_dir_all(&cache_dir)?;
-            Ok(Cache::from_path(fs::canonicalize(cache_dir)?))
-        } else if let Some(project_dirs) = project_dirs {
-            Ok(Cache::from_path(project_dirs.cache_dir().to_path_buf()))
+            Cache::from_path(cache_dir)
+        } else if let Some(project_dirs) = ProjectDirs::from("", "", "puffin") {
+            Cache::from_path(project_dirs.cache_dir())
         } else {
-            let cache_dir = ".puffin_cache";
-            fs::create_dir_all(cache_dir)?;
-            Ok(Cache::from_path(fs::canonicalize(cache_dir)?))
+            Cache::from_path(".puffin_cache")
         }
     }
 }

--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -185,13 +185,13 @@ pub(crate) async fn sync_requirements(
             .await
             .context("Failed to download distributions")?;
 
-        let download_s = if wheels.len() == 1 { "" } else { "s" };
+        let s = if wheels.len() == 1 { "" } else { "s" };
         writeln!(
             printer,
             "{}",
             format!(
                 "Downloaded {} in {}",
-                format!("{} package{}", wheels.len(), download_s).bold(),
+                format!("{} package{}", wheels.len(), s).bold(),
                 elapsed(start.elapsed())
             )
             .dimmed()


### PR DESCRIPTION
## Summary

Even if this will typically be in the user's application folder (rather than a local directory), it's still a good practice.

Closes https://github.com/astral-sh/puffin/issues/280.