### PR TITLE
Derive `Debug` for `CachedClientError`

### DIFF
--- a/crates/puffin-client/src/cached_client.rs
+++ b/crates/puffin-client/src/cached_client.rs
@@ -12,6 +12,7 @@ use puffin_cache::CacheEntry;
 use puffin_fs::write_atomic;
 
 /// Either a cached client error or a (user specified) error from the callback
+#[derive(Debug)]
 pub enum CachedClientError<CallbackError> {
     Client(crate::Error),
     Callback(CallbackError),


### PR DESCRIPTION
Discovered while debugging https://github.com/astral-sh/puffin/pull/702