### PR TITLE
Fix typos configuration

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,12 +1,17 @@
 [files]
 extend-exclude = [
-    "**/resources/**/*",
-    "**/snapshots/**/*",
+    "**/snapshots/",
     "scripts/**/*.in",
 ]
+ignore-hidden = false
 
-[default.extend-words]
-BA = "BA" # acronym for "Bad Allowed", used in testing.
-Nd = "Nd" # secret codeword used by friendly bards
-borken = "borken" # the word is borken :(
+[default]
+extend-ignore-re = [
+    "FRiENDlY-\\.\\.\\.-_-BARd",
+    "FrIeNdLy-\\._\\.-bArD",
+    "I borken you cache",
+    "eb1ba5f5",
+]
+
+[default.extend-identifiers]
 seeked = "seeked" # special term used for streams

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -164,7 +164,7 @@ impl<'a> FlatIndexClient<'a> {
                         match File::try_from(file, base.as_url().as_str()) {
                             Ok(file) => Some(file),
                             Err(err) => {
-                                // Ignore files with unparseable version specifiers.
+                                // Ignore files with unparsable version specifiers.
                                 warn!("Skipping file in {url}: {err}");
                                 None
                             }

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -486,7 +486,7 @@ fn dependency_excludes_range_of_compatible_versions() {
 /// There is a non-contiguous range of compatible versions for the requested package
 /// `a`, but another dependency `c` excludes the range. This is the same as
 /// `dependency-excludes-range-of-compatible-versions` but some of the versions of
-/// `a` are incompatible for another reason e.g. dependency on non-existant package
+/// `a` are incompatible for another reason e.g. dependency on non-existent package
 /// `d`.
 ///
 /// ```text


### PR DESCRIPTION
## Summary

Narrow down excludes for `typos` and fix 2 additional misspellings.

BTW pre-commit can be run in CI: https://github.com/szepeviktor/pre-commit-on-you/actions/runs/7971275239/job/21760614908