### PR TITLE
`cargo run` run `puffin` by default

### DIFF
--- a/crates/puffin-cli/Cargo.toml
+++ b/crates/puffin-cli/Cargo.toml
@@ -8,6 +8,7 @@ documentation = { workspace = true }
 repository = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
+default-run = "puffin"
 
 [lints]
 workspace = true


### PR DESCRIPTION
`cargo run` now runs `puffin` by default. `cargo run --bin puffin-dev` remains working.