### PR TITLE
Add spans to all significant tasks

### DIFF
--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use configparser::ini::Ini;
 use fs_err as fs;
 use fs_err::File;
-use tracing::{debug, span, Level};
+use tracing::{debug, info_span};
 
 use pypi_types::DirectUrl;
 
@@ -51,7 +51,7 @@ pub fn install_wheel(
     let metadata = dist_info_metadata(&dist_info_prefix, &wheel)?;
     let (name, _version) = parse_metadata(&dist_info_prefix, &metadata)?;
 
-    let _my_span = span!(Level::DEBUG, "install_wheel", name);
+    let _my_span = info_span!("install_wheel", name);
 
     // We're going step by step though
     // https://packaging.python.org/en/latest/specifications/binary-distribution-format/#installing-a-wheel-distribution-1-0-py32-none-any-whl

--- a/crates/install-wheel-rs/src/wheel.rs
+++ b/crates/install-wheel-rs/src/wheel.rs
@@ -13,7 +13,7 @@ use mailparse::MailHeaderMap;
 use rustc_hash::{FxHashMap, FxHashSet};
 use sha2::{Digest, Sha256};
 use tempfile::tempdir;
-use tracing::{debug, error, span, warn, Level};
+use tracing::{debug, error, instrument, warn};
 use walkdir::WalkDir;
 use zip::result::ZipError;
 use zip::write::FileOptions;
@@ -894,6 +894,7 @@ pub fn parse_key_value_file(
 ///
 /// Wheel 1.0: <https://www.python.org/dev/peps/pep-0427/>
 #[allow(clippy::too_many_arguments)]
+#[instrument(skip_all, fields(name = %filename.name))]
 pub fn install_wheel(
     location: &InstallLocation<LockedDir>,
     reader: impl Read + Seek,
@@ -907,7 +908,6 @@ pub fn install_wheel(
     sys_executable: impl AsRef<Path>,
 ) -> Result<String, Error> {
     let name = &filename.name;
-    let _my_span = span!(Level::DEBUG, "install_wheel", name = name.as_ref());
 
     let base_location = location.venv_root();
 

--- a/crates/puffin-client/src/html.rs
+++ b/crates/puffin-client/src/html.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use tl::HTMLTag;
+use tracing::instrument;
 use url::Url;
 
 use pep440_rs::VersionSpecifiers;
@@ -16,6 +17,7 @@ pub(crate) struct SimpleHtml {
 
 impl SimpleHtml {
     /// Parse the list of [`File`]s from the simple HTML page returned by the given URL.
+    #[instrument(skip(text))]
     pub(crate) fn parse(text: &str, url: &Url) -> Result<Self, Error> {
         let dom = tl::parse(text, tl::ParserOptions::default())?;
 

--- a/crates/puffin-dev/src/resolve_many.rs
+++ b/crates/puffin-dev/src/resolve_many.rs
@@ -8,7 +8,7 @@ use futures::StreamExt;
 use indicatif::ProgressStyle;
 use itertools::Itertools;
 use tokio::time::Instant;
-use tracing::{info, info_span, span, Level, Span};
+use tracing::{info, info_span, Span};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 use distribution_types::IndexUrls;
@@ -97,8 +97,6 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
             let build_dispatch = build_dispatch.clone();
             let client = client.clone();
             async move {
-                let span = span!(Level::TRACE, "fetching");
-                let _enter = span.enter();
                 let start = Instant::now();
 
                 let requirement = if args.latest_version && requirement.version_or_url.is_none() {
@@ -120,7 +118,6 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
                 };
 
                 let result = build_dispatch.resolve(&[requirement.clone()]).await;
-
                 (requirement.to_string(), start.elapsed(), result)
             }
         })

--- a/crates/puffin-distribution/src/distribution_database.rs
+++ b/crates/puffin-distribution/src/distribution_database.rs
@@ -9,7 +9,7 @@ use fs_err::tokio as fs;
 use thiserror::Error;
 use tokio::task::JoinError;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
-use tracing::debug;
+use tracing::{debug, instrument};
 use url::Url;
 
 use distribution_filename::{WheelFilename, WheelFilenameError};
@@ -101,6 +101,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
     }
 
     /// Either fetch the wheel or fetch and build the source distribution
+    #[instrument(skip(self))]
     pub async fn get_or_build_wheel(
         &self,
         dist: Dist,
@@ -252,6 +253,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
     /// Returns the [`Metadata21`], along with a "precise" URL for the source distribution, if
     /// possible. For example, given a Git dependency with a reference to a branch or tag, return a
     /// URL with a precise reference to the current commit of that branch or tag.
+    #[instrument(skip(self))]
     pub async fn get_or_build_wheel_metadata(
         &self,
         dist: &Dist,

--- a/crates/puffin-installer/src/downloader.rs
+++ b/crates/puffin-installer/src/downloader.rs
@@ -61,7 +61,6 @@ impl<'a, Context: BuildContext + Send + Sync> Downloader<'a, Context> {
     }
 
     /// Fetch, build, and unzip the distributions in parallel.
-    #[instrument(name = "download_distributions", skip_all, fields(total = distributions.len()))]
     pub fn download_stream<'stream>(
         &'stream self,
         distributions: Vec<Dist>,
@@ -81,6 +80,7 @@ impl<'a, Context: BuildContext + Send + Sync> Downloader<'a, Context> {
     }
 
     /// Download, build, and unzip a set of downloaded wheels.
+    #[instrument(skip_all, fields(total = distributions.len()))]
     pub async fn download(
         &self,
         mut distributions: Vec<Dist>,

--- a/crates/puffin-resolver/src/resolver.rs
+++ b/crates/puffin-resolver/src/resolver.rs
@@ -13,7 +13,7 @@ use pubgrub::solver::{Incompatibility, State};
 use pubgrub::type_aliases::DependencyConstraints;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::select;
-use tracing::{debug, trace};
+use tracing::{debug, instrument, trace};
 use url::Url;
 
 use distribution_filename::WheelFilename;
@@ -302,6 +302,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
     }
 
     /// Run the `PubGrub` solver.
+    #[instrument(skip_all)]
     async fn solve(
         &self,
         request_sink: &futures::channel::mpsc::UnboundedSender<Request>,

--- a/crates/puffin-resolver/src/version_map.rs
+++ b/crates/puffin-resolver/src/version_map.rs
@@ -2,7 +2,7 @@ use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
-use tracing::warn;
+use tracing::{instrument, warn};
 
 use distribution_filename::DistFilename;
 use pep508_rs::MarkerEnvironment;
@@ -23,6 +23,7 @@ pub struct VersionMap(BTreeMap<PubGrubVersion, PrioritizedDistribution>);
 
 impl VersionMap {
     /// Initialize a [`VersionMap`] from the given metadata.
+    #[instrument(skip_all, fields(package_name = %package_name))]
     pub(crate) fn from_metadata(
         metadata: SimpleMetadata,
         package_name: &PackageName,


### PR DESCRIPTION
I've tried to investigate puffin's performance wrt to builds and parallelism in general, but found the previous instrumentation to granular. I've tried to add spans to every function that either needs noticeable io or cpu resources without creating duplication. This also fixes some wrong tracing usage on async functions (https://docs.rs/tracing/latest/tracing/struct.Span.html#in-asynchronous-code) and some spans that weren't actually entered.