### PR TITLE
Hide `--exclude-newer` from the command line

### DIFF
--- a/crates/puffin/src/main.rs
+++ b/crates/puffin/src/main.rs
@@ -264,7 +264,7 @@ struct PipCompileArgs {
     /// Timestamps are given either as RFC 3339 timestamps such as `2006-12-02T02:07:43Z` or as
     /// UTC dates in the same format such as `2006-12-02`. Dates are interpreted as including this
     /// day, i.e. until midnight UTC that day.
-    #[arg(long, value_parser = date_or_datetime)]
+    #[arg(long, value_parser = date_or_datetime, hide = true)]
     exclude_newer: Option<DateTime<Utc>>,
 }
 
@@ -476,7 +476,7 @@ struct PipInstallArgs {
     /// Timestamps are given either as RFC 3339 timestamps such as `2006-12-02T02:07:43Z` or as
     /// UTC dates in the same format such as `2006-12-02`. Dates are interpreted as including this
     /// day, i.e. until midnight UTC that day.
-    #[arg(long, value_parser = date_or_datetime)]
+    #[arg(long, value_parser = date_or_datetime, hide = true)]
     exclude_newer: Option<DateTime<Utc>>,
 }
 


### PR DESCRIPTION
This exists for our own test suite.