### PR TITLE
Avoid persisting manifest data in standalone file

### DIFF
--- a/crates/puffin-cache/src/lib.rs
+++ b/crates/puffin-cache/src/lib.rs
@@ -294,9 +294,9 @@ pub enum CacheBucket {
     /// directories in the cache.
     ///
     /// Cache structure:
-    ///  * `built-wheels-v0/pypi/foo/34a17436ed1e9669/{metadata.msgpack, foo-1.0.0.zip, foo-1.0.0-py3-none-any.whl, ...other wheels}`
-    ///  * `built-wheels-v0/<digest(index-url)>/foo/foo-1.0.0.zip/{metadata.msgpack, foo-1.0.0-py3-none-any.whl, ...other wheels}`
-    ///  * `built-wheels-v0/url/<digest(url)>/foo/foo-1.0.0.zip/{metadata.msgpack, foo-1.0.0-py3-none-any.whl, ...other wheels}`
+    ///  * `built-wheels-v0/pypi/foo/34a17436ed1e9669/{manifest.msgpack, metadata.msgpack, foo-1.0.0.zip, foo-1.0.0-py3-none-any.whl, ...other wheels}`
+    ///  * `built-wheels-v0/<digest(index-url)>/foo/foo-1.0.0.zip/{manifest.msgpack, metadata.msgpack, foo-1.0.0-py3-none-any.whl, ...other wheels}`
+    ///  * `built-wheels-v0/url/<digest(url)>/foo/foo-1.0.0.zip/{manifest.msgpack, metadata.msgpack, foo-1.0.0-py3-none-any.whl, ...other wheels}`
     ///  * `built-wheels-v0/git/<digest(url)>/<git sha>/foo/foo-1.0.0.zip/{metadata.msgpack, foo-1.0.0-py3-none-any.whl, ...other wheels}`
     ///
     /// But the url filename does not need to be a valid source dist filename
@@ -322,34 +322,27 @@ pub enum CacheBucket {
     /// ├── git
     /// │   └── a67db8ed076e3814
     /// │       └── 843b753e9e8cb74e83cac55598719b39a4d5ef1f
+    /// │           ├── manifest.msgpack
     /// │           ├── metadata.msgpack
     /// │           └── pydantic_extra_types-2.1.0-py3-none-any.whl
     /// ├── pypi
     /// │   └── django
     /// │       └── django-allauth-0.51.0.tar.gz
     /// │           ├── django_allauth-0.51.0-py3-none-any.whl
+    /// │           ├── manifest.msgpack
     /// │           └── metadata.msgpack
     /// └── url
     ///     └── 6781bd6440ae72c2
     ///         └── werkzeug
     ///             └── werkzeug-3.0.1.tar.gz
+    ///                 ├── manifest.msgpack
     ///                 ├── metadata.msgpack
     ///                 └── werkzeug-3.0.1-py3-none-any.whl
     /// ```
     ///
-    /// Structurally, the inside of a `metadata.msgpack` looks like:
-    /// ```json
-    /// {
-    ///   "data": {
-    ///     "django_allauth-0.51.0-py3-none-any.whl": {
-    ///       "metadata-version": "2.1",
-    ///       "name": "django-allauth",
-    ///       "version": "0.51.0",
-    ///       ...
-    ///     }
-    ///   }
-    /// }
-    /// ```
+    /// Structurally, the `manifest.msgpack` is empty, and only contains the caching information
+    /// needed to invalidate the cache. The `metadata.msgpack` contains the metadata of the source
+    /// distribution.
     BuiltWheels,
     /// Flat index responses, a format very similar to the simple metadata API.
     ///

--- a/crates/puffin-distribution/src/source/manifest.rs
+++ b/crates/puffin-distribution/src/source/manifest.rs
@@ -1,62 +1,7 @@
-use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
-use distribution_filename::WheelFilename;
-use platform_tags::Tags;
-use pypi_types::Metadata21;
-
+/// The [`Manifest`] exists as an empty serializable struct we can use to test for cache freshness.
+///
+/// TODO(charlie): Store a unique ID, rather than an empty struct.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-pub(crate) struct Manifest {
-    /// The metadata for the distribution, as returned by `prepare_metadata_for_build_wheel`.
-    metadata: Option<Metadata21>,
-    /// The built wheels for the distribution, each of which was returned from `build_wheel`.
-    built_wheels: FxHashMap<WheelFilename, DiskFilenameAndMetadata>,
-}
-
-impl Manifest {
-    /// Set the prepared metadata.
-    pub(crate) fn set_metadata(&mut self, metadata: Metadata21) {
-        self.metadata = Some(metadata);
-    }
-
-    /// Insert a built wheel into the manifest.
-    pub(crate) fn insert_wheel(
-        &mut self,
-        filename: WheelFilename,
-        disk_filename_and_metadata: DiskFilenameAndMetadata,
-    ) {
-        self.built_wheels
-            .insert(filename, disk_filename_and_metadata);
-    }
-
-    /// Find a compatible wheel in the manifest.
-    pub(crate) fn find_wheel(
-        &self,
-        tags: &Tags,
-    ) -> Option<(&WheelFilename, &DiskFilenameAndMetadata)> {
-        self.built_wheels
-            .iter()
-            .find(|(filename, _)| filename.is_compatible(tags))
-    }
-
-    /// Find a metadata in the manifest.
-    pub(crate) fn find_metadata(&self) -> Option<&Metadata21> {
-        // If we already have a prepared metadata, return it.
-        if let Some(metadata) = &self.metadata {
-            return Some(metadata);
-        }
-
-        // Otherwise, return the metadata from any of the built wheels.
-        let wheel = self.built_wheels.values().next()?;
-        Some(&wheel.metadata)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct DiskFilenameAndMetadata {
-    /// Relative, un-normalized wheel filename in the cache, which can be different than
-    /// `WheelFilename::to_string`.
-    pub(crate) disk_filename: String,
-    /// The [`Metadata21`] of the wheel.
-    pub(crate) metadata: Metadata21,
-}
+pub(crate) struct Manifest;


### PR DESCRIPTION
## Summary

This PR gets rid of the manifest that we store for source distributions. Historically, that manifest included the source distribution metadata, plus a list of built wheels.

The problem with the manifest is that it duplicates state, since we now have to look at both the manifest and the filesystem to understand the cache state. Instead, I think we should treat the cache as the source of truth, and get rid of the duplicated state in the manifest.

Now, we store the manifest (which is merely used to check for cache freshness -- in future PRs, I will repurpose it though, so I left it around), then the distribution metadata as its own file, then any distributions in the same directory. When we want to see if there are any valid distributions, we `readdir` on the directory. This is also much more consistent with how the install plan works.
