### PR TITLE
Avoid double resolution during source builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,7 @@ dependencies = [
  "puffin-git",
  "puffin-normalize",
  "pypi-types",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
@@ -2245,6 +2246,7 @@ name = "puffin-build"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "distribution-types",
  "fs-err",
  "gourgeist",
  "indoc",
@@ -2637,6 +2639,7 @@ name = "puffin-traits"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "distribution-types",
  "pep508_rs",
  "puffin-cache",
  "puffin-interpreter",

--- a/crates/distribution-types/Cargo.toml
+++ b/crates/distribution-types/Cargo.toml
@@ -23,6 +23,7 @@ pypi-types = { path = "../pypi-types" }
 
 anyhow = { workspace = true }
 fs-err = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -25,7 +25,7 @@
 //! * [`CachedRegistryDist`]
 //! * [`CachedDirectUrlDist`]
 //!
-//! TODO(konstin): Track all kinds from [`Dist`]
+//! TODO(konstin): Track all kinds from [`Dist`].
 //!
 //! ## `InstalledDist`
 //! An [`InstalledDist`] is built distribution (wheel) that is installed in a virtual environment,
@@ -35,8 +35,7 @@
 //!
 //! Since we read this information from [`direct_url.json`](https://packaging.python.org/en/latest/specifications/direct-url-data-structure/), it doesn't match the information [`Dist`] exactly.
 //!
-//! TODO(konstin): Track all kinds from [`Dist`]
-//! TODO(konstin): Track all kinds from [`Dist`]
+//! TODO(konstin): Track all kinds from [`Dist`].
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -54,6 +53,7 @@ pub use crate::cached::*;
 pub use crate::error::*;
 pub use crate::id::*;
 pub use crate::installed::*;
+pub use crate::resolution::*;
 pub use crate::traits::*;
 
 mod any;
@@ -62,6 +62,7 @@ pub mod direct_url;
 mod error;
 mod id;
 mod installed;
+mod resolution;
 mod traits;
 
 #[derive(Debug, Clone)]

--- a/crates/distribution-types/src/resolution.rs
+++ b/crates/distribution-types/src/resolution.rs
@@ -1,0 +1,116 @@
+use rustc_hash::FxHashMap;
+
+use pep508_rs::Requirement;
+use puffin_normalize::PackageName;
+
+use crate::{BuiltDist, Dist, SourceDist};
+
+/// A set of packages pinned at specific versions.
+#[derive(Debug, Default, Clone)]
+pub struct Resolution(FxHashMap<PackageName, Dist>);
+
+impl Resolution {
+    /// Create a new resolution from the given pinned packages.
+    pub fn new(packages: FxHashMap<PackageName, Dist>) -> Self {
+        Self(packages)
+    }
+
+    /// Return the distribution for the given package name, if it exists.
+    pub fn get(&self, package_name: &PackageName) -> Option<&Dist> {
+        self.0.get(package_name)
+    }
+
+    /// Iterate over the [`PackageName`] entities in this resolution.
+    pub fn packages(&self) -> impl Iterator<Item = &PackageName> {
+        self.0.keys()
+    }
+
+    /// Iterate over the [`Dist`] entities in this resolution.
+    pub fn distributions(&self) -> impl Iterator<Item = &Dist> {
+        self.0.values()
+    }
+
+    /// Iterate over the [`Dist`] entities in this resolution.
+    pub fn into_distributions(self) -> impl Iterator<Item = Dist> {
+        self.0.into_values()
+    }
+
+    /// Return the number of distributions in this resolution.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Return `true` if there are no pinned packages in this resolution.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Return the set of [`Requirement`]s that this resolution represents.
+    pub fn requirements(&self) -> Vec<Requirement> {
+        let mut requirements = self
+            .0
+            .values()
+            .cloned()
+            .map(Requirement::from)
+            .collect::<Vec<_>>();
+        requirements.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+        requirements
+    }
+}
+
+impl From<Dist> for Requirement {
+    fn from(dist: Dist) -> Self {
+        match dist {
+            Dist::Built(BuiltDist::Registry(wheel)) => Requirement {
+                name: wheel.name,
+                extras: None,
+                version_or_url: Some(pep508_rs::VersionOrUrl::VersionSpecifier(
+                    pep440_rs::VersionSpecifiers::from(
+                        pep440_rs::VersionSpecifier::equals_version(wheel.version),
+                    ),
+                )),
+                marker: None,
+            },
+            Dist::Built(BuiltDist::DirectUrl(wheel)) => Requirement {
+                name: wheel.filename.name,
+                extras: None,
+                version_or_url: Some(pep508_rs::VersionOrUrl::Url(wheel.url)),
+                marker: None,
+            },
+            Dist::Built(BuiltDist::Path(wheel)) => Requirement {
+                name: wheel.filename.name,
+                extras: None,
+                version_or_url: Some(pep508_rs::VersionOrUrl::Url(wheel.url)),
+                marker: None,
+            },
+            Dist::Source(SourceDist::Registry(sdist)) => Requirement {
+                name: sdist.name,
+                extras: None,
+                version_or_url: Some(pep508_rs::VersionOrUrl::VersionSpecifier(
+                    pep440_rs::VersionSpecifiers::from(
+                        pep440_rs::VersionSpecifier::equals_version(sdist.version),
+                    ),
+                )),
+                marker: None,
+            },
+            Dist::Source(SourceDist::DirectUrl(sdist)) => Requirement {
+                name: sdist.name,
+                extras: None,
+                version_or_url: Some(pep508_rs::VersionOrUrl::Url(sdist.url)),
+                marker: None,
+            },
+            Dist::Source(SourceDist::Git(sdist)) => Requirement {
+                name: sdist.name,
+                extras: None,
+                version_or_url: Some(pep508_rs::VersionOrUrl::Url(sdist.url)),
+                marker: None,
+            },
+            Dist::Source(SourceDist::Path(sdist)) => Requirement {
+                name: sdist.name,
+                extras: None,
+                version_or_url: Some(pep508_rs::VersionOrUrl::Url(sdist.url)),
+                marker: None,
+            },
+        }
+    }
+}

--- a/crates/puffin-build/Cargo.toml
+++ b/crates/puffin-build/Cargo.toml
@@ -14,6 +14,7 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
+distribution-types = { path = "../distribution-types" }
 gourgeist = { path = "../gourgeist" }
 pep508_rs = { path = "../pep508-rs" }
 platform-host = { path = "../platform-host" }

--- a/crates/puffin-build/src/lib.rs
+++ b/crates/puffin-build/src/lib.rs
@@ -13,6 +13,7 @@ use std::process::Output;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use distribution_types::Resolution;
 use fs_err as fs;
 use fs_err::DirEntry;
 use indoc::formatdoc;
@@ -211,7 +212,7 @@ impl Display for BuildKind {
 pub struct SourceBuildContext {
     /// Cache the first resolution of `pip`, `setuptools` and `wheel` we made for setup.py (and
     /// some PEP 517) builds so we can reuse it
-    setup_py_resolution: Arc<Mutex<Option<Vec<Requirement>>>>,
+    setup_py_resolution: Arc<Mutex<Option<Resolution>>>,
 }
 
 /// Holds the state through a series of PEP 517 frontend to backend calls or a single setup.py
@@ -654,13 +655,13 @@ async fn create_pep517_build_environment(
             .cloned()
             .chain(extra_requires)
             .collect();
-        let resolved_requirements = build_context
+        let resolution = build_context
             .resolve(&requirements)
             .await
             .map_err(|err| Error::RequirementsInstall("build-system.requires (resolve)", err))?;
 
         build_context
-            .install(&resolved_requirements, venv)
+            .install(&resolution, venv)
             .await
             .map_err(|err| Error::RequirementsInstall("build-system.requires (install)", err))?;
     }

--- a/crates/puffin-cli/src/commands/pip_install.rs
+++ b/crates/puffin-cli/src/commands/pip_install.rs
@@ -7,7 +7,7 @@ use fs_err as fs;
 use itertools::Itertools;
 use tracing::debug;
 
-use distribution_types::{AnyDist, Metadata};
+use distribution_types::{AnyDist, Metadata, Resolution};
 use install_wheel_rs::linker::LinkMode;
 use pep508_rs::Requirement;
 use platform_host::Platform;
@@ -18,8 +18,7 @@ use puffin_dispatch::BuildDispatch;
 use puffin_installer::{Downloader, InstallPlan, Reinstall, SitePackages};
 use puffin_interpreter::Virtualenv;
 use puffin_resolver::{
-    Manifest, PreReleaseMode, ResolutionGraph, ResolutionManifest, ResolutionMode,
-    ResolutionOptions, Resolver,
+    Manifest, PreReleaseMode, ResolutionGraph, ResolutionMode, ResolutionOptions, Resolver,
 };
 use puffin_traits::OnceMap;
 use pypi_types::IndexUrls;
@@ -272,7 +271,7 @@ async fn resolve(
 /// Install a set of requirements into the current environment.
 #[allow(clippy::too_many_arguments)]
 async fn install(
-    resolution: &ResolutionManifest,
+    resolution: &Resolution,
     reinstall: &Reinstall,
     link_mode: LinkMode,
     index_urls: IndexUrls,
@@ -456,11 +455,7 @@ async fn install(
 }
 
 /// Validate the installed packages in the virtual environment.
-fn validate(
-    resolution: &ResolutionManifest,
-    venv: &Virtualenv,
-    mut printer: Printer,
-) -> Result<()> {
+fn validate(resolution: &Resolution, venv: &Virtualenv, mut printer: Printer) -> Result<()> {
     let site_packages = SitePackages::from_executable(venv)?;
     let diagnostics = site_packages.diagnostics()?;
     for diagnostic in diagnostics {

--- a/crates/puffin-resolver/src/finder.rs
+++ b/crates/puffin-resolver/src/finder.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use futures::StreamExt;
 use rustc_hash::FxHashMap;
 
-use distribution_types::{Dist, Metadata};
+use distribution_types::{Dist, Metadata, Resolution};
 use pep440_rs::Version;
 use pep508_rs::{Requirement, VersionOrUrl};
 use platform_tags::{TagPriority, Tags};
@@ -18,7 +18,6 @@ use puffin_normalize::PackageName;
 use pypi_types::IndexUrl;
 
 use crate::error::ResolveError;
-use crate::resolution::ResolutionManifest;
 
 pub struct DistFinder<'a> {
     tags: &'a Tags,
@@ -48,12 +47,9 @@ impl<'a> DistFinder<'a> {
     }
 
     /// Resolve a set of pinned packages into a set of wheels.
-    pub async fn resolve(
-        &self,
-        requirements: &[Requirement],
-    ) -> Result<ResolutionManifest, ResolveError> {
+    pub async fn resolve(&self, requirements: &[Requirement]) -> Result<Resolution, ResolveError> {
         if requirements.is_empty() {
-            return Ok(ResolutionManifest::default());
+            return Ok(Resolution::default());
         }
 
         // A channel to fetch package metadata (e.g., given `flask`, fetch all versions).
@@ -99,7 +95,7 @@ impl<'a> DistFinder<'a> {
             if let Some(reporter) = self.reporter.as_ref() {
                 reporter.on_complete();
             }
-            return Ok(ResolutionManifest::new(resolution));
+            return Ok(Resolution::new(resolution));
         }
 
         // Otherwise, wait for the package stream to complete.
@@ -133,7 +129,7 @@ impl<'a> DistFinder<'a> {
             reporter.on_complete();
         }
 
-        Ok(ResolutionManifest::new(resolution))
+        Ok(Resolution::new(resolution))
     }
 
     /// select a version that satisfies the requirement, preferring wheels to source distributions.

--- a/crates/puffin-resolver/src/lib.rs
+++ b/crates/puffin-resolver/src/lib.rs
@@ -3,7 +3,7 @@ pub use finder::{DistFinder, Reporter as FinderReporter};
 pub use manifest::Manifest;
 pub use prerelease_mode::PreReleaseMode;
 pub use pubgrub::PubGrubReportFormatter;
-pub use resolution::{ResolutionGraph, ResolutionManifest};
+pub use resolution::ResolutionGraph;
 pub use resolution_mode::ResolutionMode;
 pub use resolution_options::ResolutionOptions;
 pub use resolver::{

--- a/crates/puffin-resolver/src/resolution.rs
+++ b/crates/puffin-resolver/src/resolution.rs
@@ -2,7 +2,6 @@ use std::hash::BuildHasherDefault;
 
 use anyhow::Result;
 use colored::Colorize;
-use itertools::Itertools;
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
 use pubgrub::range::Range;
@@ -11,9 +10,9 @@ use pubgrub::type_aliases::SelectedDependencies;
 use rustc_hash::FxHashMap;
 use url::Url;
 
-use distribution_types::{BuiltDist, Dist, Metadata, PackageId, SourceDist};
-use pep440_rs::{Version, VersionSpecifier, VersionSpecifiers};
-use pep508_rs::{Requirement, VerbatimUrl, VersionOrUrl};
+use distribution_types::{Dist, Metadata, PackageId};
+use pep440_rs::Version;
+use pep508_rs::{Requirement, VerbatimUrl};
 use puffin_normalize::{ExtraName, PackageName};
 use puffin_traits::OnceMap;
 use pypi_types::Metadata21;
@@ -21,51 +20,6 @@ use pypi_types::Metadata21;
 use crate::pins::FilePins;
 use crate::pubgrub::{PubGrubDistribution, PubGrubPackage, PubGrubPriority, PubGrubVersion};
 use crate::ResolveError;
-
-/// A set of packages pinned at specific versions.
-#[derive(Debug, Default)]
-pub struct ResolutionManifest(FxHashMap<PackageName, Dist>);
-
-impl ResolutionManifest {
-    /// Create a new resolution from the given pinned packages.
-    pub(crate) fn new(packages: FxHashMap<PackageName, Dist>) -> Self {
-        Self(packages)
-    }
-
-    /// Return the distribution for the given package name, if it exists.
-    pub fn get(&self, package_name: &PackageName) -> Option<&Dist> {
-        self.0.get(package_name)
-    }
-
-    /// Iterate over the [`PackageName`] entities in this resolution.
-    pub fn packages(&self) -> impl Iterator<Item = &PackageName> {
-        self.0.keys()
-    }
-
-    /// Iterate over the [`Dist`] entities in this resolution.
-    pub fn into_distributions(self) -> impl Iterator<Item = Dist> {
-        self.0.into_values()
-    }
-
-    /// Return the number of distributions in this resolution.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Return `true` if there are no pinned packages in this resolution.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Return the set of [`Requirement`]s that this resolution represents.
-    pub fn requirements(&self) -> Vec<Requirement> {
-        self.0
-            .values()
-            .sorted_by_key(|package| package.name())
-            .map(as_requirement)
-            .collect()
-    }
-}
 
 /// A complete resolution graph in which every node represents a pinned package and every edge
 /// represents a dependency between two pinned packages.
@@ -224,7 +178,9 @@ impl ResolutionGraph {
         nodes.sort_unstable_by_key(|(_, package)| package.name());
         self.petgraph
             .node_indices()
-            .map(|node| as_requirement(&self.petgraph[node]))
+            .map(|node| &self.petgraph[node])
+            .cloned()
+            .map(Requirement::from)
             .collect()
     }
 
@@ -283,9 +239,9 @@ impl std::fmt::Display for ResolutionGraph {
     }
 }
 
-impl From<ResolutionGraph> for ResolutionManifest {
+impl From<ResolutionGraph> for distribution_types::Resolution {
     fn from(graph: ResolutionGraph) -> Self {
-        Self(
+        Self::new(
             graph
                 .petgraph
                 .node_indices()
@@ -297,58 +253,6 @@ impl From<ResolutionGraph> for ResolutionManifest {
                 })
                 .collect(),
         )
-    }
-}
-
-/// Create a [`Requirement`] from a [`Dist`].
-fn as_requirement(dist: &Dist) -> Requirement {
-    match dist {
-        Dist::Built(BuiltDist::Registry(wheel)) => Requirement {
-            name: wheel.name.clone(),
-            extras: None,
-            version_or_url: Some(VersionOrUrl::VersionSpecifier(VersionSpecifiers::from(
-                VersionSpecifier::equals_version(wheel.version.clone()),
-            ))),
-            marker: None,
-        },
-        Dist::Built(BuiltDist::DirectUrl(wheel)) => Requirement {
-            name: wheel.filename.name.clone(),
-            extras: None,
-            version_or_url: Some(VersionOrUrl::Url(wheel.url.clone())),
-            marker: None,
-        },
-        Dist::Built(BuiltDist::Path(wheel)) => Requirement {
-            name: wheel.filename.name.clone(),
-            extras: None,
-            version_or_url: Some(VersionOrUrl::Url(wheel.url.clone())),
-            marker: None,
-        },
-        Dist::Source(SourceDist::Registry(sdist)) => Requirement {
-            name: sdist.name.clone(),
-            extras: None,
-            version_or_url: Some(VersionOrUrl::VersionSpecifier(VersionSpecifiers::from(
-                VersionSpecifier::equals_version(sdist.version.clone()),
-            ))),
-            marker: None,
-        },
-        Dist::Source(SourceDist::DirectUrl(sdist)) => Requirement {
-            name: sdist.name.clone(),
-            extras: None,
-            version_or_url: Some(VersionOrUrl::Url(sdist.url.clone())),
-            marker: None,
-        },
-        Dist::Source(SourceDist::Git(sdist)) => Requirement {
-            name: sdist.name.clone(),
-            extras: None,
-            version_or_url: Some(VersionOrUrl::Url(sdist.url.clone())),
-            marker: None,
-        },
-        Dist::Source(SourceDist::Path(sdist)) => Requirement {
-            name: sdist.name.clone(),
-            extras: None,
-            version_or_url: Some(VersionOrUrl::Url(sdist.url.clone())),
-            marker: None,
-        },
     }
 }
 

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -12,6 +12,7 @@ use anyhow::Result;
 use chrono::{DateTime, Utc};
 use once_cell::sync::Lazy;
 
+use distribution_types::Resolution;
 use pep508_rs::{MarkerEnvironment, Requirement, StringVersion};
 use platform_host::{Arch, Os, Platform};
 use platform_tags::Tags;
@@ -53,13 +54,13 @@ impl BuildContext for DummyContext {
     fn resolve<'a>(
         &'a self,
         _requirements: &'a [Requirement],
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Requirement>>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Resolution>> + Send + 'a>> {
         panic!("The test should not need to build source distributions")
     }
 
     fn install<'a>(
         &'a self,
-        _requirements: &'a [Requirement],
+        _resolution: &'a Resolution,
         _venv: &'a Virtualenv,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
         panic!("The test should not need to build source distributions")

--- a/crates/puffin-traits/Cargo.toml
+++ b/crates/puffin-traits/Cargo.toml
@@ -13,6 +13,7 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
+distribution-types = { path = "../distribution-types" }
 pep508_rs = { path = "../pep508-rs" }
 puffin-cache = { path = "../puffin-cache" }
 puffin-interpreter = { path = "../puffin-interpreter" }

--- a/crates/puffin-traits/src/lib.rs
+++ b/crates/puffin-traits/src/lib.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 
 use anyhow::Result;
 
+use distribution_types::Resolution;
 pub use once_map::OnceMap;
 use pep508_rs::Requirement;
 use puffin_cache::Cache;
@@ -75,13 +76,13 @@ pub trait BuildContext {
     fn resolve<'a>(
         &'a self,
         requirements: &'a [Requirement],
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Requirement>>> + Send + 'a>>;
+    ) -> Pin<Box<dyn Future<Output = Result<Resolution>> + Send + 'a>>;
 
     /// Install the given set of package versions into the virtual environment. The environment must
     /// use the same base python as [`BuildContext::base_python`]
     fn install<'a>(
         &'a self,
-        requirements: &'a [Requirement],
+        resolution: &'a Resolution,
         venv: &'a Virtualenv,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
 


### PR DESCRIPTION
## Summary

This PR ensures that we re-use the resolution to install the build dependencies when building a source distribution. Currently, we only pass along the list of requirements, and then use the `Finder` to map each requirement to a distribution. But we already determine the correct distribution when resolving!

Closes https://github.com/astral-sh/puffin/issues/655.
