### PR TITLE
Rust 1.75

### DIFF
--- a/crates/distribution-types/src/index_url.rs
+++ b/crates/distribution-types/src/index_url.rs
@@ -105,3 +105,11 @@ impl<'a> IntoIterator for &'a IndexUrls {
         self.index.iter().chain(self.extra_index.iter())
     }
 }
+
+impl<'a> IndexUrls {
+    pub fn iter(
+        &'a self,
+    ) -> Chain<std::option::Iter<'a, IndexUrl>, std::slice::Iter<'a, IndexUrl>> {
+        self.into_iter()
+    }
+}

--- a/crates/puffin-build/src/lib.rs
+++ b/crates/puffin-build/src/lib.rs
@@ -8,7 +8,6 @@ use std::future::Future;
 use std::io;
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 use std::process::Output;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -544,16 +543,14 @@ impl SourceBuild {
 }
 
 impl SourceBuildTrait for SourceBuild {
-    fn metadata<'a>(
-        &'a mut self,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<Option<PathBuf>>> + Send + 'a>> {
+    fn metadata(&mut self) -> impl Future<Output = anyhow::Result<Option<PathBuf>>> + Send {
         Box::pin(async { Ok(self.get_metadata_without_build().await?) })
     }
 
     fn wheel<'a>(
         &'a self,
         wheel_dir: &'a Path,
-    ) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + Send + 'a>> {
+    ) -> impl Future<Output = anyhow::Result<String>> + Send + 'a {
         Box::pin(async { Ok(self.build(wheel_dir).await?) })
     }
 }

--- a/crates/puffin-dev/src/main.rs
+++ b/crates/puffin-dev/src/main.rs
@@ -58,7 +58,7 @@ enum Cli {
     ResolveMany(ResolveManyArgs),
     InstallMany(InstallManyArgs),
     /// Resolve requirements passed on the CLI
-    ResolveCli(ResolveCliArgs),
+    Resolve(ResolveCliArgs),
     WheelMetadata(WheelMetadataArgs),
 }
 
@@ -75,7 +75,7 @@ async fn run() -> Result<()> {
         Cli::InstallMany(args) => {
             install_many::install_many(args).await?;
         }
-        Cli::ResolveCli(args) => {
+        Cli::Resolve(args) => {
             resolve_cli::resolve_cli(args).await?;
         }
         Cli::WheelMetadata(args) => wheel_metadata::wheel_metadata(args).await?,

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -4,7 +4,6 @@
 
 use std::future::Future;
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 
 use anyhow::{bail, Context, Result};
 use itertools::Itertools;
@@ -86,7 +85,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
     fn resolve<'data>(
         &'data self,
         requirements: &'data [Requirement],
-    ) -> Pin<Box<dyn Future<Output = Result<Resolution>> + Send + 'data>> {
+    ) -> impl Future<Output = Result<Resolution>> + Send + 'data {
         Box::pin(async {
             let markers = self.interpreter.markers();
             let tags = self.interpreter.tags()?;
@@ -119,7 +118,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
         &'data self,
         resolution: &'data Resolution,
         venv: &'data Virtualenv,
-    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'data>> {
+    ) -> impl Future<Output = Result<()>> + Send + 'data {
         Box::pin(async move {
             debug!(
                 "Installing in {} in {}",
@@ -223,7 +222,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
         subdirectory: Option<&'data Path>,
         package_id: &'data str,
         build_kind: BuildKind,
-    ) -> Pin<Box<dyn Future<Output = Result<SourceBuild>> + Send + 'data>> {
+    ) -> impl Future<Output = Result<SourceBuild>> + Send + 'data {
         Box::pin(async move {
             if self.no_build {
                 bail!("Building source distributions is disabled");

--- a/crates/puffin-resolver/src/resolver.rs
+++ b/crates/puffin-resolver/src/resolver.rs
@@ -1,7 +1,6 @@
 //! Given a set of requirements, find a set of compatible packages.
 
 use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -52,7 +51,7 @@ pub trait ResolverProvider: Send + Sync {
     fn get_version_map<'io>(
         &'io self,
         package_name: &'io PackageName,
-    ) -> Pin<Box<dyn Future<Output = VersionMapResponse> + Send + 'io>>;
+    ) -> impl Future<Output = VersionMapResponse> + Send + 'io;
 
     /// Get the metadata for a distribution.
     ///
@@ -62,7 +61,7 @@ pub trait ResolverProvider: Send + Sync {
     fn get_or_build_wheel_metadata<'io>(
         &'io self,
         dist: &'io Dist,
-    ) -> Pin<Box<dyn Future<Output = WheelMetadataResponse> + Send + 'io>>;
+    ) -> impl Future<Output = WheelMetadataResponse> + Send + 'io;
 
     /// Set the [`Reporter`] to use for this installer.
     #[must_use]
@@ -109,7 +108,7 @@ impl<'a, Context: BuildContext + Send + Sync> ResolverProvider
     fn get_version_map<'io>(
         &'io self,
         package_name: &'io PackageName,
-    ) -> Pin<Box<dyn Future<Output = VersionMapResponse> + Send + 'io>> {
+    ) -> impl Future<Output = VersionMapResponse> + Send + 'io {
         Box::pin(
             self.client
                 .simple(package_name)
@@ -134,7 +133,7 @@ impl<'a, Context: BuildContext + Send + Sync> ResolverProvider
     fn get_or_build_wheel_metadata<'io>(
         &'io self,
         dist: &'io Dist,
-    ) -> Pin<Box<dyn Future<Output = WheelMetadataResponse> + Send + 'io>> {
+    ) -> impl Future<Output = WheelMetadataResponse> + Send + 'io {
         Box::pin(self.fetcher.get_or_build_wheel_metadata(dist))
     }
 

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -3,9 +3,7 @@
 //! Integration tests for the resolver. These tests rely on a live network connection, and hit
 //! `PyPI` directly.
 
