### PR TITLE
Use atomic writes for the cache consistently

### DIFF
--- a/crates/gourgeist/src/bare.rs
+++ b/crates/gourgeist/src/bare.rs
@@ -73,7 +73,7 @@ pub fn create_bare_venv(location: &Utf8Path, interpreter: &Interpreter) -> io::R
         }
     }
     fs::create_dir_all(location)?;
-    // TODO: I bet on windows we'll have to strip the prefix again
+    // TODO(konstin): I bet on windows we'll have to strip the prefix again
     let location = location.canonicalize_utf8()?;
     let bin_dir = {
         #[cfg(unix)]

--- a/crates/puffin-cache/Cargo.toml
+++ b/crates/puffin-cache/Cargo.toml
@@ -19,7 +19,7 @@ pypi-types = { path = "../pypi-types" }
 cachedir = { workspace = true }
 clap = { workspace = true, features = ["derive"], optional = true }
 directories = { workspace = true }
-fs-err = { workspace = true }
+fs-err = { workspace = true, features = ["tokio"] }
 hex = { workspace = true }
 seahash = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/puffin-cache/src/lib.rs
+++ b/crates/puffin-cache/src/lib.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use fs_err as fs;
-use tempfile::{tempdir, TempDir};
+use tempfile::{tempdir, NamedTempFile, TempDir};
 
 pub use canonical_url::{CanonicalUrl, RepositoryUrl};
 #[cfg(feature = "clap")]
@@ -342,4 +342,46 @@ impl Display for CacheBucket {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.to_str())
     }
+}
+
+/// Write `data` to `path` atomically using a temporary file and atomic rename.   
+pub async fn write_atomic(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> io::Result<()> {
+    let temp_file = NamedTempFile::new_in(
+        path.as_ref()
+            .parent()
+            .expect("Cache path must have a parent"),
+    )?;
+    fs_err::tokio::write(&temp_file, &data).await?;
+    temp_file.persist(&path).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "Failed to persist temporary file to {}: {}",
+                path.as_ref().display(),
+                err.error
+            ),
+        )
+    })?;
+    Ok(())
+}
+
+/// Write `data` to `path` atomically using a temporary file and atomic rename.   
+pub fn write_atomic_sync(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> io::Result<()> {
+    let temp_file = NamedTempFile::new_in(
+        path.as_ref()
+            .parent()
+            .expect("Cache path must have a parent"),
+    )?;
+    fs_err::write(&temp_file, &data)?;
+    temp_file.persist(&path).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "Failed to persist temporary file to {}: {}",
+                path.as_ref().display(),
+                err.error
+            ),
+        )
+    })?;
+    Ok(())
 }

--- a/crates/puffin-cli/src/commands/venv.rs
+++ b/crates/puffin-cli/src/commands/venv.rs
@@ -88,10 +88,6 @@ fn venv_impl(
     )
     .into_diagnostic()?;
 
-    // If the path already exists, remove it.
-    fs::remove_file(path).ok();
-    fs::remove_dir_all(path).ok();
-
     writeln!(
         printer,
         "Creating virtual environment at: {}",


### PR DESCRIPTION
Ensure we're using atomic writes everywhere in our cache to avoid broken cache records and error with parallel puffin actions (https://github.com/astral-sh/puffin/pull/544#issuecomment-1838841581).

All json files that are written to the cache are written atomically and the build wheels are written to temp dir and then moved atomically. I didn't touch venv creation though, i don't think that's worth it since python does not support atomic package installation through its design.