### PR TITLE
Add yank warnings at end of messages

### DIFF
--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -197,33 +197,6 @@ pub(crate) async fn pip_sync(
         resolution.into_distributions().collect::<Vec<_>>()
     };
 
-    // TODO(konstin): Also check the cache whether any cached or installed dist is already known to
-    // have been yanked, we currently don't show this message on the second run anymore
-    for dist in &remote {
-        let Some(file) = dist.file() else {
-            continue;
-        };
-        match &file.yanked {
-            None | Some(Yanked::Bool(false)) => {}
-            Some(Yanked::Bool(true)) => {
-                writeln!(
-                    printer,
-                    "{}{} {dist} is yanked. Refresh your lockfile to pin an un-yanked version.",
-                    "warning".yellow().bold(),
-                    ":".bold(),
-                )?;
-            }
-            Some(Yanked::Reason(reason)) => {
-                writeln!(
-                    printer,
-                    "{}{} {dist} is yanked (reason: \"{reason}\"). Refresh your lockfile to pin an un-yanked version.",
-                    "warning".yellow().bold(),
-                    ":".bold(),
-                )?;
-            }
-        }
-    }
-
     // Download, build, and unzip any missing distributions.
     let wheels = if remote.is_empty() {
         Vec::new()
@@ -234,7 +207,7 @@ pub(crate) async fn pip_sync(
             .with_reporter(DownloadReporter::from(printer).with_length(remote.len() as u64));
 
         let wheels = downloader
-            .download(remote, &in_flight)
+            .download(remote.clone(), &in_flight)
             .await
             .context("Failed to download distributions")?;
 
@@ -360,6 +333,33 @@ pub(crate) async fn pip_sync(
                 ":".bold(),
                 diagnostic.message().bold()
             )?;
+        }
+    }
+
+    // TODO(konstin): Also check the cache whether any cached or installed dist is already known to
+    // have been yanked, we currently don't show this message on the second run anymore
+    for dist in &remote {
+        let Some(file) = dist.file() else {
+            continue;
+        };
+        match &file.yanked {
+            None | Some(Yanked::Bool(false)) => {}
+            Some(Yanked::Bool(true)) => {
+                writeln!(
+                    printer,
+                    "{}{} {dist} is yanked. Refresh your lockfile to pin an un-yanked version.",
+                    "warning".yellow().bold(),
+                    ":".bold(),
+                )?;
+            }
+            Some(Yanked::Reason(reason)) => {
+                writeln!(
+                    printer,
+                    "{}{} {dist} is yanked (reason: \"{reason}\"). Refresh your lockfile to pin an un-yanked version.",
+                    "warning".yellow().bold(),
+                    ":".bold(),
+                )?;
+            }
         }
     }
 

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -3132,11 +3132,11 @@ fn transitive_package_only_yanked_in_range_opt_in() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    warning: bluebird==1.0.0 is yanked.
     Downloaded 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + albatross==0.1.0
      + bluebird==1.0.0
+    warning: bluebird==1.0.0 is yanked.
     "###);
 
     // Since the user included a dependency on `b` with an exact specifier, the yanked
@@ -3252,12 +3252,12 @@ fn transitive_yanked_and_unyanked_dependency_opt_in() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    warning: crow==2.0.0 is yanked.
     Downloaded 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + albatross==1.0.0
      + bluebird==1.0.0
      + crow==2.0.0
+    warning: crow==2.0.0 is yanked.
     "###);
 
     // Since the user explicitly selected the yanked version of `c`, it can be

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -904,10 +904,10 @@ fn warn_on_yanked_version() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    warning: colorama==0.4.2 is yanked (reason: "Bad build, missing files, will not install"). Refresh your lockfile to pin an un-yanked version.
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
      + colorama==0.4.2
+    warning: colorama==0.4.2 is yanked (reason: "Bad build, missing files, will not install"). Refresh your lockfile to pin an un-yanked version.
     "###
     );
 


### PR DESCRIPTION
Resolves #1292.

## Summary

Move the yanked warnings for `uv pip sync` and `uv pip install` to the end of the commands, as per #1292.

## Test Plan

I ran the unit tests: `cargo nextest run`