### PR TITLE
Enforce target and interpreter `requires-python` versions

### DIFF
--- a/crates/puffin-cli/src/commands/pip_compile.rs
+++ b/crates/puffin-cli/src/commands/pip_compile.rs
@@ -124,16 +124,14 @@ pub(crate) async fn pip_compile(
     // Determine the compatible platform tags.
     let tags = Tags::from_interpreter(venv.interpreter())?;
 
+    // Determine the interpreter to use for resolution.
+    let interpreter = venv.interpreter().clone();
+
     // Determine the markers to use for resolution.
     let markers = python_version.map_or_else(
         || Cow::Borrowed(venv.interpreter().markers()),
         |python_version| Cow::Owned(python_version.markers(venv.interpreter().markers())),
     );
-    // Inject the fake python version if necessary
-    let interpreter_info = venv
-        .interpreter()
-        .clone()
-        .patch_markers(markers.clone().into_owned());
 
     // Instantiate a client.
     let client = RegistryClientBuilder::new(cache.clone())
@@ -143,7 +141,7 @@ pub(crate) async fn pip_compile(
     let build_dispatch = BuildDispatch::new(
         client.clone(),
         cache.clone(),
-        interpreter_info,
+        interpreter,
         fs::canonicalize(venv.python_executable())?,
         no_build,
         index_urls,

--- a/crates/puffin-interpreter/src/interpreter.rs
+++ b/crates/puffin-interpreter/src/interpreter.rs
@@ -95,12 +95,6 @@ impl Interpreter {
     pub fn sys_executable(&self) -> &Path {
         &self.sys_executable
     }
-
-    /// Inject markers of a fake python version
-    #[must_use]
-    pub fn patch_markers(self, markers: MarkerEnvironment) -> Self {
-        Self { markers, ..self }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/crates/puffin-resolver/src/resolver.rs
+++ b/crates/puffin-resolver/src/resolver.rs
@@ -551,7 +551,8 @@ impl<'a, Context: BuildContext + Send + Sync> Resolver<'a, Context> {
                         metadata,
                         &package_name,
                         self.tags,
-                        self.build_context.interpreter().version(),
+                        self.markers,
+                        self.build_context.interpreter(),
                         self.exclude_newer.as_ref(),
                     );
                     self.index


### PR DESCRIPTION
## Summary

This PR modifies the behavior of our `--python-version` override in two ways:

1. First, we always use the "real" interpreter in the source distribution builder. I think this is correct. We don't need to use the fake markers for recursive builds, because all we care about is the top-level resolution, and we already assume that a single source distribution will always return the same metadata regardless of its build environment.
2. Second, we require that source distributions are compatible with _both_ the "real" interpreter version and the marker environment. This ensures that we don't try to build source distributions that are compatible with our interpreter, but incompatible with the target version.

Closes https://github.com/astral-sh/puffin/issues/407.