### PR TITLE
Remove clone from `RegistryWheelIndex`

### DIFF
--- a/crates/puffin-dev/src/install_many.rs
+++ b/crates/puffin-dev/src/install_many.rs
@@ -142,16 +142,16 @@ async fn install_chunk(
         .collect::<Vec<_>>();
 
     let mut registry_index = RegistryWheelIndex::new(build_dispatch.cache(), tags, index_locations);
-    let (cached, uncached): (Vec<_>, Vec<_>) = dists.into_iter().partition_map(|dist| {
+    let (cached, uncached): (Vec<_>, Vec<_>) = dists.iter().partition_map(|dist| {
         // We always want the wheel for the latest version not whatever matching is in cache.
         let VersionOrUrl::Version(version) = dist.version_or_url() else {
-            unreachable!();
+            unreachable!("Only registry distributions are supported");
         };
 
         if let Some(cached) = registry_index.get_version(dist.name(), version) {
             Either::Left(CachedDist::Registry(cached.clone()))
         } else {
-            Either::Right(dist)
+            Either::Right(dist.clone())
         }
     });
     info!("Cached: {}, Uncached {}", cached.len(), uncached.len());

--- a/crates/puffin-distribution/src/index/registry_wheel_index.rs
+++ b/crates/puffin-distribution/src/index/registry_wheel_index.rs
@@ -19,7 +19,7 @@ pub struct RegistryWheelIndex<'a> {
     cache: &'a Cache,
     tags: &'a Tags,
     index_locations: &'a IndexLocations,
-    index: FxHashMap<PackageName, BTreeMap<Version, CachedRegistryDist>>,
+    index: FxHashMap<&'a PackageName, BTreeMap<Version, CachedRegistryDist>>,
 }
 
 impl<'a> RegistryWheelIndex<'a> {
@@ -38,7 +38,7 @@ impl<'a> RegistryWheelIndex<'a> {
     /// If the package is not yet indexed, this will index the package by reading from the cache.
     pub fn get(
         &mut self,
-        name: &PackageName,
+        name: &'a PackageName,
     ) -> impl Iterator<Item = (&Version, &CachedRegistryDist)> {
         self.get_impl(name).iter().rev()
     }
@@ -48,15 +48,15 @@ impl<'a> RegistryWheelIndex<'a> {
     /// If the package is not yet indexed, this will index the package by reading from the cache.
     pub fn get_version(
         &mut self,
-        name: &PackageName,
+        name: &'a PackageName,
         version: &Version,
     ) -> Option<&CachedRegistryDist> {
         self.get_impl(name).get(version)
     }
 
     /// Get an entry in the index.
-    fn get_impl(&mut self, name: &PackageName) -> &BTreeMap<Version, CachedRegistryDist> {
-        let versions = match self.index.entry(name.clone()) {
+    fn get_impl(&mut self, name: &'a PackageName) -> &BTreeMap<Version, CachedRegistryDist> {
+        let versions = match self.index.entry(name) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => entry.insert(Self::index(
                 name,


### PR DESCRIPTION
Doesn't need to own the package names.