### PR TITLE
uv-cache: Add hidden alias for --no-cache-dir

### DIFF
--- a/crates/uv-cache/src/cli.rs
+++ b/crates/uv-cache/src/cli.rs
@@ -11,7 +11,7 @@ use crate::Cache;
 #[derive(Parser, Debug, Clone)]
 pub struct CacheArgs {
     /// Avoid reading from or writing to the cache.
-    #[arg(global = true, long, short)]
+    #[arg(global = true, long, short, alias = "no-cache-dir")]
     no_cache: bool,
 
     /// Path to the cache directory.


### PR DESCRIPTION
This is for compatability with pip install --no-cache-dir

Closes https://github.com/astral-sh/uv/issues/1373