### PR TITLE
Fix fallback download when index does not support HTTP range requests

### DIFF
--- a/crates/puffin-client/src/registry_client.rs
+++ b/crates/puffin-client/src/registry_client.rs
@@ -299,14 +299,15 @@ impl RegistryClient {
         let result = self
             .client
             .get_cached_with_callback(req, &cache_entry, read_metadata_from_initial_response)
-            .await;
+            .await
+            .map_err(crate::Error::from);
 
         match result {
             Ok(metadata) => return Ok(metadata),
-            Err(CachedClientError::Callback(Error::AsyncHttpRangeReader(
+            Err(Error::AsyncHttpRangeReader(
                 AsyncHttpRangeReaderError::HttpRangeRequestUnsupported,
-            ))) => {}
-            Err(err) => return Err(err.into()),
+            )) => {}
+            Err(err) => return Err(err),
         }
 
         // The range request version failed (this is bad, the webserver should support this), fall


### PR DESCRIPTION
Otherwise, when a server does not support HTTP range requests we throw an error instead of downloading without range requests.