### PR TITLE
Use string display instead of debug for url parse trace

### DIFF
--- a/crates/uv-client/src/html.rs
+++ b/crates/uv-client/src/html.rs
@@ -18,7 +18,7 @@ pub(crate) struct SimpleHtml {
 
 impl SimpleHtml {
     /// Parse the list of [`File`]s from the simple HTML page returned by the given URL.
-    #[instrument(skip(text))]
+    #[instrument(skip_all, fields(url = % url))]
     pub(crate) fn parse(text: &str, url: &Url) -> Result<Self, Error> {
         let dom = tl::parse(text, tl::ParserOptions::default())?;
 


### PR DESCRIPTION
e.g. 

`uv_client::html::parse url=https://download.pytorch.org/whl/torch_stable.html` 

instead of

`uv_client::html::parse url=Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("download.pytorch.org")), port: None, path: "/whl/torch_stable.html", query: None, fragment: None }`