### PR TITLE
Use normalized display in tests and other small windows fixes

### DIFF
--- a/crates/distribution-types/src/index_url.rs
+++ b/crates/distribution-types/src/index_url.rs
@@ -269,6 +269,7 @@ impl From<IndexLocations> for IndexUrls {
 }
 
 #[cfg(test)]
+#[cfg(unix)]
 mod test {
     use super::*;
 

--- a/crates/install-wheel-rs/src/lib.rs
+++ b/crates/install-wheel-rs/src/lib.rs
@@ -1,4 +1,4 @@
-//! Takes a wheel and installs it into a venv..
+//! Takes a wheel and installs it into a venv.
 
 use std::io;
 use std::io::{Read, Seek};
@@ -14,6 +14,7 @@ use distribution_filename::WheelFilename;
 pub use install_location::{normalize_name, InstallLocation, LockedDir};
 use pep440_rs::Version;
 use platform_host::{Arch, Os};
+use puffin_fs::NormalizedDisplay;
 use puffin_normalize::PackageName;
 pub use record::RecordEntry;
 pub use script::Script;
@@ -37,7 +38,7 @@ pub enum Error {
     #[error(transparent)]
     Io(#[from] io::Error),
     /// Custom error type to add a path to error reading a file from a zip
-    #[error("Failed to reflink {from} to {to}")]
+    #[error("Failed to reflink {} to {}", from.normalized_display(), to.normalized_display())]
     Reflink {
         from: PathBuf,
         to: PathBuf,
@@ -78,7 +79,7 @@ pub enum Error {
     DirectUrlJson(#[from] serde_json::Error),
     #[error("No .dist-info directory found")]
     MissingDistInfo,
-    #[error("Cannot uninstall package; RECORD file not found at: {0}")]
+    #[error("Cannot uninstall package; RECORD file not found at: {}", _0.normalized_display())]
     MissingRecord(PathBuf),
     #[error("Multiple .dist-info directories found: {0}")]
     MultipleDistInfo(String),

--- a/crates/puffin/src/commands/pip_compile.rs
+++ b/crates/puffin/src/commands/pip_compile.rs
@@ -353,7 +353,14 @@ pub(crate) async fn pip_compile(
         writeln!(
             writer,
             "{}",
-            format!("#    puffin {}", env::args().skip(1).join(" ")).green()
+            format!(
+                "#    puffin {}",
+                env::args_os()
+                    .skip(1)
+                    .map(|arg| arg.normalized_display().to_string())
+                    .join(" ")
+            )
+            .green()
         )?;
     }
 

--- a/crates/puffin/tests/pip_sync.rs
+++ b/crates/puffin/tests/pip_sync.rs
@@ -13,6 +13,7 @@ use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
 use url::Url;
 
 use common::{create_venv, venv_to_interpreter, BIN_NAME, INSTA_FILTERS};
+use puffin_fs::NormalizedDisplay;
 
 mod common;
 
@@ -2726,10 +2727,10 @@ fn sync_editable() -> Result<()> {
             # via poetry-editable
         -e file://{current_dir}/../../scripts/editable-installs/poetry_editable
         ",
-        current_dir = current_dir.display(),
+        current_dir = current_dir.normalized_display(),
     })?;
 
-    let filter_path = regex::escape(&requirements_txt.display().to_string());
+    let filter_path = regex::escape(&requirements_txt.normalized_display().to_string());
     let filters = INSTA_FILTERS
         .iter()
         .chain(&[
@@ -2885,7 +2886,7 @@ fn sync_editable_and_registry() -> Result<()> {
         "
     })?;
 
-    let filter_path = regex::escape(&requirements_txt.display().to_string());
+    let filter_path = regex::escape(&requirements_txt.normalized_display().to_string());
     let filters = INSTA_FILTERS
         .iter()
         .chain(&[
@@ -2931,7 +2932,7 @@ fn sync_editable_and_registry() -> Result<()> {
         "
     })?;
 
-    let filter_path = requirements_txt.display().to_string();
+    let filter_path = regex::escape(&requirements_txt.normalized_display().to_string());
     let filters = INSTA_FILTERS
         .iter()
         .chain(&[
@@ -2973,7 +2974,7 @@ fn sync_editable_and_registry() -> Result<()> {
         "
     })?;
 
-    let filter_path = requirements_txt.display().to_string();
+    let filter_path = requirements_txt.normalized_display().to_string();
     let filters = INSTA_FILTERS
         .iter()
         .chain(&[
@@ -3010,7 +3011,7 @@ fn sync_editable_and_registry() -> Result<()> {
         "
     })?;
 
-    let filter_path = requirements_txt.display().to_string();
+    let filter_path = requirements_txt.normalized_display().to_string();
     let filters = INSTA_FILTERS
         .iter()
         .chain(&[
@@ -3069,7 +3070,13 @@ fn incompatible_wheel() -> Result<()> {
         Url::from_file_path(wheel.path()).unwrap()
     ))?;
 
-    let wheel_dir = regex::escape(&wheel_dir.path().canonicalize()?.display().to_string());
+    let wheel_dir = regex::escape(
+        &wheel_dir
+            .path()
+            .canonicalize()?
+            .normalized_display()
+            .to_string(),
+    );
     let filters: Vec<_> = iter::once((wheel_dir.as_str(), "[TEMP_DIR]"))
         .chain(INSTA_FILTERS.to_vec())
         .collect();
@@ -3188,7 +3195,7 @@ fn find_links() -> Result<()> {
     "})?;
 
     let project_root = fs_err::canonicalize(std::env::current_dir()?.join("../.."))?;
-    let project_root_string = regex::escape(&project_root.display().to_string());
+    let project_root_string = regex::escape(&project_root.normalized_display().to_string());
     let filters: Vec<_> = iter::once((project_root_string.as_str(), "[PROJECT_ROOT]"))
         .chain(INSTA_FILTERS.to_vec())
         .collect();

--- a/crates/puffin/tests/venv.rs
+++ b/crates/puffin/tests/venv.rs
@@ -7,6 +7,8 @@ use assert_fs::prelude::*;
 use insta_cmd::_macro_support::insta;
 use insta_cmd::{assert_cmd_snapshot, get_cargo_bin};
 
+use puffin_fs::NormalizedDisplay;
+
 use common::BIN_NAME;
 
 mod common;
@@ -17,7 +19,7 @@ fn create_venv() -> Result<()> {
     let cache_dir = assert_fs::TempDir::new()?;
     let venv = temp_dir.child(".venv");
 
-    let filter_venv = regex::escape(&venv.display().to_string());
+    let filter_venv = regex::escape(&venv.normalized_display().to_string());
     insta::with_settings!({
         filters => vec![
             (r"Using Python 3\.\d+\.\d+ interpreter at .+", "Using Python [VERSION] interpreter at [PATH]"),
@@ -53,7 +55,7 @@ fn create_venv_defaults_to_cwd() -> Result<()> {
     let cache_dir = assert_fs::TempDir::new()?;
     let venv = temp_dir.child(".venv");
 
-    let filter_venv = regex::escape(&venv.display().to_string());
+    let filter_venv = regex::escape(&venv.normalized_display().to_string());
     insta::with_settings!({
         filters => vec![
             (r"Using Python 3\.\d+\.\d+ interpreter at .+", "Using Python [VERSION] interpreter at [PATH]"),
@@ -88,7 +90,7 @@ fn seed() -> Result<()> {
     let cache_dir = assert_fs::TempDir::new()?;
     let venv = temp_dir.child(".venv");
 
-    let filter_venv = regex::escape(&venv.display().to_string());
+    let filter_venv = regex::escape(&venv.normalized_display().to_string());
     insta::with_settings!({
         filters => vec![
             (r"Using Python 3\.\d+\.\d+ interpreter at .+", "Using Python [VERSION] interpreter at [PATH]"),
@@ -163,7 +165,7 @@ fn create_venv_unknown_python_patch() -> Result<()> {
     let cache_dir = assert_fs::TempDir::new()?;
     let venv = temp_dir.child(".venv");
 
-    let filter_venv = regex::escape(&venv.display().to_string());
+    let filter_venv = regex::escape(&venv.normalized_display().to_string());
     insta::with_settings!({
         filters => vec![
             (r"Using Python 3\.\d+\.\d+ interpreter at .+", "Using Python [VERSION] interpreter at [PATH]"),
@@ -198,7 +200,7 @@ fn create_venv_python_patch() -> Result<()> {
     let cache_dir = assert_fs::TempDir::new()?;
     let venv = temp_dir.child(".venv");
 
-    let filter_venv = regex::escape(&venv.display().to_string());
+    let filter_venv = regex::escape(&venv.normalized_display().to_string());
     insta::with_settings!({
         filters => vec![
             (r"interpreter at .+", "interpreter at [PATH]"),


### PR DESCRIPTION
Split out from the large test refactoring PR. Use `normalized_display` in tests and two more thiserror derives to match snapshots and output, and other small windows fixes.