### PR TITLE
Accommodate minute-level filters in Insta

### DIFF
--- a/crates/puffin/tests/common/mod.rs
+++ b/crates/puffin/tests/common/mod.rs
@@ -17,7 +17,7 @@ pub static EXCLUDE_NEWER: &str = "2023-11-18T12:00:00Z";
 pub const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"--cache-dir [^\s]+", "--cache-dir [CACHE_DIR]"),
     // Operation times
-    (r"(\d+\.)?\d+(ms|s)", "[TIME]"),
+    (r"(\d+m )?(\d+\.)?\d+(ms|s)", "[TIME]"),
     // Puffin versions
     (r"v\d+\.\d+\.\d+", "v[VERSION]"),
     // File sizes


### PR DESCRIPTION
I don't know why `compile_editable` took over a minute in this case, but seems like it did? Hard to test this fix.

https://github.com/astral-sh/puffin/actions/runs/7734769259/job/21089338951?pr=1216