### PR TITLE
Add a Ctrl+C handler to the confirm workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
+dependencies = [
+ "nix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,6 +1876,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,6 +2336,7 @@ dependencies = [
  "chrono",
  "clap",
  "console",
+ "ctrlc",
  "distribution-filename",
  "distribution-types",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ clap = { version = "4.4.13" }
 configparser = { version = "3.0.4" }
 console = { version = "0.15.8", default-features = false }
 csv = { version = "1.3.0" }
+ctrlc = { version = "3.4.2" }
 dashmap = { version = "5.5.3" }
 data-encoding = { version = "2.5.0" }
 derivative = { version = "2.2.0" }

--- a/crates/puffin/Cargo.toml
+++ b/crates/puffin/Cargo.toml
@@ -48,6 +48,7 @@ anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 console = { workspace = true }
+ctrlc = { workspace = true  }
 dunce = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }

--- a/crates/puffin/src/confirm.rs
+++ b/crates/puffin/src/confirm.rs
@@ -6,6 +6,19 @@ use console::{style, Key, Term};
 /// This is a slimmed-down version of [`dialoguer::Confirm`], with the post-confirmation report
 /// enabled.
 pub(crate) fn confirm(message: &str, term: &Term, default: bool) -> Result<bool> {
+    ctrlc::set_handler(move || {
+        let term = Term::stderr();
+        term.show_cursor().ok();
+        term.flush().ok();
+
+        #[allow(clippy::exit, clippy::cast_possible_wrap)]
+        std::process::exit(if cfg!(windows) {
+            0xC000_013A_u32 as i32
+        } else {
+            130
+        });
+    })?;
+
     let prompt = format!(
         "{} {} {} {} {}",
         style("?".to_string()).for_stderr().yellow(),


### PR DESCRIPTION
Fixes an issue whereby exiting the confirmation prompt can lead to your cursor disappearing: https://github.com/console-rs/dialoguer/issues/294.

See: https://github.com/mitsuhiko/rye/blob/b839a2c5b7e648e9e5d836a8bf5f703c9807d615/rye/src/main.rs#L36-L48.
