### PR TITLE
is_http_range_requests_unsupported should return true on Method Not Allowed

### DIFF
--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -166,6 +166,16 @@ impl ErrorKind {
                 return true;
             }
 
+            // The server returned a "Method Not Allowed" error, indicating it doesn't support
+            // HEAD requests, so we can't check for range requests.
+            ErrorKind::RequestError(err) => {
+                if let Some(status) = err.status() {
+                    if status == reqwest::StatusCode::METHOD_NOT_ALLOWED {
+                        return true;
+                    }
+                }
+            }
+
             // The server doesn't support range requests, but we only discovered this while
             // unzipping due to erroneous server behavior.
             ErrorKind::Zip(_, ZipError::UpstreamReadError(err)) => {


### PR DESCRIPTION
## Summary

Azure Artifacts does not allow HEAD requests when attempting to download packages. This expands error handling in `is_http_range_requests_unsupported` to identify HTTP 405 (Method Not Allowed) error codes, and return `true` (i.e. Range requests will not be supported). This partially addresses #1458 – after this change, Azure Artifacts downloads still fail, but due to 401 Not Authorized instead of 405 Method Not Allowed.

## Test Plan

I ran something akin to

```
RUST_LOG=trace cargo run -- pip install --index-url=https://REDACTED:REDACTED@pkgs.dev.azure.com/REDACTED/_packaging/REDACTED/pypi/simple/ --upgrade --verbose private-package
```

without this code, and got a 405 failure:

```
error: Failed to download: private-package==1.2.3
  Caused by: HTTP status client error (405 Method Not Allowed) for url (https://pkgs.dev.azure.com/REDACTED/_packaging/REDACTED/pypi/download/private-package/1.2.3/private_package-1.2.3-py3-none-any.whl#sha256=REDACTED)
  ```

with this code, I get a 401 failure:

```
error: Failed to download: private-package==1.2.3
  Caused by: HTTP status client error (401 Unauthorized) for url (https://pkgs.dev.azure.com/REDACTED/_packaging/REDACTED/pypi/download/private-package/1.2.3/private_package-1.2.3-py3-none-any.whl#sha256=REDACTED)
```

## Caveats

I'm not seeing a non HEAD request being reported as being fired, so I'm not sure I'm doing this correctly!