### PR TITLE
Invert default feature for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - name: "Tests"
         run: |
           source .env
-          cargo nextest run --all --all-features --status-level skip --failure-output immediate-final --no-fail-fast -j 12
+          cargo nextest run --all --status-level skip --failure-output immediate-final --no-fail-fast -j 12
 
   # TODO(konstin): Merge with the cargo-test job once the tests pass
   windows:

--- a/crates/puffin-resolver/Cargo.toml
+++ b/crates/puffin-resolver/Cargo.toml
@@ -67,5 +67,6 @@ once_cell = { version = "1.19.0" }
 insta = { version = "1.34.0" }
 
 [features]
+default = ["pypi"]
 # Introduces a dependency on PyPI.
 pypi = []

--- a/crates/puffin/Cargo.toml
+++ b/crates/puffin/Cargo.toml
@@ -88,7 +88,7 @@ regex = { version = "1.10.3" }
 reqwest = { version = "0.11.23", features = ["blocking", "rustls"], default-features = false }
 
 [features]
-default = ["flate2/zlib-ng"]
+default = ["flate2/zlib-ng", "python", "pypi", "git", "maturin"]
 # Introduces a dependency on a local Python installation.
 python = []
 # Introduces a dependency on PyPI.


### PR DESCRIPTION
## Summary

We have some flags in Puffin that enable us to opt-in to certain tests. To date, they've been opt-in, so we've run our tests with `--all-features`. This PR makes them opt-out, and we now run tests with default features.

The main motivation here is that I want to get tests working for macOS on CI, but for unknown reasons, macOS can't compile the PyO3 features at the same time as everything else due to strange linker issues. By avoiding `--all-features` for tests, we thus avoid unnecessarily including features that we don't actually use in Puffin.

I verified that the exact same number of tests (439) are run before and after this change. For users, the primary difference is that you now need to specify `--no-default-features --features pypi --features python` to avoid (e.g.) including the Git tests.
