### PR TITLE
Allow identical `VIRTUAL_ENV` and `CONDA_PREFIX` env vars

### DIFF
--- a/crates/puffin-interpreter/src/virtual_env.rs
+++ b/crates/puffin-interpreter/src/virtual_env.rs
@@ -121,6 +121,7 @@ pub(crate) fn detect_virtual_env(target: &PythonPlatform) -> Result<Option<PathB
             );
             return Ok(Some(PathBuf::from(dir)));
         }
+        (Some(venv), Some(conda)) if venv == conda => return Ok(Some(PathBuf::from(venv))),
         (Some(_), Some(_)) => {
             return Err(Error::Conflict);
         }


### PR DESCRIPTION
Port of https://github.com/PyO3/maturin/pull/1879 for https://github.com/PyO3/maturin/issues/1878