### PR TITLE
Revert to non-Apple Silicon runners

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -59,7 +59,7 @@ jobs:
           path: dist
 
   macos-x86_64:
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,7 +97,7 @@ jobs:
             *.sha256
 
   macos-universal:
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We rolled this back in Ruff too due to compatibility issues.