### PR TITLE
Allow non-nested archives for `hexdump` and others

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -787,7 +787,11 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
         drop(span);
 
         // Extract the top-level directory.
-        let extracted = uv_extract::strip_component(temp_dir.path())?;
+        let extracted = match uv_extract::strip_component(temp_dir.path()) {
+            Ok(top_level) => top_level,
+            Err(uv_extract::Error::NonSingularArchive(_)) => temp_dir.into_path(),
+            Err(err) => return Err(err.into()),
+        };
 
         // Persist it to the cache.
         fs_err::tokio::create_dir_all(cache_path.parent().expect("Cache entry to have parent"))

--- a/crates/uv-extract/src/error.rs
+++ b/crates/uv-extract/src/error.rs
@@ -13,7 +13,9 @@ pub enum Error {
     #[error("Unsupported archive type: {0}")]
     UnsupportedArchive(PathBuf),
     #[error(
-        "The top level of the archive must only contain a list directory, but it contains: {0:?}"
+        "The top-level of the archive must only contain a list directory, but it contains: {0:?}"
     )]
-    InvalidArchive(Vec<OsString>),
+    NonSingularArchive(Vec<OsString>),
+    #[error("The top-level of the archive must only contain a list directory, but it's empty")]
+    EmptyArchive,
 }

--- a/crates/uv-extract/src/sync.rs
+++ b/crates/uv-extract/src/sync.rs
@@ -115,10 +115,14 @@ pub fn strip_component(source: impl AsRef<Path>) -> Result<PathBuf, Error> {
     // TODO(konstin): Verify the name of the directory.
     let top_level =
         fs_err::read_dir(source.as_ref())?.collect::<std::io::Result<Vec<fs_err::DirEntry>>>()?;
-    let [root] = top_level.as_slice() else {
-        return Err(Error::InvalidArchive(
-            top_level.into_iter().map(|e| e.file_name()).collect(),
-        ));
-    };
-    Ok(root.path())
+    match top_level.as_slice() {
+        [root] => Ok(root.path()),
+        [] => Err(Error::EmptyArchive),
+        _ => Err(Error::NonSingularArchive(
+            top_level
+                .into_iter()
+                .map(|entry| entry.file_name())
+                .collect(),
+        )),
+    }
 }


### PR DESCRIPTION
## Summary#1562 

It turns out that `hexdump` uses an invalid source distribution format whereby the contents aren't nested in a top-level directory -- instead, they're all just flattened at the top-level. In looking at pip's source (https://github.com/pypa/pip/blob/51de88ca6459fdd5213f86a54b021a80884572f9/src/pip/_internal/utils/unpacking.py#L62), it only strips the top-level directory if all entries have the same directory prefix (i.e., if it's the only thing in the directory). This PR accommodates these "invalid" distributions.

I can't find any history on this method in `pip`. It looks like it dates back over 15 years ago, to before `pip` was even called `pip`.

Closes https://github.com/astral-sh/uv/issues/1376.
