### PR TITLE
Share a single `Index` across resolutions

### DIFF
--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -14,6 +14,7 @@ use puffin_client::{FlatIndex, FlatIndexClient, RegistryClient, RegistryClientBu
 use puffin_dispatch::BuildDispatch;
 use puffin_installer::{Downloader, InstallPlan, Reinstall, ResolvedEditable, SitePackages};
 use puffin_interpreter::Virtualenv;
+use puffin_resolver::InMemoryIndex;
 use puffin_traits::{InFlight, SetupPyStrategy};
 use pypi_types::Yanked;
 use requirements_txt::EditableRequirement;
@@ -70,6 +71,9 @@ pub(crate) async fn pip_sync(
         FlatIndex::from_entries(entries, tags)
     };
 
+    // Create a shared in-memory index.
+    let index = InMemoryIndex::default();
+
     // Track in-flight downloads, builds, etc., across resolutions.
     let in_flight = InFlight::default();
 
@@ -80,6 +84,7 @@ pub(crate) async fn pip_sync(
         venv.interpreter(),
         &index_locations,
         &flat_index,
+        &index,
         &in_flight,
         venv.python_executable(),
         setup_py,

--- a/crates/puffin-cli/src/commands/venv.rs
+++ b/crates/puffin-cli/src/commands/venv.rs
@@ -15,6 +15,7 @@ use puffin_cache::Cache;
 use puffin_client::{FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
 use puffin_interpreter::Interpreter;
+use puffin_resolver::InMemoryIndex;
 use puffin_traits::{BuildContext, InFlight, SetupPyStrategy};
 
 use crate::commands::ExitStatus;
@@ -139,6 +140,9 @@ async fn venv_impl(
             FlatIndex::from_entries(entries, tags)
         };
 
+        // Create a shared in-memory index.
+        let index = InMemoryIndex::default();
+
         // Track in-flight downloads, builds, etc., across resolutions.
         let in_flight = InFlight::default();
 
@@ -149,6 +153,7 @@ async fn venv_impl(
             interpreter,
             index_locations,
             &flat_index,
+            &index,
             &in_flight,
             venv.python_executable(),
             SetupPyStrategy::default(),

--- a/crates/puffin-dev/src/build.rs
+++ b/crates/puffin-dev/src/build.rs
@@ -12,6 +12,7 @@ use puffin_cache::{Cache, CacheArgs};
 use puffin_client::{FlatIndex, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
 use puffin_interpreter::Virtualenv;
+use puffin_resolver::InMemoryIndex;
 use puffin_traits::{BuildContext, BuildKind, InFlight, SetupPyStrategy};
 
 #[derive(Parser)]
@@ -56,6 +57,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
     let client = RegistryClientBuilder::new(cache.clone()).build();
     let index_urls = IndexLocations::default();
     let flat_index = FlatIndex::default();
+    let index = InMemoryIndex::default();
     let setup_py = SetupPyStrategy::default();
     let in_flight = InFlight::default();
 
@@ -65,6 +67,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
         venv.interpreter(),
         &index_urls,
         &flat_index,
+        &index,
         &in_flight,
         venv.python_executable(),
         setup_py,

--- a/crates/puffin-dev/src/install_many.rs
+++ b/crates/puffin-dev/src/install_many.rs
@@ -24,7 +24,7 @@ use puffin_distribution::RegistryWheelIndex;
 use puffin_installer::Downloader;
 use puffin_interpreter::Virtualenv;
 use puffin_normalize::PackageName;
-use puffin_resolver::DistFinder;
+use puffin_resolver::{DistFinder, InMemoryIndex};
 use puffin_traits::{BuildContext, InFlight, SetupPyStrategy};
 
 #[derive(Parser)]
@@ -61,6 +61,7 @@ pub(crate) async fn install_many(args: InstallManyArgs) -> Result<()> {
     let client = RegistryClientBuilder::new(cache.clone()).build();
     let index_locations = IndexLocations::default();
     let flat_index = FlatIndex::default();
+    let index = InMemoryIndex::default();
     let setup_py = SetupPyStrategy::default();
     let in_flight = InFlight::default();
     let tags = venv.interpreter().tags()?;
@@ -71,6 +72,7 @@ pub(crate) async fn install_many(args: InstallManyArgs) -> Result<()> {
         venv.interpreter(),
         &index_locations,
         &flat_index,
+        &index,
         &in_flight,
         venv.python_executable(),
         setup_py,

--- a/crates/puffin-dev/src/resolve_cli.rs
+++ b/crates/puffin-dev/src/resolve_cli.rs
@@ -16,7 +16,7 @@ use puffin_cache::{Cache, CacheArgs};
 use puffin_client::{FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
 use puffin_interpreter::Virtualenv;
-use puffin_resolver::{Manifest, ResolutionOptions, Resolver};
+use puffin_resolver::{InMemoryIndex, Manifest, ResolutionOptions, Resolver};
 use puffin_traits::{InFlight, SetupPyStrategy};
 
 #[derive(ValueEnum, Default, Clone)]
@@ -65,6 +65,7 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
         let entries = client.fetch(index_locations.flat_indexes()).await?;
         FlatIndex::from_entries(entries, venv.interpreter().tags()?)
     };
+    let index = InMemoryIndex::default();
     let in_flight = InFlight::default();
 
     let build_dispatch = BuildDispatch::new(
@@ -73,6 +74,7 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
         venv.interpreter(),
         &index_locations,
         &flat_index,
+        &index,
         &in_flight,
         venv.python_executable(),
         SetupPyStrategy::default(),
@@ -89,6 +91,7 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
         tags,
         &client,
         &flat_index,
+        &index,
         &build_dispatch,
     );
     let resolution_graph = resolver.resolve().await.with_context(|| {

--- a/crates/puffin-dev/src/resolve_many.rs
+++ b/crates/puffin-dev/src/resolve_many.rs
@@ -20,6 +20,7 @@ use puffin_client::{FlatIndex, RegistryClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
 use puffin_interpreter::Virtualenv;
 use puffin_normalize::PackageName;
+use puffin_resolver::InMemoryIndex;
 use puffin_traits::{BuildContext, InFlight, SetupPyStrategy};
 
 #[derive(Parser)]
@@ -75,6 +76,7 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
     let client = RegistryClientBuilder::new(cache.clone()).build();
     let index_locations = IndexLocations::default();
     let flat_index = FlatIndex::default();
+    let index = InMemoryIndex::default();
     let setup_py = SetupPyStrategy::default();
     let in_flight = InFlight::default();
 
@@ -84,6 +86,7 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
         venv.interpreter(),
         &index_locations,
         &flat_index,
+        &index,
         &in_flight,
         venv.python_executable(),
         setup_py,

--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -16,7 +16,7 @@ use puffin_cache::Cache;
 use puffin_client::{FlatIndex, RegistryClient};
 use puffin_installer::{Downloader, InstallPlan, Installer, Reinstall, SitePackages};
 use puffin_interpreter::{Interpreter, Virtualenv};
-use puffin_resolver::{Manifest, ResolutionOptions, Resolver};
+use puffin_resolver::{InMemoryIndex, Manifest, ResolutionOptions, Resolver};
 use puffin_traits::{BuildContext, BuildKind, InFlight, SetupPyStrategy};
 
 /// The main implementation of [`BuildContext`], used by the CLI, see [`BuildContext`]
@@ -27,6 +27,7 @@ pub struct BuildDispatch<'a> {
     interpreter: &'a Interpreter,
     index_locations: &'a IndexLocations,
     flat_index: &'a FlatIndex,
+    index: &'a InMemoryIndex,
     in_flight: &'a InFlight,
     base_python: PathBuf,
     setup_py: SetupPyStrategy,
@@ -43,6 +44,7 @@ impl<'a> BuildDispatch<'a> {
         interpreter: &'a Interpreter,
         index_locations: &'a IndexLocations,
         flat_index: &'a FlatIndex,
+        index: &'a InMemoryIndex,
         in_flight: &'a InFlight,
         base_python: PathBuf,
         setup_py: SetupPyStrategy,
@@ -54,6 +56,7 @@ impl<'a> BuildDispatch<'a> {
             interpreter,
             index_locations,
             flat_index,
+            index,
             in_flight,
             base_python,
             setup_py,
@@ -104,6 +107,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
             tags,
             self.client,
             self.flat_index,
+            self.index,
             self,
         );
         let graph = resolver.resolve().await.with_context(|| {

--- a/crates/puffin-resolver/src/lib.rs
+++ b/crates/puffin-resolver/src/lib.rs
@@ -5,7 +5,9 @@ pub use prerelease_mode::PreReleaseMode;
 pub use resolution::{Diagnostic, DisplayResolutionGraph, ResolutionGraph};
 pub use resolution_mode::ResolutionMode;
 pub use resolution_options::ResolutionOptions;
-pub use resolver::{BuildId, Reporter as ResolverReporter, Resolver, ResolverProvider};
+pub use resolver::{
+    BuildId, InMemoryIndex, Reporter as ResolverReporter, Resolver, ResolverProvider,
+};
 
 mod candidate_selector;
 mod error;

--- a/crates/puffin-resolver/src/resolver/index.rs
+++ b/crates/puffin-resolver/src/resolver/index.rs
@@ -10,7 +10,7 @@ use crate::version_map::VersionMap;
 
 /// In-memory index of package metadata.
 #[derive(Default)]
-pub(crate) struct Index {
+pub struct InMemoryIndex {
     /// A map from package name to the metadata for that package and the index where the metadata
     /// came from.
     pub(crate) packages: OnceMap<PackageName, VersionMap>,
@@ -24,7 +24,7 @@ pub(crate) struct Index {
     pub(crate) redirects: DashMap<Url, Url>,
 }
 
-impl Index {
+impl InMemoryIndex {
     /// Cancel all waiting tasks.
     ///
     /// Warning: waiting on tasks that have been canceled will cause the index to hang.

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -18,8 +18,8 @@ use puffin_cache::Cache;
 use puffin_client::{FlatIndex, RegistryClientBuilder};
 use puffin_interpreter::{Interpreter, Virtualenv};
 use puffin_resolver::{
-    DisplayResolutionGraph, Manifest, PreReleaseMode, ResolutionGraph, ResolutionMode,
-    ResolutionOptions, Resolver,
+    DisplayResolutionGraph, InMemoryIndex, Manifest, PreReleaseMode, ResolutionGraph,
+    ResolutionMode, ResolutionOptions, Resolver,
 };
 use puffin_traits::{BuildContext, BuildKind, SetupPyStrategy, SourceBuildTrait};
 
@@ -101,6 +101,7 @@ async fn resolve(
 ) -> Result<ResolutionGraph> {
     let client = RegistryClientBuilder::new(Cache::temp()?).build();
     let flat_index = FlatIndex::default();
+    let index = InMemoryIndex::default();
     let interpreter = Interpreter::artificial(
         Platform::current()?,
         markers.clone(),
@@ -120,6 +121,7 @@ async fn resolve(
         tags,
         &client,
         &flat_index,
+        &index,
         &build_context,
     );
     Ok(resolver.resolve().await?)


### PR DESCRIPTION
## Summary

This PR uses a single `Index` that's shared between the top-level resolver and any sub-resolutions happen in the course of that top-level resolution (namely, to resolve build dependencies for any source distributions).

In theory it's an optimization, since (e.g.) if we have two packages that both need the `flit-core` build system, and we attempt to build them both at once, we'll only fetch its metadata _once_, and share it across the two resolutions. In practice, I haven't been able to get this to show up in benchmarks. I suspect you'd need a _lot_ of source distributions for it to matter... Though it may still be worth doing, it strikes me as a cleaner design.

Closes #200.

Closes #541.