### PR TITLE
Print activation instructions for a venv after one has been created

### DIFF
--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -14,7 +14,6 @@ use distribution_types::{DistributionMetadata, IndexLocations, Name};
 use gourgeist::Prompt;
 use pep508_rs::Requirement;
 use platform_host::Platform;
-use platform_host::Os;
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
@@ -196,22 +195,23 @@ async fn venv_impl(
         }
     }
 
-    match &platform.os() {
-        Os::Windows => {
-            writeln!(
-                printer,
-                "Activate with .\\{}\\Scripts\\activate.ps1",
-                path.normalized_display().cyan()
-            )
-        },
-        _ => {
-            writeln!(
-                printer,
-                "Activate with source {}/bin/activate",
-                path.normalized_display().cyan()
-            )
-        }
-    }.into_diagnostic()?;
+    if cfg!(windows) {
+        writeln!(
+            printer,
+            "Activate with:\n\
+            - Powershell: .\\{0}\\Scripts\\activate.ps1\n\
+            - CMD: .\\{0}\\Scripts\\activate.bat",
+            path.normalized_display().cyan()
+        )
+        .into_diagnostic()?;
+    } else {
+        writeln!(
+            printer,
+            "Activate with: source {0}/bin/activate",
+            path.normalized_display().cyan()
+        )
+        .into_diagnostic()?;
+    };
 
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -14,6 +14,7 @@ use distribution_types::{DistributionMetadata, IndexLocations, Name};
 use gourgeist::Prompt;
 use pep508_rs::Requirement;
 use platform_host::Platform;
+use platform_host::Os;
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
@@ -194,6 +195,23 @@ async fn venv_impl(
             .into_diagnostic()?;
         }
     }
