### PR TITLE
Document RUST_LOG=trace for additional logging verbosity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,3 +80,11 @@ RUST_LOG=uv=info TRACING_DURATIONS_FILE=target/traces/jupyter.ndjson cargo run -
 ```shell
 RUST_LOG=uv=info TRACING_DURATIONS_FILE=target/traces/jupyter.ndjson cargo run --features tracing-durations-export --bin uv-dev --profile profiling -- resolve jupyter
 ```
+
+### Trace-level logging
+
+You can enable `trace` level logging using the `RUST_LOG` environment variable, i.e.
+
+```shell
+RUST_LOG=trace uv …
+```


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This improves Contributing documentation to specifically mention `trace` level logging can be obtained via `RUST_LOG=trace uv …` as mentioned here: https://github.com/astral-sh/uv/issues/1569#issuecomment-1951489407

## Test Plan

Compare the output of

```
uv pip install --verbose requests
```

and

```
RUST_LOG=trace uv pip install --verbose requests
```
