### PR TITLE
Remove setuptools & wheel from seed packages (#1602)

### DIFF
--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -22,7 +22,6 @@ use uv_interpreter::{find_default_python, find_requested_python, Error};
 use uv_resolver::{InMemoryIndex, OptionsBuilder};
 use uv_traits::{BuildContext, InFlight, NoBuild, SetupPyStrategy};
 
-
 use pep440_rs::VersionSpecifier;
 
 use crate::commands::ExitStatus;

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -22,8 +22,6 @@ use uv_interpreter::{find_default_python, find_requested_python, Error};
 use uv_resolver::{InMemoryIndex, OptionsBuilder};
 use uv_traits::{BuildContext, InFlight, NoBuild, SetupPyStrategy};
 
-use pep440_rs::VersionSpecifier;
-
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
@@ -163,10 +161,10 @@ async fn venv_impl(
         .with_options(OptionsBuilder::new().exclude_newer(exclude_newer).build());
 
         // Resolve the seed packages.
-        let version_specifier = VersionSpecifier::from_str("<3.12").unwrap();
+        let version_specifier = (3, 12);
         let mut requirements = vec![Requirement::from_str("pip").unwrap()];
 
-        if version_specifier.contains(interpreter.python_version()) {
+        if version_specifier > interpreter.python_tuple() {
             requirements.push(Requirement::from_str("setuptools").unwrap());
             requirements.push(Requirement::from_str("wheel").unwrap());
         }

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -161,10 +161,10 @@ async fn venv_impl(
         .with_options(OptionsBuilder::new().exclude_newer(exclude_newer).build());
 
         // Resolve the seed packages.
-        let version_specifier = (3, 12);
         let mut requirements = vec![Requirement::from_str("pip").unwrap()];
 
-        if version_specifier > interpreter.python_tuple() {
+        // Only include `setuptools` and `wheel` on Python <3.12
+        if interpreter.python_tuple() < (3, 12) {
             requirements.push(Requirement::from_str("setuptools").unwrap());
             requirements.push(Requirement::from_str("wheel").unwrap());
         }

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -166,7 +166,7 @@ async fn venv_impl(
         let version_specifier = VersionSpecifier::from_str("<3.12").unwrap();
         let mut requirements = vec![Requirement::from_str("pip").unwrap()];
 
-        if version_specifier.contains(&interpreter.python_version()) {
+        if version_specifier.contains(interpreter.python_version()) {
             requirements.push(Requirement::from_str("setuptools").unwrap());
             requirements.push(Requirement::from_str("wheel").unwrap());
         }

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -162,9 +162,7 @@ async fn venv_impl(
         // Resolve the seed packages.
         let resolution = build_dispatch
             .resolve(&[
-                Requirement::from_str("wheel").unwrap(),
                 Requirement::from_str("pip").unwrap(),
-                Requirement::from_str("setuptools").unwrap(),
             ])
             .await
             .map_err(VenvError::Seed)?;

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -162,9 +162,7 @@ fn seed() -> Result<()> {
     ----- stderr -----
     Using Python [VERSION] interpreter at [PATH]
     Creating virtualenv at: /home/ferris/project/.venv
-     + setuptools==68.2.2
      + pip==23.3.1
-     + wheel==0.41.3
     "###
     );
 

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -172,6 +172,52 @@ fn seed() -> Result<()> {
 }
 
 #[test]
+fn seed_older_python_version() -> Result<()> {
+    let temp_dir = assert_fs::TempDir::new()?;
+    let cache_dir = assert_fs::TempDir::new()?;
+    let bin = create_bin_with_executables(&temp_dir, &["3.10"]).expect("Failed to create bin dir");
+    let venv = temp_dir.child(".venv");
+
+    let filter_venv = regex::escape(&venv.normalized_display().to_string());
+    let filters = &[
+        (
+            r"Using Python 3\.\d+\.\d+ interpreter at .+",
+            "Using Python [VERSION] interpreter at [PATH]",
+        ),
+        (&filter_venv, "/home/ferris/project/.venv"),
+    ];
+    uv_snapshot!(filters, Command::new(get_bin())
+        .arg("venv")
+        .arg(venv.as_os_str())
+        .arg("--seed")
+        .arg("--python")
+        .arg("3.10")
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .arg("--exclude-newer")
+        .arg(EXCLUDE_NEWER)
+        .env("UV_NO_WRAP", "1")
+        .env("UV_TEST_PYTHON_PATH", bin)
+        .current_dir(&temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using Python [VERSION] interpreter at [PATH]
+    Creating virtualenv at: /home/ferris/project/.venv
+     + setuptools==68.2.2
+     + pip==23.3.1
+     + wheel==0.41.3
+    "###
+    );
+
+    venv.assert(predicates::path::is_dir());
+
+    Ok(())
+}
+
+#[test]
 fn create_venv_unknown_python_minor() -> Result<()> {
     let temp_dir = assert_fs::TempDir::new()?;
     let cache_dir = assert_fs::TempDir::new()?;


### PR DESCRIPTION
## Summary
Removed `wheel` and `setuptools` from seed packages list when creating a virtual environment

Closes https://github.com/astral-sh/uv/issues/1602

## Test Plan
Ran the command `cargo nextest run` :
<img width="564" alt="image" src="https://github.com/astral-sh/uv/assets/6116387/14ed2da6-1b3e-4598-a49f-29dd8c4cb19b">

