### PR TITLE
fix 'pip install' for zips with bunk permissions

### DIFF
--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -142,6 +142,15 @@ pub enum ErrorKind {
 }
 
 impl ErrorKind {
+    /// Returns true if this error kind corresponds to an I/O "not found"
+    /// error.
+    pub(crate) fn is_file_not_exists(&self) -> bool {
+        let ErrorKind::Io(ref err) = *self else {
+            return false;
+        };
+        matches!(err.kind(), std::io::ErrorKind::NotFound)
+    }
+
     pub(crate) fn from_middleware(err: reqwest_middleware::Error) -> Self {
         if let reqwest_middleware::Error::Middleware(ref underlying) = err {
             if let Some(err) = underlying.downcast_ref::<OfflineError>() {

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -14,6 +14,7 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
 ) -> Result<(), Error> {
+    let target = target.as_ref();
     let mut reader = reader.compat();
     let mut zip = async_zip::base::read::stream::ZipFileReader::new(&mut reader);
 
@@ -22,7 +23,7 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
     while let Some(mut entry) = zip.next_with_entry().await? {
         // Construct the (expected) path to the file on-disk.
         let path = entry.reader().entry().filename().as_str()?;
-        let path = target.as_ref().join(path);
+        let path = target.join(path);
         let is_dir = entry.reader().entry().dir()?;
 
         // Either create the directory or write the file to disk.
@@ -81,7 +82,7 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
             if has_any_executable_bit != 0 {
                 // Construct the (expected) path to the file on-disk.
                 let path = entry.filename().as_str()?;
-                let path = target.as_ref().join(path);
+                let path = target.join(path);
 
                 let permissions = fs_err::tokio::metadata(&path).await?.permissions();
                 fs_err::tokio::set_permissions(

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1219,3 +1219,39 @@ fn install_sdist_resolution_lowest() -> Result<()> {
 
     Ok(())
 }
+
+/// Tests that we can install a package from a zip file that has bunk
+/// permissions.
+///
+/// See: <https://github.com/astral-sh/uv/issues/1453>
+#[test]
+fn direct_url_zip_file_bunk_permissions() -> Result<()> {
+    let context = TestContext::new("3.12");
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str(
+        "opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v2023.11.06.145820.zip",
+    )?;
+
+    uv_snapshot!(command(&context)
+        .arg("-r")
+        .arg("requirements.txt")
+        .arg("--strict"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    Downloaded 5 packages in [TIME]
+    Installed 6 packages in [TIME]
+     + distro==1.8.0
+     + opensafely-pipeline==2023.11.6.145820 (from https://github.com/opensafely-core/pipeline/archive/refs/tags/v2023.11.06.145820.zip)
+     + pydantic==1.10.13
+     + ruyaml==0.91.0
+     + setuptools==68.2.2
+     + typing-extensions==4.8.0
+    "###
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This fixes an issue where installing a source dist from a `zip` file could
fail if the permissions in the `zip` file were bunk. Namely, after extracting
a `zip` file, we go through each record and set the permissions on each file
based on the permissions recorded in the `zip` file. But apparently, those
permissions are sometimes present but `0`, which in turn caused us to set the
permissions to `0` on files and thus prevent our access to them.

We fix this by treating "absent permissions" and "permissions of mode 0" as the
same thing.

Fixes #1453
