### PR TITLE
Improve error messages for 'file not found' case

### DIFF
--- a/crates/distribution-types/src/error.rs
+++ b/crates/distribution-types/src/error.rs
@@ -10,4 +10,7 @@ pub enum Error {
 
     #[error("Unable to extract filename from URL: {0}")]
     UrlFilename(Url),
+
+    #[error("Unable to locate distribution at: {0}")]
+    NotFound(Url, #[source] std::io::Error),
 }

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -198,7 +198,8 @@ impl Dist {
             let path = url
                 .to_file_path()
                 .map_err(|()| Error::UrlFilename(url.clone()))?
-                .canonicalize()?;
+                .canonicalize()
+                .map_err(|err| Error::NotFound(url.clone(), err))?;
             return if path
                 .extension()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("whl"))

--- a/crates/puffin-cli/tests/snapshots/pip_compile__compile_git_mismatched_name.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_compile__compile_git_mismatched_name.snap
@@ -6,17 +6,17 @@ info:
     - pip-compile
     - requirements.in
     - "--cache-dir"
-    - /tmp/.tmpR1rZex
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpUI3Kjp
     - "--exclude-newer"
     - "2023-11-18T12:00:00Z"
   env:
-    VIRTUAL_ENV: /tmp/.tmpy0g4rP/.venv
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpDZkiLP/.venv
 ---
 success: false
 exit_code: 2
 ----- stdout -----
 
 ----- stderr -----
-error: Failed to download and build dask @ git+https://github.com/pallets/flask.git@3.0.0
+error: Failed to download and build: dask @ git+https://github.com/pallets/flask.git@3.0.0
   Caused by: Package metadata name `flask` does not match given name `dask`
 

--- a/crates/puffin-cli/tests/snapshots/pip_compile__compile_wheel_path_dependency_missing.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_compile__compile_wheel_path_dependency_missing.snap
@@ -1,0 +1,22 @@
+---
+source: crates/puffin-cli/tests/pip_compile.rs
+info:
+  program: puffin
+  args:
+    - pip-compile
+    - requirements.in
+    - "--cache-dir"
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpI36Udp
+    - "--exclude-newer"
+    - "2023-11-18T12:00:00Z"
+  env:
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpuH6gF4/.venv
+---
+success: false
+exit_code: 2
+----- stdout -----
+
+----- stderr -----
+error: Unable to locate distribution at: file://[TEMP_DIR]/flask-3.0.0-py3-none-any.whl
+  Caused by: No such file or directory (os error 2)
+

--- a/crates/puffin-client/src/cached_client.rs
+++ b/crates/puffin-client/src/cached_client.rs
@@ -125,7 +125,7 @@ impl CachedClient {
                     serde_json::to_vec(&data_with_cache_policy).map_err(crate::Error::from)?,
                 )
                 .await
-                .map_err(crate::Error::from)?;
+                .map_err(crate::Error::CacheWrite)?;
                 Ok(data_with_cache_policy.data)
             }
             CachedResponse::ModifiedOrNew(res, cache_policy) => {
@@ -136,12 +136,12 @@ impl CachedClient {
                     let data_with_cache_policy = DataWithCachePolicy { data, cache_policy };
                     fs_err::tokio::create_dir_all(&cache_entry.dir)
                         .await
-                        .map_err(crate::Error::from)?;
+                        .map_err(crate::Error::CacheWrite)?;
                     let data =
                         serde_json::to_vec(&data_with_cache_policy).map_err(crate::Error::from)?;
                     write_atomic(cache_entry.path(), data)
                         .await
-                        .map_err(crate::Error::from)?;
+                        .map_err(crate::Error::CacheWrite)?;
                     Ok(data_with_cache_policy.data)
                 } else {
                     Ok(data)

--- a/crates/puffin-client/src/error.rs
+++ b/crates/puffin-client/src/error.rs
@@ -68,7 +68,10 @@ pub enum Error {
     Zip(WheelFilename, #[source] ZipError),
 
     #[error("Failed to write to the client cache")]
-    IO(#[from] io::Error),
+    CacheWrite(#[source] io::Error),
+
+    #[error(transparent)]
+    Io(#[from] io::Error),
 
     /// An [`io::Error`] with a filename attached
     #[error(transparent)]

--- a/crates/puffin-resolver/src/error.rs
+++ b/crates/puffin-resolver/src/error.rs
@@ -5,7 +5,7 @@ use pubgrub::report::{DefaultStringReporter, Reporter};
 use thiserror::Error;
 use url::Url;
 
-use distribution_types::{BuiltDist, SourceDist};
+use distribution_types::{BuiltDist, PathBuiltDist, PathSourceDist, SourceDist};
 use pep508_rs::Requirement;
 use puffin_distribution::DistributionDatabaseError;
 use puffin_normalize::PackageName;
@@ -54,11 +54,17 @@ pub enum ResolveError {
     #[error(transparent)]
     DistributionType(#[from] distribution_types::Error),
 
-    #[error("Failed to download {0}")]
+    #[error("Failed to download: {0}")]
     Fetch(Box<BuiltDist>, #[source] DistributionDatabaseError),
 
-    #[error("Failed to download and build {0}")]
+    #[error("Failed to download and build: {0}")]
     FetchAndBuild(Box<SourceDist>, #[source] DistributionDatabaseError),
+
+    #[error("Failed to read: {0}")]
+    Read(Box<PathBuiltDist>, #[source] DistributionDatabaseError),
+
+    #[error("Failed to build: {0}")]
+    Build(Box<PathSourceDist>, #[source] DistributionDatabaseError),
 }
 
 impl<T> From<futures::channel::mpsc::TrySendError<T>> for ResolveError {

--- a/crates/puffin-resolver/src/resolver.rs
+++ b/crates/puffin-resolver/src/resolver.rs
@@ -17,7 +17,7 @@ use url::Url;
 use waitmap::WaitMap;
 
 use distribution_filename::WheelFilename;
-use distribution_types::{Dist, Identifier, Metadata, SourceDist, VersionOrUrl};
+use distribution_types::{BuiltDist, Dist, Identifier, Metadata, SourceDist, VersionOrUrl};
 use pep508_rs::{MarkerEnvironment, Requirement};
 use platform_tags::Tags;
 use puffin_cache::CanonicalUrl;
@@ -610,6 +610,12 @@ impl<'a, Context: BuildContext + Send + Sync> Resolver<'a, Context> {
                     .get_or_build_wheel_metadata(&dist)
                     .await
                     .map_err(|err| match dist.clone() {
+                        Dist::Built(BuiltDist::Path(built_dist)) => {
+                            ResolveError::Read(Box::new(built_dist), err)
+                        }
+                        Dist::Source(SourceDist::Path(source_dist)) => {
+                            ResolveError::Build(Box::new(source_dist), err)
+                        }
                         Dist::Built(built_dist) => ResolveError::Fetch(Box::new(built_dist), err),
                         Dist::Source(source_dist) => {
                             ResolveError::FetchAndBuild(Box::new(source_dist), err)


### PR DESCRIPTION
Right now, if you specify a wheel that doesn't exist, you get: `no such file or directory` with no additional context. Oops!