### PR TITLE
Allow injecting certificate for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ cache-*
 
 # python tmp files
 __pycache__
+
+scripts/offlinepi/mitmproxy-ca-cert.pem
+scripts/offlinepi/responses.dat

--- a/crates/puffin-client/Cargo.toml
+++ b/crates/puffin-client/Cargo.toml
@@ -35,3 +35,6 @@ url = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros"] }
+
+[features]
+puffin-test-custom-ca-cert = []


### PR DESCRIPTION
Built on #609

When activating the `puffin-test-custom-ca-cert` feature, you can inject a custom ssl certificate by setting `PUFFIN_TEST_CA_CERT_PEM` to a pem file, e.g.

```bash
PUFFIN_TEST_CA_CERT_PEM=$(pwd)/mitmproxy-ca-cert.pem ./offlinepi record cargo test --features pypi --features puffin-test-custom-ca-cert -- --test-threads=1 
```

This feature is off by default, so this is not possible in release builds.