### PR TITLE
feat: Allow uv pip install to fetch requirements files from a remote URL.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,6 +2753,7 @@ dependencies = [
  "pep440_rs 0.4.0",
  "pep508_rs",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/requirements-txt/Cargo.toml
+++ b/crates/requirements-txt/Cargo.toml
@@ -22,6 +22,7 @@ uv-warnings = { path = "../uv-warnings" }
 fs-err = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
+reqwest = { workspace = true, features = ["blocking"] }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -1111,20 +1111,6 @@ mod test {
     }
 
     #[test]
-    fn url_test() -> Result<()> {
-        let temp_dir = assert_fs::TempDir::new()?;
-        let error = RequirementsTxt::parse("https://example.com/requirements.txt", temp_dir.path())
-            .unwrap_err();
-        let errors = anyhow::Error::new(error).chain().join("\n");
-
-        insta::assert_display_snapshot!(errors, @r###"
-        Unsupported URL (expected a `file://` scheme) in `<REQUIREMENTS_TXT>`: `https://example.com/requirements.txt`
-        "###);
-
-        Ok(())
-    }
-
-    #[test]
     fn invalid_include_missing_file() -> Result<()> {
         let temp_dir = assert_fs::TempDir::new()?;
         let missing_txt = temp_dir.child("missing.txt");

--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -119,7 +119,6 @@ pub(crate) async fn pip_compile(
         // As an optimization, skip reading the lockfile is we're upgrading all packages anyway.
         .filter(|_| !upgrade.is_all())
         .filter(|output_file| output_file.exists())
-        .map(Path::to_path_buf)
         .map(RequirementsSource::from_path)
         .as_ref()
         .map(|source| RequirementsSpecification::from_source(source, &extras))

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -434,7 +434,7 @@ struct PipInstallArgs {
 
     /// Install all packages listed in the given requirements files.
     #[clap(short, long, group = "sources")]
-    requirement: Vec<PathBuf>,
+    requirement: Vec<String>,
 
     /// Install the editable package based on the provided local file path.
     #[clap(short, long, group = "sources")]
@@ -794,18 +794,18 @@ async fn run() -> Result<ExitStatus> {
             let cache = cache.with_refresh(Refresh::from_args(args.refresh, args.refresh_package));
             let requirements = args
                 .src_file
-                .into_iter()
-                .map(RequirementsSource::from_path)
+                .iter()
+                .map(|path_buf| RequirementsSource::from_path(path_buf.as_path()))
                 .collect::<Vec<_>>();
             let constraints = args
                 .constraint
-                .into_iter()
-                .map(RequirementsSource::from_path)
+                .iter()
+                .map(|path_buf| RequirementsSource::from_path(path_buf.as_path()))
                 .collect::<Vec<_>>();
             let overrides = args
                 .r#override
-                .into_iter()
-                .map(RequirementsSource::from_path)
+                .iter()
+                .map(|path_buf| RequirementsSource::from_path(path_buf.as_path()))
                 .collect::<Vec<_>>();
             let index_urls = IndexLocations::from_args(
                 args.index_url,
@@ -875,8 +875,8 @@ async fn run() -> Result<ExitStatus> {
             );
             let sources = args
                 .src_file
-                .into_iter()
-                .map(RequirementsSource::from_path)
+                .iter()
+                .map(|path_buf| RequirementsSource::from_path(path_buf.as_path()))
                 .collect::<Vec<_>>();
             let reinstall = Reinstall::from_args(args.reinstall, args.reinstall_package);
             let no_binary = NoBinary::from_args(args.no_binary);
@@ -916,18 +916,18 @@ async fn run() -> Result<ExitStatus> {
                 .chain(
                     args.requirement
                         .into_iter()
-                        .map(RequirementsSource::from_path),
+                        .map(RequirementsSource::from_string),
                 )
                 .collect::<Vec<_>>();
             let constraints = args
                 .constraint
-                .into_iter()
-                .map(RequirementsSource::from_path)
+                .iter()
+                .map(|path_buf| RequirementsSource::from_path(path_buf.as_path()))
                 .collect::<Vec<_>>();
             let overrides = args
                 .r#override
-                .into_iter()
-                .map(RequirementsSource::from_path)
+                .iter()
+                .map(|path_buf| RequirementsSource::from_path(path_buf.as_path()))
                 .collect::<Vec<_>>();
             let index_urls = IndexLocations::from_args(
                 args.index_url,
@@ -992,8 +992,8 @@ async fn run() -> Result<ExitStatus> {
                 .chain(args.editable.into_iter().map(RequirementsSource::Editable))
                 .chain(
                     args.requirement
-                        .into_iter()
-                        .map(RequirementsSource::from_path),
+                        .iter()
+                        .map(|path_buf| RequirementsSource::from_path(path_buf.as_path())),
                 )
                 .collect::<Vec<_>>();
             commands::pip_uninstall(&sources, cache, printer).await


### PR DESCRIPTION
## Summary

Fixes #1481 

Allow `uv pip install` to fetch requirements files from a remote URL. 

## Questions

Apologies for the questions; this is my first Rust code in a long time.

1. Using `reqwest` like this feels wrong and it doesn't work: `::blocking` complains about dropping the current runtime, and I'm not inclined to change the function and all of its calling functions to `async`. Is there a better way?
2. Is it OK to use `String` type for "something that can be a PathBuf or URL"? Is there a better type to use?

## TODO
- [ ] add tests
  - [ ] mock HTTP calls in tests

## Test Plan

1. Add unit tests.
2. Smoke test in CLI with `uv pip install -r <valid_url/to/requirements.txt>`
