### PR TITLE
Set buffer size when unzipping

### DIFF
--- a/crates/puffin-extract/src/lib.rs
+++ b/crates/puffin-extract/src/lib.rs
@@ -50,7 +50,9 @@ pub async fn unzip_no_seek<R: tokio::io::AsyncRead + Unpin>(
                 fs_err::tokio::create_dir_all(parent).await?;
             }
             let file = fs_err::tokio::File::create(path).await?;
-            let mut writer = tokio::io::BufWriter::new(file);
+            let size =
+                usize::try_from(entry.reader().entry().uncompressed_size()).unwrap_or(usize::MAX);
+            let mut writer = tokio::io::BufWriter::with_capacity(size, file);
             let mut reader = entry.reader_mut().compat();
             tokio::io::copy(&mut reader, &mut writer).await?;
         }


### PR DESCRIPTION
The zip archive includes an uncompressed size header, which we can use to preallocate.