### PR TITLE
Remove insta_cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,20 +1545,8 @@ dependencies = [
  "lazy_static",
  "linked-hash-map",
  "regex",
- "serde",
  "similar",
  "yaml-rust",
-]
-
-[[package]]
-name = "insta-cmd"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809d3023d1d6e8d5c2206f199251f75cb26180e41f18cb0f22dd119161cb5127"
-dependencies = [
- "insta",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2486,7 +2474,6 @@ dependencies = [
  "indicatif",
  "indoc",
  "insta",
- "insta-cmd",
  "install-wheel-rs",
  "itertools 0.12.1",
  "miette",

--- a/crates/puffin/Cargo.toml
+++ b/crates/puffin/Cargo.toml
@@ -83,7 +83,6 @@ assert_fs = { version = "1.1.0" }
 filetime = { version = "0.2.23" }
 indoc = { version = "2.0.4" }
 insta = { version = "1.34.0", features = ["filters"] }
-insta-cmd = { version = "0.4.0" }
 predicates = { version = "3.0.4" }
 regex = { version = "1.10.3" }
 reqwest = { version = "0.11.23", features = ["blocking", "rustls"], default-features = false }

--- a/crates/puffin/tests/add.rs
+++ b/crates/puffin/tests/add.rs
@@ -2,10 +2,8 @@ use std::process::Command;
 
 use anyhow::Result;
 use assert_fs::prelude::*;
-use insta_cmd::get_cargo_bin;
 
-use crate::common::puffin_snapshot;
-use common::BIN_NAME;
+use crate::common::{get_bin, puffin_snapshot};
 
 mod common;
 
@@ -14,7 +12,7 @@ fn missing_pyproject_toml() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let pyproject_toml = temp_dir.child("pyproject.toml");
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("add")
         .arg("flask")
         .current_dir(&temp_dir), @r###"
@@ -40,7 +38,7 @@ fn missing_project_table() -> Result<()> {
     let pyproject_toml = temp_dir.child("pyproject.toml");
     pyproject_toml.touch()?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("add")
         .arg("flask")
         .current_dir(&temp_dir), @r###"
@@ -73,7 +71,7 @@ name = "project"
 "#,
     )?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("add")
         .arg("flask")
         .current_dir(&temp_dir), @r###"
@@ -110,7 +108,7 @@ dependencies = [
 "#,
     )?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("add")
         .arg("flask==2.0.0")
         .current_dir(&temp_dir), @r###"
@@ -145,7 +143,7 @@ dependencies = ["flask==1.0.0"]
 "#,
     )?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("add")
         .arg("requests")
         .current_dir(&temp_dir), @r###"

--- a/crates/puffin/tests/pip_compile.rs
+++ b/crates/puffin/tests/pip_compile.rs
@@ -9,14 +9,13 @@ use assert_fs::prelude::*;
 use assert_fs::TempDir;
 use indoc::indoc;
 use insta::assert_snapshot;
-use insta_cmd::get_cargo_bin;
 use itertools::Itertools;
 use url::Url;
 
-use common::{puffin_snapshot, TestContext, BIN_NAME, INSTA_FILTERS};
+use common::{puffin_snapshot, TestContext, INSTA_FILTERS};
 use puffin_fs::NormalizedDisplay;
 
-use crate::common::EXCLUDE_NEWER;
+use crate::common::{get_bin, EXCLUDE_NEWER};
 
 mod common;
 
@@ -74,7 +73,7 @@ fn missing_venv() -> Result<()> {
     let cache_dir = TempDir::new()?;
     let venv = temp_dir.child(".venv");
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
             .arg("pip")
             .arg("compile")
             .arg("requirements.in")
@@ -1412,7 +1411,7 @@ fn compile_exclude_newer() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("tqdm")?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
             .arg("pip")
             .arg("compile")
             .arg("requirements.in")
@@ -1438,7 +1437,7 @@ fn compile_exclude_newer() -> Result<()> {
 
     // Use a date as input instead.
     // We interpret a date as including this day
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
             .arg("pip")
             .arg("compile")
             .arg("requirements.in")
@@ -1461,7 +1460,7 @@ fn compile_exclude_newer() -> Result<()> {
     );
 
     // Check the error message for invalid datetime
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
             .arg("pip")
             .arg("compile")
             .arg("requirements.in")
@@ -2024,7 +2023,7 @@ fn compile_editable() -> Result<()> {
         .chain(INSTA_FILTERS.to_vec())
         .collect();
 
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
             .arg("pip")
             .arg("compile")
             .arg(requirements_in.path())
@@ -2169,7 +2168,7 @@ fn compile_html() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("jinja2<=3.1.2")?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
             .arg("pip")
             .arg("compile")
             .arg("requirements.in")

--- a/crates/puffin/tests/pip_compile_scenarios.rs
+++ b/crates/puffin/tests/pip_compile_scenarios.rs
@@ -14,9 +14,9 @@ use assert_fs::fixture::{FileWriteStr, PathChild};
 use fs_err::os::unix::fs::symlink as symlink_file;
 #[cfg(windows)]
 use fs_err::os::windows::fs::symlink_file;
-use insta_cmd::get_cargo_bin;
 
-use common::{puffin_snapshot, TestContext, BIN_NAME, INSTA_FILTERS};
+use crate::common::get_bin;
+use common::{puffin_snapshot, TestContext, INSTA_FILTERS};
 use puffin_interpreter::find_requested_python;
 
 mod common;
@@ -42,7 +42,7 @@ pub(crate) fn create_bin_with_executables(
 fn command(context: &TestContext, python_versions: &[&str]) -> Command {
     let bin = create_bin_with_executables(&context.temp_dir, python_versions)
         .expect("Failed to create bin dir");
-    let mut command = Command::new(get_cargo_bin(BIN_NAME));
+    let mut command = Command::new(get_bin());
     command
         .arg("pip")
         .arg("compile")

--- a/crates/puffin/tests/pip_install.rs
+++ b/crates/puffin/tests/pip_install.rs
@@ -7,15 +7,16 @@ use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use indoc::indoc;
-use insta_cmd::get_cargo_bin;
 
-use common::{puffin_snapshot, TestContext, BIN_NAME, EXCLUDE_NEWER, INSTA_FILTERS};
+use common::{puffin_snapshot, TestContext, EXCLUDE_NEWER, INSTA_FILTERS};
+
+use crate::common::get_bin;
 
 mod common;
 
 /// Create a `pip install` command with options shared across scenarios.
 fn command(context: &TestContext) -> Command {
-    let mut command = Command::new(get_cargo_bin(BIN_NAME));
+    let mut command = Command::new(get_bin());
     command
         .arg("pip")
         .arg("install")
@@ -343,7 +344,7 @@ fn install_editable() -> Result<()> {
         .collect::<Vec<_>>();
 
     // Install the editable package.
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("install")
         .arg("-e")
@@ -370,7 +371,7 @@ fn install_editable() -> Result<()> {
     );
 
     // Install it again (no-op).
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("install")
         .arg("-e")
@@ -392,7 +393,7 @@ fn install_editable() -> Result<()> {
     );
 
     // Add another, non-editable dependency.
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("install")
         .arg("-e")
@@ -447,7 +448,7 @@ fn install_editable_and_registry() -> Result<()> {
         .collect();
 
     // Install the registry-based version of Black.
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("install")
         .arg("black")
@@ -476,7 +477,7 @@ fn install_editable_and_registry() -> Result<()> {
     );
 
     // Install the editable version of Black. This should remove the registry-based version.
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("install")
         .arg("-e")
@@ -503,7 +504,7 @@ fn install_editable_and_registry() -> Result<()> {
 
     // Re-install the registry-based version of Black. This should be a no-op, since we have a
     // version of Black installed (the editable version) that satisfies the requirements.
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("install")
         .arg("black")
@@ -524,7 +525,7 @@ fn install_editable_and_registry() -> Result<()> {
     );
 
     // Re-install Black at a specific version. This should replace the editable version.
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("install")
         .arg("black==23.10.0")

--- a/crates/puffin/tests/pip_install_scenarios.rs
+++ b/crates/puffin/tests/pip_install_scenarios.rs
@@ -10,11 +10,10 @@ use std::process::Command;
 
 use assert_cmd::assert::Assert;
 use assert_cmd::prelude::*;
-use insta_cmd::get_cargo_bin;
 
-use common::{venv_to_interpreter, BIN_NAME, INSTA_FILTERS};
+use common::{venv_to_interpreter, INSTA_FILTERS};
 
-use crate::common::{puffin_snapshot, TestContext};
+use crate::common::{get_bin, puffin_snapshot, TestContext};
 
 mod common;
 
@@ -42,7 +41,7 @@ fn assert_not_installed(venv: &Path, package: &'static str, temp_dir: &Path) {
 
 /// Create a `pip install` command with options shared across all scenarios.
 fn command(context: &TestContext) -> Command {
-    let mut command = Command::new(get_cargo_bin(BIN_NAME));
+    let mut command = Command::new(get_bin());
     command
         .arg("pip")
         .arg("install")

--- a/crates/puffin/tests/pip_sync.rs
+++ b/crates/puffin/tests/pip_sync.rs
@@ -8,13 +8,12 @@ use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use indoc::indoc;
-use insta_cmd::get_cargo_bin;
 use url::Url;
 
-use common::{create_venv, puffin_snapshot, venv_to_interpreter, BIN_NAME, INSTA_FILTERS};
+use common::{create_venv, puffin_snapshot, venv_to_interpreter, INSTA_FILTERS};
 use puffin_fs::NormalizedDisplay;
 
-use crate::common::TestContext;
+use crate::common::{get_bin, TestContext};
 
 mod common;
 
@@ -32,7 +31,7 @@ fn check_command(venv: &Path, command: &str, temp_dir: &Path) {
 
 /// Create a `pip sync` command with options shared across scenarios.
 fn command(context: &TestContext) -> Command {
-    let mut command = Command::new(get_cargo_bin(BIN_NAME));
+    let mut command = Command::new(get_bin());
     command
         .arg("pip")
         .arg("sync")
@@ -70,7 +69,7 @@ fn missing_venv() -> Result<()> {
     let cache_dir = assert_fs::TempDir::new()?;
     let venv = temp_dir.child(".venv");
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("pip")
         .arg("sync")
         .arg("requirements.txt")
@@ -275,7 +274,7 @@ fn link() -> Result<()> {
     requirements_txt.touch()?;
     requirements_txt.write_str("MarkupSafe==2.1.3")?;
 
-    Command::new(get_cargo_bin(BIN_NAME))
+    Command::new(get_bin())
         .arg("pip")
         .arg("sync")
         .arg("requirements.txt")
@@ -288,7 +287,7 @@ fn link() -> Result<()> {
         .success();
 
     let venv2 = context.temp_dir.child(".venv2");
-    Command::new(get_cargo_bin(BIN_NAME))
+    Command::new(get_bin())
         .arg("venv")
         .arg(venv2.as_os_str())
         .arg("--cache-dir")
@@ -300,7 +299,7 @@ fn link() -> Result<()> {
         .success();
     venv2.assert(predicates::path::is_dir());
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("pip")
         .arg("sync")
         .arg("requirements.txt")
@@ -1198,7 +1197,7 @@ fn install_url_source_dist_cached() -> Result<()> {
     let parent = assert_fs::TempDir::new()?;
     let venv = create_venv(&parent, &context.cache_dir, "3.12");
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("clean")
         .arg("tqdm")
         .arg("--cache-dir")
@@ -1286,7 +1285,7 @@ fn install_git_source_dist_cached() -> Result<()> {
     let parent = assert_fs::TempDir::new()?;
     let venv = create_venv(&parent, &context.cache_dir, "3.12");
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("clean")
         .arg("werkzeug")
         .arg("--cache-dir")
@@ -1373,7 +1372,7 @@ fn install_registry_source_dist_cached() -> Result<()> {
     let parent = assert_fs::TempDir::new()?;
     let venv = create_venv(&parent, &context.cache_dir, "3.12");
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("clean")
         .arg("future")
         .arg("--cache-dir")
@@ -1474,7 +1473,7 @@ fn install_path_source_dist_cached() -> Result<()> {
     let parent = assert_fs::TempDir::new()?;
     let venv = create_venv(&parent, &context.cache_dir, "3.12");
 
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("clean")
         .arg("wheel")
         .arg("--cache-dir")
@@ -1575,7 +1574,7 @@ fn install_path_built_dist_cached() -> Result<()> {
     let parent = assert_fs::TempDir::new()?;
     let venv = create_venv(&parent, &context.cache_dir, "3.12");
 
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("clean")
         .arg("tomli")
         .arg("--cache-dir")
@@ -1662,7 +1661,7 @@ fn install_url_built_dist_cached() -> Result<()> {
     let parent = assert_fs::TempDir::new()?;
     let venv = create_venv(&parent, &context.cache_dir, "3.12");
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("clean")
         .arg("tqdm")
         .arg("--cache-dir")
@@ -2062,7 +2061,7 @@ fn sync_editable() -> Result<()> {
         .collect::<Vec<_>>();
 
     // Install the editable packages.
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("sync")
         .arg(requirements_txt.path())
@@ -2088,7 +2087,7 @@ fn sync_editable() -> Result<()> {
     );
 
     // Reinstall the editable packages.
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("sync")
         .arg(requirements_txt.path())
@@ -2150,7 +2149,7 @@ fn sync_editable() -> Result<()> {
     // Don't create a git diff.
     fs_err::write(python_source_file, python_version_1)?;
 
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("sync")
         .arg(requirements_txt.path())
@@ -2201,7 +2200,7 @@ fn sync_editable_and_registry() -> Result<()> {
         ])
         .copied()
         .collect::<Vec<_>>();
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
             .arg("pip")
             .arg("sync")
         .arg(requirements_txt.path())
@@ -2244,7 +2243,7 @@ fn sync_editable_and_registry() -> Result<()> {
         ])
         .copied()
         .collect::<Vec<_>>();
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
             .arg("pip")
             .arg("sync")
         .arg(requirements_txt.path())
@@ -2283,7 +2282,7 @@ fn sync_editable_and_registry() -> Result<()> {
         ])
         .copied()
         .collect::<Vec<_>>();
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
             .arg("pip")
             .arg("sync")
         .arg(requirements_txt.path())
@@ -2317,7 +2316,7 @@ fn sync_editable_and_registry() -> Result<()> {
         ])
         .copied()
         .collect::<Vec<_>>();
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
             .arg("pip")
             .arg("sync")
         .arg(requirements_txt.path())

--- a/crates/puffin/tests/pip_uninstall.rs
+++ b/crates/puffin/tests/pip_uninstall.rs
@@ -4,13 +4,12 @@ use std::process::Command;
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
-use insta_cmd::get_cargo_bin;
 use url::Url;
 
-use common::{puffin_snapshot, BIN_NAME, INSTA_FILTERS};
+use common::{puffin_snapshot, INSTA_FILTERS};
 use puffin_fs::NormalizedDisplay;
 
-use crate::common::{venv_to_interpreter, TestContext};
+use crate::common::{get_bin, venv_to_interpreter, TestContext};
 
 mod common;
 
@@ -18,7 +17,7 @@ mod common;
 fn no_arguments() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .current_dir(&temp_dir), @r###"
@@ -43,7 +42,7 @@ fn no_arguments() -> Result<()> {
 fn invalid_requirement() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("flask==1.0.x")
@@ -66,7 +65,7 @@ fn invalid_requirement() -> Result<()> {
 fn missing_requirements_txt() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("-r")
@@ -92,7 +91,7 @@ fn invalid_requirements_txt_requirement() -> Result<()> {
     requirements_txt.touch()?;
     requirements_txt.write_str("flask==1.0.x")?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("-r")
@@ -116,7 +115,7 @@ fn invalid_requirements_txt_requirement() -> Result<()> {
 fn missing_pyproject_toml() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("-r")
@@ -142,7 +141,7 @@ fn invalid_pyproject_toml_syntax() -> Result<()> {
     pyproject_toml.touch()?;
     pyproject_toml.write_str("123 - 456")?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("-r")
@@ -172,7 +171,7 @@ fn invalid_pyproject_toml_schema() -> Result<()> {
     pyproject_toml.touch()?;
     pyproject_toml.write_str("[project]")?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("-r")
@@ -207,7 +206,7 @@ dependencies = ["flask==1.0.x"]
 "#,
     )?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("-r")
@@ -240,7 +239,7 @@ fn uninstall() -> Result<()> {
     requirements_txt.touch()?;
     requirements_txt.write_str("MarkupSafe==2.1.3")?;
 
-    Command::new(get_cargo_bin(BIN_NAME))
+    Command::new(get_bin())
         .arg("pip")
         .arg("sync")
         .arg("requirements.txt")
@@ -258,7 +257,7 @@ fn uninstall() -> Result<()> {
         .assert()
         .success();
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("MarkupSafe")
@@ -294,7 +293,7 @@ fn missing_record() -> Result<()> {
     requirements_txt.touch()?;
     requirements_txt.write_str("MarkupSafe==2.1.3")?;
 
-    Command::new(get_cargo_bin(BIN_NAME))
+    Command::new(get_bin())
         .arg("pip")
         .arg("sync")
         .arg("requirements.txt")
@@ -343,7 +342,7 @@ fn missing_record() -> Result<()> {
     .chain(INSTA_FILTERS.to_vec())
     .collect();
 
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("MarkupSafe")
@@ -382,7 +381,7 @@ fn uninstall_editable_by_name() -> Result<()> {
     requirements_txt.touch()?;
     requirements_txt.write_str("-e ../../scripts/editable-installs/poetry_editable")?;
 
-    Command::new(get_cargo_bin(BIN_NAME))
+    Command::new(get_bin())
         .arg("pip")
         .arg("sync")
         .arg(requirements_txt.path())
@@ -399,7 +398,7 @@ fn uninstall_editable_by_name() -> Result<()> {
         .success();
 
     // Uninstall the editable by name.
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("poetry-editable")
@@ -444,7 +443,7 @@ fn uninstall_editable_by_path() -> Result<()> {
     requirements_txt.touch()?;
     requirements_txt.write_str("-e ../../scripts/editable-installs/poetry_editable")?;
 
-    Command::new(get_cargo_bin(BIN_NAME))
+    Command::new(get_bin())
         .arg("pip")
         .arg("sync")
         .arg(requirements_txt.path())
@@ -461,7 +460,7 @@ fn uninstall_editable_by_path() -> Result<()> {
         .success();
 
     // Uninstall the editable by path.
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("-e")
@@ -507,7 +506,7 @@ fn uninstall_duplicate_editable() -> Result<()> {
     requirements_txt.touch()?;
     requirements_txt.write_str("-e ../../scripts/editable-installs/poetry_editable")?;
 
-    Command::new(get_cargo_bin(BIN_NAME))
+    Command::new(get_bin())
         .arg("pip")
         .arg("sync")
         .arg(requirements_txt.path())
@@ -524,7 +523,7 @@ fn uninstall_duplicate_editable() -> Result<()> {
         .success();
 
     // Uninstall the editable by both path and name.
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("pip")
         .arg("uninstall")
         .arg("poetry-editable")

--- a/crates/puffin/tests/remove.rs
+++ b/crates/puffin/tests/remove.rs
@@ -2,11 +2,8 @@ use std::process::Command;
 
 use anyhow::Result;
 use assert_fs::prelude::*;
-use insta_cmd::get_cargo_bin;
 
-use common::BIN_NAME;
-
-use crate::common::puffin_snapshot;
+use crate::common::{get_bin, puffin_snapshot};
 
 mod common;
 
@@ -15,7 +12,7 @@ fn missing_pyproject_toml() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let pyproject_toml = temp_dir.child("pyproject.toml");
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("remove")
         .arg("flask")
         .current_dir(&temp_dir), @r###"
@@ -41,7 +38,7 @@ fn missing_project_table() -> Result<()> {
     let pyproject_toml = temp_dir.child("pyproject.toml");
     pyproject_toml.touch()?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("remove")
         .arg("flask")
         .current_dir(&temp_dir), @r###"
@@ -72,7 +69,7 @@ name = "project"
 "#,
     )?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("remove")
         .arg("flask")
         .current_dir(&temp_dir), @r###"
@@ -110,7 +107,7 @@ dependencies = [
 "#,
     )?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("remove")
         .arg("requests")
         .current_dir(&temp_dir), @r###"
@@ -152,7 +149,7 @@ dependencies = [
 "#,
     )?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("remove")
         .arg("flask")
         .current_dir(&temp_dir), @r###"
@@ -189,7 +186,7 @@ dependencies = [
 "#,
     )?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("remove")
         .arg("requests")
         .current_dir(&temp_dir), @r###"
@@ -225,7 +222,7 @@ dependencies = [
 "#,
     )?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("remove")
         .arg("Flask")
         .current_dir(&temp_dir), @r###"
@@ -260,7 +257,7 @@ dependencies = ["flask==1.0.0", "requests"]
 "#,
     )?;
 
-    puffin_snapshot!(Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(Command::new(get_bin())
         .arg("remove")
         .arg("requests")
         .current_dir(&temp_dir), @r###"

--- a/crates/puffin/tests/venv.rs
+++ b/crates/puffin/tests/venv.rs
@@ -4,12 +4,10 @@ use std::process::Command;
 
 use anyhow::Result;
 use assert_fs::prelude::*;
-use insta_cmd::get_cargo_bin;
 
-use common::BIN_NAME;
 use puffin_fs::NormalizedDisplay;
 
-use crate::common::puffin_snapshot;
+use crate::common::{get_bin, puffin_snapshot};
 
 mod common;
 
@@ -27,7 +25,7 @@ fn create_venv() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
     ];
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
         .arg(venv.as_os_str())
         .arg("--python")
@@ -64,7 +62,7 @@ fn create_venv_defaults_to_cwd() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
     ];
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
         .arg("--python")
         .arg("3.12")
@@ -100,7 +98,7 @@ fn seed() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
     ];
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
         .arg(venv.as_os_str())
         .arg("--seed")
@@ -141,7 +139,7 @@ fn create_venv_unknown_python_minor() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
     ];
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
         .arg(venv.as_os_str())
         .arg("--python")
@@ -177,7 +175,7 @@ fn create_venv_unknown_python_patch() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
     ];
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
         .arg(venv.as_os_str())
         .arg("--python")
@@ -210,7 +208,7 @@ fn create_venv_python_patch() -> Result<()> {
         (r"interpreter at .+", "interpreter at [PATH]"),
         (&filter_venv, "/home/ferris/project/.venv"),
     ];
-    puffin_snapshot!(filters, Command::new(get_cargo_bin(BIN_NAME))
+    puffin_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
         .arg(venv.as_os_str())
         .arg("--python")

--- a/scripts/scenarios/templates/compile.mustache
+++ b/scripts/scenarios/templates/compile.mustache
@@ -14,9 +14,9 @@ use assert_fs::fixture::{FileWriteStr, PathChild};
 use fs_err::os::unix::fs::symlink as symlink_file;
 #[cfg(windows)]
 use fs_err::os::windows::fs::symlink_file;
-use insta_cmd::get_cargo_bin;
 
-use common::{puffin_snapshot, TestContext, BIN_NAME, INSTA_FILTERS};
+use crate::common::get_bin;
+use common::{puffin_snapshot, TestContext, INSTA_FILTERS};
 use puffin_interpreter::find_requested_python;
 
 mod common;
@@ -42,7 +42,7 @@ pub(crate) fn create_bin_with_executables(
 fn command(context: &TestContext, python_versions: &[&str]) -> Command {
     let bin = create_bin_with_executables(&context.temp_dir, python_versions)
         .expect("Failed to create bin dir");
-    let mut command = Command::new(get_cargo_bin(BIN_NAME));
+    let mut command = Command::new(get_bin());
     command
         .arg("pip")
         .arg("compile")

--- a/scripts/scenarios/templates/install.mustache
+++ b/scripts/scenarios/templates/install.mustache
@@ -10,13 +10,13 @@ use std::process::Command;
 
 use assert_cmd::assert::Assert;
 use assert_cmd::prelude::*;
-use insta_cmd::get_cargo_bin;
 
-use common::{venv_to_interpreter, BIN_NAME, INSTA_FILTERS};
+use common::{venv_to_interpreter, INSTA_FILTERS};
 
-use crate::common::{puffin_snapshot, TestContext};
+use crate::common::{get_bin, puffin_snapshot, TestContext};
 
 mod common;
+
 
 fn assert_command(venv: &Path, command: &str, temp_dir: &Path) -> Assert {
     Command::new(venv_to_interpreter(venv))
@@ -42,7 +42,7 @@ fn assert_not_installed(venv: &Path, package: &'static str, temp_dir: &Path) {
 
 /// Create a `pip install` command with options shared across all scenarios.
 fn command(context: &TestContext) -> Command {
-    let mut command = Command::new(get_cargo_bin(BIN_NAME));
+    let mut command = Command::new(get_bin());
     command
         .arg("pip")
         .arg("install")


### PR DESCRIPTION
We need more flexible filters than those `inta` offers, and `insta_cmd` makes it impossible to plug in programmatic filters. At the same time we use barely any of `insta_cmd`'s features. We can replace the subset we need in about 50 loc.