### PR TITLE
Add an editable index to the site-packages registry

### DIFF
--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Result};
 use fs_err as fs;
+use url::Url;
 
 use pep440_rs::Version;
 use puffin_normalize::PackageName;
@@ -139,5 +140,16 @@ impl InstalledDist {
         let contents = fs::read(&path)?;
         Metadata21::parse(&contents)
             .with_context(|| format!("Failed to parse METADATA file at: {}", path.display()))
+    }
+
+    /// Return the [`Url`] of the distribution, if it is editable.
+    pub fn editable(&self) -> Option<&Url> {
+        match self {
+            Self::Url(InstalledDirectUrlDist {
+                url: DirectUrl::LocalDirectory { url, dir_info },
+                ..
+            }) if dir_info.editable == Some(true) => Some(url),
+            _ => None,
+        }
     }
 }

--- a/crates/puffin-cli/src/commands/freeze.rs
+++ b/crates/puffin-cli/src/commands/freeze.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use distribution_types::Metadata;
+use itertools::Itertools;
 use tracing::debug;
 
 use platform_host::Platform;
@@ -21,7 +23,10 @@ pub(crate) fn freeze(cache: &Cache, _printer: Printer) -> Result<ExitStatus> {
 
     // Build the installed index.
     let site_packages = SitePackages::from_executable(&python)?;
-    for dist in site_packages.distributions() {
+    for dist in site_packages
+        .iter()
+        .sorted_unstable_by(|a, b| a.name().cmp(b.name()))
+    {
         #[allow(clippy::print_stdout)]
         {
             println!("{dist}");

--- a/crates/puffin-cli/src/commands/pip_uninstall.rs
+++ b/crates/puffin-cli/src/commands/pip_uninstall.rs
@@ -78,11 +78,7 @@ pub(crate) async fn pip_uninstall(
 
         // Identify all editables that are installed.
         for editable in &editables {
-            if let Some(distribution) = site_packages
-                .editables()
-                .find(|(_dist, url, _dir_info)| url == editable)
-                .map(|(dist, _url, _dir_info)| dist)
-            {
+            if let Some(distribution) = site_packages.get_editable(editable) {
                 distributions.push(distribution);
             } else {
                 writeln!(


### PR DESCRIPTION
This PR modifies `SitePackages` to store all distributions in a flat vector, and maintain two indexes (hash maps) from "per-element data for an element in the vector" to "index of that element". This enables us to maintain a map on both package name and editable URL.