### PR TITLE
Always pair package names with ranges in error messages

### DIFF
--- a/crates/puffin-cli/tests/pip_compile.rs
+++ b/crates/puffin-cli/tests/pip_compile.rs
@@ -670,8 +670,8 @@ fn compile_python_37() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching Python>=3.8 and
-              black==23.10.1 depends on Python>=3.8, black==23.10.1 is forbidden.
+          ╰─▶ Because there are no versions of Python>=3.8 and black==23.10.1 depends
+              on Python>=3.8, black==23.10.1 is forbidden.
               And because root depends on black==23.10.1, version solving failed.
         "###);
     });
@@ -1405,8 +1405,8 @@ fn conflicting_direct_url_dependency() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching werkzeug==3.0.0 and root
-              depends on werkzeug==3.0.0, version solving failed.
+          ╰─▶ Because there are no versions of werkzeug==3.0.0 and root depends on
+              werkzeug==3.0.0, version solving failed.
         "###);
     });
 
@@ -1555,8 +1555,8 @@ fn conflicting_transitive_url_dependency() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because flask==3.0.0 depends on werkzeug>=3.0.0 and there is no
-              available version matching werkzeug>=3.0.0, flask==3.0.0 is forbidden.
+          ╰─▶ Because flask==3.0.0 depends on werkzeug>=3.0.0 and there are no
+              versions of werkzeug>=3.0.0, flask==3.0.0 is forbidden.
               And because root depends on flask==3.0.0, version solving failed.
         "###);
     });
@@ -1899,8 +1899,8 @@ dependencies = ["django==300.1.4"]
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching django==300.1.4 and
-              my-project depends on django==300.1.4, version solving failed.
+          ╰─▶ Because there are no versions of django==300.1.4 and my-project depends
+              on django==300.1.4, version solving failed.
         "###);
     });
 
@@ -2225,8 +2225,8 @@ fn compile_yanked_version_indirect() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching attrs>20.3.0, <21.2.0 and
-              root depends on attrs>20.3.0, <21.2.0, version solving failed.
+          ╰─▶ Because there are no versions of attrs>20.3.0, <21.2.0 and root depends
+              on attrs>20.3.0, <21.2.0, version solving failed.
         "###);
     });
 

--- a/crates/puffin-cli/tests/pip_install.rs
+++ b/crates/puffin-cli/tests/pip_install.rs
@@ -77,9 +77,8 @@ fn no_solution() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because there is no available version matching flask>3.0.0 and
-          flask==3.0.0 depends on werkzeug>=3.0.0, flask>=3.0.0 depends on
-          werkzeug>=3.0.0.
+      ╰─▶ Because there are no versions of flask>3.0.0 and flask==3.0.0 depends on
+          werkzeug>=3.0.0, flask>=3.0.0 depends on werkzeug>=3.0.0.
           And because root depends on flask>=3.0.0 and root depends on
           werkzeug<1.0.0, version solving failed.
     "###);

--- a/crates/puffin-cli/tests/pip_install_scenarios.rs
+++ b/crates/puffin-cli/tests/pip_install_scenarios.rs
@@ -82,7 +82,7 @@ fn excluded_only_version() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching a<1.0.0 | >1.0.0 and root depends on a<1.0.0 | >1.0.0, version solving failed.
+          ╰─▶ Because there are no versions of a<1.0.0 | >1.0.0 and root depends on a<1.0.0 | >1.0.0, version solving failed.
         "###);
     });
 
@@ -150,7 +150,7 @@ fn excluded_only_compatible_version() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching a<1.0.0 | >1.0.0, <2.0.0 | >2.0.0, <3.0.0 | >3.0.0 and a==1.0.0 depends on b==1.0.0, a<2.0.0 depends on b==1.0.0.
+          ╰─▶ Because there are no versions of a<1.0.0 | >1.0.0, <2.0.0 | >2.0.0, <3.0.0 | >3.0.0 and a==1.0.0 depends on b==1.0.0, a<2.0.0 depends on b==1.0.0.
               And because a==3.0.0 depends on b==3.0.0, a<2.0.0 | >2.0.0 depends on b<=1.0.0 | >=3.0.0.
               And because root depends on b>=2.0.0, <3.0.0 and root depends on a<2.0.0 | >2.0.0, version solving failed.
         "###);
