### PR TITLE
Do not remove uv itself on pip sync

### DIFF
--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -381,7 +381,10 @@ impl<'a> Planner<'a> {
             let seed_packages = !venv.cfg().is_ok_and(|cfg| cfg.is_gourgeist());
             for dist_info in site_packages {
                 if seed_packages
-                    && matches!(dist_info.name().as_ref(), "pip" | "setuptools" | "wheel")
+                    && matches!(
+                        dist_info.name().as_ref(),
+                        "pip" | "setuptools" | "wheel" | "uv"
+                    )
                 {
                     debug!("Preserving seed package: {dist_info}");
                     continue;


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Added `uv` to the list of the preserved packages when building the installer plan. In that case `uv` is not going to be removed when, for example, using `python -m uv pip sync requirements.txt` when requirements.txt does not contain `uv`, but `uv` is installed in that venv.

Closes #1631 

## Test Plan

Got through the example attached to https://github.com/astral-sh/uv/issues/1631 and did see the uv deletion in the output
```
$ python -m uv pip sync requirements.txt
Installed 1 package in 20ms
 + ruff==0.2.2
```
