### PR TITLE
Perform 3 retries by default instead of 0 on failed index requests

### DIFF
--- a/crates/puffin-client/src/registry_client.rs
+++ b/crates/puffin-client/src/registry_client.rs
@@ -42,7 +42,7 @@ impl RegistryClientBuilder {
             index_urls: IndexUrls::default(),
             proxy: Url::parse("https://pypi-metadata.ruff.rs").unwrap(),
             cache,
-            retries: 0,
+            retries: 3,
         }
     }
 }


### PR DESCRIPTION
As a user, I'd expect retries to occur by default.

We should also expose this via a setting probably.