### PR TITLE
Use consistent parse terminology in pyproject error

### DIFF
--- a/crates/puffin-cli/src/requirements.rs
+++ b/crates/puffin-cli/src/requirements.rs
@@ -117,7 +117,7 @@ impl RequirementsSpecification {
             RequirementsSource::PyprojectToml(path) => {
                 let contents = fs::read_to_string(path)?;
                 let pyproject_toml = toml::from_str::<pyproject_toml::PyProjectToml>(&contents)
-                    .with_context(|| format!("Failed to read `{}`", path.display()))?;
+                    .with_context(|| format!("Failed to parse `{}`", path.display()))?;
                 let mut used_extras = FxHashSet::default();
                 let mut requirements = Vec::new();
                 let mut project_name = None;

--- a/crates/puffin-cli/tests/pip_uninstall.rs
+++ b/crates/puffin-cli/tests/pip_uninstall.rs
@@ -142,7 +142,7 @@ fn invalid_pyproject_toml_syntax() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to read `pyproject.toml`
+    error: Failed to parse `pyproject.toml`
       Caused by: TOML parse error at line 1, column 5
       |
     1 | 123 - 456
@@ -171,7 +171,7 @@ fn invalid_pyproject_toml_schema() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to read `pyproject.toml`
+    error: Failed to parse `pyproject.toml`
       Caused by: TOML parse error at line 1, column 1
       |
     1 | [project]
@@ -205,7 +205,7 @@ dependencies = ["flask==1.0.x"]
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to read `pyproject.toml`
+    error: Failed to parse `pyproject.toml`
       Caused by: TOML parse error at line 3, column 16
       |
     3 | dependencies = ["flask==1.0.x"]


### PR DESCRIPTION
We use `parse` for the other file types.