### PR TITLE
Fix bootstrap install script on windows

### DIFF
--- a/scripts/bootstrap/install.py
+++ b/scripts/bootstrap/install.py
@@ -30,7 +30,6 @@
 
 import hashlib
 import json
-import os
 import platform
 import shutil
 import sys


### PR DESCRIPTION
Windows doesn't support symlinks, doesn't use a `bin` directory and all pythons are called `python.exe`.

Note that this is still broken, `.\bin\python3.10.13` is missing its .exe extension and renaming it to `.\bin\python3.10.13.exe` makes it complain about not finding python310.dll.