### PR TITLE
Use full Python version when determining compatibility

### DIFF
--- a/crates/puffin-cli/tests/snapshots/venv__create_venv.snap
+++ b/crates/puffin-cli/tests/snapshots/venv__create_venv.snap
@@ -4,7 +4,7 @@ info:
   program: puffin
   args:
     - venv
-    - /var/folders/bc/qlsk3t6x7c9fhhbvvcg68k9c0000gp/T/.tmprOsp0M/.venv
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpINXhJh/.venv
     - "--python"
     - python3.12
 ---
@@ -13,6 +13,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-Using Python 3.11 at [PATH]
+Using Python [VERSION] at [PATH]
 Creating virtual environment at: /home/ferris/project/.venv
 

--- a/crates/puffin-cli/tests/snapshots/venv__create_venv_defaults_to_cwd.snap
+++ b/crates/puffin-cli/tests/snapshots/venv__create_venv_defaults_to_cwd.snap
@@ -12,6 +12,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-Using Python 3.11 at [PATH]
+Using Python [VERSION] at [PATH]
 Creating virtual environment at: .venv
 

--- a/crates/puffin-cli/tests/venv.rs
+++ b/crates/puffin-cli/tests/venv.rs
@@ -18,7 +18,7 @@ fn create_venv() -> Result<()> {
 
     insta::with_settings!({
         filters => vec![
-            (r"Using Python 3.12 at .+", "Using Python 3.11 at [PATH]"),
+            (r"Using Python 3\.\d+\.\d+ at .+", "Using Python [VERSION] at [PATH]"),
             (temp_dir.to_str().unwrap(), "/home/ferris/project"),
         ]
     }, {
@@ -42,7 +42,7 @@ fn create_venv_defaults_to_cwd() -> Result<()> {
 
     insta::with_settings!({
         filters => vec![
-            (r"Using Python 3.12 at .+", "Using Python 3.11 at [PATH]"),
+            (r"Using Python 3\.\d+\.\d+ at .+", "Using Python [VERSION] at [PATH]"),
             (temp_dir.to_str().unwrap(), "/home/ferris/project"),
         ]
     }, {

--- a/crates/puffin-interpreter/src/interpreter.rs
+++ b/crates/puffin-interpreter/src/interpreter.rs
@@ -75,7 +75,7 @@ impl Interpreter {
 
     /// Returns the Python version.
     pub fn version(&self) -> &Version {
-        &self.markers.python_version.version
+        &self.markers.python_full_version.version
     }
 
     /// Returns the Python version as a simple tuple.

--- a/crates/puffin-resolver/src/finder.rs
+++ b/crates/puffin-resolver/src/finder.rs
@@ -149,11 +149,11 @@ impl<'a> DistFinder<'a> {
             // compatibility and wheels which may be tagged `py3-none-any` but
             // have `requires-python: ">=3.9"`
             // TODO(konstin): https://github.com/astral-sh/puffin/issues/406
-            if !file
+            if file
                 .requires_python
                 .as_ref()
-                .map_or(true, |requires_python| {
-                    requires_python.contains(self.interpreter.version())
+                .is_some_and(|requires_python| {
+                    !requires_python.contains(self.interpreter.version())
                 })
             {
                 continue;


### PR DESCRIPTION
## Summary

When resolving with Python 3.7.13, I was failing to find a matching distribution that required Python 3.7.9 or later.