### PR TITLE
Remove refresh checks from the install plan

### DIFF
--- a/crates/puffin-cache/src/lib.rs
+++ b/crates/puffin-cache/src/lib.rs
@@ -160,6 +160,15 @@ impl Cache {
         CacheEntry::new(self.bucket(cache_bucket).join(dir), file)
     }
 
+    /// Returns `true` if a cache entry must be revalidated given the [`Refresh`] policy.
+    pub fn must_revalidate(&self, package: &PackageName) -> bool {
+        match &self.refresh {
+            Refresh::None => false,
+            Refresh::All(_) => true,
+            Refresh::Packages(packages, _) => packages.contains(package),
+        }
+    }
+
     /// Returns `true` if a cache entry is up-to-date given the [`Refresh`] policy.
     pub fn freshness(
         &self,

--- a/crates/puffin-distribution/src/index/registry_wheel_index.rs
+++ b/crates/puffin-distribution/src/index/registry_wheel_index.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashMap;
 use distribution_types::{CachedRegistryDist, FlatIndexLocation, IndexLocations, IndexUrl};
 use pep440_rs::Version;
 use platform_tags::Tags;
-use puffin_cache::{Cache, CacheBucket, Freshness, WheelCache};
+use puffin_cache::{Cache, CacheBucket, WheelCache};
 use puffin_fs::{directories, symlinks};
 use puffin_normalize::PackageName;
 
@@ -94,7 +94,7 @@ impl<'a> RegistryWheelIndex<'a> {
                 WheelCache::Index(index_url).remote_wheel_dir(package.to_string()),
             );
 
-            Self::add_directory(&wheel_dir, package, cache, tags, &mut versions);
+            Self::add_directory(&wheel_dir, tags, &mut versions);
 
             // Index all the built wheels, created by downloading and building source distributions
             // from the registry.
@@ -109,13 +109,7 @@ impl<'a> RegistryWheelIndex<'a> {
                 let cache_shard = cache_shard.shard(shard);
                 let manifest_entry = cache_shard.entry(MANIFEST);
                 if let Ok(Some(manifest)) = read_http_manifest(&manifest_entry) {
-                    Self::add_directory(
-                        cache_shard.join(manifest.id()),
-                        package,
-                        cache,
-                        tags,
-                        &mut versions,
-                    );
+                    Self::add_directory(cache_shard.join(manifest.id()), tags, &mut versions);
                 };
             }
         }
@@ -128,8 +122,6 @@ impl<'a> RegistryWheelIndex<'a> {
     /// Each subdirectory in the given path is expected to be that of an unzipped wheel.
     fn add_directory(
         path: impl AsRef<Path>,
-        package: &PackageName,
-        cache: &Cache,
         tags: &Tags,
         versions: &mut BTreeMap<Version, CachedRegistryDist>,
     ) {
@@ -138,13 +130,6 @@ impl<'a> RegistryWheelIndex<'a> {
             match CachedWheel::from_path(&wheel_dir) {
                 None => {}
                 Some(dist_info) => {
-                    if cache
-                        .freshness(&dist_info.entry, Some(package))
-                        .is_ok_and(Freshness::is_stale)
-                    {
-                        continue;
-                    }
-
                     let dist_info = dist_info.into_registry_dist();
 
                     // Pick the wheel with the highest priority


### PR DESCRIPTION
## Summary

Rather than checking cache freshness in the install plan, it's a lot simple to have the install plan _never_ return cached data when the refresh policy is in place, and then rely on the distribution database to check for freshness. The original implementation didn't support this, since the distribution database was rebuilding things too often. Now, it rarely rebuilds (it's much better about this), so it seems conceptually much simpler to split up the responsibilities like this.
