### PR TITLE
Remove existing built wheels when building source distributions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,6 +2261,7 @@ dependencies = [
  "once_cell",
  "pep508_rs",
  "platform-host",
+ "puffin-fs",
  "puffin-interpreter",
  "puffin-traits",
  "pypi-types",
@@ -2363,6 +2364,7 @@ dependencies = [
  "http-cache-semantics",
  "install-wheel-rs",
  "puffin-cache",
+ "puffin-fs",
  "puffin-normalize",
  "pypi-types",
  "reqwest",
@@ -2460,6 +2462,7 @@ dependencies = [
  "platform-tags",
  "puffin-cache",
  "puffin-client",
+ "puffin-fs",
  "puffin-git",
  "puffin-normalize",
  "puffin-traits",
@@ -2476,6 +2479,14 @@ dependencies = [
  "tracing",
  "url",
  "zip",
+]
+
+[[package]]
+name = "puffin-fs"
+version = "0.0.1"
+dependencies = [
+ "fs-err",
+ "tempfile",
 ]
 
 [[package]]
@@ -2537,6 +2548,7 @@ dependencies = [
  "pep508_rs",
  "platform-host",
  "puffin-cache",
+ "puffin-fs",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/README.md
+++ b/crates/README.md
@@ -68,6 +68,10 @@ Implements the traits defined in `puffin-traits`.
 Client for interacting with built distributions (wheels) and source distributions (sdists).
 Capable of fetching metadata, distribution contents, etc.
 
+## [puffin-fs](./puffin-fs)
+
+Utilities for interacting with the filesystem.
+
 ## [puffin-git](./puffin-git)
 
 Functionality for interacting with Git repositories.

--- a/crates/puffin-build/Cargo.toml
+++ b/crates/puffin-build/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 gourgeist = { path = "../gourgeist" }
 pep508_rs = { path = "../pep508-rs" }
 platform-host = { path = "../platform-host" }
+puffin-fs = { path = "../puffin-fs" }
 puffin-interpreter = { path = "../puffin-interpreter" }
 puffin-traits = { path = "../puffin-traits" }
 pypi-types = { path = "../pypi-types" }

--- a/crates/puffin-cache/src/lib.rs
+++ b/crates/puffin-cache/src/lib.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use fs_err as fs;
-use tempfile::{tempdir, NamedTempFile, TempDir};
+use tempfile::{tempdir, TempDir};
 
 pub use canonical_url::{CanonicalUrl, RepositoryUrl};
 #[cfg(feature = "clap")]
@@ -342,46 +342,4 @@ impl Display for CacheBucket {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.to_str())
     }
-}
-
-/// Write `data` to `path` atomically using a temporary file and atomic rename.   
-pub async fn write_atomic(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> io::Result<()> {
-    let temp_file = NamedTempFile::new_in(
-        path.as_ref()
-            .parent()
-            .expect("Cache path must have a parent"),
-    )?;
-    fs_err::tokio::write(&temp_file, &data).await?;
-    temp_file.persist(&path).map_err(|err| {
-        io::Error::new(
-            io::ErrorKind::Other,
-            format!(
-                "Failed to persist temporary file to {}: {}",
-                path.as_ref().display(),
-                err.error
-            ),
-        )
-    })?;
-    Ok(())
-}
-
-/// Write `data` to `path` atomically using a temporary file and atomic rename.   
-pub fn write_atomic_sync(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> io::Result<()> {
-    let temp_file = NamedTempFile::new_in(
-        path.as_ref()
-            .parent()
-            .expect("Cache path must have a parent"),
-    )?;
-    fs_err::write(&temp_file, &data)?;
-    temp_file.persist(&path).map_err(|err| {
-        io::Error::new(
-            io::ErrorKind::Other,
-            format!(
-                "Failed to persist temporary file to {}: {}",
-                path.as_ref().display(),
-                err.error
-            ),
-        )
-    })?;
-    Ok(())
 }

--- a/crates/puffin-client/Cargo.toml
+++ b/crates/puffin-client/Cargo.toml
@@ -8,6 +8,7 @@ distribution-filename = { path = "../distribution-filename" }
 distribution-types = { path = "../distribution-types" }
 install-wheel-rs = { path = "../install-wheel-rs" }
 puffin-cache = { path = "../puffin-cache" }
+puffin-fs = { path = "../puffin-fs" }
 puffin-normalize = { path = "../puffin-normalize" }
 pypi-types = { path = "../pypi-types" }
 

--- a/crates/puffin-client/src/cached_client.rs
+++ b/crates/puffin-client/src/cached_client.rs
@@ -8,7 +8,8 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace, warn};
 
-use puffin_cache::{write_atomic, CacheEntry};
+use puffin_cache::CacheEntry;
+use puffin_fs::write_atomic;
 
 /// Either a cached client error or a (user specified) error from the callback
 pub enum CachedClientError<CallbackError> {

--- a/crates/puffin-distribution/Cargo.toml
+++ b/crates/puffin-distribution/Cargo.toml
@@ -19,6 +19,7 @@ install-wheel-rs = { path = "../install-wheel-rs" }
 platform-tags = { path = "../platform-tags" }
 puffin-cache = { path = "../puffin-cache" }
 puffin-client = { path = "../puffin-client" }
+puffin-fs = { path = "../puffin-fs" }
 puffin-git = { path = "../puffin-git" }
 puffin-normalize = { path = "../puffin-normalize" }
 puffin-traits = { path = "../puffin-traits" }

--- a/crates/puffin-distribution/src/distribution_database.rs
+++ b/crates/puffin-distribution/src/distribution_database.rs
@@ -192,6 +192,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                     debug!("Fetching disk-based wheel from registry: {dist} ({size})");
 
                     // Download the wheel into the cache.
+                    // TODO(charlie): Use an atomic write, and remove any existing files or directories.
                     fs::create_dir_all(&cache_entry.dir).await?;
                     let mut writer = fs::File::create(cache_entry.path()).await?;
                     tokio::io::copy(&mut reader.compat(), &mut writer).await?;
@@ -224,7 +225,8 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                 // Fetch the wheel.
                 let reader = self.client.stream_external(&wheel.url).await?;
 
-                // Download the wheel to the directory.
+                // Download the wheel into the cache.
+                // TODO(charlie): Use an atomic write, and remove any existing files or directories.
                 fs::create_dir_all(&cache_entry.dir).await?;
                 let mut writer = fs::File::create(&cache_entry.path()).await?;
                 tokio::io::copy(&mut reader.compat(), &mut writer).await?;

--- a/crates/puffin-distribution/src/source_dist.rs
+++ b/crates/puffin-distribution/src/source_dist.rs
@@ -24,8 +24,9 @@ use distribution_types::direct_url::{DirectArchiveUrl, DirectGitUrl};
 use distribution_types::{GitSourceDist, Identifier, RemoteSource, SourceDist};
 use install_wheel_rs::read_dist_info;
 use platform_tags::Tags;
-use puffin_cache::{digest, write_atomic, CacheBucket, CacheEntry, CanonicalUrl, WheelCache};
-use puffin_client::{CachedClient, CachedClientError, DataWithCachePolicy, Error};
+use puffin_cache::{digest, CacheBucket, CacheEntry, CanonicalUrl, WheelCache};
+use puffin_client::{CachedClient, CachedClientError, DataWithCachePolicy};
+use puffin_fs::write_atomic;
 use puffin_git::{Fetch, GitSource};
 use puffin_normalize::PackageName;
 use puffin_traits::BuildContext;
@@ -473,15 +474,15 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
         let cache_dir = self.build_context.cache().bucket(CacheBucket::BuiltWheels);
         fs::create_dir_all(&cache_dir)
             .await
-            .map_err(Error::CacheWrite)?;
-        let temp_dir = tempfile::tempdir_in(cache_dir).map_err(Error::CacheWrite)?;
+            .map_err(puffin_client::Error::CacheWrite)?;
+        let temp_dir = tempfile::tempdir_in(cache_dir).map_err(puffin_client::Error::CacheWrite)?;
         let sdist_file = temp_dir.path().join(source_dist_filename);
         let mut writer = tokio::fs::File::create(&sdist_file)
             .await
-            .map_err(Error::CacheWrite)?;
+            .map_err(puffin_client::Error::CacheWrite)?;
         tokio::io::copy(&mut reader, &mut writer)
             .await
-            .map_err(Error::CacheWrite)?;
+            .map_err(puffin_client::Error::CacheWrite)?;
         Ok((Some(temp_dir), sdist_file))
     }
 

--- a/crates/puffin-fs/Cargo.toml
+++ b/crates/puffin-fs/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "puffin-fs"
+version = "0.0.1"
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+fs-err = { workspace = true, features = ["tokio"] }
+tempfile = { workspace = true }

--- a/crates/puffin-fs/src/lib.rs
+++ b/crates/puffin-fs/src/lib.rs
@@ -1,0 +1,105 @@
+use std::path::Path;
+
+use tempfile::NamedTempFile;
+
+/// Write `data` to `path` atomically using a temporary file and atomic rename.
+pub async fn write_atomic(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> std::io::Result<()> {
+    let temp_file = NamedTempFile::new_in(
+        path.as_ref()
+            .parent()
+            .expect("Write path must have a parent"),
+    )?;
+    fs_err::tokio::write(&temp_file, &data).await?;
+    temp_file.persist(&path).map_err(|err| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "Failed to persist temporary file to {}: {}",
+                path.as_ref().display(),
+                err.error
+            ),
+        )
+    })?;
+    Ok(())
+}
+
+/// Write `data` to `path` atomically using a temporary file and atomic rename.
+pub fn write_atomic_sync(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> std::io::Result<()> {
+    let temp_file = NamedTempFile::new_in(
+        path.as_ref()
+            .parent()
+            .expect("Write path must have a parent"),
+    )?;
+    fs_err::write(&temp_file, &data)?;
+    temp_file.persist(&path).map_err(|err| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "Failed to persist temporary file to {}: {}",
+                path.as_ref().display(),
+                err.error
+            ),
+        )
+    })?;
+    Ok(())
+}
+
+/// Rename `from` to `to` atomically using a temporary file and atomic rename.
+///
+/// Returns `false` if the `to` path already existed and thus was removed before performing the
+/// rename.
+pub fn rename_atomic_sync(from: impl AsRef<Path>, to: impl AsRef<Path>) -> std::io::Result<bool> {
+    // Remove the destination if it exists.
+    let safe = if let Ok(metadata) = fs_err::metadata(&to) {
+        if metadata.is_dir() {
+            fs_err::remove_dir_all(&to)?;
+        } else {
+            fs_err::remove_file(&to)?;
+        }
+        false
+    } else {
+        true
+    };
+
+    // Move the source file to the destination.
+    fs_err::rename(from, to)?;
+
+    Ok(safe)
+}
+
+/// Copy `from` to `to` atomically using a temporary file and atomic rename.
+///
+/// Returns `false` if the `to` path already existed and thus was removed before performing the
+/// rename.
+pub fn copy_atomic_sync(from: impl AsRef<Path>, to: impl AsRef<Path>) -> std::io::Result<bool> {
+    // Copy to a temporary file.
+    let temp_file =
+        NamedTempFile::new_in(to.as_ref().parent().expect("Write path must have a parent"))?;
+    fs_err::copy(from, &temp_file)?;
+
+    // Remove the destination if it exists.
+    let safe = if let Ok(metadata) = fs_err::metadata(&to) {
+        if metadata.is_dir() {
+            fs_err::remove_dir_all(&to)?;
+        } else {
+            fs_err::remove_file(&to)?;
+        }
+        false
+    } else {
+        true
+    };
+
+    // Move the temporary file to the destination.
+    temp_file.persist(&to).map_err(|err| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "Failed to persist temporary file to {}: {}",
+                to.as_ref().display(),
+                err.error
+            ),
+        )
+    })?;
+
+    Ok(safe)
+}

