### PR TITLE
Use `anstream` for all color control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
 name = "gourgeist"
 version = "0.0.4"
 dependencies = [
+ "anstream",
  "camino",
  "clap",
  "fs-err",
@@ -2699,6 +2700,7 @@ dependencies = [
 name = "puffin-warnings"
 version = "0.0.1"
 dependencies = [
+ "anstream",
  "colored",
  "once_cell",
  "rustc-hash",

--- a/crates/gourgeist/Cargo.toml
+++ b/crates/gourgeist/Cargo.toml
@@ -21,6 +21,7 @@ platform-host = { path = "../platform-host" }
 puffin-cache = { path = "../puffin-cache" }
 puffin-interpreter = { path = "../puffin-interpreter" }
 
+anstream = { workspace = true }
 camino = { workspace = true }
 clap = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/gourgeist/src/main.rs
+++ b/crates/gourgeist/src/main.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::process::ExitCode;
 use std::time::Instant;
 
+use anstream::eprintln;
 use camino::Utf8PathBuf;
 use clap::Parser;
 use tracing::info;

--- a/crates/puffin-cli/src/logging.rs
+++ b/crates/puffin-cli/src/logging.rs
@@ -1,4 +1,3 @@
-use std::io::IsTerminal;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -22,10 +21,6 @@ pub(crate) enum Level {
 /// environment variable) along with the formatting of the output. For example, [`Level::Verbose`]
 /// includes targets and timestamps, along with all `puffin=debug` messages by default.
 pub(crate) fn setup_logging(level: Level) {
-    if !std::io::stderr().is_terminal() {
-        colored::control::set_override(false);
-    }
-
     match level {
         Level::Default => {
             // Show nothing, but allow `RUST_LOG` to override.

--- a/crates/puffin-cli/src/main.rs
+++ b/crates/puffin-cli/src/main.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use std::str::FromStr;
 
+use anstream::eprintln;
 use anyhow::Result;
 use chrono::{DateTime, Days, NaiveDate, NaiveTime, Utc};
 use clap::{Args, Parser, Subcommand};

--- a/crates/puffin-dev/src/install_many.rs
+++ b/crates/puffin-dev/src/install_many.rs
@@ -2,6 +2,7 @@ use std::iter::Iterator;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use anstream::eprintln;
 use anyhow::{Context, Result};
 use clap::Parser;
 use futures::StreamExt;

--- a/crates/puffin-dev/src/main.rs
+++ b/crates/puffin-dev/src/main.rs
@@ -4,6 +4,7 @@ use std::io::IsTerminal;
 use std::process::ExitCode;
 use std::time::Instant;
 
+use anstream::eprintln;
 use anyhow::Result;
 use clap::Parser;
 use colored::Colorize;
@@ -46,7 +47,7 @@ mod wheel_metadata;
 enum Cli {
     /// Build a source distribution into a wheel
     Build(BuildArgs),
-    /// Resolve many requirements independently in parallel and report failures and sucesses.
+    /// Resolve many requirements independently in parallel and report failures and successes.
     ///
     /// Run `scripts/popular_packages/pypi_8k_downloads.sh` once, then
     /// ```bash
@@ -86,10 +87,6 @@ async fn run() -> Result<()> {
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    if !std::io::stderr().is_terminal() {
-        colored::control::set_override(false);
-    }
-
     let indicatif_layer = IndicatifLayer::new();
     let indicatif_compatible_writer_layer = tracing_subscriber::fmt::layer()
         .with_writer(indicatif_layer.get_stderr_writer())

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -116,8 +116,6 @@ async fn resolve(
 
 #[tokio::test]
 async fn black() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![Requirement::from_str("black<=23.9.1").unwrap()]);
     let options = ResolutionOptions::new(
         ResolutionMode::default(),
@@ -146,8 +144,6 @@ async fn black() -> Result<()> {
 
 #[tokio::test]
 async fn black_colorama() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![
         Requirement::from_str("black[colorama]<=23.9.1").unwrap()
     ]);
@@ -180,8 +176,6 @@ async fn black_colorama() -> Result<()> {
 /// Resolve Black with an invalid extra. The resolver should ignore the extra.
 #[tokio::test]
 async fn black_tensorboard() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![
         Requirement::from_str("black[tensorboard]<=23.9.1").unwrap()
     ]);
@@ -212,8 +206,6 @@ async fn black_tensorboard() -> Result<()> {
 
 #[tokio::test]
 async fn black_python_310() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![Requirement::from_str("black<=23.9.1").unwrap()]);
     let options = ResolutionOptions::new(
         ResolutionMode::default(),
@@ -248,8 +240,6 @@ async fn black_python_310() -> Result<()> {
 /// respected.
 #[tokio::test]
 async fn black_mypy_extensions() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::new(
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![Requirement::from_str("mypy-extensions<0.4.4").unwrap()],
@@ -287,8 +277,6 @@ async fn black_mypy_extensions() -> Result<()> {
 /// ignored when resolving constraints.
 #[tokio::test]
 async fn black_mypy_extensions_extra() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::new(
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![Requirement::from_str("mypy-extensions[extra]<0.4.4").unwrap()],
@@ -326,8 +314,6 @@ async fn black_mypy_extensions_extra() -> Result<()> {
 /// introduce new dependencies.
 #[tokio::test]
 async fn black_flake8() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::new(
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![Requirement::from_str("flake8<1").unwrap()],
@@ -363,8 +349,6 @@ async fn black_flake8() -> Result<()> {
 
 #[tokio::test]
 async fn black_lowest() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![Requirement::from_str("black>21").unwrap()]);
     let options = ResolutionOptions::new(
         ResolutionMode::Lowest,
@@ -393,8 +377,6 @@ async fn black_lowest() -> Result<()> {
 
 #[tokio::test]
 async fn black_lowest_direct() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![Requirement::from_str("black>21").unwrap()]);
     let options = ResolutionOptions::new(
         ResolutionMode::LowestDirect,
@@ -423,8 +405,6 @@ async fn black_lowest_direct() -> Result<()> {
 
 #[tokio::test]
 async fn black_respect_preference() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::new(
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![],
@@ -460,8 +440,6 @@ async fn black_respect_preference() -> Result<()> {
 
 #[tokio::test]
 async fn black_ignore_preference() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::new(
         vec![Requirement::from_str("black<=23.9.1").unwrap()],
         vec![],
@@ -497,8 +475,6 @@ async fn black_ignore_preference() -> Result<()> {
 
 #[tokio::test]
 async fn black_disallow_prerelease() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![Requirement::from_str("black<=20.0").unwrap()]);
     let options = ResolutionOptions::new(
         ResolutionMode::default(),
@@ -517,8 +493,6 @@ async fn black_disallow_prerelease() -> Result<()> {
 
 #[tokio::test]
 async fn black_allow_prerelease_if_necessary() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![Requirement::from_str("black<=20.0").unwrap()]);
     let options = ResolutionOptions::new(
         ResolutionMode::default(),
@@ -537,8 +511,6 @@ async fn black_allow_prerelease_if_necessary() -> Result<()> {
 
 #[tokio::test]
 async fn pylint_disallow_prerelease() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![Requirement::from_str("pylint==2.3.0").unwrap()]);
     let options = ResolutionOptions::new(
         ResolutionMode::default(),
@@ -563,8 +535,6 @@ async fn pylint_disallow_prerelease() -> Result<()> {
 
 #[tokio::test]
 async fn pylint_allow_prerelease() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![Requirement::from_str("pylint==2.3.0").unwrap()]);
     let options = ResolutionOptions::new(
         ResolutionMode::default(),
@@ -589,8 +559,6 @@ async fn pylint_allow_prerelease() -> Result<()> {
 
 #[tokio::test]
 async fn pylint_allow_explicit_prerelease_without_marker() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![
         Requirement::from_str("pylint==2.3.0").unwrap(),
         Requirement::from_str("isort>=5.0.0").unwrap(),
@@ -618,8 +586,6 @@ async fn pylint_allow_explicit_prerelease_without_marker() -> Result<()> {
 
 #[tokio::test]
 async fn pylint_allow_explicit_prerelease_with_marker() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![
         Requirement::from_str("pylint==2.3.0").unwrap(),
         Requirement::from_str("isort>=5.0.0b").unwrap(),
@@ -649,8 +615,6 @@ async fn pylint_allow_explicit_prerelease_with_marker() -> Result<()> {
 /// fail with a pre-release-centric hint.
 #[tokio::test]
 async fn msgraph_sdk() -> Result<()> {
-    colored::control::set_override(false);
-
     let manifest = Manifest::simple(vec![Requirement::from_str("msgraph-sdk==1.0.0").unwrap()]);
     let options = ResolutionOptions::new(
         ResolutionMode::default(),

--- a/crates/puffin-warnings/Cargo.toml
+++ b/crates/puffin-warnings/Cargo.toml
@@ -13,6 +13,7 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
+anstream = { workspace = true }
 colored = { workspace = true }
 once_cell = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/puffin-warnings/src/lib.rs
+++ b/crates/puffin-warnings/src/lib.rs
@@ -3,7 +3,11 @@ use std::sync::Mutex;
 
 // macro hygiene: The user might not have direct dependencies on those crates
 #[doc(hidden)]
+pub use anstream;
+
+#[doc(hidden)]
 pub use colored;
+
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashSet;
 
@@ -19,6 +23,7 @@ pub fn enable() {
 #[macro_export]
 macro_rules! warn_user {
     ($($arg:tt)*) => {
+        use $crate::anstream::eprintln;
         use $crate::colored::Colorize;
 
         if $crate::ENABLED.load(std::sync::atomic::Ordering::SeqCst) {
@@ -36,6 +41,7 @@ pub static WARNINGS: Lazy<Mutex<FxHashSet<String>>> = Lazy::new(Mutex::default);
 #[macro_export]
 macro_rules! warn_user_once {
     ($($arg:tt)*) => {
+        use $crate::anstream::eprintln;
         use $crate::colored::Colorize;
 
         if $crate::ENABLED.load(std::sync::atomic::Ordering::SeqCst) {


### PR DESCRIPTION
## Summary

We can use `anstream` for all color control, rather than going through `colored`. Note that we still need the `colored` crate, since `colored` and `anstream` solve different problems. (`anstream` recommends using `owo-colors` alongside it, but `colored` seems to work fine?)

Resolves the issue raised in https://github.com/astral-sh/puffin/pull/742 via `anstream` rather than `colored`.

Closes https://github.com/astral-sh/puffin/issues/782.
