### PR TITLE
Enable selective cache purging in `puffin clean`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,11 +2288,14 @@ dependencies = [
  "directories",
  "fs-err",
  "hex",
+ "puffin-fs",
+ "puffin-normalize",
  "pypi-types",
  "seahash",
  "serde",
  "serde_json",
  "tempfile",
+ "tracing",
  "url",
 ]
 
@@ -2491,6 +2494,7 @@ version = "0.0.1"
 dependencies = [
  "fs-err",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/puffin-cache/Cargo.toml
+++ b/crates/puffin-cache/Cargo.toml
@@ -14,6 +14,8 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
+puffin-fs = { path = "../puffin-fs" }
+puffin-normalize = { path = "../puffin-normalize" }
 pypi-types = { path = "../pypi-types" }
 
 cachedir = { workspace = true }
@@ -25,4 +27,5 @@ seahash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/puffin-cache/src/wheel.rs
+++ b/crates/puffin-cache/src/wheel.rs
@@ -12,8 +12,9 @@ use crate::{digest, CanonicalUrl};
 ///
 /// Use [`WheelCache::remote_wheel_dir`] for remote wheel metadata caching and
 /// [`WheelCache::built_wheel_dir`] for built source distributions metadata caching.
+#[derive(Debug, Clone)]
 pub enum WheelCache<'a> {
-    /// Either pypi or an alternative index, which we key by index URL.
+    /// Either PyPI or an alternative index, which we key by index URL.
     Index(&'a IndexUrl),
     /// A direct URL dependency, which we key by URL.
     Url(&'a Url),
@@ -29,11 +30,18 @@ pub enum WheelCache<'a> {
 impl<'a> WheelCache<'a> {
     fn bucket(&self) -> PathBuf {
         match self {
-            WheelCache::Index(IndexUrl::Pypi) => PathBuf::from("pypi"),
-            WheelCache::Index(url) => PathBuf::from("index").join(digest(&CanonicalUrl::new(url))),
-            WheelCache::Url(url) => PathBuf::from("url").join(digest(&CanonicalUrl::new(url))),
-            WheelCache::Path(url) => PathBuf::from("path").join(digest(&CanonicalUrl::new(url))),
-            WheelCache::Git(url, sha) => PathBuf::from("git")
+            WheelCache::Index(IndexUrl::Pypi) => WheelCacheKind::Pypi.root(),
+            WheelCache::Index(url) => WheelCacheKind::Index
+                .root()
+                .join(digest(&CanonicalUrl::new(url))),
+            WheelCache::Url(url) => WheelCacheKind::Url
+                .root()
+                .join(digest(&CanonicalUrl::new(url))),
+            WheelCache::Path(url) => WheelCacheKind::Path
+                .root()
+                .join(digest(&CanonicalUrl::new(url))),
+            WheelCache::Git(url, sha) => WheelCacheKind::Git
+                .root()
                 .join(digest(&CanonicalUrl::new(url)))
                 .join(sha),
         }
@@ -47,5 +55,41 @@ impl<'a> WheelCache<'a> {
     /// Metadata of a built source distribution. See [`CacheBucket::BuiltWheels`]
     pub fn built_wheel_dir(&self, filename: impl AsRef<Path>) -> PathBuf {
         self.bucket().join(filename)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WheelCacheKind {
+    /// A cache of data from PyPI.
+    Pypi,
+    /// A cache of data from an alternative index.
+    Index,
+    /// A cache of data from an arbitrary URL.
+    Url,
+    /// A cache of data from a local path.
+    Path,
+    /// A cache of data from a Git repository.
+    Git,
+}
+
+impl WheelCacheKind {
+    pub(crate) fn to_str(self) -> &'static str {
+        match self {
+            WheelCacheKind::Pypi => "pypi",
+            WheelCacheKind::Index => "index",
+            WheelCacheKind::Url => "url",
+            WheelCacheKind::Path => "path",
+            WheelCacheKind::Git => "git",
+        }
+    }
+
+    pub(crate) fn root(self) -> PathBuf {
+        Path::new(self.to_str()).to_path_buf()
+    }
+}
+
+impl AsRef<Path> for WheelCacheKind {
+    fn as_ref(&self) -> &Path {
+        self.to_str().as_ref()
     }
 }

--- a/crates/puffin-cli/src/main.rs
+++ b/crates/puffin-cli/src/main.rs
@@ -68,7 +68,7 @@ enum Commands {
     /// Uninstall packages from the current environment.
     PipUninstall(PipUninstallArgs),
     /// Clear the cache.
-    Clean,
+    Clean(CleanArgs),
     /// Enumerate the installed packages in the current environment.
     Freeze,
     /// Create a virtual environment.
@@ -211,6 +211,12 @@ struct PipUninstallArgs {
 }
 
 #[derive(Args)]
+struct CleanArgs {
+    /// The packages to remove from the cache.
+    package: Vec<PackageName>,
+}
+
+#[derive(Args)]
 struct VenvArgs {
     /// The Python interpreter to use for the virtual environment.
     // Short `-p` to match `virtualenv`
@@ -321,7 +327,7 @@ async fn inner() -> Result<ExitStatus> {
                 .collect::<Vec<_>>();
             commands::pip_uninstall(&sources, cache, printer).await
         }
-        Commands::Clean => commands::clean(&cache, printer),
+        Commands::Clean(args) => commands::clean(&cache, &args.package, printer),
         Commands::Freeze => commands::freeze(&cache, printer),
         Commands::Venv(args) => commands::venv(&args.name, args.python.as_deref(), &cache, printer),
         Commands::Add(args) => commands::add(&args.name, printer),

--- a/crates/puffin-cli/tests/pip_sync.rs
+++ b/crates/puffin-cli/tests/pip_sync.rs
@@ -994,6 +994,54 @@ fn install_url_source_dist_cached() -> Result<()> {
 
     check_command(&venv, "import tqdm", &temp_dir);
 
+    // Clear the cache, then re-run the installation in a new virtual environment.
+    let parent = assert_fs::TempDir::new()?;
+    let venv = create_venv_py312(&parent, &cache_dir);
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("clean")
+            .arg("tqdm")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Cleared 1 entry for package: tqdm
+        "###);
+    });
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-sync")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 1 package in [TIME]
+        Downloaded 1 package in [TIME]
+        Unzipped 1 package in [TIME]
+        Installed 1 package in [TIME]
+         + tqdm @ https://files.pythonhosted.org/packages/62/06/d5604a70d160f6a6ca5fd2ba25597c24abd5c5ca5f437263d177ac242308/tqdm-4.66.1.tar.gz
+        "###);
+    });
+
+    check_command(&venv, "import tqdm", &temp_dir);
+
     Ok(())
 }
 
@@ -1060,6 +1108,54 @@ fn install_git_source_dist_cached() -> Result<()> {
 
     check_command(&venv, "import werkzeug", &temp_dir);
 
+    // Clear the cache, then re-run the installation in a new virtual environment.
+    let parent = assert_fs::TempDir::new()?;
+    let venv = create_venv_py312(&parent, &cache_dir);
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("clean")
+            .arg("werkzeug")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Cleared 1 entry for package: werkzeug
+        "###);
+    });
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-sync")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 1 package in [TIME]
+        Downloaded 1 package in [TIME]
+        Unzipped 1 package in [TIME]
+        Installed 1 package in [TIME]
+         + werkzeug @ git+https://github.com/pallets/werkzeug.git@af160e0b6b7ddd81c22f1652c728ff5ac72d5c74
+        "###);
+    });
+
+    check_command(&venv, "import werkzeug", &temp_dir);
+
     Ok(())
 }
 
