### PR TITLE
Pre-fetch dependencies when resolving from a lockfile

### DIFF
--- a/crates/puffin-resolver/src/candidate_selector.rs
+++ b/crates/puffin-resolver/src/candidate_selector.rs
@@ -47,6 +47,11 @@ impl CandidateSelector {
     pub(crate) fn prerelease_strategy(&self) -> &PreReleaseStrategy {
         &self.prerelease_strategy
     }
+
+    #[inline]
+    pub(crate) fn packages(&self) -> impl Iterator<Item = &PackageName> + '_ {
+        self.preferences.packages()
+    }
 }
 
 /// A set of pinned packages that should be preserved during resolution, if possible.
@@ -54,8 +59,14 @@ impl CandidateSelector {
 struct Preferences(FxHashMap<PackageName, Version>);
 
 impl Preferences {
+    #[inline]
     fn get(&self, package_name: &PackageName) -> Option<&Version> {
         self.0.get(package_name)
+    }
+
+    #[inline]
+    fn packages(&self) -> impl Iterator<Item = &PackageName> + '_ {
+        self.0.keys()
     }
 }
 

--- a/scripts/bench/__main__.py
+++ b/scripts/bench/__main__.py
@@ -839,7 +839,6 @@ class Puffin(Suite):
                 "--output-file",
                 baseline,
             ],
-            cwd=cwd,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )


### PR DESCRIPTION
## Summary

Surprisingly, this makes incremental resolution... consistently slower? So seems like we shouldn't merge this?

```text
❯ python -m scripts.bench --puffin-path ./target/release/main --puffin-path ./target/release/puffin scripts/requirements/home-assistant.in --benchmark resolve-incremental --min-runs 50
Benchmark 1: ./target/release/main (resolve-incremental)
  Time (mean ± σ):     174.8 ms ±   6.3 ms    [User: 270.8 ms, System: 702.4 ms]
  Range (min … max):   158.1 ms … 191.4 ms    50 runs

Benchmark 2: ./target/release/puffin (resolve-incremental)
  Time (mean ± σ):     183.3 ms ±   9.0 ms    [User: 276.1 ms, System: 794.8 ms]
  Range (min … max):   168.2 ms … 217.6 ms    50 runs

Summary
  './target/release/main (resolve-incremental)' ran
    1.05 ± 0.06 times faster than './target/release/puffin (resolve-incremental)'
```

Closes #1206.
