### PR TITLE
Use `same-file` to detect interpreter shims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,6 +2643,7 @@ dependencies = [
  "puffin-fs",
  "regex",
  "rmp-serde",
+ "same-file",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ reqwest-middleware = { version = "0.2.4" }
 reqwest-retry = { version = "0.3.0" }
 rmp-serde = { version = "1.1.2" }
 rustc-hash = { version = "1.1.0" }
+same-file = { version = "1.0.6" }
 seahash = { version = "4.1.0" }
 serde = { version = "1.0.194" }
 serde_json = { version = "1.0.111" }

--- a/crates/puffin-interpreter/Cargo.toml
+++ b/crates/puffin-interpreter/Cargo.toml
@@ -25,6 +25,7 @@ fs-err = { workspace = true, features = ["tokio"] }
 once_cell = { workspace = true }
 regex = { workspace = true }
 rmp-serde = { workspace = true }
+same-file = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/puffin-interpreter/src/interpreter.rs
+++ b/crates/puffin-interpreter/src/interpreter.rs
@@ -392,7 +392,7 @@ impl InterpreterQueryResult {
 
         // If `executable` is a pyenv shim, a bash script that redirects to the activated
         // python executable at another path, we're not allowed to cache the interpreter info.
-        if executable == info.sys_executable {
+        if same_file::is_same_file(executable, &info.sys_executable).unwrap_or(false) {
             fs::create_dir_all(cache_entry.dir())?;
             write_atomic_sync(
                 cache_entry.path(),


### PR DESCRIPTION
Our existing detection doesn't work on Windows, because we canoncalize the interpreter path but not `info.sys_executable`, so the former includes the UNC prefix, etc. This is cross-platform and gets at the intent of the check.
