### PR TITLE
bench: ignore empty requirements lines

### DIFF
--- a/scripts/bench/__main__.py
+++ b/scripts/bench/__main__.py
@@ -261,7 +261,9 @@ class Poetry(Suite):
         # Parse all dependencies from the requirements file.
         with open(requirements_file) as fp:
             requirements = [
-                Requirement(line) for line in fp if not line.lstrip().startswith("#")
+                Requirement(line)
+                for line in fp
+                if not line.lstrip().startswith("#") and len(line.strip()) > 0
             ]
 
         # Create a Poetry project.


### PR DESCRIPTION
In particular, this script previously choked on the `home-assistant.in`
requirements file because it contains many empty lines.
