### PR TITLE
Support dotted function paths for script entrypoints

### DIFF
--- a/crates/install-wheel-rs/src/script.rs
+++ b/crates/install-wheel-rs/src/script.rs
@@ -1,3 +1,4 @@
+use once_cell::sync::Lazy;
 use regex::Regex;
 use rustc_hash::FxHashSet;
 use serde::Serialize;
@@ -43,9 +44,11 @@ impl Script {
         //  between the object reference and the left square bracket, between the extra names and the square brackets and colons delimiting them,
         //  and after the right square bracket."
         // – https://packaging.python.org/en/latest/specifications/entry-points/#file-format
-        let script_regex = Regex::new(r"^(?P<module>[\w\d_\-.]+)\s*:\s*(?P<function>[\w\d_\-.]+)(?:\s*\[\s*(?P<extras>(?:[^,]+,?\s*)+)\])?\s*$").unwrap();
+        static SCRIPT_REGEX: Lazy<Regex> = Lazy::new(|| {
+            Regex::new(r"^(?P<module>[\w\d_\-.]+)\s*:\s*(?P<function>[\w\d_\-.]+)(?:\s*\[\s*(?P<extras>(?:[^,]+,?\s*)+)\])?\s*$").unwrap()
+        });
 
-        let captures = script_regex
+        let captures = SCRIPT_REGEX
             .captures(value)
             .ok_or_else(|| Error::InvalidWheel(format!("invalid console script: '{value}'")))?;
         if let Some(script_extras) = captures.name("extras") {

--- a/crates/install-wheel-rs/src/script.rs
+++ b/crates/install-wheel-rs/src/script.rs
@@ -16,6 +16,8 @@ pub struct Script {
     pub module: String,
     #[pyo3(get)]
     pub function: String,
+    #[pyo3(get)]
+    pub import_name: String,
 }
 
 /// A script defining the name of the runnable entrypoint and the module and function that should be

--- a/crates/install-wheel-rs/src/script.rs
+++ b/crates/install-wheel-rs/src/script.rs
@@ -16,8 +16,6 @@ pub struct Script {
     pub module: String,
     #[pyo3(get)]
     pub function: String,
-    #[pyo3(get)]
-    pub import_name: String,
 }
 
 /// A script defining the name of the runnable entrypoint and the module and function that should be
@@ -28,7 +26,6 @@ pub struct Script {
     pub script_name: String,
     pub module: String,
     pub function: String,
-    pub import_name: String,
 }
 
 impl Script {
@@ -64,17 +61,17 @@ impl Script {
             }
         }
 
-        let function = captures.name("function").unwrap().as_str().to_string();
-        let import_name = function
-            .split_once('.')
-            .map_or(function.as_str(), |(import_name, _)| import_name)
-            .to_string();
         Ok(Some(Script {
             script_name: script_name.to_string(),
             module: captures.name("module").unwrap().as_str().to_string(),
-            function,
-            import_name,
+            function: captures.name("function").unwrap().as_str().to_string(),
         }))
+    }
+
+    pub fn import_name(&self) -> &str {
+        self.function
+            .split_once('.')
+            .map_or(&self.function, |(import_name, _)| import_name)
     }
 }
 
@@ -116,6 +113,6 @@ mod test {
             .unwrap()
             .unwrap();
         assert_eq!(script.function, "mod_bar.sub_foo.func_baz");
-        assert_eq!(script.import_name, "mod_bar");
+        assert_eq!(script.import_name(), "mod_bar");
     }
 }

--- a/crates/install-wheel-rs/src/script.rs
+++ b/crates/install-wheel-rs/src/script.rs
@@ -63,7 +63,7 @@ impl Script {
         }
 
         let function =  captures.name("function").unwrap().as_str().to_string();
-        let import_path = function.split_once('.').map_or(function.clone(), |(import_path, _)| import_path.to_string());
+        let import_path = function.split_once('.').map_or(function.as_str(), |(import_path, _)| import_path).to_string();
         Ok(Some(Script {
             script_name: script_name.to_string(),
             module: captures.name("module").unwrap().as_str().to_string(),

--- a/crates/install-wheel-rs/src/script.rs
+++ b/crates/install-wheel-rs/src/script.rs
@@ -26,6 +26,7 @@ pub struct Script {
     pub script_name: String,
     pub module: String,
     pub function: String,
+    pub import_path: String
 }
 
 impl Script {
@@ -61,10 +62,13 @@ impl Script {
             }
         }
 
+        let function =  captures.name("function").unwrap().as_str().to_string();
+        let import_path = function.split_once('.').map_or(function.clone(), |(import_path, _)| import_path.to_string());
         Ok(Some(Script {
             script_name: script_name.to_string(),
             module: captures.name("module").unwrap().as_str().to_string(),
-            function: captures.name("function").unwrap().as_str().to_string(),
+            function,
+            import_path,
         }))
     }
 }
@@ -98,4 +102,14 @@ mod test {
             );
         }
     }
