### PR TITLE
Consistent use of `BIN_NAME` in activation scripts

### DIFF
--- a/crates/gourgeist/src/activator/activate
+++ b/crates/gourgeist/src/activator/activate
@@ -52,7 +52,7 @@ fi
 export VIRTUAL_ENV
 
 _OLD_VIRTUAL_PATH="$PATH"
-PATH="$VIRTUAL_ENV/bin:$PATH"
+PATH="$VIRTUAL_ENV/{{ BIN_NAME }}:$PATH"
 export PATH
 
 if [ "x" != x ] ; then

--- a/crates/gourgeist/src/activator/activate.csh
+++ b/crates/gourgeist/src/activator/activate.csh
@@ -13,7 +13,7 @@ deactivate nondestructive
 setenv VIRTUAL_ENV '{{ VIRTUAL_ENV_DIR }}'
 
 set _OLD_VIRTUAL_PATH="$PATH:q"
-setenv PATH "$VIRTUAL_ENV:q/bin:$PATH:q"
+setenv PATH "$VIRTUAL_ENV:q/{{ BIN_NAME }}:$PATH:q"
 
 
 

--- a/crates/gourgeist/src/activator/activate.fish
+++ b/crates/gourgeist/src/activator/activate.fish
@@ -66,7 +66,7 @@ if test (echo $FISH_VERSION | head -c 1) -lt 3
 else
     set -gx _OLD_VIRTUAL_PATH $PATH
 end
-set -gx PATH "$VIRTUAL_ENV"'/bin' $PATH
+set -gx PATH "$VIRTUAL_ENV"'/{{ BIN_NAME }}' $PATH
 
 # Prompt override provided?
 # If not, just use the environment name.

--- a/crates/gourgeist/src/activator/activate.nu
+++ b/crates/gourgeist/src/activator/activate.nu
@@ -33,7 +33,7 @@ export-env {
     }
 
     let virtual_env = '{{ VIRTUAL_ENV_DIR }}'
-    let bin = 'bin'
+    let bin = '{{ BIN_NAME }}'
 
     let is_windows = ($nu.os-info.family) == 'windows'
     let path_name = (if (has-env 'Path') {

--- a/crates/gourgeist/src/activator/activate_this.py
+++ b/crates/gourgeist/src/activator/activate_this.py
@@ -18,7 +18,7 @@ except NameError as exc:
     raise AssertionError(msg) from exc
 
 bin_dir = os.path.dirname(abs_file)
-base = bin_dir[: -len("bin") - 1]  # strip away the bin part from the __file__, plus the path separator
+base = bin_dir[: -len("{{ BIN_NAME }}") - 1]  # strip away the bin part from the __file__, plus the path separator
 
 # prepend bin to PATH (this file is inside the bin directory)
 os.environ["PATH"] = os.pathsep.join([bin_dir, *os.environ.get("PATH", "").split(os.pathsep)])


### PR DESCRIPTION
This PR fixes the bug where the `BIN_NAME` replacement field wasn't being used in the activator scripts.

fixes: #1518 

## Test plan

As I don't have a Windows machine, I switched the `bin_name` value here to point to `Scripts` on `unix` platform:

https://github.com/astral-sh/uv/blob/2a76c5908416b1e4c565349c86bc41a01515c8bf/crates/gourgeist/src/bare.rs#L99-L105

<details><summary>Code diff</summary>
<p>

```diff
```diff
diff --git a/crates/gourgeist/src/bare.rs b/crates/gourgeist/src/bare.rs
index 4c7808d3..0e0b41cf 100644
--- a/crates/gourgeist/src/bare.rs
+++ b/crates/gourgeist/src/bare.rs
@@ -97,9 +97,9 @@ pub fn create_bare_venv(location: &Utf8Path, interpreter: &Interpreter) -> io::R
     // TODO(konstin): I bet on windows we'll have to strip the prefix again
     let location = location.canonicalize_utf8()?;
     let bin_name = if cfg!(unix) {
-        "bin"
-    } else if cfg!(windows) {
         "Scripts"
+    } else if cfg!(windows) {
+        "bin"
     } else {
         unimplemented!("Only Windows and Unix are supported")
     };
```

</p>
</details> 

I then created the virtual environment as usual and tested out that the path modifications were correct:

```console
$ cargo run --bin uv -- venv
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/uv venv`
Using Python 3.12.1 interpreter at /Users/dhruv/.pyenv/versions/3.12.1/bin/python3.12
Creating virtualenv at: .venv

$ source .venv/Scripts/activate

$ echo $PATH
/Users/dhruv/work/astral/uv/.venv/Scripts:[...]

$ which python
/Users/dhruv/work/astral/uv/.venv/Scripts/python
```

I'm not sure how else to test this without having access to a Windows machine