### PR TITLE
Refactor incompatiblity tracking for distributions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "cache-key",
+ "chrono",
  "data-encoding",
  "distribution-filename",
  "fs-err",

--- a/crates/distribution-types/Cargo.toml
+++ b/crates/distribution-types/Cargo.toml
@@ -25,6 +25,7 @@ uv-normalize = { path = "../uv-normalize" }
 pypi-types = { path = "../pypi-types" }
 
 anyhow = { workspace = true }
+chrono = { workspace = true }
 data-encoding = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }

--- a/crates/distribution-types/src/prioritized_distribution.rs
+++ b/crates/distribution-types/src/prioritized_distribution.rs
@@ -105,7 +105,7 @@ impl PrioritizedDist {
     ) {
         // Track the highest-priority wheel.
         if let Some((.., existing_compatibility)) = &self.0.wheel {
-            if compatibility.is_higher_priority(existing_compatibility) {
+            if compatibility.is_more_compatible(existing_compatibility) {
                 self.0.wheel = Some((dist, compatibility));
             }
         } else {
@@ -126,7 +126,7 @@ impl PrioritizedDist {
     ) {
         // Track the highest-priority source.
         if let Some((.., existing_compatibility)) = &self.0.source {
-            if compatibility.is_higher_priority(existing_compatibility) {
+            if compatibility.is_more_compatible(existing_compatibility) {
                 self.0.source = Some((dist, compatibility));
             }
         } else {
@@ -250,7 +250,11 @@ impl WheelCompatibility {
         matches!(self, Self::Compatible(_))
     }
 
-    pub fn is_higher_priority(&self, other: &WheelCompatibility) -> bool {
+    /// Return `true` if the current compatibility is more compatible than another.
+    ///
+    /// Compatible wheels are always higher more compatible than incompatible wheels.
+    /// Compatible wheel ordering is determined by tag priority.
+    pub fn is_more_compatible(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Compatible(_), Self::Incompatible(_)) => true,
             (Self::Compatible(tag_priority), Self::Compatible(other_tag_priority)) => {
@@ -265,7 +269,12 @@ impl WheelCompatibility {
 }
 
 impl SourceDistCompatibility {
-    pub fn is_higher_priority(&self, other: &SourceDistCompatibility) -> bool {
+    /// Return the higher priority compatibility.
+    ///
+    /// Compatible source distributions are always higher priority than incompatible source distributions.
+    /// Compatible source distribution priority is arbitrary.
+    /// Incompatible source distribution priority selects a source distribution that was "closest" to being usable.
+    pub fn is_more_compatible(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Compatible, Self::Incompatible(_)) => true,
             (Self::Compatible, Self::Compatible) => false, // Arbitary
@@ -287,7 +296,7 @@ impl From<TagCompatibility> for WheelCompatibility {
 }
 
 impl IncompatibleSource {
-    fn is_more_compatible(&self, other: &IncompatibleSource) -> bool {
+    fn is_more_compatible(&self, other: &Self) -> bool {
         match self {
             Self::ExcludeNewer(timestamp_self) => match other {
                 // Smaller timestamps are closer to the cut-off time
@@ -312,7 +321,7 @@ impl IncompatibleSource {
 }
 
 impl IncompatibleWheel {
-    fn is_more_compatible(&self, other: &IncompatibleWheel) -> bool {
+    fn is_more_compatible(&self, other: &Self) -> bool {
         match self {
             Self::ExcludeNewer(timestamp_self) => match other {
                 // Smaller timestamps are closer to the cut-off time

--- a/crates/pypi-types/src/simple_json.rs
+++ b/crates/pypi-types/src/simple_json.rs
@@ -89,7 +89,15 @@ impl DistInfoMetadata {
 }
 
 #[derive(
-    Debug, Clone, Serialize, Deserialize, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
 )]
 #[archive(check_bytes)]
 #[archive_attr(derive(Debug))]

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -11,12 +11,12 @@ use url::Url;
 use distribution_filename::DistFilename;
 use distribution_types::{
     BuiltDist, Dist, File, FileLocation, FlatIndexLocation, IndexUrl, PrioritizedDist,
-    RegistryBuiltDist, RegistrySourceDist, SourceDist,
+    RegistryBuiltDist, RegistrySourceDist, SourceDist, SourceDistCompatibility,
 };
 use pep440_rs::Version;
 use pep508_rs::VerbatimUrl;
 use platform_tags::Tags;
-use pypi_types::{Hashes, Yanked};
+use pypi_types::Hashes;
 use uv_auth::safe_copy_url_auth;
 use uv_cache::{Cache, CacheBucket};
 use uv_normalize::PackageName;
@@ -307,19 +307,13 @@ impl FlatIndex {
                 }));
                 match distributions.0.entry(version) {
                     Entry::Occupied(mut entry) => {
-                        entry.get_mut().insert_built(
-                            dist,
-                            None,
-                            Yanked::default(),
-                            None,
-                            compatibility.into(),
-                        );
+                        entry
+                            .get_mut()
+                            .insert_built(dist, None, compatibility.into());
                     }
                     Entry::Vacant(entry) => {
                         entry.insert(PrioritizedDist::from_built(
                             dist,
-                            None,
-                            Yanked::default(),
                             None,
                             compatibility.into(),
                         ));
@@ -334,16 +328,17 @@ impl FlatIndex {
                 }));
                 match distributions.0.entry(filename.version) {
                     Entry::Occupied(mut entry) => {
-                        entry
-                            .get_mut()
-                            .insert_source(dist, None, Yanked::default(), None);
+                        entry.get_mut().insert_source(
+                            dist,
+                            None,
+                            SourceDistCompatibility::Compatible,
+                        );
                     }
                     Entry::Vacant(entry) => {
                         entry.insert(PrioritizedDist::from_source(
                             dist,
                             None,
-                            Yanked::default(),
-                            None,
+                            SourceDistCompatibility::Compatible,
                         ));
                     }
                 }

--- a/crates/uv-dev/src/install_many.rs
+++ b/crates/uv-dev/src/install_many.rs
@@ -122,6 +122,7 @@ async fn install_chunk(
         venv.interpreter(),
         &FlatIndex::default(),
         &NoBinary::None,
+        &NoBuild::None,
     )
     .resolve_stream(requirements)
     .collect()

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -1,7 +1,7 @@
 use pubgrub::range::Range;
 use rustc_hash::FxHashMap;
 
-use distribution_types::CompatibleDist;
+use distribution_types::{CompatibleDist, IncompatibleDist, IncompatibleSource};
 use distribution_types::{DistributionMetadata, IncompatibleWheel, Name, PrioritizedDist};
 use pep440_rs::Version;
 use pep508_rs::{MarkerEnvironment, Requirement, VersionOrUrl};
@@ -192,7 +192,7 @@ impl CandidateSelector {
         for (version, maybe_dist) in versions {
             steps += 1;
 
-            let dist = if version.any_prerelease() {
+            let candidate = if version.any_prerelease() {
                 if range.contains(version) {
                     match allow_prerelease {
                         AllowPreRelease::Yes => {
@@ -209,7 +209,7 @@ impl CandidateSelector {
                             );
                             // If pre-releases are allowed, treat them equivalently
                             // to stable distributions.
-                            dist
+                            Candidate::new(package_name, version, dist)
                         }
                         AllowPreRelease::IfNecessary => {
                             let Some(dist) = maybe_dist.prioritized_dist() else {
@@ -235,7 +235,7 @@ impl CandidateSelector {
                 // current range.
                 prerelease = Some(PreReleaseCandidate::NotNecessary);
 
-                // Always return the first-matching stable distribution.
+                // Return the first-matching stable distribution.
                 if range.contains(version) {
                     let Some(dist) = maybe_dist.prioritized_dist() else {
                         continue;
@@ -248,18 +248,27 @@ impl CandidateSelector {
                         steps,
                         version,
                     );
-                    dist
+                    Candidate::new(package_name, version, dist)
                 } else {
                     continue;
                 }
             };
 
-            // Skip empty candidates due to exclude newer
-            if dist.exclude_newer() && dist.incompatible_wheel().is_none() && dist.get().is_none() {
+            // If candidate is not compatible due to exclude newer, continue searching.
+            // This is a special case — we pretend versions with exclude newer incompatibilities
+            // do not exist so that they are not present in error messages in our test suite
+            // We cannot
+            if matches!(
+                candidate.dist(),
+                CandidateDist::Incompatible(
+                    IncompatibleDist::Source(IncompatibleSource::ExcludeNewer(_))
+                        | IncompatibleDist::Wheel(IncompatibleWheel::ExcludeNewer(_))
+                )
+            ) {
                 continue;
             }
 
-            return Some(Candidate::new(package_name, version, dist));
+            return Some(candidate);
         }
         tracing::trace!(
             "exhausted all candidates for package {:?} with range {:?} \
@@ -281,23 +290,26 @@ impl CandidateSelector {
 #[derive(Debug, Clone)]
 pub(crate) enum CandidateDist<'a> {
     Compatible(CompatibleDist<'a>),
-    Incompatible(Option<&'a IncompatibleWheel>),
-    ExcludeNewer,
+    Incompatible(IncompatibleDist),
 }
 
 impl<'a> From<&'a PrioritizedDist> for CandidateDist<'a> {
     fn from(value: &'a PrioritizedDist) -> Self {
         if let Some(dist) = value.get() {
             CandidateDist::Compatible(dist)
-        } else if value.exclude_newer() && value.incompatible_wheel().is_none() {
-            // If empty because of exclude-newer, mark as a special case
-            CandidateDist::ExcludeNewer
         } else {
-            CandidateDist::Incompatible(
-                value
-                    .incompatible_wheel()
-                    .map(|(_, incompatibility)| incompatibility),
-            )
+            // TODO(zanieb)
+            // We always return the source distribution (if one exists) instead of the wheel
+            // but in the future we may want to return both so the resolver can explain
+            // why neither distribution kind can be used.
+            let dist = if let Some((_, incompatibility)) = value.incompatible_source() {
+                IncompatibleDist::Source(incompatibility.clone())
+            } else if let Some((_, incompatibility)) = value.incompatible_wheel() {
+                IncompatibleDist::Wheel(incompatibility.clone())
+            } else {
+                IncompatibleDist::Unavailable
+            };
+            CandidateDist::Incompatible(dist)
         }
     }
 }

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -256,8 +256,10 @@ impl CandidateSelector {
 
             // If candidate is not compatible due to exclude newer, continue searching.
             // This is a special case — we pretend versions with exclude newer incompatibilities
-            // do not exist so that they are not present in error messages in our test suite
-            // We cannot
+            // do not exist so that they are not present in error messages in our test suite.
+            // TODO(zanieb): Now that `--exclude-newer` is user facing we may want to consider
+            // flagging this behavior such that we _will_ report filtered distributions due to
+            // exclude-newer in our error messages.
             if matches!(
                 candidate.dist(),
                 CandidateDist::Incompatible(

--- a/crates/uv-resolver/src/finder.rs
+++ b/crates/uv-resolver/src/finder.rs
@@ -154,8 +154,10 @@ impl<'a> DistFinder<'a> {
                     Some(version.clone()),
                     resolvable_dist
                         .compatible_wheel()
-                        .map(|(dist, tag_priority)| (dist.dist.clone(), tag_priority)),
-                    resolvable_dist.source().map(|dist| dist.dist.clone()),
+                        .map(|(dist, tag_priority)| (dist.clone(), tag_priority)),
+                    resolvable_dist
+                        .compatible_source()
+                        .map(std::clone::Clone::clone),
                 )
             } else {
                 (None, None, None)

--- a/crates/uv-resolver/src/finder.rs
+++ b/crates/uv-resolver/src/finder.rs
@@ -5,7 +5,7 @@
 use anyhow::Result;
 use futures::{stream, Stream, StreamExt, TryStreamExt};
 use rustc_hash::FxHashMap;
-use uv_traits::NoBinary;
+use uv_traits::{NoBinary, NoBuild};
 
 use distribution_filename::DistFilename;
 use distribution_types::{Dist, IndexUrl, Resolution};
@@ -26,6 +26,7 @@ pub struct DistFinder<'a> {
     interpreter: &'a Interpreter,
     flat_index: &'a FlatIndex,
     no_binary: &'a NoBinary,
+    no_build: &'a NoBuild,
 }
 
 impl<'a> DistFinder<'a> {
@@ -36,6 +37,7 @@ impl<'a> DistFinder<'a> {
         interpreter: &'a Interpreter,
         flat_index: &'a FlatIndex,
         no_binary: &'a NoBinary,
+        no_build: &'a NoBuild,
     ) -> Self {
         Self {
             tags,
@@ -44,6 +46,7 @@ impl<'a> DistFinder<'a> {
             interpreter,
             flat_index,
             no_binary,
+            no_build,
         }
     }
 
@@ -135,6 +138,11 @@ impl<'a> DistFinder<'a> {
             NoBinary::All => true,
             NoBinary::Packages(packages) => packages.contains(&requirement.name),
         };
+        let no_build = match self.no_build {
+            NoBuild::None => false,
+            NoBuild::All => true,
+            NoBuild::Packages(packages) => packages.contains(&requirement.name),
+        };
 
         // Prioritize the flat index by initializing the "best" matches with its entries.
         let matching_override = if let Some(flat_index) = flat_index {
@@ -215,7 +223,7 @@ impl<'a> DistFinder<'a> {
             }
 
             // Find the most-compatible sdist, if no wheel was found.
-            if best_wheel.is_none() {
+            if !no_build && best_wheel.is_none() {
                 for version_sdist in files.source_dists {
                     // Only add dists compatible with the python version.
                     // This is relevant for source dists which give no other indication of their

--- a/crates/uv-resolver/src/pins.rs
+++ b/crates/uv-resolver/src/pins.rs
@@ -15,10 +15,10 @@ pub(crate) struct FilePins(FxHashMap<PackageName, FxHashMap<pep440_rs::Version, 
 impl FilePins {
     /// Pin a candidate package.
     pub(crate) fn insert(&mut self, candidate: &Candidate, dist: &CompatibleDist) {
-        self.0.entry(candidate.name().clone()).or_default().insert(
-            candidate.version().clone(),
-            dist.for_installation().dist.clone(),
-        );
+        self.0
+            .entry(candidate.name().clone())
+            .or_default()
+            .insert(candidate.version().clone(), dist.for_installation().clone());
     }
 
     /// Return the pinned file for the given package name and version, if it exists.

--- a/crates/uv-resolver/src/python_requirement.rs
+++ b/crates/uv-resolver/src/python_requirement.rs
@@ -1,5 +1,4 @@
-use distribution_types::{CompatibleDist, Dist};
-use pep440_rs::{Version, VersionSpecifiers};
+use pep440_rs::Version;
 use pep508_rs::MarkerEnvironment;
 use uv_interpreter::Interpreter;
 
@@ -29,43 +28,5 @@ impl PythonRequirement {
     /// Return the target version of Python.
     pub fn target(&self) -> &Version {
         &self.target
-    }
-
-    /// If the dist doesn't match the given Python requirement, return the version specifiers.
-    pub(crate) fn validate_dist<'a>(
-        &self,
-        dist: &'a CompatibleDist,
-    ) -> Option<&'a VersionSpecifiers> {
-        // Validate the _installed_ file.
-        let requires_python = dist.for_installation().requires_python.as_ref()?;
-
-        // If the dist doesn't support the target Python version, return the failing version
-        // specifiers.
-        if !requires_python.contains(self.target()) {
-            return Some(requires_python);
-        }
-
-        // If the dist is a source distribution, and doesn't support the installed Python
-        // version, return the failing version specifiers, since we won't be able to build it.
-        if matches!(dist.for_installation().dist, Dist::Source(_))
-            && !requires_python.contains(self.installed())
-        {
-            return Some(requires_python);
-        }
-
-        // Validate the resolved file.
-        let requires_python = dist.for_resolution().requires_python.as_ref()?;
-
-        // If the dist is a source distribution, and doesn't support the installed Python
-        // version, return the failing version specifiers, since we won't be able to build it.
-        // This isn't strictly necessary, since if `dist.resolve_metadata()` is a source distribution, it
-        // should be the same file as `dist.install_metadata()` (validated above).
-        if matches!(dist.for_resolution().dist, Dist::Source(_))
-            && !requires_python.contains(self.installed())
-        {
-            return Some(requires_python);
-        }
-
-        None
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -133,6 +133,7 @@ impl<'a, Context: BuildContext + Send + Sync> Resolver<'a, DefaultResolverProvid
             AllowedYanks::from_manifest(&manifest, markers),
             options.exclude_newer,
             build_context.no_binary(),
+            build_context.no_build(),
         );
         Self::new_custom_io(
             manifest,
@@ -389,7 +390,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                                 }
                                 IncompatibleDist::Source(incompatibility) => {
                                     match incompatibility {
-                                        IncompatibleSource::NoBuild => "no wheels are available and building from source is disabled".to_string(),
+                                        IncompatibleSource::NoBuild => "no wheels are usable and building from source is disabled".to_string(),
                                         IncompatibleSource::Yanked(yanked) => match yanked {
                                             Yanked::Bool(_) => "it was yanked".to_string(),
                                             Yanked::Reason(reason) => format!(

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -341,8 +341,10 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                         // Incompatible requires-python versions are special in that we track
                         // them as incompatible dependencies instead of marking the package version
                         // as unavailable directly
-                        UnavailableVersion::IncompatibleDist(IncompatibleDist::Source(IncompatibleSource::RequiresPython(requires_python))
-| IncompatibleDist::Wheel(IncompatibleWheel::RequiresPython(requires_python))) => {
+                        UnavailableVersion::IncompatibleDist(
+                            IncompatibleDist::Source(IncompatibleSource::RequiresPython(requires_python))
+                            | IncompatibleDist::Wheel(IncompatibleWheel::RequiresPython(requires_python))
+                        ) => {
                             let python_version = requires_python
                                 .iter()
                                 .map(PubGrubSpecifier::try_from)

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -14,15 +14,15 @@ use pubgrub::solver::{Incompatibility, State};
 use rustc_hash::{FxHashMap, FxHashSet};
 use tokio::select;
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, info_span, instrument, trace, warn, Instrument};
+use tracing::{debug, info_span, instrument, trace, Instrument};
 use url::Url;
 
 use distribution_filename::WheelFilename;
 use distribution_types::{
-    BuiltDist, Dist, DistributionMetadata, IncompatibleWheel, Name, RemoteSource, SourceDist,
-    VersionOrUrl,
+    BuiltDist, Dist, DistributionMetadata, IncompatibleDist, IncompatibleSource, IncompatibleWheel,
+    Name, RemoteSource, SourceDist, VersionOrUrl,
 };
-use pep440_rs::{Version, VersionSpecifiers, MIN_VERSION};
+use pep440_rs::{Version, MIN_VERSION};
 use pep508_rs::{MarkerEnvironment, Requirement};
 use platform_tags::{IncompatibleTag, Tags};
 use pypi_types::{Metadata21, Yanked};
@@ -53,6 +53,7 @@ pub use crate::resolver::provider::{
 };
 use crate::resolver::reporter::Facade;
 pub use crate::resolver::reporter::{BuildId, Reporter};
+
 use crate::yanks::AllowedYanks;
 use crate::{DependencyMode, Options};
 
@@ -65,12 +66,8 @@ mod urls;
 /// Unlike [`PackageUnavailable`] this applies to a single version of the package
 #[derive(Debug, Clone)]
 pub(crate) enum UnavailableVersion {
-    /// Version is incompatible due to the `Requires-Python` version specifiers for that package.
-    RequiresPython(VersionSpecifiers),
-    /// Version is incompatible because it is yanked
-    Yanked(Yanked),
     /// Version is incompatible because it has no usable distributions
-    NoDistributions(Option<IncompatibleWheel>),
+    IncompatibleDist(IncompatibleDist),
 }
 
 /// The package is unavailable and cannot be used
@@ -97,7 +94,6 @@ pub struct Resolver<'a, Provider: ResolverProvider> {
     constraints: Constraints,
     overrides: Overrides,
     editables: Editables,
-    allowed_yanks: AllowedYanks,
     urls: Urls,
     dependency_mode: DependencyMode,
     markers: &'a MarkerEnvironment,
@@ -134,6 +130,7 @@ impl<'a, Context: BuildContext + Send + Sync> Resolver<'a, DefaultResolverProvid
             flat_index,
             tags,
             PythonRequirement::new(interpreter, markers),
+            AllowedYanks::from_manifest(&manifest, markers),
             options.exclude_newer,
             build_context.no_binary(),
         );
@@ -163,7 +160,6 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
             unavailable_packages: DashMap::default(),
             visited: DashSet::default(),
             selector: CandidateSelector::for_resolution(options, &manifest, markers),
-            allowed_yanks: AllowedYanks::from_manifest(&manifest, markers),
             dependency_mode: options.dependency_mode,
             urls: Urls::from_manifest(&manifest, markers)?,
             project: manifest.project,
@@ -341,10 +337,11 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                 ResolverVersion::Available(version) => version,
                 ResolverVersion::Unavailable(version, unavailable) => {
                     let reason = match unavailable {
-                        UnavailableVersion::RequiresPython(requires_python) => {
-                            // Incompatible requires-python versions are special in that we track
-                            // them as incompatible dependencies instead of marking the package version
-                            // as unavailable directly
+                        // Incompatible requires-python versions are special in that we track
+                        // them as incompatible dependencies instead of marking the package version
+                        // as unavailable directly
+                        UnavailableVersion::IncompatibleDist(IncompatibleDist::Source(IncompatibleSource::RequiresPython(requires_python))
+| IncompatibleDist::Wheel(IncompatibleWheel::RequiresPython(requires_python))) => {
                             let python_version = requires_python
                                 .iter()
                                 .map(PubGrubSpecifier::try_from)
@@ -363,30 +360,51 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                             state.partial_solution.add_decision(next.clone(), version);
                             continue;
                         }
-                        UnavailableVersion::Yanked(yanked) => match yanked {
-                            Yanked::Bool(_) => "it was yanked".to_string(),
-                            Yanked::Reason(reason) => format!(
-                                "it was yanked (reason: {})",
-                                reason.trim().trim_end_matches('.')
-                            ),
-                        },
-                        UnavailableVersion::NoDistributions(best_incompatible) => {
-                            if let Some(best_incompatible) = best_incompatible {
-                                match best_incompatible {
-                                    IncompatibleWheel::NoBinary => "no source distribution is available and using wheels is disabled".to_string(),
-                                    IncompatibleWheel::RequiresPython => "no wheels are available that meet your required Python version".to_string(),
-                                    IncompatibleWheel::Tag(tag) => {
-                                        match tag {
-                                            IncompatibleTag::Invalid => "no wheels are available with valid tags".to_string(),
-                                            IncompatibleTag::Python => "no wheels are available with a matching Python implementation".to_string(),
-                                            IncompatibleTag::Abi => "no wheels are available with a matching Python ABI".to_string(),
-                                            IncompatibleTag::Platform => "no wheels are available with a matching platform".to_string(),
+                        UnavailableVersion::IncompatibleDist(incompatibility) => {
+                            match incompatibility {
+                                IncompatibleDist::Wheel(incompatibility) => {
+                                    match incompatibility {
+                                        IncompatibleWheel::NoBinary => "no source distribution is available and using wheels is disabled".to_string(),
+                                        IncompatibleWheel::Tag(tag) => {
+                                            match tag {
+                                                IncompatibleTag::Invalid => "no wheels are available with valid tags".to_string(),
+                                                IncompatibleTag::Python => "no wheels are available with a matching Python implementation".to_string(),
+                                                IncompatibleTag::Abi => "no wheels are available with a matching Python ABI".to_string(),
+                                                IncompatibleTag::Platform => "no wheels are available with a matching platform".to_string(),
+                                            }
                                         }
+                                        IncompatibleWheel::Yanked(yanked) => match yanked {
+                                            Yanked::Bool(_) => "it was yanked".to_string(),
+                                            Yanked::Reason(reason) => format!(
+                                                "it was yanked (reason: {})",
+                                                reason.trim().trim_end_matches('.')
+                                            ),
+                                        },
+                                        IncompatibleWheel::ExcludeNewer(ts) => match ts {
+                                            Some(_) => "it was published after the exclude newer time".to_string(),
+                                            None => "it has no publish time".to_string()
+                                        }
+                                        IncompatibleWheel::RequiresPython(_) => unreachable!(),
                                     }
                                 }
-                            } else {
-                                // TODO(zanieb): It's unclear why we would encounter this case still
-                                "no wheels are available for your system".to_string()
+                                IncompatibleDist::Source(incompatibility) => {
+                                    match incompatibility {
+                                        IncompatibleSource::NoBuild => "no wheels are available and building from source is disabled".to_string(),
+                                        IncompatibleSource::Yanked(yanked) => match yanked {
+                                            Yanked::Bool(_) => "it was yanked".to_string(),
+                                            Yanked::Reason(reason) => format!(
+                                                "it was yanked (reason: {})",
+                                                reason.trim().trim_end_matches('.')
+                                            ),
+                                        },
+                                        IncompatibleSource::ExcludeNewer(ts) => match ts {
+                                            Some(_) => "it was published after the exclude newer time".to_string(),
+                                            None => "it has no publish time".to_string()
+                                        }
+                                        IncompatibleSource::RequiresPython(_) => unreachable!(),
+                                    }
+                                }
+                                IncompatibleDist::Unavailable => "no distributions are available".to_string()
                             }
                         }
                     };
@@ -521,7 +539,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
     #[instrument(skip_all, fields(%package))]
     async fn choose_version(
         &self,
-        package: &PubGrubPackage,
+        package: &'a PubGrubPackage,
         range: &Range<Version>,
         pins: &mut FilePins,
         request_sink: &tokio::sync::mpsc::Sender<Request>,
@@ -644,41 +662,14 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
 
                 let dist = match candidate.dist() {
                     CandidateDist::Compatible(dist) => dist,
-                    CandidateDist::ExcludeNewer => {
-                        // If the version is incompatible because of `exclude_newer`, pretend the versions do not exist
-                        return Ok(None);
-                    }
                     CandidateDist::Incompatible(incompatibility) => {
-                        // If the version is incompatible because no distributions match, exit early.
+                        // If the version is incompatible because no distributions are compatible, exit early.
                         return Ok(Some(ResolverVersion::Unavailable(
                             candidate.version().clone(),
-                            UnavailableVersion::NoDistributions(incompatibility.cloned()),
+                            UnavailableVersion::IncompatibleDist(incompatibility.clone()),
                         )));
                     }
                 };
-
-                // If the version is incompatible because it was yanked, exit early.
-                if dist.yanked().is_yanked() {
-                    if self
-                        .allowed_yanks
-                        .allowed(package_name, candidate.version())
-                    {
-                        warn!("Allowing yanked version: {}", candidate.package_id());
-                    } else {
-                        return Ok(Some(ResolverVersion::Unavailable(
-                            candidate.version().clone(),
-                            UnavailableVersion::Yanked(dist.yanked().clone()),
-                        )));
-                    }
-                }
-
-                // If the version is incompatible because of its Python requirement
-                if let Some(requires_python) = self.python_requirement.validate_dist(dist) {
-                    return Ok(Some(ResolverVersion::Unavailable(
-                        candidate.version().clone(),
-                        UnavailableVersion::RequiresPython(requires_python.clone()),
-                    )));
-                }
 
                 if let Some(extra) = extra {
                     debug!(
@@ -687,7 +678,6 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                         extra,
                         candidate.version(),
                         dist.for_resolution()
-                            .dist
                             .filename()
                             .unwrap_or(Cow::Borrowed("unknown filename"))
                     );
@@ -697,7 +687,6 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                         candidate.name(),
                         candidate.version(),
                         dist.for_resolution()
-                            .dist
                             .filename()
                             .unwrap_or(Cow::Borrowed("unknown filename"))
                     );
@@ -711,7 +700,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
 
                 // Emit a request to fetch the metadata for this version.
                 if self.index.distributions.register(candidate.package_id()) {
-                    let dist = dist.for_resolution().dist.clone();
+                    let dist = dist.for_resolution().clone();
                     request_sink.send(Request::Dist(dist)).await?;
                 }
 
@@ -1023,7 +1012,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                 };
 
                 // Try to find a compatible version. If there aren't any compatible versions,
-                // short-circuit and return `None`.
+                // short-circuit.
                 let Some(candidate) = self.selector.select(&package_name, &range, version_map)
                 else {
                     return Ok(None);
@@ -1034,14 +1023,9 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                     return Ok(None);
                 };
 
-                // If the Python version is incompatible, short-circuit.
-                if self.python_requirement.validate_dist(dist).is_some() {
-                    return Ok(None);
-                }
-
                 // Emit a request to fetch the metadata for this version.
                 if self.index.distributions.register(candidate.package_id()) {
-                    let dist = dist.for_resolution().dist.clone();
+                    let dist = dist.for_resolution().clone();
 
                     let (metadata, precise) = self
                         .provider

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -14,6 +14,7 @@ use uv_traits::{BuildContext, NoBinary};
 
 use crate::python_requirement::PythonRequirement;
 use crate::version_map::VersionMap;
+use crate::yanks::AllowedYanks;
 
 pub type PackageVersionsResult = Result<VersionsResponse, uv_client::Error>;
 pub type WheelMetadataResult = Result<(Metadata21, Option<Url>), uv_distribution::Error>;
@@ -66,6 +67,7 @@ pub struct DefaultResolverProvider<'a, Context: BuildContext + Send + Sync> {
     flat_index: FlatIndex,
     tags: Tags,
     python_requirement: PythonRequirement,
+    allowed_yanks: AllowedYanks,
     exclude_newer: Option<DateTime<Utc>>,
     no_binary: NoBinary,
 }
@@ -79,6 +81,7 @@ impl<'a, Context: BuildContext + Send + Sync> DefaultResolverProvider<'a, Contex
         flat_index: &'a FlatIndex,
         tags: &'a Tags,
         python_requirement: PythonRequirement,
+        allowed_yanks: AllowedYanks,
         exclude_newer: Option<DateTime<Utc>>,
         no_binary: &'a NoBinary,
     ) -> Self {
@@ -88,6 +91,7 @@ impl<'a, Context: BuildContext + Send + Sync> DefaultResolverProvider<'a, Contex
             flat_index: flat_index.clone(),
             tags: tags.clone(),
             python_requirement,
+            allowed_yanks,
             exclude_newer,
             no_binary: no_binary.clone(),
         }
@@ -113,6 +117,7 @@ impl<'a, Context: BuildContext + Send + Sync> ResolverProvider
                 &index,
                 &self.tags,
                 &self.python_requirement,
+                &self.allowed_yanks,
                 self.exclude_newer.as_ref(),
                 self.flat_index.get(package_name).cloned(),
                 &self.no_binary,

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -10,7 +10,7 @@ use pypi_types::Metadata21;
 use uv_client::{FlatIndex, RegistryClient};
 use uv_distribution::DistributionDatabase;
 use uv_normalize::PackageName;
-use uv_traits::{BuildContext, NoBinary};
+use uv_traits::{BuildContext, NoBinary, NoBuild};
 
 use crate::python_requirement::PythonRequirement;
 use crate::version_map::VersionMap;
@@ -70,6 +70,7 @@ pub struct DefaultResolverProvider<'a, Context: BuildContext + Send + Sync> {
     allowed_yanks: AllowedYanks,
     exclude_newer: Option<DateTime<Utc>>,
     no_binary: NoBinary,
+    no_build: NoBuild,
 }
 
 impl<'a, Context: BuildContext + Send + Sync> DefaultResolverProvider<'a, Context> {
@@ -84,6 +85,7 @@ impl<'a, Context: BuildContext + Send + Sync> DefaultResolverProvider<'a, Contex
         allowed_yanks: AllowedYanks,
         exclude_newer: Option<DateTime<Utc>>,
         no_binary: &'a NoBinary,
+        no_build: &'a NoBuild,
     ) -> Self {
         Self {
             fetcher,
@@ -94,6 +96,7 @@ impl<'a, Context: BuildContext + Send + Sync> DefaultResolverProvider<'a, Contex
             allowed_yanks,
             exclude_newer,
             no_binary: no_binary.clone(),
+            no_build: no_build.clone(),
         }
     }
 }
@@ -121,6 +124,7 @@ impl<'a, Context: BuildContext + Send + Sync> ResolverProvider
                 self.exclude_newer.as_ref(),
                 self.flat_index.get(package_name).cloned(),
                 &self.no_binary,
+                &self.no_build,
             ))),
             Err(err) => match err.into_kind() {
                 uv_client::ErrorKind::PackageNotFound(_) => {

--- a/crates/uv-resolver/src/yanks.rs
+++ b/crates/uv-resolver/src/yanks.rs
@@ -49,11 +49,12 @@ impl AllowedYanks {
         Self(allowed_yanks)
     }
 
-    /// Returns `true` if the given package version is allowed, even if it's marked as yanked by
-    /// the relevant index.
-    pub(crate) fn allowed(&self, package_name: &PackageName, version: &Version) -> bool {
-        self.0
-            .get(package_name)
-            .is_some_and(|allowed_yanks| allowed_yanks.contains(version))
+    /// Returns versions for the given package which are allowed even if marked as yanked by the
+    /// relevant index.
+    pub(crate) fn allowed_versions(
+        &self,
+        package_name: &PackageName,
+    ) -> Option<&FxHashSet<Version>> {
+        self.0.get(package_name)
     }
 }

--- a/crates/uv-resolver/src/yanks.rs
+++ b/crates/uv-resolver/src/yanks.rs
@@ -8,8 +8,8 @@ use crate::Manifest;
 
 /// A set of package versions that are permitted, even if they're marked as yanked by the
 /// relevant index.
-#[derive(Debug, Default)]
-pub(crate) struct AllowedYanks(FxHashMap<PackageName, FxHashSet<Version>>);
+#[derive(Debug, Default, Clone)]
+pub struct AllowedYanks(FxHashMap<PackageName, FxHashSet<Version>>);
 
 impl AllowedYanks {
     pub(crate) fn from_manifest(manifest: &Manifest, markers: &MarkerEnvironment) -> Self {

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -220,9 +220,15 @@ pub(crate) async fn pip_sync(
     } else {
         let start = std::time::Instant::now();
 
-        let wheel_finder =
-            uv_resolver::DistFinder::new(tags, &client, venv.interpreter(), &flat_index, no_binary)
-                .with_reporter(FinderReporter::from(printer).with_length(remote.len() as u64));
+        let wheel_finder = uv_resolver::DistFinder::new(
+            tags,
+            &client,
+            venv.interpreter(),
+            &flat_index,
+            no_binary,
+            no_build,
+        )
+        .with_reporter(FinderReporter::from(printer).with_length(remote.len() as u64));
         let resolution = wheel_finder.resolve(&remote).await?;
 
         let s = if resolution.len() == 1 { "" } else { "s" };

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -3445,12 +3445,13 @@ fn no_wheels_no_build() {
         .arg("no-wheels-no-build-a")
         , @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download and build: albatross==1.0.0
-      Caused by: Building source distributions is disabled
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only albatross==1.0.0 is available and albatross==1.0.0 is unusable because no wheels are usable and building from source is disabled, we can conclude that all versions of albatross cannot be used.
+          And because you require albatross, we can conclude that the requirements are unsatisfiable.
     "###);
 
     assert_not_installed(&context.venv, "no_wheels_no_build_a", &context.temp_dir);


### PR DESCRIPTION
Extends the "compatibility" types introduced in #1293 to apply to source distributions as well as wheels.

- We now track the most-relevant incompatible source distribution
- Exclude newer, Python requirements, and yanked versions are all tracked as incompatibilities in the new model (this lets us remove `DistMetadata`!)