### PR TITLE
Fix the `compile_python_37` test with python 3.7 installed

### DIFF
--- a/crates/puffin/tests/pip_compile.rs
+++ b/crates/puffin/tests/pip_compile.rs
@@ -676,8 +676,19 @@ fn compile_python_37() -> Result<()> {
     let requirements_in = temp_dir.child("requirements.in");
     requirements_in.write_str("black==23.10.1")?;
 
+    let filters: Vec<_> = [
+        // 3.7 may not be installed
+        (
+            "warning: The requested Python version 3.7 is not available; .* will be used to build dependencies instead.\n",
+            "",
+        ),
+    ]
+    .into_iter()
+    .chain(INSTA_FILTERS.to_vec())
+    .collect();
+
     insta::with_settings!({
-        filters => INSTA_FILTERS.to_vec()
+        filters => filters
     }, {
         assert_cmd_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
             .arg("pip")
@@ -696,7 +707,6 @@ fn compile_python_37() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: The requested Python version 3.7 is not available; 3.12.1 will be used to build dependencies instead.
           × No solution found when resolving dependencies:
           ╰─▶ Because the requested Python version (3.7) does not satisfy Python>=3.8
               and black==23.10.1 depends on Python>=3.8, we can conclude that


### PR DESCRIPTION
Make the test `compile_python_37` pass whether python 3.7 is installed or not by muting the warning for a missing 3.7. The resolution error is independent of whether 3.7 is installed or not.