### PR TITLE
Use full Python version for installed version

### DIFF
--- a/crates/puffin-resolver/src/pubgrub/report.rs
+++ b/crates/puffin-resolver/src/pubgrub/report.rs
@@ -37,17 +37,8 @@ impl ReportFormatter<PubGrubPackage, Range<Version>> for PubGrubReportFormatter<
             External::NoVersions(package, set) => {
                 if matches!(package, PubGrubPackage::Python(_)) {
                     if let Some(python) = self.python_requirement {
-                        if python.target().release().iter().eq(python
-                            .installed()
-                            .release()
-                            .iter()
-                            .take(2))
-                        {
+                        if python.target() == python.installed() {
                             // Simple case, the installed version is the same as the target version
-                            // N.B. Usually the target version does not include anything past the
-                            //      minor version mumber so we only compare to part of the installed
-                            //      version. If the target version is longer, we'll do the complex
-                            //      display instead.
                             return format!(
                                 "the current {package} version ({}) does not satisfy {}",
                                 python.target(),

--- a/crates/puffin-resolver/src/python_requirement.rs
+++ b/crates/puffin-resolver/src/python_requirement.rs
@@ -16,7 +16,7 @@ impl PythonRequirement {
     pub fn new(interpreter: &Interpreter, markers: &MarkerEnvironment) -> Self {
         Self {
             installed: interpreter.version().clone(),
-            target: markers.python_version.version.clone(),
+            target: markers.python_full_version.version.clone(),
         }
     }
 

--- a/crates/puffin/tests/pip_install_scenarios.rs
+++ b/crates/puffin/tests/pip_install_scenarios.rs
@@ -2554,7 +2554,7 @@ fn requires_python_version_does_not_exist() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because the current Python version (3.7) does not satisfy Python>=4.0 and albatross==1.0.0 depends on Python>=4.0, we can conclude that albatross==1.0.0 cannot be used.
+          ╰─▶ Because the current Python version (3.7.17) does not satisfy Python>=4.0 and albatross==1.0.0 depends on Python>=4.0, we can conclude that albatross==1.0.0 cannot be used.
               And because you require albatross==1.0.0 we can conclude that the requirements are unsatisfiable.
         "###);
     });
@@ -2611,7 +2611,7 @@ fn requires_python_version_less_than_current() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because the current Python version (3.9) does not satisfy Python<=3.8 and albatross==1.0.0 depends on Python<=3.8, we can conclude that albatross==1.0.0 cannot be used.
+          ╰─▶ Because the current Python version (3.9.18) does not satisfy Python<=3.8 and albatross==1.0.0 depends on Python<=3.8, we can conclude that albatross==1.0.0 cannot be used.
               And because you require albatross==1.0.0 we can conclude that the requirements are unsatisfiable.
         "###);
     });
@@ -2668,7 +2668,7 @@ fn requires_python_version_greater_than_current() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because the current Python version (3.9) does not satisfy Python>=3.10 and albatross==1.0.0 depends on Python>=3.10, we can conclude that albatross==1.0.0 cannot be used.
+          ╰─▶ Because the current Python version (3.9.18) does not satisfy Python>=3.10 and albatross==1.0.0 depends on Python>=3.10, we can conclude that albatross==1.0.0 cannot be used.
               And because you require albatross==1.0.0 we can conclude that the requirements are unsatisfiable.
         "###);
     });
@@ -2876,22 +2876,22 @@ fn requires_python_version_greater_than_current_excluded() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ Because the current Python version (3.9) does not satisfy Python>=3.10,<3.11 and the current Python version (3.9) does not satisfy Python>=3.12, we can conclude that any of:
+          ╰─▶ Because the current Python version (3.9.18) does not satisfy Python>=3.10,<3.11 and the current Python version (3.9.18) does not satisfy Python>=3.12, we can conclude that any of:
                   Python>=3.10,<3.11
                   Python>=3.12
                are incompatible.
-              And because the current Python version (3.9) does not satisfy Python>=3.11,<3.12 we can conclude that Python>=3.10 are incompatible.
+              And because the current Python version (3.9.18) does not satisfy Python>=3.11,<3.12 we can conclude that Python>=3.10 are incompatible.
               And because albatross==2.0.0 depends on Python>=3.10 and there are no versions of albatross that satisfy any of:
                   albatross>2.0.0,<3.0.0
                   albatross>3.0.0,<4.0.0
                   albatross>4.0.0
               we can conclude that albatross>=2.0.0,<3.0.0 cannot be used. (1)
 
-              Because the current Python version (3.9) does not satisfy Python>=3.11,<3.12 and the current Python version (3.9) does not satisfy Python>=3.12, we can conclude that Python>=3.11 are incompatible.
+              Because the current Python version (3.9.18) does not satisfy Python>=3.11,<3.12 and the current Python version (3.9.18) does not satisfy Python>=3.12, we can conclude that Python>=3.11 are incompatible.
               And because albatross==3.0.0 depends on Python>=3.11 we can conclude that albatross==3.0.0 cannot be used.
               And because we know from (1) that albatross>=2.0.0,<3.0.0 cannot be used, we can conclude that albatross>=2.0.0,<4.0.0 cannot be used. (2)
 
-              Because the current Python version (3.9) does not satisfy Python>=3.12 and albatross==4.0.0 depends on Python>=3.12, we can conclude that albatross==4.0.0 cannot be used.
+              Because the current Python version (3.9.18) does not satisfy Python>=3.12 and albatross==4.0.0 depends on Python>=3.12, we can conclude that albatross==4.0.0 cannot be used.
               And because we know from (2) that albatross>=2.0.0,<4.0.0 cannot be used, we can conclude that albatross>=2.0.0 cannot be used.
               And because you require albatross>=2.0.0 we can conclude that the requirements are unsatisfiable.
         "###);


### PR DESCRIPTION
## Summary

`interpreter.version()` returns the `python_full_version`, but the marker variant uses `python_version` instead of `python_full_version` -- so it's omitting the patch.