### PR TITLE
Document that Python 3.12.0 is required to run benchmarks

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-All benchmarks were computed on macOS using Python 3.12 (for non-Puffin tools), and come with a few
+All benchmarks were computed on macOS using Python 3.12.0 (for non-Puffin tools), and come with a few
 important caveats:
 
 - Benchmark performance may vary dramatically across different operating systems and filesystems.
@@ -83,7 +83,7 @@ python -m scripts.bench \
     --puffin \
     --poetry \
     --pip-sync \
-    --benchmark resolve-warm \
+    --benchmark install-warm \
     scripts/requirements/compiled/trio.txt \
     --json
 ```


### PR DESCRIPTION
Update the Benchmark documentation to explicitly document that it requires Python 3.12.0 to run the non puffin benchmarks:

```
Benchmark 2: poetry (resolve-warm)

Current Python version (3.12.1) is not allowed by the project (3.12).
Please change python executable via the "env use" command.
Error: Command terminated with non-zero exit code: 1. Use the '-i'/'--ignore-failure' option if you want to ignore this. Alternatively, use the '--show-output' option to debug what went wrong.
```
