### PR TITLE
Change benchmarks to use 3.12.1

### DIFF
--- a/scripts/bench/__main__.py
+++ b/scripts/bench/__main__.py
@@ -357,7 +357,7 @@ class Poetry(Suite):
                 "bench",
                 "--no-interaction",
                 "--python",
-                "3.12",
+                "3.12.1",
             ],
             cwd=cwd,
             stdout=subprocess.DEVNULL,


### PR DESCRIPTION
We can wait to merge this until later, but we explicitly bootstrap 3.12.1 and the benches should not pin 3.12.0