### PR TITLE
Enable macOS checks on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,69 +18,63 @@ env:
   PYTHON_VERSION: "3.12"
 
 jobs:
-#  cargo-fmt:
-#    name: "cargo fmt"
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: "Install Rust toolchain"
-#        run: rustup component add rustfmt
-#      - name: "rustfmt"
-#        run: cargo fmt --all --check
-#
-#  cargo-clippy:
-#    name: "cargo clippy"
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: "Install Rust toolchain"
-#        run: |
-#          rustup component add clippy
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          save-if: ${{ github.ref == 'refs/heads/main' }}
-#      - name: "Clippy"
-#        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
-#
-#  cargo-test:
-#    strategy:
-#      matrix:
-#        os: [ubuntu-latest]
-#    runs-on:
-#      # We use the large GitHub actions runners for faster testing
-#      # For Ubuntu and Windows, this requires Organization-level configuration
-#      # See: https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-ubuntu-and-windows-larger-runners
-#      labels: ${{ matrix.os }}-large
-#    name: "cargo test | ${{ matrix.os }}"
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: "Install bootstrap dependencies"
-#        if: matrix.os == 'macos-latest'
-#        run: |
-#          brew install coreutils
-#      - name: "Install required Python versions"
-#        run: |
-#          scripts/bootstrap/install.sh
-#      - name: "Install Rust toolchain"
-#        run: rustup show
-#      - uses: rui314/setup-mold@v1
-#      - name: "Install cargo nextest"
-#        uses: taiki-e/install-action@v2
-#        with:
-#          tool: cargo-nextest
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          prefix-key: "1193"
-#      - name: "Tests"
-#        run: |
-#          source .env
-#          cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 12
+  cargo-fmt:
+    name: "cargo fmt"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Install Rust toolchain"
+        run: rustup component add rustfmt
+      - name: "rustfmt"
+        run: cargo fmt --all --check
+
+  cargo-clippy:
+    name: "cargo clippy"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Install Rust toolchain"
+        run: |
+          rustup component add clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: "Clippy"
+        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+  cargo-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on:
+      # We use the large GitHub actions runners for faster testing
+      # For Ubuntu and Windows, this requires Organization-level configuration
+      # See: https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-ubuntu-and-windows-larger-runners
+      labels: ${{ matrix.os }}-large
+    name: "cargo test | ${{ matrix.os }}"
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Install required Python versions"
+        run: |
+          scripts/bootstrap/install.sh
+      - name: "Install Rust toolchain"
+        run: rustup show
+      - uses: rui314/setup-mold@v1
+      - name: "Install cargo nextest"
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: "Tests"
+        run: |
+          source .env
+          cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 12
 
   macos:
-    # For cost efficiency, run macOS tests on main, but not on PR.
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on:
-      labels: macos-latest-large
+      labels: macos-14
     name: "cargo test | macos"
     steps:
       - uses: actions/checkout@v4
@@ -99,52 +93,52 @@ jobs:
           tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "11193"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: "Tests"
         run: |
           source .env
           cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 12
 
-#  # TODO(konstin): Merge with the cargo-test job once the tests pass
-#  windows:
-#    runs-on: windows-latest-large
-#    name: "cargo check | windows"
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: "Install Rust toolchain"
-#        run: rustup component add clippy
-#      - name: "Install Python for bootstrapping"
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: 3.12
-#      - name: "Install Python binaries"
-#        run: |
-#          pip install zstandard==0.22.0
-#          python scripts/bootstrap/install.py
-#          # ex) The path needs to be updated downstream
-#          $env:Path = "$pwd\bin" + $env:Path
-#      - uses: rui314/setup-mold@v1
-#      - uses: Swatinem/rust-cache@v2
-#      - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
-#
-#  # Separate job for the nightly crate
-#  windows-trampoline:
-#    runs-on: windows-latest
-#    name: "check windows trampoline"
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: "Install Rust toolchain"
-#        working-directory: crates/puffin-trampoline
-#        run: |
-#          rustup target add x86_64-pc-windows-msvc
-#          rustup component add clippy rust-src --toolchain nightly-2024-01-23-x86_64-pc-windows-msvc
-#      - uses: rui314/setup-mold@v1
-#      - uses: Swatinem/rust-cache@v2
-#        with:
-#          workspaces: "crates/puffin-trampoline"
-#      - name: "Clippy"
-#        working-directory: crates/puffin-trampoline
-#        run: cargo clippy --all-features --locked -- -D warnings
-#      - name: "Build"
-#        working-directory: crates/puffin-trampoline
-#        run: cargo build --release -Z build-std=core,panic_abort,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-pc-windows-msvc
+  # TODO(konstin): Merge with the cargo-test job once the tests pass
+  windows:
+    runs-on: windows-latest-large
+    name: "cargo check | windows"
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Install Rust toolchain"
+        run: rustup component add clippy
+      - name: "Install Python for bootstrapping"
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.12
+      - name: "Install Python binaries"
+        run: |
+          pip install zstandard==0.22.0
+          python scripts/bootstrap/install.py
+          # ex) The path needs to be updated downstream
+          $env:Path = "$pwd\bin" + $env:Path
+      - uses: rui314/setup-mold@v1
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+
+  # Separate job for the nightly crate
+  windows-trampoline:
+    runs-on: windows-latest
+    name: "check windows trampoline"
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Install Rust toolchain"
+        working-directory: crates/puffin-trampoline
+        run: |
+          rustup target add x86_64-pc-windows-msvc
+          rustup component add clippy rust-src --toolchain nightly-2024-01-23-x86_64-pc-windows-msvc
+      - uses: rui314/setup-mold@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "crates/puffin-trampoline"
+      - name: "Clippy"
+        working-directory: crates/puffin-trampoline
+        run: cargo clippy --all-features --locked -- -D warnings
+      - name: "Build"
+        working-directory: crates/puffin-trampoline
+        run: cargo build --release -Z build-std=core,panic_abort,alloc -Z build-std-features=compiler-builtins-mem --target x86_64-pc-windows-msvc


### PR DESCRIPTION
## Summary

Enables tests for macOS in CI, using the M1 runners (which are free in public, but count against our quota in private 
repos). For now, I'm just running them on `main` to save quota.

I did the math, and the M1 runners are the best value:

![Screenshot 2024-01-30 at 9 33 36 PM](https://github.com/astral-sh/puffin/assets/1309177/bd5a14b6-740c-487f-bcad-81c0fce5b62e)

Closes #1053.