### PR TITLE
Split version map out from resolver index

### DIFF
--- a/crates/puffin-client/src/registry_client.rs
+++ b/crates/puffin-client/src/registry_client.rs
@@ -421,7 +421,7 @@ pub async fn read_metadata_async(
     Ok(metadata)
 }
 
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct VersionFiles {
     pub wheels: Vec<(WheelFilename, File)>,
     pub source_dists: Vec<(SourceDistFilename, File)>,
@@ -447,7 +447,7 @@ impl VersionFiles {
     }
 }
 
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct SimpleMetadata(BTreeMap<Version, VersionFiles>);
 
 impl SimpleMetadata {
@@ -506,7 +506,7 @@ impl IntoIterator for SimpleMetadata {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 enum MediaType {
     Json,
     Html,

--- a/crates/puffin-resolver/src/error.rs
+++ b/crates/puffin-resolver/src/error.rs
@@ -1,6 +1,7 @@
 use std::convert::Infallible;
 use std::fmt::Formatter;
 
+use dashmap::DashMap;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, DerivationTree, Reporter};
 use rustc_hash::FxHashMap;
@@ -12,7 +13,6 @@ use pep440_rs::Version;
 use pep508_rs::Requirement;
 use puffin_distribution::DistributionDatabaseError;
 use puffin_normalize::PackageName;
-use puffin_traits::OnceMap;
 
 use crate::candidate_selector::CandidateSelector;
 use crate::pubgrub::{PubGrubPackage, PubGrubPython, PubGrubReportFormatter};
@@ -161,7 +161,7 @@ impl NoSolutionError {
     pub(crate) fn with_available_versions(
         mut self,
         python_requirement: &PythonRequirement,
-        package_versions: &OnceMap<PackageName, VersionMap>,
+        package_versions: &DashMap<PackageName, VersionMap>,
     ) -> Self {
         let mut available_versions = FxHashMap::default();
         for package in self.derivation_tree.packages() {

--- a/crates/puffin-resolver/src/resolution.rs
+++ b/crates/puffin-resolver/src/resolution.rs
@@ -42,7 +42,7 @@ impl ResolutionGraph {
     pub(crate) fn from_state(
         selection: &SelectedDependencies<PubGrubPackage, Version>,
         pins: &FilePins,
-        packages: &OnceMap<PackageName, VersionMap>,
+        packages: &DashMap<PackageName, VersionMap>,
         distributions: &OnceMap<PackageId, Metadata21>,
         redirects: &DashMap<Url, Url>,
         state: &State<PubGrubPackage, Range<Version>, PubGrubPriority>,

--- a/crates/puffin-resolver/src/resolver/index.rs
+++ b/crates/puffin-resolver/src/resolver/index.rs
@@ -6,14 +6,13 @@ use puffin_normalize::PackageName;
 use puffin_traits::OnceMap;
 use pypi_types::Metadata21;
 
-use crate::version_map::VersionMap;
+use crate::resolver::provider::PackageMetadata;
 
 /// In-memory index of package metadata.
 #[derive(Default)]
 pub(crate) struct Index {
-    /// A map from package name to the metadata for that package and the index where the metadata
-    /// came from.
-    pub(crate) packages: OnceMap<PackageName, VersionMap>,
+    /// A map from package name to the metadata for that package.
+    pub(crate) packages: OnceMap<PackageName, PackageMetadata>,
 
     /// A map from package ID to metadata for that distribution.
     pub(crate) distributions: OnceMap<PackageId, Metadata21>,

--- a/crates/puffin-resolver/src/resolver/provider.rs
+++ b/crates/puffin-resolver/src/resolver/provider.rs
@@ -1,43 +1,45 @@
 use std::future::Future;
 
 use anyhow::Result;
-use chrono::{DateTime, Utc};
 use futures::FutureExt;
 use url::Url;
 
-use distribution_types::Dist;
-use platform_tags::Tags;
-use puffin_client::{FlatIndex, RegistryClient};
+use distribution_types::{Dist, IndexUrl};
+use puffin_client::{FlatDistributions, FlatIndex, RegistryClient, SimpleMetadata};
 use puffin_distribution::{DistributionDatabase, DistributionDatabaseError};
 use puffin_normalize::PackageName;
 use puffin_traits::BuildContext;
 use pypi_types::Metadata21;
 
-use crate::python_requirement::PythonRequirement;
-use crate::version_map::VersionMap;
-use crate::yanks::AllowedYanks;
+#[derive(Debug)]
+pub enum PackageMetadata {
+    /// The metadata came from an index, and may be accompanied by a list of distributions from
+    /// `--find-links` that should override the index.
+    Simple(IndexUrl, SimpleMetadata, Option<FlatDistributions>),
+    /// The metadata wasn't present in the index, but was found in `--find-links`.
+    FindLinks(FlatDistributions),
+}
 
-type VersionMapResponse = Result<VersionMap, puffin_client::Error>;
+type PackageMetadataResponse = Result<PackageMetadata, puffin_client::Error>;
 type WheelMetadataResponse = Result<(Metadata21, Option<Url>), DistributionDatabaseError>;
 
 pub trait ResolverProvider: Send + Sync {
-    /// Get the version map for a package.
-    fn get_version_map<'io>(
+    /// Get the metadata for a package.
+    fn get_package_metadata<'io>(
         &'io self,
         package_name: &'io PackageName,
-    ) -> impl Future<Output = VersionMapResponse> + Send + 'io;
+    ) -> impl Future<Output = PackageMetadataResponse> + Send + 'io;
 
     /// Get the metadata for a distribution.
     ///
-    /// For a wheel, this is done by querying it's (remote) metadata, for a source dist we
-    /// (fetch and) build the source distribution and return the metadata from the built
-    /// distribution.
+    /// For a wheel, we query its (remote) metadata. For a source distribution, we fetch and build
+    /// the distribution, then return the metadata from the built wheeel.
     fn get_or_build_wheel_metadata<'io>(
         &'io self,
         dist: &'io Dist,
     ) -> impl Future<Output = WheelMetadataResponse> + Send + 'io;
 
-    /// Set the [`puffin_distribution::Reporter`] to use for this installer.
+    /// Set the [`puffin_distribution::Reporter`]..
     #[must_use]
     fn with_reporter(self, reporter: impl puffin_distribution::Reporter + 'static) -> Self;
 }
@@ -51,31 +53,18 @@ pub struct DefaultResolverProvider<'a, Context: BuildContext + Send + Sync> {
     fetcher: DistributionDatabase<'a, Context>,
     /// These are the entries from `--find-links` that act as overrides for index responses.
     flat_index: &'a FlatIndex,
-    tags: &'a Tags,
-    python_requirement: PythonRequirement<'a>,
-    exclude_newer: Option<DateTime<Utc>>,
-    allowed_yanks: AllowedYanks,
 }
 
 impl<'a, Context: BuildContext + Send + Sync> DefaultResolverProvider<'a, Context> {
-    /// Reads the flat index entries and builds the provider.
     pub fn new(
         client: &'a RegistryClient,
         fetcher: DistributionDatabase<'a, Context>,
         flat_index: &'a FlatIndex,
-        tags: &'a Tags,
-        python_requirement: PythonRequirement<'a>,
-        exclude_newer: Option<DateTime<Utc>>,
-        allowed_yanks: AllowedYanks,
     ) -> Self {
         Self {
             client,
             fetcher,
             flat_index,
-            tags,
-            python_requirement,
-            exclude_newer,
-            allowed_yanks,
         }
     }
 }
@@ -83,29 +72,24 @@ impl<'a, Context: BuildContext + Send + Sync> DefaultResolverProvider<'a, Contex
 impl<'a, Context: BuildContext + Send + Sync> ResolverProvider
     for DefaultResolverProvider<'a, Context>
 {
-    fn get_version_map<'io>(
+    fn get_package_metadata<'io>(
         &'io self,
         package_name: &'io PackageName,
-    ) -> impl Future<Output = VersionMapResponse> + Send + 'io {
+    ) -> impl Future<Output = PackageMetadataResponse> + Send + 'io {
         self.client
             .simple(package_name)
             .map(move |result| match result {
-                Ok((index, metadata)) => Ok(VersionMap::from_metadata(
+                Ok((index, metadata)) => Ok(PackageMetadata::Simple(
+                    index,
                     metadata,
-                    package_name,
-                    &index,
-                    self.tags,
-                    &self.python_requirement,
-                    &self.allowed_yanks,
-                    self.exclude_newer.as_ref(),
                     self.flat_index.get(package_name).cloned(),
                 )),
                 Err(
                     err @ (puffin_client::Error::PackageNotFound(_)
                     | puffin_client::Error::NoIndex(_)),
                 ) => {
-                    if let Some(flat_index) = self.flat_index.get(package_name).cloned() {
-                        Ok(VersionMap::from(flat_index))
+                    if let Some(distributions) = self.flat_index.get(package_name).cloned() {
+                        Ok(PackageMetadata::FindLinks(distributions))
                     } else {
                         Err(err)
                     }

--- a/crates/puffin-resolver/src/version_map.rs
+++ b/crates/puffin-resolver/src/version_map.rs
@@ -18,7 +18,7 @@ use crate::yanks::AllowedYanks;
 
 /// A map from versions to distributions.
 #[derive(Debug, Default, Clone)]
-pub struct VersionMap(BTreeMap<Version, PrioritizedDistribution>);
+pub(crate) struct VersionMap(BTreeMap<Version, PrioritizedDistribution>);
 
 impl VersionMap {
     /// Initialize a [`VersionMap`] from the given metadata.

--- a/crates/puffin-resolver/src/yanks.rs
+++ b/crates/puffin-resolver/src/yanks.rs
@@ -7,7 +7,7 @@ use puffin_normalize::PackageName;
 /// A set of package versions that are permitted, even if they're marked as yanked by the
 /// relevant index.
 #[derive(Debug, Default)]
-pub struct AllowedYanks(FxHashMap<PackageName, FxHashSet<Version>>);
+pub(crate) struct AllowedYanks(FxHashMap<PackageName, FxHashSet<Version>>);
 
 impl AllowedYanks {
     /// Returns `true` if the given package version is allowed, even if it's marked as yanked by


### PR DESCRIPTION
## Summary

This is a change I'm considering but not sold on. Right now, the `Index` in the resolver looks like:

```rust
/// In-memory index of package metadata.
#[derive(Default)]
pub(crate) struct Index {
    /// A map from package name to the metadata for that package and the index where the metadata
    /// came from.
    pub(crate) packages: OnceMap<PackageName, VersionMap>,

    /// A map from package ID to metadata for that distribution.
    pub(crate) distributions: OnceMap<PackageId, Metadata21>,

    /// A map from source URL to precise URL.
    pub(crate) redirects: OnceMap<Url, Url>,
}
```

I want to change this to something that can be universally shared across resolutions... But `packages` (for example) is _not_ shareable, because `VersionMap` is a function of "API response + tags + Python requirement", where the latter two are parameters to the resolution.

Specifically, if the user passed in `--python-version`, and we tried to reuse the stored `VersionMap` here when resolving dependencies for a source distribution build, we could end up doing the wrong thing, because the `VersionMap` would be _wrong_.

So, instead, I'm proposing that we change `Index` to resolution-agnostic data, and move any resolution-specific data into other fields on the resolver. That would allow us to share `Index` across resolutions safely.

The specific change here changes from `pub(crate) packages: OnceMap<PackageName, VersionMap>` to `pub(crate) packages: OnceMap<PackageName, (IndexUrl, BaseUrl, SimpleMetadata)>` -- that's static response data that doesn't rely on the resolution inputs. We then have to compute the `VersionMap` from those parameters and store it separately.

The main downside here is that we now need to clone `SimpleMetadata` (since we're storing it _and_ the `VersionMap`), and we need to use a separate hash map for the versions.
