### PR TITLE
Add warning if venv found but not active

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4451,6 +4451,7 @@ dependencies = [
  "tracing",
  "uv-cache",
  "uv-fs",
+ "uv-warnings",
  "which",
 ]
 

--- a/crates/uv-interpreter/Cargo.toml
+++ b/crates/uv-interpreter/Cargo.toml
@@ -20,6 +20,7 @@ platform-host = { path = "../platform-host" }
 platform-tags = { path = "../platform-tags" }
 uv-cache = { path = "../uv-cache" }
 uv-fs = { path = "../uv-fs" }
+uv-warnings = { path = "../uv-warnings" }
 
 fs-err = { workspace = true, features = ["tokio"] }
 once_cell = { workspace = true }

--- a/crates/uv-interpreter/src/virtual_env.rs
+++ b/crates/uv-interpreter/src/virtual_env.rs
@@ -7,6 +7,7 @@ use tracing::debug;
 use platform_host::Platform;
 use uv_cache::Cache;
 use uv_fs::{LockedFile, Normalized};
+use uv_warnings::warn_user;
 
 use crate::cfg::Configuration;
 use crate::python_platform::PythonPlatform;
@@ -129,6 +130,7 @@ pub(crate) fn detect_virtual_env(target: &PythonPlatform) -> Result<Option<PathB
                 return Err(Error::BrokenVenv(dot_venv, python));
             }
             debug!("Found a virtualenv named .venv at: {}", dot_venv.display());
+            warn_user!("A virtualenv was found, but it is not active.");
             return Ok(Some(dot_venv));
         }
     }


### PR DESCRIPTION
Closes #1408

I couldn't come up with a good way to add a test for this since all the test macros seem to have a virtual environment active. I'm happy to add one if pointed in the right direction.