### PR TITLE
Use dummy reporter instead of option reporter

### DIFF
--- a/crates/puffin-cli/src/commands/pip_install.rs
+++ b/crates/puffin-cli/src/commands/pip_install.rs
@@ -395,9 +395,9 @@ async fn install(
     let wheels = wheels.into_iter().chain(local).collect::<Vec<_>>();
     if !wheels.is_empty() {
         let start = std::time::Instant::now();
-        puffin_installer::Installer::new(venv)
+        let reporter = InstallReporter::from(printer).with_length(wheels.len() as u64);
+        puffin_installer::Installer::new(venv, reporter)
             .with_link_mode(link_mode)
-            .with_reporter(InstallReporter::from(printer).with_length(wheels.len() as u64))
             .install(&wheels)?;
 
         let s = if wheels.len() == 1 { "" } else { "s" };

--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -245,9 +245,9 @@ pub(crate) async fn sync_requirements(
     let wheels = wheels.into_iter().chain(local).collect::<Vec<_>>();
     if !wheels.is_empty() {
         let start = std::time::Instant::now();
-        puffin_installer::Installer::new(&venv)
+        let reporter = InstallReporter::from(printer).with_length(wheels.len() as u64);
+        puffin_installer::Installer::new(&venv, reporter)
             .with_link_mode(link_mode)
-            .with_reporter(InstallReporter::from(printer).with_length(wheels.len() as u64))
             .install(&wheels)?;
 
         let s = if wheels.len() == 1 { "" } else { "s" };

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -16,6 +16,7 @@ use platform_tags::Tags;
 use puffin_build::{BuildKind, SourceBuild, SourceBuildContext};
 use puffin_cache::Cache;
 use puffin_client::RegistryClient;
+use puffin_installer::InstallDummyReporter;
 use puffin_installer::{Downloader, InstallPlan, Installer, Reinstall};
 use puffin_interpreter::{Interpreter, Virtualenv};
 use puffin_resolver::{DistFinder, Manifest, ResolutionOptions, Resolver};
@@ -205,7 +206,7 @@ impl BuildContext for BuildDispatch {
                     if wheels.len() == 1 { "" } else { "s" },
                     wheels.iter().map(ToString::to_string).join(", ")
                 );
-                Installer::new(venv)
+                Installer::new(venv, InstallDummyReporter)
                     .install(&wheels)
                     .context("Failed to install build dependencies")?;
             }
@@ -214,7 +215,7 @@ impl BuildContext for BuildDispatch {
         })
     }
 
-    #[instrument(skip_all, fields(source_dist = source_dist, subdirectory = ?subdirectory))]
+    #[instrument(skip_all, fields(source_dist = source_dist, subdirectory = ? subdirectory))]
     fn setup_build<'a>(
         &'a self,
         source: &'a Path,

--- a/crates/puffin-installer/src/lib.rs
+++ b/crates/puffin-installer/src/lib.rs
@@ -1,5 +1,7 @@
 pub use downloader::{Downloader, Reporter as DownloadReporter};
-pub use installer::{Installer, Reporter as InstallReporter};
+pub use installer::{
+    DummyReporter as InstallDummyReporter, Installer, Reporter as InstallReporter,
+};
 pub use plan::{InstallPlan, Reinstall};
 pub use site_packages::SitePackages;
 pub use uninstall::uninstall;


### PR DESCRIPTION
I'm experimenting with getting with of the `if let Some(reporter) = self.reporter {...}` and `with_reporter()` methods. Added bonus is that we see where we're currently loosing information, as we currently do in `BuildDispatch::install`.