### PR TITLE
Improve retry of pip install scenario tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,6 +3,11 @@
 slow-timeout = "10s"
 
 [[profile.default.overrides]]
-# The following test has a non-determinstic snapshot
-filter = 'test(excluded_only_compatible_version|dependency_excludes_range_of_compatible_versions)'
-retries = 3
+# Some of these tests have a non-determinstic snapshot
+filter = 'binary(pip_install_scenarios)'
+retries = 2
+
+[[profile.no-retry.overrides]]
+# An optional profile to avoid retries
+filter = 'binary(pip_install_scenarios)'
+retries = 0


### PR DESCRIPTION
Follow-up to #996 with retries of the full `pip_install_scenario` module since there are a few tests that flake and tracking down the non-determinism is proving to be quite complicated.

Adds a profile that can be used to disable retries, e.g. `--profile no-retry` when you expect the scenario to change.

As before, hopefully this is a short-term measure.