### PR TITLE
Add an extra struct around the package-to-flat index map

### DIFF
--- a/crates/puffin-cli/src/commands/pip_sync.rs
+++ b/crates/puffin-cli/src/commands/pip_sync.rs
@@ -139,8 +139,7 @@ pub(crate) async fn pip_sync(
     } else {
         let start = std::time::Instant::now();
 
-        let flat_index_files = client.flat_index().await?;
-        let flat_index = FlatIndex::from_files(flat_index_files, tags);
+        let flat_index = FlatIndex::from_files(client.flat_index().await?, tags);
 
         let wheel_finder =
             puffin_resolver::DistFinder::new(tags, &client, venv.interpreter(), &flat_index)

--- a/crates/puffin-client/src/lib.rs
+++ b/crates/puffin-client/src/lib.rs
@@ -1,6 +1,6 @@
 pub use cached_client::{CachedClient, CachedClientError, DataWithCachePolicy};
 pub use error::Error;
-pub use flat_index::FlatIndex;
+pub use flat_index::{FlatDistributions, FlatIndex, FlatIndexEntry};
 pub use registry_client::{
     read_metadata_async, RegistryClient, RegistryClientBuilder, SimpleMetadata, VersionFiles,
 };

--- a/crates/puffin-dev/src/install_many.rs
+++ b/crates/puffin-dev/src/install_many.rs
@@ -18,7 +18,7 @@ use pep508_rs::Requirement;
 use platform_host::Platform;
 use platform_tags::Tags;
 use puffin_cache::{Cache, CacheArgs};
-use puffin_client::{RegistryClient, RegistryClientBuilder};
+use puffin_client::{FlatIndex, RegistryClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
 use puffin_distribution::RegistryWheelIndex;
 use puffin_installer::Downloader;
@@ -104,7 +104,7 @@ async fn install_chunk(
     index_locations: &IndexLocations,
 ) -> Result<()> {
     let resolution: Vec<_> =
-        DistFinder::new(tags, client, venv.interpreter(), &FxHashMap::default())
+        DistFinder::new(tags, client, venv.interpreter(), &FlatIndex::default())
             .resolve_stream(requirements)
             .collect()
             .await;

--- a/crates/puffin-resolver/src/finder.rs
+++ b/crates/puffin-resolver/src/finder.rs
@@ -10,7 +10,7 @@ use distribution_filename::DistFilename;
 use distribution_types::{Dist, IndexUrl, Resolution};
 use pep508_rs::{Requirement, VersionOrUrl};
 use platform_tags::Tags;
-use puffin_client::{FlatIndex, RegistryClient, SimpleMetadata};
+use puffin_client::{FlatDistributions, FlatIndex, RegistryClient, SimpleMetadata};
 use puffin_interpreter::Interpreter;
 use puffin_normalize::PackageName;
 
@@ -21,7 +21,7 @@ pub struct DistFinder<'a> {
     client: &'a RegistryClient,
     reporter: Option<Box<dyn Reporter>>,
     interpreter: &'a Interpreter,
-    flat_index: &'a FxHashMap<PackageName, FlatIndex>,
+    flat_index: &'a FlatIndex,
 }
 
 impl<'a> DistFinder<'a> {
@@ -30,7 +30,7 @@ impl<'a> DistFinder<'a> {
         tags: &'a Tags,
         client: &'a RegistryClient,
         interpreter: &'a Interpreter,
-        flat_index: &'a FxHashMap<PackageName, FlatIndex>,
+        flat_index: &'a FlatIndex,
     ) -> Self {
         Self {
             tags,
@@ -56,7 +56,7 @@ impl<'a> DistFinder<'a> {
     async fn resolve_requirement(
         &self,
         requirement: &Requirement,
-        flat_index: Option<&FlatIndex>,
+        flat_index: Option<&FlatDistributions>,
     ) -> Result<(PackageName, Dist), ResolveError> {
         match requirement.version_or_url.as_ref() {
             None | Some(VersionOrUrl::VersionSpecifier(_)) => {
@@ -118,7 +118,7 @@ impl<'a> DistFinder<'a> {
         requirement: &Requirement,
         metadata: SimpleMetadata,
         index: &IndexUrl,
-        flat_index: Option<&FlatIndex>,
+        flat_index: Option<&FlatDistributions>,
     ) -> Option<Dist> {
         // Prioritize the flat index by initializing the "best" matches with its entries.
         let matching_override = if let Some(flat_index) = flat_index {

--- a/crates/puffin-resolver/src/resolver/mod.rs
+++ b/crates/puffin-resolver/src/resolver/mod.rs
@@ -24,7 +24,7 @@ use distribution_types::{
 use pep440_rs::{Version, VersionSpecifiers, MIN_VERSION};
 use pep508_rs::{MarkerEnvironment, Requirement};
 use platform_tags::Tags;
-use puffin_client::RegistryClient;
+use puffin_client::{FlatIndex, RegistryClient};
 use puffin_distribution::DistributionDatabase;
 use puffin_interpreter::Interpreter;
 use puffin_normalize::PackageName;
@@ -89,6 +89,7 @@ impl<'a, Context: BuildContext + Send + Sync> Resolver<'a, DefaultResolverProvid
         let provider = DefaultResolverProvider::new(
             client,
             DistributionDatabase::new(build_context.cache(), tags, client, build_context),
+            FlatIndex::from_files(client.flat_index().await?, tags),
             tags,
             PythonRequirement::new(interpreter, markers),
             options.exclude_newer,
@@ -97,8 +98,7 @@ impl<'a, Context: BuildContext + Send + Sync> Resolver<'a, DefaultResolverProvid
                 .iter()
                 .chain(manifest.constraints.iter())
                 .collect(),
-        )
-        .await?;
+        );
         Ok(Self::new_custom_io(
             manifest,
             options,

--- a/crates/puffin-resolver/src/version_map.rs
+++ b/crates/puffin-resolver/src/version_map.rs
@@ -8,7 +8,7 @@ use distribution_filename::DistFilename;
 use distribution_types::{Dist, IndexUrl, PrioritizedDistribution, ResolvableDist};
 use pep440_rs::Version;
 use platform_tags::Tags;
-use puffin_client::{FlatIndex, SimpleMetadata};
+use puffin_client::{FlatDistributions, SimpleMetadata};
 use puffin_normalize::PackageName;
 use puffin_warnings::warn_user_once;
 use pypi_types::{Hashes, Yanked};
@@ -32,11 +32,11 @@ impl VersionMap {
         python_requirement: &PythonRequirement,
         allowed_yanks: &AllowedYanks,
         exclude_newer: Option<&DateTime<Utc>>,
-        flat_index: Option<FlatIndex>,
+        flat_index: Option<FlatDistributions>,
     ) -> Self {
         // If we have packages of the same name from find links, gives them priority, otherwise start empty
         let mut version_map: BTreeMap<Version, PrioritizedDistribution> =
-            flat_index.map(|overrides| overrides.0).unwrap_or_default();
+            flat_index.map(Into::into).unwrap_or_default();
 
         // Collect compatible distributions.
         for (version, files) in metadata {
@@ -155,8 +155,8 @@ impl VersionMap {
     }
 }
 
-impl From<FlatIndex> for VersionMap {
-    fn from(flat_index: FlatIndex) -> Self {
-        Self(flat_index.0)
+impl From<FlatDistributions> for VersionMap {
+    fn from(flat_index: FlatDistributions) -> Self {
+        Self(flat_index.into())
     }
 }


### PR DESCRIPTION
## Summary

`FlatIndex` is now the thing that's keyed on `PackageName`, while `FlatDistributions` is what used to be called `FlatIndex` (a map from version to `PrioritizedDistribution`, for a single package). I find this a bit clearer, since we can also remove the `from_files` that doesn't return `Self`, which I had trouble following.