### PR TITLE
Add `--color always|never|auto` interface

### DIFF
--- a/crates/puffin/src/main.rs
+++ b/crates/puffin/src/main.rs
@@ -77,8 +77,13 @@ struct Cli {
 
 #[derive(Debug, Clone, clap::ValueEnum)]
 pub enum ColorChoice {
+    /// Enables colored output only when the output is going to a terminal or TTY with support.
     Auto,
+
+    /// Enables colored output regardless of the detected environment.
     Always,
+
+    /// Disables colored output.
     Never,
 }
 


### PR DESCRIPTION
Extends #1048 interface providing a more general interface that I think should be standard.

Allows forcing colors to be on _or_ off. e.g. `NO_COLOR=1 pip install pip-tools --color always` would be colored.

Hides the `--no-color` option as it only exists for compatibility (and seems better than throwing an error when people assume it will exist).

Has a nice side-effect of documenting our coloring behaviors e.g.

```
--color <COLOR>
    Control colors in output
    
    [default: auto]

    Possible values:
    - auto:   Enables colored output only when the output is going to a terminal or TTY with support
    - always: Enables colored output regardless of the detected environment
    - never:  Disables colored output
```