@@ -258,9 +258,9 @@ fn dependency_excludes_range_of_compatible_versions() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching a<1.0.0 | >1.0.0, <2.0.0 | >3.0.0 and a==1.0.0 depends on b==1.0.0, a<2.0.0 depends on b==1.0.0. (1)
+          ╰─▶ Because there are no versions of a<1.0.0 | >1.0.0, <2.0.0 | >3.0.0 and a==1.0.0 depends on b==1.0.0, a<2.0.0 depends on b==1.0.0. (1)
 
-              Because there is no available version matching c<1.0.0 | >1.0.0, <2.0.0 | >2.0.0 and c==1.0.0 depends on a<2.0.0, c<2.0.0 depends on a<2.0.0.
+              Because there are no versions of c<1.0.0 | >1.0.0, <2.0.0 | >2.0.0 and c==1.0.0 depends on a<2.0.0, c<2.0.0 depends on a<2.0.0.
               And because c==2.0.0 depends on a>=3.0.0, c depends on a<2.0.0 | >=3.0.0.
               And because a<2.0.0 depends on b==1.0.0 (1), a!=3.0.0, c*, b!=1.0.0 are incompatible.
               And because a==3.0.0 depends on b==3.0.0, c depends on b<=1.0.0 | >=3.0.0.
@@ -386,10 +386,10 @@ fn dependency_excludes_non_contiguous_range_of_compatible_versions() -> Result<(
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because a==1.0.0 depends on b==1.0.0 and there is no available version matching a<1.0.0 | >1.0.0, <2.0.0 | >3.0.0, a<2.0.0 depends on b==1.0.0.
+          ╰─▶ Because a==1.0.0 depends on b==1.0.0 and there are no versions of a<1.0.0 | >1.0.0, <2.0.0 | >3.0.0, a<2.0.0 depends on b==1.0.0.
               And because a==3.0.0 depends on b==3.0.0, a<2.0.0 | >=3.0.0 depends on b<=1.0.0 | >=3.0.0. (1)
 
-              Because there is no available version matching c<1.0.0 | >1.0.0, <2.0.0 | >2.0.0 and c==1.0.0 depends on a<2.0.0, c<2.0.0 depends on a<2.0.0.
+              Because there are no versions of c<1.0.0 | >1.0.0, <2.0.0 | >2.0.0 and c==1.0.0 depends on a<2.0.0, c<2.0.0 depends on a<2.0.0.
               And because c==2.0.0 depends on a>=3.0.0, c depends on a<2.0.0 | >=3.0.0.
               And because a<2.0.0 | >=3.0.0 depends on b<=1.0.0 | >=3.0.0 (1), c depends on b<=1.0.0 | >=3.0.0.
               And because root depends on b>=2.0.0, <3.0.0 and root depends on c, version solving failed.
@@ -521,7 +521,7 @@ fn requires_package_only_prereleases_in_range() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching a>0.1.0 and root depends on a>0.1.0, version solving failed.
+          ╰─▶ Because there are no versions of a>0.1.0 and root depends on a>0.1.0, version solving failed.
         "###);
     });
 
@@ -1114,8 +1114,8 @@ fn requires_transitive_package_only_prereleases_in_range() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching b>0.1 and a==0.1.0 depends on b>0.1, a==0.1.0 is forbidden.
-              And because there is no available version matching a<0.1.0 | >0.1.0 and root depends on a, version solving failed.
+          ╰─▶ Because there are no versions of b>0.1 and a==0.1.0 depends on b>0.1, a==0.1.0 is forbidden.
+              And because there are no versions of a<0.1.0 | >0.1.0 and root depends on a, version solving failed.
         "###);
     });
 
