### PR TITLE
Fix failing test

### DIFF
--- a/crates/puffin-cli/tests/pip_compile.rs
+++ b/crates/puffin-cli/tests/pip_compile.rs
@@ -2776,6 +2776,8 @@ fn trailing_slash() -> Result<()> {
             .arg(cache_dir.path())
             .arg("--index-url")
             .arg("https://test.pypi.org/simple")
+            .arg("--exclude-newer")
+            .arg(EXCLUDE_NEWER)
             .env("VIRTUAL_ENV", venv.as_os_str())
             .current_dir(&temp_dir), @r###"
         success: true
@@ -2802,6 +2804,8 @@ fn trailing_slash() -> Result<()> {
             .arg(cache_dir.path())
             .arg("--index-url")
             .arg("https://test.pypi.org/simple/")
+            .arg("--exclude-newer")
+            .arg(EXCLUDE_NEWER)
             .env("VIRTUAL_ENV", venv.as_os_str())
             .current_dir(&temp_dir), @r###"
         success: true


### PR DESCRIPTION
Didn't use `exclude-newer` so a more recent version is getting grabbed.