### PR TITLE
feat: Add base for settings, and relocate venv-name default to it.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4075,6 +4086,7 @@ dependencies = [
  "distribution-filename",
  "distribution-types",
  "dunce",
+ "etcetera",
  "filetime",
  "flate2",
  "fs-err",
@@ -4106,6 +4118,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-durations-export",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ directories = { version = "5.0.1" }
 dirs = { version = "5.0.1" }
 dunce = { version = "1.0.4" }
 either = { version = "1.9.0" }
+etcetera = { version = "0.8.0" }
 flate2 = { version = "1.0.28", default-features = false }
 fs-err = { version = "2.11.0" }
 fs2 = { version = "0.4.3" }
@@ -97,6 +98,7 @@ tokio-stream = { version = "0.1.14" }
 tokio-tar = { version = "0.3.1" }
 tokio-util = { version = "0.7.10", features = ["compat"] }
 toml = { version = "0.8.8" }
+toml_edit = { version = "0.22" }
 tracing = { version = "0.1.40" }
 tracing-durations-export = { version = "0.2.0", features = ["plot"] }
 tracing-indicatif = { version = "0.3.6" }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -44,6 +44,7 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true }
 ctrlc = { workspace = true  }
 dunce = { workspace = true }
+etcetera = { workspace = true }
 flate2 = { workspace = true, default-features = false }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
@@ -59,6 +60,7 @@ textwrap = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 tracing = { workspace = true }
 tracing-durations-export = { workspace = true, features = ["plot"], optional = true }
 tracing-subscriber = { workspace = true }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1,0 +1,49 @@
+use etcetera::base_strategy::{BaseStrategy, Xdg};
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+use toml_edit::Document;
+
+pub(crate) struct Settings {
+    pub(crate) venv_name: PathBuf,
+}
+
+impl Settings {
+    pub(crate) fn read() -> anyhow::Result<Self> {
+        let strategy = Xdg::new()?;
+        let config_dir = strategy.config_dir().join("uv");
+
+        let config_file = config_dir.with_extension("toml");
+
+        let content = read_file(&config_file);
+        let document = content.parse::<Document>().unwrap_or(Document::new());
+
+        let venv_name = PathBuf::from(
+            document
+                .get("venv-name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(".venv")
+                .to_string(),
+        );
+
+        Ok(Self { venv_name })
+    }
+
+    pub(crate) fn set_venv_name(&mut self, maybe_name: Option<PathBuf>) {
+        if let Some(name) = maybe_name {
+            self.venv_name = name;
+        }
+    }
+}
+
+fn read_file(path: &Path) -> String {
+    if let Ok(file) = File::open(path) {
+        let mut reader = BufReader::new(file);
+
+        let mut contents = String::new();
+        reader.read_to_string(&mut contents).unwrap_or(0);
+        contents
+    } else {
+        String::new()
+    }
+}


### PR DESCRIPTION
Relocates the `.venv` default venv name into a settings file that can be customized.

I couple of decisions I'm certain will end up getting questioned:

* etcetera vs dirs: Using `etcetera` preempts the moment where someone uses `dirs` to implement settings and annoy all the macos users who dont want their settings to live in `Application Support/`. (Like all the other rust tools using dirs/dirs-next that end up getting issues reported against them).
* Addition of `toml_edit` over `toml`. Mostly I'm just unfamiliar with `toml` and already have working code using toml-edit 😬 . Secondarily I figured long-term you'd probably implement `uv init` or `uv add` that will want to write toml, and you'll end up swapping to `toml_edit` then anyways.

---

If you're not ready to commit to specific settings, or otherwise already have a system (i.e. something from ruff) in mind that you'd want to replicate, feel free to close this. Rather than submitting an issue, I figured I could quickly do the thing I'd otherwise be requesting.

I didn't attempt to implement any tests in case this was quickly dead in the water.