@@ -1267,8 +1267,8 @@ fn requires_transitive_prerelease_and_stable_dependency() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching c==2.0.0b1 and a==1.0.0 depends on c==2.0.0b1, a==1.0.0 is forbidden.
-              And because there is no available version matching a<1.0.0 | >1.0.0 and root depends on a, version solving failed.
+          ╰─▶ Because there are no versions of c==2.0.0b1 and a==1.0.0 depends on c==2.0.0b1, a==1.0.0 is forbidden.
+              And because there are no versions of a<1.0.0 | >1.0.0 and root depends on a, version solving failed.
 
               hint: c was requested with a pre-release marker (e.g., ==2.0.0b1), but pre-releases weren't enabled (try: `--prerelease=allow`)
         "###);
@@ -1464,9 +1464,9 @@ fn requires_transitive_prerelease_and_stable_dependency_many_versions() -> Resul
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching b<1.0.0 | >1.0.0 and b==1.0.0 depends on c, b depends on c.
-              And because there is no available version matching c>=2.0.0b1, b depends on c<2.0.0b1.
-              And because a==1.0.0 depends on c>=2.0.0b1 and there is no available version matching a<1.0.0 | >1.0.0, b*, a* are incompatible.
+          ╰─▶ Because there are no versions of b<1.0.0 | >1.0.0 and b==1.0.0 depends on c, b depends on c.
+              And because there are no versions of c>=2.0.0b1, b depends on c<2.0.0b1.
+              And because a==1.0.0 depends on c>=2.0.0b1 and there are no versions of a<1.0.0 | >1.0.0, b*, a* are incompatible.
               And because root depends on b and root depends on a, version solving failed.
 
               hint: c was requested with a pre-release marker (e.g., >=2.0.0b1), but pre-releases weren't enabled (try: `--prerelease=allow`)
@@ -1563,8 +1563,8 @@ fn requires_transitive_prerelease_and_stable_dependency_many_versions_holes() ->
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching c>1.0.0, <2.0.0a5 | >2.0.0a7, <2.0.0b1 | >2.0.0b1, <2.0.0b5 and a==1.0.0 depends on c>1.0.0, <2.0.0a5 | >2.0.0a7, <2.0.0b1 | >2.0.0b1, <2.0.0b5, a==1.0.0 is forbidden.
-              And because there is no available version matching a<1.0.0 | >1.0.0 and root depends on a, version solving failed.
+          ╰─▶ Because there are no versions of c>1.0.0, <2.0.0a5 | >2.0.0a7, <2.0.0b1 | >2.0.0b1, <2.0.0b5 and a==1.0.0 depends on c>1.0.0, <2.0.0a5 | >2.0.0a7, <2.0.0b1 | >2.0.0b1, <2.0.0b5, a==1.0.0 is forbidden.
+              And because there are no versions of a<1.0.0 | >1.0.0 and root depends on a, version solving failed.
 
               hint: c was requested with a pre-release marker (e.g., >1.0.0, <2.0.0a5 | >2.0.0a7, <2.0.0b1 | >2.0.0b1, <2.0.0b5), but pre-releases weren't enabled (try: `--prerelease=allow`)
         "###);
@@ -1677,7 +1677,7 @@ fn requires_exact_version_does_not_exist() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching a==2.0.0 and root depends on a==2.0.0, version solving failed.
+          ╰─▶ Because there are no versions of a==2.0.0 and root depends on a==2.0.0, version solving failed.
         "###);
     });
 
@@ -1733,7 +1733,7 @@ fn requires_greater_version_does_not_exist() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching a>1.0.0 and root depends on a>1.0.0, version solving failed.
+          ╰─▶ Because there are no versions of a>1.0.0 and root depends on a>1.0.0, version solving failed.
         "###);
     });
 
