### PR TITLE
Ensure we retain existing environment variables during `python -m uv`

### DIFF
--- a/python/uv/__main__.py
+++ b/python/uv/__main__.py
@@ -50,10 +50,10 @@ def find_uv_bin() -> str:
 if __name__ == "__main__":
     uv = os.fsdecode(find_uv_bin())
 
-    env = {}
+    env = os.environ.copy()
     venv = detect_virtualenv()
     if venv:
-        env["VIRTUAL_ENV"] = venv
+        env.setdefault("VIRTUAL_ENV", venv)
 
     if sys.platform == "win32":
         import subprocess


### PR DESCRIPTION
From https://github.com/astral-sh/uv/issues/1623#issuecomment-1951368507

I thought I checked this was working correctly in #1504 but I guess the environment is not preserved like I thought.