### PR TITLE
Add nextest config for retry of flaky test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,4 +5,4 @@ slow-timeout = "10s"
 [[profile.default.overrides]]
 # The following test has a non-determinstic snapshot
 filter = 'test(excluded_only_compatible_version|dependency_excludes_range_of_compatible_versions)'
-retries = 2
+retries = 3


### PR DESCRIPTION
We should definitely sort this out per #863 but until then I want to stop getting false reports of failed CI please and this seems better than turning off the test entirely.

Alternatively #993