@@ -1790,7 +1790,7 @@ fn requires_less_version_does_not_exist() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching a<2.0.0 and root depends on a<2.0.0, version solving failed.
+          ╰─▶ Because there are no versions of a<2.0.0 and root depends on a<2.0.0, version solving failed.
         "###);
     });
 
@@ -1974,7 +1974,7 @@ fn requires_transitive_incompatible_with_root_version() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching a<1.0.0 | >1.0.0 and a==1.0.0 depends on b==2.0.0, a depends on b==2.0.0.
+          ╰─▶ Because there are no versions of a<1.0.0 | >1.0.0 and a==1.0.0 depends on b==2.0.0, a depends on b==2.0.0.
               And because root depends on a and root depends on b==1.0.0, version solving failed.
         "###);
     });
@@ -2050,8 +2050,8 @@ fn requires_transitive_incompatible_with_transitive() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching b<1.0.0 | >1.0.0 and b==1.0.0 depends on c==2.0.0, b depends on c==2.0.0.
-              And because a==1.0.0 depends on c==1.0.0 and there is no available version matching a<1.0.0 | >1.0.0, a*, b* are incompatible.
+          ╰─▶ Because there are no versions of b<1.0.0 | >1.0.0 and b==1.0.0 depends on c==2.0.0, b depends on c==2.0.0.
+              And because a==1.0.0 depends on c==1.0.0 and there are no versions of a<1.0.0 | >1.0.0, a*, b* are incompatible.
               And because root depends on b and root depends on a, version solving failed.
         "###);
     });
@@ -2112,7 +2112,7 @@ fn requires_python_version_does_not_exist() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching Python>=4.0 and a==1.0.0 depends on Python>=4.0, a==1.0.0 is forbidden.
+          ╰─▶ Because there are no versions of Python>=4.0 and a==1.0.0 depends on Python>=4.0, a==1.0.0 is forbidden.
               And because root depends on a==1.0.0, version solving failed.
         "###);
     });
@@ -2169,7 +2169,7 @@ fn requires_python_version_less_than_current() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching Python<=3.8 and a==1.0.0 depends on Python<=3.8, a==1.0.0 is forbidden.
+          ╰─▶ Because there are no versions of Python<=3.8 and a==1.0.0 depends on Python<=3.8, a==1.0.0 is forbidden.
               And because root depends on a==1.0.0, version solving failed.
         "###);
     });
@@ -2229,7 +2229,7 @@ fn requires_python_version_greater_than_current() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching Python>=3.10 and a==1.0.0 depends on Python>=3.10, a==1.0.0 is forbidden.
+          ╰─▶ Because there are no versions of Python>=3.10 and a==1.0.0 depends on Python>=3.10, a==1.0.0 is forbidden.
               And because root depends on a==1.0.0, version solving failed.
         "###);
     });
@@ -2311,7 +2311,7 @@ fn requires_python_version_greater_than_current_many() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching a==1.0.0 and root depends on a==1.0.0, version solving failed.
+          ╰─▶ Because there are no versions of a==1.0.0 and root depends on a==1.0.0, version solving failed.
         "###);
     });
 
@@ -2447,15 +2447,15 @@ fn requires_python_version_greater_than_current_excluded() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because there is no available version matching Python>=3.10, <3.11 and there is no available version matching Python>=3.12, Python>=3.10, <3.11 | >=3.12 are incompatible.
-              And because there is no available version matching Python>=3.11, <3.12, Python>=3.10 are incompatible.
-              And because a==2.0.0 depends on Python>=3.10 and there is no available version matching a>2.0.0, <3.0.0 | >3.0.0, <4.0.0 | >4.0.0, a>=2.0.0, <3.0.0 is forbidden. (1)
+          ╰─▶ Because there are no versions of Python>=3.10, <3.11 and there are no versions of Python>=3.12, Python>=3.10, <3.11 | >=3.12 are incompatible.
+              And because there are no versions of Python>=3.11, <3.12, Python>=3.10 are incompatible.
+              And because a==2.0.0 depends on Python>=3.10 and there are no versions of a>2.0.0, <3.0.0 | >3.0.0, <4.0.0 | >4.0.0, a>=2.0.0, <3.0.0 is forbidden. (1)
 
