### PR TITLE
Avoid attempting rename in copy fallback path

### DIFF
--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -416,11 +416,12 @@ fn hardlink_wheel_files(
                         // Removing and recreating would lead to race conditions.
                         let tempdir = tempdir_in(&site_packages)?;
                         let tempfile = tempdir.path().join(entry.file_name());
-                        if fs::hard_link(path, &tempfile).is_err() {
+                        if fs::hard_link(path, &tempfile).is_ok() {
+                            fs_err::rename(&tempfile, &out_path)?;
+                        } else {
                             fs::copy(path, &out_path)?;
                             attempt = Attempt::UseCopyFallback;
                         }
-                        fs_err::rename(&tempfile, &out_path)?;
                     } else {
                         fs::copy(path, &out_path)?;
                         attempt = Attempt::UseCopyFallback;


### PR DESCRIPTION
## Summary

This _could_ fix https://github.com/astral-sh/uv/issues/1454, but I'm not sure. I was able to replicate by forcing a bunch of error states. But, in short, if we fail to hardlink on the initial copy due to a file existing, and then fail _again_, we fallback to copying. But if we copy, then the tempfile doesn't exist, and so the `fs_err::rename(&tempfile, &out_path)?;` will fail with "File not found".

This PR just ensures that the cases are explicitly mutually exclusive: we only attempt to rename if the hardlink succeeded.