### PR TITLE
Fix typo in bench docs

### DIFF
--- a/scripts/bench/__main__.py
+++ b/scripts/bench/__main__.py
@@ -10,7 +10,8 @@ To set up the required environment, run:
 
     cargo build --release
     ./target/release/puffin venv
-    ./target/release/puffin pip-sync ./scripts/requirements.txt
+    ./target/release/puffin pip-sync ./scripts/bench/requirements.txt
+    source .venv/bin/activate
 
 Example usage:
 


### PR DESCRIPTION
Add missing /bench in the requirements path