### PR TITLE
Avoid unnecessary permissions changes for copy paths

### DIFF
--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -353,21 +353,8 @@ fn copy_wheel_files(
             continue;
         }
 
-        // Copy the file.
+        // Copy the file, which will also set its permissions.
         fs::copy(path, &out_path)?;
-
-        #[cfg(unix)]
-        {
-            use std::fs::Permissions;
-            use std::os::unix::fs::PermissionsExt;
-
-            if let Ok(metadata) = entry.metadata() {
-                fs::set_permissions(
-                    &out_path,
-                    Permissions::from_mode(metadata.permissions().mode()),
-                )?;
-            }
-        }
 
         count += 1;
     }

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,0 @@
-ziglang


### PR DESCRIPTION
In Rust, `fs::copy` automatically preserves permissions (see: https://doc.rust-lang.org/std/fs/fn.copy.html).

Elsewhere, when copying from the zip archive out to the cache, we can set permissions during file creation, rather than as a separate call.

Both of these should be slightly more efficient.