### PR TITLE
Remove `base` from `RegistryBuiltDist` and `RegistrySourceDist`

### DIFF
--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -47,7 +47,6 @@ use distribution_filename::WheelFilename;
 use pep440_rs::Version;
 use pep508_rs::VerbatimUrl;
 use puffin_normalize::PackageName;
-use pypi_types::BaseUrl;
 use requirements_txt::EditableRequirement;
 
 pub use crate::any::*;
@@ -153,7 +152,6 @@ pub struct RegistryBuiltDist {
     pub version: Version,
     pub file: File,
     pub index: IndexUrl,
-    pub base: BaseUrl,
 }
 
 /// A built distribution (wheel) that exists at an arbitrary URL.
@@ -180,7 +178,6 @@ pub struct RegistrySourceDist {
     pub version: Version,
     pub file: File,
     pub index: IndexUrl,
-    pub base: BaseUrl,
 }
 
 /// A source distribution that exists at an arbitrary URL.
@@ -210,13 +207,7 @@ pub struct PathSourceDist {
 
 impl Dist {
     /// Create a [`Dist`] for a registry-based distribution.
-    pub fn from_registry(
-        name: PackageName,
-        version: Version,
-        file: File,
-        index: IndexUrl,
-        base: BaseUrl,
-    ) -> Self {
+    pub fn from_registry(name: PackageName, version: Version, file: File, index: IndexUrl) -> Self {
         if Path::new(&file.filename)
             .extension()
             .is_some_and(|ext| ext.eq_ignore_ascii_case("whl"))
@@ -226,7 +217,6 @@ impl Dist {
                 version,
                 file,
                 index,
-                base,
             }))
         } else {
             Self::Source(SourceDist::Registry(RegistrySourceDist {
@@ -234,7 +224,6 @@ impl Dist {
                 version,
                 file,
                 index,
-                base,
             }))
         }
     }

--- a/crates/puffin-client/src/registry_client.rs
+++ b/crates/puffin-client/src/registry_client.rs
@@ -121,7 +121,7 @@ impl RegistryClient {
     pub async fn simple(
         &self,
         package_name: &PackageName,
-    ) -> Result<(IndexUrl, BaseUrl, SimpleMetadata), Error> {
+    ) -> Result<(IndexUrl, SimpleMetadata), Error> {
         if self.index_urls.no_index() {
             return Err(Error::NoIndex(package_name.as_ref().to_string()));
         }
@@ -174,14 +174,14 @@ impl RegistryClient {
                             let base = BaseUrl::from(url.clone());
                             let metadata =
                                 SimpleMetadata::from_files(data.files, package_name, &base);
-                            Ok((base, metadata))
+                            Ok(metadata)
                         }
                         MediaType::Html => {
                             let text = response.text().await?;
                             let SimpleHtml { base, files } = SimpleHtml::parse(&text, &url)
                                 .map_err(|err| Error::from_html_err(err, url.clone()))?;
                             let metadata = SimpleMetadata::from_files(files, package_name, &base);
-                            Ok((base, metadata))
+                            Ok(metadata)
                         }
                     }
                 }
@@ -194,7 +194,7 @@ impl RegistryClient {
 
             // Fetch from the index.
             return match result {
-                Ok((base, metadata)) => Ok((index.clone(), base, metadata)),
+                Ok(metadata) => Ok((index.clone(), metadata)),
                 Err(CachedClientError::Client(Error::RequestError(err))) => {
                     if err.status() == Some(StatusCode::NOT_FOUND) {
                         continue;

--- a/crates/puffin-dev/src/resolve_many.rs
+++ b/crates/puffin-dev/src/resolve_many.rs
@@ -47,7 +47,7 @@ async fn find_latest_version(
     client: RegistryClient,
     package_name: &PackageName,
 ) -> Option<Version> {
-    let (_, _, simple_metadata) = client.simple(package_name).await.ok()?;
+    let (_, simple_metadata) = client.simple(package_name).await.ok()?;
     let (version, _) = simple_metadata.into_iter().next()?;
     Some(version.clone())
 }

--- a/crates/puffin-resolver/src/finder.rs
+++ b/crates/puffin-resolver/src/finder.rs
@@ -53,7 +53,7 @@ impl<'a> DistFinder<'a> {
         match requirement.version_or_url.as_ref() {
             None | Some(VersionOrUrl::VersionSpecifier(_)) => {
                 // Query the index(es) (cached) to get the URLs for the available files.
-                let (index, base, metadata) = self.client.simple(&requirement.name).await?;
+                let (index, metadata) = self.client.simple(&requirement.name).await?;
 
                 // Pick a version that satisfies the requirement.
                 let Some(ParsedFile {
@@ -64,7 +64,7 @@ impl<'a> DistFinder<'a> {
                 else {
                     return Err(ResolveError::NotFound(requirement.clone()));
                 };
-                let distribution = Dist::from_registry(name, version, file, index, base);
+                let distribution = Dist::from_registry(name, version, file, index);
 
                 if let Some(reporter) = self.reporter.as_ref() {
                     reporter.on_progress(&distribution);

--- a/crates/puffin-resolver/src/resolver/provider.rs
+++ b/crates/puffin-resolver/src/resolver/provider.rs
@@ -82,12 +82,11 @@ impl<'a, Context: BuildContext + Send + Sync> ResolverProvider
     ) -> impl Future<Output = VersionMapResponse> + Send + 'io {
         self.client
             .simple(package_name)
-            .map_ok(move |(index, base, metadata)| {
+            .map_ok(move |(index, metadata)| {
                 VersionMap::from_metadata(
                     metadata,
                     package_name,
                     &index,
-                    &base,
                     self.tags,
                     &self.python_requirement,
                     &self.allowed_yanks,

--- a/crates/puffin-resolver/src/version_map.rs
+++ b/crates/puffin-resolver/src/version_map.rs
@@ -11,7 +11,7 @@ use platform_tags::{TagPriority, Tags};
 use puffin_client::SimpleMetadata;
 use puffin_normalize::PackageName;
 use puffin_warnings::warn_user_once;
-use pypi_types::{BaseUrl, Hashes, Yanked};
+use pypi_types::{Hashes, Yanked};
 
 use crate::pubgrub::PubGrubVersion;
 use crate::python_requirement::PythonRequirement;
@@ -29,7 +29,6 @@ impl VersionMap {
         metadata: SimpleMetadata,
         package_name: &PackageName,
         index: &IndexUrl,
-        base: &BaseUrl,
         tags: &Tags,
         python_requirement: &PythonRequirement,
         allowed_yanks: &AllowedYanks,
@@ -87,7 +86,6 @@ impl VersionMap {
                             filename.version.clone(),
                             file,
                             index.clone(),
-                            base.clone(),
                         );
                         match version_map.entry(version.clone().into()) {
                             Entry::Occupied(mut entry) => {
@@ -111,7 +109,6 @@ impl VersionMap {
                             filename.version.clone(),
                             file,
                             index.clone(),
-                            base.clone(),
                         );
                         match version_map.entry(version.clone().into()) {
                             Entry::Occupied(mut entry) => {


### PR DESCRIPTION
Follow-up to https://github.com/astral-sh/puffin/pull/917 i found rebasing the find-links PRs, this field became unused through the absolute URLs.