### PR TITLE
Read from `/bin/sh` if `/bin/ls` cannot be found when determing libc path

### DIFF
--- a/crates/platform-host/src/linux.rs
+++ b/crates/platform-host/src/linux.rs
@@ -127,17 +127,27 @@ fn get_musl_version(ld_path: impl AsRef<Path>) -> std::io::Result<Option<(u16, u
 
 /// Find musl libc path from executable's ELF header.
 fn find_libc() -> Result<PathBuf, PlatformError> {
-    let buffer = fs::read("/bin/ls")?;
-    let error_str = "Couldn't parse /bin/ls for detecting the ld version";
-    let elf = Elf::parse(&buffer)
-        .map_err(|err| PlatformError::OsVersionDetectionError(format!("{error_str}: {err}")))?;
-    if let Some(elf_interpreter) = elf.interpreter {
-        Ok(PathBuf::from(elf_interpreter))
-    } else {
-        Err(PlatformError::OsVersionDetectionError(
-            error_str.to_string(),
-        ))
+    // We'll try to parse the first file we read successfully
+    for path in ["/bin/ls", "/bin/sh"] {
+        let Ok(buffer) = fs::read(path) else {
+            continue;
+        };
+        let elf = Elf::parse(&buffer).map_err(|err| {
+            PlatformError::OsVersionDetectionError(format!(
+                "Couldn't parse {path} to detect the ld version: {err}"
+            ))
+        })?;
+        if let Some(elf_interpreter) = elf.interpreter {
+            return Ok(PathBuf::from(elf_interpreter));
+        }
+
+        return Err(PlatformError::OsVersionDetectionError(format!(
+            "Couldn't parse {path} to detect the ld version"
+        )));
     }
+    Err(PlatformError::OsVersionDetectionError(
+        "Failed to find binary at `/bin/ls` or `/bin/sh` to read ld version from".to_string(),
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I'm not sure if we should just switch to _always_ reading from sh instead?