### PR TITLE
Treat missing package name error as an unsupported requirement

### DIFF
--- a/crates/pep508-rs/src/verbatim_url.rs
+++ b/crates/pep508-rs/src/verbatim_url.rs
@@ -5,18 +5,20 @@ use std::path::{Component, Path, PathBuf};
 
 use once_cell::sync::Lazy;
 use regex::Regex;
-use serde::{Deserialize, Serialize};
 use url::Url;
 
 /// A wrapper around [`Url`] that preserves the original string.
 #[derive(Debug, Clone, Eq, derivative::Derivative)]
 #[derivative(PartialEq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VerbatimUrl {
     /// The parsed URL.
-    #[serde(
-        serialize_with = "Url::serialize_internal",
-        deserialize_with = "Url::deserialize_internal"
+    #[cfg_attr(
+        feature = "serde",
+        serde(
+            serialize_with = "Url::serialize_internal",
+            deserialize_with = "Url::deserialize_internal"
+        )
     )]
     url: Url,
     /// The URL as it was provided by the user.


### PR DESCRIPTION
## Summary

Based on user feedback. Calling it a "parse error" is misleading, since this is really something we don't support, but that users can work around.
