### PR TITLE
bench: set log level to WARN, make --verbose raise it to INFO

### DIFF
--- a/scripts/bench/__main__.py
+++ b/scripts/bench/__main__.py
@@ -517,12 +517,6 @@ class Puffin(Suite):
 
 def main():
     """Run the benchmark."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-
     parser = argparse.ArgumentParser(
         description="Benchmark Puffin against other packaging tools."
     )
@@ -603,6 +597,11 @@ def main():
     )
 
     args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARN,
+        format="%(asctime)s %(levelname)s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
     verbose = args.verbose
     warmup = args.warmup


### PR DESCRIPTION
I personally found the output by default somewhat noisy, especially for
large requirements files. Since --verbose is already a thing, I propose
making the extra output opt-in.