+
+    #[test]
+    fn test_split_of_import_name_from_function() {
+            let entrypoint = "foomod:mod_bar.sub_foo.func_baz";
+
+            let script = Script::from_value("script", entrypoint, None).unwrap().unwrap();
+            assert_eq!(script.function, "mod_bar.sub_foo.func_baz");
+            assert_eq!(script.import_path, "mod_bar");
+    }
+
 }

--- a/crates/install-wheel-rs/src/script.rs
+++ b/crates/install-wheel-rs/src/script.rs
@@ -26,7 +26,7 @@ pub struct Script {
     pub script_name: String,
     pub module: String,
     pub function: String,
-    pub import_path: String
+    pub import_name: String
 }
 
 impl Script {
@@ -63,12 +63,12 @@ impl Script {
         }
 
         let function =  captures.name("function").unwrap().as_str().to_string();
-        let import_path = function.split_once('.').map_or(function.as_str(), |(import_path, _)| import_path).to_string();
+        let import_name = function.split_once('.').map_or(function.as_str(), |(import_name, _)| import_name).to_string();
         Ok(Some(Script {
             script_name: script_name.to_string(),
             module: captures.name("module").unwrap().as_str().to_string(),
             function,
-            import_path,
+            import_name,
         }))
     }
 }
@@ -109,7 +109,7 @@ mod test {
 
             let script = Script::from_value("script", entrypoint, None).unwrap().unwrap();
             assert_eq!(script.function, "mod_bar.sub_foo.func_baz");
-            assert_eq!(script.import_path, "mod_bar");
+            assert_eq!(script.import_name, "mod_bar");
     }
 
 }

--- a/crates/install-wheel-rs/src/script.rs
+++ b/crates/install-wheel-rs/src/script.rs
@@ -28,7 +28,7 @@ pub struct Script {
     pub script_name: String,
     pub module: String,
     pub function: String,
-    pub import_name: String
+    pub import_name: String,
 }
 
 impl Script {
@@ -64,8 +64,11 @@ impl Script {
             }
         }
 
