### PR TITLE
Raise an error when `pip-sync` manifest contains duplicates

### DIFF
--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -75,7 +75,9 @@ pub(crate) async fn sync_requirements(
         "Using Python interpreter: {}",
         venv.python_executable().display()
     );
+
     // Determine the current environment markers.
+    let markers = venv.interpreter().markers();
     let tags = Tags::from_interpreter(venv.interpreter())?;
 
     // Partition into those that should be linked from the cache (`local`), those that need to be
@@ -84,7 +86,7 @@ pub(crate) async fn sync_requirements(
         local,
         remote,
         extraneous,
-    } = InstallPlan::try_from_requirements(requirements, &index_urls, cache, &venv, &tags)
+    } = InstallPlan::from_requirements(requirements, &index_urls, cache, &venv, markers, &tags)
         .context("Failed to determine installation plan")?;
 
     // Nothing to do.

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -126,17 +126,19 @@ impl BuildContext for BuildDispatch {
                 venv.root().display(),
             );
 
+            let markers = self.interpreter.markers();
             let tags = Tags::from_interpreter(&self.interpreter)?;
 
             let InstallPlan {
                 local,
                 remote,
                 extraneous,
-            } = InstallPlan::try_from_requirements(
+            } = InstallPlan::from_requirements(
                 requirements,
                 &self.index_urls,
                 self.cache(),
                 venv,
+                markers,
                 &tags,
             )?;
 


### PR DESCRIPTION
Also ensures that we filter out any incompatible requirements when building the install plan. In general, we assume that requirements were generated by `pip-compile`, in which case all requirements should be compatible and there should be no duplicates; but we should handle this case gracefully.

Closes https://github.com/astral-sh/puffin/issues/582.
