### PR TITLE
Move `uv clean` to `uv cache clean`

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ If you're running into caching issues, uv includes a few escape hatches:
 - To force uv to revalidate cached data for all dependencies, run `uv pip install --refresh ...`.
 - To force uv to revalidate cached data for a specific dependency, run, e.g., `uv pip install --refresh-package flask ...`.
 - To force uv to ignore existing installed versions, run `uv pip install --reinstall ...`.
-- To clear the global cache entirely, run `uv clean`.
+- To clear the global cache entirely, run `uv cache clean`.
 
 ### Resolution strategy
 


### PR DESCRIPTION
## Summary

This opens up space to add other cache-related commands. (`uv clean` continues to work for backwards compatibility but is hidden from the CLI.)
