### PR TITLE
Run custom insta filters before generic filters

### DIFF
--- a/crates/puffin-cli/tests/common/mod.rs
+++ b/crates/puffin-cli/tests/common/mod.rs
@@ -10,8 +10,8 @@ use std::path::PathBuf;
 pub(crate) const BIN_NAME: &str = "puffin";
 
 pub(crate) const INSTA_FILTERS: &[(&str, &str)] = &[
-    (r"(\d+\.)?\d+(ms|s)", "[TIME]"),
     (r"--cache-dir .*", "--cache-dir [CACHE_DIR]"),
+    (r"(\d+\.)?\d+(ms|s)", "[TIME]"),
 ];
 
 /// Create a virtual environment named `.venv` in a temporary directory.

--- a/crates/puffin-cli/tests/pip_compile.rs
+++ b/crates/puffin-cli/tests/pip_compile.rs
@@ -1,5 +1,6 @@
 #![cfg(all(feature = "python", feature = "pypi"))]
 
+use std::iter;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -906,8 +907,9 @@ fn compile_git_https_dependency() -> Result<()> {
     requirements_in.write_str("flask @ git+https://github.com/pallets/flask.git")?;
 
     // In addition to the standard filters, remove the `main` commit, which will change frequently.
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((r"@(\d|\w){40}", "@[COMMIT]"));
+    let filters: Vec<_> = iter::once((r"@(\d|\w){40}", "@[COMMIT]"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     insta::with_settings!({
         filters => filters
@@ -2011,8 +2013,9 @@ fn compile_wheel_path_dependency() -> Result<()> {
     requirements_in.write_str(&format!("flask @ file://{}", flask_wheel.path().display()))?;
 
     // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((r"file://.*/", "file://[TEMP_DIR]/"));
+    let filters: Vec<_> = iter::once((r"file://.*/", "file://[TEMP_DIR]/"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     insta::with_settings!({
         filters => filters
@@ -2072,8 +2075,9 @@ fn compile_source_distribution_path_dependency() -> Result<()> {
     requirements_in.write_str(&format!("flask @ file://{}", flask_wheel.path().display()))?;
 
     // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((r"file://.*/", "file://[TEMP_DIR]/"));
+    let filters: Vec<_> = iter::once((r"file://.*/", "file://[TEMP_DIR]/"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     insta::with_settings!({
         filters => filters
@@ -2127,8 +2131,9 @@ fn compile_wheel_path_dependency_missing() -> Result<()> {
     requirements_in.write_str("flask @ file:///path/to/flask-3.0.0-py3-none-any.whl")?;
 
     // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((r"file://.*/", "file://[TEMP_DIR]/"));
+    let filters: Vec<_> = iter::once((r"file://.*/", "file://[TEMP_DIR]/"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     insta::with_settings!({
         filters => filters

--- a/crates/puffin-cli/tests/pip_install.rs
+++ b/crates/puffin-cli/tests/pip_install.rs
@@ -1,5 +1,6 @@
 #![cfg(all(feature = "python", feature = "pypi"))]
 
+use std::iter;
 use std::path::Path;
 use std::process::Command;
 
@@ -447,8 +448,9 @@ fn install_editable() -> Result<()> {
     let current_dir = std::env::current_dir()?;
     let workspace_dir = current_dir.join("..").join("..").canonicalize()?;
 
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((workspace_dir.to_str().unwrap(), "[WORKSPACE_DIR]"));
+    let filters = iter::once((workspace_dir.to_str().unwrap(), "[WORKSPACE_DIR]"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     // Install the editable package.
     insta::with_settings!({
@@ -583,8 +585,9 @@ fn install_editable_and_registry() -> Result<()> {
     let current_dir = std::env::current_dir()?;
     let workspace_dir = current_dir.join("..").join("..").canonicalize()?;
 
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((workspace_dir.to_str().unwrap(), "[WORKSPACE_DIR]"));
+    let filters: Vec<_> = iter::once((workspace_dir.to_str().unwrap(), "[WORKSPACE_DIR]"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     // Install the registry-based version of Black.
     insta::with_settings!({

--- a/crates/puffin-cli/tests/pip_sync.rs
+++ b/crates/puffin-cli/tests/pip_sync.rs
@@ -1,5 +1,6 @@
 #![cfg(all(feature = "python", feature = "pypi"))]
 
+use std::iter;
 use std::path::Path;
 use std::process::Command;
 
@@ -1050,8 +1051,9 @@ fn install_local_wheel() -> Result<()> {
     requirements_txt.write_str(&format!("tomli @ file://{}", archive.path().display()))?;
 
     // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((r"file://.*/", "file://[TEMP_DIR]/"));
+    let filters: Vec<_> = iter::once((r"file://.*/", "file://[TEMP_DIR]/"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     insta::with_settings!({
         filters => filters
@@ -1098,8 +1100,9 @@ fn install_local_source_distribution() -> Result<()> {
     requirements_txt.write_str(&format!("wheel @ file://{}", archive.path().display()))?;
 
     // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((r"file://.*/", "file://[TEMP_DIR]/"));
+    let filters: Vec<_> = iter::once((r"file://.*/", "file://[TEMP_DIR]/"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     insta::with_settings!({
         filters => filters
@@ -1584,8 +1587,9 @@ fn install_path_source_dist_cached() -> Result<()> {
     requirements_txt.write_str(&format!("wheel @ file://{}", archive.path().display()))?;
 
     // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((r"file://.*/", "file://[TEMP_DIR]/"));
+    let filters: Vec<_> = iter::once((r"file://.*/", "file://[TEMP_DIR]/"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     insta::with_settings!({
         filters => filters.clone()
@@ -1707,8 +1711,9 @@ fn install_path_built_dist_cached() -> Result<()> {
     requirements_txt.write_str(&format!("tomli @ file://{}", archive.path().display()))?;
 
     // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((r"file://.*/", "file://[TEMP_DIR]/"));
+    let filters: Vec<_> = iter::once((r"file://.*/", "file://[TEMP_DIR]/"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     insta::with_settings!({
         filters => filters.clone()
@@ -2556,9 +2561,10 @@ fn incompatible_wheel() -> Result<()> {
     let requirements_txt = temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!("foo @ file://{}", wheel.path().display()))?;
 
-    let mut filters = INSTA_FILTERS.to_vec();
     let wheel_dir = wheel_dir.path().canonicalize()?.display().to_string();
-    filters.push((&wheel_dir, "[TEMP_DIR]"));
+    let filters: Vec<_> = iter::once((wheel_dir.as_str(), "[TEMP_DIR]"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     insta::with_settings!({
         filters => filters

--- a/crates/puffin-cli/tests/pip_uninstall.rs
+++ b/crates/puffin-cli/tests/pip_uninstall.rs
@@ -1,3 +1,4 @@
+use std::iter;
 use std::process::Command;
 
 use anyhow::Result;
@@ -310,11 +311,12 @@ fn missing_record() -> Result<()> {
         .join("MarkupSafe-2.1.3.dist-info");
     std::fs::remove_file(dist_info.join("RECORD"))?;
 
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((
+    let filters: Vec<_> = iter::once((
         "RECORD file not found at: .*/.venv",
         "RECORD file not found at: [VENV_PATH]",
-    ));
+    ))
+    .chain(INSTA_FILTERS.to_vec())
+    .collect();
 
     insta::with_settings!({
         filters => filters,
@@ -347,8 +349,9 @@ fn uninstall_editable_by_name() -> Result<()> {
     let current_dir = std::env::current_dir()?;
     let workspace_dir = current_dir.join("..").join("..").canonicalize()?;
 
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((workspace_dir.to_str().unwrap(), "[WORKSPACE_DIR]"));
+    let filters: Vec<_> = iter::once((workspace_dir.to_str().unwrap(), "[WORKSPACE_DIR]"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     let requirements_txt = temp_dir.child("requirements.txt");
     requirements_txt.touch()?;
@@ -408,8 +411,9 @@ fn uninstall_editable_by_path() -> Result<()> {
     let current_dir = std::env::current_dir()?;
     let workspace_dir = current_dir.join("..").join("..").canonicalize()?;
 
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((workspace_dir.to_str().unwrap(), "[WORKSPACE_DIR]"));
+    let filters: Vec<_> = iter::once((workspace_dir.to_str().unwrap(), "[WORKSPACE_DIR]"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     let requirements_txt = temp_dir.child("requirements.txt");
     requirements_txt.touch()?;
@@ -469,8 +473,9 @@ fn uninstall_duplicate_editable() -> Result<()> {
     let current_dir = std::env::current_dir()?;
     let workspace_dir = current_dir.join("..").join("..").canonicalize()?;
 
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.push((workspace_dir.to_str().unwrap(), "[WORKSPACE_DIR]"));
+    let filters: Vec<_> = iter::once((workspace_dir.to_str().unwrap(), "[WORKSPACE_DIR]"))
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     let requirements_txt = temp_dir.child("requirements.txt");
     requirements_txt.touch()?;


### PR DESCRIPTION
I've noticed some non-deterministic test failures when a temp dir looks like a timestamp (https://github.com/astral-sh/puffin/actions/runs/7410022542/job/20161416805). Running the custom filters for e.g. the temp dirs before the generic time filters should fix that.