### PR TITLE
Add `CACHEDIR.TAG` to uv-created virtualenvs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,7 @@ name = "gourgeist"
 version = "0.0.4"
 dependencies = [
  "anstream",
+ "cachedir",
  "camino",
  "clap",
  "directories",

--- a/crates/gourgeist/Cargo.toml
+++ b/crates/gourgeist/Cargo.toml
@@ -26,6 +26,7 @@ uv-cache = { path = "../uv-cache" }
 uv-interpreter = { path = "../uv-interpreter" }
 
 anstream = { workspace = true }
+cachedir = { workspace = true }
 camino = { workspace = true }
 clap = { workspace = true, features = ["derive"], optional = true }
 directories = { workspace = true }

--- a/crates/gourgeist/src/bare.rs
+++ b/crates/gourgeist/src/bare.rs
@@ -108,6 +108,10 @@ pub fn create_bare_venv(location: &Utf8Path, interpreter: &Interpreter) -> io::R
     };
     let bin_dir = location.join(bin_name);
 
+    // Add the CACHEDIR.TAG.
+    cachedir::ensure_tag(&location)?;
+
+    // Create a `.gitignore` file to ignore all files in the venv.
     fs::write(location.join(".gitignore"), "*")?;
 
     // Different names for the python interpreter


### PR DESCRIPTION
## Summary

Just as we mark virtualenvs as `gitignore`d by default, we should also mark them as `CACHEDIR.TAG`, to ensure that they aren't included in backups, etc.

Closes https://github.com/astral-sh/uv/issues/1648.

## Test Plan

Ran `cargo run venv` and:

```
❯ ls .venv
CACHEDIR.TAG bin          lib          pyvenv.cfg
```
