### PR TITLE
Impl Version debug as display

### DIFF
--- a/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_build_tag.snap
+++ b/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_build_tag.snap
@@ -7,18 +7,7 @@ Ok(
         name: PackageName(
             "foo",
         ),
-        version: Version {
-            epoch: 0,
-            release: [
-                1,
-                2,
-                3,
-            ],
-            pre: None,
-            post: None,
-            dev: None,
-            local: None,
-        },
+        version: "1.2.3",
         python_tag: [
             "python",
         ],

--- a/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_multiple_tags.snap
+++ b/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_multiple_tags.snap
@@ -7,18 +7,7 @@ Ok(
         name: PackageName(
             "foo",
         ),
-        version: Version {
-            epoch: 0,
-            release: [
-                1,
-                2,
-                3,
-            ],
-            pre: None,
-            post: None,
-            dev: None,
-            local: None,
-        },
+        version: "1.2.3",
         python_tag: [
             "ab",
             "cd",

--- a/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_single_tags.snap
+++ b/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_single_tags.snap
@@ -7,18 +7,7 @@ Ok(
         name: PackageName(
             "foo",
         ),
-        version: Version {
-            epoch: 0,
-            release: [
-                1,
-                2,
-                3,
-            ],
-            pre: None,
-            post: None,
-            dev: None,
-            local: None,
-        },
+        version: "1.2.3",
         python_tag: [
             "foo",
         ],

--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -11,7 +11,7 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::{max, Ordering};
 #[cfg(feature = "pyo3")]
 use std::collections::hash_map::DefaultHasher;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::iter;
 use std::str::FromStr;
@@ -259,7 +259,7 @@ impl FromStr for LocalSegment {
 ///
 /// let version = Version::from_str("1.19").unwrap();
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Version {
     /// The [versioning epoch](https://peps.python.org/pep-0440/#version-epochs). Normally just 0,
     /// but you can increment it if you switched the versioning scheme.
@@ -530,6 +530,12 @@ impl Display for Version {
             })
             .unwrap_or_default();
         write!(f, "{epoch}{release}{pre}{post}{dev}{local}")
+    }
+}
+
+impl Debug for Version {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "\"{}\"", self)
     }
 }
 

--- a/crates/puffin-resolver/src/pubgrub/version.rs
+++ b/crates/puffin-resolver/src/pubgrub/version.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use once_cell::sync::Lazy;
 
 /// A PubGrub-compatible wrapper around a PEP 440 version.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PubGrubVersion(pep440_rs::Version);
 
 impl PubGrubVersion {
@@ -27,6 +27,12 @@ impl PubGrubVersion {
 }
 
 impl std::fmt::Display for PubGrubVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::fmt::Debug for PubGrubVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-basic.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-basic.txt.snap
@@ -16,18 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            24,
-                                            2,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.24.2",
                                 },
                             ],
                         ),
@@ -50,18 +39,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            0,
-                                            0,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.0.0",
                                 },
                             ],
                         ),
@@ -84,18 +62,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            8,
-                                            2,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.8.2",
                                 },
                             ],
                         ),
@@ -118,17 +85,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2023,
-                                            3,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2023.3",
                                 },
                             ],
                         ),
@@ -151,18 +108,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            16,
-                                            0,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.16.0",
                                 },
                             ],
                         ),
@@ -185,17 +131,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2023,
-                                            3,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2023.3",
                                 },
                             ],
                         ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-a.txt.snap
@@ -16,17 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: LessThan,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            2,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.2",
                                 },
                             ],
                         ),
@@ -50,18 +40,7 @@ RequirementsTxt {
                         [
                             VersionSpecifier {
                                 operator: Equal,
-                                version: Version {
-                                    epoch: 0,
-                                    release: [
-                                        2,
-                                        1,
-                                        15,
-                                    ],
-                                    pre: None,
-                                    post: None,
-                                    dev: None,
-                                    local: None,
-                                },
+                                version: "2.1.15",
                             },
                         ],
                     ),
@@ -80,17 +59,7 @@ RequirementsTxt {
                         [
                             VersionSpecifier {
                                 operator: Equal,
-                                version: Version {
-                                    epoch: 0,
-                                    release: [
-                                        2023,
-                                        3,
-                                    ],
-                                    pre: None,
-                                    post: None,
-                                    dev: None,
-                                    local: None,
-                                },
+                                version: "2023.3",
                             },
                         ],
                     ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-b.txt.snap
@@ -16,18 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            1,
-                                            15,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.1.15",
                                 },
                             ],
                         ),
@@ -50,17 +39,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2023,
-                                            3,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2023.3",
                                 },
                             ],
                         ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-for-poetry.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-for-poetry.txt.snap
@@ -16,18 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            0,
-                                            5,
-                                            1,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "0.5.1",
                                 },
                             ],
                         ),
@@ -50,17 +39,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            0,
-                                            4,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "0.4",
                                 },
                             ],
                         ),
@@ -101,29 +80,11 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: GreaterThanEqual,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1",
                                 },
                                 VersionSpecifier {
                                     operator: LessThan,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2",
                                 },
                             ],
                         ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-a.txt.snap
@@ -28,18 +28,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            24,
-                                            2,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.24.2",
                                 },
                             ],
                         ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
