### PR TITLE
Add tests for repeated installs with source distributions

### DIFF
--- a/crates/puffin-cli/tests/snapshots/pip_sync__install_local_source_distribution.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_sync__install_local_source_distribution.snap
@@ -6,9 +6,9 @@ info:
     - pip-sync
     - requirements.txt
     - "--cache-dir"
-    - /tmp/.tmpvKBMwz
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpD0MMCB
   env:
-    VIRTUAL_ENV: /tmp/.tmpDB96k4/.venv
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpSwXmTa/.venv
 ---
 success: true
 exit_code: 0
@@ -19,5 +19,5 @@ Resolved 1 package in [TIME]
 Downloaded 1 package in [TIME]
 Unzipped 1 package in [TIME]
 Installed 1 package in [TIME]
- + flask @ file://[TEMP_DIR]/flask-3.0.0.tar.gz
+ + wheel @ file://[TEMP_DIR]/wheel-0.42.0.tar.gz
 

--- a/crates/puffin-cli/tests/snapshots/pip_sync__install_local_wheel.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_sync__install_local_wheel.snap
@@ -6,9 +6,9 @@ info:
     - pip-sync
     - requirements.txt
     - "--cache-dir"
-    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpKx7cY5
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpOaWXtJ
   env:
-    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpEz5kWW/.venv
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpl1QcDF/.venv
 ---
 success: true
 exit_code: 0
@@ -19,5 +19,5 @@ Resolved 1 package in [TIME]
 Downloaded 1 package in [TIME]
 Unzipped 1 package in [TIME]
 Installed 1 package in [TIME]
- + flask @ file://[TEMP_DIR]/flask-3.0.0-py3-none-any.whl
+ + tomli @ file://[TEMP_DIR]/tomli-3.0.1-py3-none-any.whl
 


### PR DESCRIPTION
Adds a few more tests for re-installs with various kinds of source distributions, and changes the tests to use packages that we can safely import (via `check_command`) for extra validation.

Once we properly respect cached built wheels, we should expect these snapshots to change, since we'll no longer download and re-build unnecessarily.