### PR TITLE
puffin-resolver: simplify version map construction

### DIFF
--- a/crates/distribution-types/src/prioritized_distribution.rs
+++ b/crates/distribution-types/src/prioritized_distribution.rs
@@ -13,10 +13,10 @@ pub struct DistRequiresPython {
 }
 
 // Boxed because `Dist` is large.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct PrioritizedDistribution(Box<PrioritizedDistributionInner>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 struct PrioritizedDistributionInner {
     /// An arbitrary source distribution for the package version.
     source: Option<DistRequiresPython>,
@@ -177,6 +177,14 @@ impl PrioritizedDistribution {
     /// Return the hashes for each distribution.
     pub fn hashes(&self) -> &[Hashes] {
         &self.0.hashes
+    }
+
+    /// Returns true if and only if this distribution does not contain any
+    /// source distributions or wheels.
+    pub fn is_empty(&self) -> bool {
+        self.0.source.is_none()
+            && self.0.compatible_wheel.is_none()
+            && self.0.incompatible_wheel.is_none()
     }
 }
 

--- a/crates/puffin-client/src/flat_index.rs
+++ b/crates/puffin-client/src/flat_index.rs
@@ -279,6 +279,19 @@ impl FlatDistributions {
     pub fn iter(&self) -> impl Iterator<Item = (&Version, &PrioritizedDistribution)> {
         self.0.iter()
     }
+
+    pub fn remove(&mut self, version: &Version) -> Option<PrioritizedDistribution> {
+        self.0.remove(version)
+    }
+}
+
+impl IntoIterator for FlatDistributions {
+    type IntoIter = std::collections::btree_map::IntoIter<Version, PrioritizedDistribution>;
+    type Item = (Version, PrioritizedDistribution);
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
 }
 
 impl From<FlatDistributions> for BTreeMap<Version, PrioritizedDistribution> {


### PR DESCRIPTION
In the process of making VersionMap construction lazy, I realized this
refactoring would be useful to me. It also simplifies a fair bit of case
analysis and does fewer BTreeMap lookups during construction. With that
said, this doesn't seem to matter for perf:

```
$ hyperfine -w10 --runs 50 \
    "puffin-main pip compile --cache-dir ~/astral/tmp/cache-main ~/astral/tmp/reqs/home-assistant-reduced.in -o /dev/null" \
    "puffin-test pip compile --cache-dir ~/astral/tmp/cache-test ~/astral/tmp/reqs/home-assistant-reduced.in -o /dev/null"
Benchmark 1: puffin-main pip compile --cache-dir ~/astral/tmp/cache-main ~/astral/tmp/reqs/home-assistant-reduced.in -o /dev/null
  Time (mean ± σ):     146.8 ms ±   4.1 ms    [User: 350.1 ms, System: 314.2 ms]
  Range (min … max):   140.7 ms … 158.0 ms    50 runs

Benchmark 2: puffin-test pip compile --cache-dir ~/astral/tmp/cache-test ~/astral/tmp/reqs/home-assistant-reduced.in -o /dev/null
  Time (mean ± σ):     146.8 ms ±   4.5 ms    [User: 359.8 ms, System: 308.3 ms]
  Range (min … max):   138.2 ms … 160.1 ms    50 runs

Summary
  puffin-main pip compile --cache-dir ~/astral/tmp/cache-main ~/astral/tmp/reqs/home-assistant-reduced.in -o /dev/null ran
    1.00 ± 0.04 times faster than puffin-test pip compile --cache-dir ~/astral/tmp/cache-test ~/astral/tmp/reqs/home-assistant-reduced.in -o /dev/null
```

But the simplification is still nice, and will decrease the delta
between what we have now and a lazy version map.
