### PR TITLE
Use zlib-ng for faster decompression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -1663,6 +1673,16 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libz-ng-sys"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81157dde2fd4ad2b45ea3a4bb47b8193b52a6346b678840d91d80d3c2cd166c5"
+dependencies = [
+ "cmake",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ data-encoding = { version = "2.5.0" }
 derivative = { version = "2.2.0" }
 directories = { version = "5.0.1" }
 dirs = { version = "5.0.1" }
+# This tells flate2 (and all libraries that depend on it, including async_compression
+# and async_zip) to use zlib-ng, which about 2x faster than the default flate2 backend
+# at decompression. See https://github.com/rust-lang/flate2-rs#backends
 flate2 = { version = "1.0.28", features = ["zlib-ng"], default-features = false }
 fs-err = { version = "2.11.0" }
 fs2 = { version = "0.4.3" }


### PR DESCRIPTION
ty @BurntSushi for the suggestion

# Bench results

Summary: 20-25% speedup in cases like flyte.txt and pdm-2913.txt, where compression is important. Other cases are either saturating my bandwidth or using source packages. No major regressions.

### scripts/bench/requirements.txt
main:
Resolved 45 packages in 709ms
Downloaded 45 packages (total size: 14586813 bytes) in 438ms (rate: 31.758675 MB/sec)
Num source packages: 0
Installed 45 packages in 57ms

ng:
Downloaded 45 packages in 428ms

### black.txt (compiled from scripts/requirements/black.in)
main:
Resolved 8 packages in 100ms
Downloaded 8 packages (total size: 1960918 bytes) in 129ms (rate: 14.4835825 MB/sec)
Num source packages: 0
Installed 8 packages in 22ms

ng:
Downloaded 8 packages in 81ms 

### boto3.txt (compiled from scripts/requirements/boto3.in)
Resolved 31 packages in 919ms
Downloaded 31 packages (total size: 39488261 bytes) in 1.52s (rate: 24.74746 MB/sec)
Num source packages: 0
Installed 31 packages in 70ms

ng:
Downloaded 31 packages in 1.26s

### dtlssocket.txt
Resolved 2 packages in 182ms
Downloaded 2 packages (total size: 2066977 bytes) in 4.98s (rate: 0.395072 MB/sec)
Num source packages: 1
Installed 2 packages in 48ms

ng:
Downloaded 2 packages in 4.94s

### flyte.txt
Resolved 107 packages in 1.51s
Downloaded 107 packages (total size: 1417831287 bytes) in 1m 02s (rate: 21.669163 MB/sec)
Num source packages: 0
Installed 107 packages in 338ms

ng:
Downloaded 107 packages in 45.64s

### pdm-2913.txt
Resolved 13 packages in 261ms
Downloaded 13 packages (total size: 31291075 bytes) in 1.32s (rate: 22.568693 MB/sec)
Num source packages: 1
Installed 13 packages in 29ms

ng:
Downloaded 13 packages in 1.08s

### scispacy.txt
Resolved 84 packages in 1.32s
Downloaded 84 packages (total size: 223013396 bytes) in 6.09s (rate: 34.916824 MB/sec)
Num source packages: 0
Installed 84 packages in 111ms

ng:
Downloaded 84 packages in 6.15s

### trio.txt
Resolved 38 packages in 370ms
Downloaded 38 packages (total size: 25506995 bytes) in 739ms (rate: 32.887703 MB/sec)
Num source packages: 0
Installed 38 packages in 61ms

ng:
Downloaded 38 packages in 703ms
