### PR TITLE
Shard the registry cache by package

### DIFF
--- a/crates/puffin-cache/src/wheel.rs
+++ b/crates/puffin-cache/src/wheel.rs
@@ -10,7 +10,7 @@ use crate::{digest, CanonicalUrl};
 
 /// Cache wheels and their metadata, both from remote wheels and built from source distributions.
 ///
-/// Use [`WheelCache::wheel_dir`] for remote wheel metadata caching and
+/// Use [`WheelCache::remote_wheel_dir`] for remote wheel metadata caching and
 /// [`WheelCache::built_wheel_dir`] for built source distributions metadata caching.
 pub enum WheelCache<'a> {
     /// Either pypi or an alternative index, which we key by index URL.
@@ -38,8 +38,8 @@ impl<'a> WheelCache<'a> {
     }
 
     /// Metadata of a remote wheel. See [`CacheBucket::Wheels`]
-    pub fn wheel_dir(&self) -> PathBuf {
-        self.bucket()
+    pub fn remote_wheel_dir(&self, package_name: impl AsRef<Path>) -> PathBuf {
+        self.bucket().join(package_name)
     }
 
     /// Metadata of a built source distribution. See [`CacheBucket::BuiltWheels`]

--- a/crates/puffin-distribution/src/index/registry_wheel_index.rs
+++ b/crates/puffin-distribution/src/index/registry_wheel_index.rs
@@ -1,11 +1,13 @@
+use std::collections::hash_map::Entry;
 use std::collections::BTreeMap;
+
 use std::path::Path;
 
 use fs_err as fs;
 use fxhash::FxHashMap;
 use tracing::warn;
 
-use distribution_types::{CachedRegistryDist, CachedWheel, Metadata};
+use distribution_types::{CachedRegistryDist, CachedWheel};
 use pep440_rs::Version;
 use platform_tags::Tags;
 use puffin_cache::{Cache, CacheBucket, WheelCache};
@@ -15,55 +17,87 @@ use pypi_types::IndexUrls;
 use crate::index::iter_directories;
 
 /// A local index of distributions that originate from a registry, like `PyPI`.
-#[derive(Debug, Default)]
-pub struct RegistryWheelIndex(FxHashMap<PackageName, BTreeMap<Version, CachedRegistryDist>>);
+#[derive(Debug)]
+pub struct RegistryWheelIndex<'a> {
+    cache: &'a Cache,
+    tags: &'a Tags,
+    index_urls: &'a IndexUrls,
+    index: FxHashMap<PackageName, BTreeMap<Version, CachedRegistryDist>>,
+}
 
