### PR TITLE
Change internal representation of `CacheEntry` to avoid allocations

### DIFF
--- a/crates/puffin-client/src/cached_client.rs
+++ b/crates/puffin-client/src/cached_client.rs
@@ -136,7 +136,7 @@ impl CachedClient {
                     .map_err(|err| CachedClientError::Callback(err))?;
                 if let Some(cache_policy) = cache_policy {
                     let data_with_cache_policy = DataWithCachePolicy { data, cache_policy };
-                    fs_err::tokio::create_dir_all(&cache_entry.dir)
+                    fs_err::tokio::create_dir_all(cache_entry.dir())
                         .await
                         .map_err(crate::Error::CacheWrite)?;
                     let data =

--- a/crates/puffin-distribution/src/distribution_database.rs
+++ b/crates/puffin-distribution/src/distribution_database.rs
@@ -136,7 +136,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
 
                     LocalWheel::InMemory(InMemoryWheel {
                         dist: dist.clone(),
-                        target: cache_entry.path(),
+                        target: cache_entry.into_path_buf(),
                         buffer,
                         filename: wheel_filename,
                     })
@@ -162,13 +162,16 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                             .remote_wheel_dir(wheel_filename.name.as_ref()),
                         filename,
                     );
-                    fs::create_dir_all(&cache_entry.dir).await?;
+                    fs::create_dir_all(&cache_entry.dir()).await?;
                     tokio::fs::rename(temp_file, &cache_entry.path()).await?;
 
                     LocalWheel::Disk(DiskWheel {
                         dist: dist.clone(),
-                        path: cache_entry.path(),
-                        target: cache_entry.with_file(wheel_filename.stem()).path(),
+                        target: cache_entry
+                            .with_file(wheel_filename.stem())
+                            .path()
+                            .to_path_buf(),
+                        path: cache_entry.into_path_buf(),
                         filename: wheel_filename,
                     })
                 };
@@ -195,13 +198,16 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                     WheelCache::Url(&wheel.url).remote_wheel_dir(wheel.name().as_ref()),
                     filename,
                 );
-                fs::create_dir_all(&cache_entry.dir).await?;
+                fs::create_dir_all(&cache_entry.dir()).await?;
                 tokio::fs::rename(temp_file, &cache_entry.path()).await?;
 
                 let local_wheel = LocalWheel::Disk(DiskWheel {
                     dist: dist.clone(),
-                    path: cache_entry.path(),
-                    target: cache_entry.with_file(wheel.filename.stem()).path(),
+                    target: cache_entry
+                        .with_file(wheel.filename.stem())
+                        .path()
+                        .to_path_buf(),
+                    path: cache_entry.into_path_buf(),
                     filename: wheel.filename.clone(),
                 });
 
@@ -218,7 +224,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                 Ok(LocalWheel::Disk(DiskWheel {
                     dist: dist.clone(),
                     path: wheel.path.clone(),
-                    target: cache_entry.path(),
+                    target: cache_entry.into_path_buf(),
                     filename: wheel.filename.clone(),
                 }))
             }

--- a/crates/puffin-installer/src/plan.rs
+++ b/crates/puffin-installer/src/plan.rs
@@ -204,11 +204,11 @@ impl InstallPlan {
                                 let cached_dist = CachedDirectUrlDist::from_url(
                                     wheel.filename,
                                     wheel.url,
-                                    cache_entry.path(),
+                                    cache_entry.into_path_buf(),
                                 );
 
                                 debug!("URL wheel requirement already cached: {cached_dist}");
-                                local.push(CachedDist::Url(cached_dist.clone()));
+                                local.push(CachedDist::Url(cached_dist));
                                 continue;
                             }
                         }
@@ -225,11 +225,11 @@ impl InstallPlan {
                                 let cached_dist = CachedDirectUrlDist::from_url(
                                     wheel.filename,
                                     wheel.url,
-                                    cache_entry.path(),
+                                    cache_entry.into_path_buf(),
                                 );
 
                                 debug!("Path wheel requirement already cached: {cached_dist}");
-                                local.push(CachedDist::Url(cached_dist.clone()));
+                                local.push(CachedDist::Url(cached_dist));
                                 continue;
                             }
                         }
@@ -244,7 +244,7 @@ impl InstallPlan {
                             if let Some(wheel) = BuiltWheelIndex::find(&cache_shard, tags) {
                                 let cached_dist = wheel.into_url_dist(url.clone());
                                 debug!("URL source requirement already cached: {cached_dist}");
-                                local.push(CachedDist::Url(cached_dist.clone()));
+                                local.push(CachedDist::Url(cached_dist));
                                 continue;
                             }
                         }
@@ -260,7 +260,7 @@ impl InstallPlan {
                             if let Some(wheel) = BuiltWheelIndex::find(&cache_shard, tags) {
                                 let cached_dist = wheel.into_url_dist(url.clone());
                                 debug!("Path source requirement already cached: {cached_dist}");
-                                local.push(CachedDist::Url(cached_dist.clone()));
+                                local.push(CachedDist::Url(cached_dist));
                                 continue;
                             }
                         }
@@ -277,7 +277,7 @@ impl InstallPlan {
                                 if let Some(wheel) = BuiltWheelIndex::find(&cache_shard, tags) {
                                     let cached_dist = wheel.into_url_dist(url.clone());
                                     debug!("Git source requirement already cached: {cached_dist}");
-                                    local.push(CachedDist::Url(cached_dist.clone()));
+                                    local.push(CachedDist::Url(cached_dist));
                                     continue;
                                 }
                             }

--- a/crates/puffin-interpreter/src/interpreter.rs
+++ b/crates/puffin-interpreter/src/interpreter.rs
@@ -209,7 +209,7 @@ impl InterpreterQueryResult {
         // If `executable` is a pyenv shim, a bash script that redirects to the activated
         // python executable at another path, we're not allowed to cache the interpreter info
         if executable == info.sys_executable {
-            fs::create_dir_all(&cache_entry.dir)?;
+            fs::create_dir_all(cache_entry.dir())?;
             // Write to the cache.
             write_atomic_sync(
                 cache_entry.path(),


### PR DESCRIPTION
Removes a TODO.