### PR TITLE
Build source distributions in the cache directory instead of the global temporary directory

### DIFF
--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -19,7 +19,7 @@ use once_cell::sync::Lazy;
 use pyproject_toml::{BuildSystem, Project};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use tempfile::{tempdir, tempdir_in, TempDir};
+use tempfile::{tempdir_in, TempDir};
 use thiserror::Error;
 use tokio::process::Command;
 use tokio::sync::Mutex;
@@ -283,7 +283,7 @@ impl SourceBuild {
         setup_py: SetupPyStrategy,
         build_kind: BuildKind,
     ) -> Result<SourceBuild, Error> {
-        let temp_dir = tempdir()?;
+        let temp_dir = tempdir_in(build_context.cache().root())?;
 
         let metadata = match fs::metadata(source) {
             Ok(metadata) => metadata,


### PR DESCRIPTION
Addresses report in https://github.com/astral-sh/uv/issues/1444 where a temporary directory is created outside of the cache directory or current virtual environment.

There is one additional usage of bare `tempdir` outside of tests we may want to change:

https://github.com/astral-sh/uv/blob/2586f655bbf650a9797c8f88b6d9066eefe7a3dc/crates/install-wheel-rs/src/wheel.rs#L567