@@ -1118,6 +1214,54 @@ fn install_registry_source_dist_cached() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
+        Installed 1 package in [TIME]
+         + future==0.18.3
+        "###);
+    });
+
+    check_command(&venv, "import future", &temp_dir);
+
+    // Clear the cache, then re-run the installation in a new virtual environment.
+    let parent = assert_fs::TempDir::new()?;
+    let venv = create_venv_py312(&parent, &cache_dir);
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("clean")
+            .arg("future")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Cleared 2 entries for package: future
+        "###);
+    });
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-sync")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 1 package in [TIME]
+        Downloaded 1 package in [TIME]
+        Unzipped 1 package in [TIME]
         Installed 1 package in [TIME]
          + future==0.18.3
         "###);
@@ -1199,6 +1343,54 @@ fn install_path_source_dist_cached() -> Result<()> {
 
     check_command(&venv, "import wheel", &temp_dir);
 
+    // Clear the cache, then re-run the installation in a new virtual environment.
+    let parent = assert_fs::TempDir::new()?;
+    let venv = create_venv_py312(&parent, &cache_dir);
+
+    insta::with_settings!({
+        filters => filters.clone()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("clean")
+            .arg("wheel")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Cleared 1 entry for package: wheel
+        "###);
+    });
+
+    insta::with_settings!({
+        filters => filters.clone()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-sync")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 1 package in [TIME]
+        Downloaded 1 package in [TIME]
+        Unzipped 1 package in [TIME]
+        Installed 1 package in [TIME]
+         + wheel @ file://[TEMP_DIR]/wheel-0.42.0.tar.gz
+        "###);
+    });
+
+    check_command(&venv, "import wheel", &temp_dir);
+
     Ok(())
 }
 