-        let function =  captures.name("function").unwrap().as_str().to_string();
-        let import_name = function.split_once('.').map_or(function.as_str(), |(import_name, _)| import_name).to_string();
+        let function = captures.name("function").unwrap().as_str().to_string();
+        let import_name = function
+            .split_once('.')
+            .map_or(function.as_str(), |(import_name, _)| import_name)
+            .to_string();
         Ok(Some(Script {
             script_name: script_name.to_string(),
             module: captures.name("module").unwrap().as_str().to_string(),
@@ -107,11 +110,12 @@ mod test {
 
     #[test]
     fn test_split_of_import_name_from_function() {
-            let entrypoint = "foomod:mod_bar.sub_foo.func_baz";
+        let entrypoint = "foomod:mod_bar.sub_foo.func_baz";
 
-            let script = Script::from_value("script", entrypoint, None).unwrap().unwrap();
-            assert_eq!(script.function, "mod_bar.sub_foo.func_baz");
-            assert_eq!(script.import_name, "mod_bar");
+        let script = Script::from_value("script", entrypoint, None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(script.function, "mod_bar.sub_foo.func_baz");
+        assert_eq!(script.import_name, "mod_bar");
     }
-
 }

--- a/crates/install-wheel-rs/src/wheel.rs
+++ b/crates/install-wheel-rs/src/wheel.rs
@@ -52,7 +52,12 @@ const LAUNCHER_AARCH64_CONSOLE: &[u8] =
 /// Wrapper script template function
 ///
 /// <https://github.com/pypa/pip/blob/7f8a6844037fb7255cfd0d34ff8e8cf44f2598d4/src/pip/_vendor/distlib/scripts.py#L41-L48>
-fn get_script_launcher(module: &str, function_path: &str, import_name: &str, shebang: &str) -> String {
+fn get_script_launcher(
+    module: &str,
+    function_path: &str,
+    import_name: &str,
+    shebang: &str,
+) -> String {
     format!(
         r##"{shebang}
 # -*- coding: utf-8 -*-

--- a/crates/install-wheel-rs/src/wheel.rs
+++ b/crates/install-wheel-rs/src/wheel.rs
@@ -52,7 +52,7 @@ const LAUNCHER_AARCH64_CONSOLE: &[u8] =
 /// Wrapper script template function
 ///
 /// <https://github.com/pypa/pip/blob/7f8a6844037fb7255cfd0d34ff8e8cf44f2598d4/src/pip/_vendor/distlib/scripts.py#L41-L48>
-fn get_script_launcher(module: &str, import_name: &str, shebang: &str) -> String {
+fn get_script_launcher(module: &str, function_path: &str, import_name: &str, shebang: &str) -> String {
     format!(
         r##"{shebang}
 # -*- coding: utf-8 -*-
@@ -61,7 +61,7 @@ import sys
 from {module} import {import_name}
 if __name__ == "__main__":
     sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
-    sys.exit({import_name}())
+    sys.exit({function_path}())
 "##
     )
 }
@@ -383,6 +383,7 @@ pub(crate) fn write_script_entrypoints(
         let launcher_python_script = get_script_launcher(
             &entrypoint.module,
             &entrypoint.function,
+            &entrypoint.import_path,
             &get_shebang(location),
         );
 
@@ -1267,6 +1268,7 @@ mod test {
                 script_name: "launcher".to_string(),
                 module: "foo.bar".to_string(),
                 function: "main".to_string(),
+                import_path: "main".to_string(),
             })
         );
         assert_eq!(
@@ -1280,6 +1282,7 @@ mod test {
                 script_name: "launcher".to_string(),
                 module: "foo.bar".to_string(),
                 function: "main".to_string(),
+                import_path: "main".to_string(),
             })
         );
         assert_eq!(
@@ -1297,6 +1300,7 @@ mod test {
                 script_name: "launcher".to_string(),
                 module: "foomod".to_string(),
                 function: "main_bar".to_string(),
+                import_path: "main_bar".to_string(),
             })
         );
     }

--- a/crates/install-wheel-rs/src/wheel.rs
+++ b/crates/install-wheel-rs/src/wheel.rs
@@ -383,7 +383,7 @@ pub(crate) fn write_script_entrypoints(
         let launcher_python_script = get_script_launcher(
             &entrypoint.module,
             &entrypoint.function,
-            &entrypoint.import_path,
+            &entrypoint.import_name,
             &get_shebang(location),
         );
 
@@ -1268,7 +1268,7 @@ mod test {
                 script_name: "launcher".to_string(),
                 module: "foo.bar".to_string(),
                 function: "main".to_string(),
-                import_path: "main".to_string(),
+                import_name: "main".to_string(),
             })
         );
         assert_eq!(
@@ -1282,7 +1282,7 @@ mod test {
                 script_name: "launcher".to_string(),
                 module: "foo.bar".to_string(),
                 function: "main".to_string(),
-                import_path: "main".to_string(),
+                import_name: "main".to_string(),
             })
         );
         assert_eq!(
@@ -1300,7 +1300,7 @@ mod test {
                 script_name: "launcher".to_string(),
                 module: "foomod".to_string(),
                 function: "main_bar".to_string(),
-                import_path: "main_bar".to_string(),
+                import_name: "main_bar".to_string(),
             })
         );
     }

--- a/crates/install-wheel-rs/src/wheel.rs
+++ b/crates/install-wheel-rs/src/wheel.rs
@@ -386,7 +386,7 @@ pub(crate) fn write_script_entrypoints(
         };
 
         // Generate the launcher script.
-        let launcher_python_script = get_script_launcher(&entrypoint, &get_shebang(location));
+        let launcher_python_script = get_script_launcher(entrypoint, &get_shebang(location));
 
         // If necessary, wrap the launcher script in a Windows launcher binary.
         if cfg!(windows) {

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -2682,7 +2682,7 @@ fn repeat_requirement() -> Result<()> {
     Resolved 1 package in [TIME]
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
-     + anyio==4.2.0
+     + anyio==4.3.0
     "###);
 
     Ok(())


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Some projects define an script entrypoint with a path separated by `.`. 

For example in Invoke...
```python
    entry_points={
        "console_scripts": [
            "invoke = invoke.main:program.run",
            "inv = invoke.main:program.run",
        ]
    },
```
Before this change `uv` tried to import 'program.run' but
this is not valid, and only up to the first dot should be
imported (as `pip` does).

Resolves: #1573

## Test Plan

- Added a unit test in script.rs to validate that the import_name is set correctly when the function path is dotted.
- Ran the unit tests (`cargo test`)

https://github.com/astral-sh/uv/assets/1203881/8774b281-0811-4520-b4d7-244d0f955cb7


