### PR TITLE
Add warning when target version does not match build version

### DIFF
--- a/crates/puffin/src/commands/pip_compile.rs
+++ b/crates/puffin/src/commands/pip_compile.rs
@@ -134,11 +134,13 @@ pub(crate) async fn pip_compile(
     if let Some(python_version) = python_version.as_ref() {
         // If the requested version does not match the version we're using warn the user
         // _unless_ they have not specified a patch version and that is the only difference
+        // _or_ if builds are disabled
         let matches_without_patch = {
             python_version.major() == interpreter.python_major()
                 && python_version.minor() == interpreter.python_minor()
         };
-        if python_version.version() != interpreter.python_version()
+        if !no_build
+            && python_version.version() != interpreter.python_version()
             && (python_version.patch().is_some() || !matches_without_patch)
         {
             warn_user!(


### PR DESCRIPTION
Follow-up to https://github.com/astral-sh/puffin/pull/1040 adding a user-facing warning when we cannot build with their requested version.

e.g.

```
❯ cargo run -- pip compile requirements.in --python-version 3.11.4 --no-build
Resolved 8 packages in 483ms
❯ cargo run -- pip compile requirements.in --python-version 3.11.4
warning: The requested Python version 3.11.4 is not available; 3.11.7 will be used to build dependencies instead.
Resolved 8 packages in 71ms
❯ cargo run -- pip compile requirements.in --python-version 3.11
Resolved 8 packages in 71ms
```