### PR TITLE
Strip UNC prefix when setting working directory

### DIFF
--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -6,7 +6,7 @@ use fs_err as fs;
 use url::Url;
 
 use pep440_rs::Version;
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_normalize::PackageName;
 
 use crate::{InstalledMetadata, InstalledVersion, Name};

--- a/crates/install-wheel-rs/src/install_location.rs
+++ b/crates/install-wheel-rs/src/install_location.rs
@@ -5,7 +5,7 @@ use fs2::FileExt;
 use fs_err::File;
 use tracing::{error, warn};
 
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 
 const INSTALL_LOCKFILE: &str = "install-wheel-rs.lock";
 

--- a/crates/install-wheel-rs/src/lib.rs
+++ b/crates/install-wheel-rs/src/lib.rs
@@ -14,7 +14,7 @@ use distribution_filename::WheelFilename;
 pub use install_location::{normalize_name, InstallLocation, LockedDir};
 use pep440_rs::Version;
 use platform_host::{Arch, Os};
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_normalize::PackageName;
 pub use record::RecordEntry;
 pub use script::Script;

--- a/crates/install-wheel-rs/src/wheel.rs
+++ b/crates/install-wheel-rs/src/wheel.rs
@@ -21,7 +21,7 @@ use zip::{ZipArchive, ZipWriter};
 
 use distribution_filename::WheelFilename;
 use pep440_rs::Version;
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_normalize::PackageName;
 use pypi_types::DirectUrl;
 
