### PR TITLE
Only write to rust cache in CI from main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,8 @@ jobs:
         run: |
           rustup component add clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: "Clippy"
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
@@ -65,6 +67,8 @@ jobs:
         with:
           tool: cargo-insta
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: "Tests (Ubuntu)"
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: cargo insta test --all --all-features --unreferenced reject

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,8 @@ jobs:
         with:
           submodules: recursive
       - uses: swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install cargo-dist
         run: ${{ matrix.install_dist }}
       - name: Build artifacts


### PR DESCRIPTION
Each cache entry is ~1 GB of our allotted 10 GB for the repository which is quite a bit. We're probably losing cache entries all the time since we add an entry per commit per pull request.

Saving the cache takes ~3 minutes ([example](https://github.com/astral-sh/puffin/actions/runs/7479909295/job/20358124969)), it's probably just slowing down CI. It's ~25% of our test runtime and ~50% of our clippy runtime.