### PR TITLE
Use `u64` instead of `u32` in `Version` fields

### DIFF
--- a/crates/puffin-distribution/src/download.rs
+++ b/crates/puffin-distribution/src/download.rs
@@ -76,6 +76,7 @@ pub struct SourceDistDownload {
 
 /// A downloaded distribution, either a wheel or a source distribution.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Download {
     Wheel(LocalWheel),
     SourceDist(SourceDistDownload),

--- a/crates/puffin-resolver/src/pubgrub/specifier.rs
+++ b/crates/puffin-resolver/src/pubgrub/specifier.rs
@@ -71,7 +71,7 @@ impl TryFrom<&VersionSpecifier> for PubGrubSpecifier {
                 } else if let Some(post) = low.post {
                     low.post = Some(post + 1);
                 } else {
-                    low.post = Some(u32::MAX);
+                    low.post = Some(u64::MAX);
                 }
                 let version = PubGrubVersion::from(specifier.version().clone());
                 Range::strictly_higher_than(version)


### PR DESCRIPTION
It turns out that it's not uncommon to use timestamps as patch versions (e.g., `20230628214621`). I believe this is the ISO 8601 "basic format". These can't be represented by a `u32`, so I think it makes sense to just bump to `u64` to remove this limitation.