@@ -16,18 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            2,
-                                            3,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.2.3",
                                 },
                             ],
                         ),
@@ -79,18 +68,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            26,
-                                            15,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.26.15",
                                 },
                             ],
                         ),
@@ -142,18 +120,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            89,
-                                            0,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.89.0",
                                 },
                             ],
                         ),
@@ -216,18 +183,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            3,
-                                            1,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.3.1",
                                 },
                             ],
                         ),
@@ -280,18 +236,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            9,
-                                            5,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.9.5",
                                 },
                             ],
                         ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-small.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-small.txt.snap
@@ -16,18 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            4,
-                                            65,
-                                            0,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "4.65.0",
                                 },
                             ],
                         ),
@@ -50,18 +39,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            0,
-                                            0,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.0.0",
                                 },
                             ],
                         ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-basic.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-basic.txt.snap
@@ -16,18 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            24,
-                                            2,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.24.2",
                                 },
                             ],
                         ),
@@ -50,18 +39,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            0,
-                                            0,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.0.0",
                                 },
                             ],
                         ),
@@ -84,18 +62,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            8,
-                                            2,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.8.2",
                                 },
                             ],
                         ),
@@ -118,17 +85,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2023,
-                                            3,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2023.3",
                                 },
                             ],
                         ),
@@ -151,18 +108,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            16,
-                                            0,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.16.0",
                                 },
                             ],
                         ),
@@ -185,17 +131,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2023,
-                                            3,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2023.3",
                                 },
                             ],
                         ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-a.txt.snap
@@ -16,17 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: LessThan,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            2,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.2",
                                 },
                             ],
                         ),
@@ -50,18 +40,7 @@ RequirementsTxt {
                         [
                             VersionSpecifier {
                                 operator: Equal,
-                                version: Version {
-                                    epoch: 0,
-                                    release: [
-                                        2,
-                                        1,
-                                        15,
-                                    ],
-                                    pre: None,
-                                    post: None,
-                                    dev: None,
-                                    local: None,
-                                },
+                                version: "2.1.15",
                             },
                         ],
                     ),
@@ -80,17 +59,7 @@ RequirementsTxt {
                         [
                             VersionSpecifier {
                                 operator: Equal,
-                                version: Version {
-                                    epoch: 0,
-                                    release: [
-                                        2023,
-                                        3,
-                                    ],
-                                    pre: None,
-                                    post: None,
-                                    dev: None,
-                                    local: None,
-                                },
+                                version: "2023.3",
                             },
                         ],
                     ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-b.txt.snap
@@ -16,18 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            1,
-                                            15,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.1.15",
                                 },
                             ],
                         ),
@@ -50,17 +39,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2023,
-                                            3,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2023.3",
                                 },
                             ],
                         ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-for-poetry.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-for-poetry.txt.snap
@@ -16,18 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            0,
-                                            5,
-                                            1,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "0.5.1",
                                 },
                             ],
                         ),
@@ -50,17 +39,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            0,
-                                            4,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "0.4",
                                 },
                             ],
                         ),
@@ -101,29 +80,11 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: GreaterThanEqual,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1",
                                 },
                                 VersionSpecifier {
                                     operator: LessThan,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2",
                                 },
                             ],
                         ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-a.txt.snap
@@ -28,18 +28,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            24,
-                                            2,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.24.2",
                                 },
                             ],
                         ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-poetry-with-hashes.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-poetry-with-hashes.txt.snap
@@ -16,18 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            2,
-                                            3,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.2.3",
                                 },
                             ],
                         ),
@@ -79,18 +68,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            26,
-                                            15,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.26.15",
                                 },
                             ],
                         ),
@@ -142,18 +120,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            89,
-                                            0,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.89.0",
                                 },
                             ],
                         ),
@@ -216,18 +183,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            3,
-                                            1,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.3.1",
                                 },
                             ],
                         ),
@@ -280,18 +236,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            2,
-                                            9,
-                                            5,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "2.9.5",
                                 },
                             ],
                         ),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-small.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-small.txt.snap
@@ -16,18 +16,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            4,
-                                            65,
-                                            0,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "4.65.0",
                                 },
                             ],
                         ),
@@ -50,18 +39,7 @@ RequirementsTxt {
                             [
                                 VersionSpecifier {
                                     operator: Equal,
-                                    version: Version {
-                                        epoch: 0,
-                                        release: [
-                                            1,
-                                            0,
-                                            0,
-                                        ],
-                                        pre: None,
-                                        post: None,
-                                        dev: None,
-                                        local: None,
-                                    },
+                                    version: "1.0.0",
                                 },
                             ],
                         ),


### PR DESCRIPTION
Currently, `dbg!` is hard to read because versions are verbose, showing all optional fields, and we have a lot of versions. Changing debug formatting to displaying the version number (which can be losslessly converted to the struct and back) makes this more readable.

See e.g. https://gist.github.com/konstin/38c0f32b109dffa73b3aa0ab86b9662b

**Before**

```text
version: Version {
    epoch: 0,
    release: [
        1,
        2,
        3,
    ],
    pre: None,
    post: None,
    dev: None,
    local: None,
},
```

**After**

```text
version: "1.2.3",
```