### PR TITLE
Use anstream consistently and remove clippy lints

### DIFF
--- a/crates/gourgeist/src/main.rs
+++ b/crates/gourgeist/src/main.rs
@@ -48,17 +48,11 @@ fn main() -> ExitCode {
     let result = run();
     info!("Took {}ms", start.elapsed().as_millis());
     if let Err(err) = result {
-        #[allow(clippy::print_stderr)]
-        {
-            eprintln!("💥 virtualenv creator failed");
-        }
+        eprintln!("💥 virtualenv creator failed");
 
         let mut last_error: Option<&(dyn Error + 'static)> = Some(&err);
         while let Some(err) = last_error {
-            #[allow(clippy::print_stderr)]
-            {
-                eprintln!("  Caused by: {err}");
-            }
+            eprintln!("  Caused by: {err}");
             last_error = err.source();
         }
         ExitCode::FAILURE

--- a/crates/puffin-dev/src/main.rs
+++ b/crates/puffin-dev/src/main.rs
@@ -1,12 +1,10 @@
-#![allow(clippy::print_stdout, clippy::print_stderr)]
-
 use std::env;
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::Instant;
 
-use anstream::eprintln;
+use anstream::{eprintln, println};
 use anyhow::Result;
 use clap::Parser;
 use owo_colors::OwoColorize;

--- a/crates/puffin-dev/src/resolve_cli.rs
+++ b/crates/puffin-dev/src/resolve_cli.rs
@@ -121,7 +121,6 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
 
     let requirements = Resolution::from(resolution_graph).requirements();
 
-    #[allow(clippy::print_stderr)]
     match args.format {
         ResolveCliFormat::Compact => {
             println!("{}", requirements.iter().map(ToString::to_string).join(" "));

--- a/crates/puffin-dev/src/wheel_metadata.rs
+++ b/crates/puffin-dev/src/wheel_metadata.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use anstream::println;
 use anyhow::Result;
 use clap::Parser;
 

--- a/crates/puffin/src/commands/freeze.rs
+++ b/crates/puffin/src/commands/freeze.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write;
 
+use anstream::println;
 use anyhow::Result;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
@@ -33,10 +34,7 @@ pub(crate) fn freeze(cache: &Cache, strict: bool, mut printer: Printer) -> Resul
         .iter()
         .sorted_unstable_by(|a, b| a.name().cmp(b.name()))
     {
-        #[allow(clippy::print_stdout)]
-        {
-            println!("{dist}");
-        }
+        println!("{dist}");
     }
 
     // Validate that the environment is consistent.

--- a/crates/puffin/src/commands/pip_compile.rs
+++ b/crates/puffin/src/commands/pip_compile.rs
@@ -298,12 +298,9 @@ pub(crate) async fn pip_compile(
 
     let resolution = match resolver.resolve().await {
         Err(puffin_resolver::ResolveError::NoSolution(err)) => {
-            #[allow(clippy::print_stderr)]
-            {
-                let report = miette::Report::msg(format!("{err}"))
-                    .context("No solution found when resolving dependencies:");
-                eprint!("{report:?}");
-            }
+            let report = miette::Report::msg(format!("{err}"))
+                .context("No solution found when resolving dependencies:");
+            eprint!("{report:?}");
             return Ok(ExitStatus::Failure);
         }
         result => result,

--- a/crates/puffin/src/commands/pip_install.rs
+++ b/crates/puffin/src/commands/pip_install.rs
@@ -218,12 +218,9 @@ pub(crate) async fn pip_install(
     {
         Ok(resolution) => Resolution::from(resolution),
         Err(Error::Resolve(puffin_resolver::ResolveError::NoSolution(err))) => {
-            #[allow(clippy::print_stderr)]
-            {
-                let report = miette::Report::msg(format!("{err}"))
-                    .context("No solution found when resolving dependencies:");
-                eprint!("{report:?}");
-            }
+            let report = miette::Report::msg(format!("{err}"))
+                .context("No solution found when resolving dependencies:");
+            eprint!("{report:?}");
             return Ok(ExitStatus::Failure);
         }
         Err(err) => return Err(err.into()),

--- a/crates/puffin/src/commands/venv.rs
+++ b/crates/puffin/src/commands/venv.rs
@@ -2,6 +2,7 @@ use std::fmt::Write;
 use std::path::Path;
 use std::str::FromStr;
 
+use anstream::eprint;
 use anyhow::Result;
 use miette::{Diagnostic, IntoDiagnostic};
 use owo_colors::OwoColorize;
@@ -35,10 +36,7 @@ pub(crate) async fn venv(
     match venv_impl(path, python_request, index_locations, seed, cache, printer).await {
         Ok(status) => Ok(status),
         Err(err) => {
-            #[allow(clippy::print_stderr)]
-            {
-                eprint!("{err:?}");
-            }
+            eprint!("{err:?}");
             Ok(ExitStatus::Failure)
         }
     }

--- a/crates/puffin/src/main.rs
+++ b/crates/puffin/src/main.rs
@@ -948,13 +948,10 @@ fn main() -> ExitCode {
     match result {
         Ok(code) => code.into(),
         Err(err) => {
-            #[allow(clippy::print_stderr)]
-            {
-                let mut causes = err.chain();
-                eprintln!("{}: {}", "error".red().bold(), causes.next().unwrap());
-                for err in causes {
-                    eprintln!("  {}: {}", "Caused by".red().bold(), err);
-                }
+            let mut causes = err.chain();
+            eprintln!("{}: {}", "error".red().bold(), causes.next().unwrap());
+            for err in causes {
+                eprintln!("  {}: {}", "Caused by".red().bold(), err);
             }
             ExitStatus::Error.into()
         }


### PR DESCRIPTION
We need to use the anstream print macros instead of the std print macros, otherwise we risk wrong color behavior (https://github.com/astral-sh/puffin/pull/1258#discussion_r1480428236). Luckily, the `print_stderr` and `print_stdout` lints catch usages of the std prints.

This PR switches over to anstream consistently and removes the now redundant clippy lints. The lints should catch missing anstream usage in the future.