### PR TITLE
puffin-cli: fix botched merge

### DIFF
--- a/crates/puffin-cli/tests/pip_install.rs
+++ b/crates/puffin-cli/tests/pip_install.rs
@@ -450,7 +450,7 @@ fn install_editable() -> Result<()> {
 
     let filters = iter::once((workspace_dir.to_str().unwrap(), "[WORKSPACE_DIR]"))
         .chain(INSTA_FILTERS.to_vec())
-        .collect();
+        .collect::<Vec<_>>();
 
     // Install the editable package.
     insta::with_settings!({


### PR DESCRIPTION
This fixes a compilation error with tests on current `main`. I didn't
track down the exact provenance, but I'd guess it's the result of a
botched merge. (i.e., Two or more PRs that pass CI independently, but
when merged cause failures.)
