### PR TITLE
Provide example of file based package install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To install a package into the virtual environment:
 uv pip install flask                # Install Flask.
 uv pip install -r requirements.txt  # Install from a requirements.txt file.
 uv pip install -e .                 # Install the current project in editable mode.
-uv pip install package@file://.     # Install the current project from disk
+uv pip install package@.            # Install the current project from disk
 ```
 
 To generate a set of locked dependencies from an input file:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To install a package into the virtual environment:
 uv pip install flask                # Install Flask.
 uv pip install -r requirements.txt  # Install from a requirements.txt file.
 uv pip install -e .                 # Install the current project in editable mode.
-uv pip install package@.            # Install the current project from disk
+uv pip install "package @ ."        # Install the current project from disk
 ```
 
 To generate a set of locked dependencies from an input file:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ To install a package into the virtual environment:
 uv pip install flask                # Install Flask.
 uv pip install -r requirements.txt  # Install from a requirements.txt file.
 uv pip install -e .                 # Install the current project in editable mode.
+uv pip install package@file://.     # Install the current project from disk
 ```
 
 To generate a set of locked dependencies from an input file:


### PR DESCRIPTION
Added example to install packages from a file w/o editable mode.

I use `pip install .` in a number of CI/CD and build scripts - it wasn't obvious to me how to achieve this with uv as  `uv pip install .` throws an error about package names being expected to start with an alphanumeric character. 


