### PR TITLE
Allow repeated dependencies when installing

### DIFF
--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -96,7 +96,7 @@ impl std::fmt::Display for VersionOrUrl<'_> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InstalledVersion<'a> {
     /// A PEP 440 version specifier, used to identify a distribution in a registry.
     Version(&'a Version),

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -506,7 +506,7 @@ async fn install(
         reinstalls,
         extraneous: _,
     } = Planner::with_requirements(&requirements)
-        .with_editable_requirements(editables)
+        .with_editable_requirements(&editables)
         .build(
             site_packages,
             reinstall,

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -142,7 +142,7 @@ pub(crate) async fn pip_sync(
         reinstalls,
         extraneous,
     } = Planner::with_requirements(&requirements)
-        .with_editable_requirements(resolved_editables.editables)
+        .with_editable_requirements(&resolved_editables.editables)
         .build(
             site_packages,
             reinstall,


### PR DESCRIPTION
## Summary

It turns out that it's not uncommon to end up with repeated packages in requirements files when running `pip-sync`, e.g., you might have `anyio==4.0.0` specified multiple times. This PR relaxes our assertions in the install plan to allow such repeated packages, as long as the requirement markers are exactly the same (i.e., they are truly duplicates).

Closes https://github.com/astral-sh/uv/issues/1552.
