### PR TITLE
Restructure Git cache to include package name

### DIFF
--- a/crates/distribution-types/src/direct_url.rs
+++ b/crates/distribution-types/src/direct_url.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Error, Result};
 use url::Url;
 
-use puffin_git::GitUrl;
+use puffin_git::{GitSha, GitUrl};
 
 #[derive(Debug)]
 pub enum DirectUrl {
@@ -89,9 +89,9 @@ fn get_subdirectory(url: &Url) -> Option<PathBuf> {
 }
 
 /// Return the Git reference of the given URL, if it exists.
-pub fn git_reference(url: &Url) -> Result<Option<String>, Error> {
+pub fn git_reference(url: &Url) -> Result<Option<GitSha>, Error> {
     let DirectGitUrl { url, .. } = DirectGitUrl::try_from(url)?;
-    Ok(url.reference().map(ToString::to_string))
+    Ok(url.precise())
 }
 
 impl TryFrom<&Url> for DirectUrl {
@@ -159,7 +159,7 @@ impl TryFrom<&DirectGitUrl> for pypi_types::DirectUrl {
             url: value.url.repository().to_string(),
             vcs_info: pypi_types::VcsInfo {
                 vcs: pypi_types::VcsKind::Git,
-                commit_id: value.url.precise().map(|oid| oid.to_string()),
+                commit_id: value.url.precise().as_ref().map(ToString::to_string),
                 requested_revision: value.url.reference().map(ToString::to_string),
             },
             subdirectory: value.subdirectory.clone(),

--- a/crates/puffin-cache/src/wheel.rs
+++ b/crates/puffin-cache/src/wheel.rs
@@ -19,11 +19,11 @@ pub enum WheelCache<'a> {
     Url(&'a Url),
     /// A path dependency, which we key by URL.
     Path(&'a Url),
-    /// A Git dependency, which we key by repository url. We use the revision as filename.
+    /// A Git dependency, which we key by URL and SHA.
     ///
-    /// Note that this variant only exists for source distributions, wheels can't be delivered
+    /// Note that this variant only exists for source distributions; wheels can't be delivered
     /// through Git.
-    Git(&'a Url),
+    Git(&'a Url, &'a str),
 }
 
 impl<'a> WheelCache<'a> {
@@ -33,7 +33,9 @@ impl<'a> WheelCache<'a> {
             WheelCache::Index(url) => PathBuf::from("index").join(digest(&CanonicalUrl::new(url))),
             WheelCache::Url(url) => PathBuf::from("url").join(digest(&CanonicalUrl::new(url))),
             WheelCache::Path(url) => PathBuf::from("path").join(digest(&CanonicalUrl::new(url))),
-            WheelCache::Git(url) => PathBuf::from("git").join(digest(&CanonicalUrl::new(url))),
+            WheelCache::Git(url, sha) => PathBuf::from("git")
+                .join(digest(&CanonicalUrl::new(url)))
+                .join(sha),
         }
     }
 

--- a/crates/puffin-distribution/src/source_dist.rs
+++ b/crates/puffin-distribution/src/source_dist.rs
@@ -488,15 +488,11 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
         let (fetch, subdirectory) = self.download_source_dist_git(&git_source_dist.url).await?;
 
         // TODO(konstin): Do we want to delete old built wheels when the git sha changed?
-        let git_sha = fetch
-            .git()
-            .precise()
-            .expect("Exact commit after checkout")
-            .to_string();
-        let cache_shard = WheelCache::Git(&git_source_dist.url);
+        let git_sha = fetch.git().precise().expect("Exact commit after checkout");
         let cache_entry = self.build_context.cache().entry(
             CacheBucket::BuiltWheels,
-            cache_shard.built_wheel_dir(&git_sha),
+            WheelCache::Git(&git_source_dist.url, &git_sha.to_short_string())
+                .remote_wheel_dir(git_source_dist.name().as_ref()),
             METADATA_JSON.to_string(),
         );
 

--- a/crates/puffin-git/src/lib.rs
+++ b/crates/puffin-git/src/lib.rs
@@ -1,9 +1,12 @@
+use std::str::FromStr;
 use url::Url;
 
-use git::GitReference;
-pub use source::{Fetch, GitSource, Reporter};
+use crate::git::GitReference;
+pub use crate::sha::GitSha;
+pub use crate::source::{Fetch, GitSource, Reporter};
 
 mod git;
+mod sha;
 mod source;
 mod util;
 
@@ -15,12 +18,12 @@ pub struct GitUrl {
     /// The reference to the commit to use, which could be a branch, tag or revision.
     reference: GitReference,
     /// The precise commit to use, if known.
-    precise: Option<git2::Oid>,
+    precise: Option<GitSha>,
 }
 
 impl GitUrl {
     #[must_use]
-    pub(crate) fn with_precise(mut self, precise: git2::Oid) -> Self {
+    pub(crate) fn with_precise(mut self, precise: GitSha) -> Self {
         self.precise = Some(precise);
         self
     }
@@ -44,7 +47,7 @@ impl GitUrl {
     }
 
     /// Return the precise commit, if known.
-    pub fn precise(&self) -> Option<git2::Oid> {
+    pub fn precise(&self) -> Option<GitSha> {
         self.precise
     }
 }
@@ -66,7 +69,7 @@ impl TryFrom<Url> for GitUrl {
             url = Url::parse(prefix)?;
         }
         let precise = if let GitReference::FullCommit(rev) = &reference {
-            Some(git2::Oid::from_str(rev)?)
+            Some(GitSha::from_str(rev)?)
         } else {
             None
         };

--- a/crates/puffin-git/src/sha.rs
+++ b/crates/puffin-git/src/sha.rs
@@ -1,0 +1,38 @@
+use std::str::FromStr;
+
+/// A complete Git SHA, i.e., a 40-character hexadecimal representation of a Git commit.
+#[derive(Debug, Copy, Clone)]
+pub struct GitSha(git2::Oid);
+
+impl GitSha {
+    /// Convert the SHA to a truncated representation, i.e., the first 16 characters of the SHA.
+    pub fn to_short_string(&self) -> String {
+        self.0.to_string()[0..16].to_string()
+    }
+}
+
+impl From<GitSha> for git2::Oid {
+    fn from(value: GitSha) -> Self {
+        value.0
+    }
+}
+
+impl From<git2::Oid> for GitSha {
+    fn from(value: git2::Oid) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for GitSha {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for GitSha {
+    type Err = git2::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Self(git2::Oid::from_str(value)?))
+    }
+}

--- a/crates/puffin-installer/src/plan.rs
+++ b/crates/puffin-installer/src/plan.rs
@@ -213,10 +213,11 @@ impl InstallPlan {
                         Dist::Source(SourceDist::Git(sdist)) => {
                             // Find the most-compatible wheel from the cache, since we don't know
                             // the filename in advance.
-                            if let Ok(Some(reference)) = git_reference(&sdist.url) {
+                            if let Ok(Some(git_sha)) = git_reference(&sdist.url) {
                                 let cache_shard = cache.shard(
                                     CacheBucket::BuiltWheels,
-                                    WheelCache::Git(&sdist.url).built_wheel_dir(reference),
+                                    WheelCache::Git(&sdist.url, &git_sha.to_short_string())
+                                        .remote_wheel_dir(sdist.name().as_ref()),
                                 );
 
                                 if let Some(wheel) = BuiltWheelIndex::find(&cache_shard, tags) {


### PR DESCRIPTION
## Summary

This PR modifies the Git wheel cache to: (1) use a shorter version of the SHA, to save space; and (2) include the package name, for consistency with all other buckets.

I considered removing the URL hash entirely, and _just_ using the SHA, which would be even _more_ consistent with other buckets. But if we remove the URL, then we won't have separate directories for subdirectories (which are part of the URL).

Before:

<img width="1035" alt="Screen Shot 2023-12-07 at 7 23 42 PM" src="https://github.com/astral-sh/puffin/assets/1309177/86afce67-682f-464f-9ba1-0b60d5b7f19f">

After:

<img width="1232" alt="Screen Shot 2023-12-07 at 8 09 23 PM" src="https://github.com/astral-sh/puffin/assets/1309177/eda42a19-974f-47fe-8c83-54a602ddfd2d">

