### PR TITLE
Add support for extras in editable requirements

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -37,6 +37,18 @@ pub enum ResolveError {
     #[error("Attempted to wait on an unregistered task")]
     Unregistered,
 
+    #[error("Attempted to wait on an unregistered task 1 ")]
+    Unregistered1,
+
+    #[error("Attempted to wait on an unregistered task 2 ")]
+    Unregistered2,
+
+    #[error("Attempted to wait on an unregistered task 3 ")]
+    Unregistered3,
+
+    #[error("Attempted to wait on an unregistered task 4 ")]
+    Unregistered4,
+
     #[error("Package metadata name `{metadata}` does not match given name `{given}`")]
     NameMismatch {
         given: PackageName,

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -37,18 +37,6 @@ pub enum ResolveError {
     #[error("Attempted to wait on an unregistered task")]
     Unregistered,
 
-    #[error("Attempted to wait on an unregistered task 1 ")]
-    Unregistered1,
-
-    #[error("Attempted to wait on an unregistered task 2 ")]
-    Unregistered2,
-
-    #[error("Attempted to wait on an unregistered task 3 ")]
-    Unregistered3,
-
-    #[error("Attempted to wait on an unregistered task 4 ")]
-    Unregistered4,
-
     #[error("Package metadata name `{metadata}` does not match given name `{given}`")]
     NameMismatch {
         given: PackageName,

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -550,7 +550,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
     /// partial solution.
     ///
     /// Returns [None] when there are no versions in the given range.
-    #[instrument(skip_all, fields(% package))]
+    #[instrument(skip_all, fields(%package))]
     async fn choose_version(
         &self,
         package: &PubGrubPackage,
@@ -614,7 +614,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                         .distributions
                         .wait(&dist.package_id())
                         .await
-                        .ok_or(ResolveError::Unregistered4)?;
+                        .ok_or(ResolveError::Unregistered)?;
                     let version = &metadata.version;
                     if range.contains(version) {
                         Ok(Some(ResolverVersion::Available(version.clone())))
@@ -642,7 +642,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                     .wait(package_name)
                     .instrument(info_span!("package_wait", %package_name))
                     .await
-                    .ok_or(ResolveError::Unregistered3)?;
+                    .ok_or(ResolveError::Unregistered)?;
                 self.visited.insert(package_name.clone());
 
                 let version_map = match *versions_response {
@@ -761,7 +761,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
     }
 
     /// Given a candidate package and version, return its dependencies.
-    #[instrument(skip_all, fields(% package, % version))]
+    #[instrument(skip_all, fields(%package, %version))]
     async fn get_dependencies(
         &self,
         package: &PubGrubPackage,
@@ -883,7 +883,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                     .wait(&package_id)
                     .instrument(info_span!("distributions_wait", %package_id))
                     .await
-                    .ok_or(ResolveError::Unregistered2)?;
+                    .ok_or(ResolveError::Unregistered)?;
 
                 let mut constraints = PubGrubDependencies::from_requirements(
                     &metadata.requires_dist,
@@ -969,7 +969,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
         Ok::<(), ResolveError>(())
     }
 
-    #[instrument(skip_all, fields(% request))]
+    #[instrument(skip_all, fields(%request))]
     async fn process_request(&self, request: Request) -> Result<Option<Response>, ResolveError> {
         match request {
             // Fetch package metadata from the registry.
@@ -1023,7 +1023,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                     .packages
                     .wait(&package_name)
                     .await
-                    .ok_or(ResolveError::Unregistered1)?;
+                    .ok_or(ResolveError::Unregistered)?;
 
                 let version_map = match *versions_response {
                     VersionsResponse::Found(ref version_map) => version_map,

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -2075,7 +2075,7 @@ fn compile_editable() -> Result<()> {
     requirements_in.write_str(indoc! {r"
         -e ../../scripts/editable-installs/poetry_editable
         -e ${PROJECT_ROOT}/../../scripts/editable-installs/maturin_editable
-        -e file://../../scripts/editable-installs/black_editable[d]
+        -e file://../../scripts/editable-installs/black_editable[dev]
         boltons # normal dependency for comparison
         "
     })?;
@@ -2122,12 +2122,14 @@ fn compile_editable() -> Result<()> {
         #   yarl
     numpy==1.26.2
         # via poetry-editable
+    uvloop==0.19.0
+        # via black
     yarl==1.9.2
         # via aiohttp
 
     ----- stderr -----
     Built 3 editables in [TIME]
-    Resolved 12 packages in [TIME]
+    Resolved 13 packages in [TIME]
     "###);
 
     Ok(())

--- a/scripts/editable-installs/black_editable/pyproject.toml
+++ b/scripts/editable-installs/black_editable/pyproject.toml
@@ -20,6 +20,10 @@ jupyter = [
   "ipython>=7.8.0",
   "tokenize-rt>=3.2.0",
 ]
+dev = [
+  "black[d]",
+  "black[uvloop]",
+]
 
 [build-system]
 requires = ["flit_core>=3.4,<4"]


### PR DESCRIPTION
## Summary

If you're developing on a package like `attrs` locally, and it has a recursive extra like `attrs[dev]`, it turns out that we then try to find the `attrs` in `attrs[dev]` from the registry, rather than recognizing that it's part of the editable.

This PR fixes the issue by making editables slightly more first-class throughout the resolver. Instead of mocking metadata, we explicitly check for extras in various places. Part of the problem here is that we treated editables as URL dependencies, but when we saw an _extra_ like `attrs[dev]`, we didn't map that back to the URL. So now, we treat them as registry dependencies, but with the appropriate guardrails throughout.

Closes https://github.com/astral-sh/uv/issues/1447.

## Test Plan

- Cloned `attrs`.
- Ran `cargo run venv && cargo run pip install -e ".[dev]" -v`.