@@ -1273,6 +1465,54 @@ fn install_path_built_dist_cached() -> Result<()> {
 
     check_command(&venv, "import tomli", &parent);
 
+    // Clear the cache, then re-run the installation in a new virtual environment.
+    let parent = assert_fs::TempDir::new()?;
+    let venv = create_venv_py312(&parent, &cache_dir);
+
+    insta::with_settings!({
+        filters => filters.clone()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("clean")
+            .arg("tomli")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Cleared 1 entry for package: tomli
+        "###);
+    });
+
+    insta::with_settings!({
+        filters => filters.clone()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-sync")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 1 package in [TIME]
+        Downloaded 1 package in [TIME]
+        Unzipped 1 package in [TIME]
+        Installed 1 package in [TIME]
+         + tomli @ file://[TEMP_DIR]/tomli-3.0.1-py3-none-any.whl
+        "###);
+    });
+
+    check_command(&venv, "import tomli", &temp_dir);
+
     Ok(())
 }
 
@@ -1331,6 +1571,54 @@ fn install_url_built_dist_cached() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
+        Installed 1 package in [TIME]
+         + tqdm @ https://files.pythonhosted.org/packages/00/e5/f12a80907d0884e6dff9c16d0c0114d81b8cd07dc3ae54c5e962cc83037e/tqdm-4.66.1-py3-none-any.whl
+        "###);
+    });
+
+    check_command(&venv, "import tqdm", &temp_dir);
+
+    // Clear the cache, then re-run the installation in a new virtual environment.
+    let parent = assert_fs::TempDir::new()?;
+    let venv = create_venv_py312(&parent, &cache_dir);
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("clean")
+            .arg("tqdm")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Cleared 1 entry for package: tqdm
+        "###);
+    });
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-sync")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 1 package in [TIME]
+        Downloaded 1 package in [TIME]
+        Unzipped 1 package in [TIME]
         Installed 1 package in [TIME]
          + tqdm @ https://files.pythonhosted.org/packages/00/e5/f12a80907d0884e6dff9c16d0c0114d81b8cd07dc3ae54c5e962cc83037e/tqdm-4.66.1-py3-none-any.whl
         "###);

--- a/crates/puffin-distribution/src/index/built_wheel_index.rs
+++ b/crates/puffin-distribution/src/index/built_wheel_index.rs
@@ -4,8 +4,7 @@ use tracing::warn;
 use distribution_types::CachedWheel;
 use platform_tags::Tags;
 use puffin_cache::CacheShard;