@@ -574,7 +574,7 @@ fn bytecode_compile_inner(
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
-        .current_dir(site_packages)
+        .current_dir(site_packages.normalized())
         .spawn()
         .map_err(Error::PythonSubcommand)?;
 

--- a/crates/puffin-build/src/lib.rs
+++ b/crates/puffin-build/src/lib.rs
@@ -27,6 +27,7 @@ use tracing::{debug, info_span, instrument, Instrument};
 
 use distribution_types::Resolution;
 use pep508_rs::Requirement;
+use puffin_fs::Normalized;
 use puffin_interpreter::{Interpreter, Virtualenv};
 use puffin_traits::{BuildContext, BuildKind, SetupPyStrategy, SourceBuildTrait};
 
@@ -562,7 +563,7 @@ impl SourceBuild {
             );
             let output = Command::new(&python_interpreter)
                 .args(["setup.py", "bdist_wheel"])
-                .current_dir(&self.source_tree)
+                .current_dir(self.source_tree.normalized())
                 .output()
                 .instrument(span)
                 .await
@@ -771,7 +772,7 @@ async fn run_python_script(
     };
     Command::new(venv.python_executable())
         .args(["-c", script])
-        .current_dir(source_tree)
+        .current_dir(source_tree.normalized())
         // Activate the venv
         .env("VIRTUAL_ENV", venv.root())
         .env("PATH", new_path)

--- a/crates/puffin-fs/src/path.rs
+++ b/crates/puffin-fs/src/path.rs
@@ -1,7 +1,12 @@
 use std::borrow::Cow;
 use std::path::Path;
 
-pub trait NormalizedDisplay {
+pub trait Normalized {
+    /// Normalize a [`Path`].
+    ///
+    /// On Windows, this will strip the `\\?\` prefix from paths. On other platforms, it's a no-op.
+    fn normalized(&self) -> &Path;
+
     /// Render a [`Path`] for user-facing display.
     ///
     /// On Windows, this will strip the `\\?\` prefix from paths. On other platforms, it's
@@ -9,7 +14,11 @@ pub trait NormalizedDisplay {
     fn normalized_display(&self) -> std::path::Display;
 }
 
-impl<T: AsRef<Path>> NormalizedDisplay for T {
+impl<T: AsRef<Path>> Normalized for T {
+    fn normalized(&self) -> &Path {
+        dunce::simplified(self.as_ref())
+    }
+
     fn normalized_display(&self) -> std::path::Display {
         dunce::simplified(self.as_ref()).display()
     }

--- a/crates/puffin-git/src/git.rs
+++ b/crates/puffin-git/src/git.rs
@@ -9,7 +9,7 @@ use std::{env, str};
 use anyhow::{anyhow, Context as _, Result};
 use cargo_util::{paths, ProcessBuilder};
 use git2::{self, ErrorClass, ObjectType};
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use reqwest::Client;
 use reqwest::StatusCode;
 use tracing::{debug, warn};

--- a/crates/puffin-installer/src/plan.rs
+++ b/crates/puffin-installer/src/plan.rs
@@ -14,7 +14,7 @@ use pep508_rs::{Requirement, VersionOrUrl};
 use platform_tags::Tags;
 use puffin_cache::{ArchiveTimestamp, Cache, CacheBucket, CacheEntry, Timestamp, WheelCache};
 use puffin_distribution::{BuiltWheelIndex, RegistryWheelIndex};
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_interpreter::Virtualenv;
 use puffin_normalize::PackageName;
 use puffin_traits::NoBinary;

--- a/crates/puffin-interpreter/src/lib.rs
+++ b/crates/puffin-interpreter/src/lib.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use pep440_rs::Version;
 use thiserror::Error;
 
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 
 pub use crate::cfg::Configuration;
 pub use crate::interpreter::Interpreter;

--- a/crates/puffin-interpreter/src/virtual_env.rs
+++ b/crates/puffin-interpreter/src/virtual_env.rs
@@ -6,7 +6,7 @@ use tracing::debug;
 
 use platform_host::Platform;
 use puffin_cache::Cache;
-use puffin_fs::{LockedFile, NormalizedDisplay};
+use puffin_fs::{LockedFile, Normalized};
 
 use crate::cfg::Configuration;
 use crate::python_platform::PythonPlatform;

--- a/crates/puffin/src/commands/clean.rs
+++ b/crates/puffin/src/commands/clean.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
 
 use puffin_cache::Cache;
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_normalize::PackageName;
 
 use crate::commands::ExitStatus;

--- a/crates/puffin/src/commands/freeze.rs
+++ b/crates/puffin/src/commands/freeze.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 use distribution_types::Name;
 use platform_host::Platform;
 use puffin_cache::Cache;
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_installer::SitePackages;
 use puffin_interpreter::Virtualenv;
 

--- a/crates/puffin/src/commands/pip_compile.rs
+++ b/crates/puffin/src/commands/pip_compile.rs
@@ -22,7 +22,7 @@ use platform_tags::Tags;
 use puffin_cache::Cache;
 use puffin_client::{FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_installer::{Downloader, NoBinary};
 use puffin_interpreter::{Interpreter, PythonVersion};
 use puffin_normalize::{ExtraName, PackageName};

--- a/crates/puffin/src/commands/pip_install.rs
+++ b/crates/puffin/src/commands/pip_install.rs
@@ -19,7 +19,7 @@ use platform_tags::Tags;
 use puffin_cache::Cache;
 use puffin_client::{FlatIndex, FlatIndexClient, RegistryClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_installer::{
     BuiltEditable, Downloader, NoBinary, Plan, Planner, Reinstall, ResolvedEditable, SitePackages,
 };

--- a/crates/puffin/src/commands/pip_sync.rs
+++ b/crates/puffin/src/commands/pip_sync.rs
@@ -12,7 +12,7 @@ use platform_tags::Tags;
 use puffin_cache::Cache;
 use puffin_client::{FlatIndex, FlatIndexClient, RegistryClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_installer::{
     Downloader, NoBinary, Plan, Planner, Reinstall, ResolvedEditable, SitePackages,
 };

--- a/crates/puffin/src/commands/pip_uninstall.rs
+++ b/crates/puffin/src/commands/pip_uninstall.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 use distribution_types::{InstalledMetadata, Name};
 use platform_host::Platform;
 use puffin_cache::Cache;
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_interpreter::Virtualenv;
 
 use crate::commands::{elapsed, ExitStatus};

--- a/crates/puffin/src/commands/venv.rs
+++ b/crates/puffin/src/commands/venv.rs
@@ -14,7 +14,7 @@ use platform_host::Platform;
 use puffin_cache::Cache;
 use puffin_client::{FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use puffin_dispatch::BuildDispatch;
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_installer::NoBinary;
 use puffin_interpreter::{find_default_python, find_requested_python, Error};
 use puffin_resolver::InMemoryIndex;

--- a/crates/puffin/src/requirements.rs
+++ b/crates/puffin/src/requirements.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashSet;
 
 use distribution_types::{FlatIndexLocation, IndexUrl};
 use pep508_rs::Requirement;
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use puffin_normalize::{ExtraName, PackageName};
 use requirements_txt::{EditableRequirement, FindLink, RequirementsTxt};
 

--- a/crates/puffin/tests/pip_compile.rs
+++ b/crates/puffin/tests/pip_compile.rs
@@ -13,7 +13,7 @@ use itertools::Itertools;
 use url::Url;
 
 use common::{puffin_snapshot, TestContext, INSTA_FILTERS};
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 
 use crate::common::{get_bin, EXCLUDE_NEWER};
 

--- a/crates/puffin/tests/pip_sync.rs
+++ b/crates/puffin/tests/pip_sync.rs
@@ -13,7 +13,7 @@ use url::Url;
 use common::{
     create_bin_with_executables, create_venv, puffin_snapshot, venv_to_interpreter, INSTA_FILTERS,
 };
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 
 use crate::common::{get_bin, TestContext};
 

--- a/crates/puffin/tests/pip_uninstall.rs
+++ b/crates/puffin/tests/pip_uninstall.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use common::{puffin_snapshot, INSTA_FILTERS};
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 use url::Url;
 
 use crate::common::{get_bin, venv_to_interpreter, TestContext};

--- a/crates/puffin/tests/venv.rs
+++ b/crates/puffin/tests/venv.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 use anyhow::Result;
 use assert_fs::prelude::*;
 
-use puffin_fs::NormalizedDisplay;
+use puffin_fs::Normalized;
 
 use crate::common::{create_bin_with_executables, get_bin, puffin_snapshot};
 

--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -46,7 +46,7 @@ use unscanny::{Pattern, Scanner};
 use url::Url;
 
 use pep508_rs::{split_scheme, Extras, Pep508Error, Pep508ErrorSource, Requirement, VerbatimUrl};
-use puffin_fs::{normalize_url_path, NormalizedDisplay};
+use puffin_fs::{normalize_url_path, Normalized};
 use puffin_normalize::ExtraName;
 
 /// We emit one of those for each requirements.txt entry
@@ -936,7 +936,7 @@ mod test {
     use fs_err as fs;
     use indoc::indoc;
     use itertools::Itertools;
-    use puffin_fs::NormalizedDisplay;
+    use puffin_fs::Normalized;
     use tempfile::tempdir;
     use test_case::test_case;
 


### PR DESCRIPTION
## Summary

For PEP 517 builds, the current working directory needs to be set to the directory of the source distribution. It turns out that on Windows, if you use a UNC path for the working directory, then relative paths are interpreted relative to the root of the current drive ([source](https://www.fileside.app/blog/2023-03-17_windows-file-paths/#paths-relative-to-the-root-of-the-current-drive)). So, when builds attempted to resolve relative paths, they always errored...

This PR ensures that we remove the UNC prefix when setting the current working directory.

Closes #1238.

## Test Plan

I tested this on my Windows machine by installing `ujson` with `--no-binary ujson`. (I don't want to add that specific test, since it's really slow to build.)