### PR TITLE
Disable color output when redirecting stderr

### DIFF
--- a/crates/puffin-cli/src/logging.rs
+++ b/crates/puffin-cli/src/logging.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -21,6 +22,10 @@ pub(crate) enum Level {
 /// environment variable) along with the formatting of the output. For example, [`Level::Verbose`]
 /// includes targets and timestamps, along with all `puffin=debug` messages by default.
 pub(crate) fn setup_logging(level: Level) {
+    if !std::io::stderr().is_terminal() {
+        colored::control::set_override(false);
+    }
+
     match level {
         Level::Default => {
             // Show nothing, but allow `RUST_LOG` to override.


### PR DESCRIPTION
I'm still confused about it, but this seems to do the right thing?

`HierarchicalLayer` internally has [`let ansi = io::stderr().is_terminal();`](https://github.com/davidbarsky/tracing-tree/blob/fcd9eed2528e41cd776b19b9ba45d338ae62a5fc/src/lib.rs#L74), so the logging itself is already correctly uncolored, but errors in the log weren't.

Test command, ran with network deactivated:

```shell
RUST_LOG=debug cargo run --bin puffin -- pip-compile -v ./scripts/popular_packages/pypi_8k_downloads.txt 2> log.txt
```

**Before**

```
[1;31merror[0m: Request error: error sending request for url (https://pypi.org/simple/apache-airflow-providers-dbt-cloud/): error trying to connect: dns error: failed to lookup address information: Temporary failure in name resolution
  [1;31mCaused by[0m: error sending request for url (https://pypi.org/simple/apache-airflow-providers-dbt-cloud/): error trying to connect: dns error: failed to lookup address information: Temporary failure in name resolution
  [1;31mCaused by[0m: error trying to connect: dns error: failed to lookup address information: Temporary failure in name resolution
  [1;31mCaused by[0m: dns error: failed to lookup address information: Temporary failure in name resolution
  [1;31mCaused by[0m: failed to lookup address information: Temporary failure in name resolution
  ```

  **After**

  ```
  error: Request error: error sending request for url (https://pypi.org/simple/fissix/): error trying to connect: dns error: failed to lookup address information: Temporary failure in name resolution
    Caused by: error sending request for url (https://pypi.org/simple/fissix/): error trying to connect: dns error: failed to lookup address information: Temporary failure in name resolution
    Caused by: error trying to connect: dns error: failed to lookup address information: Temporary failure in name resolution
    Caused by: dns error: failed to lookup address information: Temporary failure in name resolution
    Caused by: failed to lookup address information: Temporary failure in name resolution
```