### PR TITLE
Split install plan into builder and struct

### DIFF
--- a/crates/puffin-dispatch/src/lib.rs
+++ b/crates/puffin-dispatch/src/lib.rs
@@ -14,7 +14,7 @@ use pep508_rs::Requirement;
 use puffin_build::{SourceBuild, SourceBuildContext};
 use puffin_cache::Cache;
 use puffin_client::{FlatIndex, RegistryClient};
-use puffin_installer::{Downloader, InstallPlan, Installer, Reinstall, SitePackages};
+use puffin_installer::{Downloader, Installer, Plan, Planner, Reinstall, SitePackages};
 use puffin_interpreter::{Interpreter, Virtualenv};
 use puffin_resolver::{InMemoryIndex, Manifest, ResolutionOptions, Resolver};
 use puffin_traits::{BuildContext, BuildKind, InFlight, SetupPyStrategy};
@@ -149,14 +149,12 @@ impl<'a> BuildContext for BuildDispatch<'a> {
             let site_packages =
                 SitePackages::from_executable(venv).context("Failed to list installed packages")?;
 
-            let InstallPlan {
+            let Plan {
                 local,
                 remote,
                 reinstalls,
                 extraneous,
-            } = InstallPlan::from_requirements(
-                &resolution.requirements(),
-                Vec::new(),
+            } = Planner::with_requirements(&resolution.requirements()).build(
                 site_packages,
                 &Reinstall::None,
                 self.index_locations,

--- a/crates/puffin-installer/src/lib.rs
+++ b/crates/puffin-installer/src/lib.rs
@@ -1,7 +1,7 @@
 pub use downloader::{Downloader, Reporter as DownloadReporter};
 pub use editable::{BuiltEditable, ResolvedEditable};
 pub use installer::{Installer, Reporter as InstallReporter};
-pub use plan::{InstallPlan, Reinstall};
+pub use plan::{Plan, Planner, Reinstall};
 pub use site_packages::SitePackages;
 pub use uninstall::uninstall;
 


### PR DESCRIPTION
The `InstallPlan` does a lot of work in the constructor, which I tend to feel is an anti-pattern. With cache refresh, it's also going to need to be made `async`, so it really feels like it should be a clearer method rather than an async, fallible constructor that does a bunch of IO. This PR splits into a `Planner` (with a `build` method) and a `Plan`.