### PR TITLE
Use ctime for interpreter timestamps

### DIFF
--- a/crates/puffin-cache/src/by_timestamp.rs
+++ b/crates/puffin-cache/src/by_timestamp.rs
@@ -1,9 +1,7 @@
-use std::time::SystemTime;
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
-pub struct CachedByTimestamp<T> {
-    pub timestamp: SystemTime,
-    pub data: T,
+pub struct CachedByTimestamp<Timestamp, Data> {
+    pub timestamp: Timestamp,
+    pub data: Data,
 }

--- a/crates/puffin-distribution/src/source/mod.rs
+++ b/crates/puffin-distribution/src/source/mod.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use anyhow::Result;
 use fs_err::tokio as fs;
@@ -912,12 +913,12 @@ pub(crate) fn read_http_manifest(
 /// If the cache entry is stale, a new entry will be created.
 pub(crate) fn read_timestamp_manifest(
     cache_entry: &CacheEntry,
-    modified: std::time::SystemTime,
+    modified: SystemTime,
 ) -> Result<Option<Manifest>, SourceDistError> {
     // If the cache entry is up-to-date, return it.
     match std::fs::read(cache_entry.path()) {
         Ok(cached) => {
-            let cached = rmp_serde::from_slice::<CachedByTimestamp<Manifest>>(&cached)?;
+            let cached = rmp_serde::from_slice::<CachedByTimestamp<SystemTime, Manifest>>(&cached)?;
             if cached.timestamp == modified {
                 return Ok(Some(cached.data));
             }
@@ -933,7 +934,7 @@ pub(crate) fn read_timestamp_manifest(
 /// If the cache entry is stale, a new entry will be created.
 pub(crate) async fn refresh_timestamp_manifest(
     cache_entry: &CacheEntry,
-    modified: std::time::SystemTime,
+    modified: SystemTime,
 ) -> Result<Manifest, SourceDistError> {
     // If the cache entry is up-to-date, return it.
     if let Some(manifest) = read_timestamp_manifest(cache_entry, modified)? {


### PR DESCRIPTION
Per https://apenwarr.ca/log/20181113, `ctime` should be a lot more conservative, and should detect things like the issue we see with the python-build-standalone builds, where the `mtime` is identical across builds.

On Windows, I'm just using `last_write_time`. But we should probably add `volume_serial_number` and other attributes via [`winapi_util`](https://docs.rs/winapi-util/latest/winapi_util/index.html).
