### PR TITLE
puffin-client: rejigger error type

### DIFF
--- a/crates/puffin-client/src/lib.rs
+++ b/crates/puffin-client/src/lib.rs
@@ -1,5 +1,5 @@
 pub use cached_client::{CacheControl, CachedClient, CachedClientError, DataWithCachePolicy};
-pub use error::Error;
+pub use error::{Error, ErrorKind};
 pub use flat_index::{FlatDistributions, FlatIndex, FlatIndexClient, FlatIndexError};
 pub use registry_client::{
     read_metadata_async, RegistryClient, RegistryClientBuilder, SimpleMetadata, VersionFiles,

--- a/crates/puffin-distribution/src/source/mod.rs
+++ b/crates/puffin-distribution/src/source/mod.rs
@@ -754,17 +754,17 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
 
         // Create a temporary directory.
         let temp_dir = tempfile::tempdir_in(self.build_context.cache().root())
-            .map_err(puffin_client::Error::CacheWrite)?;
+            .map_err(puffin_client::ErrorKind::CacheWrite)?;
 
         // Download the source distribution to a temporary file.
         let mut writer = tokio::io::BufWriter::new(
             fs_err::tokio::File::create(temp_dir.path().join(source_dist_filename))
                 .await
-                .map_err(puffin_client::Error::CacheWrite)?,
+                .map_err(puffin_client::ErrorKind::CacheWrite)?,
         );
         tokio::io::copy(&mut reader, &mut writer)
             .await
-            .map_err(puffin_client::Error::CacheWrite)?;
+            .map_err(puffin_client::ErrorKind::CacheWrite)?;
 
         Ok(temp_dir)
     }

--- a/crates/puffin-resolver/src/resolver/provider.rs
+++ b/crates/puffin-resolver/src/resolver/provider.rs
@@ -105,17 +105,17 @@ impl<'a, Context: BuildContext + Send + Sync> ResolverProvider
                     self.flat_index.get(package_name).cloned(),
                     self.no_binary,
                 )),
-                Err(
-                    err @ (puffin_client::Error::PackageNotFound(_)
-                    | puffin_client::Error::NoIndex(_)),
-                ) => {
-                    if let Some(flat_index) = self.flat_index.get(package_name).cloned() {
-                        Ok(VersionMap::from(flat_index))
-                    } else {
-                        Err(err)
+                Err(err) => match err.into_kind() {
+                    kind @ (puffin_client::ErrorKind::PackageNotFound(_)
+                    | puffin_client::ErrorKind::NoIndex(_)) => {
+                        if let Some(flat_index) = self.flat_index.get(package_name).cloned() {
+                            Ok(VersionMap::from(flat_index))
+                        } else {
+                            Err(kind.into())
+                        }
                     }
-                }
-                Err(err) => Err(err),
+                    kind => Err(kind.into()),
+                },
             })
     }
 


### PR DESCRIPTION
This PR changes the error type to be boxed internally so that it uses
less size on the stack. This makes functions returning `Result<T,
Error>`, in particular, return something much smaller.

The specific thing that motivated this was Clippy lints firing when I
tried to refactor code in this crate.

I chose to achieve boxing by splitting the enum out into a separate
type, and then wiring up the necessary `From` impl to make error
conversions easy, and then making `Error` itself opaque. We could expose
the `Box`, but there isn't a ton of benefit in doing so because one
cannot pattern match through a `Box`.

This required using more explicit error conversions in several places.
And as a result, I was able to remove all `#[from]` attributes on
non-transparent error variants.
