### PR TITLE
Test that cache errors are non-fatal

### DIFF
--- a/crates/puffin-cli/tests/pip_compile.rs
+++ b/crates/puffin-cli/tests/pip_compile.rs
@@ -2603,6 +2603,7 @@ fn compile_editable() -> Result<()> {
 }
 
 #[test]
+#[ignore]
 fn cache_errors_are_non_fatal() -> Result<()> {
     let temp_dir = TempDir::new()?;
     let cache_dir = TempDir::new()?;


### PR DESCRIPTION
The test creates a cache from multiple sources and injects faults (once using invalid data and once by making the files unreadable on the fs level), then resolves again.

I didn't test git because it has its own locking and correctness logic.

The main drawback is that this test is slow (2.5s for me), we could `#[ignore]` it.