### PR TITLE
Share flat index across resolutions

### DIFF
--- a/crates/puffin-client/src/flat_index.rs
+++ b/crates/puffin-client/src/flat_index.rs
@@ -1,19 +1,172 @@
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 
+use reqwest::Response;
 use rustc_hash::FxHashMap;
-use tracing::instrument;
+use tracing::{debug, info_span, instrument, warn, Instrument};
+use url::Url;
 
 use distribution_filename::DistFilename;
 use distribution_types::{
-    BuiltDist, Dist, File, IndexUrl, PrioritizedDistribution, RegistryBuiltDist,
-    RegistrySourceDist, SourceDist,
+    BuiltDist, Dist, File, FileLocation, FlatIndexLocation, IndexUrl, PrioritizedDistribution,
+    RegistryBuiltDist, RegistrySourceDist, SourceDist,
 };
 use pep440_rs::Version;
+use pep508_rs::VerbatimUrl;
 use platform_tags::Tags;
+use puffin_cache::{Cache, CacheBucket};
 use puffin_normalize::PackageName;
+use pypi_types::Hashes;
 
-pub type FlatIndexEntry = (DistFilename, File, IndexUrl);
+use crate::html::SimpleHtml;
+use crate::{Error, RegistryClient};
+
+type FlatIndexEntry = (DistFilename, File, IndexUrl);
+
+/// A client for reading distributions from `--find-links` entries (either local directories or
+/// remote HTML indexes).
+#[derive(Debug, Clone)]
+pub struct FlatIndexClient<'a> {
+    client: &'a RegistryClient,
+    cache: &'a Cache,
+}
+
+impl<'a> FlatIndexClient<'a> {
+    /// Create a new [`FlatIndexClient`].
+    pub fn new(client: &'a RegistryClient, cache: &'a Cache) -> Self {
+        Self { client, cache }
+    }
+
+    /// Read the directories and flat remote indexes from `--find-links`.
+    #[allow(clippy::result_large_err)]
+    pub async fn fetch(
+        &self,
+        indexes: impl Iterator<Item = &FlatIndexLocation>,
+    ) -> Result<Vec<FlatIndexEntry>, Error> {
+        let mut dists = Vec::new();
+        // TODO(konstin): Parallelize reads over flat indexes.
+        for flat_index in indexes {
+            let index_dists = match flat_index {
+                FlatIndexLocation::Path(path) => {
+                    Self::read_from_directory(path).map_err(Error::FindLinks)?
+                }
+                FlatIndexLocation::Url(url) => self.read_from_url(url).await?,
+            };
+            if index_dists.is_empty() {
+                warn!("No packages found in `--find-links` entry: {}", flat_index);
+            } else {
+                debug!(
+                    "Found {} package{} in `--find-links` entry: {}",
+                    index_dists.len(),
+                    if index_dists.len() == 1 { "" } else { "s" },
+                    flat_index
+                );
+            }
+            dists.extend(index_dists);
+        }
+        Ok(dists)
+    }
+
+    /// Read a flat remote index from a `--find-links` URL.
+    async fn read_from_url(&self, url: &Url) -> Result<Vec<FlatIndexEntry>, Error> {
+        let cache_entry = self.cache.entry(
+            CacheBucket::FlatIndex,
+            "html",
+            format!("{}.msgpack", cache_key::digest(&url.to_string())),
+        );
+        let cached_client = self.client.cached_client();
+
+        let flat_index_request = cached_client
+            .uncached()
+            .get(url.clone())
+            .header("Accept-Encoding", "gzip")
+            .header("Accept", "text/html")
+            .build()?;
+        let parse_simple_response = |response: Response| {
+            async {
+                let text = response.text().await?;
+                let SimpleHtml { base, files } = SimpleHtml::parse(&text, url)
+                    .map_err(|err| Error::from_html_err(err, url.clone()))?;
+
+                let files: Vec<File> = files
+                    .into_iter()
+                    .filter_map(|file| {
+                        match File::try_from(file, &base) {
+                            Ok(file) => Some(file),
+                            Err(err) => {
+                                // Ignore files with unparseable version specifiers.
+                                warn!("Skipping file in {url}: {err}");
+                                None
+                            }
+                        }
+                    })
+                    .collect();
+                Ok(files)
+            }
+            .instrument(info_span!("parse_flat_index_html", url = % url))
+        };
+        let files = cached_client
+            .get_cached_with_callback(flat_index_request, &cache_entry, parse_simple_response)
+            .await?;
+        Ok(files
+            .into_iter()
+            .filter_map(|file| {
+                Some((
+                    DistFilename::try_from_normalized_filename(&file.filename)?,
+                    file,
+                    IndexUrl::Url(url.clone()),
+                ))
+            })
+            .collect())
+    }
+
+    /// Read a flat remote index from a `--find-links` directory.
+    fn read_from_directory(path: &PathBuf) -> Result<Vec<FlatIndexEntry>, std::io::Error> {
+        // Absolute paths are required for the URL conversion.
+        let path = fs_err::canonicalize(path)?;
+        let url = Url::from_directory_path(&path).expect("URL is already absolute");
+        let url = VerbatimUrl::unknown(url);
+
+        let mut dists = Vec::new();
+        for entry in fs_err::read_dir(&path)? {
+            let entry = entry?;
+            let metadata = entry.metadata()?;
+            if !metadata.is_file() {
+                continue;
+            }
+
+            let Ok(filename) = entry.file_name().into_string() else {
+                warn!(
+                    "Skipping non-UTF-8 filename in `--find-links` directory: {}",
+                    entry.file_name().to_string_lossy()
+                );
+                continue;
+            };
+
+            let file = File {
+                dist_info_metadata: None,
+                filename: filename.to_string(),
+                hashes: Hashes { sha256: None },
+                requires_python: None,
+                size: None,
+                upload_time: None,
+                url: FileLocation::Path(entry.path().to_path_buf(), url.clone()),
+                yanked: None,
+            };
+
+            let Some(filename) = DistFilename::try_from_normalized_filename(&filename) else {
+                debug!(
+                    "Ignoring `--find-links` entry (expected a wheel or source distribution filename): {}",
+                    entry.path().display()
+                );
+                continue;
+            };
+            dists.push((filename, file, IndexUrl::Pypi));
+        }
+        Ok(dists)
+    }
+}
 
 /// A set of [`PrioritizedDistribution`] from a `--find-links` entry, indexed by [`PackageName`]
 /// and [`Version`].
