### PR TITLE
Control pip timeout duration via environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4316,6 +4316,7 @@ dependencies = [
  "uv-cache",
  "uv-fs",
  "uv-normalize",
+ "uv-warnings",
 ]
 
 [[package]]

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -14,6 +14,7 @@ platform-tags = { path = "../platform-tags" }
 uv-cache = { path = "../uv-cache" }
 uv-fs = { path = "../uv-fs", features = ["tokio"] }
 uv-normalize = { path = "../uv-normalize" }
+uv-warnings = { path = "../uv-warnings" }
 pypi-types = { path = "../pypi-types" }
 
 async-trait = { workspace = true }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -24,6 +24,7 @@ use pep440_rs::Version;
 use pypi_types::{Metadata21, SimpleJson};
 use uv_cache::{Cache, CacheBucket, WheelCache};
 use uv_normalize::PackageName;
+use uv_warnings::warn_user_once;
 
 use crate::cached_client::CacheControl;
 use crate::html::SimpleHtml;
@@ -93,7 +94,7 @@ impl RegistryClientBuilder {
                 }
                 Err(_) => default_timeout,
             };
-            debug!("Pip request timeout is {}.", timeout);
+            debug!("Using registry request timeout of {}s", timeout);
             // Disallow any connections.
             let client_core = ClientBuilder::new()
                 .user_agent("uv")

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
+use std::env;
 use std::fmt::Debug;
 use std::path::Path;
 use std::str::FromStr;
-use std::env;
 
 use async_http_range_reader::AsyncHttpRangeReader;
 use async_zip::tokio::read::seek::ZipFileReader;


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Add the environment variable `UV_REQUEST_TIMEOUT` to allow control over pip timeouts.

Closes #1549 

## Test Plan

I built uv in the repository top Dockerfile, set the timeout to 3 seconds, and ran `uv pip install torch`.
I measured the execution time with the time command and confirmed that the process finished at a value close to the timeout we set.

```bash
root@037c69228cdc:~# time UV_REQUEST_TIMEOUT=3 /uv pip install torch
Resolved 22 packages in 25ms
error: Failed to download distributions
  Caused by: Failed to fetch wheel: nvidia-cusolver-cu12==11.4.5.107
  Caused by: Failed to extract source distribution
  Caused by: request or response body error: operation timed out
  Caused by: operation timed out

real    0m3.064s
user    0m0.225s
sys     0m0.240s
```