### PR TITLE
Remove `Option` wrapper from requirement extras

### DIFF
--- a/crates/distribution-types/src/resolution.rs
+++ b/crates/distribution-types/src/resolution.rs
@@ -66,7 +66,7 @@ impl From<Dist> for Requirement {
         match dist {
             Dist::Built(BuiltDist::Registry(wheel)) => Requirement {
                 name: wheel.filename.name,
-                extras: None,
+                extras: vec![],
                 version_or_url: Some(pep508_rs::VersionOrUrl::VersionSpecifier(
                     pep440_rs::VersionSpecifiers::from(
                         pep440_rs::VersionSpecifier::equals_version(wheel.filename.version),
@@ -76,19 +76,19 @@ impl From<Dist> for Requirement {
             },
             Dist::Built(BuiltDist::DirectUrl(wheel)) => Requirement {
                 name: wheel.filename.name,
-                extras: None,
+                extras: vec![],
                 version_or_url: Some(pep508_rs::VersionOrUrl::Url(wheel.url)),
                 marker: None,
             },
             Dist::Built(BuiltDist::Path(wheel)) => Requirement {
                 name: wheel.filename.name,
-                extras: None,
+                extras: vec![],
                 version_or_url: Some(pep508_rs::VersionOrUrl::Url(wheel.url)),
                 marker: None,
             },
             Dist::Source(SourceDist::Registry(sdist)) => Requirement {
                 name: sdist.filename.name,
-                extras: None,
+                extras: vec![],
                 version_or_url: Some(pep508_rs::VersionOrUrl::VersionSpecifier(
                     pep440_rs::VersionSpecifiers::from(
                         pep440_rs::VersionSpecifier::equals_version(sdist.filename.version),
@@ -98,19 +98,19 @@ impl From<Dist> for Requirement {
             },
             Dist::Source(SourceDist::DirectUrl(sdist)) => Requirement {
                 name: sdist.name,
-                extras: None,
+                extras: vec![],
                 version_or_url: Some(pep508_rs::VersionOrUrl::Url(sdist.url)),
                 marker: None,
             },
             Dist::Source(SourceDist::Git(sdist)) => Requirement {
                 name: sdist.name,
-                extras: None,
+                extras: vec![],
                 version_or_url: Some(pep508_rs::VersionOrUrl::Url(sdist.url)),
                 marker: None,
             },
             Dist::Source(SourceDist::Path(sdist)) => Requirement {
                 name: sdist.name,
-                extras: None,
+                extras: vec![],
                 version_or_url: Some(pep508_rs::VersionOrUrl::Url(sdist.url)),
                 marker: None,
             },

--- a/crates/puffin-installer/src/site_packages.rs
+++ b/crates/puffin-installer/src/site_packages.rs
@@ -94,7 +94,7 @@ impl<'a> SitePackages<'a> {
     pub fn requirements(&self) -> impl Iterator<Item = Requirement> + '_ {
         self.iter().map(|dist| Requirement {
             name: dist.name().clone(),
-            extras: None,
+            extras: vec![],
             version_or_url: Some(match dist.installed_version() {
                 InstalledVersion::Version(version) => {
                     pep508_rs::VersionOrUrl::VersionSpecifier(pep440_rs::VersionSpecifiers::from(

--- a/crates/puffin-resolver/src/pubgrub/dependencies.rs
+++ b/crates/puffin-resolver/src/pubgrub/dependencies.rs
@@ -52,7 +52,6 @@ impl PubGrubDependencies {
                     .extras
                     .clone()
                     .into_iter()
-                    .flatten()
                     .map(|extra| to_pubgrub(requirement, Some(extra))),
             ) {
                 let (package, version) = result?;
@@ -104,7 +103,6 @@ impl PubGrubDependencies {
                     .extras
                     .clone()
                     .into_iter()
-                    .flatten()
                     .map(|extra| to_pubgrub(constraint, Some(extra))),
             ) {
                 let (package, version) = result?;

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-basic.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-basic.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "numpy",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -32,7 +32,7 @@ RequirementsTxt {
                 name: PackageName(
                     "pandas",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -55,7 +55,7 @@ RequirementsTxt {
                 name: PackageName(
                     "python-dateutil",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -78,7 +78,7 @@ RequirementsTxt {
                 name: PackageName(
                     "pytz",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -101,7 +101,7 @@ RequirementsTxt {
                 name: PackageName(
                     "six",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -124,7 +124,7 @@ RequirementsTxt {
                 name: PackageName(
                     "tzdata",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-a.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "django-debug-toolbar",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -33,7 +33,7 @@ RequirementsTxt {
             name: PackageName(
                 "django",
             ),
-            extras: None,
+            extras: [],
             version_or_url: Some(
                 VersionSpecifier(
                     VersionSpecifiers(
@@ -52,7 +52,7 @@ RequirementsTxt {
             name: PackageName(
                 "pytz",
             ),
-            extras: None,
+            extras: [],
             version_or_url: Some(
                 VersionSpecifier(
                     VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-b.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "django",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -32,7 +32,7 @@ RequirementsTxt {
                 name: PackageName(
                     "pytz",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-editable.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-editable.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "numpy",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: None,
                 marker: None,
             },
@@ -21,13 +21,11 @@ RequirementsTxt {
                 name: PackageName(
                     "pandas",
                 ),
-                extras: Some(
-                    [
-                        ExtraName(
-                            "tabulate",
-                        ),
-                    ],
-                ),
+                extras: [
+                    ExtraName(
+                        "tabulate",
+                    ),
+                ],
                 version_or_url: Some(
                     Url(
                         VerbatimUrl {

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-for-poetry.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-for-poetry.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "inflection",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -32,7 +32,7 @@ RequirementsTxt {
                 name: PackageName(
                     "upsidedown",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -55,7 +55,7 @@ RequirementsTxt {
                 name: PackageName(
                     "numpy",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: None,
                 marker: None,
             },
@@ -67,13 +67,11 @@ RequirementsTxt {
                 name: PackageName(
                     "pandas",
                 ),
-                extras: Some(
-                    [
-                        ExtraName(
-                            "tabulate",
-                        ),
-                    ],
-                ),
+                extras: [
+                    ExtraName(
+                        "tabulate",
+                    ),
+                ],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-a.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "tomli",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: None,
                 marker: None,
             },
@@ -21,7 +21,7 @@ RequirementsTxt {
                 name: PackageName(
                     "numpy",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-b.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "tomli",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: None,
                 marker: None,
             },

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "werkzeug",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -61,7 +61,7 @@ RequirementsTxt {
                 name: PackageName(
                     "urllib3",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -113,7 +113,7 @@ RequirementsTxt {
                 name: PackageName(
                     "ansicon",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -176,7 +176,7 @@ RequirementsTxt {
                 name: PackageName(
                     "requests-oauthlib",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -229,7 +229,7 @@ RequirementsTxt {
                 name: PackageName(
                     "psycopg2",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-small.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-small.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "tqdm",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -32,7 +32,7 @@ RequirementsTxt {
                 name: PackageName(
                     "tomli-w",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-whitespace.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-whitespace.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "numpy",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: None,
                 marker: None,
             },
@@ -21,13 +21,11 @@ RequirementsTxt {
                 name: PackageName(
                     "pandas",
                 ),
-                extras: Some(
-                    [
-                        ExtraName(
-                            "tabulate",
-                        ),
-                    ],
-                ),
+                extras: [
+                    ExtraName(
+                        "tabulate",
+                    ),
+                ],
                 version_or_url: Some(
                     Url(
                         VerbatimUrl {

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-basic.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-basic.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "numpy",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -32,7 +32,7 @@ RequirementsTxt {
                 name: PackageName(
                     "pandas",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -55,7 +55,7 @@ RequirementsTxt {
                 name: PackageName(
                     "python-dateutil",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -78,7 +78,7 @@ RequirementsTxt {
                 name: PackageName(
                     "pytz",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -101,7 +101,7 @@ RequirementsTxt {
                 name: PackageName(
                     "six",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -124,7 +124,7 @@ RequirementsTxt {
                 name: PackageName(
                     "tzdata",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-a.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "django-debug-toolbar",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -33,7 +33,7 @@ RequirementsTxt {
             name: PackageName(
                 "django",
             ),
-            extras: None,
+            extras: [],
             version_or_url: Some(
                 VersionSpecifier(
                     VersionSpecifiers(
@@ -52,7 +52,7 @@ RequirementsTxt {
             name: PackageName(
                 "pytz",
             ),
-            extras: None,
+            extras: [],
             version_or_url: Some(
                 VersionSpecifier(
                     VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-b.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "django",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -32,7 +32,7 @@ RequirementsTxt {
                 name: PackageName(
                     "pytz",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-for-poetry.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-for-poetry.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "inflection",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -32,7 +32,7 @@ RequirementsTxt {
                 name: PackageName(
                     "upsidedown",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -55,7 +55,7 @@ RequirementsTxt {
                 name: PackageName(
                     "numpy",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: None,
                 marker: None,
             },
@@ -67,13 +67,11 @@ RequirementsTxt {
                 name: PackageName(
                     "pandas",
                 ),
-                extras: Some(
-                    [
-                        ExtraName(
-                            "tabulate",
-                        ),
-                    ],
-                ),
+                extras: [
+                    ExtraName(
+                        "tabulate",
+                    ),
+                ],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-a.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "tomli",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: None,
                 marker: None,
             },
@@ -21,7 +21,7 @@ RequirementsTxt {
                 name: PackageName(
                     "numpy",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-b.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "tomli",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: None,
                 marker: None,
             },

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-poetry-with-hashes.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-poetry-with-hashes.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "werkzeug",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -61,7 +61,7 @@ RequirementsTxt {
                 name: PackageName(
                     "urllib3",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -113,7 +113,7 @@ RequirementsTxt {
                 name: PackageName(
                     "ansicon",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -176,7 +176,7 @@ RequirementsTxt {
                 name: PackageName(
                     "requests-oauthlib",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -229,7 +229,7 @@ RequirementsTxt {
                 name: PackageName(
                     "psycopg2",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-small.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-small.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "tqdm",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(
@@ -32,7 +32,7 @@ RequirementsTxt {
                 name: PackageName(
                     "tomli-w",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: Some(
                     VersionSpecifier(
                         VersionSpecifiers(

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-whitespace.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-whitespace.txt.snap
@@ -9,7 +9,7 @@ RequirementsTxt {
                 name: PackageName(
                     "numpy",
                 ),
-                extras: None,
+                extras: [],
                 version_or_url: None,
                 marker: None,
             },
@@ -21,13 +21,11 @@ RequirementsTxt {
                 name: PackageName(
                     "pandas",
                 ),
-                extras: Some(
-                    [
-                        ExtraName(
-                            "tabulate",
-                        ),
-                    ],
-                ),
+                extras: [
+                    ExtraName(
+                        "tabulate",
+                    ),
+                ],
                 version_or_url: Some(
                     Url(
                         VerbatimUrl {


### PR DESCRIPTION
There's no semantic difference between `None` and empty, so seems simpler to represent this way.