--- a/crates/puffin-interpreter/Cargo.toml
+++ b/crates/puffin-interpreter/Cargo.toml
@@ -17,6 +17,7 @@ pep440_rs = { path = "../pep440-rs" }
 pep508_rs = { path = "../pep508-rs", features = ["serde"] }
 platform-host = { path = "../platform-host" }
 puffin-cache = { path = "../puffin-cache" }
+puffin-fs = { path = "../puffin-fs" }
 
 fs-err = { workspace = true, features = ["tokio"] }
 serde_json = { workspace = true }

--- a/crates/puffin-interpreter/src/interpreter.rs
+++ b/crates/puffin-interpreter/src/interpreter.rs
@@ -9,7 +9,8 @@ use tracing::debug;
 use pep440_rs::Version;
 use pep508_rs::MarkerEnvironment;
 use platform_host::Platform;
-use puffin_cache::{digest, write_atomic_sync, Cache, CacheBucket};
+use puffin_cache::{digest, Cache, CacheBucket};
+use puffin_fs::write_atomic_sync;
 
 use crate::python_platform::PythonPlatform;
 use crate::Error;


### PR DESCRIPTION
This PR modifies the source distribution building to replace any existing targets after building the new wheel. In some cases, the existence of an existing target may be indicative of a bug, so we warn. It's partially a workaround for some (but not all) of the errors in https://github.com/astral-sh/puffin/issues/554.
