### PR TITLE
Copy over editorconfig and set line ending to LF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Set git's `eol` setting to `LF` fortext file to have consistent line endings when working on the checked-out project.

Copy over Ruff's editor config settings. 