### PR TITLE
Initial windows support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
 dependencies = [
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.4",
  "serde",
 ]
 
@@ -1115,7 +1115,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.4",
  "regex-syntax 0.8.2",
 ]
 
@@ -1378,7 +1378,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.4",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -2267,6 +2267,7 @@ dependencies = [
  "clap",
  "distribution-filename",
  "distribution-types",
+ "filetime",
  "flate2",
  "fs-err",
  "futures",
@@ -2300,6 +2301,7 @@ dependencies = [
  "puffin-workspace",
  "pypi-types",
  "pyproject-toml",
+ "regex",
  "requirements-txt",
  "reqwest",
  "rustc-hash",
@@ -2948,13 +2950,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.4",
  "regex-syntax 0.8.2",
 ]
 
@@ -2969,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -864,8 +864,22 @@ mod test {
     /// Ensure that we don't accidentally grow the `Dist` sizes.
     #[test]
     fn dist_size() {
-        assert!(std::mem::size_of::<Dist>() <= 240);
-        assert!(std::mem::size_of::<BuiltDist>() <= 240);
-        assert!(std::mem::size_of::<SourceDist>() <= 168);
+        // At time of writing, Unix is at 240, Windows is at 248.
+        assert!(
+            std::mem::size_of::<Dist>() <= 248,
+            "{}",
+            std::mem::size_of::<Dist>()
+        );
+        assert!(
+            std::mem::size_of::<BuiltDist>() <= 248,
+            "{}",
+            std::mem::size_of::<BuiltDist>()
+        );
+        // At time of writing, unix is at 168, windows is at 176.
+        assert!(
+            std::mem::size_of::<SourceDist>() <= 176,
+            "{}",
+            std::mem::size_of::<SourceDist>()
+        );
     }
 }