+
+    match &platform.os() {
+        Os::Windows => {
+            writeln!(
+                printer,
+                "Activate with .\\{}\\Scripts\\activate.ps1",
+                path.normalized_display().cyan()
+            )
+        },
+        _ => {
+            writeln!(
+                printer,
+                "Activate with source {}/bin/activate",
+                path.normalized_display().cyan()
+            )
+        }
+    }.into_diagnostic()?;
 
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -207,7 +207,7 @@ async fn venv_impl(
     } else {
         writeln!(
             printer,
-            "Activate with: source {0}/bin/activate",
+            "Activate with: source {}/bin/activate",
             path.normalized_display().cyan()
         )
         .into_diagnostic()?;

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -198,9 +198,7 @@ async fn venv_impl(
     if cfg!(windows) {
         writeln!(
             printer,
-            "Activate with:\n\
-            - Powershell: .\\{0}\\Scripts\\activate.ps1\n\
-            - CMD: {0}\\Scripts\\activate.bat",
+            "Activate with: {}\\Scripts\\activate",
             path.normalized_display().cyan()
         )
         .into_diagnostic()?;

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -200,7 +200,7 @@ async fn venv_impl(
             printer,
             "Activate with:\n\
             - Powershell: .\\{0}\\Scripts\\activate.ps1\n\
-            - CMD: .\\{0}\\Scripts\\activate.bat",
+            - CMD: {0}\\Scripts\\activate.bat",
             path.normalized_display().cyan()
         )
         .into_diagnostic()?;

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -198,6 +198,7 @@ async fn venv_impl(
     if cfg!(windows) {
         writeln!(
             printer,
+            // This should work whether the user is on CMD or PowerShell:
             "Activate with: {}\\Scripts\\activate",
             path.normalized_display().cyan()
         )

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -200,12 +200,17 @@ fn seed_older_python_version() -> Result<()> {
     let venv = temp_dir.child(".venv");
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
+    let filter_prompt = r"Activate with: (?:.*)\\Scripts\\activate";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
             "Using Python [VERSION] interpreter at [PATH]",
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
+        (
+            &filter_prompt,
+            "Activate with: source /home/ferris/project/.venv/bin/activate",
+        ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
         .arg("venv")

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -20,6 +20,7 @@ fn create_venv() -> Result<()> {
 
     // Create a virtual environment at `.venv`.
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -27,8 +28,8 @@ fn create_venv() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            r".*?\\\.venv\\Scripts\\activate\.ps1", 
-            "Activate with source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt, 
+            "Activate with: source /home/ferris/project/.venv/bin/activate"
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -49,7 +50,7 @@ fn create_venv() -> Result<()> {
     ----- stderr -----
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: /home/ferris/project/.venv
-    Activate with source /home/ferris/project/.venv/bin/activate
+    Activate with: source /home/ferris/project/.venv/bin/activate
     "###
     );
 
@@ -57,6 +58,7 @@ fn create_venv() -> Result<()> {
 
     // Create a virtual environment at the same location, which should replace it.
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -64,8 +66,8 @@ fn create_venv() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            r".*?\\\.venv\\Scripts\\activate\.ps1", 
-            "Activate with source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt, 
+            "Activate with: source /home/ferris/project/.venv/bin/activate"
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -87,7 +89,7 @@ fn create_venv() -> Result<()> {
     ----- stderr -----
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: /home/ferris/project/.venv
-    Activate with source /home/ferris/project/.venv/bin/activate
+    Activate with: source /home/ferris/project/.venv/bin/activate
     "###
     );
 
@@ -104,6 +106,7 @@ fn create_venv_defaults_to_cwd() -> Result<()> {
     let venv = temp_dir.child(".venv");
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -111,8 +114,8 @@ fn create_venv_defaults_to_cwd() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            r".*?\\\.venv\\Scripts\\activate\.ps1", 
-            "Activate with source .venv/bin/activate"
+            &filter_prompt,
+            "Activate with: source .venv/bin/activate"
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -133,7 +136,7 @@ fn create_venv_defaults_to_cwd() -> Result<()> {
     ----- stderr -----
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: .venv
-    Activate with source .venv/bin/activate
+    Activate with: source .venv/bin/activate
     "###
     );
 
@@ -150,6 +153,7 @@ fn seed() -> Result<()> {
     let venv = temp_dir.child(".venv");
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -157,8 +161,8 @@ fn seed() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            r".*?\\\.venv\\Scripts\\activate\.ps1", 
-            "Activate with source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt, 
+            "Activate with: source /home/ferris/project/.venv/bin/activate"
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -228,7 +232,7 @@ fn seed_older_python_version() -> Result<()> {
      + setuptools==68.2.2
      + pip==23.3.1
      + wheel==0.41.3
-    Activate with source /home/ferris/project/.venv/bin/activate
+    Activate with: source /home/ferris/project/.venv/bin/activate
     "###
     );
 
@@ -337,12 +341,13 @@ fn create_venv_python_patch() -> Result<()> {
     let venv = temp_dir.child(".venv");
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
     let filters = &[
         (r"interpreter at .+", "interpreter at [PATH]"),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            r".*?\\\.venv\\Scripts\\activate\.ps1", 
-            "Activate with source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt, 
+            "Activate with: source /home/ferris/project/.venv/bin/activate"
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -430,6 +435,7 @@ fn empty_dir_exists() -> Result<()> {
     venv.create_dir_all()?;
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -437,8 +443,8 @@ fn empty_dir_exists() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            r".*?\\\.venv\\Scripts\\activate\.ps1", 
-            "Activate with source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt, 
+            "Activate with: source /home/ferris/project/.venv/bin/activate"
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -460,7 +466,7 @@ fn empty_dir_exists() -> Result<()> {
     ----- stderr -----
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: /home/ferris/project/.venv
-    Activate with source /home/ferris/project/.venv/bin/activate
+    Activate with: source /home/ferris/project/.venv/bin/activate
     "###
     );
 
@@ -526,6 +532,7 @@ fn virtualenv_compatibility() -> Result<()> {
 
     // Create a virtual environment at `.venv`, passing the redundant `--clear` flag.
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -533,8 +540,8 @@ fn virtualenv_compatibility() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            r".*?\\\.venv\\Scripts\\activate\.ps1", 
-            "Activate with source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt, 
+            "Activate with: source /home/ferris/project/.venv/bin/activate"
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -557,7 +564,7 @@ fn virtualenv_compatibility() -> Result<()> {
     warning: virtualenv's `--clear` has no effect (uv always clears the virtual environment).
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: /home/ferris/project/.venv
-    Activate with source /home/ferris/project/.venv/bin/activate
+    Activate with: source /home/ferris/project/.venv/bin/activate
     "###
     );
 

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -183,6 +183,7 @@ fn seed() -> Result<()> {
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: /home/ferris/project/.venv
      + pip==23.3.1
+    Activate with: source /home/ferris/project/.venv/bin/activate
     "###
     );
 

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -20,7 +20,7 @@ fn create_venv() -> Result<()> {
 
     // Create a virtual environment at `.venv`.
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -28,8 +28,8 @@ fn create_venv() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            &filter_prompt, 
-            "Activate with: source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt,
+            "Activate with: source /home/ferris/project/.venv/bin/activate",
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -58,7 +58,7 @@ fn create_venv() -> Result<()> {
 
     // Create a virtual environment at the same location, which should replace it.
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -66,8 +66,8 @@ fn create_venv() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            &filter_prompt, 
-            "Activate with: source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt,
+            "Activate with: source /home/ferris/project/.venv/bin/activate",
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -106,17 +106,14 @@ fn create_venv_defaults_to_cwd() -> Result<()> {
     let venv = temp_dir.child(".venv");
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
             "Using Python [VERSION] interpreter at [PATH]",
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
-        (
-            &filter_prompt,
-            "Activate with: source .venv/bin/activate"
-        ),
+        (&filter_prompt, "Activate with: source .venv/bin/activate"),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
@@ -153,7 +150,7 @@ fn seed() -> Result<()> {
     let venv = temp_dir.child(".venv");
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -161,8 +158,8 @@ fn seed() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            &filter_prompt, 
-            "Activate with: source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt,
+            "Activate with: source /home/ferris/project/.venv/bin/activate",
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -341,13 +338,13 @@ fn create_venv_python_patch() -> Result<()> {
     let venv = temp_dir.child(".venv");
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
     let filters = &[
         (r"interpreter at .+", "interpreter at [PATH]"),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            &filter_prompt, 
-            "Activate with: source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt,
+            "Activate with: source /home/ferris/project/.venv/bin/activate",
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -435,7 +432,7 @@ fn empty_dir_exists() -> Result<()> {
     venv.create_dir_all()?;
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -443,8 +440,8 @@ fn empty_dir_exists() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            &filter_prompt, 
-            "Activate with: source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt,
+            "Activate with: source /home/ferris/project/.venv/bin/activate",
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
@@ -532,7 +529,7 @@ fn virtualenv_compatibility() -> Result<()> {
 
     // Create a virtual environment at `.venv`, passing the redundant `--clear` flag.
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: \.\\(\.\w+)\\Scripts\\activate\.ps1\n- CMD: \.\\(\.\w+)\\Scripts\\activate\.bat";
+    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -540,8 +537,8 @@ fn virtualenv_compatibility() -> Result<()> {
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
         (
-            &filter_prompt, 
-            "Activate with: source /home/ferris/project/.venv/bin/activate"
+            &filter_prompt,
+            "Activate with: source /home/ferris/project/.venv/bin/activate",
         ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -26,6 +26,10 @@ fn create_venv() -> Result<()> {
             "Using Python [VERSION] interpreter at [PATH]",
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
+        (
+            r".*?\\\.venv\\Scripts\\activate\.ps1", 
+            "Activate with source /home/ferris/project/.venv/bin/activate"
+        ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
@@ -58,6 +62,10 @@ fn create_venv() -> Result<()> {
             "Using Python [VERSION] interpreter at [PATH]",
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
+        (
+            r".*?\\\.venv\\Scripts\\activate\.ps1", 
+            "Activate with source /home/ferris/project/.venv/bin/activate"
+        ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
@@ -100,6 +108,10 @@ fn create_venv_defaults_to_cwd() -> Result<()> {
             "Using Python [VERSION] interpreter at [PATH]",
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
+        (
+            r".*?\\\.venv\\Scripts\\activate\.ps1", 
+            "Activate with source .venv/bin/activate"
+        ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
@@ -141,6 +153,10 @@ fn seed() -> Result<()> {
             "Using Python [VERSION] interpreter at [PATH]",
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
+        (
+            r".*?\\\.venv\\Scripts\\activate\.ps1", 
+            "Activate with source /home/ferris/project/.venv/bin/activate"
+        ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
@@ -320,6 +336,10 @@ fn create_venv_python_patch() -> Result<()> {
     let filters = &[
         (r"interpreter at .+", "interpreter at [PATH]"),
         (&filter_venv, "/home/ferris/project/.venv"),
+        (
+            r".*?\\\.venv\\Scripts\\activate\.ps1", 
+            "Activate with source /home/ferris/project/.venv/bin/activate"
+        ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
@@ -412,6 +432,10 @@ fn empty_dir_exists() -> Result<()> {
             "Using Python [VERSION] interpreter at [PATH]",
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
+        (
+            r".*?\\\.venv\\Scripts\\activate\.ps1", 
+            "Activate with source /home/ferris/project/.venv/bin/activate"
+        ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
         .arg("venv")
@@ -503,6 +527,10 @@ fn virtualenv_compatibility() -> Result<()> {
             "Using Python [VERSION] interpreter at [PATH]",
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
+        (
+            r".*?\\\.venv\\Scripts\\activate\.ps1", 
+            "Activate with source /home/ferris/project/.venv/bin/activate"
+        ),
     ];
     uv_snapshot!(filters, Command::new(get_bin())
         .arg("venv")

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -20,7 +20,7 @@ fn create_venv() -> Result<()> {
 
     // Create a virtual environment at `.venv`.
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
+    let filter_prompt = r"Activate with: (?:.*)\\Scripts\\activate";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -58,7 +58,7 @@ fn create_venv() -> Result<()> {
 
     // Create a virtual environment at the same location, which should replace it.
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
+    let filter_prompt = r"Activate with: (?:.*)\\Scripts\\activate";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -106,7 +106,7 @@ fn create_venv_defaults_to_cwd() -> Result<()> {
     let venv = temp_dir.child(".venv");
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
+    let filter_prompt = r"Activate with: (?:.*)\\Scripts\\activate";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -150,7 +150,7 @@ fn seed() -> Result<()> {
     let venv = temp_dir.child(".venv");
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
+    let filter_prompt = r"Activate with: (?:.*)\\Scripts\\activate";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -338,7 +338,7 @@ fn create_venv_python_patch() -> Result<()> {
     let venv = temp_dir.child(".venv");
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
+    let filter_prompt = r"Activate with: (?:.*)\\Scripts\\activate";
     let filters = &[
         (r"interpreter at .+", "interpreter at [PATH]"),
         (&filter_venv, "/home/ferris/project/.venv"),
@@ -432,7 +432,7 @@ fn empty_dir_exists() -> Result<()> {
     venv.create_dir_all()?;
 
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
+    let filter_prompt = r"Activate with: (?:.*)\\Scripts\\activate";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
@@ -529,7 +529,7 @@ fn virtualenv_compatibility() -> Result<()> {
 
     // Create a virtual environment at `.venv`, passing the redundant `--clear` flag.
     let filter_venv = regex::escape(&venv.normalized_display().to_string());
-    let filter_prompt = r"(?s)Activate with:\n- Powershell: .*\n- CMD: .*";
+    let filter_prompt = r"Activate with: (?:.*)\\Scripts\\activate";
     let filters = &[
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -49,6 +49,7 @@ fn create_venv() -> Result<()> {
     ----- stderr -----
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: /home/ferris/project/.venv
+    Activate with source /home/ferris/project/.venv/bin/activate
     "###
     );
 
@@ -86,6 +87,7 @@ fn create_venv() -> Result<()> {
     ----- stderr -----
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: /home/ferris/project/.venv
+    Activate with source /home/ferris/project/.venv/bin/activate
     "###
     );
 
@@ -131,6 +133,7 @@ fn create_venv_defaults_to_cwd() -> Result<()> {
     ----- stderr -----
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: .venv
+    Activate with source .venv/bin/activate
     "###
     );
 
@@ -225,6 +228,7 @@ fn seed_older_python_version() -> Result<()> {
      + setuptools==68.2.2
      + pip==23.3.1
      + wheel==0.41.3
+    Activate with source /home/ferris/project/.venv/bin/activate
     "###
     );
 
@@ -456,6 +460,7 @@ fn empty_dir_exists() -> Result<()> {
     ----- stderr -----
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: /home/ferris/project/.venv
+    Activate with source /home/ferris/project/.venv/bin/activate
     "###
     );
 
@@ -552,6 +557,7 @@ fn virtualenv_compatibility() -> Result<()> {
     warning: virtualenv's `--clear` has no effect (uv always clears the virtual environment).
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: /home/ferris/project/.venv
+    Activate with source /home/ferris/project/.venv/bin/activate
     "###
     );
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

- Add prompts for users to activate the `.venv` after it has been created.
- Closes [https://github.com/astral-sh/uv/issues/1326](https://github.com/astral-sh/uv/issues/1326)

If the platform os matches `Os::Windows` then we provide the following prompt:
```rust
writeln!(
   printer,
   "Activate with .\\{}\\Scripts\\activate.ps1",
   path.normalized_display().cyan()
)
```

Otherwise we provide the following prompt:
```rust
writeln!(
  printer,
  "Activate with source {}/bin/activate",
  path.normalized_display().cyan()
)
```

I've added additional filters in `crates/uv/tests/venv.rs` so there shouldn't be issues on any of the CI runs (not sure what some of the Windows paths could look like, so these filters might need to be changed):
```rust
        (
            r".*?\\\.venv\\Scripts\\activate\.ps1", 
            "Activate with source /home/ferris/project/.venv/bin/activate"
        )
```

## Test Plan

<!-- How was it tested? -->

- Ran tests in `crates/uv/tests/venv.rs` and updated snapshots.
- Ran `uv venv` in a Docker container to test that the output is correct (running Ubuntu)