### PR TITLE
Set index URLs for seeding venv

### DIFF
--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -128,6 +128,7 @@ async fn venv_impl(
 
         // Instantiate a client.
         let client = RegistryClientBuilder::new(cache.clone())
+            .index_urls(index_locations.index_urls())
             .connectivity(connectivity)
             .build();
 


### PR DESCRIPTION
Just an oversight due to builder pattern.

Closes https://github.com/astral-sh/uv/issues/1752.