### PR TITLE
Fix incorrect unknown size marker in traces

### DIFF
--- a/crates/puffin-client/src/cached_client.rs
+++ b/crates/puffin-client/src/cached_client.rs
@@ -220,8 +220,7 @@ impl CachedClient {
                 }
             }
         } else {
-            debug!("Not cached {url}");
-            // No reusable cache
+            debug!("No cache entry for: {url}");
             self.fresh_request(req, converted_req).await?
         };
         Ok(cached_response)


### PR DESCRIPTION
It said `(unknown size)` for _all_ disk-based wheels.