### PR TITLE
Add a dedicated error message to hint users towards enabling pre-releases

### DIFF
--- a/crates/puffin-resolver/src/candidate_selector.rs
+++ b/crates/puffin-resolver/src/candidate_selector.rs
@@ -13,7 +13,7 @@ use crate::resolution_mode::ResolutionStrategy;
 use crate::version_map::{ResolvableFile, VersionMap};
 use crate::{Manifest, ResolutionOptions};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct CandidateSelector {
     resolution_strategy: ResolutionStrategy,
     prerelease_strategy: PreReleaseStrategy,
@@ -35,10 +35,22 @@ impl CandidateSelector {
             preferences: Preferences::from(manifest.preferences.as_slice()),
         }
     }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn resolution_strategy(&self) -> &ResolutionStrategy {
+        &self.resolution_strategy
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn prerelease_strategy(&self) -> &PreReleaseStrategy {
+        &self.prerelease_strategy
+    }
 }
 
 /// A set of pinned packages that should be preserved during resolution, if possible.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Preferences(FxHashMap<PackageName, PubGrubVersion>);
 
 impl Preferences {

--- a/crates/puffin-resolver/src/prerelease_mode.rs
+++ b/crates/puffin-resolver/src/prerelease_mode.rs
@@ -27,7 +27,7 @@ pub enum PreReleaseMode {
 
 /// Like [`PreReleaseMode`], but with any additional information required to select a candidate,
 /// like the set of direct dependencies.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum PreReleaseStrategy {
     /// Disallow all pre-release versions.
     Disallow,

--- a/crates/puffin-resolver/src/pubgrub/mod.rs
+++ b/crates/puffin-resolver/src/pubgrub/mod.rs
@@ -2,7 +2,7 @@ pub(crate) use crate::pubgrub::dependencies::PubGrubDependencies;
 pub(crate) use crate::pubgrub::distribution::PubGrubDistribution;
 pub(crate) use crate::pubgrub::package::PubGrubPackage;
 pub(crate) use crate::pubgrub::priority::{PubGrubPriorities, PubGrubPriority};
-pub(crate) use crate::pubgrub::report::PubGrubReportFormatter;
+pub(crate) use crate::pubgrub::report::{PubGrubHints, PubGrubReportFormatter};
 pub(crate) use crate::pubgrub::version::{PubGrubVersion, MIN_VERSION};
 
 mod dependencies;

--- a/crates/puffin-resolver/src/pubgrub/report.rs
+++ b/crates/puffin-resolver/src/pubgrub/report.rs
@@ -1,8 +1,12 @@
+use crate::candidate_selector::CandidateSelector;
+use crate::prerelease_mode::PreReleaseStrategy;
+use colored::Colorize;
+use derivative::Derivative;
 use pubgrub::range::Range;
-use pubgrub::report::{External, ReportFormatter};
+use pubgrub::report::{DerivationTree, External, ReportFormatter};
 use pubgrub::term::Term;
 use pubgrub::type_aliases::Map;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::{PubGrubPackage, PubGrubVersion};
 
@@ -10,21 +14,6 @@ use super::{PubGrubPackage, PubGrubVersion};
 pub(crate) struct PubGrubReportFormatter<'a> {
     /// The versions that were available for each package
     pub(crate) available_versions: &'a FxHashMap<PubGrubPackage, Vec<PubGrubVersion>>,
-}
-
-impl PubGrubReportFormatter<'_> {
-    fn simplify_set(
-        &self,
-        set: &Range<PubGrubVersion>,
-        package: &PubGrubPackage,
-    ) -> Range<PubGrubVersion> {
-        set.simplify(
-            self.available_versions
-                .get(package)
-                .unwrap_or(&vec![])
-                .iter(),
-        )
-    }
 }
 
 impl ReportFormatter<PubGrubPackage, Range<PubGrubVersion>> for PubGrubReportFormatter<'_> {
