### PR TITLE
Respect existing versions when pip-installing

### DIFF
--- a/crates/puffin-cli/tests/pip_install.rs
+++ b/crates/puffin-cli/tests/pip_install.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::process::Command;
 
 use anyhow::Result;
+use assert_cmd::assert::Assert;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use insta_cmd::_macro_support::insta;
@@ -16,13 +17,12 @@ mod common;
 // Exclude any packages uploaded after this date.
 static EXCLUDE_NEWER: &str = "2023-11-18T12:00:00Z";
 
-fn check_command(venv: &Path, command: &str, temp_dir: &Path) {
+fn assert_command(venv: &Path, command: &str, temp_dir: &Path) -> Assert {
     Command::new(venv.join("bin").join("python"))
         .arg("-c")
         .arg(command)
         .current_dir(temp_dir)
         .assert()
-        .success();
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn install_package() -> Result<()> {
         "###);
     });
 
-    check_command(&venv, "import flask", &temp_dir);
+    assert_command(&venv, "import flask", &temp_dir).success();
 
     Ok(())
 }
@@ -139,7 +139,7 @@ fn install_requirements_txt() -> Result<()> {
         "###);
     });
 
-    check_command(&venv, "import flask", &temp_dir);
+    assert_command(&venv, "import flask", &temp_dir).success();
 
     // Install Jinja2 (which should already be installed, but shouldn't remove other packages).
     let requirements_txt = temp_dir.child("requirements.txt");
@@ -168,7 +168,236 @@ fn install_requirements_txt() -> Result<()> {
         "###);
     });
 
-    check_command(&venv, "import flask", &temp_dir);
+    assert_command(&venv, "import flask", &temp_dir).success();
+
+    Ok(())
+}
+
+/// Respect installed versions when resolving.
+#[test]
+fn respect_installed() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let cache_dir = assert_fs::TempDir::new()?;
+    let venv = create_venv_py312(&temp_dir, &cache_dir);
+
+    // Install Flask.
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("Flask==2.3.2")?;
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-install")
+            .arg("-r")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .arg("--exclude-newer")
+            .arg(EXCLUDE_NEWER)
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 7 packages in [TIME]
+        Resolved 7 packages in [TIME]
+        Downloaded 7 packages in [TIME]
+        Installed 7 packages in [TIME]
+         + blinker==1.7.0
+         + click==8.1.7
+         + flask==2.3.2
+         + itsdangerous==2.1.2
+         + jinja2==3.1.2
+         + markupsafe==2.1.3
+         + werkzeug==3.0.1
+        "###);
+    });
+
+    assert_command(&venv, "import flask", &temp_dir).success();
+
+    // Re-install Flask. We should respect the existing version.
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("Flask")?;
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-install")
+            .arg("-r")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .arg("--exclude-newer")
+            .arg(EXCLUDE_NEWER)
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 7 packages in [TIME]
+        Audited 7 packages in [TIME]
+        "###);
+    });
+
+    assert_command(&venv, "import flask", &temp_dir).success();
+
+    // Install a newer version of Flask. We should upgrade it.
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("Flask==2.3.3")?;
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-install")
+            .arg("-r")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .arg("--exclude-newer")
+            .arg(EXCLUDE_NEWER)
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 7 packages in [TIME]
+        Resolved 1 package in [TIME]
+        Downloaded 1 package in [TIME]
+        Installed 1 package in [TIME]
+         - flask==2.3.2
+         + flask==2.3.3
+        "###);
+    });
+
+    // Re-install Flask. We should upgrade it.
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("Flask")?;
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-install")
+            .arg("-r")
+            .arg("requirements.txt")
+            .arg("--reinstall-package")
+            .arg("Flask")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .arg("--exclude-newer")
+            .arg(EXCLUDE_NEWER)
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 7 packages in [TIME]
+        Resolved 1 package in [TIME]
+        Downloaded 1 package in [TIME]
+        Installed 1 package in [TIME]
+         - flask==2.3.3
+         + flask==3.0.0
+        "###);
+    });
+
+    Ok(())
+}
+
+/// Like `pip`, we (unfortunately) allow incompatible environments.
+#[test]
+fn allow_incompatibilities() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let cache_dir = assert_fs::TempDir::new()?;
+    let venv = create_venv_py312(&temp_dir, &cache_dir);
+
+    // Install Flask, which relies on `Werkzeug>=3.0.0`.
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("Flask")?;
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-install")
+            .arg("-r")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .arg("--exclude-newer")
+            .arg(EXCLUDE_NEWER)
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 7 packages in [TIME]
+        Resolved 7 packages in [TIME]
+        Downloaded 7 packages in [TIME]
+        Installed 7 packages in [TIME]
+         + blinker==1.7.0
+         + click==8.1.7
+         + flask==3.0.0
+         + itsdangerous==2.1.2
+         + jinja2==3.1.2
+         + markupsafe==2.1.3
+         + werkzeug==3.0.1
+        "###);
+    });
+
+    assert_command(&venv, "import flask", &temp_dir).success();
+
+    // Install an incompatible version of Jinja2.
+    let requirements_txt = temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("jinja2==2.11.3")?;
+
+    insta::with_settings!({
+        filters => INSTA_FILTERS.to_vec()
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("pip-install")
+            .arg("-r")
+            .arg("requirements.txt")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .arg("--exclude-newer")
+            .arg(EXCLUDE_NEWER)
+            .env("VIRTUAL_ENV", venv.as_os_str())
+            .current_dir(&temp_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Resolved 2 packages in [TIME]
+        Resolved 1 package in [TIME]
+        Downloaded 1 package in [TIME]
+        Installed 1 package in [TIME]
+         - jinja2==3.1.2
+         + jinja2==2.11.3
+        "###);
+    });
+
+    // This no longer works, since we have an incompatible version of Jinja2.
+    assert_command(&venv, "import flask", &temp_dir).failure();
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

When running `puffin pip-install`, we should respect versions that are already installed in the environment. For example, if you run `puffin pip-install flask==2.0.0` and then `puffin pip-install flask`, we should avoid upgrading Flask. The most natural way to model this is to mark them as "preferences".

(It's not enough to just filter those requirements out prior to resolving, since we may not have the _dependencies_ of those packages installed. We _could_ recursively verify this across the `site-packages`, but that would be a larger PR.)
