### PR TITLE
Canonicalize paths to interpreter executables before checking modified time

### DIFF
--- a/crates/puffin-interpreter/src/interpreter.rs
+++ b/crates/puffin-interpreter/src/interpreter.rs
@@ -281,7 +281,7 @@ impl InterpreterQueryResult {
         );
 
         // `modified()` is infallible on windows and unix (i.e., all platforms we support).
-        let modified = fs_err::metadata(executable)?.modified()?;
+        let modified = fs_err::metadata(fs_err::canonicalize(executable)?)?.modified()?;
 
         // Read from the cache.
         if let Ok(data) = fs::read(cache_entry.path()) {


### PR DESCRIPTION
If the executable is a symbolic link, checking the modified time will not reflect changes to the source file e.g.

```
❯ touch foo
❯ ln -s foo foobar
❯ gstat -c %Y foo
1705958431
❯ gstat -c %Y foobar
1705958438
❯ touch foo
❯ gstat -c %Y foobar
1705958438
```

This can result in a stale cache being treated as fresh; for example, when Rye changes the interpreter linked in a virtual environment.