### PR TITLE
Always run `get_requires_for_build_wheel`

### DIFF
--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -339,20 +339,16 @@ impl SourceBuild {
             .await
             .map_err(|err| Error::RequirementsInstall("build-system.requires (install)", err))?;
 
-        // If we're using the default backend configuration, skip `get_requires_for_build_*`, since
-        // we already installed the requirements above.
         if let Some(pep517_backend) = &pep517_backend {
-            if pep517_backend != &default_backend {
-                create_pep517_build_environment(
-                    &source_tree,
-                    &venv,
-                    pep517_backend,
-                    build_context,
-                    &package_id,
-                    build_kind,
-                )
-                .await?;
-            }
+            create_pep517_build_environment(
+                &source_tree,
+                &venv,
+                pep517_backend,
+                build_context,
+                &package_id,
+                build_kind,
+            )
+            .await?;
         }
 
         Ok(Self {


### PR DESCRIPTION
## Summary

I want to revisit this as I think it's still skippable in some cases, but for now, let's be more conservative.

Closes https://github.com/astral-sh/uv/issues/1582.

## Test Plan

Cloned `https://github.com/OCA/mis-builder/blob/3aea4235697bac0f74d446e610e2b934b0994e06/setup/mis_builder/setup.py#L4`, and ran `cargo run pip install -e mis_builder`.
