### PR TITLE
Disable line wrapping during scenario tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "miette"
 version = "5.10.0"
-source = "git+https://github.com/zkat/miette.git?rev=fd77257cee0f5d03aa7dccb4ba8cbaa40c1a88c6#fd77257cee0f5d03aa7dccb4ba8cbaa40c1a88c6"
+source = "git+https://github.com/zkat/miette.git?rev=b0744462adbbfbb6d845f382db36be883c7f3c45#b0744462adbbfbb6d845f382db36be883c7f3c45"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "miette-derive"
 version = "5.10.0"
-source = "git+https://github.com/zkat/miette.git?rev=fd77257cee0f5d03aa7dccb4ba8cbaa40c1a88c6#fd77257cee0f5d03aa7dccb4ba8cbaa40c1a88c6"
+source = "git+https://github.com/zkat/miette.git?rev=b0744462adbbfbb6d845f382db36be883c7f3c45#b0744462adbbfbb6d845f382db36be883c7f3c45"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ indicatif = { version = "0.17.7" }
 indoc = { version = "2.0.4" }
 itertools = { version = "0.11.0" }
 mailparse = { version = "0.14.0" }
-# For additional textwrap options: https://github.com/zkat/miette/pull/321
-miette =  { git = "https://github.com/zkat/miette.git", rev = "fd77257cee0f5d03aa7dccb4ba8cbaa40c1a88c6" }
+# For additional textwrap options: https://github.com/zkat/miette/pull/321, https://github.com/zkat/miette/pull/328
+miette =  { git = "https://github.com/zkat/miette.git", rev = "b0744462adbbfbb6d845f382db36be883c7f3c45" }
 once_cell = { version = "1.18.0" }
 petgraph = { version = "0.6.4" }
 platform-info = { version = "2.0.2" }

--- a/crates/puffin-cli/src/commands/pip_compile.rs
+++ b/crates/puffin-cli/src/commands/pip_compile.rs
@@ -57,6 +57,7 @@ pub(crate) async fn pip_compile(
                 .break_words(false)
                 .word_separator(textwrap::WordSeparator::AsciiSpace)
                 .word_splitter(textwrap::WordSplitter::NoHyphenation)
+                .wrap_lines(env::var("PUFFIN_NO_WRAP").map(|_| false).unwrap_or(true))
                 .build(),
         )
     }))?;

--- a/crates/puffin-cli/src/commands/pip_install.rs
+++ b/crates/puffin-cli/src/commands/pip_install.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::fmt::Write;
 use std::path::Path;
 
@@ -58,6 +59,7 @@ pub(crate) async fn pip_install(
                 .break_words(false)
                 .word_separator(textwrap::WordSeparator::AsciiSpace)
                 .word_splitter(textwrap::WordSplitter::NoHyphenation)
+                .wrap_lines(env::var("PUFFIN_NO_WRAP").map(|_| false).unwrap_or(true))
                 .build(),
         )
     }))?;

--- a/crates/puffin-cli/tests/pip_install_scenarios.rs
+++ b/crates/puffin-cli/tests/pip_install_scenarios.rs
@@ -43,6 +43,7 @@ fn requires_package_does_not_exist() -> Result<()> {
             .arg("--cache-dir")
             .arg(cache_dir.path())
             .env("VIRTUAL_ENV", venv.as_os_str())
+            .env("PUFFIN_NO_WRAP", "1")
             .current_dir(&temp_dir), @r###"
         success: false
         exit_code: 2
@@ -87,6 +88,7 @@ fn requires_exact_version_does_not_exist() -> Result<()> {
             .arg("--cache-dir")
             .arg(cache_dir.path())
             .env("VIRTUAL_ENV", venv.as_os_str())
+            .env("PUFFIN_NO_WRAP", "1")
             .current_dir(&temp_dir), @r###"
         success: false
         exit_code: 1
@@ -94,11 +96,7 @@ fn requires_exact_version_does_not_exist() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no version of
-              a
-              available matching ==2.0.0 and root depends on
-              a==2.0.0, version solving
-              failed.
+          ╰─▶ Because there is no version of a available matching ==2.0.0 and root depends on a==2.0.0, version solving failed.
         "###);
     });
 
@@ -137,6 +135,7 @@ fn requires_greater_version_does_not_exist() -> Result<()> {
             .arg("--cache-dir")
             .arg(cache_dir.path())
             .env("VIRTUAL_ENV", venv.as_os_str())
+            .env("PUFFIN_NO_WRAP", "1")
             .current_dir(&temp_dir), @r###"
         success: false
         exit_code: 1
@@ -144,11 +143,7 @@ fn requires_greater_version_does_not_exist() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no version of
-              a
-              available matching >1.0.0 and root depends on
-              a>1.0.0, version
-              solving failed.
+          ╰─▶ Because there is no version of a available matching >1.0.0 and root depends on a>1.0.0, version solving failed.
         "###);
     });
 
