### PR TITLE
Remove dedicated `flate2` features from Puffin

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -338,7 +338,7 @@ jobs:
             *.tar.gz
             *.sha256
 
-  # Like `linux-arm`, but use `--no-default-features --features flate2-rust_backend` when
+  # Like `linux-arm`, but use `--no-default-features --features flate2/rust_backend` when
   # building Puffin.
   linux-s390x:
     runs-on: ubuntu-latest
@@ -363,7 +363,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release --locked --out dist --no-default-features --features flate2-rust_backend
+          args: --release --locked --out dist --no-default-features --features flate2/rust_backend
       - uses: uraimo/run-on-arch-action@v2
         if: matrix.platform.arch != 'ppc64'
         name: Test wheel
@@ -405,7 +405,7 @@ jobs:
             *.sha256
 
 
-  # Like `linux-arm`, but use `--no-default-features --features flate2-rust_backend` when
+  # Like `linux-arm`, but use `--no-default-features --features flate2/rust_backend` when
   # building Puffin, and install the `gcc-powerpc64-linux-gnu` package.
   linux-powerpc:
     runs-on: ubuntu-latest
@@ -432,7 +432,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release --locked --out dist --no-default-features --features flate2-rust_backend
+          args: --release --locked --out dist --no-default-features --features flate2/rust_backend
           before-script-linux: |
             if command -v yum &> /dev/null; then
                 yum update -y

--- a/crates/puffin/Cargo.toml
+++ b/crates/puffin/Cargo.toml
@@ -88,7 +88,7 @@ regex = { version = "1.10.3" }
 reqwest = { version = "0.11.23", features = ["blocking", "rustls"], default-features = false }
 
 [features]
-default = ["flate2-zlib-ng"]
+default = ["flate2/zlib-ng"]
 # Introduces a dependency on a local Python installation.
 python = []
 # Introduces a dependency on PyPI.
@@ -97,7 +97,3 @@ pypi = []
 git = []
 # Introduces a dependency on Maturin.
 maturin = []
-# Adds the `libz-ng` feature to flate2.
-flate2-zlib-ng = ["flate2/zlib-ng"]
-# Adds the `rust_backend` feature to flate2.
-flate2-rust_backend = ["flate2/rust_backend"]


### PR DESCRIPTION
We should be able to enable and disable these without crate-internal features.