@@ -135,6 +124,125 @@ impl ReportFormatter<PubGrubPackage, Range<PubGrubVersion>> for PubGrubReportFor
             slice => {
                 let str_terms: Vec<_> = slice.iter().map(|(p, t)| format!("{p} {t}")).collect();
                 str_terms.join(", ") + " are incompatible"
+            }
+        }
+    }
+}
+
+impl PubGrubReportFormatter<'_> {
+    fn simplify_set(
+        &self,
+        set: &Range<PubGrubVersion>,
+        package: &PubGrubPackage,
+    ) -> Range<PubGrubVersion> {
+        set.simplify(
+            self.available_versions
+                .get(package)
+                .unwrap_or(&vec![])
+                .iter(),
+        )
+    }
+}
+
+/// A set of hints to help users resolve errors by providing additional context or modifying
+/// their requirements.
+#[derive(Debug, Default)]
+pub(crate) struct PubGrubHints(FxHashSet<PubGrubHint>);
+
+impl PubGrubHints {
+    /// Create a set of hints from a derivation tree.
+    pub(crate) fn from_derivation_tree(
+        derivation_tree: &DerivationTree<PubGrubPackage, Range<PubGrubVersion>>,
+        selector: &CandidateSelector,
+    ) -> Self {
+        let mut hints = Self::default();
+        match derivation_tree {
+            DerivationTree::External(external) => match external {
+                External::NoVersions(package, set) => {
+                    // Determine whether a pre-release marker appeared in the version requirements.
+                    if set.bounds().any(PubGrubVersion::any_prerelease) {
+                        // Determine whether pre-releases were allowed for this package.
+                        let allowed_prerelease = match selector.prerelease_strategy() {
+                            PreReleaseStrategy::Disallow => false,
+                            PreReleaseStrategy::Allow => true,
+                            PreReleaseStrategy::IfNecessary => false,
+                            PreReleaseStrategy::Explicit(packages) => {
+                                if let PubGrubPackage::Package(package, ..) = package {
+                                    packages.contains(package)
+                                } else {
+                                    false
+                                }
+                            }
+                            PreReleaseStrategy::IfNecessaryOrExplicit(packages) => {
+                                if let PubGrubPackage::Package(package, ..) = package {
+                                    packages.contains(package)
+                                } else {
+                                    false
+                                }
+                            }
+                        };
+
+                        if !allowed_prerelease {
+                            hints.insert(PubGrubHint::NoVersionsWithPreRelease {
+                                package: package.clone(),
+                                range: set.clone(),
+                            });
+                        }
+                    }
+                }
+                External::NotRoot(..) => {}
+                External::UnavailableDependencies(..) => {}
+                External::UnusableDependencies(..) => {}
+                External::FromDependencyOf(..) => {}
+            },
+            DerivationTree::Derived(derived) => {
+                hints.extend(Self::from_derivation_tree(&derived.cause1, selector));
+                hints.extend(Self::from_derivation_tree(&derived.cause2, selector));
+            }
+        }
+        hints
+    }
+
+    /// Iterate over the hints in the set.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &PubGrubHint> {
+        self.0.iter()
+    }
+
+    /// Insert a hint into the set.
+    fn insert(&mut self, hint: PubGrubHint) -> bool {
+        self.0.insert(hint)
+    }
+
+    /// Extend the set with another set of hints.
+    fn extend(&mut self, hints: Self) {
+        self.0.extend(hints.0);
+    }
+}
+
+#[derive(Derivative, Debug, Clone)]
+#[derivative(Hash, PartialEq, Eq)]
+pub(crate) enum PubGrubHint {
+    /// A package was requested with a pre-release marker, but pre-releases weren't enabled for
+    /// that package.
+    NoVersionsWithPreRelease {
+        package: PubGrubPackage,
+        #[derivative(PartialEq = "ignore", Hash = "ignore")]
+        range: Range<PubGrubVersion>,
+    },
+}
+
+impl std::fmt::Display for PubGrubHint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PubGrubHint::NoVersionsWithPreRelease { package, range } => {
+                write!(
+                    f,
+                    "{}{} {} was requested with a pre-release marker (e.g., {}), but pre-releases weren't enabled (try: `--prerelease=allow`)",
+                    "hint".bold().cyan(),
+                    ":".bold(),
+                    format!("{package}").bold(),
+                    format!("{range}").bold(),
+                )
             }
         }
     }

--- a/crates/puffin-resolver/src/resolution_mode.rs
+++ b/crates/puffin-resolver/src/resolution_mode.rs
@@ -18,7 +18,7 @@ pub enum ResolutionMode {
 
 /// Like [`ResolutionMode`], but with any additional information required to select a candidate,
 /// like the set of direct dependencies.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum ResolutionStrategy {
     /// Resolve the highest compatible version of each package.
     Highest,

--- a/crates/puffin-resolver/src/resolver.rs
+++ b/crates/puffin-resolver/src/resolver.rs
@@ -290,7 +290,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                 resolution.map_err(|err| {
                     // Add version information to improve unsat error messages
                     if let ResolveError::NoSolution(err) = err {
-                        ResolveError::NoSolution(err.update_available_versions(&self.index.packages))
+                        ResolveError::NoSolution(err.with_available_versions(&self.index.packages).with_selector(self.selector.clone()))
                     } else {
                         err
                     }


### PR DESCRIPTION
This PR adds a dedicated error message for resolutions that fail, but might've succeeded if pre-releases were allowed. Specifically, if we see a failed resolution, and failed to find a version for a package that included a pre-release marker, we add a hint nudging the user to explicitly enable all pre-releases.

We'd prefer a solution like https://github.com/astral-sh/puffin/pull/666, but believe that it will break some assumptions in PubGrub, so this is the lighter-weight solution.

Closes https://github.com/astral-sh/puffin/issues/659.