### PR TITLE
Add venv tests for missing Python versions

### DIFF
--- a/crates/puffin/tests/venv.rs
+++ b/crates/puffin/tests/venv.rs
@@ -121,3 +121,75 @@ fn seed() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn create_venv_unknown_python_minor() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let cache_dir = assert_fs::TempDir::new()?;
+    let venv = temp_dir.child(".venv");
+
+    let filter_venv = regex::escape(&venv.display().to_string());
+    insta::with_settings!({
+        filters => vec![
+            (r"Using Python 3\.\d+\.\d+ interpreter at .+", "Using Python [VERSION] interpreter at [PATH]"),
+            (&filter_venv, "/home/ferris/project/.venv"),
+        ]
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("venv")
+            .arg(venv.as_os_str())
+            .arg("--python")
+            .arg("3.15")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .current_dir(&temp_dir), @r###"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+
+        ----- stderr -----
+          × Couldn't find `python3.15` in PATH
+          ╰─▶ cannot find binary path
+        "###);
+    });
+
+    venv.assert(predicates::path::missing());
+
+    Ok(())
+}
+
+#[test]
+fn create_venv_unknown_python_patch() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let cache_dir = assert_fs::TempDir::new()?;
+    let venv = temp_dir.child(".venv");
+
+    let filter_venv = regex::escape(&venv.display().to_string());
+    insta::with_settings!({
+        filters => vec![
+            (r"Using Python 3\.\d+\.\d+ interpreter at .+", "Using Python [VERSION] interpreter at [PATH]"),
+            (&filter_venv, "/home/ferris/project/.venv"),
+        ]
+    }, {
+        assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+            .arg("venv")
+            .arg(venv.as_os_str())
+            .arg("--python")
+            .arg("3.8.0")
+            .arg("--cache-dir")
+            .arg(cache_dir.path())
+            .current_dir(&temp_dir), @r###"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+
+        ----- stderr -----
+          × Couldn't find `3.8.0` in PATH
+          ╰─▶ cannot find binary path
+        "###);
+    });
+
+    venv.assert(predicates::path::missing());
+
+    Ok(())
+}


### PR DESCRIPTION
These demonstrate some lackluster error messages.