### PR TITLE
Improve tracing when encountering invalid `requires-python` values

### DIFF
--- a/crates/pep440-rs/src/version_specifier.rs
+++ b/crates/pep440-rs/src/version_specifier.rs
@@ -232,6 +232,13 @@ impl std::fmt::Display for VersionSpecifiersParseError {
     }
 }
 
+impl VersionSpecifiersParseError {
+    /// The string that failed to parse
+    pub fn line(&self) -> &String {
+        &self.inner.line
+    }
+}
+
 impl std::error::Error for VersionSpecifiersParseError {}
 
 /// A version range such such as `>1.2.3`, `<=4!5.6.7-a8.post9.dev0` or `== 4.1.*`. Parse with


### PR DESCRIPTION
Unsure what the easiest way to test this is, it is hard to publish invalid requires-python specifiers with hatchling