### PR TITLE
Set read and write permissions for extracted files

### DIFF
--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -75,7 +75,10 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
             let path = target.as_ref().join(path);
 
             if let Some(mode) = entry.unix_permissions() {
-                fs_err::set_permissions(&path, Permissions::from_mode(mode))?;
+                // Create a file with read and write permissions.
+                // Otherwise, databricks-0.2.dist-info/RECORD in databricks-0.2-py2.py3-none-any.whl has 000 permissions.
+                let permissions = Permissions::from_mode(mode | 0o660);
+                fs_err::set_permissions(&path, permissions)?;
             }
         }
     }

--- a/crates/uv-extract/src/sync.rs
+++ b/crates/uv-extract/src/sync.rs
@@ -57,6 +57,8 @@ pub fn unzip<R: Send + std::io::Read + std::io::Seek + HasLength>(
                 if let Some(mode) = file.unix_mode() {
                     options.mode(mode);
                 }
+                // Create a file with read and write permissions.
+                options.read(true).write(true);
             }
 
             // Copy the file contents.

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -2709,3 +2709,26 @@ fn conflicting_requirement() -> Result<()> {
 
     Ok(())
 }
+
+/// Avoid creating a file with 000 permissions
+#[test]
+fn set_read_permissions() -> Result<()> {
+    let context = TestContext::new("3.12");
+    let requirements_in = context.temp_dir.child("requirements.in");
+    requirements_in.write_str("databricks==0.2")?;
+
+    uv_snapshot!(command(&context)
+        .arg("requirements.in"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Downloaded 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + databricks==0.2
+    "###);
+
+    Ok(())
+}


### PR DESCRIPTION
A file in a wheel/zip can have 000 permissions on unix. We have to set the permissions to at least read and write.

Fixes #1740.