### PR TITLE
Improve wheel cache docs: Unzipping is lazy

### DIFF
--- a/crates/puffin-cache/src/lib.rs
+++ b/crates/puffin-cache/src/lib.rs
@@ -213,9 +213,11 @@ pub enum CacheBucket {
     /// TODO(konstin): The cache policy should be on the source dist level, the metadata we can put
     /// next to the wheels as in the `Wheels` bucket.
     ///
-    /// When resolving, we only build the wheel and store the archive file in the cache, when
-    /// installing, we unpack it and store it as directory under the same name, so it's a mix of
-    /// wheel archive zip files and unzipped wheel directories in the cache.
+    /// Source distributions are built into zipped wheel files (as PEP 517 specifies) and unzipped
+    /// lazily before installing. So when resolving, we only build the wheel and store the archive
+    /// file in the cache, when installing, we unpack it and replace the zip file with an unzipped
+    /// directory under the same. You may find a mix of wheel archive zip files and unzipped
+    /// wheel directories in the cache.
     ///
     /// Cache structure:
     ///  * `built-wheels-v0/pypi/foo-1.0.0.zip/{metadata.json, foo-1.0.0-py3-none-any.whl, ...other wheels}`

--- a/crates/puffin-installer/src/unzipper.rs
+++ b/crates/puffin-installer/src/unzipper.rs
@@ -63,7 +63,7 @@ impl Unzipper {
                             normalized_path.display()
                         );
                     }
-                    fs_err::rename(staging.path(), &normalized_path)?;
+                    fs_err::rename(staging.into_path(), &normalized_path)?;
 
                     Ok(normalized_path)
                 }


### PR DESCRIPTION
Also sneaking `fs_err::rename(staging.into_path(), &normalized_path)?` in here, for a better resolution of https://github.com/astral-sh/puffin/pull/524#discussion_r1412459016