### PR TITLE
Add basic windows CI (clippy only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
     name: "cargo check | windows"
     steps:
       - uses: actions/checkout@v4
+      - name: "Install Rust toolchain"
+        run: rustup component add clippy
       - name: "Install Pythons"
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Add basic windows (clippy only), until cargo test passes and we can merge it with the cargo-test job above.