### PR TITLE
Canonicalize virtualenv path once

### DIFF
--- a/crates/puffin-cli/src/commands/pip_compile.rs
+++ b/crates/puffin-cli/src/commands/pip_compile.rs
@@ -142,7 +142,7 @@ pub(crate) async fn pip_compile(
         client.clone(),
         cache.clone(),
         interpreter,
-        fs_err::canonicalize(venv.python_executable())?,
+        venv.python_executable(),
         no_build,
         index_urls,
     )

--- a/crates/puffin-cli/src/commands/pip_install.rs
+++ b/crates/puffin-cli/src/commands/pip_install.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Utc};
 use colored::Colorize;
-use fs_err as fs;
 use itertools::Itertools;
 use tempfile::tempdir_in;
 use tracing::debug;
@@ -137,7 +136,7 @@ pub(crate) async fn pip_install(
         client.clone(),
         cache.clone(),
         interpreter,
-        fs::canonicalize(venv.python_executable())?,
+        venv.python_executable(),
         no_build,
         index_urls.clone(),
     )

--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -2,7 +2,6 @@ use std::fmt::Write;
 
 use anyhow::{bail, Context, Result};
 use colored::Colorize;
-use fs_err as fs;
 use itertools::Itertools;
 use tracing::debug;
 
@@ -66,7 +65,7 @@ pub(crate) async fn pip_sync(
         client.clone(),
         cache.clone(),
         venv.interpreter().clone(),
-        fs::canonicalize(venv.python_executable())?,
+        venv.python_executable(),
         no_build,
         index_urls.clone(),
     );

--- a/crates/puffin-dev/src/build.rs
+++ b/crates/puffin-dev/src/build.rs
@@ -58,7 +58,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
         RegistryClientBuilder::new(cache.clone()).build(),
         cache,
         venv.interpreter().clone(),
-        fs::canonicalize(venv.python_executable())?,
+        venv.python_executable(),
         false,
         IndexUrls::default(),
     );

--- a/crates/puffin-dev/src/resolve_cli.rs
+++ b/crates/puffin-dev/src/resolve_cli.rs
@@ -5,7 +5,7 @@ use anstream::println;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use clap::{Parser, ValueEnum};
-use fs_err as fs;
+
 use fs_err::File;
 use itertools::Itertools;
 use petgraph::dot::{Config as DotConfig, Dot};
@@ -55,7 +55,7 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
         client.clone(),
         cache.clone(),
         venv.interpreter().clone(),
-        fs::canonicalize(venv.python_executable())?,
+        venv.python_executable(),
         args.no_build,
         IndexUrls::default(),
     );

--- a/crates/puffin-dev/src/resolve_many.rs
+++ b/crates/puffin-dev/src/resolve_many.rs
@@ -56,7 +56,7 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
         RegistryClientBuilder::new(cache.clone()).build(),
         cache.clone(),
         venv.interpreter().clone(),
-        fs::canonicalize(venv.python_executable())?,
+        venv.python_executable(),
         args.no_build,
         IndexUrls::default(),
     );

--- a/crates/puffin-interpreter/src/virtual_env.rs
+++ b/crates/puffin-interpreter/src/virtual_env.rs
@@ -24,6 +24,7 @@ impl Virtualenv {
         let Some(venv) = detect_virtual_env(&platform)? else {
             return Err(Error::NotFound);
         };
+        let venv = fs_err::canonicalize(venv)?;
         let executable = platform.venv_python(&venv);
         let interpreter = Interpreter::query(&executable, platform.0, cache)?;
 


### PR DESCRIPTION
This avoids filesystem calls when creating a `BuildDispatch`.