### PR TITLE
Consolidate `UnusableDependencies` into a generic `Unavailable` incompatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "pubgrub"
 version = "0.2.1"
-source = "git+https://github.com/zanieb/pubgrub?rev=0e02ea9fc8d021fb6a6b9e77b09ade4332068f42#0e02ea9fc8d021fb6a6b9e77b09ade4332068f42"
+source = "git+https://github.com/zanieb/pubgrub?rev=7a573e3902ff338abdcf3b87682e4c6d04845f2f#7a573e3902ff338abdcf3b87682e4c6d04845f2f"
 dependencies = [
  "indexmap 2.1.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ owo-colors = { version = "3.5.0" }
 petgraph = { version = "0.6.4" }
 platform-info = { version = "2.0.2" }
 plist = { version = "1.6.0" }
-pubgrub = { git = "https://github.com/zanieb/pubgrub", rev = "0e02ea9fc8d021fb6a6b9e77b09ade4332068f42" }
+pubgrub = { git = "https://github.com/zanieb/pubgrub", rev = "7a573e3902ff338abdcf3b87682e4c6d04845f2f" }
 pyo3 = { version = "0.20.2" }
 pyo3-log = { version = "0.9.0"}
 pyproject-toml = { version = "0.8.1" }

--- a/crates/puffin-resolver/src/error.rs
+++ b/crates/puffin-resolver/src/error.rs
@@ -49,10 +49,10 @@ pub enum ResolveError {
     #[error("~= operator requires at least two release segments: {0}")]
     InvalidTildeEquals(pep440_rs::VersionSpecifier),
 
-    #[error("Conflicting URLs for package `{0}`:\n- {1}\n- {2}")]
+    #[error("There are conflicting URLs for package `{0}`:\n- {1}\n- {2}")]
     ConflictingUrls(PackageName, String, String),
 
-    #[error("Conflicting versions for `{0}`: {1}")]
+    #[error("There are conflicting versions for `{0}`: {1}")]
     ConflictingVersions(String, String),
 
     #[error("Package `{0}` attempted to resolve via URL: {1}. URL dependencies must be expressed as direct requirements or constraints. Consider adding `{0} @ {1}` to your dependencies or constraints file.")]

--- a/crates/puffin/tests/pip_compile.rs
+++ b/crates/puffin/tests/pip_compile.rs
@@ -1516,7 +1516,8 @@ fn conflicting_repeated_url_dependency_version_mismatch() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ root dependencies are unusable: Conflicting URLs for package `werkzeug`:
+          ╰─▶ your requirements cannot be used because there are conflicting URLs for
+              package `werkzeug`:
               - https://files.pythonhosted.org/packages/bd/24/11c3ea5a7e866bf2d97f0501d0b4b1c9bbeade102bb4b588f0d2919a5212/Werkzeug-2.0.1-py3-none-any.whl
               - https://files.pythonhosted.org/packages/ff/1d/960bb4017c68674a1cb099534840f18d3def3ce44aed12b5ed8b78e0153e/Werkzeug-2.0.0-py3-none-any.whl
         "###);
@@ -1556,7 +1557,8 @@ fn conflicting_repeated_url_dependency_version_match() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ root dependencies are unusable: Conflicting URLs for package `werkzeug`:
+          ╰─▶ your requirements cannot be used because there are conflicting URLs for
+              package `werkzeug`:
               - git+https://github.com/pallets/werkzeug.git@2.0.0
               - https://files.pythonhosted.org/packages/ff/1d/960bb4017c68674a1cb099534840f18d3def3ce44aed12b5ed8b78e0153e/Werkzeug-2.0.0-py3-none-any.whl
         "###);
@@ -1900,8 +1902,8 @@ dependencies = ["django==5.0b1", "django==5.0a1"]
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ my-project dependencies are unusable: Conflicting versions for `django`:
-              `django==5.0b1` does not intersect with `django==5.0a1`
+          ╰─▶ my-project cannot be used because there are conflicting versions for
+              `django`: `django==5.0b1` does not intersect with `django==5.0a1`
         "###);
     });
 

--- a/crates/puffin/tests/pip_install_scenarios.rs
+++ b/crates/puffin/tests/pip_install_scenarios.rs
@@ -1245,7 +1245,7 @@ fn direct_incompatible_versions() -> Result<()> {
 
         ----- stderr -----
           × No solution found when resolving dependencies:
-          ╰─▶ root dependencies are unusable: Conflicting versions for `albatross`: `albatross==1.0.0` does not intersect with `albatross==2.0.0`
+          ╰─▶ your requirements cannot be used because there are conflicting versions for `albatross`: `albatross==1.0.0` does not intersect with `albatross==2.0.0`
         "###);
     });
 


### PR DESCRIPTION
Requires https://github.com/zanieb/pubgrub/pull/20

In short, `UnusableDependencies` can be generalized into `Unavailable` which encompasses incompatibilities where a package range which is unusable for some inherent reason as well as when its dependencies are unusable. We can eventually use this to track more incompatibilities in the solver. I made the reason string required because I can't see a case where we should leave it out.

Additionally, this improves the display of conflicts in the root requirements.