### PR TITLE
Typo: editable -> editables

### DIFF
--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -106,7 +106,7 @@ pub struct RequirementsTxt {
     /// Constraints included with `-c`
     pub constraints: Vec<Requirement>,
     /// Editables with `-e`
-    pub editable: Vec<EditableRequirement>,
+    pub editables: Vec<EditableRequirement>,
 }
 
 impl RequirementsTxt {
@@ -193,7 +193,7 @@ impl RequirementsTxt {
                     data.requirements.push(requirement_entry);
                 }
                 RequirementsTxtStatement::EditableRequirement(editable) => {
-                    data.editable.push(editable);
+                    data.editables.push(editable);
                 }
             }
         }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-basic.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-basic.txt.snap
@@ -144,5 +144,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-a.txt.snap
@@ -68,5 +68,5 @@ RequirementsTxt {
             marker: None,
         },
     ],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-b.txt.snap
@@ -52,5 +52,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-editable.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-editable.txt.snap
@@ -54,5 +54,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-empty.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-empty.txt.snap
@@ -5,5 +5,5 @@ expression: actual
 RequirementsTxt {
     requirements: [],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-for-poetry.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-for-poetry.txt.snap
@@ -97,5 +97,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-a.txt.snap
@@ -41,5 +41,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-b.txt.snap
@@ -18,5 +18,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
@@ -281,5 +281,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-small.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-small.txt.snap
@@ -52,5 +52,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-whitespace.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-whitespace.txt.snap
@@ -54,5 +54,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-basic.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-basic.txt.snap
@@ -144,5 +144,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-a.txt.snap
@@ -68,5 +68,5 @@ RequirementsTxt {
             marker: None,
         },
     ],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-b.txt.snap
@@ -52,5 +52,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-empty.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-empty.txt.snap
@@ -5,5 +5,5 @@ expression: actual
 RequirementsTxt {
     requirements: [],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-for-poetry.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-for-poetry.txt.snap
@@ -97,5 +97,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-a.txt.snap
@@ -41,5 +41,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-b.txt.snap
@@ -18,5 +18,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-poetry-with-hashes.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-poetry-with-hashes.txt.snap
@@ -281,5 +281,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-small.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-small.txt.snap
@@ -52,5 +52,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-whitespace.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-whitespace.txt.snap
@@ -54,5 +54,5 @@ RequirementsTxt {
         },
     ],
     constraints: [],
-    editable: [],
+    editables: [],
 }


### PR DESCRIPTION
Split out to minimize the diff in #587