### PR TITLE
Remove `.whl` extension for cached, unzipped wheels

### DIFF
--- a/crates/distribution-types/src/cached.rs
+++ b/crates/distribution-types/src/cached.rs
@@ -1,5 +1,4 @@
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use anyhow::Result;
 use url::Url;
@@ -125,6 +124,7 @@ impl CachedDist {
 }
 
 impl CachedDirectUrlDist {
+    /// Initialize a [`CachedDirectUrlDist`] from a [`WheelFilename`], [`Url`], and [`Path`].
     pub fn from_url(filename: WheelFilename, url: Url, path: PathBuf) -> Self {
         Self {
             filename,
@@ -135,7 +135,7 @@ impl CachedDirectUrlDist {
 }
 
 impl CachedRegistryDist {
-    /// Try to parse a distribution from a cached directory name (like `django-5.0a1`).
+    /// Try to parse a distribution from a cached directory name (like `typing-extensions-4.8.0-py3-none-any`).
     pub fn try_from_path(path: &Path) -> Result<Option<Self>> {
         let Some(file_name) = path.file_name() else {
             return Ok(None);
@@ -143,9 +143,12 @@ impl CachedRegistryDist {
         let Some(file_name) = file_name.to_str() else {
             return Ok(None);
         };
-        let Ok(filename) = WheelFilename::from_str(file_name) else {
+        let Ok(filename) = WheelFilename::from_stem(file_name) else {
             return Ok(None);
         };
+        if path.is_file() {
+            return Ok(None);
+        }
 
         let path = path.to_path_buf();
 

--- a/crates/puffin-distribution/src/download.rs
+++ b/crates/puffin-distribution/src/download.rs
@@ -15,7 +15,7 @@ use crate::error::Error;
 pub struct InMemoryWheel {
     /// The remote distribution from which this wheel was downloaded.
     pub(crate) dist: Dist,
-    /// The parsed filename
+    /// The parsed filename.
     pub(crate) filename: WheelFilename,
     /// The contents of the wheel.
     pub(crate) buffer: Vec<u8>,
@@ -28,7 +28,7 @@ pub struct InMemoryWheel {
 pub struct DiskWheel {
     /// The remote distribution from which this wheel was downloaded.
     pub(crate) dist: Dist,
-    /// The parsed filename
+    /// The parsed filename.
     pub(crate) filename: WheelFilename,
     /// The path to the downloaded wheel.
     pub(crate) path: PathBuf,
@@ -41,7 +41,7 @@ pub struct DiskWheel {
 pub struct BuiltWheel {
     /// The remote source distribution from which this wheel was built.
     pub(crate) dist: Dist,
-    /// The parsed filename
+    /// The parsed filename.
     pub(crate) filename: WheelFilename,
     /// The path to the built wheel.
     pub(crate) path: PathBuf,

--- a/crates/puffin-distribution/src/source_dist.rs
+++ b/crates/puffin-distribution/src/source_dist.rs
@@ -92,8 +92,13 @@ type Metadata21s = FxHashMap<WheelFilename, DiskFilenameAndMetadata>;
 /// The information about the wheel we either just built or got from the cache
 #[derive(Debug, Clone)]
 pub struct BuiltWheelMetadata {
+    /// The path to the built wheel.
     pub path: PathBuf,
+    /// The expected path to the downloaded wheel's entry in the cache.
+    pub target: PathBuf,
+    /// The parsed filename.
     pub filename: WheelFilename,
+    /// The metadata of the built wheel.
     pub metadata: Metadata21,
 }
 
@@ -105,6 +110,7 @@ impl BuiltWheelMetadata {
     ) -> Self {
         Self {
             path: cache_entry.dir.join(&cached_data.disk_filename),
+            target: cache_entry.dir.join(filename.stem()),
             filename: filename.clone(),
             metadata: cached_data.metadata.clone(),
         }
@@ -206,6 +212,7 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
                 // Read the metadata from the wheel.
                 let filename = WheelFilename::from_str(&disk_filename)?;
                 let path = wheel_dir.join(disk_filename);
+                let target = wheel_dir.join(filename.stem());
                 let metadata = read_metadata(&filename, &path)?;
 
                 if let Some(task) = task {
@@ -216,6 +223,7 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
 
                 BuiltWheelMetadata {
                     path,
+                    target,
                     filename,
                     metadata,
                 }
@@ -452,8 +460,12 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
             }
         }
 
+        let path = cache_entry.dir.join(&disk_filename);
+        let target = cache_entry.dir.join(filename.stem());
+
         Ok(BuiltWheelMetadata {
-            path: cache_entry.dir.join(&disk_filename),
+            path,
+            target,
             filename,
             metadata,
         })

--- a/crates/puffin-installer/src/plan.rs
+++ b/crates/puffin-installer/src/plan.rs
@@ -112,11 +112,9 @@ impl InstallPlan {
                 Some(VersionOrUrl::Url(url)) => {
                     // TODO(konstin): Add source dist url support. It's more tricky since we don't
                     // know yet whether source dist is fresh in the cache.
-                    if let Ok((disk_filename, filename)) =
-                        url.filename().and_then(|disk_filename| {
-                            let filename = WheelFilename::from_str(disk_filename)?;
-                            Ok((disk_filename, filename))
-                        })
+                    if let Ok(filename) = url
+                        .filename()
+                        .and_then(|disk_filename| Ok(WheelFilename::from_str(disk_filename)?))
                     {
                         if requirement.name != filename.name {
                             bail!(
@@ -129,7 +127,7 @@ impl InstallPlan {
                         let cache_entry = cache.entry(
                             CacheBucket::Wheels,
                             WheelCache::Url(url).wheel_dir(),
-                            disk_filename.to_string(),
+                            filename.stem(),
                         );
 
                         // Ignore zipped wheels, which represent intermediary cached artifacts.

--- a/crates/puffin-installer/src/registry_index.rs
+++ b/crates/puffin-installer/src/registry_index.rs
@@ -41,11 +41,6 @@ impl RegistryIndex {
                     }
                 };
 
-                // Ignore zipped wheels, which represent intermediary cached artifacts.
-                if !path.is_dir() {
-                    continue;
-                }
-
                 match CachedRegistryDist::try_from_path(&path) {
                     Ok(None) => {}
                     Ok(Some(dist_info)) => {


### PR DESCRIPTION
## Summary

This PR uses the wheel stem (e.g.,  `foo-1.2.3-py3-none-any`) instead of the wheel name (e.g., `foo-1.2.3-py3-none-any.whl`) when storing unzipped wheels in the cache, which removes a class of confusing issues around overwrites and directory-vs.-file collisions.

For now, we retain _both_ the zipped and unzipped wheels in the cache, though we can easily change this by storing the zipped wheels in a temporary directory.

Closes https://github.com/astral-sh/puffin/issues/573.

## Test Plan

Some examples from my local cache:

<img width="835" alt="Screen Shot 2023-12-05 at 4 09 55 PM" src="https://github.com/astral-sh/puffin/assets/1309177/784146aa-b080-416e-9767-40c843fe5d6a">
<img width="847" alt="Screen Shot 2023-12-05 at 4 12 14 PM" src="https://github.com/astral-sh/puffin/assets/1309177/4bc7f30f-bef3-47f1-b4e8-da9cabf87f28">
<img width="637" alt="Screen Shot 2023-12-05 at 4 09 50 PM" src="https://github.com/astral-sh/puffin/assets/1309177/25ca4944-4a06-4a08-ac85-c6f7d8b5c8ea">
