### PR TITLE
Accept relative file paths in CLI requirements

### DIFF
--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -402,8 +402,8 @@ impl FromStr for Requirement {
 
 impl Requirement {
     /// Parse a [Dependency Specifier](https://packaging.python.org/en/latest/specifications/dependency-specifiers/)
-    pub fn parse(input: &str, working_dir: Option<&Path>) -> Result<Self, Pep508Error> {
-        parse(&mut Cursor::new(input), working_dir)
+    pub fn parse(input: &str, working_dir: impl AsRef<Path>) -> Result<Self, Pep508Error> {
+        parse(&mut Cursor::new(input), Some(working_dir.as_ref()))
     }
 }
 

--- a/crates/puffin/src/requirements.rs
+++ b/crates/puffin/src/requirements.rs
@@ -1,7 +1,6 @@
 //! A standard interface for working with heterogeneous sources of requirements.
 
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use fs_err as fs;
@@ -86,7 +85,7 @@ impl RequirementsSpecification {
     ) -> Result<Self> {
         Ok(match source {
             RequirementsSource::Package(name) => {
-                let requirement = Requirement::from_str(name)
+                let requirement = Requirement::parse(name, std::env::current_dir()?)
                     .with_context(|| format!("Failed to parse `{name}`"))?;
                 Self {
                     project: None,

--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -574,21 +574,19 @@ fn parse_requirement_and_hashes(
         }
     };
     let requirement =
-        Requirement::parse(&content[start..end], Some(working_dir)).map_err(|err| {
-            match err.message {
-                Pep508ErrorSource::String(_) | Pep508ErrorSource::UrlError(_) => {
-                    RequirementsTxtParserError::Pep508 {
-                        source: err,
-                        start,
-                        end,
-                    }
+        Requirement::parse(&content[start..end], working_dir).map_err(|err| match err.message {
+            Pep508ErrorSource::String(_) | Pep508ErrorSource::UrlError(_) => {
+                RequirementsTxtParserError::Pep508 {
+                    source: err,
+                    start,
+                    end,
                 }
-                Pep508ErrorSource::UnsupportedRequirement(_) => {
-                    RequirementsTxtParserError::UnsupportedRequirement {
-                        source: err,
-                        start,
-                        end,
-                    }
+            }
+            Pep508ErrorSource::UnsupportedRequirement(_) => {
+                RequirementsTxtParserError::UnsupportedRequirement {
+                    source: err,
+                    start,
+                    end,
                 }
             }
         })?;


### PR DESCRIPTION
## Summary

See: https://github.com/astral-sh/puffin/issues/1181.

## Test Plan

```
❯ cargo run -- pip install packse@../../zanieb/packse
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/puffin pip install 'packse@../../zanieb/packse'`
error: Distribution not found at: file:///Users/crmarsh/zanieb/packse
```