-use std::future::Future;
 use std::path::{Path, PathBuf};
-use std::pin::Pin;
 use std::str::FromStr;
 
 use anyhow::Result;
@@ -51,45 +49,37 @@ impl BuildContext for DummyContext {
         panic!("The test should not need to build source distributions")
     }
 
-    fn resolve<'a>(
-        &'a self,
-        _requirements: &'a [Requirement],
-    ) -> Pin<Box<dyn Future<Output = Result<Resolution>> + Send + 'a>> {
+    async fn resolve<'a>(&'a self, _requirements: &'a [Requirement]) -> Result<Resolution> {
         panic!("The test should not need to build source distributions")
     }
 
-    fn install<'a>(
+    async fn install<'a>(
         &'a self,
         _resolution: &'a Resolution,
         _venv: &'a Virtualenv,
-    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+    ) -> Result<()> {
         panic!("The test should not need to build source distributions")
     }
 
-    fn setup_build<'a>(
+    async fn setup_build<'a>(
         &'a self,
         _source: &'a Path,
         _subdirectory: Option<&'a Path>,
         _package_id: &'a str,
         _build_kind: BuildKind,
-    ) -> Pin<Box<dyn Future<Output = Result<Self::SourceDistBuilder>> + Send + 'a>> {
-        Box::pin(async { Ok(DummyBuilder) })
+    ) -> Result<Self::SourceDistBuilder> {
+        Ok(DummyBuilder)
     }
 }
 
 struct DummyBuilder;
 
 impl SourceBuildTrait for DummyBuilder {
-    fn metadata<'a>(
-        &'a mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<Option<PathBuf>>> + Send + 'a>> {
+    async fn metadata(&mut self) -> Result<Option<PathBuf>> {
         panic!("The test should not need to build source distributions")
     }
 
-    fn wheel<'a>(
-        &'a self,
-        _wheel_dir: &'a Path,
-    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+    async fn wheel<'a>(&'a self, _wheel_dir: &'a Path) -> Result<String> {
         panic!("The test should not need to build source distributions")
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.74"
+channel = "1.75"


### PR DESCRIPTION
The `async fn` and return-position `impl Trait` in traits improve `BuildContext` ergonomics. The traits use `impl Future` over `async fn` to make the send bound explicit (https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html).

The remaining changes are due to clippy.