### PR TITLE
Rebase: Uninstall existing non-editable versions when installing editable requirements bug

### DIFF
--- a/crates/distribution-types/src/resolution.rs
+++ b/crates/distribution-types/src/resolution.rs
@@ -2,7 +2,6 @@ use rustc_hash::FxHashMap;
 
 use pep508_rs::Requirement;
 use puffin_normalize::PackageName;
-use requirements_txt::EditableRequirement;
 
 use crate::{BuiltDist, Dist, PathSourceDist, SourceDist};
 
@@ -58,31 +57,6 @@ impl Resolution {
             })
             .collect::<Vec<_>>();
         requirements.sort_unstable_by(|a, b| a.name.cmp(&b.name));
-        requirements
-    }
-
-    /// Return the set of [`EditableRequirement`]s that this resolution represents.
-    pub fn editable_requirements(&self) -> Vec<EditableRequirement> {
-        let mut requirements = self
-            .0
-            .values()
-            .filter_map(|dist| {
-                let Dist::Source(SourceDist::Path(PathSourceDist {
-                    url,
-                    path,
-                    editable: true,
-                    ..
-                })) = dist
-                else {
-                    return None;
-                };
-                Some(EditableRequirement::Path {
-                    path: path.clone(),
-                    url: url.clone(),
-                })
-            })
-            .collect::<Vec<_>>();
-        requirements.sort_unstable_by(|a, b| a.url().cmp(b.url()));
         requirements
     }
 }

--- a/crates/puffin-client/src/registry_client.rs
+++ b/crates/puffin-client/src/registry_client.rs
@@ -100,7 +100,7 @@ impl RegistryClientBuilder {
 }
 
 /// A client for fetching packages from a `PyPI`-compatible index.
-// TODO(konstin): Clean up the clients once we moved everything to common caching
+// TODO(konstin): Clean up the clients once we moved everything to common caching.
 #[derive(Debug, Clone)]
 pub struct RegistryClient {
     pub(crate) index_urls: IndexUrls,

--- a/crates/puffin-installer/src/editable.rs
+++ b/crates/puffin-installer/src/editable.rs
@@ -1,9 +1,59 @@
-use distribution_types::{CachedDist, LocalEditable};
+use distribution_types::{CachedDist, InstalledDist, LocalEditable, Metadata, VersionOrUrl};
+use puffin_normalize::PackageName;
 use pypi_types::Metadata21;
 
+/// An editable distribution that has been built.
 #[derive(Debug, Clone)]
 pub struct BuiltEditable {
     pub editable: LocalEditable,
     pub wheel: CachedDist,
     pub metadata: Metadata21,
+}
+
+/// An editable distribution that has been resolved to a concrete distribution.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum ResolvedEditable {
+    /// The editable is already installed in the environment.
+    Installed(InstalledDist),
+    /// The editable has been built and is ready to be installed.
+    Built(BuiltEditable),
+}
+
+impl Metadata for BuiltEditable {
+    fn name(&self) -> &PackageName {
+        &self.metadata.name
+    }
+
+    fn version_or_url(&self) -> VersionOrUrl {
+        VersionOrUrl::Version(&self.metadata.version)
+    }
+}
+
+impl Metadata for ResolvedEditable {
+    fn name(&self) -> &PackageName {
+        match self {
+            Self::Installed(dist) => dist.name(),
+            Self::Built(dist) => dist.name(),
+        }
+    }
+
+    fn version_or_url(&self) -> VersionOrUrl {
+        match self {
+            Self::Installed(dist) => dist.version_or_url(),
+            Self::Built(dist) => dist.version_or_url(),
+        }
+    }
+}
+
+impl std::fmt::Display for BuiltEditable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", self.name(), self.version_or_url())
+    }
+}
+
+impl std::fmt::Display for ResolvedEditable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", self.name(), self.version_or_url())
+    }
 }

--- a/crates/puffin-installer/src/lib.rs
+++ b/crates/puffin-installer/src/lib.rs
@@ -1,7 +1,7 @@
 pub use downloader::{Downloader, Reporter as DownloadReporter};
-pub use editable::BuiltEditable;
+pub use editable::{BuiltEditable, ResolvedEditable};
 pub use installer::{Installer, Reporter as InstallReporter};
-pub use plan::{EditableMode, InstallPlan, Reinstall};
+pub use plan::{InstallPlan, Reinstall};
 pub use site_packages::SitePackages;
 pub use uninstall::uninstall;
 

--- a/scripts/editable-installs/black_editable/black/__init__.py
+++ b/scripts/editable-installs/black_editable/black/__init__.py
@@ -1,0 +1,2 @@
+def a():
+    pass

--- a/scripts/editable-installs/black_editable/pyproject.toml
+++ b/scripts/editable-installs/black_editable/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "black"
+version = "0.1.0"
+description = ""
+authors = ["konstin <konstin@mailbox.org>"]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Separate branch for rebasing #677 onto main because i don't trust the rebase enough to force push.

Closes #677.

---

If you install `black` from PyPI, then `-e ../black`, we need to uninstall the existing `black`. This sounds simple, but that in turn requires that we _know_ `-e ../black` maps to the package `black`, so that we can mark it for uninstallation in the install plan. This, in turn, means that we need to build editable dependencies prior to the install plan.

This is just a bunch of reorganization to fix that specific bug (installing multiple versions of `black` if you run through the above workflow): we now run through the list of editables upfront, mark those that are already installed, build those that aren't, and then ensure that `InstallPlan` correctly removes those that need to be removed, etc.

Closes #676.