### PR TITLE
Cleanup deps and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,9 +2035,7 @@ name = "pep440_rs"
 version = "0.3.12"
 dependencies = [
  "indoc",
- "once_cell",
  "pyo3",
- "regex",
  "serde",
  "tracing",
  "unicode-width",
@@ -2818,7 +2816,6 @@ dependencies = [
  "pep440_rs 0.3.12",
  "pep508_rs",
  "puffin-normalize",
- "puffin-warnings",
  "regex",
  "rfc2047-decoder",
  "serde",

--- a/crates/distribution-types/src/cached.rs
+++ b/crates/distribution-types/src/cached.rs
@@ -120,7 +120,7 @@ impl CachedDist {
 }
 
 impl CachedDirectUrlDist {
-    /// Initialize a [`CachedDirectUrlDist`] from a [`WheelFilename`], [`Url`], and [`Path`].
+    /// Initialize a [`CachedDirectUrlDist`] from a [`WheelFilename`], [`url::Url`], and [`Path`].
     pub fn from_url(filename: WheelFilename, url: VerbatimUrl, path: PathBuf) -> Self {
         Self {
             filename,

--- a/crates/gourgeist/Cargo.toml
+++ b/crates/gourgeist/Cargo.toml
@@ -35,8 +35,8 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, optional = true }
 which = { workspace = true }
 
 [features]
-cli = ["clap"]
+cli = ["clap", "tracing-subscriber"]

--- a/crates/pep440-rs/Cargo.toml
+++ b/crates/pep440-rs/Cargo.toml
@@ -17,9 +17,7 @@ name = "pep440_rs"
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
-once_cell = { workspace = true }
 pyo3 = { workspace = true, optional = true, features = ["extension-module", "abi3-py37"] }
-regex = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 tracing = { workspace = true, optional = true }
 unicode-width = { workspace = true }

--- a/crates/pep440-rs/src/lib.rs
+++ b/crates/pep440-rs/src/lib.rs
@@ -12,10 +12,6 @@
 //! assert!(version_specifiers.iter().all(|specifier| specifier.contains(&version)));
 //! ```
 //!
-//! The error handling and diagnostics is a bit overdone because this my parser-and-diagnostics
-//! learning project (which kinda failed because the byte based regex crate and char-based
-//! diagnostics don't mix well)
-//!
 //! PEP 440 has a lot of unintuitive features, including:
 //!
 //! * An epoch that you can prefix the version which, e.g. `1!1.2.3`. Lower epoch always means lower

--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -101,7 +101,6 @@ impl FromStr for Operator {
             "<=" => Self::LessThanEqual,
             ">" => Self::GreaterThan,
             ">=" => Self::GreaterThanEqual,
-            // Should be forbidden by the regex if called from normal parsing
             other => {
                 return Err(OperatorParseError {
                     got: other.to_string(),
@@ -666,8 +665,7 @@ impl FromStr for Version {
 
     /// Parses a version such as `1.19`, `1.0a1`,`1.0+abc.5` or `1!2012.2`
     ///
-    /// Note that this variant doesn't allow the version to end with a star, see
-    /// [`Self::from_str_star`] if you want to parse versions for specifiers
+    /// Note that this doesn't allow wildcard versions.
     fn from_str(version: &str) -> Result<Self, Self::Err> {
         Parser::new(version.as_bytes()).parse()
     }
@@ -2766,7 +2764,7 @@ mod tests {
     }
 
     #[test]
-    fn test_regex_mismatch() {
+    fn test_invalid_word() {
         let result = Version::from_str("blergh");
         assert_eq!(result.unwrap_err(), ErrorKind::NoLeadingNumber.into());
     }

--- a/crates/pep440-rs/src/version_specifier.rs
+++ b/crates/pep440-rs/src/version_specifier.rs
@@ -1279,7 +1279,7 @@ mod tests {
     }
 
     #[test]
-    fn test_regex_mismatch() {
+    fn test_invalid_word() {
         let result = VersionSpecifiers::from_str("blergh");
         assert_eq!(
             result.unwrap_err().inner.err,

--- a/crates/puffin-cache/src/lib.rs
+++ b/crates/puffin-cache/src/lib.rs
@@ -392,7 +392,7 @@ pub enum CacheBucket {
     ///  * `simple-v0/pypi/<package_name>.msgpack`
     ///  * `simple-v0/<digest(index_url)>/<package_name>.msgpack`
     ///
-    /// The response is parsed into [`puffin_client::SimpleMetadata`] before storage.
+    /// The response is parsed into `puffin_client::SimpleMetadata` before storage.
     Simple,
 }
 

--- a/crates/puffin-interpreter/src/lib.rs
+++ b/crates/puffin-interpreter/src/lib.rs
@@ -4,6 +4,7 @@ use std::time::SystemTimeError;
 
 use thiserror::Error;
 
+pub use crate::cfg::Configuration;
 pub use crate::interpreter::Interpreter;
 pub use crate::python_version::PythonVersion;
 pub use crate::virtual_env::Virtualenv;

--- a/crates/puffin-resolver/src/lib.rs
+++ b/crates/puffin-resolver/src/lib.rs
@@ -2,7 +2,7 @@ pub use error::ResolveError;
 pub use finder::{DistFinder, Reporter as FinderReporter};
 pub use manifest::Manifest;
 pub use prerelease_mode::PreReleaseMode;
-pub use resolution::ResolutionGraph;
+pub use resolution::{Diagnostic, ResolutionGraph};
 pub use resolution_mode::ResolutionMode;
 pub use resolution_options::ResolutionOptions;
 pub use resolver::{BuildId, Reporter as ResolverReporter, Resolver, ResolverProvider};

--- a/crates/puffin-resolver/src/resolver/provider.rs
+++ b/crates/puffin-resolver/src/resolver/provider.rs
@@ -37,7 +37,7 @@ pub trait ResolverProvider: Send + Sync {
         dist: &'io Dist,
     ) -> impl Future<Output = WheelMetadataResponse> + Send + 'io;
 
-    /// Set the [`Reporter`] to use for this installer.
+    /// Set the [`puffin_distribution::Reporter`] to use for this installer.
     #[must_use]
     fn with_reporter(self, reporter: impl puffin_distribution::Reporter + 'static) -> Self;
 }

--- a/crates/pypi-types/Cargo.toml
+++ b/crates/pypi-types/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 pep440_rs = { path = "../pep440-rs", features = ["serde"] }
 pep508_rs = { path = "../pep508-rs", features = ["serde"] }
 puffin-normalize = { path = "../puffin-normalize" }
-puffin-warnings = { path = "../puffin-warnings" }
 
 chrono = { workspace = true, features = ["serde"] }
 mailparse = { workspace = true }


### PR DESCRIPTION
Fix warnings from `cargo +nightly udeps` and `cargo doc`.

Removes all mentions of regex from pep440_rs.