### PR TITLE
Add `UV_NO_CACHE` environment variable

### DIFF
--- a/crates/uv-cache/src/cli.rs
+++ b/crates/uv-cache/src/cli.rs
@@ -11,7 +11,13 @@ use crate::Cache;
 #[derive(Parser, Debug, Clone)]
 pub struct CacheArgs {
     /// Avoid reading from or writing to the cache.
-    #[arg(global = true, long, short, alias = "no-cache-dir")]
+    #[arg(
+        global = true,
+        long,
+        short,
+        alias = "no-cache-dir",
+        env = "UV_NO_CACHE"
+    )]
     no_cache: bool,
 
     /// Path to the cache directory.


### PR DESCRIPTION
It's a little picky about the value, but that seems okay.

```
❯ ./target/debug/uv pip install trio
Audited 1 package in 4ms
❯ UV_NO_CACHE=true ./target/debug/uv pip install trio
Audited 1 package in 50ms
```

Closes #1382 