### PR TITLE
Add some instructions about build dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 You need [Rust](https://rustup.rs/), a C compiler, and CMake to build Puffin. To run the tests, you need Python 3.8, 3.9 and 3.12.
 
-To run the tests we recommend [nextest](https://nexte.st/) as faster `cargo test` replacement. Make sure to run the tests with `--all-features`, otherwise you'll miss most of our integration tests.
+To run the tests we recommend [nextest](https://nexte.st/). Make sure to run the tests with `--all-features`, otherwise you'll miss most of our integration tests.
 
 ### Linux
 


### PR DESCRIPTION
You need to install cmake on windows, so i added a hint about using `pipx install cmake`, and some more general notes on building and testing puffin.

See #817