### PR TITLE
Add editable install support to `pip-install`

### DIFF
--- a/crates/distribution-types/src/editable.rs
+++ b/crates/distribution-types/src/editable.rs
@@ -8,7 +8,7 @@ use requirements_txt::EditableRequirement;
 #[derive(Debug, Clone)]
 pub struct LocalEditable {
     pub requirement: EditableRequirement,
-    /// Either the path to the editable or its checkout
+    /// Either the path to the editable or its checkout.
     pub path: PathBuf,
 }
 

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -47,6 +47,7 @@ use pep440_rs::Version;
 use pep508_rs::VerbatimUrl;
 use puffin_normalize::PackageName;
 use pypi_types::{File, IndexUrl};
+use requirements_txt::EditableRequirement;
 
 pub use crate::any::*;
 pub use crate::cached::*;
@@ -240,6 +241,28 @@ impl Dist {
                 name,
                 url,
             })))
+        }
+    }
+
+    /// Create a [`Dist`] for a local editable distribution.
+    pub fn from_editable(name: PackageName, editable: LocalEditable) -> Result<Self, Error> {
+        match editable.requirement {
+            EditableRequirement::Path { url, path } => {
+                Ok(Self::Source(SourceDist::Path(PathSourceDist {
+                    name,
+                    url,
+                    path,
+                    editable: true,
+                })))
+            }
+            EditableRequirement::Url(url) => Ok(Self::Source(SourceDist::Path(PathSourceDist {
+                name,
+                path: url
+                    .to_file_path()
+                    .map_err(|()| Error::UrlFilename(url.to_url()))?,
+                url,
+                editable: true,
+            }))),
         }
     }
 

--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -15,7 +15,7 @@ use platform_tags::Tags;
 use puffin_cache::Cache;
 use puffin_client::RegistryClientBuilder;
 use puffin_dispatch::BuildDispatch;
-use puffin_installer::{Downloader, InstallPlan, Reinstall, SitePackages};
+use puffin_installer::{Downloader, EditableMode, InstallPlan, Reinstall, SitePackages};
 use puffin_interpreter::Virtualenv;
 use puffin_traits::OnceMap;
 use pypi_types::{IndexUrls, Yanked};
@@ -98,6 +98,7 @@ pub(crate) async fn sync_requirements(
         cache,
         &venv,
         &tags,
+        EditableMode::Immutable,
     )
     .context("Failed to determine installation plan")?;
 
@@ -193,7 +194,7 @@ pub(crate) async fn sync_requirements(
         DownloadReporter::from(printer).with_length((editables.len() + remote.len()) as u64),
     );
 
-    // We must not cache editable wheels, so we put them in a temp dir.
+    // Build any editable requirements.
     let editable_wheel_dir = tempdir_in(venv.root())?;
     let built_editables = if editables.is_empty() {
         Vec::new()

--- a/crates/puffin-cli/src/main.rs
+++ b/crates/puffin-cli/src/main.rs
@@ -246,6 +246,10 @@ struct PipInstallArgs {
     #[clap(short, long, group = "sources")]
     requirement: Vec<PathBuf>,
 
+    /// Install the editable package based on the provided local file path.
+    #[clap(short, long, group = "sources")]
+    editable: Vec<String>,
+
     /// Constrain versions using the given requirements files.
     ///
     /// Constraints files are `requirements.txt`-like files that only control the _version_ of a
@@ -480,6 +484,7 @@ async fn inner() -> Result<ExitStatus> {
                 .package
                 .into_iter()
                 .map(RequirementsSource::Package)
+                .chain(args.editable.into_iter().map(RequirementsSource::Editable))
                 .chain(args.requirement.into_iter().map(RequirementsSource::from))
                 .collect::<Vec<_>>();
             let constraints = args

--- a/crates/puffin-cli/tests/pip_compile.rs
+++ b/crates/puffin-cli/tests/pip_compile.rs
@@ -2560,7 +2560,7 @@ fn compile_editable() -> Result<()> {
     requirements_in.write_str(indoc! {r"
         -e ../../scripts/editable-installs/poetry_editable
         -e ../../scripts/editable-installs/maturin_editable
-        boltons # normal depedency for comparison
+        boltons # normal dependency for comparison
         "
     })?;
 

--- a/crates/puffin-cli/tests/pip_sync.rs
+++ b/crates/puffin-cli/tests/pip_sync.rs
@@ -2090,7 +2090,7 @@ fn reinstall_package() -> Result<()> {
 }
 
 #[test]
-fn install_editable() -> Result<()> {
+fn sync_editable() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let cache_dir = assert_fs::TempDir::new()?;
     let venv = create_venv_py312(&temp_dir, &cache_dir);

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -16,7 +16,7 @@ use platform_tags::Tags;
 use puffin_build::{SourceBuild, SourceBuildContext};
 use puffin_cache::Cache;
 use puffin_client::RegistryClient;
-use puffin_installer::{Downloader, InstallPlan, Installer, Reinstall};
+use puffin_installer::{Downloader, EditableMode, InstallPlan, Installer, Reinstall};
 use puffin_interpreter::{Interpreter, Virtualenv};
 use puffin_resolver::{Manifest, ResolutionOptions, Resolver};
 use puffin_traits::{BuildContext, BuildKind, OnceMap};
@@ -147,6 +147,7 @@ impl BuildContext for BuildDispatch {
                 self.cache(),
                 venv,
                 &tags,
+                EditableMode::default(),
             )?;
 
             // Resolve any registry-based requirements.

--- a/crates/puffin-installer/src/downloader.rs
+++ b/crates/puffin-installer/src/downloader.rs
@@ -13,14 +13,8 @@ use puffin_cache::Cache;
 use puffin_client::RegistryClient;
 use puffin_distribution::{DistributionDatabase, DistributionDatabaseError, LocalWheel, Unzip};
 use puffin_traits::{BuildContext, OnceMap};
-use pypi_types::Metadata21;
 
-#[derive(Debug, Clone)]
-pub struct BuiltEditable {
-    pub editable: LocalEditable,
-    pub wheel: CachedDist,
-    pub metadata: Metadata21,
-}
+use crate::editable::BuiltEditable;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/crates/puffin-installer/src/editable.rs
+++ b/crates/puffin-installer/src/editable.rs
@@ -1,0 +1,9 @@
+use distribution_types::{CachedDist, LocalEditable};
+use pypi_types::Metadata21;
+
+#[derive(Debug, Clone)]
+pub struct BuiltEditable {
+    pub editable: LocalEditable,
+    pub wheel: CachedDist,
+    pub metadata: Metadata21,
+}

--- a/crates/puffin-installer/src/lib.rs
+++ b/crates/puffin-installer/src/lib.rs
@@ -1,10 +1,12 @@
 pub use downloader::{Downloader, Reporter as DownloadReporter};
+pub use editable::BuiltEditable;
 pub use installer::{Installer, Reporter as InstallReporter};
-pub use plan::{InstallPlan, Reinstall};
+pub use plan::{EditableMode, InstallPlan, Reinstall};
 pub use site_packages::SitePackages;
 pub use uninstall::uninstall;
 
 mod downloader;
+mod editable;
 mod installer;
 mod plan;
 mod site_packages;


### PR DESCRIPTION
Per the title: adds support for `-e` installs to `puffin pip-install`. There were some challenges here around threading the editable installs to the right places. Namely, we want to build _once_, then reuse the editable installs from the resolution. At present, we were losing the `editable: true` flag on the `Dist` that came back through the resolution, so it required some changes to the resolver.

Closes https://github.com/astral-sh/puffin/issues/672.