### PR TITLE
Fix list rendering in `venv --help` output

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -632,15 +632,15 @@ struct VenvArgs {
     /// The Python interpreter to use for the virtual environment.
     ///
     /// Supported formats:
-    /// * `-p 3.10` searches for an installed Python 3.10 (`py --list-paths` on Windows, `python3.10` on Linux/Mac).
+    /// - `3.10` searches for an installed Python 3.10 (`py --list-paths` on Windows, `python3.10` on Linux/Mac).
     ///   Specifying a patch version is not supported.
-    /// * `-p python3.10` or `-p python.exe` looks for a binary in `PATH`.
-    /// * `-p /home/ferris/.local/bin/python3.10` uses this exact Python.
+    /// - `python3.10` or `python.exe` looks for a binary in `PATH`.
+    /// - `/home/ferris/.local/bin/python3.10` uses this exact Python.
     ///
     /// Note that this is different from `--python-version` in `pip compile`, which takes `3.10` or `3.10.13` and
     /// doesn't look for a Python interpreter on disk.
     // Short `-p` to match `virtualenv`
-    #[clap(short, long)]
+    #[clap(short, long, verbatim_doc_comment)]
     python: Option<String>,
 
     /// Install seed packages (`pip`, `setuptools`, and `wheel`) into the virtual environment.


### PR DESCRIPTION
## Summary 

Use [`verbatim_doc_comment`](https://docs.rs/clap/latest/clap/_derive/index.html#arg-attributes) to preserve the formatting of the venv `python` command line option to avoid that the list formatting gets mangled. 

I changed the lists to use `-` which is what clap uses to render possible options (see color) and removed the `-p` in front of each format (again, to match claps possible options rendering)

Fixes https://github.com/astral-sh/uv/issues/1364

## Test Plan

```
Create a virtual environment

Usage: uv venv [OPTIONS] [NAME]

Arguments:
  [NAME]
          The path to the virtual environment to create
          
          [default: .venv]

Options:
  -p, --python <PYTHON>
          The Python interpreter to use for the virtual environment.
          
          Supported formats:
          - `3.10` searches for an installed Python 3.10 (`py --list-paths` on Windows, `python3.10` on Linux/Mac).
            Specifying a patch version is not supported.
          - `python3.10` or `python.exe` looks for a binary in `PATH`.
          - `/home/ferris/.local/bin/python3.10` uses this exact Python.
          
          Note that this is different from `--python-version` in `pip compile`, which takes `3.10` or `3.10.13` and
          doesn't look for a Python interpreter on disk.

      --seed
          Install seed packages (`pip`, `setuptools`, and `wheel`) into the virtual environment

  -i, --index-url <INDEX_URL>
          The URL of the Python Package Index
          
          [env: UV_INDEX_URL=]
          [default: https://pypi.org/simple]

      --extra-index-url <EXTRA_INDEX_URL>
          Extra URLs of package indexes to use, in addition to `--index-url`

  -q, --quiet
          Do not print any output

      --no-index
          Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those discovered via `--find-links`

  -v, --verbose
          Use verbose output

      --offline
          Run offline, i.e., without accessing the network

      --color <COLOR>
          Control colors in output
          
          [default: auto]

          Possible values:
          - auto:   Enables colored output only when the output is going to a terminal or TTY with support
          - always: Enables colored output regardless of the detected environment
          - never:  Disables colored output

  -n, --no-cache
          Avoid reading from or writing to the cache
          
          [env: UV_NO_CACHE=]

      --cache-dir <CACHE_DIR>
          Path to the cache directory
          
          [env: UV_CACHE_DIR=]

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version

```