### PR TITLE
puffin-client: decouple serde from cached client

### DIFF
--- a/crates/puffin-client/src/lib.rs
+++ b/crates/puffin-client/src/lib.rs
@@ -1,4 +1,6 @@
-pub use cached_client::{CacheControl, CachedClient, CachedClientError, DataWithCachePolicy};
+pub use cached_client::{
+    CacheControl, Cacheable, CachedClient, CachedClientError, DataWithCachePolicy, SerdeCacheable,
+};
 pub use error::{Error, ErrorKind};
 pub use flat_index::{FlatDistributions, FlatIndex, FlatIndexClient, FlatIndexError};
 pub use registry_client::{

--- a/crates/puffin-distribution/src/source/mod.rs
+++ b/crates/puffin-distribution/src/source/mod.rs
@@ -935,9 +935,11 @@ pub(crate) fn read_http_manifest(
     cache_entry: &CacheEntry,
 ) -> Result<Option<Manifest>, SourceDistError> {
     match std::fs::read(cache_entry.path()) {
-        Ok(cached) => Ok(Some(
-            rmp_serde::from_slice::<DataWithCachePolicy<Manifest>>(&cached)?.data,
-        )),
+        Ok(cached) => {
+            let raw = rmp_serde::from_slice::<DataWithCachePolicy>(&cached)?;
+            let manifest = rmp_serde::from_slice::<Manifest>(&raw.data)?;
+            Ok(Some(manifest))
+        }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(err) => Err(err.into()),
     }


### PR DESCRIPTION
The motivation for this change is that I'd like to use something that
*isn't* Serde to manage serialization of cached data. Simultaneously,
we'd like to keep existing uses of Serde still working. So this change
does a bit of surgery to a `CachedClient` to remove the coupling with
Serde's serialization traits by introducing a new trait that abstracts
over the Serde operations we need.

We do one other little change here, which is to make deserialization be
performed in two steps: one for the envelope and then another for the
actual data. This is non-ideal for performance, but is necessary for now
I think in order to make zero-copy deserialization work. Namely, the
envelope contains a bunch of HTTP related cache data from an external
crate, and it is not possible to implement the necessary traits to make
it zero-copy deserializeable. So to work around that, we make the
envelope something that stands on its own and contains the raw bytes of
the data we're caching. It is likely that we will eventually want to
remove this two-step serialization process, but to do so and
simultaneously support zero-copy will likely require forking the
`http-cache-semantics` crate (or convincing them to optionally support
`rkyv`).
