### PR TITLE
Remove `SourceDistDownload` struct

### DIFF
--- a/crates/puffin-distribution/src/download.rs
+++ b/crates/puffin-distribution/src/download.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use zip::ZipArchive;
 
 use distribution_filename::WheelFilename;
-use distribution_types::{Dist, SourceDist};
+use distribution_types::Dist;
 use install_wheel_rs::read_dist_info;
 use pypi_types::Metadata21;
 
@@ -86,57 +86,6 @@ impl LocalWheel {
     }
 }
 
-/// A downloaded source distribution.
-#[derive(Debug, Clone)]
-pub struct SourceDistDownload {
-    /// The remote distribution from which this source distribution was downloaded.
-    pub(crate) dist: SourceDist,
-    /// The path to the downloaded archive or directory.
-    pub(crate) sdist_file: PathBuf,
-    /// The subdirectory within the archive or directory.
-    pub(crate) subdirectory: Option<PathBuf>,
-}
-
-/// A downloaded distribution, either a wheel or a source distribution.
-#[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
-pub enum Download {
-    Wheel(LocalWheel),
-    SourceDist(SourceDistDownload),
-}
-
-impl std::fmt::Display for Download {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Download::Wheel(wheel) => write!(f, "{wheel}"),
-            Download::SourceDist(sdist) => write!(f, "{sdist}"),
-        }
-    }
-}
-
-impl std::fmt::Display for LocalWheel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.remote())
-    }
-}
-
-impl std::fmt::Display for SourceDistDownload {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.remote())
-    }
-}
-
-impl BuiltWheel {
-    /// Read the [`Metadata21`] from a wheel.
-    pub fn read_dist_info(&self) -> Result<Metadata21, Error> {
-        let mut archive = ZipArchive::new(fs_err::File::open(&self.path)?)?;
-        let dist_info = read_dist_info(&self.filename, &mut archive).map_err(|err| {
-            Error::DistInfo(Box::new(self.filename.clone()), self.dist.to_string(), err)
-        })?;
-        Ok(Metadata21::parse(&dist_info)?)
-    }
-}
-
 impl DiskWheel {
     /// Return the [`Dist`] from which this wheel was downloaded.
     pub fn remote(&self) -> &Dist {
@@ -159,9 +108,19 @@ impl BuiltWheel {
     }
 }
 
-impl SourceDistDownload {
-    /// Return the [`Dist`] from which this source distribution was downloaded.
-    pub fn remote(&self) -> &SourceDist {
-        &self.dist
+impl std::fmt::Display for LocalWheel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.remote())
+    }
+}
+
+impl BuiltWheel {
+    /// Read the [`Metadata21`] from a wheel.
+    pub fn read_dist_info(&self) -> Result<Metadata21, Error> {
+        let mut archive = ZipArchive::new(fs_err::File::open(&self.path)?)?;
+        let dist_info = read_dist_info(&self.filename, &mut archive).map_err(|err| {
+            Error::DistInfo(Box::new(self.filename.clone()), self.dist.to_string(), err)
+        })?;
+        Ok(Metadata21::parse(&dist_info)?)
     }
 }

--- a/crates/puffin-distribution/src/lib.rs
+++ b/crates/puffin-distribution/src/lib.rs
@@ -1,5 +1,5 @@
 pub use distribution_database::{DistributionDatabase, DistributionDatabaseError};
-pub use download::{DiskWheel, Download, InMemoryWheel, LocalWheel, SourceDistDownload};
+pub use download::{DiskWheel, InMemoryWheel, LocalWheel};
 pub use index::{BuiltWheelIndex, RegistryWheelIndex};
 pub use reporter::Reporter;
 pub use source_dist::{SourceDistCachedBuilder, SourceDistError};

--- a/crates/puffin-distribution/src/source_dist.rs
+++ b/crates/puffin-distribution/src/source_dist.rs
@@ -35,7 +35,7 @@ use puffin_traits::{BuildContext, SourceBuildTrait};
 use pypi_types::Metadata21;
 
 use crate::locks::LockedFile;
-use crate::{Reporter, SourceDistDownload};
+use crate::Reporter;
 
 /// The caller is responsible for adding the source dist information to the error chain
 #[derive(Debug, Error)]
@@ -237,18 +237,12 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
             let (temp_dir, sdist_file) = self.download_source_dist_url(response, filename).await?;
             drop(span);
 
-            let download = SourceDistDownload {
-                dist: source_dist.clone(),
-                sdist_file: sdist_file.clone(),
-                subdirectory: subdirectory.map(Path::to_path_buf),
-            };
-
             let (disk_filename, wheel_filename, metadata) = self
                 .build_source_dist(
-                    &download.dist,
+                    source_dist,
                     temp_dir,
-                    &download.sdist_file,
-                    download.subdirectory.as_deref(),
+                    &sdist_file,
+                    subdirectory,
                     &cache_entry,
                 )
                 .await?;


### PR DESCRIPTION
This is created in one place, then immediately destructed into fields.