### PR TITLE
Use a consistent `Timestamp` struct

### DIFF
--- a/crates/puffin-cache/src/by_timestamp.rs
+++ b/crates/puffin-cache/src/by_timestamp.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+use crate::timestamp::Timestamp;
+
 #[derive(Deserialize, Serialize)]
-pub struct CachedByTimestamp<Timestamp, Data> {
+pub struct CachedByTimestamp<Data> {
     pub timestamp: Timestamp,
     pub data: Data,
 }

--- a/crates/puffin-cache/src/timestamp.rs
+++ b/crates/puffin-cache/src/timestamp.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// A timestamp used to measure changes to a file.
+///
+/// On Unix, this uses `ctime` as a conservative approach. `ctime` should detect all
+/// modifications, including some that we don't care about, like hardlink modifications.
+/// On other platforms, it uses `mtime`.
+///
+/// See: <https://github.com/restic/restic/issues/2179>
+/// See: <https://apenwarr.ca/log/20181113>
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+pub struct Timestamp(std::time::SystemTime);
+
+impl Timestamp {
+    /// Return the [`Timestamp`] for the given path.
+    pub fn from_path(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        let metadata = path.as_ref().metadata()?;
+        Ok(Self::from_metadata(&metadata))
+    }
+
+    /// Return the [`Timestamp`] for the given metadata.
+    pub fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+
+            let ctime = u64::try_from(metadata.ctime()).expect("ctime to be representable as u64");
+            let ctime_nsec = u32::try_from(metadata.ctime_nsec())
+                .expect("ctime_nsec to be representable as u32");
+            let duration = std::time::Duration::new(ctime, ctime_nsec);
+            Self(std::time::UNIX_EPOCH + duration)
+        }
+
+        #[cfg(not(unix))]
+        {
+            let modified = metadata.modified().expect("modified time to be available");
+            Self(modified)
+        }
+    }
+
+    /// Return the current [`Timestamp`].
+    pub fn now() -> Self {
+        Self(std::time::SystemTime::now())
+    }
+}

--- a/crates/puffin-distribution/src/distribution_database.rs
+++ b/crates/puffin-distribution/src/distribution_database.rs
@@ -14,7 +14,7 @@ use distribution_types::{
     BuiltDist, DirectGitUrl, Dist, FileLocation, LocalEditable, Name, SourceDist,
 };
 use platform_tags::Tags;
-use puffin_cache::{Cache, CacheBucket, WheelCache};
+use puffin_cache::{Cache, CacheBucket, Timestamp, WheelCache};
 use puffin_client::{CacheControl, CachedClientError, RegistryClient};
 use puffin_extract::unzip_no_seek;
 use puffin_fs::metadata_if_exists;
@@ -138,7 +138,9 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                             metadata_if_exists(cache_entry.path())?,
                             metadata_if_exists(path)?,
                         ) {
-                            if cache_metadata.modified()? > path_metadata.modified()? {
+                            let cache_modified = Timestamp::from_metadata(&cache_metadata);
+                            let path_modified = Timestamp::from_metadata(&path_metadata);
+                            if cache_modified >= path_modified {
                                 return Ok(LocalWheel::Unzipped(UnzippedWheel {
                                     dist: dist.clone(),
                                     target: cache_entry.into_path_buf(),
@@ -278,7 +280,9 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                     metadata_if_exists(cache_entry.path())?,
                     metadata_if_exists(&wheel.path)?,
                 ) {
-                    if cache_metadata.modified()? > path_metadata.modified()? {
+                    let cache_modified = Timestamp::from_metadata(&cache_metadata);
+                    let path_modified = Timestamp::from_metadata(&path_metadata);
+                    if cache_modified >= path_modified {
                         return Ok(LocalWheel::Unzipped(UnzippedWheel {
                             dist: dist.clone(),
                             target: cache_entry.into_path_buf(),

--- a/crates/puffin-distribution/src/source/mod.rs
+++ b/crates/puffin-distribution/src/source/mod.rs
@@ -3,7 +3,6 @@
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::SystemTime;
 
 use anyhow::Result;
 use fs_err::tokio as fs;
@@ -950,7 +949,7 @@ pub(crate) fn read_timestamp_manifest(
     // If the cache entry is up-to-date, return it.
     match std::fs::read(cache_entry.path()) {
         Ok(cached) => {
-            let cached = rmp_serde::from_slice::<CachedByTimestamp<SystemTime, Manifest>>(&cached)?;
+            let cached = rmp_serde::from_slice::<CachedByTimestamp<Manifest>>(&cached)?;
             if cached.timestamp == modified.timestamp() {
                 return Ok(Some(cached.data));
             }


### PR DESCRIPTION
## Summary

This PR uses `ctime` consistently on Unix as a more conservative approach to change detection. It also ensures that our timestamp abstraction is entirely internal, so we can change the representation and logic easily across the codebase in the future.