@@ -188,6 +183,7 @@ fn requires_less_version_does_not_exist() -> Result<()> {
             .arg("--cache-dir")
             .arg(cache_dir.path())
             .env("VIRTUAL_ENV", venv.as_os_str())
+            .env("PUFFIN_NO_WRAP", "1")
             .current_dir(&temp_dir), @r###"
         success: false
         exit_code: 1
@@ -195,11 +191,7 @@ fn requires_less_version_does_not_exist() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no version of
-              a
-              available matching <2.0.0 and root depends on
-              a<2.0.0, version solving
-              failed.
+          ╰─▶ Because there is no version of a available matching <2.0.0 and root depends on a<2.0.0, version solving failed.
         "###);
     });
 
@@ -239,6 +231,7 @@ fn transitive_requires_package_does_not_exist() -> Result<()> {
             .arg("--cache-dir")
             .arg(cache_dir.path())
             .env("VIRTUAL_ENV", venv.as_os_str())
+            .env("PUFFIN_NO_WRAP", "1")
             .current_dir(&temp_dir), @r###"
         success: false
         exit_code: 2
@@ -287,6 +280,7 @@ fn requires_direct_incompatible_versions() -> Result<()> {
             .arg("--cache-dir")
             .arg(cache_dir.path())
             .env("VIRTUAL_ENV", venv.as_os_str())
+            .env("PUFFIN_NO_WRAP", "1")
             .current_dir(&temp_dir), @r###"
         success: false
         exit_code: 1
@@ -294,10 +288,7 @@ fn requires_direct_incompatible_versions() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ root dependencies are unusable: Conflicting versions
-              for `a`:
-              `a==1.0.0` does not
-              intersect with `a==2.0.0`
+          ╰─▶ root dependencies are unusable: Conflicting versions for `a`: `a==1.0.0` does not intersect with `a==2.0.0`
         "###);
     });
 
@@ -346,6 +337,7 @@ fn requires_transitive_incompatible_with_root_version() -> Result<()> {
             .arg("--cache-dir")
             .arg(cache_dir.path())
             .env("VIRTUAL_ENV", venv.as_os_str())
+            .env("PUFFIN_NO_WRAP", "1")
             .current_dir(&temp_dir), @r###"
         success: false
         exit_code: 1
@@ -353,20 +345,8 @@ fn requires_transitive_incompatible_with_root_version() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because
-              a==1.0.0
-              depends on
-              b==2.0.0
-              and there is no version of
-              a
-              available matching <1.0.0 | >1.0.0,
-              a depends on
-              b==2.0.0.
-              And because root depends on
-              b==1.0.0
-              and root depends on
-              a, version
-              solving failed.
+          ╰─▶ Because a==1.0.0 depends on b==2.0.0 and there is no version of a available matching <1.0.0 | >1.0.0, a depends on b==2.0.0.
+              And because root depends on b==1.0.0 and root depends on a, version solving failed.
         "###);
     });
 
@@ -419,6 +399,7 @@ fn requires_transitive_incompatible_with_transitive() -> Result<()> {
             .arg("--cache-dir")
             .arg(cache_dir.path())
             .env("VIRTUAL_ENV", venv.as_os_str())
+            .env("PUFFIN_NO_WRAP", "1")
             .current_dir(&temp_dir), @r###"
         success: false
         exit_code: 1
@@ -426,28 +407,9 @@ fn requires_transitive_incompatible_with_transitive() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no version of
-              a
-              available matching <1.0.0 | >1.0.0 and
-              a==1.0.0
-              depends on
-              c==1.0.0,
-              a depends on
-              c==1.0.0.
-              And because
-              b==1.0.0
-              depends on
-              c==2.0.0
-              and there is no version of
-              b
-              available matching <1.0.0 | >1.0.0,
-              a *,
-              b * are
-              incompatible.
-              And because root depends on
-              a and root
-              depends on b,
-              version solving failed.
+          ╰─▶ Because there is no version of a available matching <1.0.0 | >1.0.0 and a==1.0.0 depends on c==1.0.0, a depends on c==1.0.0.
+              And because b==1.0.0 depends on c==2.0.0 and there is no version of b available matching <1.0.0 | >1.0.0, a *, b * are incompatible.
+              And because root depends on a and root depends on b, version solving failed.
         "###);
     });
 

--- a/scripts/scenarios/template.mustache
+++ b/scripts/scenarios/template.mustache
@@ -49,6 +49,7 @@ fn {{normalized_name}}() -> Result<()> {
             .arg("--cache-dir")
             .arg(cache_dir.path())
             .env("VIRTUAL_ENV", venv.as_os_str())
+            .env("PUFFIN_NO_WRAP", "1")
             .current_dir(&temp_dir), @r###"<snapshot>
         "###);
     });


### PR DESCRIPTION
Adds support for a `PUFFIN_NO_WRAP` environment variable which disables line wrapping in `miette` output.

We set this variable in the scenario tests to improve the readability of snapshots.

I contributed the ability to disable line wrapping upstream at https://github.com/zkat/miette/pull/328
