### PR TITLE
Use `parse_headers` rather than parsing body

### DIFF
--- a/crates/pypi-types/src/metadata.rs
+++ b/crates/pypi-types/src/metadata.rs
@@ -75,8 +75,7 @@ pub enum Error {
 impl Metadata21 {
     /// Parse distribution metadata from metadata bytes
     pub fn parse(content: &[u8]) -> Result<Self, Error> {
-        let msg = mailparse::parse_mail(content)?;
-        let headers = msg.get_headers();
+        let (headers, _) = mailparse::parse_headers(content)?;
 
         let get_first_value = |name| {
             headers.get_first_header(name).and_then(|header| {


### PR DESCRIPTION
Looking at the internals, this should make almost no difference in performance, but anyway...