### PR TITLE
Add `--reinstall` flag to `pip-sync`

### DIFF
--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -15,7 +15,7 @@ use puffin_cache::Cache;
 use puffin_client::RegistryClientBuilder;
 use puffin_dispatch::BuildDispatch;
 use puffin_distribution::DistributionDatabase;
-use puffin_installer::InstallPlan;
+use puffin_installer::{InstallPlan, Reinstall};
 use puffin_interpreter::Virtualenv;
 use pypi_types::{IndexUrls, Yanked};
 
@@ -27,6 +27,7 @@ use crate::requirements::{ExtrasSpecification, RequirementsSource, RequirementsS
 /// Install a set of locked requirements into the current Python environment.
 pub(crate) async fn pip_sync(
     sources: &[RequirementsSource],
+    reinstall: &Reinstall,
     link_mode: LinkMode,
     index_urls: IndexUrls,
     no_build: bool,
@@ -48,6 +49,7 @@ pub(crate) async fn pip_sync(
 
     sync_requirements(
         &requirements,
+        reinstall,
         link_mode,
         index_urls,
         no_build,
@@ -60,6 +62,7 @@ pub(crate) async fn pip_sync(
 /// Install a set of locked requirements into the current Python environment.
 pub(crate) async fn sync_requirements(
     requirements: &[Requirement],
+    reinstall: &Reinstall,
     link_mode: LinkMode,
     index_urls: IndexUrls,
     no_build: bool,
@@ -86,8 +89,16 @@ pub(crate) async fn sync_requirements(
         local,
         remote,
         extraneous,
-    } = InstallPlan::from_requirements(requirements, &index_urls, cache, &venv, markers, &tags)
-        .context("Failed to determine installation plan")?;
+    } = InstallPlan::from_requirements(
+        requirements,
+        reinstall,
+        &index_urls,
+        cache,
+        &venv,
+        markers,
+        &tags,
+    )
+    .context("Failed to determine installation plan")?;
 
     // Nothing to do.
     if remote.is_empty() && local.is_empty() && extraneous.is_empty() {

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -18,7 +18,7 @@ use puffin_build::{SourceBuild, SourceBuildContext};
 use puffin_cache::Cache;
 use puffin_client::RegistryClient;
 use puffin_distribution::DistributionDatabase;
-use puffin_installer::{InstallPlan, Installer, Unzipper};
+use puffin_installer::{InstallPlan, Installer, Reinstall, Unzipper};
 use puffin_interpreter::{Interpreter, Virtualenv};
 use puffin_resolver::{DistFinder, Manifest, ResolutionOptions, Resolver};
 use puffin_traits::BuildContext;
@@ -135,6 +135,7 @@ impl BuildContext for BuildDispatch {
                 extraneous,
             } = InstallPlan::from_requirements(
                 requirements,
+                &Reinstall::None,
                 &self.index_urls,
                 self.cache(),
                 venv,

--- a/crates/puffin-installer/src/lib.rs
+++ b/crates/puffin-installer/src/lib.rs
@@ -1,5 +1,5 @@
 pub use installer::{Installer, Reporter as InstallReporter};
-pub use plan::InstallPlan;
+pub use plan::{InstallPlan, Reinstall};
 pub use site_packages::SitePackages;
 pub use uninstall::uninstall;
 pub use unzipper::{Reporter as UnzipReporter, Unzipper};


### PR DESCRIPTION
## Summary

This PR adds two flags to `pip-sync`: `--reinstall`, and `--reinstall-package [PACKAGE]`. The former reinstalls all packages in the requirements, while the latter can be repeated and reinstalls all specified packages.

For our purposes, a reinstall includes (1) purging the cache, and (2) marking any already-installed versions as extraneous.

Closes #572.

Closes https://github.com/astral-sh/puffin/issues/271.