### PR TITLE
Small instrumentation improvements

### DIFF
--- a/crates/distribution-types/src/id.rs
+++ b/crates/distribution-types/src/id.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter};
+
 /// A unique identifier for a package (e.g., `black==23.10.0`).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PackageId(String);
@@ -5,6 +7,12 @@ pub struct PackageId(String);
 impl PackageId {
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
+    }
+}
+
+impl Display for PackageId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
     }
 }
 

--- a/crates/puffin-client/src/registry_client.rs
+++ b/crates/puffin-client/src/registry_client.rs
@@ -241,7 +241,7 @@ impl RegistryClient {
     /// 1. From a [PEP 658](https://peps.python.org/pep-0658/) data-dist-info-metadata url
     /// 2. From a remote wheel by partial zip reading
     /// 3. From a (temp) download of a remote wheel (this is a fallback, the webserver should support range requests)
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(%built_dist))]
     pub async fn wheel_metadata(&self, built_dist: &BuiltDist) -> Result<Metadata21, Error> {
         let metadata = match &built_dist {
             BuiltDist::Registry(wheel) => match &wheel.file.url {

--- a/crates/puffin-dev/src/main.rs
+++ b/crates/puffin-dev/src/main.rs
@@ -4,11 +4,12 @@ use std::env;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use anstream::eprintln;
 use anyhow::Result;
 use clap::Parser;
+use owo_colors::OwoColorize;
 use tracing::debug;
 use tracing_durations_export::plot::PlotConfig;
 use tracing_durations_export::DurationsLayerBuilder;
@@ -17,7 +18,6 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
-use owo_colors::OwoColorize;
 use resolve_many::ResolveManyArgs;
 
 use crate::build::{build, BuildArgs};
@@ -100,7 +100,7 @@ async fn main() -> ExitCode {
         }
         let plot_config = PlotConfig {
             multi_lane: true,
-            min_length: Some(Duration::from_secs_f32(0.002)),
+            min_length: None,
             remove: Some(
                 ["get_cached_with_callback".to_string()]
                     .into_iter()

--- a/crates/puffin-distribution/src/distribution_database.rs
+++ b/crates/puffin-distribution/src/distribution_database.rs
@@ -330,7 +330,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
     /// Returns the [`Metadata21`], along with a "precise" URL for the source distribution, if
     /// possible. For example, given a Git dependency with a reference to a branch or tag, return a
     /// URL with a precise reference to the current commit of that branch or tag.
-    #[instrument(skip(self))]
+    #[instrument(skip_all, fields(%dist))]
     pub async fn get_or_build_wheel_metadata(
         &self,
         dist: &Dist,

--- a/crates/puffin/src/logging.rs
+++ b/crates/puffin/src/logging.rs
@@ -79,7 +79,7 @@ pub(crate) fn setup_duration() -> (
         }
         let plot_config = PlotConfig {
             multi_lane: true,
-            min_length: Some(std::time::Duration::from_secs_f32(0.002)),
+            min_length: None,
             remove: Some(
                 ["get_cached_with_callback".to_string()]
                     .into_iter()


### PR DESCRIPTION
Less verbose span fields for `Dist`s by using the display impl and no more min length in the tracing durations plot config for comparability (we lose spans due to a speedup otherwise). Both wait points in the solver loop are now instrumented so we can inspect what we're waiting for to progress in the solver.