### PR TITLE
Prompt user for missing `-r` and `-e` flags in `pip install`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,6 +2360,7 @@ dependencies = [
  "assert_fs",
  "chrono",
  "clap",
+ "console",
  "distribution-filename",
  "distribution-types",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ cargo-util = { version = "0.2.8" }
 chrono = { version = "0.4.31" }
 clap = { version = "4.4.13" }
 configparser = { version = "3.0.4" }
+console = { version = "0.15.8", default-features = false }
 csv = { version = "1.3.0" }
 dashmap = { version = "5.5.3" }
 data-encoding = { version = "2.5.0" }

--- a/crates/puffin/Cargo.toml
+++ b/crates/puffin/Cargo.toml
@@ -47,6 +47,8 @@ anstream = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+console = { workspace = true }
+dunce = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 indicatif = { workspace = true }
@@ -68,7 +70,6 @@ tracing-tree = { workspace = true }
 url = { workspace = true }
 waitmap = { workspace = true }
 which = { workspace = true }
-dunce = "1.0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.39"

--- a/crates/puffin/src/commands/pip_compile.rs
+++ b/crates/puffin/src/commands/pip_compile.rs
@@ -118,7 +118,7 @@ pub(crate) async fn pip_compile(
         .filter(|_| !upgrade.is_all())
         .filter(|output_file| output_file.exists())
         .map(Path::to_path_buf)
-        .map(RequirementsSource::from)
+        .map(RequirementsSource::from_path)
         .as_ref()
         .map(|source| RequirementsSpecification::from_source(source, &extras))
         .transpose()?

--- a/crates/puffin/src/confirm.rs
+++ b/crates/puffin/src/confirm.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use console::{style, Key, Term};
+
+/// Prompt the user for confirmation in the given [`Term`].
+///
+/// This is a slimmed-down version of [`dialoguer::Confirm`], with the post-confirmation report
+/// enabled.
+pub(crate) fn confirm(message: &str, term: &Term, default: bool) -> Result<bool> {
+    let prompt = format!(
+        "{} {} {} {} {}",
+        style("?".to_string()).for_stderr().yellow(),
+        style(message).for_stderr().white().bold(),
+        style("[y/n]").for_stderr().black().bright(),
+        style("›").for_stderr().black().bright(),
+        style(if default { "yes" } else { "no" })
+            .for_stderr()
+            .cyan(),
+    );
+
+    term.write_str(&prompt)?;
+    term.hide_cursor()?;
+    term.flush()?;
+
+    // Match continuously on every keystroke, and do not wait for user to hit the
+    // `Enter` key.
+    let response = loop {
+        let input = term.read_key()?;
+        match input {
+            Key::Char('y' | 'Y') => break true,
+            Key::Char('n' | 'N') => break false,
+            Key::Enter => break default,
+            _ => {}
+        };
+    };
+
+    let report = format!(
+        "{} {} {} {}",
+        style("✔".to_string()).for_stderr().green(),
+        style(message).for_stderr().white().bold(),
+        style("·").for_stderr().black().bright(),
+        style(if response { "yes" } else { "no" })
+            .for_stderr()
+            .cyan(),
+    );
+
+    term.clear_line()?;
+    term.write_line(&report)?;
+    term.show_cursor()?;
+    term.flush()?;
+
+    Ok(response)
+}

--- a/crates/puffin/src/main.rs
+++ b/crates/puffin/src/main.rs
@@ -40,6 +40,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 mod commands;
 mod compat;
+mod confirm;
 mod logging;
 mod printer;
 mod requirements;
@@ -670,17 +671,17 @@ async fn run() -> Result<ExitStatus> {
             let requirements = args
                 .src_file
                 .into_iter()
-                .map(RequirementsSource::from)
+                .map(RequirementsSource::from_path)
                 .collect::<Vec<_>>();
             let constraints = args
                 .constraint
                 .into_iter()
-                .map(RequirementsSource::from)
+                .map(RequirementsSource::from_path)
                 .collect::<Vec<_>>();
             let overrides = args
                 .r#override
                 .into_iter()
-                .map(RequirementsSource::from)
+                .map(RequirementsSource::from_path)
                 .collect::<Vec<_>>();
             let index_urls = IndexLocations::from_args(
                 args.index_url,
@@ -739,7 +740,7 @@ async fn run() -> Result<ExitStatus> {
             let sources = args
                 .src_file
                 .into_iter()
-                .map(RequirementsSource::from)
+                .map(RequirementsSource::from_path)
                 .collect::<Vec<_>>();
             let reinstall = Reinstall::from_args(args.reinstall, args.reinstall_package);
             let no_binary = NoBinary::from_args(args.no_binary, args.no_binary_package);
@@ -768,19 +769,23 @@ async fn run() -> Result<ExitStatus> {
             let requirements = args
                 .package
                 .into_iter()
-                .map(RequirementsSource::Package)
+                .map(RequirementsSource::from_package)
                 .chain(args.editable.into_iter().map(RequirementsSource::Editable))
-                .chain(args.requirement.into_iter().map(RequirementsSource::from))
+                .chain(
+                    args.requirement
+                        .into_iter()
+                        .map(RequirementsSource::from_path),
+                )
                 .collect::<Vec<_>>();
             let constraints = args
                 .constraint
                 .into_iter()
-                .map(RequirementsSource::from)
+                .map(RequirementsSource::from_path)
                 .collect::<Vec<_>>();
             let overrides = args
                 .r#override
                 .into_iter()
-                .map(RequirementsSource::from)
+                .map(RequirementsSource::from_path)
                 .collect::<Vec<_>>();
             let index_urls = IndexLocations::from_args(
                 args.index_url,
@@ -827,9 +832,13 @@ async fn run() -> Result<ExitStatus> {
             let sources = args
                 .package
                 .into_iter()
-                .map(RequirementsSource::Package)
+                .map(RequirementsSource::from_package)
                 .chain(args.editable.into_iter().map(RequirementsSource::Editable))
-                .chain(args.requirement.into_iter().map(RequirementsSource::from))
+                .chain(
+                    args.requirement
+                        .into_iter()
+                        .map(RequirementsSource::from_path),
+                )
                 .collect::<Vec<_>>();
             commands::pip_uninstall(&sources, cache, printer).await
         }


### PR DESCRIPTION
## Summary

If the user runs a command like `pip install requirements.txt`, we now prompt them to ask if they meant to include the `-r` flag:

![Screenshot 2024-01-29 at 8 38 29 PM](https://github.com/astral-sh/puffin/assets/1309177/82b9f7a2-2526-4144-b200-a5015e5b8a4b)

![Screenshot 2024-01-29 at 8 38 33 PM](https://github.com/astral-sh/puffin/assets/1309177/bd8ebb51-2537-4540-a0e0-718e66a1c69c)

The specific logic is: if the requirement ends in `.txt` or `.in`, and the file exists locally, prompt the user for `-r`. If the requirement contains a directory separator, and the directory exists locally, prompt the user for `-e`.

Closes #1166.