### PR TITLE
Retain passwords in Git URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,6 +4163,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
+ "base64 0.21.7",
  "chrono",
  "clap",
  "clap_complete_command",

--- a/crates/cache-key/src/canonical_url.rs
+++ b/crates/cache-key/src/canonical_url.rs
@@ -117,15 +117,6 @@ impl RepositoryUrl {
             }
         }
 
-        // If using HTTPS, treat a username as a PAT
-        if url.scheme().starts_with("https")
-            && immutable_url.password().is_none()
-            && !immutable_url.username().is_empty()
-        {
-            url.set_password(Some(immutable_url.username())).unwrap();
-            url.set_username("").unwrap();
-        }
-
         // Drop any fragments and query parameters.
         url.set_fragment(None);
         url.set_query(None);

--- a/crates/cache-key/src/canonical_url.rs
+++ b/crates/cache-key/src/canonical_url.rs
@@ -107,13 +107,14 @@ impl RepositoryUrl {
     pub fn new(url: &Url) -> RepositoryUrl {
         let mut url = CanonicalUrl::new(url).0;
 
-        // Clone to avoid borrow checker issues
-        let immutable_url = url.clone();
-
         // If a Git URL ends in a reference (like a branch, tag, or commit), remove it.
         if url.scheme().starts_with("git+") {
-            if let Some((prefix, _)) = immutable_url.path().rsplit_once('@') {
-                url.set_path(prefix);
+            if let Some(prefix) = url
+                .path()
+                .rsplit_once('@')
+                .map(|(prefix, _suffix)| prefix.to_string())
+            {
+                url.set_path(&prefix);
             }
         }
 

--- a/crates/cache-key/src/canonical_url.rs
+++ b/crates/cache-key/src/canonical_url.rs
@@ -109,8 +109,8 @@ impl RepositoryUrl {
 
         // If a Git URL ends in a reference (like a branch, tag, or commit), remove it.
         if url.scheme().starts_with("git+") {
-            if let Some((prefix, _)) = url.as_str().rsplit_once('@') {
-                url = prefix.parse().unwrap();
+            if let Some((prefix, _)) = url.clone().path().rsplit_once('@') {
+                url.set_path(prefix);
             }
         }
 

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -65,9 +65,9 @@ impl TryFrom<Url> for GitUrl {
         // If the URL ends with a reference, like `https://git.example.com/MyProject.git@v1.0`,
         // extract it.
         let mut reference = GitReference::DefaultBranch;
-        if let Some((prefix, rev)) = url.as_str().rsplit_once('@') {
+        if let Some((prefix, rev)) = url.clone().path().rsplit_once('@') {
             reference = GitReference::from_rev(rev);
-            url = Url::parse(prefix)?;
+            url.set_path(prefix);
         }
         let precise = if let GitReference::FullCommit(rev) = &reference {
             Some(GitSha::from_str(rev)?)

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -62,15 +62,16 @@ impl TryFrom<Url> for GitUrl {
         url.set_fragment(None);
         url.set_query(None);
 
-        // Clone to avoid borrow checker issues
-        let immutable_url = url.clone();
-
         // If the URL ends with a reference, like `https://git.example.com/MyProject.git@v1.0`,
         // extract it.
         let mut reference = GitReference::DefaultBranch;
-        if let Some((prefix, rev)) = immutable_url.path().rsplit_once('@') {
-            reference = GitReference::from_rev(rev);
-            url.set_path(prefix);
+        if let Some((prefix, suffix)) = url
+            .path()
+            .rsplit_once('@')
+            .map(|(prefix, suffix)| (prefix.to_string(), suffix.to_string()))
+        {
+            reference = GitReference::from_rev(&suffix);
+            url.set_path(&prefix);
         }
 
         let precise = if let GitReference::FullCommit(rev) = &reference {

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -73,15 +73,6 @@ impl TryFrom<Url> for GitUrl {
             url.set_path(prefix);
         }
 
-        // If using HTTPS, treat a username as a PAT
-        if url.scheme().starts_with("https")
-            && immutable_url.password().is_none()
-            && !immutable_url.username().is_empty()
-        {
-            url.set_password(Some(immutable_url.username())).unwrap();
-            url.set_username("").unwrap();
-        }
-
         let precise = if let GitReference::FullCommit(rev) = &reference {
             Some(GitSha::from_str(rev)?)
         } else {

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -39,6 +39,7 @@ requirements-txt = { path = "../requirements-txt" }
 
 anstream = { workspace = true }
 anyhow = { workspace = true }
+base64 = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 clap_complete_command = { workspace = true }

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -87,6 +87,15 @@ impl TestContext {
             .current_dir(&self.temp_dir)
             .assert()
     }
+
+    /// Assert a package is installed with the given version.
+    pub fn assert_installed(&self, package: &'static str, version: &'static str) {
+        self.assert_command(
+            format!("import {package} as package; print(package.__version__, end='')").as_str(),
+        )
+        .success()
+        .stdout(version);
+    }
 }
 
 pub fn venv_to_interpreter(venv: &Path) -> PathBuf {

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -732,7 +732,7 @@ fn install_git_public_https() {
 
 /// Install a package from a private GitHub repository using a PAT
 #[test]
-fn install_git_private_https_pat() {
+fn install_git_private_https_pat_no_username() {
     let context = TestContext::new("3.8");
 
     // This is a fine-grained token that only has read-only access to the `uv-private-pypackage` repository
@@ -750,6 +750,35 @@ fn install_git_private_https_pat() {
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
      + uv-private-pypackage==0.1.0 (from git+https://:github_pat_[SIZE]GIZA7Q0qxQCNd[SIZE]VVCf_8ZeenAddxUYnR82xy7geDJo5DsazrjdVjfh3TH[TIME]nE3IXVTWKSJ9DInbt@github.com/astral-test/uv-private-pypackage@c44e30b5d3e49dab7dbbe543a331fbf0e4dc3b37)
+    "###);
+
+    context.assert_installed("uv_private_pypackage", "0.1.0");
+}
+
+/// Install a package from a private GitHub repository using a PAT
+#[test]
+fn install_git_private_https_pat() {
+    let context = TestContext::new("3.8");
+
+    // This is a fine-grained token that only has read-only access to the `uv-private-pypackage` repository
+    let token = "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";
+    let user = "astral-test-bot";
+
+    uv_snapshot!(command(&context)
+        .arg(format!("uv-private-pypackage @ git+https://{user}:{token}@github.com/astral-test/uv-private-pypackage"))
+        , @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to download and build: uv-private-pypackage @ git+https://astral-test-bot:github_pat_[SIZE]GIZA7Q0qxQCNd[SIZE]VVCf_8ZeenAddxUYnR82xy7geDJo5DsazrjdVjfh3TH[TIME]nE3IXVTWKSJ9DInbt@github.com/astral-test/uv-private-pypackage
+      Caused by: Git operation failed
+      Caused by: failed to clone into: /private/var/folders/bc/qlsk3t6x7c9fhhbvvcg68k9c0000gp/T/.tmpijslxX/git-v0/db/732d1383ce6d692d
+      Caused by: failed to authenticate when downloading repository
+
+    * attempted to find username/password via git's `credential.helper` support, but failed
+      Caused by: failed to acquire username/password from local configuration
     "###);
 
     context.assert_installed("uv_private_pypackage", "0.1.0");

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -735,7 +735,7 @@ fn install_git_public_https() {
     Resolved 1 package in [TIME]
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
-     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@395ba191b190da0451c1e67a9b4a1cb5340398e5)
+     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
     "###);
 
     context.assert_installed("uv_public_pypackage", "0.1.0");
@@ -761,7 +761,7 @@ fn install_git_private_https_pat() {
     Resolved 1 package in [TIME]
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
-     + uv-private-pypackage==0.1.0 (from git+https://:***@github.com/astral-test/uv-private-pypackage@c44e30b5d3e49dab7dbbe543a331fbf0e4dc3b37)
+     + uv-private-pypackage==0.1.0 (from git+https://:***@github.com/astral-test/uv-private-pypackage@6c09ce9ae81f50670a60abd7d95f30dd416d00ac)
     "###);
 
     context.assert_installed("uv_private_pypackage", "0.1.0");

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -721,6 +721,7 @@ fn install_no_index_version() {
 
 /// Install a package from a public GitHub repository
 #[test]
+#[cfg(feature = "git")]
 fn install_git_public_https() {
     let context = TestContext::new("3.8");
 
@@ -743,6 +744,7 @@ fn install_git_public_https() {
 
 /// Install a package from a private GitHub repository using a PAT
 #[test]
+#[cfg(feature = "git")]
 fn install_git_private_https_pat() {
     let context = TestContext::new("3.8");
     let token = decode_token(READ_ONLY_GITHUB_TOKEN);
@@ -769,6 +771,7 @@ fn install_git_private_https_pat() {
 
 /// Install a package from a private GitHub repository using a PAT
 #[test]
+#[cfg(feature = "git")]
 fn install_git_private_https_pat_and_username() {
     let context = TestContext::new("3.8");
     let token = decode_token(READ_ONLY_GITHUB_TOKEN);

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -708,6 +708,53 @@ fn install_no_index_version() {
     context.assert_command("import flask").failure();
 }
 
+/// Install a package from a public GitHub repository
+#[test]
+fn install_git_public_https() {
+    let context = TestContext::new("3.8");
+
+    uv_snapshot!(command(&context)
+        .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage")
+        , @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Downloaded 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@395ba191b190da0451c1e67a9b4a1cb5340398e5)
+    "###);
+
+    context.assert_installed("uv_public_pypackage", "0.1.0");
+}
+
+/// Install a package from a private GitHub repository using a PAT
+#[test]
+fn install_git_private_https_pat() {
+    let context = TestContext::new("3.8");
+
+    // This is a fine-grained token that only has read-only access to the `uv-private-pypackage` repository
+    let token = "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";
+
+    uv_snapshot!(command(&context)
+        .arg(format!("uv-private-pypackage @ git+https://{token}@github.com/astral-test/uv-private-pypackage"))
+        , @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Downloaded 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv-private-pypackage==0.1.0 (from git+https://github_pat_[SIZE]GIZA7Q0qxQCNd[SIZE]VVCf_8ZeenAddxUYnR82xy7geDJo5DsazrjdVjfh3TH[TIME]nE3IXVTWKSJ9DInbt@github.com/astral-test/uv-private-pypackage@c44e30b5d3e49dab7dbbe543a331fbf0e4dc3b37)
+    "###);
+
+    context.assert_installed("uv_private_pypackage", "0.1.0");
+}
+
 /// Install a package without using pre-built wheels.
 #[test]
 fn reinstall_no_binary() {

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -749,7 +749,7 @@ fn install_git_private_https_pat() {
     Resolved 1 package in [TIME]
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
-     + uv-private-pypackage==0.1.0 (from git+https://github_pat_[SIZE]GIZA7Q0qxQCNd[SIZE]VVCf_8ZeenAddxUYnR82xy7geDJo5DsazrjdVjfh3TH[TIME]nE3IXVTWKSJ9DInbt@github.com/astral-test/uv-private-pypackage@c44e30b5d3e49dab7dbbe543a331fbf0e4dc3b37)
+     + uv-private-pypackage==0.1.0 (from git+https://:github_pat_[SIZE]GIZA7Q0qxQCNd[SIZE]VVCf_8ZeenAddxUYnR82xy7geDJo5DsazrjdVjfh3TH[TIME]nE3IXVTWKSJ9DInbt@github.com/astral-test/uv-private-pypackage@c44e30b5d3e49dab7dbbe543a331fbf0e4dc3b37)
     "###);
 
     context.assert_installed("uv_private_pypackage", "0.1.0");

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -23,7 +23,8 @@ const READ_ONLY_GITHUB_TOKEN: &[&str] = &[
     "NVZMaExzZmtFMHZ1ZEVNd0pPZXZkV040WUdTcmk2WXREeFB4TFlybGlwRTZONEpHV01FMnFZQWJVUm4=",
 ];
 
-/// Decode a
+/// Decode a split, base64 encoded authentication token.
+/// We split and encode the token to bypass revoke by GitHub's secret scanning
 fn decode_token(content: &[&str]) -> String {
     let token = content
         .iter()

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -778,7 +778,35 @@ fn install_git_private_https_pat() {
     context.assert_installed("uv_private_pypackage", "0.1.0");
 }
 
-/// Install a package from a private GitHub repository using a PAT
+/// Install a package from a private GitHub repository at a specific commit using a PAT
+#[test]
+#[cfg(feature = "git")]
+fn install_git_private_https_pat_at_ref() {
+    let context = TestContext::new("3.8");
+    let token = decode_token(READ_ONLY_GITHUB_TOKEN);
+
+    let mut filters = INSTA_FILTERS.to_vec();
+    filters.insert(0, (&token, "***"));
+
+    uv_snapshot!(filters, command(&context)
+        .arg(format!("uv-private-pypackage @ git+https://{token}@github.com/astral-test/uv-private-pypackage@6c09ce9ae81f50670a60abd7d95f30dd416d00ac"))
+        , @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Downloaded 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv-private-pypackage==0.1.0 (from git+https://***@github.com/astral-test/uv-private-pypackage@6c09ce9ae81f50670a60abd7d95f30dd416d00ac)
+    "###);
+
+    context.assert_installed("uv_private_pypackage", "0.1.0");
+}
+
+/// Install a package from a private GitHub repository using a PAT and username
+/// An arbitrary username is supported when using a PAT.
 #[test]
 #[cfg(feature = "git")]
 fn install_git_private_https_pat_and_username() {


### PR DESCRIPTION
Fixes handling of GitHub PATs in HTTPS URLs, which were otherwise dropped. We now supporting the following authentication schemes:

```
git+https://<user>:<token>/...
git+https://<token>/...
```

On Windows, the username is required. We can consider adding a special-case for this in the future, but this just matches libgit2's behavior.

I tested with fine-grained tokens, OAuth tokens, and "classic" tokens. There's test coverage for fine-grained tokens in CI where we use a real private repository and PAT. Yes, the PAT is committed to make this test usable by anyone. It has read-only permissions to the single repository, expires Feb 1 2025, and is in an isolated organization and GitHub account.

Does not yet address SSH authentication (see #1781)

Related:
- https://github.com/astral-sh/uv/issues/1514
- https://github.com/astral-sh/uv/issues/1452