### PR TITLE
Don't install incompatible path and url wheels

### DIFF
--- a/crates/puffin-cli/tests/pip_sync.rs
+++ b/crates/puffin-cli/tests/pip_sync.rs
@@ -2509,7 +2509,7 @@ fn incompatible_wheel() -> Result<()> {
 
         ----- stderr -----
         error: Failed to determine installation plan
-          Caused by: A path dependency is not compatible with the current platform: [TEMP_DIR]/foo-1.2.3-not-compatible-wheel.whl
+          Caused by: A path dependency is incompatible with the current platform: [TEMP_DIR]/foo-1.2.3-not-compatible-wheel.whl
         "###);
     });
 

--- a/crates/puffin-installer/src/plan.rs
+++ b/crates/puffin-installer/src/plan.rs
@@ -194,7 +194,7 @@ impl InstallPlan {
                         Dist::Built(BuiltDist::DirectUrl(wheel)) => {
                             if !wheel.filename.is_compatible(tags) {
                                 bail!(
-                                    "A url dependency is not compatible with the current platform: {}",
+                                    "A URL dependency is incompatible with the current platform: {}",
                                     wheel.url
                                 );
                             }
@@ -222,7 +222,7 @@ impl InstallPlan {
                         Dist::Built(BuiltDist::Path(wheel)) => {
                             if !wheel.filename.is_compatible(tags) {
                                 bail!(
-                                    "A path dependency is not compatible with the current platform: {}",
+                                    "A path dependency is incompatible with the current platform: {}",
                                     wheel.path.display()
                                 );
                             }


### PR DESCRIPTION
Add early tag checking for path and url wheels.

This does not check for resolve for consistency with index wheels.