### PR TITLE
Offer tip when users omits pip prefix

### DIFF
--- a/crates/puffin/tests/pip_sync.rs
+++ b/crates/puffin/tests/pip_sync.rs
@@ -56,6 +56,24 @@ fn uninstall_command(context: &TestContext) -> Command {
 }
 
 #[test]
+fn missing_pip() {
+    puffin_snapshot!(Command::new(get_bin()).arg("sync"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: unrecognized subcommand 'sync'
+
+      tip: a similar subcommand exists: 'puffin pip sync'
+
+    Usage: puffin [OPTIONS] <COMMAND>
+
+    For more information, try '--help'.
+    "###);
+}
+
+#[test]
 fn missing_requirements_txt() {
     let context = TestContext::new("3.12");
 


### PR DESCRIPTION
## Summary

Open to other opinions here. We could just continue (and warn), prompt the user with a confirmation, etc.

(The weird thing about those two options is we might need to validate the command-line arguments _before_ we do that -- so you could get errors for bad arguments, and then get a warning that your subcommand is wrong. I can probably avoid that with more work if it feels like a better out come though.)

Closes https://github.com/astral-sh/puffin/issues/1256.
