### PR TITLE
Un-escape HTML entities when decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,6 +2380,7 @@ dependencies = [
  "distribution-types",
  "fs-err",
  "futures",
+ "html-escape",
  "http",
  "http-cache-semantics",
  "insta",
@@ -4026,6 +4036,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ git2 = { version = "0.18.1" }
 glob = { version = "0.3.1" }
 goblin = { version = "0.7.1" }
 hex = { version = "0.4.3" }
+html-escape = { version = "0.2.13" }
 http = { version = "0.2.9" }
 http-cache-semantics = { version = "1.0.1" }
 indicatif = { version = "0.17.7" }

--- a/crates/puffin-client/Cargo.toml
+++ b/crates/puffin-client/Cargo.toml
@@ -17,6 +17,7 @@ async_http_range_reader = { workspace = true }
 async_zip = { workspace = true, features = ["tokio"] }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
+html-escape = { workspace = true }
 http = { workspace = true }
 http-cache-semantics = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/puffin-client/src/html.rs
+++ b/crates/puffin-client/src/html.rs
@@ -111,8 +111,9 @@ impl SimpleHtml {
             link.attributes().get("data-requires-python").flatten()
         {
             let requires_python = std::str::from_utf8(requires_python.as_bytes())?;
+            let requires_python = html_escape::decode_html_entities(requires_python);
             let requires_python =
-                VersionSpecifiers::from_str(requires_python).map_err(Error::Pep440)?;
+                VersionSpecifiers::from_str(&requires_python).map_err(Error::Pep440)?;
             Some(requires_python)
         } else {
             None
@@ -124,7 +125,8 @@ impl SimpleHtml {
             link.attributes().get("data-dist-info-metadata").flatten()
         {
             let dist_info_metadata = std::str::from_utf8(dist_info_metadata.as_bytes())?;
-            match dist_info_metadata {
+            let dist_info_metadata = html_escape::decode_html_entities(dist_info_metadata);
+            match dist_info_metadata.as_ref() {
                 "true" => Some(DistInfoMetadata::Bool(true)),
                 "false" => Some(DistInfoMetadata::Bool(false)),
                 fragment => Some(DistInfoMetadata::Hashes(Self::parse_hash(fragment, &url)?)),
@@ -137,6 +139,7 @@ impl SimpleHtml {
         // attribute.
         let yanked = if let Some(yanked) = link.attributes().get("data-yanked").flatten() {
             let yanked = std::str::from_utf8(yanked.as_bytes())?;
+            let yanked = html_escape::decode_html_entities(yanked);
             Some(Yanked::Reason(yanked.to_string()))
         } else {
             None


### PR DESCRIPTION
I don't have a good testing strategy here (I'm manually testing against `devpi` via `packse`), but the HTML index uses (e.g.) `data-requires-python="&gt;=3.8"`, so we need to decode.