### PR TITLE
Preserve trailing slash for `--find-links` URLs

### DIFF
--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -153,8 +153,9 @@ impl<'a> FlatIndexClient<'a> {
             .map_err(ErrorKind::RequestError)?;
         let parse_simple_response = |response: Response| {
             async {
+                let url = response.url().clone();
                 let text = response.text().await.map_err(ErrorKind::RequestError)?;
-                let SimpleHtml { base, files } = SimpleHtml::parse(&text, url)
+                let SimpleHtml { base, files } = SimpleHtml::parse(&text, &url)
                     .map_err(|err| Error::from_html_err(err, url.clone()))?;
 
                 let files: Vec<File> = files
@@ -163,7 +164,7 @@ impl<'a> FlatIndexClient<'a> {
                         match File::try_from(file, base.as_url().as_str()) {
                             Ok(file) => Some(file),
                             Err(err) => {
-                                // Ignore files with unparsable version specifiers.
+                                // Ignore files with unparseable version specifiers.
                                 warn!("Skipping file in {url}: {err}");
                                 None
                             }


### PR DESCRIPTION
## Summary

We should allow a `--find-links` URL to be provided as _either_ (e.g.) `https://wheelhouse.acsone.eu/manylinux1` or `https://wheelhouse.acsone.eu/manylinux1/`. By using the response URL, we can "always do the right thing" (it will always have a trailing slash, or always return a `.html` suffix) rather than attempting to sniff out the URL kind in advance.

Closes https://github.com/astral-sh/uv/issues/1683.

## Test Plan

- `cargo run pip install requests --force-reinstall --no-index --find-links https://wheelhouse.acsone.eu/manylinux1 -n`
- `cargo run pip install requests --force-reinstall --no-index --find-links https://wheelhouse.acsone.eu/manylinux1/ -n`
