### PR TITLE
Ignore empty `VIRTUAL_ENV` variables

### DIFF
--- a/crates/puffin-cli/src/commands/clean.rs
+++ b/crates/puffin-cli/src/commands/clean.rs
@@ -31,10 +31,10 @@ pub(crate) fn clean(cache: &Cache, mut printer: Printer) -> Result<ExitStatus> {
     {
         if entry.file_type()?.is_dir() {
             fs::remove_dir_all(entry.path())
-                .with_context(|| format!("Failed to clear cache at {}", cache.root().display()))?;
+                .with_context(|| format!("Failed to clear cache at: {}", cache.root().display()))?;
         } else {
             fs::remove_file(entry.path())
-                .with_context(|| format!("Failed to clear cache at {}", cache.root().display()))?;
+                .with_context(|| format!("Failed to clear cache at: {}", cache.root().display()))?;
         }
     }
 

--- a/crates/puffin-interpreter/src/lib.rs
+++ b/crates/puffin-interpreter/src/lib.rs
@@ -15,17 +15,17 @@ mod virtual_env;
 pub enum Error {
     #[error("Expected {0} to be a virtual environment, but pyvenv.cfg is missing")]
     MissingPyVenvCfg(PathBuf),
-    #[error("Your virtualenv at {0} is broken. It contains a pyvenv.cfg but no python at {1}")]
+    #[error("Detected a broken virtualenv at: {0}. It contains a pyvenv.cfg but no Python binary at: {1}")]
     BrokenVenv(PathBuf, PathBuf),
     #[error("Both VIRTUAL_ENV and CONDA_PREFIX are set. Please unset one of them.")]
     Conflict,
-    #[error("Couldn't find a virtualenv or conda environment (Looked for VIRTUAL_ENV, CONDA_PREFIX and .venv)")]
+    #[error("Failed to locate a virtualenv or Conda environment (checked: VIRTUAL_ENV, CONDA_PREFIX, and .venv)")]
     NotFound,
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error("Invalid modified date on {0}")]
     SystemTime(PathBuf, #[source] SystemTimeError),
-    #[error("Failed to query python interpreter at {interpreter}")]
+    #[error("Failed to query python interpreter at: {interpreter}")]
     PythonSubcommandLaunch {
         interpreter: PathBuf,
         #[source]


### PR DESCRIPTION
I'm not sure how my interpreter gets into this state, but it's certainly wrong to respect these.