### PR TITLE
Don't preserve timestamp in streaming unzip

### DIFF
--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -92,7 +92,6 @@ pub async fn untar<R: tokio::io::AsyncBufRead + Unpin>(
 ) -> Result<(), Error> {
     let decompressed_bytes = async_compression::tokio::bufread::GzipDecoder::new(reader);
     let mut archive = tokio_tar::ArchiveBuilder::new(decompressed_bytes)
-        .set_preserve_permissions(false)
         .set_preserve_mtime(false)
         .build();
     Ok(archive.unpack(target.as_ref()).await?)

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -93,6 +93,7 @@ pub async fn untar<R: tokio::io::AsyncBufRead + Unpin>(
     let decompressed_bytes = async_compression::tokio::bufread::GzipDecoder::new(reader);
     let mut archive = tokio_tar::ArchiveBuilder::new(decompressed_bytes)
         .set_preserve_permissions(false)
+        .set_preserve_mtime(false)
         .build();
     Ok(archive.unpack(target.as_ref()).await?)
 }


### PR DESCRIPTION
## Summary

Don't preserve mtime to work around alexcrichton/tar-rs#349. Same as #634 except for the streaming unzip.

Fixes #1748.

## Test Plan

Added the tomli source dist as test case.
