### PR TITLE
Search and replace windows specific tests in deps

### DIFF
--- a/crates/puffin/tests/pip_sync.rs
+++ b/crates/puffin/tests/pip_sync.rs
@@ -920,7 +920,7 @@ fn warn_on_yanked_version() -> Result<()> {
     // This version is yanked.
     requirements_in.write_str("colorama==0.4.2")?;
 
-    puffin_snapshot!(INSTA_FILTERS, command(&context)
+    puffin_snapshot!(INSTA_FILTERS, windows_filters=false, command(&context)
         .arg("requirements.txt")
         .arg("--strict"), @r###"
         success: true


### PR DESCRIPTION
Remove windows-only dependencies from the snapshot output using regex. We now do the filtering entirely on our without relying on insta settings.

435 tests run: 430 passed (30 slow), 5 failed, 1 skipped