### PR TITLE
Share in-flight map across resolutions

### DIFF
--- a/crates/puffin-cli/src/commands/venv.rs
+++ b/crates/puffin-cli/src/commands/venv.rs
@@ -15,7 +15,7 @@ use puffin_cache::Cache;
 use puffin_client::{FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
 use puffin_interpreter::Interpreter;
-use puffin_traits::{BuildContext, SetupPyStrategy};
+use puffin_traits::{BuildContext, InFlight, SetupPyStrategy};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -139,6 +139,9 @@ async fn venv_impl(
             FlatIndex::from_entries(entries, tags)
         };
 
+        // Track in-flight downloads, builds, etc., across resolutions.
+        let in_flight = InFlight::default();
+
         // Prep the build context.
         let build_dispatch = BuildDispatch::new(
             &client,
@@ -146,6 +149,7 @@ async fn venv_impl(
             interpreter,
             index_locations,
             &flat_index,
+            &in_flight,
             venv.python_executable(),
             SetupPyStrategy::default(),
             true,

--- a/crates/puffin-dev/src/build.rs
+++ b/crates/puffin-dev/src/build.rs
@@ -12,7 +12,7 @@ use puffin_cache::{Cache, CacheArgs};
 use puffin_client::{FlatIndex, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
 use puffin_interpreter::Virtualenv;
-use puffin_traits::{BuildContext, BuildKind, SetupPyStrategy};
+use puffin_traits::{BuildContext, BuildKind, InFlight, SetupPyStrategy};
 
 #[derive(Parser)]
 pub(crate) struct BuildArgs {
@@ -57,6 +57,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
     let index_urls = IndexLocations::default();
     let flat_index = FlatIndex::default();
     let setup_py = SetupPyStrategy::default();
+    let in_flight = InFlight::default();
 
     let build_dispatch = BuildDispatch::new(
         &client,
@@ -64,6 +65,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
         venv.interpreter(),
         &index_urls,
         &flat_index,
+        &in_flight,
         venv.python_executable(),
         setup_py,
         false,

--- a/crates/puffin-dev/src/resolve_cli.rs
+++ b/crates/puffin-dev/src/resolve_cli.rs
@@ -17,7 +17,7 @@ use puffin_client::{FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
 use puffin_interpreter::Virtualenv;
 use puffin_resolver::{Manifest, ResolutionOptions, Resolver};
-use puffin_traits::SetupPyStrategy;
+use puffin_traits::{InFlight, SetupPyStrategy};
 
 #[derive(ValueEnum, Default, Clone)]
 pub(crate) enum ResolveCliFormat {
@@ -65,6 +65,7 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
         let entries = client.fetch(index_locations.flat_indexes()).await?;
         FlatIndex::from_entries(entries, venv.interpreter().tags()?)
     };
+    let in_flight = InFlight::default();
 
     let build_dispatch = BuildDispatch::new(
         &client,
@@ -72,6 +73,7 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
         venv.interpreter(),
         &index_locations,
         &flat_index,
+        &in_flight,
         venv.python_executable(),
         SetupPyStrategy::default(),
         args.no_build,

--- a/crates/puffin-dev/src/resolve_many.rs
+++ b/crates/puffin-dev/src/resolve_many.rs
@@ -20,7 +20,7 @@ use puffin_client::{FlatIndex, RegistryClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
 use puffin_interpreter::Virtualenv;
 use puffin_normalize::PackageName;
-use puffin_traits::{BuildContext, SetupPyStrategy};
+use puffin_traits::{BuildContext, InFlight, SetupPyStrategy};
 
 #[derive(Parser)]
 pub(crate) struct ResolveManyArgs {
@@ -76,6 +76,7 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
     let index_locations = IndexLocations::default();
     let flat_index = FlatIndex::default();
     let setup_py = SetupPyStrategy::default();
+    let in_flight = InFlight::default();
 
     let build_dispatch = BuildDispatch::new(
         &client,
@@ -83,6 +84,7 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
         venv.interpreter(),
         &index_locations,
         &flat_index,
+        &in_flight,
         venv.python_executable(),
         setup_py,
         args.no_build,

--- a/crates/puffin-traits/src/lib.rs
+++ b/crates/puffin-traits/src/lib.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
-use distribution_types::Resolution;
+use distribution_types::{CachedDist, DistributionId, Resolution};
 pub use once_map::OnceMap;
 use pep508_rs::Requirement;
 use puffin_cache::Cache;
@@ -122,6 +122,12 @@ pub trait SourceBuildTrait {
     /// Returns the filename of the built wheel inside the given `wheel_dir`.
     fn wheel<'a>(&'a self, wheel_dir: &'a Path)
         -> impl Future<Output = Result<String>> + Send + 'a;
+}
+
+#[derive(Default)]
+pub struct InFlight {
+    /// The in-flight distribution downloads.
+    pub downloads: OnceMap<DistributionId, Result<CachedDist, String>>,
 }
 
 /// The strategy to use when building source distributions that lack a `pyproject.toml`.


### PR DESCRIPTION
## Summary

This PR fixes a subtle bug in `pip install` when using `--reinstall`. If a package depends on a build system directly (e.g., `waitress` depends on `setuptools`), and then you have other packages that also need the build system to build a source distribution, right now, we don't share the `OnceMap` between those cases.

This lifts the `InFlight` tracking up a level, so that it's initialized once per command, then shared everywhere.

## Test Plan

I'm having trouble coming up with an identical test-case and hesitant to add this slow test to the suite... But if you run `pip install --reinstall` with:

```
waitress @ git+https://github.com/zanieb/waitress
devpi-server @ git+https://github.com/zanieb/devpi#subdirectory=server
```

It fails consistently on `main` and passes here.