### PR TITLE
Add dedicated ID types to avoid opaque strings

### DIFF
--- a/crates/distribution-types/src/id.rs
+++ b/crates/distribution-types/src/id.rs
@@ -1,0 +1,50 @@
+/// A unique identifier for a package (e.g., `black==23.10.0`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PackageId(String);
+
+impl PackageId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+/// A unique identifier for a distribution (e.g., `black-23.10.0-py3-none-any.whl`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DistributionId(String);
+
+impl DistributionId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+/// A unique identifier for a resource, like a URL or a Git repository.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ResourceId(String);
+
+impl ResourceId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl From<&PackageId> for PackageId {
+    /// Required for `WaitMap::wait`.
+    fn from(value: &PackageId) -> Self {
+        value.clone()
+    }
+}
+
+impl From<&DistributionId> for DistributionId {
+    /// Required for `WaitMap::wait`.
+    fn from(value: &DistributionId) -> Self {
+        value.clone()
+    }
+}
+
+impl From<&ResourceId> for ResourceId {
+    /// Required for `WaitMap::wait`.
+    fn from(value: &ResourceId) -> Self {
+        value.clone()
+    }
+}

--- a/crates/puffin-distribution/src/locks.rs
+++ b/crates/puffin-distribution/src/locks.rs
@@ -8,11 +8,11 @@ use rustc_hash::FxHashMap;
 use tokio::sync::Mutex;
 use tracing::error;
 
-use distribution_types::Identifier;
+use distribution_types::{Identifier, ResourceId};
 
 /// A set of locks used to prevent concurrent access to the same resource.
 #[derive(Debug, Default)]
-pub(crate) struct Locks(Mutex<FxHashMap<String, Arc<Mutex<()>>>>);
+pub(crate) struct Locks(Mutex<FxHashMap<ResourceId, Arc<Mutex<()>>>>);
 
 impl Locks {
     /// Acquire a lock on the given resource.

--- a/crates/puffin-normalize/src/package_name.rs
+++ b/crates/puffin-normalize/src/package_name.rs
@@ -28,7 +28,7 @@ impl PackageName {
 }
 
 impl From<&PackageName> for PackageName {
-    /// Required for `WaitMap::wait`
+    /// Required for `WaitMap::wait`.
     fn from(package_name: &PackageName) -> Self {
         package_name.clone()
     }

--- a/crates/puffin-resolver/src/candidate_selector.rs
+++ b/crates/puffin-resolver/src/candidate_selector.rs
@@ -1,7 +1,7 @@
 use pubgrub::range::Range;
 use rustc_hash::FxHashMap;
 
-use distribution_types::Dist;
+use distribution_types::{Dist, Metadata};
 use pep508_rs::{Requirement, VersionOrUrl};
 use puffin_normalize::PackageName;
 use pypi_types::IndexUrl;
@@ -250,5 +250,15 @@ impl<'a> Candidate<'a> {
             self.resolve().clone().into(),
             index,
         )
+    }
+}
+
+impl Metadata for Candidate<'_> {
+    fn name(&self) -> &PackageName {
+        self.name
+    }
+
+    fn version_or_url(&self) -> distribution_types::VersionOrUrl {
+        distribution_types::VersionOrUrl::Version(self.version.into())
     }
 }

--- a/crates/puffin-resolver/src/file.rs
+++ b/crates/puffin-resolver/src/file.rs
@@ -62,13 +62,6 @@ impl DistFile {
             Self::Sdist(sdist) => sdist.filename.as_str(),
         }
     }
-
-    pub(crate) fn sha256(&self) -> &str {
-        match self {
-            Self::Wheel(wheel) => &wheel.hashes.sha256,
-            Self::Sdist(sdist) => &sdist.hashes.sha256,
-        }
-    }
 }
 
 impl From<DistFile> for File {

--- a/crates/puffin-resolver/src/resolution.rs
+++ b/crates/puffin-resolver/src/resolution.rs
@@ -11,7 +11,7 @@ use pubgrub::type_aliases::SelectedDependencies;
 use rustc_hash::FxHashMap;
 use url::Url;
 
-use distribution_types::{BuiltDist, Dist, Metadata, SourceDist};
+use distribution_types::{BuiltDist, Dist, Metadata, PackageId, SourceDist};
 use pep440_rs::{Version, VersionSpecifier, VersionSpecifiers};
 use pep508_rs::{Requirement, VersionOrUrl};
 use puffin_normalize::{ExtraName, PackageName};
@@ -82,7 +82,7 @@ impl ResolutionGraph {
     pub(crate) fn from_state(
         selection: &SelectedDependencies<PubGrubPackage, PubGrubVersion>,
         pins: &FilePins,
-        distributions: &OnceMap<String, Metadata21>,
+        distributions: &OnceMap<PackageId, Metadata21>,
         redirects: &OnceMap<Url, Url>,
         state: &State<PubGrubPackage, Range<PubGrubVersion>, PubGrubPriority>,
     ) -> Result<Self, ResolveError> {


### PR DESCRIPTION
This allows us to enforce type safety within the resolver. For example, in the index, we can remove `String` as a key type and enforce that callers _must_ present us with a `PackageId`. (This actually caught one bug, where we were using the SHA rather than the package ID. That bug shouldn't have had any effect given where it was, since those are 1:1, but it's still problematic.)