### PR TITLE
Introduce separate traits for ahead-of-time and installed metadata

### DIFF
--- a/crates/distribution-types/src/any.rs
+++ b/crates/distribution-types/src/any.rs
@@ -2,48 +2,40 @@ use puffin_normalize::PackageName;
 
 use crate::cached::CachedDist;
 use crate::installed::InstalledDist;
-use crate::traits::Metadata;
-use crate::{Dist, VersionOrUrl};
+use crate::{InstalledMetadata, InstalledVersion, Name};
 
 /// A distribution which is either installable, is a wheel in our cache or is already installed.
 #[derive(Debug, Clone)]
-pub enum AnyDist {
-    Remote(Dist),
+pub enum LocalDist {
     Cached(CachedDist),
     Installed(InstalledDist),
 }
 
-impl Metadata for AnyDist {
+impl Name for LocalDist {
     fn name(&self) -> &PackageName {
         match self {
-            Self::Remote(dist) => dist.name(),
             Self::Cached(dist) => dist.name(),
             Self::Installed(dist) => dist.name(),
         }
     }
+}
 
-    fn version_or_url(&self) -> VersionOrUrl {
+impl InstalledMetadata for LocalDist {
+    fn installed_version(&self) -> InstalledVersion {
         match self {
-            Self::Remote(dist) => dist.version_or_url(),
-            Self::Cached(dist) => dist.version_or_url(),
-            Self::Installed(dist) => dist.version_or_url(),
+            Self::Cached(dist) => dist.installed_version(),
+            Self::Installed(dist) => dist.installed_version(),
         }
     }
 }
 
-impl From<Dist> for AnyDist {
-    fn from(dist: Dist) -> Self {
-        Self::Remote(dist)
-    }
-}
-
-impl From<CachedDist> for AnyDist {
+impl From<CachedDist> for LocalDist {
     fn from(dist: CachedDist) -> Self {
         Self::Cached(dist)
     }
 }
 
-impl From<InstalledDist> for AnyDist {
+impl From<InstalledDist> for LocalDist {
     fn from(dist: InstalledDist) -> Self {
         Self::Installed(dist)
     }

--- a/crates/distribution-types/src/cached.rs
+++ b/crates/distribution-types/src/cached.rs
@@ -7,8 +7,10 @@ use pep508_rs::VerbatimUrl;
 use puffin_normalize::PackageName;
 
 use crate::direct_url::{DirectUrl, LocalFileUrl};
-use crate::traits::Metadata;
-use crate::{BuiltDist, Dist, SourceDist, VersionOrUrl};
+use crate::{
+    BuiltDist, Dist, DistributionMetadata, InstalledMetadata, InstalledVersion, Name, SourceDist,
+    VersionOrUrl,
+};
 
 /// A built distribution (wheel) that exists in the local cache.
 #[derive(Debug, Clone)]
@@ -31,42 +33,6 @@ pub struct CachedDirectUrlDist {
     pub url: VerbatimUrl,
     pub path: PathBuf,
     pub editable: bool,
-}
-
-impl Metadata for CachedRegistryDist {
-    fn name(&self) -> &PackageName {
-        &self.filename.name
-    }
-
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Version(&self.filename.version)
-    }
-}
-
-impl Metadata for CachedDirectUrlDist {
-    fn name(&self) -> &PackageName {
-        &self.filename.name
-    }
-
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::VersionedUrl(self.url.raw(), &self.filename.version)
-    }
-}
-
-impl Metadata for CachedDist {
-    fn name(&self) -> &PackageName {
-        match self {
-            Self::Registry(dist) => dist.name(),
-            Self::Url(dist) => dist.name(),
-        }
-    }
-
-    fn version_or_url(&self) -> VersionOrUrl {
-        match self {
-            Self::Registry(dist) => dist.version_or_url(),
-            Self::Url(dist) => dist.version_or_url(),
-        }
-    }
 }
 
 impl CachedDist {
@@ -202,6 +168,69 @@ impl CachedWheel {
             url,
             path: self.path,
             editable: false,
+        }
+    }
+}
+
+impl Name for CachedRegistryDist {
+    fn name(&self) -> &PackageName {
+        &self.filename.name
+    }
+}
+
+impl Name for CachedDirectUrlDist {
+    fn name(&self) -> &PackageName {
+        &self.filename.name
+    }
+}
+
+impl Name for CachedDist {
+    fn name(&self) -> &PackageName {
+        match self {
+            Self::Registry(dist) => dist.name(),
+            Self::Url(dist) => dist.name(),
+        }
+    }
+}
+
+impl DistributionMetadata for CachedRegistryDist {
+    fn version_or_url(&self) -> VersionOrUrl {
+        VersionOrUrl::Version(&self.filename.version)
+    }
+}
+
+impl DistributionMetadata for CachedDirectUrlDist {
+    fn version_or_url(&self) -> VersionOrUrl {
+        VersionOrUrl::Url(&self.url)
+    }
+}
+
+impl DistributionMetadata for CachedDist {
+    fn version_or_url(&self) -> VersionOrUrl {
+        match self {
+            Self::Registry(dist) => dist.version_or_url(),
+            Self::Url(dist) => dist.version_or_url(),
+        }
+    }
+}
+
+impl InstalledMetadata for CachedRegistryDist {
+    fn installed_version(&self) -> InstalledVersion {
+        InstalledVersion::Version(&self.filename.version)
+    }
+}
+
+impl InstalledMetadata for CachedDirectUrlDist {
+    fn installed_version(&self) -> InstalledVersion {
+        InstalledVersion::Url(&self.url, &self.filename.version)
+    }
+}
+
+impl InstalledMetadata for CachedDist {
+    fn installed_version(&self) -> InstalledVersion {
+        match self {
+            Self::Registry(dist) => dist.installed_version(),
+            Self::Url(dist) => dist.installed_version(),
         }
     }
 }

--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -8,7 +8,7 @@ use url::Url;
 use pep440_rs::Version;
 use puffin_normalize::PackageName;
 
-use crate::{Metadata, VersionOrUrl};
+use crate::{InstalledMetadata, InstalledVersion, Name};
 
 /// A built distribution (wheel) that is installed in a virtual environment.
 #[derive(Debug, Clone)]
@@ -33,42 +33,6 @@ pub struct InstalledDirectUrlDist {
     pub url: Url,
     pub editable: bool,
     pub path: PathBuf,
-}
-
-impl Metadata for InstalledRegistryDist {
-    fn name(&self) -> &PackageName {
-        &self.name
-    }
-
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Version(&self.version)
-    }
-}
-
-impl Metadata for InstalledDirectUrlDist {
-    fn name(&self) -> &PackageName {
-        &self.name
-    }
-
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::VersionedUrl(&self.url, &self.version)
-    }
-}
-
-impl Metadata for InstalledDist {
-    fn name(&self) -> &PackageName {
-        match self {
-            Self::Registry(dist) => dist.name(),
-            Self::Url(dist) => dist.name(),
-        }
-    }
-
-    fn version_or_url(&self) -> VersionOrUrl {
-        match self {
-            Self::Registry(dist) => dist.version_or_url(),
-            Self::Url(dist) => dist.version_or_url(),
-        }
-    }
 }
 
 impl InstalledDist {
@@ -147,6 +111,48 @@ impl InstalledDist {
         match self {
             Self::Registry(_) => None,
             Self::Url(dist) => dist.editable.then_some(&dist.url),
+        }
+    }
+}
+
+impl Name for InstalledRegistryDist {
+    fn name(&self) -> &PackageName {
+        &self.name
+    }
+}
+
+impl Name for InstalledDirectUrlDist {
+    fn name(&self) -> &PackageName {
+        &self.name
+    }
+}
+
+impl Name for InstalledDist {
+    fn name(&self) -> &PackageName {
+        match self {
+            Self::Registry(dist) => dist.name(),
+            Self::Url(dist) => dist.name(),
+        }
+    }
+}
+
+impl InstalledMetadata for InstalledRegistryDist {
+    fn installed_version(&self) -> InstalledVersion {
+        InstalledVersion::Version(&self.version)
+    }
+}
+
+impl InstalledMetadata for InstalledDirectUrlDist {
+    fn installed_version(&self) -> InstalledVersion {
+        InstalledVersion::Url(&self.url, &self.version)
+    }
+}
+
+impl InstalledMetadata for InstalledDist {
+    fn installed_version(&self) -> InstalledVersion {
+        match self {
+            Self::Registry(dist) => dist.installed_version(),
+            Self::Url(dist) => dist.installed_version(),
         }
     }
 }

--- a/crates/puffin-cli/src/commands/freeze.rs
+++ b/crates/puffin-cli/src/commands/freeze.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
-use distribution_types::Metadata;
 use itertools::Itertools;
 use tracing::debug;
 
+use distribution_types::Name;
 use platform_host::Platform;
 use puffin_cache::Cache;
 use puffin_installer::SitePackages;

--- a/crates/puffin-cli/src/commands/mod.rs
+++ b/crates/puffin-cli/src/commands/mod.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 pub(crate) use add::add;
 pub(crate) use clean::clean;
-use distribution_types::Metadata;
+use distribution_types::InstalledMetadata;
 pub(crate) use freeze::freeze;
 pub(crate) use pip_compile::{extra_name_with_clap_error, pip_compile};
 pub(crate) use pip_install::pip_install;
@@ -70,7 +70,7 @@ pub(super) enum ChangeEventKind {
 }
 
 #[derive(Debug)]
-pub(super) struct ChangeEvent<T: Metadata> {
+pub(super) struct ChangeEvent<T: InstalledMetadata> {
     dist: T,
     kind: ChangeEventKind,
 }

--- a/crates/puffin-cli/src/commands/pip_install.rs
+++ b/crates/puffin-cli/src/commands/pip_install.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use tempfile::tempdir_in;
 use tracing::debug;
 
-use distribution_types::{AnyDist, LocalEditable, Metadata, Resolution};
+use distribution_types::{InstalledMetadata, LocalDist, LocalEditable, Name, Resolution};
 use install_wheel_rs::linker::LinkMode;
 use pep508_rs::{MarkerEnvironment, Requirement};
 use platform_host::Platform;
@@ -518,11 +518,11 @@ async fn install(
     for event in reinstalls
         .into_iter()
         .map(|distribution| ChangeEvent {
-            dist: AnyDist::from(distribution),
+            dist: LocalDist::from(distribution),
             kind: ChangeEventKind::Removed,
         })
         .chain(wheels.into_iter().map(|distribution| ChangeEvent {
-            dist: AnyDist::from(distribution),
+            dist: LocalDist::from(distribution),
             kind: ChangeEventKind::Added,
         }))
         .sorted_unstable_by(|a, b| {
@@ -539,7 +539,7 @@ async fn install(
                     " {} {}{}",
                     "+".green(),
                     event.dist.name().as_ref().white().bold(),
-                    event.dist.version_or_url().to_string().dimmed()
+                    event.dist.installed_version().to_string().dimmed()
                 )?;
             }
             ChangeEventKind::Removed => {
@@ -548,7 +548,7 @@ async fn install(
                     " {} {}{}",
                     "-".red(),
                     event.dist.name().as_ref().white().bold(),
-                    event.dist.version_or_url().to_string().dimmed()
+                    event.dist.installed_version().to_string().dimmed()
                 )?;
             }
         }

--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -5,7 +5,7 @@ use colored::Colorize;
 use itertools::Itertools;
 use tracing::debug;
 
-use distribution_types::{AnyDist, LocalEditable, Metadata};
+use distribution_types::{InstalledMetadata, LocalDist, LocalEditable, Name};
 use install_wheel_rs::linker::LinkMode;
 use platform_host::Platform;
 use platform_tags::Tags;
@@ -271,11 +271,11 @@ pub(crate) async fn pip_sync(
         .into_iter()
         .chain(reinstalls.into_iter())
         .map(|distribution| ChangeEvent {
-            dist: AnyDist::from(distribution),
+            dist: LocalDist::from(distribution),
             kind: ChangeEventKind::Removed,
         })
         .chain(wheels.into_iter().map(|distribution| ChangeEvent {
-            dist: AnyDist::from(distribution),
+            dist: LocalDist::from(distribution),
             kind: ChangeEventKind::Added,
         }))
         .sorted_unstable_by(|a, b| {
@@ -292,7 +292,7 @@ pub(crate) async fn pip_sync(
                     " {} {}{}",
                     "+".green(),
                     event.dist.name().as_ref().white().bold(),
-                    event.dist.version_or_url().to_string().dimmed()
+                    event.dist.installed_version().to_string().dimmed()
                 )?;
             }
             ChangeEventKind::Removed => {
@@ -301,7 +301,7 @@ pub(crate) async fn pip_sync(
                     " {} {}{}",
                     "-".red(),
                     event.dist.name().as_ref().white().bold(),
-                    event.dist.version_or_url().to_string().dimmed()
+                    event.dist.installed_version().to_string().dimmed()
                 )?;
             }
         }

--- a/crates/puffin-cli/src/commands/pip_uninstall.rs
+++ b/crates/puffin-cli/src/commands/pip_uninstall.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use colored::Colorize;
 use tracing::debug;
 
-use distribution_types::Metadata;
+use distribution_types::{InstalledMetadata, Name};
 use platform_host::Platform;
 use puffin_cache::Cache;
 use puffin_interpreter::Virtualenv;
@@ -143,7 +143,7 @@ pub(crate) async fn pip_uninstall(
             " {} {}{}",
             "-".red(),
             distribution.name().as_ref().white().bold(),
-            distribution.version_or_url().to_string().dimmed()
+            distribution.installed_version().to_string().dimmed()
         )?;
     }
 

--- a/crates/puffin-client/src/registry_client.rs
+++ b/crates/puffin-client/src/registry_client.rs
@@ -17,7 +17,7 @@ use tracing::{debug, trace};
 use url::Url;
 
 use distribution_filename::{DistFilename, SourceDistFilename, WheelFilename};
-use distribution_types::{BuiltDist, Metadata};
+use distribution_types::{BuiltDist, Name};
 use install_wheel_rs::find_dist_info;
 use pep440_rs::Version;
 use puffin_cache::{digest, Cache, CacheBucket, CanonicalUrl, WheelCache};

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -10,7 +10,7 @@ use anyhow::{bail, Context, Result};
 use itertools::Itertools;
 use tracing::{debug, instrument};
 
-use distribution_types::{CachedDist, Metadata, Resolution};
+use distribution_types::{CachedDist, Name, Resolution};
 use pep508_rs::Requirement;
 use platform_tags::Tags;
 use puffin_build::{SourceBuild, SourceBuildContext};

--- a/crates/puffin-distribution/src/distribution_database.rs
+++ b/crates/puffin-distribution/src/distribution_database.rs
@@ -14,7 +14,7 @@ use url::Url;
 
 use distribution_filename::{WheelFilename, WheelFilenameError};
 use distribution_types::direct_url::DirectGitUrl;
-use distribution_types::{BuiltDist, Dist, LocalEditable, Metadata, SourceDist};
+use distribution_types::{BuiltDist, Dist, LocalEditable, Name, SourceDist};
 use platform_tags::Tags;
 use puffin_cache::{digest, Cache, CacheBucket, WheelCache};
 use puffin_client::RegistryClient;

--- a/crates/puffin-distribution/src/reporter.rs
+++ b/crates/puffin-distribution/src/reporter.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use url::Url;
 
-use distribution_types::Metadata;
+use distribution_types::SourceDist;
 
 pub trait Reporter: Send + Sync {
     /// Callback to invoke when a source distribution build is kicked off.
-    fn on_build_start(&self, dist: &dyn Metadata) -> usize;
+    fn on_build_start(&self, dist: &SourceDist) -> usize;
 
     /// Callback to invoke when a source distribution build is complete.
-    fn on_build_complete(&self, dist: &dyn Metadata, id: usize);
+    fn on_build_complete(&self, dist: &SourceDist, id: usize);
 
     /// Callback to invoke when a repository checkout begins.
     fn on_checkout_start(&self, url: &Url, rev: &str) -> usize;

--- a/crates/puffin-distribution/src/source_dist.rs
+++ b/crates/puffin-distribution/src/source_dist.rs
@@ -22,7 +22,7 @@ use zip::ZipArchive;
 use distribution_filename::{WheelFilename, WheelFilenameError};
 use distribution_types::direct_url::{DirectArchiveUrl, DirectGitUrl};
 use distribution_types::{
-    Dist, GitSourceDist, LocalEditable, Metadata, PathSourceDist, RemoteSource, SourceDist,
+    Dist, GitSourceDist, LocalEditable, Name, PathSourceDist, RemoteSource, SourceDist,
 };
 use install_wheel_rs::read_dist_info;
 use platform_tags::Tags;

--- a/crates/puffin-installer/src/downloader.rs
+++ b/crates/puffin-installer/src/downloader.rs
@@ -7,7 +7,7 @@ use tokio::task::JoinError;
 use tracing::{instrument, warn};
 use url::Url;
 
-use distribution_types::{CachedDist, Dist, LocalEditable, Metadata, RemoteSource};
+use distribution_types::{CachedDist, Dist, LocalEditable, RemoteSource, SourceDist};
 use platform_tags::Tags;
 use puffin_cache::Cache;
 use puffin_client::RegistryClient;
@@ -231,16 +231,16 @@ impl<'a, Context: BuildContext + Send + Sync> Downloader<'a, Context> {
 pub trait Reporter: Send + Sync {
     /// Callback to invoke when a wheel is unzipped. This implies that the wheel was downloaded and,
     /// if necessary, built.
-    fn on_progress(&self, dist: &dyn Metadata);
+    fn on_progress(&self, dist: &CachedDist);
 
     /// Callback to invoke when the operation is complete.
     fn on_complete(&self);
 
     /// Callback to invoke when a source distribution build is kicked off.
-    fn on_build_start(&self, dist: &dyn Metadata) -> usize;
+    fn on_build_start(&self, dist: &SourceDist) -> usize;
 
     /// Callback to invoke when a source distribution build is complete.
-    fn on_build_complete(&self, dist: &dyn Metadata, id: usize);
+    fn on_build_complete(&self, dist: &SourceDist, id: usize);
 
     /// Callback to invoke when a editable build is kicked off.
     fn on_editable_build_start(&self, dist: &LocalEditable) -> usize;
@@ -267,11 +267,11 @@ impl From<Arc<dyn Reporter>> for Facade {
 }
 
 impl puffin_distribution::Reporter for Facade {
-    fn on_build_start(&self, dist: &dyn Metadata) -> usize {
+    fn on_build_start(&self, dist: &SourceDist) -> usize {
         self.reporter.on_build_start(dist)
     }
 
-    fn on_build_complete(&self, dist: &dyn Metadata, id: usize) {
+    fn on_build_complete(&self, dist: &SourceDist, id: usize) {
         self.reporter.on_build_complete(dist, id);
     }
 

--- a/crates/puffin-installer/src/editable.rs
+++ b/crates/puffin-installer/src/editable.rs
@@ -1,4 +1,6 @@
-use distribution_types::{CachedDist, InstalledDist, LocalEditable, Metadata, VersionOrUrl};
+use distribution_types::{
+    CachedDist, InstalledDist, InstalledMetadata, InstalledVersion, LocalEditable, Name,
+};
 use puffin_normalize::PackageName;
 use pypi_types::Metadata21;
 
@@ -20,40 +22,44 @@ pub enum ResolvedEditable {
     Built(BuiltEditable),
 }
 
-impl Metadata for BuiltEditable {
+impl Name for BuiltEditable {
     fn name(&self) -> &PackageName {
         &self.metadata.name
     }
-
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Version(&self.metadata.version)
-    }
 }
 
-impl Metadata for ResolvedEditable {
+impl Name for ResolvedEditable {
     fn name(&self) -> &PackageName {
         match self {
             Self::Installed(dist) => dist.name(),
             Self::Built(dist) => dist.name(),
         }
     }
+}
 
-    fn version_or_url(&self) -> VersionOrUrl {
+impl InstalledMetadata for BuiltEditable {
+    fn installed_version(&self) -> InstalledVersion {
+        self.wheel.installed_version()
+    }
+}
+
+impl InstalledMetadata for ResolvedEditable {
+    fn installed_version(&self) -> InstalledVersion {
         match self {
-            Self::Installed(dist) => dist.version_or_url(),
-            Self::Built(dist) => dist.version_or_url(),
+            Self::Installed(dist) => dist.installed_version(),
+            Self::Built(dist) => dist.installed_version(),
         }
     }
 }
 
 impl std::fmt::Display for BuiltEditable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}{}", self.name(), self.version_or_url())
+        write!(f, "{}{}", self.name(), self.installed_version())
     }
 }
 
 impl std::fmt::Display for ResolvedEditable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}{}", self.name(), self.version_or_url())
+        write!(f, "{}{}", self.name(), self.installed_version())
     }
 }

--- a/crates/puffin-installer/src/plan.rs
+++ b/crates/puffin-installer/src/plan.rs
@@ -5,8 +5,8 @@ use rustc_hash::FxHashSet;
 use tracing::{debug, warn};
 
 use distribution_types::direct_url::git_reference;
-use distribution_types::{BuiltDist, Dist, SourceDist};
-use distribution_types::{CachedDirectUrlDist, CachedDist, InstalledDist, Metadata};
+use distribution_types::{BuiltDist, Dist, Name, SourceDist};
+use distribution_types::{CachedDirectUrlDist, CachedDist, InstalledDist};
 use pep508_rs::{Requirement, VersionOrUrl};
 use platform_tags::Tags;
 use puffin_cache::{Cache, CacheBucket, WheelCache};

--- a/crates/puffin-installer/src/site_packages.rs
+++ b/crates/puffin-installer/src/site_packages.rs
@@ -5,7 +5,7 @@ use fs_err as fs;
 use rustc_hash::{FxHashMap, FxHashSet};
 use url::Url;
 
-use distribution_types::{InstalledDist, Metadata, VersionOrUrl};
+use distribution_types::{InstalledDist, InstalledMetadata, InstalledVersion, Name};
 use pep440_rs::{Version, VersionSpecifiers};
 use pep508_rs::{Requirement, VerbatimUrl};
 use puffin_interpreter::Virtualenv;
@@ -94,14 +94,13 @@ impl<'a> SitePackages<'a> {
         self.iter().map(|dist| Requirement {
             name: dist.name().clone(),
             extras: None,
-            version_or_url: Some(match dist.version_or_url() {
-                VersionOrUrl::Version(version) => {
+            version_or_url: Some(match dist.installed_version() {
+                InstalledVersion::Version(version) => {
                     pep508_rs::VersionOrUrl::VersionSpecifier(pep440_rs::VersionSpecifiers::from(
                         pep440_rs::VersionSpecifier::equals_version(version.clone()),
                     ))
                 }
-                VersionOrUrl::Url(url) => pep508_rs::VersionOrUrl::Url(url.clone()),
-                VersionOrUrl::VersionedUrl(url, ..) => {
+                InstalledVersion::Url(url, ..) => {
                     pep508_rs::VersionOrUrl::Url(VerbatimUrl::unknown(url.clone()))
                 }
             }),

--- a/crates/puffin-resolver/src/candidate_selector.rs
+++ b/crates/puffin-resolver/src/candidate_selector.rs
@@ -1,7 +1,7 @@
 use pubgrub::range::Range;
 use rustc_hash::FxHashMap;
 
-use distribution_types::{Dist, Metadata};
+use distribution_types::{Dist, DistributionMetadata, Name};
 use pep508_rs::{Requirement, VersionOrUrl};
 use puffin_normalize::PackageName;
 use pypi_types::IndexUrl;
@@ -253,11 +253,13 @@ impl<'a> Candidate<'a> {
     }
 }
 
-impl Metadata for Candidate<'_> {
+impl Name for Candidate<'_> {
     fn name(&self) -> &PackageName {
         self.name
     }
+}
 
+impl DistributionMetadata for Candidate<'_> {
     fn version_or_url(&self) -> distribution_types::VersionOrUrl {
         distribution_types::VersionOrUrl::Version(self.version.into())
     }

--- a/crates/puffin-resolver/src/finder.rs
+++ b/crates/puffin-resolver/src/finder.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use futures::StreamExt;
 use rustc_hash::FxHashMap;
 
-use distribution_types::{Dist, Metadata, Resolution};
+use distribution_types::{Dist, Resolution};
 use pep440_rs::Version;
 use pep508_rs::{Requirement, VersionOrUrl};
 use platform_tags::{TagPriority, Tags};
@@ -235,7 +235,7 @@ enum Response {
 
 pub trait Reporter: Send + Sync {
     /// Callback to invoke when a package is resolved to a specific distribution.
-    fn on_progress(&self, dist: &dyn Metadata);
+    fn on_progress(&self, dist: &Dist);
 
     /// Callback to invoke when the resolution is complete.
     fn on_complete(&self);

--- a/crates/puffin-resolver/src/pubgrub/distribution.rs
+++ b/crates/puffin-resolver/src/pubgrub/distribution.rs
@@ -1,4 +1,4 @@
-use distribution_types::{Metadata, VersionOrUrl};
+use distribution_types::{DistributionMetadata, Name, VersionOrUrl};
 use pep508_rs::VerbatimUrl;
 use puffin_normalize::PackageName;
 
@@ -20,14 +20,16 @@ impl<'a> PubGrubDistribution<'a> {
     }
 }
 
-impl Metadata for PubGrubDistribution<'_> {
+impl Name for PubGrubDistribution<'_> {
     fn name(&self) -> &PackageName {
         match self {
             Self::Registry(name, _) => name,
             Self::Url(name, _) => name,
         }
     }
+}
 
+impl DistributionMetadata for PubGrubDistribution<'_> {
     fn version_or_url(&self) -> VersionOrUrl {
         match self {
             Self::Registry(_, version) => VersionOrUrl::Version((*version).into()),

--- a/crates/puffin-resolver/src/resolution.rs
+++ b/crates/puffin-resolver/src/resolution.rs
@@ -10,7 +10,7 @@ use pubgrub::type_aliases::SelectedDependencies;
 use rustc_hash::FxHashMap;
 use url::Url;
 
-use distribution_types::{Dist, LocalEditable, Metadata, PackageId, Verbatim};
+use distribution_types::{Dist, DistributionMetadata, LocalEditable, Name, PackageId, Verbatim};
 use pep440_rs::Version;
 use pep508_rs::{Requirement, VerbatimUrl};
 use puffin_normalize::{ExtraName, PackageName};

--- a/crates/puffin-resolver/src/resolver.rs
+++ b/crates/puffin-resolver/src/resolver.rs
@@ -19,7 +19,7 @@ use url::Url;
 
 use distribution_filename::WheelFilename;
 use distribution_types::{
-    BuiltDist, Dist, LocalEditable, Metadata, PackageId, SourceDist, VersionOrUrl,
+    BuiltDist, Dist, DistributionMetadata, LocalEditable, Name, PackageId, SourceDist, VersionOrUrl,
 };
 use pep508_rs::{MarkerEnvironment, Requirement};
 use platform_tags::Tags;
@@ -799,10 +799,10 @@ pub trait Reporter: Send + Sync {
     fn on_complete(&self);
 
     /// Callback to invoke when a source distribution build is kicked off.
-    fn on_build_start(&self, dist: &dyn Metadata) -> usize;
+    fn on_build_start(&self, dist: &SourceDist) -> usize;
 
     /// Callback to invoke when a source distribution build is complete.
-    fn on_build_complete(&self, dist: &dyn Metadata, id: usize);
+    fn on_build_complete(&self, dist: &SourceDist, id: usize);
 
     /// Callback to invoke when a repository checkout begins.
     fn on_checkout_start(&self, url: &Url, rev: &str) -> usize;
@@ -817,11 +817,11 @@ struct Facade {
 }
 
 impl puffin_distribution::Reporter for Facade {
-    fn on_build_start(&self, dist: &dyn Metadata) -> usize {
+    fn on_build_start(&self, dist: &SourceDist) -> usize {
         self.reporter.on_build_start(dist)
     }
 
-    fn on_build_complete(&self, dist: &dyn Metadata, id: usize) {
+    fn on_build_complete(&self, dist: &SourceDist, id: usize) {
         self.reporter.on_build_complete(dist, id);
     }
 


### PR DESCRIPTION
This is a pure refactor to follow-up #690, to separate the metadata that we know upfront about distributions (like the version, for registry-based distributions) vs. the metadata that requires building (like the version, for URL-based distributions).