### PR TITLE
Include `Accept` header specifying that we can only parse JSON responses

### DIFF
--- a/crates/puffin-client/src/registry_client.rs
+++ b/crates/puffin-client/src/registry_client.rs
@@ -153,6 +153,7 @@ impl RegistryClient {
                 .uncached()
                 .get(url.clone())
                 .header("Accept-Encoding", "gzip")
+                .header("Accept", "application/vnd.pypi.simple.v1+json")
                 .build()?;
             let parse_simple_response = |response: Response| async {
                 let bytes = response.bytes().await?;


### PR DESCRIPTION
Otherwise, when an index does not support the query variable we get an HTML response and a JSON parse error.