### PR TITLE
Better error messages on expect failures in resolver

### DIFF
--- a/crates/uv-resolver/src/resolution.rs
+++ b/crates/uv-resolver/src/resolution.rs
@@ -121,7 +121,10 @@ impl ResolutionGraph {
                         if !metadata.provides_extras.contains(extra) {
                             let pinned_package = pins
                                 .get(package_name, version)
-                                .expect("Every package should be pinned")
+                                .expect(&format!(
+                                    "Every package should be pinned: {:?}",
+                                    package_name
+                                ))
                                 .clone();
 
                             diagnostics.push(Diagnostic::MissingExtra {
@@ -130,14 +133,18 @@ impl ResolutionGraph {
                             });
                         }
                     } else {
-                        let metadata = distributions
-                            .get(&dist.package_id())
-                            .expect("Every package should have metadata");
+                        let metadata = distributions.get(&dist.package_id()).expect(&format!(
+                            "Every package should have metadata: {:?}",
+                            dist.package_id()
+                        ));
 
                         if !metadata.provides_extras.contains(extra) {
                             let pinned_package = pins
                                 .get(package_name, version)
-                                .expect("Every package should be pinned")
+                                .expect(&format!(
+                                    "Every package should be pinned: {:?}",
+                                    package_name
+                                ))
                                 .clone();
 
                             diagnostics.push(Diagnostic::MissingExtra {
@@ -150,9 +157,10 @@ impl ResolutionGraph {
                 PubGrubPackage::Package(package_name, Some(extra), Some(url)) => {
                     // Validate that the `extra` exists.
                     let dist = PubGrubDistribution::from_url(package_name, url);
-                    let metadata = distributions
-                        .get(&dist.package_id())
-                        .expect("Every package should have metadata");
+                    let metadata = distributions.get(&dist.package_id()).expect(&format!(
+                        "Every package should have metadata: {:?}",
+                        dist.package_id()
+                    ));
 
                     if !metadata.provides_extras.contains(extra) {
                         let url = redirects.get(url).map_or_else(

--- a/crates/uv-resolver/src/resolution.rs
+++ b/crates/uv-resolver/src/resolution.rs
@@ -121,10 +121,9 @@ impl ResolutionGraph {
                         if !metadata.provides_extras.contains(extra) {
                             let pinned_package = pins
                                 .get(package_name, version)
-                                .expect(&format!(
-                                    "Every package should be pinned: {:?}",
-                                    package_name
-                                ))
+                                .unwrap_or_else(|| {
+                                    panic!("Every package should be pinned: {package_name:?}")
+                                })
                                 .clone();
 
                             diagnostics.push(Diagnostic::MissingExtra {
@@ -133,18 +132,19 @@ impl ResolutionGraph {
                             });
                         }
                     } else {
-                        let metadata = distributions.get(&dist.package_id()).expect(&format!(
-                            "Every package should have metadata: {:?}",
-                            dist.package_id()
-                        ));
+                        let metadata = distributions.get(&dist.package_id()).unwrap_or_else(|| {
+                            panic!(
+                                "Every package should have metadata: {:?}",
+                                dist.package_id()
+                            )
+                        });
 
                         if !metadata.provides_extras.contains(extra) {
                             let pinned_package = pins
                                 .get(package_name, version)
-                                .expect(&format!(
-                                    "Every package should be pinned: {:?}",
-                                    package_name
-                                ))
+                                .unwrap_or_else(|| {
+                                    panic!("Every package should be pinned: {package_name:?}")
+                                })
                                 .clone();
 
                             diagnostics.push(Diagnostic::MissingExtra {
@@ -157,10 +157,12 @@ impl ResolutionGraph {
                 PubGrubPackage::Package(package_name, Some(extra), Some(url)) => {
                     // Validate that the `extra` exists.
                     let dist = PubGrubDistribution::from_url(package_name, url);
-                    let metadata = distributions.get(&dist.package_id()).expect(&format!(
-                        "Every package should have metadata: {:?}",
-                        dist.package_id()
-                    ));
+                    let metadata = distributions.get(&dist.package_id()).unwrap_or_else(|| {
+                        panic!(
+                            "Every package should have metadata: {:?}",
+                            dist.package_id()
+                        )
+                    });
 
                     if !metadata.provides_extras.contains(extra) {
                         let url = redirects.get(url).map_or_else(


### PR DESCRIPTION
I ran into some (tricky to reproduce) panics while using uv, would be useful to have a better error message to track down the source of the problem