### PR TITLE
Remove `platform-tags` dependency on `puffin-interpreter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,7 +2127,6 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "platform-host",
- "puffin-interpreter",
  "rustc-hash",
 ]
 
@@ -2599,6 +2598,7 @@ dependencies = [
  "pep440_rs 0.3.12",
  "pep508_rs",
  "platform-host",
+ "platform-tags",
  "puffin-cache",
  "puffin-fs",
  "rmp-serde",

--- a/crates/platform-tags/Cargo.toml
+++ b/crates/platform-tags/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 platform-host = { path = "../platform-host" }
-puffin-interpreter = { path = "../puffin-interpreter" }
 
 anyhow = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/platform-tags/src/lib.rs
+++ b/crates/platform-tags/src/lib.rs
@@ -4,7 +4,6 @@ use anyhow::{Error, Result};
 use rustc_hash::FxHashMap;
 
 use platform_host::{Arch, Os, Platform, PlatformError};
-use puffin_interpreter::Interpreter;
 
 /// A set of compatible tags for a given Python version and platform.
 ///
@@ -32,10 +31,6 @@ impl Tags {
                 .or_insert(TagPriority::try_from(index).expect("valid tag priority"));
         }
         Self { map }
-    }
-
-    pub fn from_interpreter(interpreter: &Interpreter) -> Result<Self, PlatformError> {
-        Self::from_env(interpreter.platform(), interpreter.simple_version())
     }
 
     /// Returns the compatible tags for the given Python version and platform.

--- a/crates/puffin-cli/src/commands/pip_compile.rs
+++ b/crates/puffin-cli/src/commands/pip_compile.rs
@@ -16,7 +16,7 @@ use tracing::debug;
 use distribution_types::LocalEditable;
 use pep508_rs::Requirement;
 use platform_host::Platform;
-use platform_tags::Tags;
+
 use puffin_cache::Cache;
 use puffin_client::RegistryClientBuilder;
 use puffin_dispatch::BuildDispatch;
@@ -126,7 +126,7 @@ pub(crate) async fn pip_compile(
 
     // Determine the tags, markers, and interpreter to use for resolution.
     let interpreter = venv.interpreter().clone();
-    let tags = Tags::from_interpreter(venv.interpreter())?;
+    let tags = venv.interpreter().tags()?;
     let markers = python_version.map_or_else(
         || Cow::Borrowed(venv.interpreter().markers()),
         |python_version| Cow::Owned(python_version.markers(venv.interpreter().markers())),

--- a/crates/puffin-cli/src/commands/pip_install.rs
+++ b/crates/puffin-cli/src/commands/pip_install.rs
@@ -123,7 +123,7 @@ pub(crate) async fn pip_install(
 
     // Determine the tags, markers, and interpreter to use for resolution.
     let interpreter = venv.interpreter().clone();
-    let tags = Tags::from_interpreter(venv.interpreter())?;
+    let tags = venv.interpreter().tags()?;
     let markers = venv.interpreter().markers();
 
     // Instantiate a client.

--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -54,7 +54,7 @@ pub(crate) async fn pip_sync(
     let _lock = venv.lock()?;
 
     // Determine the current environment markers.
-    let tags = Tags::from_interpreter(venv.interpreter())?;
+    let tags = venv.interpreter().tags()?;
 
     // Prep the registry client.
     let client = RegistryClientBuilder::new(cache.clone())

--- a/crates/puffin-dev/src/install_many.rs
+++ b/crates/puffin-dev/src/install_many.rs
@@ -58,7 +58,7 @@ pub(crate) async fn install_many(args: InstallManyArgs) -> Result<()> {
     let venv = Virtualenv::from_env(platform, &cache)?;
     let client = RegistryClientBuilder::new(cache.clone()).build();
     let index_urls = IndexUrls::default();
-    let tags = Tags::from_interpreter(venv.interpreter())?;
+    let tags = venv.interpreter().tags()?;
     let build_dispatch = BuildDispatch::new(
         &client,
         &cache,

--- a/crates/puffin-dev/src/resolve_cli.rs
+++ b/crates/puffin-dev/src/resolve_cli.rs
@@ -12,7 +12,7 @@ use petgraph::dot::{Config as DotConfig, Dot};
 
 use pep508_rs::Requirement;
 use platform_host::Platform;
-use platform_tags::Tags;
+
 use puffin_cache::{Cache, CacheArgs};
 use puffin_client::RegistryClientBuilder;
 use puffin_dispatch::BuildDispatch;
@@ -63,7 +63,7 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
     );
 
     // Copied from `BuildDispatch`
-    let tags = Tags::from_interpreter(venv.interpreter())?;
+    let tags = venv.interpreter().tags()?;
     let resolver = Resolver::new(
         Manifest::simple(args.requirements.clone()),
         ResolutionOptions::default(),

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -12,7 +12,7 @@ use tracing::{debug, instrument};
 
 use distribution_types::{CachedDist, Name, Resolution};
 use pep508_rs::Requirement;
-use platform_tags::Tags;
+
 use puffin_build::{SourceBuild, SourceBuildContext};
 use puffin_cache::Cache;
 use puffin_client::RegistryClient;
@@ -90,11 +90,12 @@ impl<'a> BuildContext for BuildDispatch<'a> {
         requirements: &'data [Requirement],
     ) -> Pin<Box<dyn Future<Output = Result<Resolution>> + Send + 'data>> {
         Box::pin(async {
-            let tags = Tags::from_interpreter(self.interpreter)?;
+            let markers = self.interpreter.markers();
+            let tags = self.interpreter.tags()?;
             let resolver = Resolver::new(
                 Manifest::simple(requirements.to_vec()),
                 self.options,
-                self.interpreter.markers(),
+                markers,
                 &tags,
                 self.client,
                 self,
@@ -132,7 +133,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
             );
 
             // Determine the current environment markers.
-            let tags = Tags::from_interpreter(self.interpreter)?;
+            let tags = self.interpreter.tags()?;
 
             // Determine the set of installed packages.
             let site_packages =

--- a/crates/puffin-interpreter/Cargo.toml
+++ b/crates/puffin-interpreter/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 pep440_rs = { path = "../pep440-rs" }
 pep508_rs = { path = "../pep508-rs", features = ["serde"] }
 platform-host = { path = "../platform-host" }
+platform-tags = { path = "../platform-tags" }
 puffin-cache = { path = "../puffin-cache" }
 puffin-fs = { path = "../puffin-fs" }
 

--- a/crates/puffin-interpreter/src/interpreter.rs
+++ b/crates/puffin-interpreter/src/interpreter.rs
@@ -7,7 +7,8 @@ use tracing::{debug, warn};
 
 use pep440_rs::Version;
 use pep508_rs::MarkerEnvironment;
-use platform_host::Platform;
+use platform_host::{Platform, PlatformError};
+use platform_tags::Tags;
 use puffin_cache::CachedByTimestamp;
 use puffin_cache::{digest, Cache, CacheBucket};
 use puffin_fs::write_atomic_sync;
@@ -72,6 +73,11 @@ impl Interpreter {
     /// Returns the [`MarkerEnvironment`] for this Python executable.
     pub fn markers(&self) -> &MarkerEnvironment {
         &self.markers
+    }
+
+    /// Returns the [`Tags`] for this Python executable.
+    pub fn tags(&self) -> Result<Tags, PlatformError> {
+        Tags::from_env(self.platform(), self.simple_version())
     }
 
     /// Returns the Python version.


### PR DESCRIPTION
Cuts off a large internal dependency chain from what is otherwise a very general crate.