-
-use crate::index::iter_directories;
+use puffin_fs::directories;
 
 /// A local index of built distributions for a specific source distribution.
 pub struct BuiltWheelIndex;
@@ -30,7 +29,7 @@ impl BuiltWheelIndex {
     pub fn find(shard: &CacheShard, tags: &Tags) -> Option<CachedWheel> {
         let mut candidate: Option<CachedWheel> = None;
 
-        for subdir in iter_directories(shard.read_dir().ok()?) {
+        for subdir in directories(&**shard) {
             match CachedWheel::from_path(&subdir) {
                 Ok(None) => {}
                 Ok(Some(dist_info)) => {

--- a/crates/puffin-distribution/src/index/mod.rs
+++ b/crates/puffin-distribution/src/index/mod.rs
@@ -1,27 +1,5 @@
-use std::path::PathBuf;
-
-use tracing::warn;
-
 pub use built_wheel_index::BuiltWheelIndex;
 pub use registry_wheel_index::RegistryWheelIndex;
 
 mod built_wheel_index;
 mod registry_wheel_index;
-
-/// Iterate over the subdirectories of a directory.
-fn iter_directories(read_dir: std::fs::ReadDir) -> impl Iterator<Item = PathBuf> {
-    read_dir
-        .filter_map(|entry| match entry {
-            Ok(entry) => Some(entry),
-            Err(err) => {
-                warn!("Failed to read entry of cache: {}", err);
-                None
-            }
-        })
-        .filter(|entry| {
-            entry
-                .file_type()
-                .map_or(false, |file_type| file_type.is_dir())
-        })
-        .map(|entry| entry.path())
-}

--- a/crates/puffin-fs/Cargo.toml
+++ b/crates/puffin-fs/Cargo.toml
@@ -15,3 +15,4 @@ workspace = true
 [dependencies]
 fs-err = { workspace = true, features = ["tokio"] }
 tempfile = { workspace = true }
+tracing = { workspace = true }

--- a/crates/puffin-fs/src/lib.rs
+++ b/crates/puffin-fs/src/lib.rs
@@ -1,6 +1,8 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use fs_err as fs;
 use tempfile::NamedTempFile;
+use tracing::warn;
 
 /// Write `data` to `path` atomically using a temporary file and atomic rename.
 pub async fn write_atomic(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> std::io::Result<()> {
@@ -42,4 +44,49 @@ pub fn write_atomic_sync(path: impl AsRef<Path>, data: impl AsRef<[u8]>) -> std:
         )
     })?;
     Ok(())
+}
+
+/// Remove the file or directory at `path`, if it exists.
+///
+/// Returns `true` if the file or directory was removed, and `false` if the path did not exist.
+pub fn force_remove_all(path: impl AsRef<Path>) -> Result<bool, std::io::Error> {
+    let path = path.as_ref();
+
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => return Err(err),
+    };
+
+    if metadata.is_dir() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
+    }
+
+    Ok(true)
+}
+
+/// Iterate over the subdirectories of a directory.
+///
+/// If the directory does not exist, returns an empty iterator.
+pub fn directories(path: impl AsRef<Path>) -> impl Iterator<Item = PathBuf> {
+    path.as_ref()
+        .read_dir()
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| match entry {
+            Ok(entry) => Some(entry),
+            Err(err) => {
+                warn!("Failed to read entry: {}", err);
+                None
+            }
+        })
+        .filter(|entry| {
+            entry
+                .file_type()
+                .map_or(false, |file_type| file_type.is_dir())
+        })
+        .map(|entry| entry.path())
 }


### PR DESCRIPTION
## Summary

This PR enables `puffin clean` to accept package names as command line arguments, and selectively purge entries from the cache tied to the given package.

Relate to #572.

## Test Plan

Modified all the caching tests to run an additional step to (1) purge the cache, and (2) re-install the package.