### PR TITLE
Towards using `prepare_metadata_for_build_wheel` in the resolver

### DIFF
--- a/crates/puffin-dev/src/build.rs
+++ b/crates/puffin-dev/src/build.rs
@@ -62,6 +62,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
         false,
         IndexUrls::default(),
     );
+
     let builder = SourceBuild::setup(
         &args.sdist,
         args.subdirectory.as_deref(),

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -66,6 +66,8 @@ impl BuildDispatch {
 }
 
 impl BuildContext for BuildDispatch {
+    type SourceDistBuilder = SourceBuild;
+
     fn cache(&self) -> &Cache {
         &self.cache
     }
@@ -213,13 +215,12 @@ impl BuildContext for BuildDispatch {
     }
 
     #[instrument(skip_all, fields(source_dist = source_dist, subdirectory = ?subdirectory))]
-    fn build_source<'a>(
+    fn setup_build<'a>(
         &'a self,
         source: &'a Path,
         subdirectory: Option<&'a Path>,
-        wheel_dir: &'a Path,
         source_dist: &'a str,
-    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<SourceBuild>> + Send + 'a>> {
         Box::pin(async move {
             if self.no_build {
                 bail!("Building source distributions is disabled");
@@ -234,7 +235,7 @@ impl BuildContext for BuildDispatch {
                 BuildKind::Wheel,
             )
             .await?;
-            Ok(builder.build(wheel_dir).await?)
+            Ok(builder)
         })
     }
 }


### PR DESCRIPTION
Make `prepare_metadata_for_build_wheel` accessible across the puffin codebase by splitting the built call into a setup, a metadata and a wheel call. This does not actually use the hook yet, but it's the required refactoring for it.

Part of #599.