### PR TITLE
Rename puffin-warnings macros to avoid tracing collision

### DIFF
--- a/crates/puffin-resolver/src/version_map.rs
+++ b/crates/puffin-resolver/src/version_map.rs
@@ -10,7 +10,7 @@ use platform_tags::{TagPriority, Tags};
 use puffin_client::SimpleMetadata;
 use puffin_interpreter::Interpreter;
 use puffin_normalize::PackageName;
-use puffin_warnings::warn_once;
+use puffin_warnings::warn_user_once;
 use pypi_types::Yanked;
 
 use crate::file::{DistFile, SdistFile, WheelFile};
@@ -63,7 +63,7 @@ impl VersionMap {
                             continue;
                         }
                         None => {
-                            warn_once!(
+                            warn_user_once!(
                                 "{} is missing an upload date, but user provided: {}",
                                 file.filename,
                                 exclude_newer,

--- a/crates/puffin-warnings/src/lib.rs
+++ b/crates/puffin-warnings/src/lib.rs
@@ -17,7 +17,7 @@ pub fn enable() {
 
 /// Warn a user, if warnings are enabled.
 #[macro_export]
-macro_rules! warn {
+macro_rules! warn_user {
     ($($arg:tt)*) => {
         use $crate::colored::Colorize;
 
@@ -34,7 +34,7 @@ pub static WARNINGS: Lazy<Mutex<FxHashSet<String>>> = Lazy::new(Mutex::default);
 /// Warn a user once, if warnings are enabled, with uniqueness determined by the content of the
 /// message.
 #[macro_export]
-macro_rules! warn_once {
+macro_rules! warn_user_once {
     ($($arg:tt)*) => {
         use $crate::colored::Colorize;
 

--- a/crates/pypi-types/src/lenient_requirement.rs
+++ b/crates/pypi-types/src/lenient_requirement.rs
@@ -6,7 +6,7 @@ use serde::{de, Deserialize, Deserializer, Serialize};
 
 use pep440_rs::{Pep440Error, VersionSpecifiers};
 use pep508_rs::{Pep508Error, Requirement};
-use puffin_warnings::warn_once;
+use puffin_warnings::warn_user_once;
 
 /// Ex) `>=7.2.0<8.0.0`
 static MISSING_COMMA: Lazy<Regex> = Lazy::new(|| Regex::new(r"(\d)([<>=~^!])").unwrap());
@@ -63,7 +63,7 @@ fn parse_with_fixups<Err, T: FromStr<Err = Err>>(input: &str, type_name: &str) -
             }
 
             if let Ok(requirement) = T::from_str(&patched_input) {
-                warn_once!(
+                warn_user_once!(
                     "Fixing invalid {type_name} by {} (before: `{input}`; after: `{patched_input}`)",
                     messages.join(", ")
                 );


### PR DESCRIPTION
Also more consistent with Ruff.