### PR TITLE
Use fs_err in more places

### DIFF
--- a/crates/puffin-distribution/src/distribution_database.rs
+++ b/crates/puffin-distribution/src/distribution_database.rs
@@ -159,7 +159,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                 );
                 fs::create_dir_all(&cache_entry.dir()).await?;
                 let target = cache_entry.into_path_buf();
-                tokio::fs::rename(temp_target, &target).await?;
+                fs_err::tokio::rename(temp_target, &target).await?;
 
                 Ok(LocalWheel::Unzipped(UnzippedWheel {
                     dist: dist.clone(),
@@ -184,7 +184,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                 );
                 fs::create_dir_all(&cache_entry.dir()).await?;
                 let target = cache_entry.into_path_buf();
-                tokio::fs::rename(temp_target, &target).await?;
+                fs_err::tokio::rename(temp_target, &target).await?;
 
                 let local_wheel = LocalWheel::Unzipped(UnzippedWheel {
                     dist: dist.clone(),

--- a/crates/puffin-distribution/src/source/mod.rs
+++ b/crates/puffin-distribution/src/source/mod.rs
@@ -834,7 +834,7 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
         // Download the source distribution to a temporary file.
         let sdist_file = temp_dir.path().join(source_dist_filename);
         let mut writer = tokio::io::BufWriter::new(
-            tokio::fs::File::create(&sdist_file)
+            fs_err::tokio::File::create(&sdist_file)
                 .await
                 .map_err(puffin_client::Error::CacheWrite)?,
         );

--- a/crates/puffin-extract/Cargo.toml
+++ b/crates/puffin-extract/Cargo.toml
@@ -16,9 +16,9 @@ workspace = true
 tokio-util = { workspace = true, features = ["compat"] }
 async_zip = { workspace = true, features = ["tokio"] }
 flate2 = { workspace = true }
-fs-err = { workspace = true }
+fs-err = { workspace = true, features = ["tokio"] }
 rayon = { workspace = true }
 tar = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["io-util"] }
 zip = { workspace = true }

--- a/crates/puffin-extract/src/lib.rs
+++ b/crates/puffin-extract/src/lib.rs
@@ -44,12 +44,12 @@ pub async fn unzip_no_seek<R: tokio::io::AsyncRead + Unpin>(
 
         // Create dir or write file
         if is_dir {
-            tokio::fs::create_dir_all(path).await?;
+            fs_err::tokio::create_dir_all(path).await?;
         } else {
             if let Some(parent) = path.parent() {
-                tokio::fs::create_dir_all(parent).await?;
+                fs_err::tokio::create_dir_all(parent).await?;
             }
-            let file = tokio::fs::File::create(path).await?;
+            let file = fs_err::tokio::File::create(path).await?;
             let mut writer = tokio::io::BufWriter::new(file);
             let mut reader = entry.reader_mut().compat();
             tokio::io::copy(&mut reader, &mut writer).await?;


### PR DESCRIPTION
Before:

```
error: Failed to download distributions
  Caused by: Failed to fetch wheel: jaxlib==0.4.23+cuda12.cudnn89
  Caused by: Directory not empty (os error 39)
```

After:

```
error: Failed to download distributions
  Caused by: Failed to fetch wheel: jaxlib==0.4.23+cuda12.cudnn89
  Caused by: failed to rename file from /home/konsti/.cache/puffin/.tmpcG7tVP/jaxlib-0.4.23+cuda12.cudnn89-cp310-cp310-manylinux2014_x86_64.whl to /home/konsti/.cache/puffin/wheels-v0/index/9ff50b883297fa9d/jaxlib/jaxlib-0.4.23+cuda12.cudnn89-cp310-cp310-manylinux2014_x86_64
  Caused by: Directory not empty (os error 39)
```