### PR TITLE
Show resource and lockfile when waiting

### DIFF
--- a/crates/puffin-cache/src/canonical_url.rs
+++ b/crates/puffin-cache/src/canonical_url.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
@@ -82,6 +83,12 @@ impl Hash for CanonicalUrl {
         // `as_str` gives the serialisation of a url (which has a spec) and so insulates against
         // possible changes in how the URL crate does hashing.
         self.0.as_str().hash(state);
+    }
+}
+
+impl std::fmt::Display for CanonicalUrl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
     }
 }
 

--- a/crates/puffin-distribution/src/source_dist.rs
+++ b/crates/puffin-distribution/src/source_dist.rs
@@ -653,7 +653,8 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
         // Avoid races between different processes, too.
         let lock_dir = git_dir.join("locks");
         fs::create_dir_all(&lock_dir).await?;
-        let _lock = LockedFile::acquire(lock_dir.join(digest(&CanonicalUrl::new(url))))?;
+        let canonical_url = CanonicalUrl::new(url);
+        let _lock = LockedFile::acquire(lock_dir.join(digest(&canonical_url)), &canonical_url)?;
 
         let DirectGitUrl { url, subdirectory } =
             DirectGitUrl::try_from(url).map_err(SourceDistError::Git)?;

--- a/crates/puffin-interpreter/src/virtual_env.rs
+++ b/crates/puffin-interpreter/src/virtual_env.rs
@@ -104,7 +104,7 @@ impl Virtualenv {
 
     /// Lock the virtual environment to prevent concurrent writes.
     pub fn lock(&self) -> Result<LockedFile, std::io::Error> {
-        LockedFile::acquire(self.root.join(".lock"))
+        LockedFile::acquire(self.root.join(".lock"), self.root.display())
     }
 }
 


### PR DESCRIPTION
We lock git checkout directories and the virtualenv to avoid two puffin instances running in parallel changing files at the same time and leading to a broken state. When one instance is blocking another, we need to inform the user (why is the program hanging?) and also add some information for them to debug the situation.

The new messages will print

```
Waiting to acquire lock for /home/konsti/projects/puffin/.venv (lockfile: /home/konsti/projects/puffin/.venv/.lock)
```

or

```
Waiting to acquire lock for git+https://github.com/pydantic/pydantic-extra-types@0ce9f207a1e09a862287ab77512f0060c1625223 (lockfile: /home/konsti/projects/puffin/cache-all-kinds/git-v0/locks/f157fd329a506a34)
```

The messages aren't perfect but clear enough to see what the contention is and in the worst case to delete the lockfile.

Fixes #714