### PR TITLE
Use `DashMap` for redirects

### DIFF
--- a/crates/puffin-resolver/src/resolution.rs
+++ b/crates/puffin-resolver/src/resolution.rs
@@ -1,6 +1,7 @@
 use std::hash::BuildHasherDefault;
 
 use anyhow::Result;
+use dashmap::DashMap;
 use owo_colors::OwoColorize;
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
@@ -43,7 +44,7 @@ impl ResolutionGraph {
         pins: &FilePins,
         packages: &OnceMap<PackageName, VersionMap>,
         distributions: &OnceMap<PackageId, Metadata21>,
-        redirects: &OnceMap<Url, Url>,
+        redirects: &DashMap<Url, Url>,
         state: &State<PubGrubPackage, Range<PubGrubVersion>, PubGrubPriority>,
         editables: FxHashMap<PackageName, (LocalEditable, Metadata21)>,
     ) -> Result<Self, ResolveError> {

--- a/crates/puffin-resolver/src/resolver/index.rs
+++ b/crates/puffin-resolver/src/resolver/index.rs
@@ -1,3 +1,4 @@
+use dashmap::DashMap;
 use url::Url;
 
 use distribution_types::PackageId;
@@ -17,8 +18,10 @@ pub(crate) struct Index {
     /// A map from package ID to metadata for that distribution.
     pub(crate) distributions: OnceMap<PackageId, Metadata21>,
 
-    /// A map from source URL to precise URL.
-    pub(crate) redirects: OnceMap<Url, Url>,
+    /// A map from source URL to precise URL. For example, the source URL
+    /// `git+https://github.com/pallets/flask.git` could be redirected to
+    /// `git+https://github.com/pallets/flask.git@c2f65dd1cfff0672b902fd5b30815f0b4137214c`.
+    pub(crate) redirects: DashMap<Url, Url>,
 }
 
 impl Index {
@@ -28,6 +31,5 @@ impl Index {
     pub(crate) fn cancel_all(&self) {
         self.packages.cancel_all();
         self.distributions.cancel_all();
-        self.redirects.cancel_all();
     }
 }

--- a/crates/puffin-resolver/src/resolver/mod.rs
+++ b/crates/puffin-resolver/src/resolver/mod.rs
@@ -66,6 +66,7 @@ pub struct Resolver<'a, Provider: ResolverProvider> {
     python_requirement: PythonRequirement<'a>,
     selector: CandidateSelector,
     index: Arc<Index>,
+    /// A map from [`PackageId`] to the `Requires-Python` version specifiers for that package.
     incompatibilities: DashMap<PackageId, VersionSpecifiers>,
     editables: FxHashMap<PackageName, (LocalEditable, Metadata21)>,
     reporter: Option<Arc<dyn Reporter>>,
@@ -703,13 +704,13 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                     if let Some(precise) = precise {
                         match distribution {
                             SourceDist::DirectUrl(sdist) => {
-                                self.index.redirects.done(sdist.url.to_url(), precise);
+                                self.index.redirects.insert(sdist.url.to_url(), precise);
                             }
                             SourceDist::Git(sdist) => {
-                                self.index.redirects.done(sdist.url.to_url(), precise);
+                                self.index.redirects.insert(sdist.url.to_url(), precise);
                             }
                             SourceDist::Path(sdist) => {
-                                self.index.redirects.done(sdist.url.to_url(), precise);
+                                self.index.redirects.insert(sdist.url.to_url(), precise);
                             }
                             SourceDist::Registry(_) => {}
                         }


### PR DESCRIPTION
## Summary

We don't need to wait on these, so it's simpler to use a standard concurrent hash map.