### PR TITLE
Search `PATH` when `python` can't be found with `py`

### DIFF
--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -36,12 +36,7 @@ impl Interpreter {
     /// Detect the interpreter info for the given Python executable.
     pub fn query(executable: &Path, platform: &Platform, cache: &Cache) -> Result<Self, Error> {
         let info = InterpreterQueryResult::query_cached(executable, cache)?;
-        // debug_assert!(
-        //     info.base_prefix == info.base_exec_prefix,
-        //     "Not a virtualenv (Python: {}, prefix: {})",
-        //     executable.display(),
-        //     info.base_prefix.display()
-        // );
+
         debug_assert!(
             info.sys_executable.is_absolute(),
             "`sys.executable` is not an absolute Python; Python installation is broken: {}",

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -36,12 +36,12 @@ impl Interpreter {
     /// Detect the interpreter info for the given Python executable.
     pub fn query(executable: &Path, platform: &Platform, cache: &Cache) -> Result<Self, Error> {
         let info = InterpreterQueryResult::query_cached(executable, cache)?;
-        debug_assert!(
-            info.base_prefix == info.base_exec_prefix,
-            "Not a virtualenv (Python: {}, prefix: {})",
-            executable.display(),
-            info.base_prefix.display()
-        );
+        // debug_assert!(
+        //     info.base_prefix == info.base_exec_prefix,
+        //     "Not a virtualenv (Python: {}, prefix: {})",
+        //     executable.display(),
+        //     info.base_prefix.display()
+        // );
         debug_assert!(
             info.sys_executable.is_absolute(),
             "`sys.executable` is not an absolute Python; Python installation is broken: {}",

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -17,8 +17,9 @@ use uv_cache::{Cache, CacheBucket, CachedByTimestamp, Freshness, Timestamp};
 use uv_fs::write_atomic_sync;
 
 use crate::python_platform::PythonPlatform;
+use crate::python_query::try_find_default_python;
 use crate::virtual_env::detect_virtual_env;
-use crate::{find_default_python, find_requested_python, Error, PythonVersion};
+use crate::{find_requested_python, Error, PythonVersion};
 
 /// A Python executable and its associated platform markers.
 #[derive(Debug, Clone)]
@@ -169,11 +170,7 @@ impl Interpreter {
         let interpreter = if let Some(python_version) = python_version {
             find_requested_python(&python_version.string, platform, cache)?
         } else {
-            match find_default_python(platform, cache) {
-                Ok(interpreter) => Some(interpreter),
-                Err(Error::NoPythonInstalled) => None,
-                Err(err) => return Err(err),
-            }
+            try_find_default_python(platform, cache)?
         };
 
         if let Some(interpreter) = interpreter {

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -2,10 +2,7 @@ use std::ffi::OsString;
 use std::io;
 use std::path::PathBuf;
 
-use pep440_rs::Version;
 use thiserror::Error;
-
-use uv_fs::Normalized;
 
 pub use crate::cfg::Configuration;
 pub use crate::interpreter::Interpreter;

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -42,16 +42,10 @@ pub enum Error {
     },
     #[error("Failed to run `py --list-paths` to find Python installations. Is Python installed?")]
     PyList(#[source] io::Error),
-    #[cfg(windows)]
-    #[error("No Python {0} found through `py --list-paths`. Is Python {0} installed?")]
-    NoSuchPython(String),
-    #[cfg(unix)]
     #[error("No Python {0} In `PATH`. Is Python {0} installed?")]
     NoSuchPython(String),
     #[error("Neither `python` nor `python3` are in `PATH`. Is Python installed?")]
-    NoPythonInstalledUnix,
-    #[error("Could not find `python.exe` in PATH and `py --list-paths` did not list any Python versions. Is Python installed?")]
-    NoPythonInstalledWindows,
+    NoPythonInstalled,
     #[error("{message}:\n--- stdout:\n{stdout}\n--- stderr:\n{stderr}\n---")]
     PythonSubcommandOutput {
         message: String,

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -58,6 +58,4 @@ pub enum Error {
     Cfg(#[from] cfg::Error),
     #[error("Error finding `{}` in PATH", _0.to_string_lossy())]
     WhichError(OsString, #[source] which::Error),
-    #[error("Interpreter at `{}` has the wrong patch version. Expected: {}, actual: {}", _0.normalized_display(), _1, _2)]
-    PatchVersionMismatch(PathBuf, String, Version),
 }

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -39,10 +39,20 @@ pub enum Error {
     },
     #[error("Failed to run `py --list-paths` to find Python installations. Is Python installed?")]
     PyList(#[source] io::Error),
+    #[cfg(windows)]
+    #[error(
+        "No Python {0} found through `py --list-paths` or in `PATH`. Is Python {0} installed?"
+    )]
+    NoSuchPython(String),
+    #[cfg(unix)]
     #[error("No Python {0} In `PATH`. Is Python {0} installed?")]
     NoSuchPython(String),
     #[error("Neither `python` nor `python3` are in `PATH`. Is Python installed?")]
-    NoPythonInstalled,
+    NoPythonInstalledUnix,
+    #[error(
+        "Could not find `python.exe` through `py --list-paths` or in 'PATH'. Is Python installed?"
+    )]
+    NoPythonInstalledWindows,
     #[error("{message}:\n--- stdout:\n{stdout}\n--- stderr:\n{stderr}\n---")]
     PythonSubcommandOutput {
         message: String,

--- a/crates/uv-interpreter/src/python_query.rs
+++ b/crates/uv-interpreter/src/python_query.rs
@@ -1,25 +1,15 @@
 //! Find a user requested python version/interpreter.
 
+use std::collections::HashSet;
 use std::env;
 use std::path::PathBuf;
-use std::process::Command;
 
-use once_cell::sync::Lazy;
+use tracing::instrument;
+
 use platform_host::Platform;
-use regex::Regex;
-use tracing::{info_span, instrument};
 use uv_cache::Cache;
 
 use crate::{Error, Interpreter};
-
-/// ```text
-/// -V:3.12          C:\Users\Ferris\AppData\Local\Programs\Python\Python312\python.exe
-/// -V:3.8           C:\Users\Ferris\AppData\Local\Programs\Python\Python38\python.exe
-/// ```
-static PY_LIST_PATHS: Lazy<Regex> = Lazy::new(|| {
-    // Without the `R` flag, paths have trailing \r
-    Regex::new(r"(?mR)^ -(?:V:)?(\d).(\d+)-?(?:arm)?(?:\d*)\s*\*?\s*(.*)$").unwrap()
-});
 
 /// Find a python version/interpreter of a specific version.
 ///
@@ -43,99 +33,38 @@ pub fn find_requested_python(
         .splitn(3, '.')
         .map(str::parse::<u8>)
         .collect::<Result<Vec<_>, _>>();
-    Ok(Some(if let Ok(versions) = versions {
+    if let Ok(versions) = versions {
         // `-p 3.10` or `-p 3.10.1`
-        if cfg!(unix) {
-            if let [_major, _minor, requested_patch] = versions.as_slice() {
-                let formatted = PathBuf::from(format!("python{}.{}", versions[0], versions[1]));
-                let Some(executable) = Interpreter::find_executable(&formatted)? else {
-                    return Ok(None);
-                };
-                let interpreter = Interpreter::query(&executable, platform, cache)?;
-                if interpreter.python_patch() != *requested_patch {
-                    return Err(Error::PatchVersionMismatch(
-                        executable,
-                        request.to_string(),
-                        interpreter.python_version().clone(),
-                    ));
-                }
-                interpreter
-            } else {
-                let formatted = PathBuf::from(format!("python{request}"));
-                let Some(executable) = Interpreter::find_executable(&formatted)? else {
-                    return Ok(None);
-                };
-                Interpreter::query(&executable, platform, cache)?
-            }
-        } else if cfg!(windows) {
-            if let Some(python_overwrite) = env::var_os("UV_TEST_PYTHON_PATH") {
-                let executable_dir = env::split_paths(&python_overwrite).find(|path| {
-                    path.as_os_str()
-                        .to_str()
-                        // Good enough since we control the bootstrap directory
-                        .is_some_and(|path| path.contains(&format!("@{request}")))
-                });
-                return if let Some(path) = executable_dir {
-                    let executable = path.join(if cfg!(unix) {
-                        "python3"
-                    } else if cfg!(windows) {
-                        "python.exe"
-                    } else {
-                        unimplemented!("Only Windows and Unix are supported")
-                    });
-                    Ok(Some(Interpreter::query(&executable, platform, cache)?))
-                } else {
-                    Ok(None)
-                };
-            }
-
-            match versions.as_slice() {
-                [major] => {
-                    let Some(executable) = installed_pythons_windows()?
-                        .into_iter()
-                        .find(|(major_, _minor, _path)| major_ == major)
-                        .map(|(_, _, path)| path)
-                    else {
-                        return Ok(None);
-                    };
-                    Interpreter::query(&executable, platform, cache)?
-                }
-                [major, minor] => {
-                    let Some(executable) = find_python_windows(*major, *minor)? else {
-                        return Ok(None);
-                    };
-                    Interpreter::query(&executable, platform, cache)?
-                }
-                [major, minor, requested_patch] => {
-                    let Some(executable) = find_python_windows(*major, *minor)? else {
-                        return Ok(None);
-                    };
-                    let interpreter = Interpreter::query(&executable, platform, cache)?;
-                    if interpreter.python_patch() != *requested_patch {
-                        return Err(Error::PatchVersionMismatch(
-                            executable,
-                            request.to_string(),
-                            interpreter.python_version().clone(),
-                        ));
-                    }
-                    interpreter
-                }
-                _ => unreachable!(),
-            }
-        } else {
-            unimplemented!("Only Windows and Unix are supported")
+        match versions.as_slice() {
+            [requested_major] => find_python(
+                PythonVersionSelector::Major(*requested_major),
+                platform,
+                cache,
+            ),
+            [major, minor] => find_python(
+                PythonVersionSelector::MajorMinor(*major, *minor),
+                platform,
+                cache,
+            ),
+            [major, minor, requested_patch] => find_python(
+                PythonVersionSelector::MajorMinorPatch(*major, *minor, *requested_patch),
+                platform,
+                cache,
+            ),
+            // SAFETY: Guaranteed by the Ok(versions) guard
+            _ => unreachable!(),
         }
     } else if !request.contains(std::path::MAIN_SEPARATOR) {
         // `-p python3.10`; Generally not used on windows because all Python are `python.exe`.
         let Some(executable) = Interpreter::find_executable(request)? else {
             return Ok(None);
         };
-        Interpreter::query(&executable, platform, cache)?
+        Ok(Some(Interpreter::query(&executable, platform, cache)?))
     } else {
         // `-p /home/ferris/.local/bin/python3.10`
         let executable = fs_err::canonicalize(request)?;
-        Interpreter::query(&executable, platform, cache)?
-    }))
+        Ok(Some(Interpreter::query(&executable, platform, cache)?))
+    }
 }
 
 /// Pick a sensible default for the python a user wants when they didn't specify a version.
@@ -144,130 +73,387 @@ pub fn find_requested_python(
 /// `python.exe` respectively.
 #[instrument]
 pub fn find_default_python(platform: &Platform, cache: &Cache) -> Result<Interpreter, Error> {
-    let current_dir = env::current_dir()?;
-    let python = if cfg!(unix) {
-        which::which_in("python3", env::var_os("UV_TEST_PYTHON_PATH"), current_dir)
-            .or_else(|_| which::which("python3"))
-            .or_else(|_| which::which("python"))
-            .map_err(|_| Error::NoPythonInstalledUnix)?
-    } else if cfg!(windows) {
-        // TODO(konstin): Is that the right order, or should we look for `py --list-paths` first? With the current way
-        // it works even if the python launcher is not installed.
-        if let Ok(python) = which::which_in(
-            "python.exe",
-            env::var_os("UV_TEST_PYTHON_PATH"),
-            current_dir,
-        )
-        .or_else(|_| which::which("python.exe"))
-        {
-            python
-        } else {
-            installed_pythons_windows()?
-                .into_iter()
-                .next()
-                .ok_or(Error::NoPythonInstalledWindows)?
-                .2
+    find_python(PythonVersionSelector::Default, platform, cache)?.ok_or(Error::NoPythonInstalled)
+}
+
+fn find_python(
+    selector: PythonVersionSelector,
+    platform: &Platform,
+    cache: &Cache,
+) -> Result<Option<Interpreter>, Error> {
+    #[allow(non_snake_case)]
+    let UV_TEST_PYTHON_PATH = env::var_os("UV_TEST_PYTHON_PATH");
+
+    if UV_TEST_PYTHON_PATH.is_none() {
+        // Use `py` to find the python installation on the system.
+        #[cfg(windows)]
+        match windows::py_list_paths(selector, platform, cache) {
+            Ok(Some(interpreter)) => return Ok(Some(interpreter)),
+            Ok(None) => {
+                // No matching Python version found, continue searching PATH
+            }
+            Err(Error::PyList(error)) => {
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    tracing::warn!(
+                        "`py` is not installed. Falling back to searching Python on the path"
+                    );
+                    // Continue searching for python installations on the path.
+                }
+            }
+            Err(error) => return Err(error),
         }
-    } else {
-        unimplemented!("Only Windows and Unix are supported")
-    };
-    let base_python = fs_err::canonicalize(python)?;
-    let interpreter = Interpreter::query(&base_python, platform, cache)?;
-    return Ok(interpreter);
-}
-
-/// Run `py --list-paths` to find the installed pythons.
-///
-/// The command takes 8ms on my machine. TODO(konstin): Implement <https://peps.python.org/pep-0514/> to read python
-/// installations from the registry instead.
-fn installed_pythons_windows() -> Result<Vec<(u8, u8, PathBuf)>, Error> {
-    // TODO(konstin): We're not checking UV_TEST_PYTHON_PATH here, no test currently depends on it.
-
-    // TODO(konstin): Special case the not found error
-    let output = info_span!("py_list_paths")
-        .in_scope(|| Command::new("py").arg("--list-paths").output())
-        .map_err(Error::PyList)?;
-
-    // There shouldn't be any output on stderr.
-    if !output.status.success() || !output.stderr.is_empty() {
-        return Err(Error::PythonSubcommandOutput {
-            message: format!(
-                "Running `py --list-paths` failed with status {}",
-                output.status
-            ),
-            stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        });
     }
 
-    // Find the first python of the version we want in the list
-    let stdout =
-        String::from_utf8(output.stdout.clone()).map_err(|err| Error::PythonSubcommandOutput {
-            message: format!("The stdout of `py --list-paths` isn't UTF-8 encoded: {err}"),
-            stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        })?;
-    let pythons = PY_LIST_PATHS
-        .captures_iter(&stdout)
-        .filter_map(|captures| {
+    let possible_names = selector.possible_names();
+    let mut checked_installs = HashSet::new();
+
+    #[allow(non_snake_case)]
+    let PATH = UV_TEST_PYTHON_PATH
+        .or(env::var_os("PATH"))
+        .unwrap_or_default();
+
+    for path in env::split_paths(&PATH) {
+        for name in possible_names.iter().flatten() {
+            if let Ok(paths) = which::which_in_global(&**name, Some(&path)) {
+                for path in paths {
+                    if checked_installs.contains(&path) {
+                        continue;
+                    }
+
+                    #[cfg(windows)]
+                    if windows::is_windows_store_shim(&path) {
+                        continue;
+                    }
+
+                    let installation = PythonInstallation::Interpreter(Interpreter::query(
+                        &path, platform, cache,
+                    )?);
+
+                    if let Some(interpreter) = installation.select(selector, platform, cache)? {
+                        return Ok(Some(interpreter));
+                    }
+
+                    checked_installs.insert(path);
+                }
+            }
+        }
+
+        // Python's `venv` model doesn't have this case because they use the `sys.executable` by default
+        // which is sufficient to support pyenv-windows. Unfortunately, we can't rely on the executing Python version.
+        // That's why we explicitly search for a Python shim as last resort.
+        #[cfg(windows)]
+        if let Ok(shims) = which::which_in_global("python.bat", Some(&path)) {
+            for shim in shims {
+                let interpreter = match Interpreter::query(&shim, platform, cache) {
+                    Ok(interpreter) => interpreter,
+                    Err(error) => {
+                        // Don't fail when querying the shim failed. E.g it's possible that no python version is selected
+                        // in the shim in which case pyenv prints to stdout.
+                        tracing::warn!("Failed to query python shim: {error}");
+                        continue;
+                    }
+                };
+
+                if let Some(interpreter) = PythonInstallation::Interpreter(interpreter)
+                    .select(selector, platform, cache)?
+                {
+                    return Ok(Some(interpreter));
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+#[derive(Debug, Clone)]
+enum PythonInstallation {
+    // Used in the windows implementation.
+    #[allow(dead_code)]
+    PyListPath {
+        major: u8,
+        minor: u8,
+        executable_path: PathBuf,
+    },
+    Interpreter(Interpreter),
+}
+
+impl PythonInstallation {
+    fn major(&self) -> u8 {
+        match self {
+            PythonInstallation::PyListPath { major, .. } => *major,
+            PythonInstallation::Interpreter(interpreter) => interpreter.python_major(),
+        }
+    }
+
+    fn minor(&self) -> u8 {
+        match self {
+            PythonInstallation::PyListPath { minor, .. } => *minor,
+            PythonInstallation::Interpreter(interpreter) => interpreter.python_minor(),
+        }
+    }
+
+    /// Selects the interpreter if it matches the selector (version specification).
+    ///
+    fn select(
+        self,
+        selector: PythonVersionSelector,
+        platform: &Platform,
+        cache: &Cache,
+    ) -> Result<Option<Interpreter>, Error> {
+        let selected = match selector {
+            PythonVersionSelector::Default => true,
+            PythonVersionSelector::Major(major) => self.major() == major,
+
+            PythonVersionSelector::MajorMinor(major, minor) => {
+                self.major() == major && self.minor() == minor
+            }
+
+            PythonVersionSelector::MajorMinorPatch(major, minor, requested_patch) => {
+                let interpreter = self.into_interpreter(platform, cache)?;
+                return Ok(
+                    if major == interpreter.python_major()
+                        && minor == interpreter.python_minor()
+                        && requested_patch == interpreter.python_patch()
+                    {
+                        Some(interpreter)
+                    } else {
+                        None
+                    },
+                );
+            }
+        };
+
+        if selected {
+            self.into_interpreter(platform, cache).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(super) fn into_interpreter(
+        self,
+        platform: &Platform,
+        cache: &Cache,
+    ) -> Result<Interpreter, Error> {
+        match self {
+            PythonInstallation::PyListPath {
+                executable_path, ..
+            } => Interpreter::query(&executable_path, platform, cache),
+            PythonInstallation::Interpreter(interpreter) => Ok(interpreter),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum PythonVersionSelector {
+    Default,
+    Major(u8),
+    MajorMinor(u8, u8),
+    MajorMinorPatch(u8, u8, u8),
+}
+
+impl PythonVersionSelector {
+    fn possible_names(self) -> [Option<std::borrow::Cow<'static, str>>; 4] {
+        let (python, python3, extension) = if cfg!(windows) {
+            (
+                std::borrow::Cow::Borrowed("python.exe"),
+                std::borrow::Cow::Borrowed("python3.exe"),
+                ".exe",
+            )
+        } else {
+            (
+                std::borrow::Cow::Borrowed("python"),
+                std::borrow::Cow::Borrowed("python3"),
+                "",
+            )
+        };
+
+        match self {
+            PythonVersionSelector::Default => [Some(python3), Some(python), None, None],
+            PythonVersionSelector::Major(major) => [
+                Some(std::borrow::Cow::Owned(format!("python{major}{extension}"))),
+                Some(python),
+                None,
+                None,
+            ],
+            PythonVersionSelector::MajorMinor(major, minor) => [
+                Some(std::borrow::Cow::Owned(format!(
+                    "python{major}.{minor}{extension}"
+                ))),
+                Some(std::borrow::Cow::Owned(format!("python{major}{extension}"))),
+                Some(python),
+                None,
+            ],
+            PythonVersionSelector::MajorMinorPatch(major, minor, patch) => [
+                Some(std::borrow::Cow::Owned(format!(
+                    "python{major}.{minor}.{patch}{extension}",
+                ))),
+                Some(std::borrow::Cow::Owned(format!(
+                    "python{major}.{minor}{extension}"
+                ))),
+                Some(std::borrow::Cow::Owned(format!("python{major}{extension}"))),
+                Some(python),
+            ],
+        }
+    }
+}
+
+#[cfg(windows)]
+mod windows {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    use once_cell::sync::Lazy;
+    use regex::Regex;
+    use tracing::info_span;
+
+    use platform_host::Platform;
+    use uv_cache::Cache;
+
+    use crate::python_query::{PythonInstallation, PythonVersionSelector};
+    use crate::{Error, Interpreter};
+
+    /// ```text
+    /// -V:3.12          C:\Users\Ferris\AppData\Local\Programs\Python\Python312\python.exe
+    /// -V:3.8           C:\Users\Ferris\AppData\Local\Programs\Python\Python38\python.exe
+    /// ```
+    static PY_LIST_PATHS: Lazy<Regex> = Lazy::new(|| {
+        // Without the `R` flag, paths have trailing \r
+        Regex::new(r"(?mR)^ -(?:V:)?(\d).(\d+)-?(?:arm)?(?:\d*)\s*\*?\s*(.*)$").unwrap()
+    });
+
+    /// Run `py --list-paths` to find the installed pythons.
+    ///
+    /// The command takes 8ms on my machine.
+    /// TODO(konstin): Implement <https://peps.python.org/pep-0514/> to read python installations from the registry instead.
+    pub(super) fn py_list_paths(
+        selector: PythonVersionSelector,
+        platform: &Platform,
+        cache: &Cache,
+    ) -> Result<Option<Interpreter>, Error> {
+        let output = info_span!("py_list_paths")
+            .in_scope(|| Command::new("py").arg("--list-paths").output())
+            .map_err(Error::PyList)?;
+
+        // There shouldn't be any output on stderr.
+        if !output.status.success() || !output.stderr.is_empty() {
+            return Err(Error::PythonSubcommandOutput {
+                message: format!(
+                    "Running `py --list-paths` failed with status {}",
+                    output.status
+                ),
+                stdout: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+
+        // Find the first python of the version we want in the list
+        let stdout =
+            String::from_utf8(output.stdout).map_err(|err| Error::PythonSubcommandOutput {
+                message: format!("The stdout of `py --list-paths` isn't UTF-8 encoded: {err}"),
+                stdout: String::from_utf8_lossy(err.as_bytes()).trim().to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            })?;
+
+        for captures in PY_LIST_PATHS.captures_iter(&stdout) {
             let (_, [major, minor, path]) = captures.extract();
-            Some((
-                major.parse::<u8>().ok()?,
-                minor.parse::<u8>().ok()?,
-                PathBuf::from(path),
-            ))
-        })
-        .collect();
-    Ok(pythons)
-}
 
-pub(crate) fn find_python_windows(major: u8, minor: u8) -> Result<Option<PathBuf>, Error> {
-    if let Some(python_overwrite) = env::var_os("UV_TEST_PYTHON_PATH") {
-        let executable_dir = env::split_paths(&python_overwrite).find(|path| {
-            path.as_os_str()
-                .to_str()
-                // Good enough since we control the bootstrap directory
-                .is_some_and(|path| path.contains(&format!("@{major}.{minor}")))
-        });
-        return Ok(executable_dir.map(|path| {
-            path.join(if cfg!(unix) {
-                "python3"
-            } else if cfg!(windows) {
-                "python.exe"
-            } else {
-                unimplemented!("Only Windows and Unix are supported")
-            })
-        }));
+            if let (Some(major), Some(minor)) = (major.parse::<u8>().ok(), minor.parse::<u8>().ok())
+            {
+                let installation = PythonInstallation::PyListPath {
+                    major,
+                    minor,
+                    executable_path: PathBuf::from(path),
+                };
+
+                if let Some(interpreter) = installation.select(selector, platform, cache)? {
+                    return Ok(Some(interpreter));
+                }
+            }
+        }
+
+        Ok(None)
     }
 
-    Ok(installed_pythons_windows()?
-        .into_iter()
-        .find(|(major_, minor_, _path)| *major_ == major && *minor_ == minor)
-        .map(|(_, _, path)| path))
+    /// On Windows we might encounter the windows store proxy shim (Enabled in Settings/Apps/Advanced app settings/App execution aliases).
+    /// This requires quite a bit of custom logic to figure out what this thing does.
+    ///
+    /// This is a pretty dumb way.  We know how to parse this reparse point, but Microsoft
+    /// does not want us to do this as the format is unstable.  So this is a best effort way.
+    /// we just hope that the reparse point has the python redirector in it, when it's not
+    /// pointing to a valid Python.
+    #[allow(unsafe_code)]
+    pub(super) fn is_windows_store_shim(path: &std::path::Path) -> bool {
+        path.to_str().map_or(false, |path| {
+            path.ends_with("Local\\Microsoft\\WindowsApps\\python.exe")
+                || path.ends_with("Local\\Microsoft\\WindowsApps\\python3.exe")
+        })
+    }
+
+    #[cfg(test)]
+    #[cfg(windows)]
+    mod tests {
+        use std::fmt::Debug;
+
+        use insta::assert_display_snapshot;
+        use itertools::Itertools;
+
+        use platform_host::Platform;
+        use uv_cache::Cache;
+
+        use crate::{find_requested_python, Error};
+
+        fn format_err<T: Debug>(err: Result<T, Error>) -> String {
+            anyhow::Error::new(err.unwrap_err())
+                .chain()
+                .join("\n  Caused by: ")
+        }
+
+        #[test]
+        fn no_such_python_path() {
+            let result = find_requested_python(
+                r"C:\does\not\exists\python3.12",
+                &Platform::current().unwrap(),
+                &Cache::temp().unwrap(),
+            );
+            insta::with_settings!({
+                filters => vec![
+                    // The exact message is host language dependent
+                    (r"Caused by: .* \(os error 3\)", "Caused by: The system cannot find the path specified. (os error 3)")
+                ]
+            }, {
+                assert_display_snapshot!(
+                    format_err(result), @r###"
+        failed to canonicalize path `C:\does\not\exists\python3.12`
+          Caused by: The system cannot find the path specified. (os error 3)
+        "###);
+            });
+        }
+    }
 }
 
+#[cfg(unix)]
 #[cfg(test)]
 mod tests {
-    use std::fmt::Debug;
-
     use insta::assert_display_snapshot;
     #[cfg(unix)]
     use insta::assert_snapshot;
     use itertools::Itertools;
+
     use platform_host::Platform;
     use uv_cache::Cache;
 
     use crate::python_query::find_requested_python;
     use crate::Error;
 
-    fn format_err<T: Debug>(err: Result<T, Error>) -> String {
+    fn format_err<T: std::fmt::Debug>(err: Result<T, Error>) -> String {
         anyhow::Error::new(err.unwrap_err())
             .chain()
             .join("\n  Caused by: ")
     }
 
     #[test]
-    #[cfg(unix)]
     fn no_such_python_version() {
         let request = "3.1000";
         let result = find_requested_python(
@@ -284,7 +470,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(unix)]
     fn no_such_python_binary() {
         let request = "python3.1000";
         let result = find_requested_python(
@@ -300,7 +485,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
     #[test]
     fn no_such_python_path() {
         let result = find_requested_python(
@@ -313,27 +497,5 @@ mod tests {
         failed to canonicalize path `/does/not/exists/python3.12`
           Caused by: No such file or directory (os error 2)
         "###);
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn no_such_python_path() {
-        let result = find_requested_python(
-            r"C:\does\not\exists\python3.12",
-            &Platform::current().unwrap(),
-            &Cache::temp().unwrap(),
-        );
-        insta::with_settings!({
-            filters => vec![
-                // The exact message is host language dependent
-                (r"Caused by: .* \(os error 3\)", "Caused by: The system cannot find the path specified. (os error 3)")
-            ]
-        }, {
-            assert_display_snapshot!(
-                format_err(result), @r###"
-        failed to canonicalize path `C:\does\not\exists\python3.12`
-          Caused by: The system cannot find the path specified. (os error 3)
-        "###);
-        });
     }
 }

--- a/crates/uv-interpreter/src/virtual_env.rs
+++ b/crates/uv-interpreter/src/virtual_env.rs
@@ -30,6 +30,13 @@ impl Virtualenv {
         let executable = platform.venv_python(&venv);
         let interpreter = Interpreter::query(&executable, &platform.0, cache)?;
 
+        debug_assert!(
+            interpreter.base_prefix == interpreter.base_exec_prefix,
+            "Not a virtualenv (Python: {}, prefix: {})",
+            executable.display(),
+            interpreter.base_prefix.display()
+        );
+
         Ok(Self {
             root: venv,
             interpreter,

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -116,8 +116,8 @@ impl TestContext {
         self.assert_command(
             format!("import {package} as package; print(package.__version__, end='')").as_str(),
         )
-            .success()
-            .stdout(version);
+        .success()
+        .stdout(version);
     }
 
     /// Generate an escaped regex pattern for the given path.
@@ -136,9 +136,9 @@ impl TestContext {
                         .display()
                         .to_string(),
                 )
-                    // Make seprators platform agnostic because on Windows we will display
-                    // paths with Unix-style separators sometimes
-                    .replace(r"\\", r"(\\|\/)")
+                // Make seprators platform agnostic because on Windows we will display
+                // paths with Unix-style separators sometimes
+                .replace(r"\\", r"(\\|\/)")
             ),
             // Include a non-canonicalized version
             format!(
@@ -293,7 +293,7 @@ pub fn create_bin_with_executables(
             &Platform::current().unwrap(),
             &Cache::temp().unwrap(),
         )?
-            .ok_or(uv_interpreter::Error::NoSuchPython(request.to_string()))?;
+        .ok_or(uv_interpreter::Error::NoSuchPython(request.to_string()))?;
         let name = interpreter
             .sys_executable()
             .file_name()

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -271,7 +271,7 @@ fn create_venv_unknown_python_minor() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-          × No Python 3.15 found through `py --list-paths`. Is Python 3.15 installed?
+          × No Python 3.15 In `PATH`. Is Python 3.15 installed?
         "###
         );
     } else {

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -271,7 +271,7 @@ fn create_venv_unknown_python_minor() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-          × No Python 3.15 In `PATH`. Is Python 3.15 installed?
+          × No Python 3.15 found through `py --list-paths` or in `PATH`. Is Python 3.15 installed?
         "###
         );
     } else {
@@ -303,6 +303,10 @@ fn create_venv_unknown_python_patch() -> Result<()> {
         (
             r"Using Python 3\.\d+\.\d+ interpreter at .+",
             "Using Python [VERSION] interpreter at [PATH]",
+        ),
+        (
+            r"No Python 3\.8\.0 found through `py --list-paths` or in `PATH`\. Is Python 3\.8\.0 installed\?",
+            "No Python 3.8.0 In `PATH`. Is Python 3.8.0 installed?",
         ),
         (&filter_venv, "/home/ferris/project/.venv"),
     ];


### PR DESCRIPTION
## Summary

This PR improves uv's compatibility with PIP when discovering python installations. 

PIP runs the following step
* if `-p` is a path, resolve that specific instance
* test if the current python version `sys.executable` matches the requested version (or if no version was requested, always use it)
* (windows): Use PEP514 to resolve the python version
* Iterate over the paths and for each path test for `python{major}.{minor}.{patch}`, `python{major}.{minor}`, `python{major}`, `python`

Our existing implementation already did some of that but not all. We now

* search for executables that match the requested version name: `python3.9` `python3.9.3` for Windows and Unix
* Search the path on windows (rather than just relying on `py`)
* Support `pyenv` shims (that's a hack)
* Filter out the windows store python shim.

I merged most of the implementation between windows and unix because they are the same in `venv` too. The only real difference is that Windows must support `py` (PEP514) and shims are awkward.

Fixes https://github.com/astral-sh/uv/issues/1310
Fixes https://github.com/astral-sh/uv/issues/1660
Fixes https://github.com/astral-sh/uv/issues/1168

## Test Plan

* Verified that running `uv venv` on Windows with no Python installed but the Windows shims activate fails with an error that Python wasn't found rather than invoking the shim
* Verified that running `uv venv` with a local pyenv environment activate selects that Python version (because it is the first in the path)
* If there's a `python.exe` on path and the `python.bat` shim, then the installation takes the `python.exe` (avoid indirection) except if the `python.exe` doesn't satisfy the requested version. 
* Verified on MacOs that `uv venv` picks up the different python versions (including pyenv)

<!-- How was it tested? -->
