### PR TITLE
Make hashes optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "anyhow",
  "cache-key",
  "chrono",
+ "data-encoding",
  "distribution-filename",
  "fs-err",
  "once_cell",
@@ -860,6 +861,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "url",
 ]

--- a/crates/distribution-types/Cargo.toml
+++ b/crates/distribution-types/Cargo.toml
@@ -24,10 +24,12 @@ requirements-txt = { path = "../requirements-txt" }
 
 anyhow = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
+data-encoding = { workspace = true }
 fs-err = { workspace = true }
 once_cell = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }

--- a/crates/distribution-types/src/id.rs
+++ b/crates/distribution-types/src/id.rs
@@ -18,6 +18,12 @@ impl DistributionId {
     }
 }
 
+impl DistributionId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 /// A unique identifier for a resource, like a URL or a Git repository.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ResourceId(String);

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -652,11 +652,19 @@ impl Identifier for Url {
 
 impl Identifier for File {
     fn distribution_id(&self) -> DistributionId {
-        DistributionId::new(self.hashes.sha256.clone())
+        if let Some(hash) = &self.hashes.sha256 {
+            DistributionId::new(hash)
+        } else {
+            self.url.distribution_id()
+        }
     }
 
     fn resource_id(&self) -> ResourceId {
-        ResourceId::new(self.hashes.sha256.clone())
+        if let Some(hash) = &self.hashes.sha256 {
+            ResourceId::new(hash)
+        } else {
+            self.url.resource_id()
+        }
     }
 }
 

--- a/crates/puffin-distribution/src/source/mod.rs
+++ b/crates/puffin-distribution/src/source/mod.rs
@@ -16,8 +16,8 @@ use zip::ZipArchive;
 
 use distribution_filename::WheelFilename;
 use distribution_types::{
-    DirectArchiveUrl, DirectGitUrl, Dist, GitSourceDist, LocalEditable, Name, PathSourceDist,
-    RemoteSource, SourceDist,
+    DirectArchiveUrl, DirectGitUrl, Dist, GitSourceDist, Identifier, LocalEditable, Name,
+    PathSourceDist, RemoteSource, SourceDist,
 };
 use install_wheel_rs::read_dist_info;
 use platform_tags::Tags;
@@ -104,7 +104,7 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
                     CacheBucket::BuiltWheels,
                     WheelCache::Index(&registry_source_dist.index)
                         .remote_wheel_dir(registry_source_dist.name.as_ref())
-                        .join(&registry_source_dist.file.hashes.sha256[..16]),
+                        .join(&registry_source_dist.file.distribution_id().as_str()[..16]),
                 );
 
                 self.url(
@@ -160,7 +160,7 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
                     CacheBucket::BuiltWheels,
                     WheelCache::Index(&registry_source_dist.index)
                         .remote_wheel_dir(registry_source_dist.name.as_ref())
-                        .join(&registry_source_dist.file.hashes.sha256[..16]),
+                        .join(&registry_source_dist.file.distribution_id().as_str()[..16]),
                 );
 
                 self.url_metadata(

--- a/crates/puffin-resolver/src/resolution.rs
+++ b/crates/puffin-resolver/src/resolution.rs
@@ -270,8 +270,10 @@ impl std::fmt::Display for DisplayResolutionGraph<'_> {
                     .filter(|hashes| !hashes.is_empty())
                 {
                     for hash in hashes {
-                        writeln!(f, " \\")?;
-                        write!(f, "    --hash={hash}")?;
+                        if let Some(hash) = hash.to_string() {
+                            writeln!(f, " \\")?;
+                            write!(f, "    --hash={hash}")?;
+                        }
                     }
                 }
             }

--- a/crates/pypi-types/src/simple_json.rs
+++ b/crates/pypi-types/src/simple_json.rs
@@ -85,14 +85,18 @@ impl Yanked {
 ///
 /// PEP 691 says multiple hashes can be included and the interpretation is left to the client, we
 /// only support SHA 256 atm.
-#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
 pub struct Hashes {
-    // TODO(charlie): Hashes should be optional.
-    pub sha256: String,
+    pub sha256: Option<String>,
 }
 
-impl std::fmt::Display for Hashes {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "sha256:{}", self.sha256)
+impl Hashes {
+    /// Format as `<algorithm>:<hash>`.
+    ///
+    /// Currently limited to SHA256.
+    pub fn to_string(&self) -> Option<String> {
+        self.sha256
+            .as_ref()
+            .map(|sha256| format!("sha256:{sha256}"))
     }
 }


### PR DESCRIPTION
There is no guarantee that indexes provide hashes at all or the sha256 we support specifically. [PEP 503](https://peps.python.org/pep-0503/#specification):

> The URL SHOULD include a hash in the form of a URL fragment with the following syntax: #<hashname>=<hashvalue>, where <hashname> is the lowercase name of the hash function (such as sha256) and <hashvalue> is the hex encoded digest.

We instead use the url as input to generate a hash when caching.