### PR TITLE
Store source distribution directly in the cache

### DIFF
--- a/crates/puffin-distribution/src/source/mod.rs
+++ b/crates/puffin-distribution/src/source/mod.rs
@@ -766,9 +766,11 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
         drop(span);
 
         // Persist the unzipped distribution to the cache.
-        self.build_context
-            .cache()
-            .persist(source_dist_dir, cache_path)
+        fs_err::tokio::create_dir_all(cache_path.parent().expect("Cache entry to have parent"))
+            .await
+            .map_err(Error::CacheWrite)?;
+        fs_err::tokio::rename(&source_dist_dir, &cache_path)
+            .await
             .map_err(Error::CacheWrite)?;
 
         Ok(cache_path)


### PR DESCRIPTION
I want to move towards using the archive bucket exclusively for wheels. We never overwrite source distributions, so there's no need to symlink them.