### PR TITLE
Replace "novel" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ uv is backed by [Astral](https://astral.sh), the creators of [Ruff](https://gith
   without Rust or Python.
 - 🧪 Tested at-scale against the top 10,000 PyPI packages.
 - 🖥️ Support for macOS, Linux, and Windows.
-- 🧰 Novel features such as [dependency version overrides](#dependency-overrides) and
+- 🧰 Advanced features such as [dependency version overrides](#dependency-overrides) and
    [alternative resolution strategies](#resolution-strategy).
 - ⁉️ Best-in-class error messages with a conflict-tracking resolver.
 - 🤝 Support for a wide range of advanced `pip` features, including: editable installs, Git


### PR DESCRIPTION
Per some prior discussion, "novel" can be confusing in this context as it's not clear what we're referring to.

PDM supports overrides — so I'll just drop this.

If anyone knows of other tools that support overrides and alternative resolution strategies please let me know I'd love to look at how they've implemented it :)