-              Because there is no available version matching Python>=3.11, <3.12 and there is no available version matching Python>=3.12, Python>=3.11 are incompatible.
+              Because there are no versions of Python>=3.11, <3.12 and there are no versions of Python>=3.12, Python>=3.11 are incompatible.
               And because a==3.0.0 depends on Python>=3.11, a==3.0.0 is forbidden.
               And because a>=2.0.0, <3.0.0 is forbidden (1), a>=2.0.0, <4.0.0 is forbidden. (2)
 
-              Because there is no available version matching Python>=3.12 and a==4.0.0 depends on Python>=3.12, a==4.0.0 is forbidden.
+              Because there are no versions of Python>=3.12 and a==4.0.0 depends on Python>=3.12, a==4.0.0 is forbidden.
               And because a>=2.0.0, <4.0.0 is forbidden (2), a>=2.0.0 is forbidden.
               And because root depends on a>=2.0.0, version solving failed.
         "###);

--- a/crates/puffin-resolver/src/pubgrub/report.rs
+++ b/crates/puffin-resolver/src/pubgrub/report.rs
@@ -33,9 +33,9 @@ impl ReportFormatter<PubGrubPackage, Range<PubGrubVersion>> for PubGrubReportFor
             External::NoVersions(package, set) => {
                 let set = self.simplify_set(set, package);
                 if set.as_ref() == &Range::full() {
-                    format!("there is no available version for {package}")
+                    format!("there are no versions of {package}")
                 } else {
-                    format!("there is no available version matching {package}{set}")
+                    format!("there are no versions of {package}{set}")
                 }
             }
             External::UnavailableDependencies(package, set) => {

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -493,7 +493,7 @@ async fn black_disallow_prerelease() -> Result<()> {
         .await
         .unwrap_err();
 
-    assert_snapshot!(err, @"Because there is no available version matching black<=20.0 and root depends on black<=20.0, version solving failed.");
+    assert_snapshot!(err, @"Because there are no versions of black<=20.0 and root depends on black<=20.0, version solving failed.");
 
     Ok(())
 }
@@ -511,7 +511,7 @@ async fn black_allow_prerelease_if_necessary() -> Result<()> {
         .await
         .unwrap_err();
 
-    assert_snapshot!(err, @"Because there is no available version matching black<=20.0 and root depends on black<=20.0, version solving failed.");
+    assert_snapshot!(err, @"Because there are no versions of black<=20.0 and root depends on black<=20.0, version solving failed.");
 
     Ok(())
 }
@@ -634,7 +634,7 @@ async fn msgraph_sdk() -> Result<()> {
         .unwrap_err();
 
     assert_snapshot!(err, @r###"
-    Because there is no available version matching msgraph-core>=1.0.0a2 and msgraph-sdk==1.0.0 depends on msgraph-core>=1.0.0a2, msgraph-sdk==1.0.0 is forbidden.
+    Because there are no versions of msgraph-core>=1.0.0a2 and msgraph-sdk==1.0.0 depends on msgraph-core>=1.0.0a2, msgraph-sdk==1.0.0 is forbidden.
     And because root depends on msgraph-sdk==1.0.0, version solving failed.
 
     hint: msgraph-core was requested with a pre-release marker (e.g., >=1.0.0a2), but pre-releases weren't enabled (try: `--prerelease=allow`)


### PR DESCRIPTION
Adjusts display of "no versions available" in error messages to be consistent with other package/range pairings i.e. we usually display "<package-name><range>".