### PR TITLE
Validate environment after `pip-sync`

### DIFF
--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -14,7 +14,7 @@ use platform_tags::Tags;
 use puffin_cache::Cache;
 use puffin_client::RegistryClientBuilder;
 use puffin_dispatch::BuildDispatch;
-use puffin_installer::{Downloader, InstallPlan, Reinstall};
+use puffin_installer::{Downloader, InstallPlan, Reinstall, SitePackages};
 use puffin_interpreter::Virtualenv;
 use puffin_traits::OnceMap;
 use pypi_types::{IndexUrls, Yanked};
@@ -268,6 +268,7 @@ pub(crate) async fn sync_requirements(
         )?;
     }
 
+    // Report on any changes in the environment.
     for event in extraneous
         .into_iter()
         .chain(reinstalls.into_iter())
@@ -306,6 +307,18 @@ pub(crate) async fn sync_requirements(
                 )?;
             }
         }
+    }
+
+    // Validate that the environment is consistent.
+    let site_packages = SitePackages::try_from_executable(&venv)?;
+    for diagnostic in site_packages.diagnostics()? {
+        writeln!(
+            printer,
+            "{}{} {}",
+            "warning".yellow().bold(),
+            ":".bold(),
+            diagnostic.message().bold()
+        )?;
     }
 
     Ok(ExitStatus::Success)

--- a/crates/puffin-cli/tests/pip_sync.rs
+++ b/crates/puffin-cli/tests/pip_sync.rs
@@ -768,8 +768,9 @@ fn warn_on_yanked_version() -> Result<()> {
 
     let requirements_in = temp_dir.child("requirements.txt");
     requirements_in.touch()?;
-    // This version is yanked
-    requirements_in.write_str("ipython==8.13.0")?;
+
+    // This version is yanked.
+    requirements_in.write_str("colorama==0.4.2")?;
 
     insta::with_settings!({
         filters => INSTA_FILTERS.to_vec()

--- a/crates/puffin-cli/tests/snapshots/pip_sync__install_dtls_socket.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_sync__install_dtls_socket.snap
@@ -6,9 +6,9 @@ info:
     - pip-sync
     - requirements.txt
     - "--cache-dir"
-    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpcRNTPf
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpOX4pkP
   env:
-    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpK40oCA/.venv
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpCpUYiO/.venv
 ---
 success: true
 exit_code: 0
@@ -19,4 +19,5 @@ Resolved 1 package in [TIME]
 Downloaded 1 package in [TIME]
 Installed 1 package in [TIME]
  + dtlssocket @ https://files.pythonhosted.org/packages/58/42/0a0442118096eb9fbc9dc70b45aee2957f7546b80545e2a05bd839380519/DTLSSocket-0.1.16.tar.gz
+warning: The package `dtlssocket` requires `cython <3`, but it's not installed.
 

--- a/crates/puffin-cli/tests/snapshots/pip_sync__warn_on_yanked_version.snap
+++ b/crates/puffin-cli/tests/snapshots/pip_sync__warn_on_yanked_version.snap
@@ -6,9 +6,9 @@ info:
     - pip-sync
     - requirements.txt
     - "--cache-dir"
-    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpR0i3bZ
+    - /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpQOqXCr
   env:
-    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmplFEoko/.venv
+    VIRTUAL_ENV: /var/folders/nt/6gf2v7_s3k13zq_t3944rwz40000gn/T/.tmpyEEM5q/.venv
 ---
 success: true
 exit_code: 0
@@ -16,8 +16,8 @@ exit_code: 0
 
 ----- stderr -----
 Resolved 1 package in [TIME]
-warning: ipython==8.13.0 is yanked (reason: "Wrong Python Pinning"). Refresh your lockfile to pin an un-yanked version.
+warning: colorama==0.4.2 is yanked (reason: "Bad build, missing files, will not install"). Refresh your lockfile to pin an un-yanked version.
 Downloaded 1 package in [TIME]
 Installed 1 package in [TIME]
- + ipython==8.13.0
+ + colorama==0.4.2
 


### PR DESCRIPTION
Not 100% sure that we actually want to do this, it seems reasonable though.

Closes https://github.com/astral-sh/puffin/issues/410.
