### PR TITLE
Document font used in benchmark charts

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -97,6 +97,8 @@ cargo run -p puffin-dev render-benchmarks install-warm.json --title "Warm Instal
 cargo run -p puffin-dev render-benchmarks install-cold.json --title "Cold Installation"
 ```
 
+You need to install the [Roboto Font](https://fonts.google.com/specimen/Roboto) if the labels are missing in the generated graph.
+
 ## Acknowledgements
 
 The inclusion of this `BENCHMARKS.md` file was inspired by the excellent benchmarking documentation


### PR DESCRIPTION
The labels were missing when I generated the charts on my Arch machine. 

Inspecting the intermediate SVG showed that we use Google's Roboto font (and the rendering library doesn't support fallback fonts).

I installed the font and TADA, the labels appeared. I extended our documentation to mention the required fonts.  


