### PR TITLE
Patch handling of `exclude_newer` when reporting incompatible wheels

### DIFF
--- a/crates/distribution-types/src/prioritized_distribution.rs
+++ b/crates/distribution-types/src/prioritized_distribution.rs
@@ -19,6 +19,8 @@ struct PrioritizedDistInner {
     incompatible_wheel: Option<(DistMetadata, IncompatibleWheel)>,
     /// The hashes for each distribution.
     hashes: Vec<Hashes>,
+    /// If exclude newer filtered files from this distribution
+    exclude_newer: bool,
 }
 
 /// A distribution that can be used for both resolution and installation.
@@ -82,6 +84,7 @@ impl PrioritizedDist {
                 )),
                 incompatible_wheel: None,
                 hashes: hash.map(|hash| vec![hash]).unwrap_or_default(),
+                exclude_newer: false,
             })),
             WheelCompatibility::Incompatible(incompatibility) => {
                 Self(Box::new(PrioritizedDistInner {
@@ -96,6 +99,7 @@ impl PrioritizedDist {
                         incompatibility,
                     )),
                     hashes: hash.map(|hash| vec![hash]).unwrap_or_default(),
+                    exclude_newer: false,
                 }))
             }
         }
@@ -117,6 +121,7 @@ impl PrioritizedDist {
             compatible_wheel: None,
             incompatible_wheel: None,
             hashes: hash.map(|hash| vec![hash]).unwrap_or_default(),
+            exclude_newer: false,
         }))
     }
 
@@ -243,6 +248,16 @@ impl PrioritizedDist {
     /// Return the incompatible built distribution, if any.
     pub fn incompatible_wheel(&self) -> Option<&(DistMetadata, IncompatibleWheel)> {
         self.0.incompatible_wheel.as_ref()
+    }
+
+    /// Set the `exclude_newer` flag
+    pub fn set_exclude_newer(&mut self) {
+        self.0.exclude_newer = true;
+    }
+
+    /// Check if any distributions were excluded by the `exclude_newer` option
+    pub fn exclude_newer(&self) -> bool {
+        self.0.exclude_newer
     }
 
     /// Return the hashes for each distribution.

--- a/crates/puffin-resolver/src/resolver/mod.rs
+++ b/crates/puffin-resolver/src/resolver/mod.rs
@@ -683,6 +683,10 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
 
                 let dist = match candidate.dist() {
                     CandidateDist::Compatible(dist) => dist,
+                    CandidateDist::ExcludeNewer => {
+                        // If the version is incomatible because of `exclude_newer`, pretend the versions do not exist
+                        return Ok(None);
+                    }
                     CandidateDist::Incompatible(incompatibility) => {
                         // If the version is incompatible because no distributions match, exit early.
                         return Ok(Some(ResolverVersion::Unavailable(

--- a/crates/puffin-resolver/src/version_map.rs
+++ b/crates/puffin-resolver/src/version_map.rs
@@ -65,6 +65,7 @@ impl VersionMap {
                 if let Some(exclude_newer) = exclude_newer {
                     match file.upload_time_utc_ms.as_ref() {
                         Some(&upload_time) if upload_time >= exclude_newer.timestamp_millis() => {
+                            priority_dist.set_exclude_newer();
                             continue;
                         }
                         None => {
@@ -72,6 +73,7 @@ impl VersionMap {
                                 "{} is missing an upload date, but user provided: {exclude_newer}",
                                 file.filename,
                             );
+                            priority_dist.set_exclude_newer();
                             continue;
                         }
                         _ => {}

--- a/crates/puffin-resolver/tests/resolver.rs
+++ b/crates/puffin-resolver/tests/resolver.rs
@@ -648,13 +648,10 @@ async fn msgraph_sdk() -> Result<()> {
         .unwrap_err();
 
     assert_snapshot!(err, @r###"
-    Because msgraph-core==1.0.0 is unusable because no wheels are available for your system and only the following versions of msgraph-core are available:
-        msgraph-core<1.0.0a2
-        msgraph-core>=1.0.0
-    we can conclude that msgraph-core>=1.0.0a2 cannot be used.
-    And because msgraph-sdk==1.0.0 depends on msgraph-core>=1.0.0a2 and you require msgraph-sdk==1.0.0, we can conclude that the requirements are unsatisfiable.
+    Because only msgraph-core<1.0.0a2 is available and msgraph-sdk==1.0.0 depends on msgraph-core>=1.0.0a2, we can conclude that msgraph-sdk==1.0.0 cannot be used.
+    And because you require msgraph-sdk==1.0.0, we can conclude that the requirements are unsatisfiable.
 
-    hint: msgraph-core was requested with a pre-release marker (e.g., msgraph-core>=1.0.0a2,<1.0.0), but pre-releases weren't enabled (try: `--prerelease=allow`)
+    hint: msgraph-core was requested with a pre-release marker (e.g., msgraph-core>=1.0.0a2), but pre-releases weren't enabled (try: `--prerelease=allow`)
     "###);
 
     Ok(())

--- a/crates/puffin/tests/pip_install.rs
+++ b/crates/puffin/tests/pip_install.rs
@@ -65,16 +65,9 @@ fn no_solution() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only the following versions of flask are available:
-              flask<=3.0.0
-              flask==3.0.1
-              flask==3.0.2
-          and flask==3.0.0 depends on werkzeug>=3.0.0, we can conclude that
-          flask>=3.0.0,<3.0.1 depends on werkzeug>=3.0.0.
-          And because flask==3.0.1 is unusable because no wheels are available
-          for your system and flask==3.0.2 is unusable because no wheels are
-          available for your system, we can conclude that flask>=3.0.0 depends
-          on werkzeug>=3.0.0.
+      ╰─▶ Because only flask<=3.0.0 is available and flask==3.0.0 depends
+          on werkzeug>=3.0.0, we can conclude that flask>=3.0.0 depends on
+          werkzeug>=3.0.0.
           And because you require flask>=3.0.0 and you require werkzeug<1.0.0, we
           can conclude that the requirements are unsatisfiable.
     "###);


### PR DESCRIPTION
A smaller alternative to https://github.com/astral-sh/puffin/pull/1298 patching the bad behavior in #1293 