### PR TITLE
Add support for relative URLs in simple metadata responses

### DIFF
--- a/crates/distribution-types/src/base_url.rs
+++ b/crates/distribution-types/src/base_url.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BaseUrl(Url);
+
+impl BaseUrl {
+    /// Parse the given URL. If it's relative, join it to the current [`BaseUrl`]. Allows for
+    /// parsing URLs that may be absolute or relative, with a known base URL.
+    pub fn join_relative(&self, url: &str) -> Result<Url, url::ParseError> {
+        match Url::parse(url) {
+            Ok(url) => Ok(url),
+            Err(err) => {
+                if err == url::ParseError::RelativeUrlWithoutBase {
+                    self.0.join(url)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+}
+
+impl From<Url> for BaseUrl {
+    fn from(url: Url) -> Self {
+        Self(url)
+    }
+}
+
+impl std::fmt::Display for BaseUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/crates/distribution-types/src/index_url.rs
+++ b/crates/distribution-types/src/index_url.rs
@@ -3,12 +3,13 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 static PYPI_URL: Lazy<Url> = Lazy::new(|| Url::parse("https://pypi.org/simple").unwrap());
 
-/// The url of an index, newtype'd to avoid mixing it with file urls
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+/// The url of an index, newtype'd to avoid mixing it with file urls.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum IndexUrl {
     Pypi,
     Url(Url),

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -47,6 +47,7 @@ use distribution_filename::WheelFilename;
 use pep440_rs::Version;
 use pep508_rs::VerbatimUrl;
 use puffin_normalize::PackageName;
+use pypi_types::BaseUrl;
 use requirements_txt::EditableRequirement;
 
 pub use crate::any::*;
@@ -152,6 +153,7 @@ pub struct RegistryBuiltDist {
     pub version: Version,
     pub file: File,
     pub index: IndexUrl,
+    pub base: BaseUrl,
 }
 
 /// A built distribution (wheel) that exists at an arbitrary URL.
@@ -178,6 +180,7 @@ pub struct RegistrySourceDist {
     pub version: Version,
     pub file: File,
     pub index: IndexUrl,
+    pub base: BaseUrl,
 }
 
 /// A source distribution that exists at an arbitrary URL.
@@ -207,7 +210,13 @@ pub struct PathSourceDist {
 
 impl Dist {
     /// Create a [`Dist`] for a registry-based distribution.
-    pub fn from_registry(name: PackageName, version: Version, file: File, index: IndexUrl) -> Self {
+    pub fn from_registry(
+        name: PackageName,
+        version: Version,
+        file: File,
+        index: IndexUrl,
+        base: BaseUrl,
+    ) -> Self {
         if Path::new(&file.filename)
             .extension()
             .is_some_and(|ext| ext.eq_ignore_ascii_case("whl"))
@@ -217,6 +226,7 @@ impl Dist {
                 version,
                 file,
                 index,
+                base,
             }))
         } else {
             Self::Source(SourceDist::Registry(RegistrySourceDist {
@@ -224,6 +234,7 @@ impl Dist {
                 version,
                 file,
                 index,
+                base,
             }))
         }
     }

--- a/crates/puffin-client/src/lib.rs
+++ b/crates/puffin-client/src/lib.rs
@@ -1,7 +1,7 @@
 pub use cached_client::{CachedClient, CachedClientError, DataWithCachePolicy};
 pub use error::Error;
 pub use registry_client::{
-    read_metadata_async, RegistryClient, RegistryClientBuilder, SimpleMetadata,
+    read_metadata_async, RegistryClient, RegistryClientBuilder, SimpleMetadata, VersionFiles,
 };
 
 mod cached_client;

--- a/crates/puffin-distribution/src/source_dist.rs
+++ b/crates/puffin-distribution/src/source_dist.rs
@@ -231,9 +231,12 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
                 .await?
             }
             SourceDist::Registry(registry_source_dist) => {
-                let url = Url::parse(&registry_source_dist.file.url).map_err(|err| {
-                    SourceDistError::UrlParse(registry_source_dist.file.url.clone(), err)
-                })?;
+                let url = registry_source_dist
+                    .base
+                    .join_relative(&registry_source_dist.file.url)
+                    .map_err(|err| {
+                        SourceDistError::UrlParse(registry_source_dist.file.url.clone(), err)
+                    })?;
 
                 // For registry source distributions, shard by package, then by SHA.
                 // Ex) `pypi/requests/a673187abc19fe6c`

--- a/crates/puffin-resolver/src/candidate_selector.rs
+++ b/crates/puffin-resolver/src/candidate_selector.rs
@@ -4,6 +4,7 @@ use rustc_hash::FxHashMap;
 use distribution_types::{Dist, DistributionMetadata, IndexUrl, Name};
 use pep508_rs::{Requirement, VersionOrUrl};
 use puffin_normalize::PackageName;
+use pypi_types::BaseUrl;
 
 use crate::file::DistFile;
 use crate::prerelease_mode::PreReleaseStrategy;
@@ -145,7 +146,7 @@ impl CandidateSelector {
     }
 
     /// Select the first-matching [`Candidate`] from a set of candidate versions and files,
-    /// preferring wheels over sdists.
+    /// preferring wheels over source distributions.
     fn select_candidate<'a>(
         versions: impl Iterator<Item = (&'a PubGrubVersion, ResolvableFile<'a>)>,
         package_name: &'a PackageName,
@@ -242,12 +243,13 @@ impl<'a> Candidate<'a> {
     }
 
     /// Return the [`Dist`] to use when resolving the candidate.
-    pub(crate) fn into_distribution(self, index: IndexUrl) -> Dist {
+    pub(crate) fn into_distribution(self, index: IndexUrl, base: BaseUrl) -> Dist {
         Dist::from_registry(
             self.name().clone(),
             self.version().clone().into(),
             self.resolve().clone().into(),
             index,
+            base,
         )
     }
 }

--- a/crates/puffin-resolver/src/error.rs
+++ b/crates/puffin-resolver/src/error.rs
@@ -12,6 +12,7 @@ use pep508_rs::Requirement;
 use puffin_distribution::DistributionDatabaseError;
 use puffin_normalize::PackageName;
 use puffin_traits::OnceMap;
+use pypi_types::BaseUrl;
 
 use crate::pubgrub::{PubGrubPackage, PubGrubReportFormatter, PubGrubVersion};
 use crate::version_map::VersionMap;
@@ -144,12 +145,12 @@ impl NoSolutionError {
     /// Only packages used in the error's derivation tree will be retrieved.
     pub(crate) fn update_available_versions(
         mut self,
-        package_versions: &OnceMap<PackageName, (IndexUrl, VersionMap)>,
+        package_versions: &OnceMap<PackageName, (IndexUrl, BaseUrl, VersionMap)>,
     ) -> Self {
         for package in self.derivation_tree.packages() {
             if let PubGrubPackage::Package(name, ..) = package {
                 if let Some(entry) = package_versions.get(name) {
-                    let (_, version_map) = entry.value();
+                    let (_, _, version_map) = entry.value();
                     self.available_versions.insert(
                         package.clone(),
                         version_map

--- a/crates/puffin-resolver/src/pins.rs
+++ b/crates/puffin-resolver/src/pins.rs
@@ -2,6 +2,7 @@ use rustc_hash::FxHashMap;
 
 use distribution_types::{File, IndexUrl};
 use puffin_normalize::PackageName;
+use pypi_types::BaseUrl;
 
 use crate::candidate_selector::Candidate;
 
@@ -10,14 +11,20 @@ use crate::candidate_selector::Candidate;
 /// For example, given `Flask==3.0.0`, the [`FilePins`] would contain a mapping from `Flask` to
 /// `3.0.0` to the specific wheel or source distribution archive that was pinned for that version.
 #[derive(Debug, Default)]
-pub(crate) struct FilePins(FxHashMap<PackageName, FxHashMap<pep440_rs::Version, (IndexUrl, File)>>);
+pub(crate) struct FilePins(
+    FxHashMap<PackageName, FxHashMap<pep440_rs::Version, (IndexUrl, BaseUrl, File)>>,
+);
 
 impl FilePins {
     /// Pin a candidate package.
-    pub(crate) fn insert(&mut self, candidate: &Candidate, index: &IndexUrl) {
+    pub(crate) fn insert(&mut self, candidate: &Candidate, index: &IndexUrl, base: &BaseUrl) {
         self.0.entry(candidate.name().clone()).or_default().insert(
             candidate.version().clone().into(),
-            (index.clone(), candidate.install().clone().into()),
+            (
+                index.clone(),
+                base.clone(),
+                candidate.install().clone().into(),
+            ),
         );
     }
 
@@ -26,7 +33,7 @@ impl FilePins {
         &self,
         name: &PackageName,
         version: &pep440_rs::Version,
-    ) -> Option<&(IndexUrl, File)> {
+    ) -> Option<&(IndexUrl, BaseUrl, File)> {
         self.0.get(name)?.get(version)
     }
 }

--- a/crates/puffin-resolver/src/resolution.rs
+++ b/crates/puffin-resolver/src/resolution.rs
@@ -55,12 +55,12 @@ impl ResolutionGraph {
             match package {
                 PubGrubPackage::Package(package_name, None, None) => {
                     let version = Version::from(version.clone());
-                    let (index, file) = pins
+                    let (index, base, file) = pins
                         .get(package_name, &version)
                         .expect("Every package should be pinned")
                         .clone();
                     let pinned_package =
-                        Dist::from_registry(package_name.clone(), version, file, index);
+                        Dist::from_registry(package_name.clone(), version, file, index, base);
 
                     let index = petgraph.add_node(pinned_package);
                     inverse.insert(package_name, index);
@@ -89,12 +89,12 @@ impl ResolutionGraph {
 
                     if !metadata.provides_extras.contains(extra) {
                         let version = Version::from(version.clone());
-                        let (index, file) = pins
+                        let (index, base, file) = pins
                             .get(package_name, &version)
                             .expect("Every package should be pinned")
                             .clone();
                         let pinned_package =
-                            Dist::from_registry(package_name.clone(), version, file, index);
+                            Dist::from_registry(package_name.clone(), version, file, index, base);
 
                         diagnostics.push(Diagnostic::MissingExtra {
                             dist: pinned_package,

--- a/crates/pypi-types/src/base_url.rs
+++ b/crates/pypi-types/src/base_url.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BaseUrl(Url);
+
+impl BaseUrl {
+    /// Parse the given URL. If it's relative, join it to the current [`BaseUrl`]. Allows for
+    /// parsing URLs that may be absolute or relative, with a known base URL.
+    pub fn join_relative(&self, url: &str) -> Result<Url, url::ParseError> {
+        match Url::parse(url) {
+            Ok(url) => Ok(url),
+            Err(err) => {
+                if err == url::ParseError::RelativeUrlWithoutBase {
+                    self.0.join(url)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+}
+
+impl From<Url> for BaseUrl {
+    fn from(url: Url) -> Self {
+        Self(url)
+    }
+}
+
+impl std::fmt::Display for BaseUrl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/crates/pypi-types/src/lib.rs
+++ b/crates/pypi-types/src/lib.rs
@@ -1,8 +1,10 @@
+pub use base_url::*;
 pub use direct_url::*;
 pub use lenient_requirement::*;
 pub use metadata::*;
 pub use simple_json::*;
 
+mod base_url;
 mod direct_url;
 mod lenient_requirement;
 mod metadata;

--- a/crates/pypi-types/src/simple_json.rs
+++ b/crates/pypi-types/src/simple_json.rs
@@ -1,7 +1,9 @@
-use chrono::{DateTime, Utc};
-use pep440_rs::VersionSpecifiers;
-use serde::{de, Deserialize, Deserializer, Serialize};
 use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use serde::{de, Deserialize, Deserializer, Serialize};
+
+use pep440_rs::VersionSpecifiers;
 
 use crate::lenient_requirement::LenientVersionSpecifiers;
 
@@ -10,13 +12,13 @@ pub struct SimpleJson {
     pub files: Vec<File>,
 }
 
-/// A single (remote) file belonging to a package, generally either a wheel or a source dist.
+/// A single (remote) file belonging to a package, either a wheel or a source distribution.
 ///
 /// <https://peps.python.org/pep-0691/#project-detail>
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct File {
-    // Not PEP 691 compliant alias used by pypi
+    // Non-PEP 691-compliant alias used by PyPI.
     #[serde(alias = "data_dist_info_metadata")]
     pub dist_info_metadata: Option<DistInfoMetadata>,
     pub filename: String,


### PR DESCRIPTION
## Summary

This PR adds support for relative URLs in the simple JSON responses. We already support relative URLs for HTML responses, but the handling has been consolidated between the two. Similar to index URLs, we now store the base alongside the metadata, and use the base when resolving the URL.

Closes #455.

## Test Plan

`cargo test` (to test HTML indexes). Separately, I also ran `cargo run -p puffin-cli -- pip-compile requirements.in -n --index-url=http://localhost:3141/packages/pypi/+simple` on the `zb/relative` branch with `packse` running, and forced both HTML and JSON by limiting the `accept` header.
