### PR TITLE
Bump simple metadata cache version

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -508,7 +508,7 @@ impl CacheBucket {
             CacheBucket::FlatIndex => "flat-index-v0",
             CacheBucket::Git => "git-v0",
             CacheBucket::Interpreter => "interpreter-v0",
-            CacheBucket::Simple => "simple-v0",
+            CacheBucket::Simple => "simple-v1",
             CacheBucket::Wheels => "wheels-v0",
             CacheBucket::Archive => "archive-v0",
         }


### PR DESCRIPTION
## Summary

We made a breaking change to the cache representation, so some folks have had to `uv clean`. Let's bump it for the next release.