### PR TITLE
Don't preserve tar mtime to work around tar-rs bug.

### DIFF
--- a/crates/puffin-build/src/lib.rs
+++ b/crates/puffin-build/src/lib.rs
@@ -689,6 +689,8 @@ fn extract_archive(sdist: &Path, extracted: &PathBuf) -> Result<PathBuf, Error> 
     {
         // .tar.gz
         let mut archive = Archive::new(GzDecoder::new(File::open(sdist)?));
+        // https://github.com/alexcrichton/tar-rs/issues/349
+        archive.set_preserve_mtime(false);
         archive.unpack(extracted)?;
     } else {
         return Err(Error::UnsupportedArchiveType(


### PR DESCRIPTION
Don't preserve mtime to work around https://github.com/alexcrichton/tar-rs/issues/349 to fix #579.