@@ -23,11 +176,11 @@ pub struct FlatIndex(FxHashMap<PackageName, FlatDistributions>);
 impl FlatIndex {
     /// Collect all files from a `--find-links` target into a [`FlatIndex`].
     #[instrument(skip_all)]
-    pub fn from_files(dists: Vec<FlatIndexEntry>, tags: &Tags) -> Self {
+    pub fn from_entries(entries: Vec<FlatIndexEntry>, tags: &Tags) -> Self {
         let mut flat_index = FxHashMap::default();
 
         // Collect compatible distributions.
-        for (filename, file, index) in dists {
+        for (filename, file, index) in entries {
             let distributions = flat_index.entry(filename.name().clone()).or_default();
             Self::add_file(distributions, file, filename, tags, index);
         }

--- a/crates/puffin-client/src/lib.rs
+++ b/crates/puffin-client/src/lib.rs
@@ -1,6 +1,6 @@
 pub use cached_client::{CachedClient, CachedClientError, DataWithCachePolicy};
 pub use error::Error;
-pub use flat_index::{FlatDistributions, FlatIndex, FlatIndexEntry};
+pub use flat_index::{FlatDistributions, FlatIndex, FlatIndexClient};
 pub use registry_client::{
     read_metadata_async, RegistryClient, RegistryClientBuilder, SimpleMetadata, VersionFiles,
 };

--- a/crates/puffin-dev/src/build.rs
+++ b/crates/puffin-dev/src/build.rs
@@ -9,7 +9,7 @@ use distribution_types::IndexLocations;
 use platform_host::Platform;
 use puffin_build::{SourceBuild, SourceBuildContext};
 use puffin_cache::{Cache, CacheArgs};
-use puffin_client::RegistryClientBuilder;
+use puffin_client::{FlatIndex, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
 use puffin_interpreter::Virtualenv;
 use puffin_traits::{BuildContext, BuildKind, SetupPyStrategy};
@@ -55,6 +55,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
     let venv = Virtualenv::from_env(platform, &cache)?;
     let client = RegistryClientBuilder::new(cache.clone()).build();
     let index_urls = IndexLocations::default();
+    let flat_index = FlatIndex::default();
     let setup_py = SetupPyStrategy::default();
 
     let build_dispatch = BuildDispatch::new(
@@ -62,6 +63,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
         &cache,
         venv.interpreter(),
         &index_urls,
+        &flat_index,
         venv.python_executable(),
         setup_py,
         false,

--- a/crates/puffin-dev/src/install_many.rs
+++ b/crates/puffin-dev/src/install_many.rs
@@ -60,6 +60,7 @@ pub(crate) async fn install_many(args: InstallManyArgs) -> Result<()> {
     let venv = Virtualenv::from_env(platform, &cache)?;
     let client = RegistryClientBuilder::new(cache.clone()).build();
     let index_locations = IndexLocations::default();
+    let flat_index = FlatIndex::default();
     let setup_py = SetupPyStrategy::default();
     let tags = venv.interpreter().tags()?;
 
@@ -68,6 +69,7 @@ pub(crate) async fn install_many(args: InstallManyArgs) -> Result<()> {
         &cache,
         venv.interpreter(),
         &index_locations,
+        &flat_index,
         venv.python_executable(),
         setup_py,
         args.no_build,

--- a/crates/puffin-dev/src/resolve_many.rs
+++ b/crates/puffin-dev/src/resolve_many.rs
@@ -16,7 +16,7 @@ use pep440_rs::{Version, VersionSpecifier, VersionSpecifiers};
 use pep508_rs::{Requirement, VersionOrUrl};
 use platform_host::Platform;
 use puffin_cache::{Cache, CacheArgs};
-use puffin_client::{RegistryClient, RegistryClientBuilder};
+use puffin_client::{FlatIndex, RegistryClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
 use puffin_interpreter::Virtualenv;
 use puffin_normalize::PackageName;
@@ -74,6 +74,7 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
     let venv = Virtualenv::from_env(platform, &cache)?;
     let client = RegistryClientBuilder::new(cache.clone()).build();
     let index_locations = IndexLocations::default();
+    let flat_index = FlatIndex::default();
     let setup_py = SetupPyStrategy::default();
 
     let build_dispatch = BuildDispatch::new(
@@ -81,6 +82,7 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
         &cache,
         venv.interpreter(),
         &index_locations,
+        &flat_index,
         venv.python_executable(),
         setup_py,
         args.no_build,

--- a/crates/puffin-resolver/src/resolver/mod.rs
+++ b/crates/puffin-resolver/src/resolver/mod.rs
@@ -77,19 +77,21 @@ impl<'a, Context: BuildContext + Send + Sync> Resolver<'a, DefaultResolverProvid
     /// Initialize a new resolver using the default backend doing real requests.
     ///
     /// Reads the flat index entries.
-    pub async fn new(
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
         manifest: Manifest,
         options: ResolutionOptions,
         markers: &'a MarkerEnvironment,
         interpreter: &'a Interpreter,
         tags: &'a Tags,
         client: &'a RegistryClient,
+        flat_index: &'a FlatIndex,
         build_context: &'a Context,
-    ) -> Result<Self, puffin_client::Error> {
+    ) -> Self {
         let provider = DefaultResolverProvider::new(
             client,
             DistributionDatabase::new(build_context.cache(), tags, client, build_context),
-            FlatIndex::from_files(client.flat_index().await?, tags),
+            flat_index,
             tags,
             PythonRequirement::new(interpreter, markers),
             options.exclude_newer,
@@ -99,13 +101,13 @@ impl<'a, Context: BuildContext + Send + Sync> Resolver<'a, DefaultResolverProvid
                 .chain(manifest.constraints.iter())
                 .collect(),
         );
-        Ok(Self::new_custom_io(
+        Self::new_custom_io(
             manifest,
             options,
             markers,
             PythonRequirement::new(interpreter, markers),
             provider,
-        ))
+        )
     }
 }
 

--- a/crates/puffin-resolver/src/resolver/provider.rs
+++ b/crates/puffin-resolver/src/resolver/provider.rs
@@ -50,7 +50,7 @@ pub struct DefaultResolverProvider<'a, Context: BuildContext + Send + Sync> {
     /// The [`DistributionDatabase`] used to build source distributions.
     fetcher: DistributionDatabase<'a, Context>,
     /// These are the entries from `--find-links` that act as overrides for index responses.
-    flat_index: FlatIndex,
+    flat_index: &'a FlatIndex,
     tags: &'a Tags,
     python_requirement: PythonRequirement<'a>,
     exclude_newer: Option<DateTime<Utc>>,
@@ -62,7 +62,7 @@ impl<'a, Context: BuildContext + Send + Sync> DefaultResolverProvider<'a, Contex
     pub fn new(
         client: &'a RegistryClient,
         fetcher: DistributionDatabase<'a, Context>,
-        flat_index: FlatIndex,
+        flat_index: &'a FlatIndex,
         tags: &'a Tags,
         python_requirement: PythonRequirement<'a>,
         exclude_newer: Option<DateTime<Utc>>,

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -15,7 +15,7 @@ use pep508_rs::{MarkerEnvironment, Requirement, StringVersion};
 use platform_host::{Arch, Os, Platform};
 use platform_tags::Tags;
 use puffin_cache::Cache;
-use puffin_client::RegistryClientBuilder;
+use puffin_client::{FlatIndex, RegistryClientBuilder};
 use puffin_interpreter::{Interpreter, Virtualenv};
 use puffin_resolver::{
     DisplayResolutionGraph, Manifest, PreReleaseMode, ResolutionGraph, ResolutionMode,
@@ -100,6 +100,7 @@ async fn resolve(
     tags: &Tags,
 ) -> Result<ResolutionGraph> {
     let client = RegistryClientBuilder::new(Cache::temp()?).build();
+    let flat_index = FlatIndex::default();
     let interpreter = Interpreter::artificial(
         Platform::current()?,
         markers.clone(),
@@ -118,9 +119,9 @@ async fn resolve(
         &interpreter,
         tags,
         &client,
+        &flat_index,
         &build_context,
-    )
-    .await?;
+    );
     Ok(resolver.resolve().await?)
 }
 


### PR DESCRIPTION
## Summary

This PR restructures the flat index fetching in a few ways:

1. It now lives in its own `FlatIndexClient`, since it felt a bit awkward (in my opinion) for it to live in `RegistryClient`.
2. We now fetch the `FlatIndex` outside of the resolver. This has a few benefits: (1) the resolver construct is no longer `async` and no longer returns `Result`, which feels better for a resolver; and (2) we can share the `FlatIndex` across resolutions rather than re-fetching it for every source distribution build.