### PR TITLE
Show available pre-releases in error hints

### DIFF
--- a/crates/puffin-cli/tests/pip_install_scenarios.rs
+++ b/crates/puffin-cli/tests/pip_install_scenarios.rs
@@ -522,6 +522,8 @@ fn requires_package_only_prereleases_in_range() -> Result<()> {
         ----- stderr -----
           × No solution found when resolving dependencies:
           ╰─▶ Because there are no versions of a>0.1.0 and root depends on a>0.1.0, version solving failed.
+
+              hint: Pre-releases are available for a in the requested range (e.g., 1.0.0a1), but pre-releases weren't enabled (try: `--prerelease=allow`)
         "###);
     });
 
@@ -1116,6 +1118,8 @@ fn requires_transitive_package_only_prereleases_in_range() -> Result<()> {
           × No solution found when resolving dependencies:
           ╰─▶ Because there are no versions of b>0.1 and a==0.1.0 depends on b>0.1, a==0.1.0 is forbidden.
               And because there are no versions of a<0.1.0 | >0.1.0 and root depends on a, version solving failed.
+
+              hint: Pre-releases are available for b in the requested range (e.g., 1.0.0a1), but pre-releases weren't enabled (try: `--prerelease=allow`)
         "###);
     });
 

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -493,7 +493,11 @@ async fn black_disallow_prerelease() -> Result<()> {
         .await
         .unwrap_err();
 
-    assert_snapshot!(err, @"Because there are no versions of black<=20.0 and root depends on black<=20.0, version solving failed.");
+    assert_snapshot!(err, @r###"
+    Because there are no versions of black<=20.0 and root depends on black<=20.0, version solving failed.
+
+    hint: Pre-releases are available for black in the requested range (e.g., 19.10b0), but pre-releases weren't enabled (try: `--prerelease=allow`)
+    "###);
 
     Ok(())
 }
@@ -511,7 +515,11 @@ async fn black_allow_prerelease_if_necessary() -> Result<()> {
         .await
         .unwrap_err();
 
-    assert_snapshot!(err, @"Because there are no versions of black<=20.0 and root depends on black<=20.0, version solving failed.");
+    assert_snapshot!(err, @r###"
+    Because there are no versions of black<=20.0 and root depends on black<=20.0, version solving failed.
+
+    hint: Pre-releases are available for black in the requested range (e.g., 19.10b0), but pre-releases weren't enabled (try: `--prerelease=allow`)
+    "###);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

If pre-releases are available for a package that we otherwise couldn't resolve, we now show a hint that includes one of the example versions.

Closes https://github.com/astral-sh/puffin/issues/811.