### PR TITLE
Add a fast-path to skip resolution when installation is complete

### DIFF
--- a/crates/puffin-cli/tests/pip_install.rs
+++ b/crates/puffin-cli/tests/pip_install.rs
@@ -161,8 +161,7 @@ fn install_requirements_txt() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        Resolved 2 packages in [TIME]
-        Audited 2 packages in [TIME]
+        Audited 1 packages in [TIME]
         "###);
     });
 
@@ -239,8 +238,7 @@ fn respect_installed() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        Resolved 7 packages in [TIME]
-        Audited 7 packages in [TIME]
+        Audited 1 packages in [TIME]
         "###);
     });
 

--- a/crates/puffin-installer/src/plan.rs
+++ b/crates/puffin-installer/src/plan.rs
@@ -307,4 +307,9 @@ impl Reinstall {
             Self::None
         }
     }
+
+    /// Returns `true` if no packages should be reinstalled.
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
 }


### PR DESCRIPTION
For a very large resolution (a few hundred packages), I see 13ms vs. 400ms for a no-op. It's worth optimizing this case, in my opinion.