-impl RegistryWheelIndex {
-    /// Build an index of cached distributions from a directory.
-    pub fn from_directory(cache: &Cache, tags: &Tags, index_urls: &IndexUrls) -> Self {
-        let mut index = Self::default();
+impl<'a> RegistryWheelIndex<'a> {
+    /// Initialize an index of cached distributions from a directory.
+    pub fn new(cache: &'a Cache, tags: &'a Tags, index_urls: &'a IndexUrls) -> Self {
+        Self {
+            cache,
+            tags,
+            index_urls,
+            index: FxHashMap::default(),
+        }
+    }
+
+    /// Return an iterator over available wheels for a given package.
+    ///
+    /// If the package is not yet indexed, this will index the package by reading from the cache.
+    pub fn get(
+        &mut self,
+        name: &PackageName,
+    ) -> impl Iterator<Item = (&Version, &CachedRegistryDist)> {
+        let versions = match self.index.entry(name.clone()) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                entry.insert(Self::index(name, self.cache, self.tags, self.index_urls))
+            }
+        };
+        versions.iter().rev()
+    }
+
+    /// Add a package to the index by reading from the cache.
+    fn index(
+        package: &PackageName,
+        cache: &Cache,
+        tags: &Tags,
+        index_urls: &IndexUrls,
+    ) -> BTreeMap<Version, CachedRegistryDist> {
+        let mut versions = BTreeMap::new();
 
         for index_url in index_urls {
             // Index all the wheels that were downloaded directly from the registry.
-            // TODO(charlie): Shard the cache by package name, and do this lazily.
-            let wheel_dir = cache
-                .bucket(CacheBucket::Wheels)
-                .join(WheelCache::Index(index_url).wheel_dir());
+            let wheel_dir = cache.shard(
+                CacheBucket::Wheels,
+                WheelCache::Index(index_url).remote_wheel_dir(package.to_string()),
+            );
 
-            index.add_directory(wheel_dir, tags);
+            Self::add_directory(&*wheel_dir, tags, &mut versions);
 
             // Index all the built wheels, created by downloading and building source distributions
             // from the registry.
-            // TODO(charlie): Shard the cache by package name, and do this lazily.
-            let built_wheel_dir = cache
-                .bucket(CacheBucket::BuiltWheels)
-                .join(WheelCache::Index(index_url).wheel_dir());
+            let built_wheel_dir = cache.shard(
+                CacheBucket::BuiltWheels,
+                WheelCache::Index(index_url).built_wheel_dir(package.to_string()),
+            );
 
+            // Built wheels have one more level of indirection, as they are keyed by the source
+            // distribution filename.
             let Ok(read_dir) = built_wheel_dir.read_dir() else {
                 continue;
             };
             for subdir in iter_directories(read_dir) {
-                index.add_directory(subdir, tags);
+                Self::add_directory(subdir, tags, &mut versions);
             }
         }
 
-        index
-    }
-
-    /// Returns a distribution from the index, if it exists.
-    pub fn by_name(
-        &self,
-        name: &PackageName,
-    ) -> impl Iterator<Item = (&Version, &CachedRegistryDist)> {
-        // Using static to extend the lifetime
-        static DEFAULT_MAP: BTreeMap<Version, CachedRegistryDist> = BTreeMap::new();
-        self.0.get(name).unwrap_or(&DEFAULT_MAP).iter().rev()
+        versions
     }
 
     /// Add the wheels in a given directory to the index.
     ///
     /// Each subdirectory in the given path is expected to be that of an unzipped wheel.
-    fn add_directory(&mut self, path: impl AsRef<Path>, tags: &Tags) {
+    fn add_directory(
+        path: impl AsRef<Path>,
+        tags: &Tags,
+        versions: &mut BTreeMap<Version, CachedRegistryDist>,
+    ) {
         let Ok(read_dir) = path.as_ref().read_dir() else {
             return;
         };
@@ -76,20 +110,13 @@ impl RegistryWheelIndex {
 
                     // Pick the wheel with the highest priority
                     let compatibility = dist_info.filename.compatibility(tags);
-                    if let Some(existing) = self
-                        .0
-                        .get_mut(dist_info.name())
-                        .and_then(|package| package.get_mut(&dist_info.filename.version))
-                    {
+                    if let Some(existing) = versions.get_mut(&dist_info.filename.version) {
                         // Override if we have better compatibility
                         if compatibility > existing.filename.compatibility(tags) {
                             *existing = dist_info;
                         }
                     } else if compatibility.is_some() {
-                        self.0
-                            .entry(dist_info.name().clone())
-                            .or_default()
-                            .insert(dist_info.filename.version.clone(), dist_info);
+                        versions.insert(dist_info.filename.version.clone(), dist_info);
                     }
                 }
                 Err(err) => {
@@ -97,8 +124,8 @@ impl RegistryWheelIndex {
                         "Invalid cache entry at {}, removing. {err}",
                         wheel_dir.display()
                     );
-                    let result = fs::remove_dir_all(&wheel_dir);
-                    if let Err(err) = result {
+
+                    if let Err(err) = fs::remove_dir_all(&wheel_dir) {
                         warn!(
                             "Failed to remove invalid cache entry at {}: {err}",
                             wheel_dir.display()

--- a/crates/puffin-normalize/src/package_name.rs
+++ b/crates/puffin-normalize/src/package_name.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer, Serialize};
@@ -54,8 +52,8 @@ impl<'de> Deserialize<'de> for PackageName {
     }
 }
 
-impl Display for PackageName {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for PackageName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
 }


### PR DESCRIPTION
## Summary

This PR modifies the cache structure in a few ways. Most notably, we now shard the set of registry wheels by package, and index them lazily when computing the install plan.

This applies both to built wheels:

<img width="989" alt="Screen Shot 2023-12-06 at 4 42 19 PM" src="https://github.com/astral-sh/puffin/assets/1309177/0e8a306f-befd-4be9-a63e-2303389837bb">

And remote wheels:

<img width="836" alt="Screen Shot 2023-12-06 at 4 42 30 PM" src="https://github.com/astral-sh/puffin/assets/1309177/7fd908cd-dd86-475e-9779-07ed067b4a1a">

For other distributions, we now consistently cache using the package name, which is really just for clarity and debuggability (we could consider omitting these):

<img width="955" alt="Screen Shot 2023-12-06 at 4 58 30 PM" src="https://github.com/astral-sh/puffin/assets/1309177/3e8d0f99-df45-429a-9175-d57b54a72e56">

Obliquely closes https://github.com/astral-sh/puffin/issues/575.
