### PR TITLE
Fix cargo warning

### DIFF
--- a/crates/puffin-interpreter/Cargo.toml
+++ b/crates/puffin-interpreter/Cargo.toml
@@ -27,4 +27,4 @@ serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 indoc = { version = "2.0.4" }
-tempfile = { worspace = true }
+tempfile = { version = "3.8.1" }


### PR DESCRIPTION
It's odd that `dev-dependencies` don't default to `dependencies` for workspace versions.