--- a/crates/gourgeist/src/activator/activate.ps1
+++ b/crates/gourgeist/src/activator/activate.ps1
@@ -46,7 +46,7 @@ else {
 
 New-Variable -Scope global -Name _OLD_VIRTUAL_PATH -Value $env:PATH
 
-$env:PATH = "$env:VIRTUAL_ENV/bin:" + $env:PATH
+$env:PATH = "$env:VIRTUAL_ENV/{{ BIN_NAME }};" + $env:PATH
 if (!$env:VIRTUAL_ENV_DISABLE_PROMPT) {
     function global:_old_virtual_prompt {
         ""

--- a/crates/install-wheel-rs/src/install_location.rs
+++ b/crates/install-wheel-rs/src/install_location.rs
@@ -89,11 +89,13 @@ impl<T: AsRef<Path>> InstallLocation<T> {
 
     /// Returns the location of the `python` interpreter.
     pub fn python(&self) -> PathBuf {
-        if cfg!(windows) {
-            self.venv_root.as_ref().join("Scripts").join("python.exe")
-        } else {
+        if cfg!(unix) {
             // canonicalize on python would resolve the symlink
             self.venv_root.as_ref().join("bin").join("python")
+        } else if cfg!(windows) {
+            self.venv_root.as_ref().join("Scripts").join("python.exe")
+        } else {
+            unimplemented!("Only Windows and Unix are supported")
         }
     }
 

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -731,9 +731,9 @@ impl MarkerExpression {
     /// # use std::str::FromStr;
     /// # use pep508_rs::{MarkerTree, Pep508Error};
     /// # use pep440_rs::Version;
+    /// # use puffin_normalize::ExtraName;
     ///
     /// # fn main() -> Result<(), Pep508Error> {
-    /// use puffin_normalize::ExtraName;
     /// let marker_tree = MarkerTree::from_str(r#"("linux" in sys_platform) and extra == 'day'"#)?;
     /// let versions: Vec<Version> = (8..12).map(|minor| Version::new([3, minor])).collect();
     /// assert!(marker_tree.evaluate_extras_and_python_version(&[ExtraName::from_str("day").unwrap()].into(), &versions));

--- a/crates/puffin-interpreter/src/get_interpreter_info.py
+++ b/crates/puffin-interpreter/src/get_interpreter_info.py
@@ -2,6 +2,7 @@ import json
 import os
 import platform
 import sys
+import sysconfig
 
 
 def format_full_version(info):
@@ -35,6 +36,7 @@ interpreter_info = {
     "markers": markers,
     "base_prefix": sys.base_prefix,
     "base_exec_prefix": sys.base_exec_prefix,
+    "stdlib": sysconfig.get_path("stdlib"),
     "sys_executable": sys.executable,
 }
 print(json.dumps(interpreter_info))

--- a/crates/puffin-interpreter/src/interpreter.rs
+++ b/crates/puffin-interpreter/src/interpreter.rs
@@ -26,6 +26,7 @@ pub struct Interpreter {
     pub(crate) markers: MarkerEnvironment,
     pub(crate) base_exec_prefix: PathBuf,
     pub(crate) base_prefix: PathBuf,
+    pub(crate) stdlib: PathBuf,
     pub(crate) sys_executable: PathBuf,
     tags: OnceCell<Tags>,
 }
@@ -51,6 +52,7 @@ impl Interpreter {
             markers: info.markers,
             base_exec_prefix: info.base_exec_prefix,
             base_prefix: info.base_prefix,
+            stdlib: info.stdlib,
             sys_executable: info.sys_executable,
             tags: OnceCell::new(),
         })
@@ -63,12 +65,14 @@ impl Interpreter {
         base_exec_prefix: PathBuf,
         base_prefix: PathBuf,
         sys_executable: PathBuf,
+        stdlib: PathBuf,
     ) -> Self {
         Self {
             platform: PythonPlatform(platform),
             markers,
             base_exec_prefix,
             base_prefix,
+            stdlib,
             sys_executable,
             tags: OnceCell::new(),
         }
@@ -280,6 +284,11 @@ impl Interpreter {
     pub fn base_prefix(&self) -> &Path {
         &self.base_prefix
     }
+
+    /// `sysconfig.get_path("stdlib")`
+    pub fn stdlib(&self) -> &Path {
+        &self.stdlib
+    }
     pub fn sys_executable(&self) -> &Path {
         &self.sys_executable
     }
@@ -290,6 +299,7 @@ pub(crate) struct InterpreterQueryResult {
     pub(crate) markers: MarkerEnvironment,
     pub(crate) base_exec_prefix: PathBuf,
     pub(crate) base_prefix: PathBuf,
+    pub(crate) stdlib: PathBuf,
     pub(crate) sys_executable: PathBuf,
 }
 
@@ -443,6 +453,7 @@ impl Timestamp {
     }
 }
 
+#[cfg(unix)]
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -458,7 +469,6 @@ mod tests {
     use crate::Interpreter;
 
     #[test]
-    #[cfg(unix)]
     fn test_cache_invalidation() {
         let mock_dir = tempdir().unwrap();
         let mocked_interpreter = mock_dir.path().join("python");
@@ -479,6 +489,7 @@ mod tests {
                 },
                 "base_exec_prefix": "/home/ferris/.pyenv/versions/3.12.0",
                 "base_prefix": "/home/ferris/.pyenv/versions/3.12.0",
+                "stdlib": "/usr/lib/python3.12",
                 "sys_executable": "/home/ferris/projects/puffin/.venv/bin/python"
             }
         "##};

--- a/crates/puffin-interpreter/src/lib.rs
+++ b/crates/puffin-interpreter/src/lib.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 pub use crate::cfg::Configuration;
 pub use crate::interpreter::Interpreter;
-pub use crate::python_query::find_requested_python;
+pub use crate::python_query::{find_default_python, find_requested_python};
 pub use crate::python_version::PythonVersion;
 pub use crate::virtual_env::Virtualenv;
 
@@ -41,10 +41,14 @@ pub enum Error {
         #[source]
         err: io::Error,
     },
-    #[error("Failed to run `py --list-paths` to find Python installations")]
+    #[error("Failed to run `py --list-paths` to find Python installations. Do you need to install Python?")]
     PyList(#[source] io::Error),
     #[error("No Python {major}.{minor} found through `py --list-paths`")]
     NoSuchPython { major: u8, minor: u8 },
+    #[error("Neither `python` nor `python3` are in `PATH`. Do you need to install Python?")]
+    NoPythonInstalledUnix,
+    #[error("Could not find `python.exe` in PATH and `py --list-paths` did not list any Python versions. Do you need to install Python?")]
+    NoPythonInstalledWindows,
     #[error("{message}:\n--- stdout:\n{stdout}\n--- stderr:\n{stderr}\n---")]
     PythonSubcommandOutput {
         message: String,

--- a/crates/puffin-interpreter/src/virtual_env.rs
+++ b/crates/puffin-interpreter/src/virtual_env.rs
@@ -45,17 +45,12 @@ impl Virtualenv {
 
     /// Returns the location of the python interpreter
     pub fn python_executable(&self) -> PathBuf {
-        #[cfg(unix)]
-        {
-            self.root.join("bin").join("python")
-        }
-        #[cfg(windows)]
-        {
-            self.root.join("Scripts").join("python.exe")
-        }
-        #[cfg(not(any(unix, windows)))]
-        {
-            compile_error!("Only windows and unix (linux, mac os, etc.) are supported")
+        if cfg!(unix) {
+            self.bin_dir().join("python")
+        } else if cfg!(windows) {
+            self.bin_dir().join("python.exe")
+        } else {
+            unimplemented!("Only Windows and Unix are supported")
         }
     }
 
@@ -82,17 +77,12 @@ impl Virtualenv {
     }
 
     pub fn bin_dir(&self) -> PathBuf {
-        #[cfg(unix)]
-        {
+        if cfg!(unix) {
             self.root().join("bin")
-        }
-        #[cfg(windows)]
-        {
+        } else if cfg!(windows) {
             self.root().join("Scripts")
-        }
-        #[cfg(not(any(unix, windows)))]
-        {
-            compile_error!("only unix (like mac and linux) and windows are supported")
+        } else {
+            unimplemented!("Only Windows and Unix are supported")
         }
     }
 

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -112,6 +112,7 @@ async fn resolve(
         PathBuf::from("/dev/null"),
         PathBuf::from("/dev/null"),
         PathBuf::from("/dev/null"),
+        PathBuf::from("/dev/null"),
     );
     let build_context = DummyContext {
         cache: Cache::temp()?,

--- a/crates/puffin/Cargo.toml
+++ b/crates/puffin/Cargo.toml
@@ -77,10 +77,12 @@ tikv-jemallocator = "0.5.4"
 [dev-dependencies]
 assert_cmd = { version = "2.0.12" }
 assert_fs = { version = "1.1.0" }
+filetime = { version = "0.2.23" }
 indoc = { version = "2.0.4" }
-insta-cmd = { version = "0.4.0" }
 insta = { version = "1.34.0", features = ["filters"] }
+insta-cmd = { version = "0.4.0" }
 predicates = { version = "3.0.4" }
+regex = { version = "1.10.3" }
 reqwest = { version = "0.11.23", features = ["blocking", "rustls"], default-features = false }
 
 [features]

--- a/crates/puffin/src/commands/venv.rs
+++ b/crates/puffin/src/commands/venv.rs
@@ -3,10 +3,8 @@ use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::Result;
-use fs_err as fs;
 use miette::{Diagnostic, IntoDiagnostic};
 use owo_colors::OwoColorize;
-use puffin_installer::NoBinary;
 use thiserror::Error;
 
 use distribution_types::{DistributionMetadata, IndexLocations, Name};
@@ -15,7 +13,8 @@ use platform_host::Platform;
 use puffin_cache::Cache;
 use puffin_client::{FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
-use puffin_interpreter::{find_requested_python, Interpreter};
+use puffin_installer::NoBinary;
+use puffin_interpreter::{find_default_python, find_requested_python, Interpreter};
 use puffin_resolver::InMemoryIndex;
 use puffin_traits::{BuildContext, InFlight, SetupPyStrategy};
 
@@ -46,29 +45,25 @@ pub(crate) async fn venv(
 
 #[derive(Error, Debug, Diagnostic)]
 enum VenvError {
-    #[error("Unable to find a Python interpreter")]
-    #[diagnostic(code(puffin::venv::python_not_found))]
-    PythonNotFound,
-
     #[error("Failed to extract Python interpreter info")]
     #[diagnostic(code(puffin::venv::interpreter))]
-    InterpreterError(#[source] puffin_interpreter::Error),
+    Interpreter(#[source] puffin_interpreter::Error),
 
     #[error("Failed to create virtual environment")]
     #[diagnostic(code(puffin::venv::creation))]
-    CreationError(#[source] gourgeist::Error),
+    Creation(#[source] gourgeist::Error),
 
     #[error("Failed to install seed packages")]
     #[diagnostic(code(puffin::venv::seed))]
-    SeedError(#[source] anyhow::Error),
+    Seed(#[source] anyhow::Error),
 
     #[error("Failed to extract interpreter tags")]
     #[diagnostic(code(puffin::venv::tags))]
-    TagsError(#[source] platform_tags::TagsError),
+    Tags(#[source] platform_tags::TagsError),
 
     #[error("Failed to resolve `--find-links` entry")]
     #[diagnostic(code(puffin::venv::flat_index))]
-    FlatIndexError(#[source] puffin_client::FlatIndexError),
+    FlatIndex(#[source] puffin_client::FlatIndexError),
 }
 
 /// Create a virtual environment.
@@ -84,17 +79,12 @@ async fn venv_impl(
     let base_python = if let Some(python_request) = python_request {
         find_requested_python(python_request).into_diagnostic()?
     } else {
-        fs::canonicalize(
-            which::which_global("python3")
-                .or_else(|_| which::which_global("python"))
-                .map_err(|_| VenvError::PythonNotFound)?,
-        )
-        .into_diagnostic()?
+        find_default_python().into_diagnostic()?
     };
 
     let platform = Platform::current().into_diagnostic()?;
     let interpreter =
-        Interpreter::query(&base_python, &platform, cache).map_err(VenvError::InterpreterError)?;
+        Interpreter::query(&base_python, &platform, cache).map_err(VenvError::Interpreter)?;
 
     writeln!(
         printer,
@@ -112,7 +102,7 @@ async fn venv_impl(
     .into_diagnostic()?;
 
     // Create the virtual environment.
-    let venv = gourgeist::create_venv(path, interpreter).map_err(VenvError::CreationError)?;
+    let venv = gourgeist::create_venv(path, interpreter).map_err(VenvError::Creation)?;
 
     // Install seed packages.
     if seed {
@@ -124,12 +114,12 @@ async fn venv_impl(
 
         // Resolve the flat indexes from `--find-links`.
         let flat_index = {
-            let tags = interpreter.tags().map_err(VenvError::TagsError)?;
+            let tags = interpreter.tags().map_err(VenvError::Tags)?;
             let client = FlatIndexClient::new(&client, cache);
             let entries = client
                 .fetch(index_locations.flat_indexes())
                 .await
-                .map_err(VenvError::FlatIndexError)?;
+                .map_err(VenvError::FlatIndex)?;
             FlatIndex::from_entries(entries, tags)
         };
 
@@ -162,13 +152,13 @@ async fn venv_impl(
                 Requirement::from_str("setuptools").unwrap(),
             ])
             .await
-            .map_err(VenvError::SeedError)?;
+            .map_err(VenvError::Seed)?;
 
         // Install into the environment.
         build_dispatch
             .install(&resolution, &venv)
             .await
-            .map_err(VenvError::SeedError)?;
+            .map_err(VenvError::Seed)?;
 
         for distribution in resolution.distributions() {
             writeln!(

--- a/crates/puffin/tests/common/mod.rs
+++ b/crates/puffin/tests/common/mod.rs
@@ -1,11 +1,12 @@
 #![allow(dead_code)]
 
+use std::path::{Path, PathBuf};
+
 use assert_cmd::Command;
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::PathChild;
 use assert_fs::TempDir;
 use insta_cmd::get_cargo_bin;
-use std::path::PathBuf;
 
 pub(crate) const BIN_NAME: &str = "puffin";
 
@@ -13,11 +14,29 @@ pub(crate) const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"--cache-dir .*", "--cache-dir [CACHE_DIR]"),
     (r"(\d+\.)?\d+(ms|s)", "[TIME]"),
     (r"v\d+\.\d+\.\d+", "v[VERSION]"),
+    // Rewrite Windows output to Unix output
+    (r"\\([\w\d])", "/$1"),
+    (r"puffin.exe", "puffin"),
+    // The exact message is host language dependent
+    (
+        r"Caused by: .* \(os error 2\)",
+        "Caused by: No such file or directory (os error 2)",
+    ),
 ];
+
+pub(crate) fn venv_to_interpreter(venv: &Path) -> PathBuf {
+    if cfg!(unix) {
+        venv.join("bin").join("python")
+    } else if cfg!(windows) {
+        venv.join("Scripts").join("python.exe")
+    } else {
+        unimplemented!("Only Windows and Unix are supported")
+    }
+}
 
 /// Create a virtual environment named `.venv` in a temporary directory.
 pub(crate) fn create_venv_py312(temp_dir: &TempDir, cache_dir: &TempDir) -> PathBuf {
-    create_venv(temp_dir, cache_dir, "python3.12")
+    create_venv(temp_dir, cache_dir, "3.12")
 }
 
 /// Create a virtual environment named `.venv` in a temporary directory with the given

--- a/crates/puffin/tests/pip_install_scenarios.rs
+++ b/crates/puffin/tests/pip_install_scenarios.rs
@@ -14,12 +14,12 @@ use assert_cmd::prelude::*;
 use insta_cmd::_macro_support::insta;
 use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
 
-use common::{create_venv, BIN_NAME, INSTA_FILTERS};
+use common::{create_venv, venv_to_interpreter, BIN_NAME, INSTA_FILTERS};
 
 mod common;
 
 fn assert_command(venv: &Path, command: &str, temp_dir: &Path) -> Assert {
-    Command::new(venv.join("bin").join("python"))
+    Command::new(venv_to_interpreter(venv))
         .arg("-c")
         .arg(command)
         .current_dir(temp_dir)

--- a/crates/puffin/tests/venv.rs
+++ b/crates/puffin/tests/venv.rs
@@ -16,17 +16,18 @@ fn create_venv() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let venv = temp_dir.child(".venv");
 
+    let filter_venv = regex::escape(&venv.display().to_string());
     insta::with_settings!({
         filters => vec![
             (r"Using Python 3\.\d+\.\d+ interpreter at .+", "Using Python [VERSION] interpreter at [PATH]"),
-            (temp_dir.to_str().unwrap(), "/home/ferris/project"),
+            (&filter_venv, "/home/ferris/project/.venv"),
         ]
     }, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .arg("venv")
             .arg(venv.as_os_str())
             .arg("--python")
-            .arg("python3.12")
+            .arg("3.12")
             .current_dir(&temp_dir), @r###"
         success: true
         exit_code: 0
@@ -48,16 +49,17 @@ fn create_venv_defaults_to_cwd() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let venv = temp_dir.child(".venv");
 
+    let filter_venv = regex::escape(&venv.display().to_string());
     insta::with_settings!({
         filters => vec![
             (r"Using Python 3\.\d+\.\d+ interpreter at .+", "Using Python [VERSION] interpreter at [PATH]"),
-            (temp_dir.to_str().unwrap(), "/home/ferris/project"),
+            (&filter_venv, "/home/ferris/project/.venv"),
         ]
     }, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .arg("venv")
             .arg("--python")
-            .arg("python3.12")
+            .arg("3.12")
             .current_dir(&temp_dir), @r###"
         success: true
         exit_code: 0
@@ -79,10 +81,11 @@ fn seed() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let venv = temp_dir.child(".venv");
 
+    let filter_venv = regex::escape(&venv.display().to_string());
     insta::with_settings!({
         filters => vec![
             (r"Using Python 3\.\d+\.\d+ interpreter at .+", "Using Python [VERSION] interpreter at [PATH]"),
-            (temp_dir.to_str().unwrap(), "/home/ferris/project"),
+            (&filter_venv, "/home/ferris/project/.venv"),
         ]
     }, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
@@ -90,7 +93,7 @@ fn seed() -> Result<()> {
             .arg(venv.as_os_str())
             .arg("--seed")
             .arg("--python")
-            .arg("python3.12")
+            .arg("3.12")
             .current_dir(&temp_dir), @r###"
         success: true
         exit_code: 0

--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -744,7 +744,8 @@ mod test {
         let err = RequirementsTxt::parse(basic, &working_dir).unwrap_err();
         let errors = anyhow::Error::new(err)
             .chain()
-            .map(ToString::to_string)
+            // Windows support
+            .map(|err| err.to_string().replace('\\', "/"))
             .collect::<Vec<_>>();
         let expected = &[
             "Unsupported URL (expected a `file://` scheme) in `./test-data/requirements-txt/unsupported-editable.txt`: http://localhost:8080/".to_string()

--- a/scripts/scenarios/templates/install.mustache
+++ b/scripts/scenarios/templates/install.mustache
@@ -14,30 +14,22 @@ use assert_cmd::prelude::*;
 use insta_cmd::_macro_support::insta;
 use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
 
-use common::{create_venv, BIN_NAME, INSTA_FILTERS};
+use common::{create_venv, BIN_NAME, INSTA_FILTERS, venv_to_interpreter};
 
 mod common;
 
 fn assert_command(venv: &Path, command: &str, temp_dir: &Path) -> Assert {
-    Command::new(venv.join("bin").join("python"))
+    Command::new(venv_to_interpreter(venv))
         .arg("-c")
         .arg(command)
         .current_dir(temp_dir)
         .assert()
 }
 
-fn assert_installed(
-    venv: &Path,
-    package: &'static str,
-    version: &'static str,
-    temp_dir: &Path,
-) {
+fn assert_installed(venv: &Path, package: &'static str, version: &'static str, temp_dir: &Path) {
     assert_command(
         venv,
-        format!(
-            "import {package} as package; print(package.__version__, end='')"
-        )
-        .as_str(),
+        format!("import {package} as package; print(package.__version__, end='')").as_str(),
         temp_dir,
     )
     .success()


### PR DESCRIPTION
## Summary

First batch of changes for windows support. Notable changes:

* Fixes all compile errors and added windows specific paths.
* Working venv creation on windows, both from a base interpreter and from a venv. This requires querying `stdlib` from the sysconfig paths to find the launcher.
* Basic url/path conversion handling for windows.
* `if cfg!(...)` instead of `#[cfg()]`. This should make it easier to keep everything compiling across platforms.

## Outlook

Test summary: 402 tests run: 299 passed (15 slow), 103 failed, 1 skipped

There are various reason for the remaining test failure:
* Windows-specific colorama and tzdata dependencies that change the snapshot slightly. This is by far the biggest batch.
* Some url-path handling issues. I fixed some in the PR, some remain.
* Lack of the latest python patch versions for older pythons on my machine, since there are no builds for windows and we need to register them in the registry for them to be picked up for `py --list-paths` (CC @zanieb RE #1070).
* Lack of entrypoint launchers.
* ... likely more