### PR TITLE
bootstrap: add 'libxcrypt-compat' to pacman install command

### DIFF
--- a/scripts/bootstrap/install.sh
+++ b/scripts/bootstrap/install.sh
@@ -10,12 +10,12 @@
 #       brew install zstd jq coreutils
 #
 #   Ubuntu
-#       
+#
 #       apt install zstd jq
 #
 #   Arch Linux
-#   
-#       pacman -S zstd jq
+#
+#       pacman -S zstd jq libxcrypt-compat
 #
 #   Windows
 #
@@ -72,7 +72,7 @@ for version in "${versions[@]}"; do
     echo "Installing $key"
 
     url=$(jq --arg key "$key" '.[$key] | .url' -r < "$versions_metadata")
-    
+
     if [ "$url" == 'null' ]; then
         echo "No matching download for $key"
         exit 1
@@ -96,7 +96,7 @@ for version in "${versions[@]}"; do
     echo "Extracting to $($realpath --relative-to="$root_dir" "$install_key")"
     mkdir -p "$install_key"
     zstd -d "$this_dir/$filename" --stdout | tar -x -C "$install_key"
-    
+
     # Setup the installation
     mv "$install_key/python/"* "$install_key"
     # Use relative paths for links so if the bin is moved they don't break


### PR DESCRIPTION
This is apparently necessary to permit Python 3.8.12 to run. Namely, it
needs to link to libcrypt.so.1, and without libxcrypt-compat, that
linking step fails.
