### PR TITLE
Add musl to python bootstrapping script

### DIFF
--- a/scripts/bootstrap/install.py
+++ b/scripts/bootstrap/install.py
@@ -33,6 +33,7 @@ import json
 import platform
 import shutil
 import sys
+import sysconfig
 import tarfile
 import tempfile
 import urllib.parse
@@ -98,7 +99,11 @@ if INSTALL_DIR.exists():
 
 # Install each version
 for version in versions:
-    key = f"{INTERPRETER}-{version}-{PLATFORM_MAP.get(PLATFORM, PLATFORM)}-{ARCH_MAP.get(ARCH, ARCH)}"
+    if platform.system() == "Linux":
+        libc = sysconfig.get_config_var("SOABI").split("-")[-1]
+    else:
+        libc = "none"
+    key = f"{INTERPRETER}-{version}-{PLATFORM_MAP.get(PLATFORM, PLATFORM)}-{ARCH_MAP.get(ARCH, ARCH)}-{libc}"
     install_dir = INSTALL_DIR / f"{INTERPRETER}@{version}"
     print(f"Installing {key}")
 

--- a/scripts/bootstrap/versions.json
+++ b/scripts/bootstrap/versions.json
@@ -1,4648 +1,6675 @@
 {
-  "cpython-3.12.1-darwin-arm64": {
+  "cpython-3.12.1-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "61e51e3490537b800fcefad718157cf775de41044e95aa538b63ab599f66f3a9"
   },
-  "cpython-3.12.1-linux-arm64": {
+  "cpython-3.12.1-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "3621be2cd8b5686e10a022f04869911cad9197a3ef77b30879fe25e792d7c249"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9009da24f436611d0bf086b8ea62aaed1c27104af5b770ddcfc92b60db06da8c"
   },
-  "cpython-3.12.1-windows-i686": {
+  "cpython-3.12.1-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "22866d35fdf58e90e75d6ba9aa78c288b452ea7041fa9bc5549eca9daa431883"
   },
-  "cpython-3.12.1-linux-ppc64le": {
+  "cpython-3.12.1-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "a94a35ecf61e9e4e9b9b64dcf1540371f35dbb3ca004018119091ca460cfffba"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b61686ce05c58c913e4fdb7e7c7105ed36d9bcdcd1a841e7f08b243f40d5cf77"
   },
-  "cpython-3.12.1-linux-s390x": {
+  "cpython-3.12.1-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-s390x-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "48aee32710363fffcad3a6fbe6461692a8b9ea23472e18fe030cca92506fff21"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "505a4fbace661a43b354a059022eb31efb406859a5f7227109ebf0f278f20503"
   },
-  "cpython-3.12.1-darwin-x86_64": {
+  "cpython-3.12.1-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "bf2b176b0426d7b4d4909c1b19bbb25b4893f9ebdc61e32df144df2b10dcc800"
   },
-  "cpython-3.12.1-linux-x86_64": {
+  "cpython-3.12.1-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "f267489a041daf4e523c03d32639de04ee59ca925dff49a8c3ce2f28a9f70a3b"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "89ef67b617b8c9804965509b2d256f53439ceede83b5b64085315f038ad81e60"
   },
-  "cpython-3.12.1-windows-x86_64": {
+  "cpython-3.12.1-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "c4b07a02d8f0986b56e010a67132e5eeba1def4991c6c06ed184f831a484a06f"
+  },
+  "cpython-3.12.1-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "d9bc1b566250bf51818976bf98bf50e1f4c59b2503b50d29250cac5ab5ef6b38"
   },
-  "cpython-3.12.1-linux-x86_64_v2": {
+  "cpython-3.12.1-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "1014f577276f4088748be20ce1c2aead66e43c83b62d19c60ab96d8c04bfbbdf"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "21a5182c499954bde10344c7cc3ba9f69a39f0b485a9420871bdf65f26587bb7"
   },
-  "cpython-3.12.1-linux-x86_64_v3": {
+  "cpython-3.12.1-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "47a85a6f99be6ec1746e25a5002a1b942d26036b78f32f6c26ff1285196b2411"
+  },
+  "cpython-3.12.1-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "9859793c937d495431f2a94a2724eab326617db18cf81f33ef1b6be67485bb4c"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d2088f53a3e160973ec34376c5a8bc4f430626ea154a57a8ae868f37b43320f3"
   },
-  "cpython-3.12.1-linux-x86_64_v4": {
+  "cpython-3.12.1-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "24f76157c615f2cf6a92437290f711b27cd5b29bcea4f17b50ee83920f307e2a"
+  },
+  "cpython-3.12.1-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "77488c12ab493258df261e203627de7fe798fe0481f687bb0f1b3c336195e87d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b5c640ffdde33f3d333ed772878694c3be79caf5707de3da23aa8f77cfad4164"
   },
-  "cpython-3.12.0-darwin-arm64": {
+  "cpython-3.12.1-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "6e521b73faee3f44161db17f8cd89599c54fbf28f28de215851f9b9e7ded8b75"
+  },
+  "cpython-3.12.0-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "25fc8cd41e975d18d13bcc8f8beffa096ff8a0b86c4a737e1c6617900092c966"
   },
-  "cpython-3.12.0-linux-arm64": {
+  "cpython-3.12.0-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "86e16b6defbbd7db0b7f98879b2b381e0e5b0ec07126cb9f5fc0cafe9869dc36"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "eb05c976374a9a44596ce340ab35e5461014f30202c3cbe10edcbfbe5ac4a6a1"
   },
-  "cpython-3.12.0-windows-i686": {
+  "cpython-3.12.0-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "465e91b6e6d0d1c40c8a4bce3642c4adcb9b75cf03fbd5fd5a33a36358249289"
   },
-  "cpython-3.12.0-linux-ppc64le": {
+  "cpython-3.12.0-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "3178a7dd91ade5db6aa9023b476235f6b8224520ce0bda322131f26fd3fdb858"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "800a89873e30e24bb1b6075f8cd718964537c5ba62bcdbefdcdae4de68ddccc4"
   },
-  "cpython-3.12.0-linux-s390x": {
+  "cpython-3.12.0-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-s390x-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "aa02889eb40c9207cef648b41b6b80eb81a741a5a5f35dfa9fc2be0132b68e67"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5b1a1effbb43df57ad014fcebf4b20089e504d89613e7b8db22d9ccb9fb00a6c"
   },
-  "cpython-3.12.0-darwin-x86_64": {
+  "cpython-3.12.0-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "3b4781e7fd4efabe574ba0954e54c35c7d5ac4dc5b2990b40796c1c6aec67d79"
   },
-  "cpython-3.12.0-linux-x86_64": {
+  "cpython-3.12.0-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "5ce861907a2751a3a7395b1aaada830c2b072acc03f3dd0bcbaaa2b7a9166fc0"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a8c38cd2e53136c579632e2938d1b857f22e496c7dba99ad9a7ad6a67b43274a"
   },
-  "cpython-3.12.0-windows-x86_64": {
+  "cpython-3.12.0-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "91b42595cb4b69ff396e746dc492caf67b952a3ed1a367a4ace1acc965ed9cdb"
+  },
+  "cpython-3.12.0-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "5bdff7ed56550d96f9b26a27a8c25f0cc58a03bff19e5f52bba84366183cab8b"
   },
-  "cpython-3.12.0-linux-x86_64_v2": {
+  "cpython-3.12.0-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "d0dce9731a9de1d9cc2528e9dd6389d4cbb6ca954a637593d2952e0849d50f07"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "572f8559f0e8a086c4380ea4417d44f6f3751afd18d01e14e04099ec33e1b199"
   },
-  "cpython-3.12.0-linux-x86_64_v3": {
+  "cpython-3.12.0-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "ec028edc5fcca34b5c5988074e44d91158d924695f26ca5885c6b4a1daa6349d"
+  },
+  "cpython-3.12.0-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "e9623e1e4cc852f67d35cf79890a2f01e7380c9f0df2fa15663ed317ac2d4e69"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1ae35f54bad2b473298858a3cb7bf811291fdd40c8159eff4ff593168ed8765e"
   },
-  "cpython-3.12.0-linux-x86_64_v4": {
+  "cpython-3.12.0-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "154cc904e028f93fa5b6dfb23aa3d9241db5c210c99a8facab9425e6a5f54a31"
+  },
+  "cpython-3.12.0-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 12,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "50e9adbee814e47a919d3d21ba71d8088076dc76aab5db1439d6d89609691883"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3c900c3495453cfa7e7626026ef0d8be3adf589b2b810969f6a9f44dba3c129d"
   },
-  "cpython-3.11.7-darwin-arm64": {
+  "cpython-3.12.0-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "7f850e95a29b43dff3656e3d403d98c30049a3a90a74aac1c6763339c6d26632"
+  },
+  "cpython-3.11.7-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "c1f3dd13825906a5eae23ed8de9b653edb620568b2e0226eef3784eb1cce7eed"
   },
-  "cpython-3.11.7-linux-arm64": {
+  "cpython-3.11.7-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "e066d3fb69162e401d2bb1f3c20798fde7c2fffcba0912d792e46d569b591ab3"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e3a375f8f16198ccf8dbede231536544265e5b4b6b0f0df97c5b29503c5864e2"
   },
-  "cpython-3.11.7-windows-i686": {
+  "cpython-3.11.7-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "6613f1f9238d19969d8a2827deec84611cb772503207056cc9f0deb89bea48cd"
   },
-  "cpython-3.11.7-linux-ppc64le": {
+  "cpython-3.11.7-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "fc2e32d265a11da50d6154a65ece5161055cfd0450cdc94d69e21f021ecff38c"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "016ed6470c599ea5cc4dbb9c3f3fe86be059ad4e1b6cd2df10e40b7ec6970f16"
   },
-  "cpython-3.11.7-linux-s390x": {
+  "cpython-3.11.7-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-s390x-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "5fee1c4d7bf370f9b74896e7575b5a94b36aba3d2d9d6746db72c8d3a6e2a4c1"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "91b33369025b7e0079f603cd2a99f9a5932daa8ded113d5090f29c075c993df7"
   },
-  "cpython-3.11.7-darwin-x86_64": {
+  "cpython-3.11.7-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "3f8caf73f2bfe22efa9666974c119727e163716e88af8ed3caa1e0ae5493de61"
   },
-  "cpython-3.11.7-linux-x86_64": {
+  "cpython-3.11.7-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "b7e19b262c19dfb82107e092ba3959b2da9b8bc53aafeb86727996afdb577221"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "01bca7a2f457d4bd2b367640d9337d12b31db73d670a16500b7a751194942103"
   },
-  "cpython-3.11.7-windows-x86_64": {
+  "cpython-3.11.7-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "f387d373d64447bbba8a5657712f93b1dbdfd7246cdfe5a0493f39b83d46ec7c"
+  },
+  "cpython-3.11.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "89d1d8f080e5494ea57918fc5ecf3d483ffef943cd5a336e64da150cd44b4aa0"
   },
-  "cpython-3.11.7-linux-x86_64_v2": {
+  "cpython-3.11.7-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "20e132bb74b85d108bc1beeffa62b18bfe7abc6774b1447d18b77df5288776cb"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "24dba70107ca3999c0a2742b3bf898f740a063736f3cd208e80e056adf19cd7f"
   },
-  "cpython-3.11.7-linux-x86_64_v3": {
+  "cpython-3.11.7-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "a6c43c58ff21316242bd43efa90837f4a344e64ba4f4306c5ddc49005bfc1dd3"
+  },
+  "cpython-3.11.7-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "b44578614acb0e4f9f8778cfac094b9079b1b5330ecac3c51a7af1e1e334cd1a"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6f5246b7cb8cc36a98025c70f829d2e5d197a7d20d51f21ca44b1e4242b13f0d"
   },
-  "cpython-3.11.7-linux-x86_64_v4": {
+  "cpython-3.11.7-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "23af703408cb9a91eb2e673640576524ba616d8d1f8af079d22e67192e174400"
+  },
+  "cpython-3.11.7-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "c6ed4abf6870feb30ab741fe51dad163bc3b334369d05aa8b162f212851a3ac4"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "74e5053f3f40d4ea018d79139d8a739c0ab0d457b8a9f1597a160bd88fbd58ab"
   },
-  "cpython-3.11.6-darwin-arm64": {
+  "cpython-3.11.7-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "63d3cd05a6c9e7597d1c2ec3d02473170a4f2eb4acf5558974c639cf787a44a1"
+  },
+  "cpython-3.11.6-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "6e9007bcbbf51203e89c34a87ed42561630a35bc4eb04a565c92ba7159fe5826"
   },
-  "cpython-3.11.6-linux-arm64": {
+  "cpython-3.11.6-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "7c621a748a4fd6ae99d8ba7ec2da59173d31475838382a13df6d2b1bf95a7059"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d63d6eb065e60899b25853fe6bbd9f60ea6c3b12f4854adc75cb818bad55f4e9"
   },
-  "cpython-3.11.6-windows-i686": {
+  "cpython-3.11.6-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "2670731428191d4476bf260c8144ccf06f9e5f8ac6f2de1dc444ca96ab627082"
   },
-  "cpython-3.11.6-linux-ppc64le": {
+  "cpython-3.11.6-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "2b3fb2ea8ee2ca290c09dfbca43428b1e8f6853290a7bc99ec394091e2f4b228"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "71c34db1165860a6bf458d817aef00dea96146130bf5f8bd7ee39b12892ef463"
   },
-  "cpython-3.11.6-linux-s390x": {
+  "cpython-3.11.6-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-s390x-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "b7a95b4861caa2cd66c1e272796048711cf063fb84f1e5b4ba447dc7593718a8"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "78252aa883fed18de7bb9b146450e42dd75d78c345f56c1301bb042317a1d4f7"
   },
-  "cpython-3.11.6-darwin-x86_64": {
+  "cpython-3.11.6-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "3685156e4139e89484c071ba1a1b85be0b4e302a786de5a170d3b0713863c2e8"
   },
-  "cpython-3.11.6-linux-x86_64": {
+  "cpython-3.11.6-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "6da291720c9fe2f63c5c55f7acc8b6094a05488453a84cfcc012e92305099ee7"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6e7889a15d861f1860ed84f3f5ea4586d198aa003b22556d91e180a44184dcd7"
   },
-  "cpython-3.11.6-windows-x86_64": {
+  "cpython-3.11.6-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "1b6e32ec93c5a18a03a9da9e2a3a3738d67b733df0795edcff9fd749c33ab931"
+  },
+  "cpython-3.11.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "38d2c2fa2f9effbf486207bef7141d1b5c385ad30729ab0c976e6a852a2a9401"
   },
-  "cpython-3.11.6-linux-x86_64_v2": {
+  "cpython-3.11.6-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "029f2bcb4a87956e8d62ebd89e31079d659a877fd2814ce7ef6ae32a230d1bb0"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2ef8df0de9c400b5d57971fe5bcff36b4dca2410504a9edbd407572ea61044e0"
   },
-  "cpython-3.11.6-linux-x86_64_v3": {
+  "cpython-3.11.6-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "a626529e7ebe28755090d16d22fc3f8b85dd7d19ab9791d224336f002b9b51a5"
+  },
+  "cpython-3.11.6-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "d11a21ee082536a800c32394b076d6b72a840b0d2e70b8e076c7831a4a1d5ed4"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d96c26d88966873184fc0ee99ca7b941d274b669b1b11e185749fc065d12908f"
   },
-  "cpython-3.11.6-linux-x86_64_v4": {
+  "cpython-3.11.6-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "cec6af027d49c6218680d78960392c4853d74d2f0244ac374ed216ed57f3a79b"
+  },
+  "cpython-3.11.6-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "0cb886edafddff9cb37607f7ec25cb10ecd68bc4741180d17513b7944430bb7b"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "865506f3eb1ff9a25f458c1b46d4fe6ceffac869ca01c203c258e3563c87630e"
   },
-  "cpython-3.11.5-darwin-arm64": {
+  "cpython-3.11.6-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "f6fb43020a46b6f82c552f95db1170c15139d2b6542d38e08ea915902e9da961"
+  },
+  "cpython-3.11.5-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "7bee180b764722a73c2599fbe2c3a6121cf6bbcb08cb3082851e93c43fe130e7"
   },
-  "cpython-3.11.5-linux-arm64": {
+  "cpython-3.11.5-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "cf131546383f0d9b81eca17c3fcb80508e01b11d9ca956d790c41baefb859d7d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ac4b1e91d1cb7027595bfa4667090406331b291b2e346fb74e42b7031b216787"
   },
-  "cpython-3.11.5-linux-i686": {
+  "cpython-3.11.5-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "e156b972b72ae2703c13da3335b16ce5db9f1f33bac27cb0c444a59d04d918fc"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "75d27b399b323c25d8250fda9857e388bf1b03ba1eb7925ec23cf12042a63a88"
   },
-  "cpython-3.11.5-windows-i686": {
+  "cpython-3.11.5-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "c9ffe9c2c88685ce3064f734cbdfede0a07de7d826fada58f8045f3bd8f81a9d"
   },
-  "cpython-3.11.5-linux-ppc64le": {
+  "cpython-3.11.5-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "0d46418101588602d7d817c24fbab7d6ce2675f0fb13d758b6a09b68c343b29d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1aee6a613385a6355bed61a9b12259a5ed16e871b5bdfe5c9fe98b46ee2bb05e"
   },
-  "cpython-3.11.5-linux-s390x": {
+  "cpython-3.11.5-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-s390x-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "a4453d38dc9293326741c8062f53527bd9781eace71c89e5453de308522aa23a"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b0819032ec336d6e1d9e9bfdba546bf854a7b7248f8720a6d07da72c4ac927e5"
   },
-  "cpython-3.11.5-darwin-x86_64": {
+  "cpython-3.11.5-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "e43d70a49919641ca2939a5a9107b13d5fef8c13af0f511a33a94bb6af2044f0"
   },
-  "cpython-3.11.5-linux-x86_64": {
+  "cpython-3.11.5-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "556d7d46c2af6f9744da03cac5304975f60de1cd5846a109814dd5c396fe9042"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "93ee095b53de5a74af18e612f55095fcf3118c3c0a87eb6344d8eaca396bfb2d"
   },
-  "cpython-3.11.5-windows-x86_64": {
+  "cpython-3.11.5-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "9dcf19ee54fb936cb9fd0f02fd655e790663534bc12e142e460c1b30a0b54dbd"
+  },
+  "cpython-3.11.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "6e4d20e6d498f9edeb3c28cb9541ad20f675f16da350b078e40a9dcfd93cdc3d"
   },
-  "cpython-3.11.5-linux-x86_64_v2": {
+  "cpython-3.11.5-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "8b684dcc304f056ad642257fc4987e6a943d0e54b01c3876f838dcc543a321e4"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d7f5abc89c66a8a1d086394c80a94a17b5b26887983dbf5a80998302f3626ab2"
   },
-  "cpython-3.11.5-linux-x86_64_v3": {
+  "cpython-3.11.5-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "bbd36a2ce9896b3f9c3fd69c8d58477bf34a08bc92276ea4ca90551071017cae"
+  },
+  "cpython-3.11.5-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "856706fdb16151ac31127151e5c9aefc82061605812b009002141fe2cf137440"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "292c37355054d6f4f864b4e772d8bd23541b744d73b3293523f461dcfcad2750"
   },
-  "cpython-3.11.5-linux-x86_64_v4": {
+  "cpython-3.11.5-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "9d697a4832d03c7c41bcde53a90d606af7804e4c142a2882e8e237fa628eecf0"
+  },
+  "cpython-3.11.5-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "6dafd07df2b82e4be32560d4b036a6f2fcaa983a49750ff546ccd9e24c93ac20"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "dfa7e0d8fbcde146c5a952f8fa8a1a1121d4b64e7e9e0153d81a06d149a101d3"
   },
-  "cpython-3.11.4-darwin-arm64": {
+  "cpython-3.11.5-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "0c10a26ab61cff71fbd64952c669d414f0fa050c8a77de128d2bbf6eec240a32"
+  },
+  "cpython-3.11.4-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "988d476c806f71a3233ff4266eda166a5d28cf83ba306ac88b4220554fc83e8c"
   },
-  "cpython-3.11.4-linux-arm64": {
+  "cpython-3.11.4-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "46982228f02dc6d8a1227289de479f938567ec8acaa361909a998a0196823809"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "37cf00439b57adf7ffef4a349d62dcf09739ba67b670e903b00b25f81fbb8a68"
   },
-  "cpython-3.11.4-linux-i686": {
+  "cpython-3.11.4-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "1bf5ba6806abbe70770e8e00b2902cbbb75dd4ff0c6e992de85e6752a9998e1a"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a9051364b5c2e28205f8484cae03d16c86b45df5d117324e846d0f5e870fe9fb"
   },
-  "cpython-3.11.4-windows-i686": {
+  "cpython-3.11.4-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "0d22f43c5bb3f27ff2f9e8c60b0d7abd391bb2cac1790b0960970ff5580f6e9a"
   },
-  "cpython-3.11.4-linux-ppc64le": {
+  "cpython-3.11.4-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "17ad84cbfbfee0ebfe309ca389fe176e75fd864c82671186e1fd9926a0c5cae9"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b9f76fd226bfcbc6a8769934b17323ca3b563f1c24660582fcccfa6d0c7146af"
   },
-  "cpython-3.11.4-linux-s390x": {
+  "cpython-3.11.4-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-s390x-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "e7cdb6602dbb5d58d04fca13f55b70c86759bf86b606cc544974876a0fcf662b"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8ef6b5fa86b4abf51865b346b7cf8df36e474ed308869fc0ac3fe82de39194a4"
   },
-  "cpython-3.11.4-darwin-x86_64": {
+  "cpython-3.11.4-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "6d9765785316c7f1c07def71b413c92c84302f798b30ee09e2e0b5da28353a51"
   },
-  "cpython-3.11.4-linux-x86_64": {
+  "cpython-3.11.4-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "b48061173c763971a28669585b47fa26cde98497eee6ebd8057849547b7282ee"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1b5fdeb2dc56c30843e7350f1684178755fae91666a0a987e5eb39074c42a052"
   },
-  "cpython-3.11.4-windows-x86_64": {
+  "cpython-3.11.4-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "fc2ea02ced875c90b8d025b409d58c4f045df8ba951bfa2b8b0a3cfe11c3b41c"
+  },
+  "cpython-3.11.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "1692d795d6199b2261161ae54250009ffad0317929302903f6f2c773befd4d76"
   },
-  "cpython-3.11.4-linux-x86_64_v2": {
+  "cpython-3.11.4-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "6626870973c017de0ab6aa89004398b993634c9bf08e8d85f0800d7506a8bef9"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "95ac78a3d834ce1feaa45bfe4997563df0bc65c3d2711a5d6d4f39d3c240ffd4"
   },
-  "cpython-3.11.4-linux-x86_64_v3": {
+  "cpython-3.11.4-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "54f9206357c118b4ea26f0e3ebe9a558153fff8c42ff4c8546d4c8464956401b"
+  },
+  "cpython-3.11.4-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "a7d43d3b3620c7a14a99c087abe6ef43bc961799919e35c23faea676bcc40b98"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "85859b2993d3c52506625e1dc62b0cb4d9e38816e290d7630fe258aae6b8bca4"
   },
-  "cpython-3.11.4-linux-x86_64_v4": {
+  "cpython-3.11.4-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "b95e54792e8db7531a1ad23d574a0fb4c8510f75d3102b2d41386460345c5383"
+  },
+  "cpython-3.11.4-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "968e48b573f4a4c8468f58f287a8893cd0229eb2731a918b19ae0fa29be4a209"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a3100464c5f1bc3beb1e15c2bf01ad1aff3888d20a25a1ded1a5baff7be54ff1"
   },
-  "cpython-3.11.3-darwin-arm64": {
+  "cpython-3.11.4-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "7e346bf5a96e3719f75889b98baf02e38dd1be812be261e5e5867d357f4f5eab"
+  },
+  "cpython-3.11.3-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "cd296d628ceebf55a78c7f6a7aed379eba9dbd72045d002e1c2c85af0d6f5049"
   },
-  "cpython-3.11.3-linux-arm64": {
+  "cpython-3.11.3-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "8b8e4c58070f8ff372cf89080f24ecb9154ccfcc7674a8a46d67bdb766a1ee95"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "991521082b0347878ba855c4986d77cc805c22ef75159bc95dd24bfd80275e27"
   },
-  "cpython-3.11.3-linux-i686": {
+  "cpython-3.11.3-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "58734b66ee8d2762911f32c6bf59f36928990dc637e494f9ac8ebdd589d64547"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7bd694eb848328e96f524ded0f9b9eca6230d71fce3cd49b335a5c33450f3e04"
   },
-  "cpython-3.11.3-windows-i686": {
+  "cpython-3.11.3-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "877c90ef778a526aa25ab417034f5e70728ac14e5eb1fa5cfd741f531203a3fc"
   },
-  "cpython-3.11.3-linux-ppc64le": {
+  "cpython-3.11.3-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "63a2f046e990bd2a790cc94a1cf04cb0dce9015a44bb633751bfb5b616fe01f2"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "241d583be3ecc34d76fafa0d186cb504ce5625eb2c0e895dc4f4073a649e5c73"
   },
-  "cpython-3.11.3-darwin-x86_64": {
+  "cpython-3.11.3-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "2fbb31a8bc6663e2d31d3054319b51a29b1915c03222a94b9d563233e11d1bef"
   },
-  "cpython-3.11.3-linux-x86_64": {
+  "cpython-3.11.3-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "b9e2e889a5797b181f086c175a03a0e011277a708199b2b20270bacfca72fb91"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "4f1192179e1f62e69b8b45f7f699e6f0100fb0b8a39aad7a48472794d0c24bd4"
   },
-  "cpython-3.11.3-windows-x86_64": {
+  "cpython-3.11.3-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "8c5adef5bc627f39e93b920af86ef740e917aa698530ff727978d446a07bbd8b"
+  },
+  "cpython-3.11.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "9d27e607fb1cb2d766e17f27853013d8c0f0b09ac53127aaff03ec89ab13370d"
   },
-  "cpython-3.11.3-linux-x86_64_v2": {
+  "cpython-3.11.3-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "c44c216e1ca81df945136a77e470137397b7c5d7f092c1954d534b7818422e1a"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f42165d39624cd664ad2c77401b03f2b86c1eaa346a8d97595dc3da9477f7ba7"
   },
-  "cpython-3.11.3-linux-x86_64_v3": {
+  "cpython-3.11.3-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "da2b6278ba05879dfa1929c38260d70ee839425fa175f253417370c97974f679"
+  },
+  "cpython-3.11.3-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "0c1f4ef6f20d8a8443f3d24b8d744ce91188450a6e5f7832d4c01725f933fdb3"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9b049c8397cb33d8ee8ce810f971569dbeddc058325120dbc9463efd05fd97f4"
   },
-  "cpython-3.11.3-linux-x86_64_v4": {
+  "cpython-3.11.3-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "ba81489c9aa454d8c76c4a0cc12c1a90c66f677f5b4eebc62348a7575983a49b"
+  },
+  "cpython-3.11.3-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "7957db46c217dc741fa7dca90e022afeeb4266242e0e87e264cb1c4b1acb95cf"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8977784dad18e495cfaaaffa4d3196cba76ddcb6ba665375a3c8d707267478b5"
   },
-  "cpython-3.11.1-darwin-arm64": {
+  "cpython-3.11.3-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "b985b9b3b57ec919272a01706fb85eef59d4877f6970419160fdf8cfffb4caa8"
+  },
+  "cpython-3.11.1-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "da187194cc351d827232b1d2d85b2855d7e25a4ada3e47bc34b4f87b1d989be5"
   },
-  "cpython-3.11.1-linux-arm64": {
+  "cpython-3.11.1-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "cd3b910dce032f0ec9b414156b391878010940368b5ea27c33b998016e9c1cb8"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8fe27d850c02aa7bb34088fad5b48df90b4b841f40e1472243b8ab9da8776e40"
   },
-  "cpython-3.11.1-linux-i686": {
+  "cpython-3.11.1-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "cce57c5fbd3ff10b91d86978b7ad15b9e02f57447d4f429c0bd4e00aa676d389"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7986ebe82c07ecd2eb94fd1b3c9ebbb2366db2360e38f29ae0543e857551d0bf"
   },
-  "cpython-3.11.1-windows-i686": {
+  "cpython-3.11.1-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "b062ac2c72a85510fb9300675bd5c716baede21e9482ef6335247b4aa006584c"
   },
-  "cpython-3.11.1-darwin-x86_64": {
+  "cpython-3.11.1-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "0eb61be53ee13cf75a30b8a164ef513a2c7995b25b118a3a503245d46231b13a"
   },
-  "cpython-3.11.1-linux-x86_64": {
+  "cpython-3.11.1-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "02332441cb610b1e1aa2d2972e261e2910cc6a950b7973cac22c0759a93c5fcd"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b5bf700afc77588d853832d10b74ba793811cbec41b02ebc2c39a8b9987aacdd"
   },
-  "cpython-3.11.1-windows-x86_64": {
+  "cpython-3.11.1-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "ec5da5b428f6d91d96cde2621c0380f67bb96e4257d2628bc70b50e75ec5f629"
+  },
+  "cpython-3.11.1-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "f5c46fffda7d7894b975af728f739b02d1cec50fd4a3ea49f69de9ceaae74b17"
   },
-  "cpython-3.11.1-linux-x86_64_v2": {
+  "cpython-3.11.1-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "988315feb234a8c630ac4f73f47d16e172e3766166f3a7213a65f8cf7a75a713"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ea2d1de07fbd276723d61cb9f3c8fe4415f1207b3351593a6985e8e4338e89e0"
   },
-  "cpython-3.11.1-linux-x86_64_v3": {
+  "cpython-3.11.1-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "8df1c3ff768c308b113e847e64726b5743c45fde3292b3ad60ffbd40e15b4ac7"
+  },
+  "cpython-3.11.1-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "8e279b25388e47124a422f300db710cdc98c64cf24bf6903f6f6e8ddbc52d743"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "be1259db03ae12ca8c8cdc1a75a3f4aa47579725f2e62f71022f6049690b6498"
   },
-  "cpython-3.11.1-linux-x86_64_v4": {
+  "cpython-3.11.1-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "c4f843cf506e3d7e230e2842f2b8e4e8f470ff3c8707e0b70d0d1285bb938986"
+  },
+  "cpython-3.11.1-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 11,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "07156373b5f910e00402ade33332141ec60bae4a2c2d0b47850b17ba50d5352d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "abf6c9a813e3c600b095ccfe0fb8c21e2b4156df342e9cf4ea34cb5759a0ff1c"
   },
-  "cpython-3.10.13-darwin-arm64": {
+  "cpython-3.11.1-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "9524d8988d552ee6be87bbda76b38431e43c68099fa1ff98368a4fea634e78ff"
+  },
+  "cpython-3.10.13-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "d1a777a0688bafd2a62050c680508769d9b6c14779f64fee591f4e135c11e711"
   },
-  "cpython-3.10.13-linux-arm64": {
+  "cpython-3.10.13-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "4e9fcb141a0c9af986f0819ab7a64c62ceb7b68f33df75753e669fc3d23a3412"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2927269de5d39b935285b676154793877102d6528a1302bab5d58c2cfbf848d9"
   },
-  "cpython-3.10.13-linux-i686": {
+  "cpython-3.10.13-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "cc5625a16fbec682d4ce40c0d185318164bd181efaa7eaf945ca63015db9fea3"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "08a3a1ff61b7ed2c87db7a9f88630781d98fabc2efb499f38ae0ead05973eb56"
   },
-  "cpython-3.10.13-windows-i686": {
+  "cpython-3.10.13-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "0e2e96365d06411a78bc1e1b19cc5a148034743fe6ecf5a5c8e890985fcadbb4"
   },
-  "cpython-3.10.13-linux-ppc64le": {
+  "cpython-3.10.13-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "9d090ea7f28366cdac01c4ae18b9ef7ca0220797af433deecb913b13cff92027"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "24d5acc86495b15ba4b907d151ae62dfbcf2dbe61313b448f470aa333c8a9793"
   },
-  "cpython-3.10.13-linux-s390x": {
+  "cpython-3.10.13-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-s390x-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "c115631f1e849900e4c4cfb8c7ee83317c5499a5d54bbc4335643dd9013a7597"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9dd2dc8f5bb6d011561a83577d4ca5d7ffcb0cd1aeecae32c8ba378eb77b2819"
   },
-  "cpython-3.10.13-darwin-x86_64": {
+  "cpython-3.10.13-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "b61f6f9cf0c35fd6df90b424e757a3bc1b483e8f8d8fadfa6c1ddd1a0c39c003"
   },
-  "cpython-3.10.13-linux-x86_64": {
+  "cpython-3.10.13-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "60e7ca89d37dd8a630a5525bda6143a66a3949c4f03c8319295ddb1d1023b425"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fade5ea8fab973421e2e721d5ea4a6fa908db56e74b8af2bf3b4f4ce10b28aeb"
   },
-  "cpython-3.10.13-windows-x86_64": {
+  "cpython-3.10.13-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "95f66cf891eb474fb1904aa63e1e6f800238f7737269a21d933912cd26cbf816"
+  },
+  "cpython-3.10.13-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "8271db063eea7a32f327121b4d828bd10b9ecd1447d01fcfe8c7518e587ede63"
   },
-  "cpython-3.10.13-linux-x86_64_v2": {
+  "cpython-3.10.13-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "83decf6de9f7b59bb85d874e0530bf109e098c79568577a30770c5a03f280dc6"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a13433753e7a4d28205df17c76e46481d7e74d9cfef61e2a10764903e5c11eb9"
   },
-  "cpython-3.10.13-linux-x86_64_v3": {
+  "cpython-3.10.13-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "6d020f3a2a61f9112e128364cec7d19c2aa2b26664f411ddc639712be552fd6b"
+  },
+  "cpython-3.10.13-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "c21e444ec4ae31acc3c567e2a8b4a4acfa0431526a8efc86d48673b1aace7793"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e183e76dd20bd89a2f2510939681987fa3964003bdaee5091533b61d5bd8ec8d"
   },
-  "cpython-3.10.13-linux-x86_64_v4": {
+  "cpython-3.10.13-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "3adc05761f244f836993c0eca2312cf65d21b8a86103d73129a5cb9233ba1116"
+  },
+  "cpython-3.10.13-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "662c0b46818e8af094156e1f1787bc877d6117ddceb338f58002c5ad17494fe0"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bc4f0719037ed1fb84439fbf89c640859b841575f6804ef88dd969613a7c4980"
   },
-  "cpython-3.10.12-darwin-arm64": {
+  "cpython-3.10.13-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.10.13%2B20240107-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "d29ee6b971179f13976559239e5741a3d7898360fd2591cc657a92ef1bfa4aa9"
+  },
+  "cpython-3.10.12-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "a7d0cadbe867cc53dd47d7327244154157a7cca02edb88cf3bb760a4f91d4e44"
   },
-  "cpython-3.10.12-linux-arm64": {
+  "cpython-3.10.12-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "bb5fa1d4ad202afc8ee4330f313c093760c9fb1af5be204dc0c6ba50c7610fea"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e30f2b4fd9bd79b9122e2975f3c17c9ddd727f8326b2e246378e81f7ecc7d74f"
   },
-  "cpython-3.10.12-linux-i686": {
+  "cpython-3.10.12-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "159124ac71c86d8617eae17db6ed9b98f01078cc9bd76073261901826f2d940d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "89c83fcdfd41c67e2dd2a037982556c657dc55fc1938c6f6cdcd5ffa614c1fb3"
   },
-  "cpython-3.10.12-windows-i686": {
+  "cpython-3.10.12-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "0743b9976f20b06d9cf12de9d1b2dfe06b13f76978275e9dac73a275624bde2c"
   },
-  "cpython-3.10.12-linux-ppc64le": {
+  "cpython-3.10.12-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "bc23f5953c329b0155309e1ac40621da53cb3d1829912ff0616250410d876785"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c318050fa91d84d447f5c8a5887a44f1cc8dd34d4c1d357cd755407d46ed1b21"
   },
-  "cpython-3.10.12-linux-s390x": {
+  "cpython-3.10.12-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-s390x-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "068a3621662e806f142945b622ff2f588f7da65db4cd6282640e6f891bfe9b9e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "756579b52acb9b13b162ac901e56ff311def443e69d7f7259a91198b76a30ecb"
   },
-  "cpython-3.10.12-darwin-x86_64": {
+  "cpython-3.10.12-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "f1fa448384dd48033825e56ee6b5afc76c5dd67dcf2b73b61d2b252ae2e87bca"
   },
-  "cpython-3.10.12-linux-x86_64": {
+  "cpython-3.10.12-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "79fe684338fa26e1af64de583cca77a3fd501d899420de398177952d5182d202"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fb7354fcee7b17dd0793ebd3f6f1fc8b7b205332afcf8d700cc1119f2dc33ff7"
   },
-  "cpython-3.10.12-windows-x86_64": {
+  "cpython-3.10.12-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "b343cbe7c41b7698b568ea5252328cdccb213100efa71da8d3db6e21afd9f6cf"
+  },
+  "cpython-3.10.12-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "cb6e7c84d9e369a0ee76c9ea73d415a113ba9982db58f44e6bab5414838d35f3"
   },
-  "cpython-3.10.12-linux-x86_64_v2": {
+  "cpython-3.10.12-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "1f3d033b9202a50a376cc1cad51bf8d57cf126ef8b8a137fb39d621bd237bde7"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b4d606147bcb75735dd55928330e111dec35fb2c825d2e3fd71eca23eaa11e5f"
   },
-  "cpython-3.10.12-linux-x86_64_v3": {
+  "cpython-3.10.12-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "78e9e5f03b4fd8ebd2253121f7ac8516d39761d28ac094d3f8025fc576ade1bd"
+  },
+  "cpython-3.10.12-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "5de8b010ce9916504ee483541cab7ffcf394af4801f6a3a159103ae753fec5e7"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3f85d12509db9cfe11785c0947d1e5baca0167e3eaa7065f9424a65fa159fb2f"
   },
-  "cpython-3.10.12-linux-x86_64_v4": {
+  "cpython-3.10.12-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "dbab7a72fa1ef45813cc25977dece74667a05a02b18dbc774aab7fcb395da424"
+  },
+  "cpython-3.10.12-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "d5996ef14cdc7ff500a729564f7f6c689e02cdfa5c95f1116dbec06b429820f6"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "259e0c20061ed25a72e72912eb212a8571d0607659edba580272db809af7206e"
   },
-  "cpython-3.10.11-darwin-arm64": {
+  "cpython-3.10.12-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "ce13736e1faa4fcb559c206c632f9232ba8f2b1f106c4af44433f3936b06d4d0"
+  },
+  "cpython-3.10.11-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "da9c8a3cd04485fd397387ea2fa56f3cac71827aafb51d8438b2868f86eb345b"
   },
-  "cpython-3.10.11-linux-arm64": {
+  "cpython-3.10.11-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "2e304c39d8af27f9abf1cf44653f5e34e7d05b665cb68e5a5474559c145e7b33"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a5271cc014f2ce2ab54a0789556c15b84668e2afcc530512818c4b87c6a94483"
   },
-  "cpython-3.10.11-linux-i686": {
+  "cpython-3.10.11-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "f55942f89c54c90af53dba603a86f90956eec87c7fb91f5dc2ae543373224ccd"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9304d6eeef48bd246a2959ebc76b20dbb2c6a81aa1d214f4471cb273c11717f2"
   },
-  "cpython-3.10.11-windows-i686": {
+  "cpython-3.10.11-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "60e76e136ab23b891ed1212e58bd11a73a19cd9fd884ec1c5653ca1c159d674e"
   },
-  "cpython-3.10.11-linux-ppc64le": {
+  "cpython-3.10.11-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "d800e3152cd53ca6cfa376e22d66b784cd07ca6ec3fec053a15c6c2b011b9a17"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ac32e3788109ff0cc536a6108072d9203217df744cf56d3a4ab0b19857d8e244"
   },
-  "cpython-3.10.11-darwin-x86_64": {
+  "cpython-3.10.11-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "e84c12aa0285235eed365971ceedf040f4d8014f5342d371e138a4da9e4e9b7c"
   },
-  "cpython-3.10.11-linux-x86_64": {
+  "cpython-3.10.11-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "38931a156ed020f5c579af37b771871b99f31e74c34fa7e093e97eb1b2d4f978"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "544e5020f71ad1525dbc92b08e429cc1e1e11866c48c07d91e99f531b9ba68b0"
   },
-  "cpython-3.10.11-windows-x86_64": {
+  "cpython-3.10.11-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "7918188e01a266915dd0945711e274d45c8d7fb540d48240e13c4fd96f43afbb"
+  },
+  "cpython-3.10.11-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "9b4dc4a335b6122ce783bc80f5015b683e3ab1a56054751c5df494db0521da67"
   },
-  "cpython-3.10.11-linux-x86_64_v2": {
+  "cpython-3.10.11-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "071f282d9b013ff9c4ed7aefa742d8ad58f9ce025a1dae86c1b05f693e6b8b5f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "cd6316c2731d2282587475e781e240677c89a678694cf3e58f12e4c2e57add43"
   },
-  "cpython-3.10.11-linux-x86_64_v3": {
+  "cpython-3.10.11-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "af8c79e71dc8d958bcf80c675b383d210e08880bf80a08e038422274551f8ee5"
+  },
+  "cpython-3.10.11-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "f1c08f668fecd54603f3616386db60eacac931a6ccde4f1d9af71e4351d49dbd"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ea5006c1545afed6f16e833a0d4bac14ec289cc0f5911e12a4ef8704a742cf8e"
   },
-  "cpython-3.10.11-linux-x86_64_v4": {
+  "cpython-3.10.11-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "532526149236ee3223af38e8946bff2d78ab7cb8756d91ed6676959a1eec4f01"
+  },
+  "cpython-3.10.11-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "1db0b39ce01b98dc25b1fee0ec9af02d0a695127713120678673e9d343148ce6"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6ebe8edb6bb89109b351e6f4361be7f1563860e1ae1cb8926c17ca19588e5fa3"
   },
-  "cpython-3.10.9-darwin-arm64": {
+  "cpython-3.10.11-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "58bd65a4e0b595b4d18dc9fc05dc384043d1106e6d0c221679eaefb277fa8784"
+  },
+  "cpython-3.10.9-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "2508b8d4b725bb45c3e03d2ddd2b8441f1a74677cb6bd6076e692c0923135ded"
   },
-  "cpython-3.10.9-linux-arm64": {
+  "cpython-3.10.9-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "3d20f40654e4356bd42c4e70ec28f4b8d8dd559884467a4e1745c08729fb740a"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2c0996dd1fe35314e06e042081b24fb53f3b7b361c3e1b94a6ed659c275ca069"
   },
-  "cpython-3.10.9-linux-i686": {
+  "cpython-3.10.9-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "ae0745620168e65df44ae60b21622d488c9dd6ca83566083c565765256315283"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f8c3a63620f412c4a9ccfb6e2435a96a55775550c81a452d164caa6d03a6a1da"
   },
-  "cpython-3.10.9-windows-i686": {
+  "cpython-3.10.9-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "3d79cfd229ec12b678bbfd79c30fb4cbad9950d6bfb29741d2315b11839998b4"
   },
-  "cpython-3.10.9-darwin-x86_64": {
+  "cpython-3.10.9-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "1153b4d3b03cf1e1d8ec93c098160586f665fcc2d162c0812140a716a688df58"
   },
-  "cpython-3.10.9-linux-x86_64": {
+  "cpython-3.10.9-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "c5f7ad956c8870573763ed58b59d7f145830a93378234b815c068c893c0d5c1e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a90a45ba7afcbd1df9aef96a614acbb210607299ac74dadbb6bd66af22be34db"
   },
-  "cpython-3.10.9-windows-x86_64": {
+  "cpython-3.10.9-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "1310f187a73b00164ec4ca34e643841c5c34cbb93fe0b3a3f9504e5ea5001ec7"
+  },
+  "cpython-3.10.9-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "4cfa6299a78a3959102c461d126e4869616f0a49c60b44220c000fc9aecddd78"
   },
-  "cpython-3.10.9-linux-x86_64_v2": {
+  "cpython-3.10.9-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "49f4a8c02efff2debbb258973b1f6efbd568e4be2e5dca07c7dcd754a7bff9cf"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fbd196fc7680e499f374a6946b3618b42980e2890a6d533993337b563bd8abb0"
   },
-  "cpython-3.10.9-linux-x86_64_v3": {
+  "cpython-3.10.9-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "430a3d75bd4f0dca37bf00bab86c4f8fd78f09a37e5cbd89e07263c5fa88327a"
+  },
+  "cpython-3.10.9-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "366bdd71ae4a8cdd86060a8e44ccd7f30d5f72864c88204bf3acf5aecfe748ef"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ece59c02c9fdc77500bc1b60636077bc0a9536d6e63052c727db11488ae2de8c"
   },
-  "cpython-3.10.9-linux-x86_64_v4": {
+  "cpython-3.10.9-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "1aae9aa444aa03e03bdf24816c8c503fa76488b00fcd1e822350ef22a05edc00"
+  },
+  "cpython-3.10.9-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "1960c5a6fe7d351dacc9e133494789c575e47210e569254b9d8128a8ce6f8931"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f4aab4df5c104f5d438a1a3b4601e45963a13c4100cbafee832336e47f6479cb"
   },
-  "cpython-3.10.8-darwin-arm64": {
+  "cpython-3.10.9-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "5abe36719d4e42de95f5c6319785cfb024699beda1e72788231962d4e24c1e67"
+  },
+  "cpython-3.10.8-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 8,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "f8ba5f87153a17717e900ff7bba20e2eefe8a53a5bd3c78f9f6922d6d910912d"
   },
-  "cpython-3.10.8-linux-arm64": {
+  "cpython-3.10.8-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "5710521ca6958dd2e50f30f2b1591eb7f6a4c55a64c9b66d3196f8257f40bc96"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "879e76260be226512693e37a28cc3a6670b5ee270a4440e4b04a7b415dba451c"
   },
-  "cpython-3.10.8-linux-i686": {
+  "cpython-3.10.8-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "0ab3156bbdc87db8a9b938662a76bb405522b408b1f94d8eb20759f277f96cd8"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ab434eccffeec4f6f51af017e4eed69d4f1ea55f48c5b89b8a8779df3fa799df"
   },
-  "cpython-3.10.8-windows-i686": {
+  "cpython-3.10.8-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 8,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "7547ea172f7fa3d7619855f28780da9feb615b6cb52c5c64d34f65b542799fee"
   },
-  "cpython-3.10.8-darwin-x86_64": {
+  "cpython-3.10.8-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 8,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "a18f81ecc7da0779be960ad35c561a834866c0e6d1310a4f742fddfd6163753f"
   },
-  "cpython-3.10.8-linux-x86_64": {
+  "cpython-3.10.8-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "59630be21c77f87b4378f0cf887cbeb6bec64c988c93f3dc795afee782a3322e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c86182951a82e761588476a0155afe99ae4ae1030e4a8e1e8bcb8e1d42f6327c"
   },
-  "cpython-3.10.8-windows-x86_64": {
+  "cpython-3.10.8-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "bb87e933afcfd2e8de045e5a691feff1fb8fb06a09315b37d187762fddfc4546"
+  },
+  "cpython-3.10.8-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 8,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "ab40f9584be896c697c5fca351ab82d7b55f01b8eb0494f0a15a67562e49161a"
   },
-  "cpython-3.10.8-linux-x86_64_v2": {
+  "cpython-3.10.8-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "9e15b5a26c076a8f157e7077f4179d31c1eb6a5c58385b1a0ed9314f267c6acc"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "96c8f51e23a1bd8b9a2d9adc0e2457fa74062f16d25d2d0d659b8a6c94631824"
   },
-  "cpython-3.10.8-linux-x86_64_v3": {
+  "cpython-3.10.8-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "c9a496301e22fabad5a27160fc199e25a10dc2775c26efa7b905ee9a58e5076a"
+  },
+  "cpython-3.10.8-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "74a4623b1d90e1ca661384442488fbed2cbb59cba9a891ff2f2fc2cdfeb423a9"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1053c4ca16bda71ae9f2a973cc82118b9e41aa6e426302d9709d9c74c60af50d"
   },
-  "cpython-3.10.8-linux-x86_64_v4": {
+  "cpython-3.10.8-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "bfcfb51a02082d1136259142b590a52a7b9f5e21bf1177bf988129b4f8f99933"
+  },
+  "cpython-3.10.8-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "85c9504ee008c40f0a01a4e11a4ada6d2e4b1ac8f483068417b84c8a11bfefad"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f23f744868d70cf2e9588aa961e9682060b6c3d6f55c65a61505e23c4895b7e4"
   },
-  "cpython-3.10.7-darwin-arm64": {
+  "cpython-3.10.8-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "0574cab92283d240650aef5cc5716969e8e1a7a40d298d23bf0922d0988b19f9"
+  },
+  "cpython-3.10.7-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "9f44cf63441a90f4ec99a032a2bda43971ae7964822daa0ee730a9cba15d50da"
   },
-  "cpython-3.10.7-linux-arm64": {
+  "cpython-3.10.7-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "f92fb53661f2ceddeb7b15ae1f165671acf4e4d4f9519a87e033981b93ee33b8"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9f346729b523e860194635eb67c9f6bc8f12728ba7ddfe4fd80f2e6d685781e3"
   },
-  "cpython-3.10.7-linux-i686": {
+  "cpython-3.10.7-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "c379f2ef58c8d83f1607357ad75e860770d748232a4eec4263564cbfa6a3efbb"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a79816c50abeb2752530f68b4d7d95b6f48392f44a9a7f135b91807d76872972"
   },
-  "cpython-3.10.7-windows-i686": {
+  "cpython-3.10.7-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "323532701cb468199d6f14031b991f945d4bbf986ca818185e17e132d3763bdf"
   },
-  "cpython-3.10.7-darwin-x86_64": {
+  "cpython-3.10.7-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "e03e28dc9fe55ea5ca06fece8f2f2a16646b217d28c0cd09ebcd512f444fdc90"
   },
-  "cpython-3.10.7-linux-x86_64": {
+  "cpython-3.10.7-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "22e59fa43657dc3487392a44a33a815d507cdd244b6609b6ad08f2661c34169c"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ce3fe27e6ca3a0e75a7f4f3b6568cd1bf967230a67e73393e94a23380dddaf10"
   },
-  "cpython-3.10.7-windows-x86_64": {
+  "cpython-3.10.7-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "7f2c933d23c0f38cf145c2d6c65b5cf53bb589690d394fd4c01b2230c23c2bff"
+  },
+  "cpython-3.10.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "5363974e6ee6c91dbd6bc3533e38b02a26abc2ff1c9a095912f237b916be22d3"
   },
-  "cpython-3.10.7-linux-x86_64_v2": {
+  "cpython-3.10.7-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "c64eee679f3bd2b3f952020a516fa17d5cb42a645784762a3fdd623ad89791c9"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fb44d19c8e4da5d5c467b6bbfc1b0350fa7faee71462fbd6ac3d69633c2b334a"
   },
-  "cpython-3.10.7-linux-x86_64_v3": {
+  "cpython-3.10.7-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "01258e2cd7a6950c31b850ae99ba7c4a351338ad3e01bab28b077d5eb7e1f509"
+  },
+  "cpython-3.10.7-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "c54217b3df5f398e52e26e16683f642b245e36232d190ee9fec45a04923de9ca"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c028a4c945329731be66285168a074ac2fc7f25d28c5bbb9bbbb532d45a82ab4"
   },
-  "cpython-3.10.7-linux-x86_64_v4": {
+  "cpython-3.10.7-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "ad93efc6c9b1bd25368b0e50e35ba6a21511d68ebfb209811585869666874cfc"
+  },
+  "cpython-3.10.7-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "3a42f3e79715b8c89484cbf753dc769598d3683ebee5618beb81c55a70f23b6f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b9ddf213ba0f69ac200dd50e5d2c6a52468307a584a64efe422ef537f446c0da"
   },
-  "cpython-3.10.6-darwin-arm64": {
+  "cpython-3.10.7-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "9f3883a4eabe72243a6677467ec117247176353d12352f1dd1d32fa0ef92a18c"
+  },
+  "cpython-3.10.6-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "159230851a69cf5cab80318bce48674244d7c6304de81f44c22ff0abdf895cfa"
   },
-  "cpython-3.10.6-linux-arm64": {
+  "cpython-3.10.6-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "6606be4283ebcfe2d83b49b05f6d06b958fe120a4d96c1eeeb072369db06b827"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "edc1c9742b824caebbc5cb224c8990aa8658b81593fd9219accf3efa3e849501"
   },
-  "cpython-3.10.6-linux-i686": {
+  "cpython-3.10.6-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "213374fd9845df5c1d3f1d2f5ac2610fe70ddba094aee0cbc2e91fd2dc808de2"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "07fa4f5499b8885d1eea49caf5476d76305ab73494b7398dfd22c14093859e4f"
   },
-  "cpython-3.10.6-windows-i686": {
+  "cpython-3.10.6-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "8d9a259e15d5a1be48ef13cd5627d7f6c15eadf41a3539e99ed1deee668c075e"
   },
-  "cpython-3.10.6-darwin-x86_64": {
+  "cpython-3.10.6-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "9405499573a7aa8b67d070d096ded4f3e571f18c2b34762606ecc8025290b122"
   },
-  "cpython-3.10.6-linux-x86_64": {
+  "cpython-3.10.6-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "8072f01279e05bad7c8d1076715db243489d1c2598f7b7d0457d0cac44fcb8b2"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "407e5951e39f5652b32b72b715c4aa772dd8c2da1065161c58c30a1f976dd1b2"
   },
-  "cpython-3.10.6-windows-x86_64": {
+  "cpython-3.10.6-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "f859a72da0bb2f1261f8cebdac931b05b59474c7cb65cee8e85c34fc014dd452"
+  },
+  "cpython-3.10.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "01dc349721594b1bb5b582651f81479a24352f718fdf6279101caa0f377b160a"
   },
-  "cpython-3.10.6-linux-x86_64_v2": {
+  "cpython-3.10.6-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "948c79667c6af3f4f859feca539cad9f940d484792edac6b30e4e1d6b022fa96"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "4a0cc9f5b57ca1eff38d0c9ee71f38f9bf28fbc34d150edd4914b32b69a84f17"
   },
-  "cpython-3.10.6-linux-x86_64_v3": {
+  "cpython-3.10.6-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "55d7d942223ca7ccb972dee02770ddd6b3cf61d674b3488f3917dac847688624"
+  },
+  "cpython-3.10.6-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "17f6cf57a42eb8fa4619e268cac77ca1e4aef96a294efa0bdf91ab067c055d8e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "38bc029b11deed33097aae7e1b2e56b6d85f06df24355ff6105bf85fbb2fcb9b"
   },
-  "cpython-3.10.6-linux-x86_64_v4": {
+  "cpython-3.10.6-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "da135320610e0e35926f2e5767b03d6c641220a4595423cbd3cf126fe1ff1868"
+  },
+  "cpython-3.10.6-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "cc554275377d0b55f43162d52752087180a51d5063e720fc7671c867442706b3"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "dc779272bd2363abda4a8a784f6dea2dd7d8b2d86cdcfae5e8970df6e5dfbd76"
   },
-  "cpython-3.10.5-darwin-arm64": {
+  "cpython-3.10.6-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "8b3349fe4919adda35edce8108d96f398479620f01efdeee1ef1c667037f1c20"
+  },
+  "cpython-3.10.5-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "f68d25dbe9daa96187fa9e05dd8969f46685547fecf1861a99af898f96a5379e"
   },
-  "cpython-3.10.5-linux-arm64": {
+  "cpython-3.10.5-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "6e5e1050549c1aa629924b1b6a3080655d9e110f88dfa734d9b1c98af924cc7d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9fa6970a3d0a5dc26c4ed272bb1836d1f1f7a8f4b9d67f634d0262ff8c1fed0b"
   },
-  "cpython-3.10.5-linux-i686": {
+  "cpython-3.10.5-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "dea116554852261e4a9e79c8926a0e4ac483f9e624084ded73b30705e221b62d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "63fcfc425adabc034c851dadfb499de3083fd7758582191c12162ad2471256b0"
   },
-  "cpython-3.10.5-windows-i686": {
+  "cpython-3.10.5-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "e201192f0aa73904bc5a5f43d1ce4c9fb243dfe02138e690676713fe02c7d662"
   },
-  "cpython-3.10.5-darwin-x86_64": {
+  "cpython-3.10.5-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "5e372e6738a733532aa985730d9a47ee4c77b7c706e91ef61d37aacbb2e54845"
   },
-  "cpython-3.10.5-linux-x86_64": {
+  "cpython-3.10.5-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "2a71e32ef8e1bbffbbfcd1825620d6a8944f97e76851bf1a14dc4fa48b626db8"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f8dfb83885d1cbc82febfa613258c1f6954ea88ef43ed7dc710d6df20efecdab"
   },
-  "cpython-3.10.5-windows-x86_64": {
+  "cpython-3.10.5-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "3682e0add14a3bac654afe467a84981628b0c7ebdccd4ebf26dfaa916238e2fe"
+  },
+  "cpython-3.10.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "cff35feefe423d4282e9a3e1bb756d0acbb2f776b1ada82c44c71ac3e1491448"
   },
-  "cpython-3.10.5-linux-x86_64_v2": {
+  "cpython-3.10.5-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "ede8d575d06ec7256756220fd7195cd7c6026e1f563e07062238e692e6f1f1c5"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fdf3ade3f03f4a755f378d9abea1e9eb6a6a3fb18ce4620d5b7a6cb223a59741"
   },
-  "cpython-3.10.5-linux-x86_64_v3": {
+  "cpython-3.10.5-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "26ad08f1e22d75501fe8579795ab8aee3e52f9c1b1037e87dd349632fa4620b5"
+  },
+  "cpython-3.10.5-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "2b1374df2117b3fe774d3ee8a4ca73878ea19328d8b190e12adbe5d185aef5ea"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "137823acc0d98178c31ce0f75cef5fb0d3850edaf692ced2fab84ef9777d2c01"
   },
-  "cpython-3.10.5-linux-x86_64_v4": {
+  "cpython-3.10.5-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "125e101edfca4477694c12b3fa310ff81326cc51a1b1b889cbfc3577ff5b8f5d"
+  },
+  "cpython-3.10.5-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "0df06da66b1fbff38e0ea4e3e55d7929a368132fb105d21bd57474abe9c9160e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "75fddbd0fa525d9455dab972c56ec8b6d39ddd62c12ab38dca81b558b1e70338"
   },
-  "cpython-3.10.4-darwin-arm64": {
+  "cpython-3.10.5-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "ee4fdc2bc4797d64de3930750a8b0327cb789ee45483a23f09c913837171dd9b"
+  },
+  "cpython-3.10.4-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "c404f226195d79933b1e0a3ec88f0b79d35c873de592e223e11008f3a37f83d6"
   },
-  "cpython-3.10.4-linux-arm64": {
+  "cpython-3.10.4-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "5d2ccef5a45d2287d73a6ff63a466b21a197beb373792e644b8881bce3b6aa55"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "092369e9d170c4c1074e1b305accb74f9486e6185d2e3f3f971869ff89538d3e"
   },
-  "cpython-3.10.4-linux-i686": {
+  "cpython-3.10.4-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "b28224a798dea965cb090f831d31aa531c6b9a14028344be6df53ab426497bb4"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ba940a74a7434fe78d81aed9fb1e5ccdc3d97191a2db35716fc94e3b6604ace0"
   },
-  "cpython-3.10.4-windows-i686": {
+  "cpython-3.10.4-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "c37a47e46de93473916f700a790cb43515f00745fba6790004e2731ec934f4d3"
   },
-  "cpython-3.10.4-darwin-x86_64": {
+  "cpython-3.10.4-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "e447f00fe53168d18cbfe110645dbf33982a17580b9e4424a411f9245d99cd21"
   },
-  "cpython-3.10.4-linux-x86_64": {
+  "cpython-3.10.4-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "15f961b087c6145f326fee30041db4af3ce0a8d24bbdefbd8d24973825728a0e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7699f76ef89b436b452eacdbab508da3cd94146ba29b099f5cb6e250afba3210"
   },
-  "cpython-3.10.4-windows-x86_64": {
+  "cpython-3.10.4-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "8b8b97f7746a3deca91ada408025457ced34f582dad2114b33ce6fec9cf35b28"
+  },
+  "cpython-3.10.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "d636dc1bcca74dd9c6e3b26f7c081b3e229336e8378fe554bf8ba65fe780a2ac"
   },
-  "cpython-3.10.4-linux-x86_64_v2": {
+  "cpython-3.10.4-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "7f93c009038a195e9e5c22dfb42d6c8bb62438438d5c5cfb3d64bb3f0066d88f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e0849600bee6c588f1aa5f4b0b9342292cfb6eb40de0c705f60bd71f22b713d0"
   },
-  "cpython-3.10.4-linux-x86_64_v3": {
+  "cpython-3.10.4-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "e036939d7b96fac35fcf9d01d2ddd6007f03f8a2e382d84ef31c0fcc37399e86"
+  },
+  "cpython-3.10.4-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "afd3e5ca794e3297807391610ce4011e459bafad5296b87156cc8b316a23d1c1"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2875d103a83ff9f9f7ec2ec3ebc43d0e89f20416cd715b83b541b33f91d59832"
   },
-  "cpython-3.10.4-linux-x86_64_v4": {
+  "cpython-3.10.4-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "b83d649edc245c2f5f6347c09344108e9558dbbdf67ab7a596a76ff451394714"
+  },
+  "cpython-3.10.4-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "bafc29f780ce8c50d6881e2f8f9dbc3be7896b2dd98c7056cbc6072aa47fdb39"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "839f9cb8f1b0e0eb347164a04323f832b945091ba3482724325d3eed1a75daab"
   },
-  "cpython-3.10.3-darwin-arm64": {
+  "cpython-3.10.4-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "3c0c1be54a9711dde87f38d1d8fe97d6d05ca55d590870371b8302d0d4588463"
+  },
+  "cpython-3.10.3-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "b1abefd0fc66922cf9749e4d5ceb97df4d3cfad0cd9cdc4bd04262a68d565698"
   },
-  "cpython-3.10.3-linux-arm64": {
+  "cpython-3.10.3-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "88d2bfc8b714b9e36e95e68129799527077827dd752357934f9d3d0ce756871e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "101284d27578438da200be1f6b9a1ba621432c5549fa5517797ec320bf75e3d5"
   },
-  "cpython-3.10.3-linux-i686": {
+  "cpython-3.10.3-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "ea82b0b12e03fdc461c2337e59cb901ecc763194588db5a97372d26f242f4951"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "43c1cd6e203bfba1a2eeb96cd2a15ce0ebde0e72ecc9555934116459347a9c28"
   },
-  "cpython-3.10.3-windows-i686": {
+  "cpython-3.10.3-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "fbc0924a138937fe435fcdb20b0c6241290558e07f158e5578bd91cc8acef469"
   },
-  "cpython-3.10.3-darwin-x86_64": {
+  "cpython-3.10.3-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "bc5d6f284b506104ff6b4e36cec84cbdb4602dfed4c6fe19971a808eb8c439ec"
   },
-  "cpython-3.10.3-linux-x86_64": {
+  "cpython-3.10.3-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "ee2251d5e59045c6fa1d4431c8a5cd0ed18923a785e7e0f47aa9d32ae0ca344e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "04760d869234ee8f801feb08edc042a6965320f6c0a7aedf92ec35501fef3b21"
   },
-  "cpython-3.10.3-windows-x86_64": {
+  "cpython-3.10.3-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "7c034d8a5787744939335ce43d64f2ddcc830a74e63773408d0c8f3c3a4e7916"
+  },
+  "cpython-3.10.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "72b91d26f54321ba90a86a3bbc711fa1ac31e0704fec352b36e70b0251ffb13c"
   },
-  "cpython-3.10.3-linux-x86_64_v2": {
+  "cpython-3.10.3-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "aac77225a0530ec6d8c5d1c6ed04d44e0a3f2173bddc3d871c595d2b82912178"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "65215230eacebebb87aa1e56d539fc1770870024dcfdadb5d0e18365c1b3b0a9"
   },
-  "cpython-3.10.3-linux-x86_64_v3": {
+  "cpython-3.10.3-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "87228dbf0063d26c67128e151f25f9de8cf5c2a041d5d424fef974cf32d5237f"
+  },
+  "cpython-3.10.3-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "e2ba74badcc2651e65ea6adbd12699e8aced8250b5723408756266558b9bc000"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e15dcd98efdde249e7c2857f80b93092245f8495d822cb6c7af3308a59729c21"
   },
-  "cpython-3.10.3-linux-x86_64_v4": {
+  "cpython-3.10.3-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "03897947f6920e12cd8fab4eca2c5c8d43ca2140f2eabf4a6d457ba8f41157f7"
+  },
+  "cpython-3.10.3-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "88a55ea1ac274efdc13cd059f2176e0c697bb7271cf7f22019aca59f63a5ca65"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "412570cf01df665c848dacc213c645a3c17aa5045b1805a86c6d9fa2d82eb9ce"
   },
-  "cpython-3.10.2-darwin-arm64": {
+  "cpython-3.10.3-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "7af8e1000ceb0a63bfdaa62fd064cb98fcf3712a5c8b71d17744f19307bfa89b"
+  },
+  "cpython-3.10.2-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "1ef939fd471a9d346a7bc43d2c16fb483ddc4f98af6dad7f08a009e299977a1a"
   },
-  "cpython-3.10.2-linux-arm64": {
+  "cpython-3.10.2-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "fb714771145a49482a113f532e4cbc21d601cf0dee4186a57fbc66ddd8d85aef"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9936f1549f950311229465de509b35c062aa474e504c20a1d6f0f632da57e002"
   },
-  "cpython-3.10.2-linux-i686": {
+  "cpython-3.10.2-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "817cc2720c9c67cf87e5c0e41e44111098ceb6372d8140c8adbdd2f0397f1e02"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9be2a667f29ed048165cfb3f5dbe61703fd3e5956f8f517ae098740ac8411c0b"
   },
-  "cpython-3.10.2-windows-i686": {
+  "cpython-3.10.2-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "698b09b1b8321a4dc43d62f6230b62adcd0df018b2bcf5f1b4a7ce53dcf23bcc"
   },
-  "cpython-3.10.2-darwin-x86_64": {
+  "cpython-3.10.2-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "bacf720c13ab67685a384f1417e9c2420972d88f29c8b7c26e72874177f2d120"
   },
-  "cpython-3.10.2-linux-x86_64": {
+  "cpython-3.10.2-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "65d2a31c3181ab15342e60a2ef92d6a0df6945200191115d0303d6e77428521c"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d22d85f60b2ef982b747adda2d1bde4a32c23c3d8f652c00ce44526750859e4e"
   },
-  "cpython-3.10.2-windows-x86_64": {
+  "cpython-3.10.2-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "df246cf27db346081935d33ce0344a185d1f08b04a4500eb1e21d4d922ee7eb4"
+  },
+  "cpython-3.10.2-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "7397e78a4fbe429144adc1f33af942bdd5175184e082ac88f3023b3a740dd1a0"
   },
-  "cpython-3.10.2-linux-x86_64_v2": {
+  "cpython-3.10.2-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "73854deefa02896c3c30dfd8ebbff384561fe28c5b0d8d0a60f5c3543ea16ed0"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8c772010a27d7fd5a3e271c835c37b73bd41bc04a737523f12a3920bf721598b"
   },
-  "cpython-3.10.2-linux-x86_64_v3": {
+  "cpython-3.10.2-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "db2474e7a0b6fa37629f26308b3c5f0a018abae4bc9529ecc2fbf6ef5e741053"
+  },
+  "cpython-3.10.2-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "f6a8c8fd758006fcdf91f81c4b753bcaaddb436d44c6a38df04a9f6d48b6bb38"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "03a6116ea6dbd5d4e667d4bec2b5032deefd604bc068908cd105327c417d0906"
   },
-  "cpython-3.10.2-linux-x86_64_v4": {
+  "cpython-3.10.2-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "d5489a850ffd2c5b85b4a52e26bb5022429e432823527c782e42c2f0dc333938"
+  },
+  "cpython-3.10.2-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "16987dd579183ca538ae6cc7928cbe3165fd0fd401d822bda5c8d5ea27ce428b"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2262abca39027b52d96b397c5d3285b07a93fafd7dde52295876a331e9fb48c4"
   },
-  "cpython-3.10.0-darwin-arm64": {
+  "cpython-3.10.2-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "b2956e7d7ed5dec84569e7381cfdbcd51dd1794f57af44864e3f2d8ee9f6a8c5"
+  },
+  "cpython-3.10.0-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.10.0-linux-arm64": {
+  "cpython-3.10.0-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-unknown-linux-gnu-lto-20211017T1616.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-unknown-linux-gnu-debug-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.10.0-linux-i686": {
+  "cpython-3.10.0-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-unknown-linux-gnu-debug-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.10.0-windows-i686": {
+  "cpython-3.10.0-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.10.0-darwin-x86_64": {
+  "cpython-3.10.0-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.10.0-linux-x86_64": {
+  "cpython-3.10.0-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 10,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-gnu-debug-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.10.0-windows-x86_64": {
+  "cpython-3.10.0-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 0,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.10.0-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.18-darwin-arm64": {
+  "cpython-3.9.18-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 18,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "b7d31a15f7af359c59b01ed9c8accb4b6bdd1237b910699e6b2d14df8e2c1cdc"
   },
-  "cpython-3.9.18-linux-arm64": {
+  "cpython-3.9.18-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "e8938f26837a5654a4ceec1e5385d49f4c56af7fa86255fede416980bd28a34f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "16a1ff546e24790bbea66a52d469aa57ef4090566b4cca6fee29528f59f28c40"
   },
-  "cpython-3.9.18-linux-i686": {
+  "cpython-3.9.18-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "9e40a541b4eb6eb0a5e2f35724a18332aea91c61e18dec77ca40da5cf2496839"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7faf8fdfbad04e0356a9d52c9b8be4d40ffef85c9ab3e312c45bd64997ef8aa9"
   },
-  "cpython-3.9.18-windows-i686": {
+  "cpython-3.9.18-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 18,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "063c531d3c65f49212c9644ab0f00360a65d7c45bc1e6f78174685e2c165b260"
   },
-  "cpython-3.9.18-linux-ppc64le": {
+  "cpython-3.9.18-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "52b37a2977a15ae5dbce77bd0c3ac45fe18ebafcc35b10b3f6d97ff58e841827"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bb8f31f18719654fd1f06724a4b37bb7a60abf8b6d14cec5fb1ba422bfa9bc31"
   },
-  "cpython-3.9.18-linux-s390x": {
+  "cpython-3.9.18-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-s390x-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "691470ca8a6a7f2b13e503153c499571f3ee3e5201d536bd071a36b30d32a68b"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "70e4418ebabe2d61b8d09c9b9a9b2e00b7f6d8658b37de2a4ff9fe8c24bc2f1d"
   },
-  "cpython-3.9.18-darwin-x86_64": {
+  "cpython-3.9.18-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 18,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "aa2e549186ab9f831169ccc32965c81ba0fa62e471129f51988f40eaa9552309"
   },
-  "cpython-3.9.18-linux-x86_64": {
+  "cpython-3.9.18-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "2cc59d95934240859e2c67fce02018d00882deb860cabbc3162501f7adfdf16f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "93ff5a32b0874ea1eb888fb735663a64a26e5fac54079c64fdd48ac379da99d4"
   },
-  "cpython-3.9.18-windows-x86_64": {
+  "cpython-3.9.18-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "ea096a98314f31186e1b0a6767d0a9b7b936a2d4003296887fd7e9fad0f50fd5"
+  },
+  "cpython-3.9.18-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 18,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "3b9c7d6ed94260b83ed8f44ee9a7b8fce392259ce6591e538601f7353061a884"
   },
-  "cpython-3.9.18-linux-x86_64_v2": {
+  "cpython-3.9.18-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "8c10de7b0c47031ac124201bb77be4e1a5f763f9285633c857b096511a050d9d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2520fa2853ddc81e43418b48217128a2a9d8b7e2a282b838ba7d3e66e2776f8d"
   },
-  "cpython-3.9.18-linux-x86_64_v3": {
+  "cpython-3.9.18-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "91e27451e1002ba29cf2e0e969654cf624ab72f3fe1c2adfd1a3aeaa1030ff0d"
+  },
+  "cpython-3.9.18-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "5beaec009e95a6cf1daf4197caebacd86cb7be3e524b528ac4efd3fc583467c8"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3ed47287cabecd02a074fad0ff8e2074ff39881e2c343e732cd1cdc62edefcbb"
   },
-  "cpython-3.9.18-linux-x86_64_v4": {
+  "cpython-3.9.18-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "20d61008ab8e1492a345521bf17f5b132d7d73d8ffd6f0dfb56d69506d2a6e73"
+  },
+  "cpython-3.9.18-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "348f32e3b453efbdb3dc6c39508d84bd8cddb9cad26433bccb22b5cae4b4cc0c"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fca812213f43eeedc67d42d6589a209a4f921b26b11454a7de361a64c8c9187b"
   },
-  "cpython-3.9.17-darwin-arm64": {
+  "cpython-3.9.18-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.9.18%2B20240107-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "bc8fbbb07f7bd22faee3e90886a9c46bc1393e695e93e67fb5cea61e4775048a"
+  },
+  "cpython-3.9.17-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 17,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "2902e2a0add6d584999fa27896b721a359f7308404e936e80b01b07aa06e8f5e"
   },
-  "cpython-3.9.17-linux-arm64": {
+  "cpython-3.9.17-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "de2eab48ca487550258db38b38cb9372143283f757b3cf9ec522eb657e41a035"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1f6c43d92ba9f4e15149cf5db6ecde11e05eee92c070a085e44f46c559520257"
   },
-  "cpython-3.9.17-linux-i686": {
+  "cpython-3.9.17-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "9984f59284048608f6734b032ff76e6bc3cb208e2235fdb511b0e478158fdb2b"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1a9b7edc16683410c27bc5b4b1761143bef7831a1ad172e7e3581c152c6837a2"
   },
-  "cpython-3.9.17-windows-i686": {
+  "cpython-3.9.17-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 17,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "ffac27bfb8bdf615d0fc6cbbe0becaa65b6ae73feec417919601497fce2be0ab"
   },
-  "cpython-3.9.17-linux-ppc64le": {
+  "cpython-3.9.17-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "c3233f54dd4719c98559a92725b89bd42d68bebd4e4065a4d567a30c7a98ca28"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bcb0ec31342df52b4555be309080a9c3224e7ff60a6291e34337ddfddef111cf"
   },
-  "cpython-3.9.17-linux-s390x": {
+  "cpython-3.9.17-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-s390x-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "4e06fb7047b92a694638ee622e8d1da9d1df2f604a2726fe8a087f748032ee7c"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bf8c846c1a4e52355d4ae294f4e1da9587d5415467eb6890bdf0f5a4c8cda396"
   },
-  "cpython-3.9.17-darwin-x86_64": {
+  "cpython-3.9.17-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 17,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "ba04f9813b78b61d60a27857949403a1b1dd8ac053e1f1aff72fe2689c238d3c"
   },
-  "cpython-3.9.17-linux-x86_64": {
+  "cpython-3.9.17-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "cec2385699c047e77d32b93442417ab7d49c3e78c946cf586380dfe0b12a36dd"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "649fff6048f4cb9e64a85eaf8e720eb4c3257e27e7c4ee46f75bfa48c18c6826"
   },
-  "cpython-3.9.17-windows-x86_64": {
+  "cpython-3.9.17-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "8496473a97e1dd43bf96fc1cf19f02f305608ef6a783e0112274e0ae01df4f2a"
+  },
+  "cpython-3.9.17-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 17,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "209983b8227e4755197dfed4f6887e45b6a133f61e7eb913c0a934b0d0c3e00f"
   },
-  "cpython-3.9.17-linux-x86_64_v2": {
+  "cpython-3.9.17-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "f50a158e8731f3d4f371c8c2bc660dea0dc7701e6d43335e6fcbf6ad90518346"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3faab5cb6c0bbb601be92575540036454fb34c0d7e4045760c62d782d8455f88"
   },
-  "cpython-3.9.17-linux-x86_64_v3": {
+  "cpython-3.9.17-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "64dbebbc6f9d5444156d641b17f1874f6f287f2d524435cfb9f1a580533146c7"
+  },
+  "cpython-3.9.17-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "f939b8bf843e6969b90f96d46c3a8460fb910745264dbc0e3d680c671cdfd543"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c38db0bd66d15fd2f29bd6299dd74040a93fbe780c811827c3f3eca04f9aa3ca"
   },
-  "cpython-3.9.17-linux-x86_64_v4": {
+  "cpython-3.9.17-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "292f0c45e88866e4a8b122db5248c9d90f73e4d43af906eb97ff084d6e9d5d62"
+  },
+  "cpython-3.9.17-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "4ad5b65d5f654dc8f1a8e4244707da5e0affbab55c95eb019111eb6498d36e94"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c9188a2b7edfb9e24d7cdfde239363ff8c79904901201041c0400d3f82923cb5"
   },
-  "cpython-3.9.16-darwin-arm64": {
+  "cpython-3.9.17-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "3f397ca020c9aa46c792c20aa5a8e96f922a5e77d02b6f87413597b88efe7f51"
+  },
+  "cpython-3.9.16-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 16,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "c86ed2bf3ff290af10f96183c53e2b29e954abb520806fbe01d3ef2f9d809a75"
   },
-  "cpython-3.9.16-linux-arm64": {
+  "cpython-3.9.16-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "6c516ed541e7f84ba8b322aa15006082701456bba7c57e68e7263d702927a76d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "57ac7ce9d3dd32c1277ee7295daf5ad7b5ecc929e65b31f11b1e7b94cd355ed1"
   },
-  "cpython-3.9.16-linux-i686": {
+  "cpython-3.9.16-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "4df4cae277ba3ff8de7a16ef3b38f7214c2b0e4cc992f09505b859b0c94f2fd8"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e2a0226165550492e895369ee1b69a515f82e12cb969656012ee8e1543409661"
   },
-  "cpython-3.9.16-windows-i686": {
+  "cpython-3.9.16-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 16,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "d7994b5febb375bb131d028f98f4902ba308913c77095457ccd159b521e20c52"
   },
-  "cpython-3.9.16-linux-ppc64le": {
+  "cpython-3.9.16-linux-ppc64le-gnu": {
     "name": "cpython",
     "arch": "ppc64le",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-ppc64le-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "3fcbf3e1090461a16cb33c66e973ea2e918fe1373e51a84892268df6b7155648"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8b2e7ddc6feb116dfa6829cfc478be90a374dc5ce123a98bc77e86d0e93e917d"
   },
-  "cpython-3.9.16-darwin-x86_64": {
+  "cpython-3.9.16-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 16,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "5809626ca7907c8ea397341f3d5eafb280ed5b19cc5622e57b14d9b4362eba50"
   },
-  "cpython-3.9.16-linux-x86_64": {
+  "cpython-3.9.16-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "9fc89e1f3e1c03b4f5cd3c289f52e53a7c5fc8779113c2af5a10b19b2e8a2c2f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "cdc1290b9bdb2f74a6c48ab24531919551128e39773365c6f3e17668216275a0"
   },
-  "cpython-3.9.16-windows-x86_64": {
+  "cpython-3.9.16-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "c397f292021b33531248ad8fede24ef6249cc6172347b2017f92b4a71845b8ed"
+  },
+  "cpython-3.9.16-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 16,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "199c821505e287c004c3796ba9ac4bd129d7793e1d833e9a7672ed03bdb397d4"
   },
-  "cpython-3.9.16-linux-x86_64_v2": {
+  "cpython-3.9.16-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "3ce0c3901a12abe123469839855b57f89d910bc4094b818b18860cdf3248bcda"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "35dcaff7a658b8c6bf5ffe1c4e2db95df5d647d28b4880a90f09bf3a70f42e8b"
   },
-  "cpython-3.9.16-linux-x86_64_v3": {
+  "cpython-3.9.16-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "73234f487b6be3c38a0f13200282d85866a248ed2ff8194b609dcf319af5e8d4"
+  },
+  "cpython-3.9.16-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "dc1c5190c8fb33bf315aad4c4af6342a95976610dadfe4e1218810e63a611431"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "4c00f35b9218e19065ba9e06c123505f056173a4f9b7eeb72ef768d0dfe8f867"
   },
-  "cpython-3.9.16-linux-x86_64_v4": {
+  "cpython-3.9.16-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "9bdf930d1b0ecd4b3e98a2b787aa25300ada62a42c20ac4d4c3bd923486e342b"
+  },
+  "cpython-3.9.16-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "54ce41739fa946e91b91d0e8d234acb4d4cfb7c4cc9f0aaf3ac6cbfb6b34ca8f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b61ccbfd13415891a9120eaaa37ad5e3f6fac3bfad6123c951c955dbaafec6c3"
   },
-  "cpython-3.9.15-darwin-arm64": {
+  "cpython-3.9.16-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "ffc2f51ce20eefaecc9d70daca4e73c051233006cd3d7a2f8dfca1189ed5584f"
+  },
+  "cpython-3.9.15-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 15,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "1799b97619572ad595cd6d309bbcc57606138a57f4e90af04e04ee31d187e22f"
   },
-  "cpython-3.9.15-linux-arm64": {
+  "cpython-3.9.15-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "4012279410b28c2688b4acfbc9189cdc8c81ef4c4f83c5e4532c39cb8685530e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "0da1f081313b088c1381206e698e70fffdffc01e1b2ce284145c24ee5f5b4cbb"
   },
-  "cpython-3.9.15-linux-i686": {
+  "cpython-3.9.15-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "7c5d8e6a4255115e96c4b987b76c203ae9c7e6655b2d52c880680f13d2f1af36"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "cbc6a14835022d89f4ca6042a06c4959d74d4bbb58e70bdbe0fe8d2928934922"
   },
-  "cpython-3.9.15-windows-i686": {
+  "cpython-3.9.15-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 15,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "a5ad2a6ace97d458ad7b2857fba519c5c332362442d88e2b23ed818f243b8a78"
   },
-  "cpython-3.9.15-darwin-x86_64": {
+  "cpython-3.9.15-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 15,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "50fd795eac55c4485e2fefbb8e7b365461817733c45becb50a7480a243e6000e"
   },
-  "cpython-3.9.15-linux-x86_64": {
+  "cpython-3.9.15-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "b6860b9872f361af78021dd2e1fe7edfe821963deab91b9a813d12d706288d3d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6a08761bb725b8d3a92144f81628febeab8b12326ca264ffe28255fa67c7bf17"
   },
-  "cpython-3.9.15-windows-x86_64": {
+  "cpython-3.9.15-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "4597f0009cfb52e748a57badab28edf84a263390b777c182b18c36d666a01440"
+  },
+  "cpython-3.9.15-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 15,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "d0f3ce1748a51779eedf155aea617c39426e3f7bfd93b4876cb172576b6e8bda"
   },
-  "cpython-3.9.15-linux-x86_64_v2": {
+  "cpython-3.9.15-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "f8a7eed2e7c63398f3ea7a714127c32bbdd9ca473af29cc10a39cb0c2340b419"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6222695583b32845fbbf17ec4a43981126ce0d6bb08b47a8c8853396e0f5e9f7"
   },
-  "cpython-3.9.15-linux-x86_64_v3": {
+  "cpython-3.9.15-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "440a4cffe00f2989628d1ff5ff0f2102998a328b3a0f605ea2fe110f93597598"
+  },
+  "cpython-3.9.15-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "03d7368bb700a9f246806931f9fae5013dc66674a19ba544e71eda4a553ec32a"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b5fbe25175f4338d6f5bb6f13ea6d714a4373a69b4d193c5037e8424ce5f53fb"
   },
-  "cpython-3.9.15-linux-x86_64_v4": {
+  "cpython-3.9.15-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "1289f63b4c3cc8a104e891b541a29642306c4bce7d0c82f571effbf52d5e2c50"
+  },
+  "cpython-3.9.15-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "4d6f17202f93f6128e47a101e84f64214e0157a97d83cc699b8039f09967086f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5bc44523a504d220e9af9acaa141ba9ac67e2fe998817cbca99b1bcc9a85d3cd"
   },
-  "cpython-3.9.14-darwin-arm64": {
+  "cpython-3.9.15-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "77217f3033392b7bb17201d57b19259cd608d1f357d4f3ce2165e1a89bef1b14"
+  },
+  "cpython-3.9.14-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 14,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "6b9d2ff724aff88a4d0790c86f2e5d17037736f35a796e71732624191ddd6e38"
   },
-  "cpython-3.9.14-linux-arm64": {
+  "cpython-3.9.14-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "b099375504383b3a30af02dcf3a9ce01b0e6fecba5b3a8729b4a0a374fee7984"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3020c743e4742d6e0e5d27fcb166c694bf1d9565369b2eaee9d68434304aebd2"
   },
-  "cpython-3.9.14-linux-i686": {
+  "cpython-3.9.14-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "612031ffd5b6dee7f4fe205afeee62a996bbd8df338ae7d0f3731a825aee04fb"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "83a11c4f3d1c0ec39119bd0513a8684b59b68c3989cf1e5042d7417d4770c904"
   },
-  "cpython-3.9.14-windows-i686": {
+  "cpython-3.9.14-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 14,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "fae990eb312314102408cb0c0453dae670f0eb468f4cbf3e72327ceaa1276b46"
   },
-  "cpython-3.9.14-darwin-x86_64": {
+  "cpython-3.9.14-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 14,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "186155e19b63da3248347415f888fbcf982c7587f6f927922ca243ae3f23ed2f"
   },
-  "cpython-3.9.14-linux-x86_64": {
+  "cpython-3.9.14-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "7f88ff09b2b57c19f4262026b0919aca59558971838093c63b68dfce7834e84d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "54529c0a8ffe621f5c9c6bdd22968cac9d3207cbd5dcd9c07bbe61140c49937e"
   },
-  "cpython-3.9.14-windows-x86_64": {
+  "cpython-3.9.14-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "5638c12d47eb81adf96615cea8a5a61e8414c3ac03a8b570d30ae9998cb6d030"
+  },
+  "cpython-3.9.14-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 14,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "49f27a3a18b4c2d765b0656c6529378a20b3e37fdb0aca9490576ff7a67243a9"
   },
-  "cpython-3.9.14-linux-x86_64_v2": {
+  "cpython-3.9.14-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "47e654a6dd5ad3bfd2a77341482a06c3bf25598f8ac76cfb95d2aa124f03f0c2"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a78cb80ca372ea98aca28d33a220b3fe91761c6dadaf92f646b82f3b569822c1"
   },
-  "cpython-3.9.14-linux-x86_64_v3": {
+  "cpython-3.9.14-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "d20c9ff5f3474a80948cc4533a799573e5e3c62cd0477224f5e1ec1da656c6be"
+  },
+  "cpython-3.9.14-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "fcb08f826412496a672512d07f8ab19b0a6d201f31514989b63502f50ac633e1"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "53d3c637264a57317b304a88ddd418463fe0b37b874495e3ae55940b5c62b363"
   },
-  "cpython-3.9.14-linux-x86_64_v4": {
+  "cpython-3.9.14-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "3ad497929e6e14596a18f4dfd09d48fb4bbefff23f06e5ca5b4d9f79ac31f646"
+  },
+  "cpython-3.9.14-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "f23a4d657ff6577405513e28101801c2b224ff0a1d1380e8a6d1b96a03c75572"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "92e5a9fd569c0b1c161958e2e1d3198cb4e27b524d02cf3008b260dba658961f"
   },
-  "cpython-3.9.13-darwin-arm64": {
+  "cpython-3.9.14-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "35681efee0142c0873cbf27d5e54eddb13e61439a563b358a02fed9909011d0e"
+  },
+  "cpython-3.9.13-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "8612e9328663c0747d1eae36b218d11c2fbc53c39ec7512c7ad6b1b57374a5dc"
   },
-  "cpython-3.9.13-linux-arm64": {
+  "cpython-3.9.13-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "e27d88c3c3424a3694f9f111dc4e881c3925aa5d9ec60ec8395a82da2d7c2f31"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8c706ebb2c8970da4fbec95b0520b4632309bc6a3e115cf309e38f181b553d14"
   },
-  "cpython-3.9.13-linux-i686": {
+  "cpython-3.9.13-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "066d4722bcc75fb16000afd745b11fb5c02847471695c67db633918969e3936b"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7d33637b48c45acf8805d5460895dca29bf2740fd2cf502fde6c6a00637db6b5"
   },
-  "cpython-3.9.13-windows-i686": {
+  "cpython-3.9.13-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "3860abee418825c6a33f76fe88773fb05eb4bc724d246f1af063106d9ea3f999"
   },
-  "cpython-3.9.13-darwin-x86_64": {
+  "cpython-3.9.13-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "16d21a6e62c19c574a4a225961e80966449095a8eb2c4150905e30d4e807cf86"
   },
-  "cpython-3.9.13-linux-x86_64": {
+  "cpython-3.9.13-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "e586b6fef3943adff4e74fbc3fe276dfbca12e9d883e273ed0c8d781b24d7d6e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "352d00a4630d0665387bcb158aec3f6c7fc5a4d14d65ac26e1b826e20611222f"
   },
-  "cpython-3.9.13-windows-x86_64": {
+  "cpython-3.9.13-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "c7e48545a8291fe1be909c4454b5c48df0ee4e69e2b5e13b6144b4199c31f895"
+  },
+  "cpython-3.9.13-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "6ef2b164cae483c61da30fb6d245762b8d6d91346d66cb421989d6d1462e5a48"
   },
-  "cpython-3.9.13-linux-x86_64_v2": {
+  "cpython-3.9.13-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "d226227c7fb70ec46c4f29d108a7024e093b2639368ab1117d7e460beebdb36a"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "37ace8159aa2f5157abea2c0d854434f21e6676b90eeaf58d313778f64540ca7"
   },
-  "cpython-3.9.13-linux-x86_64_v3": {
+  "cpython-3.9.13-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "0648910f5f0341f192da23a6e58aedbfdbd0ee17d41207fcaf25c957f295dfa7"
+  },
+  "cpython-3.9.13-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "57685a2f1c96a7b5156276f499e70a7eaa8a8fa17a1475c9d3b9cc1035e6e3f3"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "59a24171f794139b41d47b3e734c82d02bc11956a4c092a3d28d94a5d0ab7f54"
   },
-  "cpython-3.9.13-linux-x86_64_v4": {
+  "cpython-3.9.13-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "b6f756062f9df0791e0148f0d37c62c3fd13b49e8fc8b18805dcac3a010c67ef"
+  },
+  "cpython-3.9.13-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "1cab8345431762dec6bd9cc3e95377bb73b04997d3d831c4b4e304923e62f81e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "920fd94d4352495a804d4ee725764ae7499b29c5f1c15d11cc4380a873498dbf"
   },
-  "cpython-3.9.12-darwin-arm64": {
+  "cpython-3.9.13-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "e2a41aab57dc2c0f61c02702510722456fb06947b620fef0e5ad2c649d4701fa"
+  },
+  "cpython-3.9.12-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "b3d09b3c12295e893ee8f2cb60e8af94d8a21fc5c65016282925220f5270b85b"
   },
-  "cpython-3.9.12-linux-arm64": {
+  "cpython-3.9.12-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "0749e4f8169b45051c440c81c17449549710d0e5821d4fdb5170b704ddd165c4"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "202ef64e43570f0843ff5895fd9c1a2c36a96b48d52842fa95842d7d11025b20"
   },
-  "cpython-3.9.12-linux-i686": {
+  "cpython-3.9.12-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "4a32d5f827e9c1fbed68e51974d78f090ccdd8c83f777a2c9f80644a96d53c3f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e52fdbe61dea847323cd6e81142d16a571dca9c0bcde3bfe5ae75a8d3d1a3bf4"
   },
-  "cpython-3.9.12-windows-i686": {
+  "cpython-3.9.12-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "361b8fa66d6b5d5623fd5e64af29cf220a693ba86d031bf7ce2b61e1ea50f568"
   },
-  "cpython-3.9.12-darwin-x86_64": {
+  "cpython-3.9.12-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "825970ae30ae7a30a5b039aa25f1b965e2d1fe046e196e61fa2a3af8fef8c5d9"
   },
-  "cpython-3.9.12-linux-x86_64": {
+  "cpython-3.9.12-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "9af4ad8e87d1d24352163d519df44f652efefe018b8c7b48ca57604054950abe"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7290ac14e43749afdb37d3c9690f300f5f0786f19982e8960566ecdc3e42c3eb"
   },
-  "cpython-3.9.12-windows-x86_64": {
+  "cpython-3.9.12-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "eb122ab2bf0b2d71926984bc7cf5fef65b415abfe01a0974ed6c1a2502fac764"
+  },
+  "cpython-3.9.12-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "c49f8b07e9c4dcfd7a5b55c131e882a4ebdf9f37fef1c7820c3ce9eb23bab8ab"
   },
-  "cpython-3.9.12-linux-x86_64_v2": {
+  "cpython-3.9.12-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "ce232a6ab127d5310101d1279adb8e1aaf1486b646d8d16a24c5317204e7655d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "53dadc107ce8d1ba5f94ca87edbeef485c8a07b2c0e942a99a7c7e163fafb6f4"
   },
-  "cpython-3.9.12-linux-x86_64_v3": {
+  "cpython-3.9.12-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "347357fa079cdc17b6becd521e64911661c6263e64f161721cf0db39466ee4c3"
+  },
+  "cpython-3.9.12-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "8a0817588c787ea08dfa0c2bcc29dfb85020762d199ae0450b7ccaaa03dea177"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e7ba8a790a3194a0847ef0b09b8dd8542b9c2ca689b2f4ee4ecb771a44ea41f2"
   },
-  "cpython-3.9.12-linux-x86_64_v4": {
+  "cpython-3.9.12-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "06011e3ea1f3265c72a15d133a76a3d308377228ac6392206348312e76c321d9"
+  },
+  "cpython-3.9.12-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "e53aea4000d55570087890662dd574e634c0271ae662b97df98307d5329a1429"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "afdd26e418ab5a2e5e10b42eb98c79bafd7c198363f70aad8628266b7f3532ab"
   },
-  "cpython-3.9.11-darwin-arm64": {
+  "cpython-3.9.12-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "281509ccab077369f69cdd88c6d82488dfa65a626350cc7290ca13954f305b4c"
+  },
+  "cpython-3.9.11-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "6d9f20607a20e2cc5ad1428f7366832dc68403fc15f2e4f195817187e7b6dbbf"
   },
-  "cpython-3.9.11-linux-arm64": {
+  "cpython-3.9.11-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "e540f92f78cc84a52a77ce621c3da5a427367205884ab4210e763bc7fdaf889c"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e1f3ae07a28a687f8602fb4d29a1b72cc5e113c61dc6769d0d85081ab3e09c71"
   },
-  "cpython-3.9.11-linux-i686": {
+  "cpython-3.9.11-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "aeb50fcc54214780244dd64c0d66bf5dec30db075c999cf2c5a58134f8d21c33"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "0be0a5f524c68d521be2417565ca43f3125b1845f996d6d62266aa431e673f93"
   },
-  "cpython-3.9.11-windows-i686": {
+  "cpython-3.9.11-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "f06338422e7e3ad25d0cd61864bdb36d565d46440dd363cbb98821d388ed377a"
   },
-  "cpython-3.9.11-darwin-x86_64": {
+  "cpython-3.9.11-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "35e649618e7e602778e72b91c9c50c97d01a0c3509d16225a1f41dd0fd6575f0"
   },
-  "cpython-3.9.11-linux-x86_64": {
+  "cpython-3.9.11-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "49dfa5cb99d4f71657dc651ad68d0fce7cc011beb59499141138ef062bd62b49"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "020bcbfff16dc5ce35a898763be3d847c97df2e14dabf483a8ec88b0455ff971"
   },
-  "cpython-3.9.11-windows-x86_64": {
+  "cpython-3.9.11-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "d83eb5c897120e32287cb6fe5c24dd2dcae00878b3f9d7002590d468bd5de0f1"
+  },
+  "cpython-3.9.11-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "1fe3c519d43737dc7743aec43f72735e1429c79e06e3901b21bad67b642f1a10"
   },
-  "cpython-3.9.11-linux-x86_64_v2": {
+  "cpython-3.9.11-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "039a1cd370a0865945abec8bec2db81067497cfeeb9be8fe7a0dcdd0c9a92361"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7d7a745a3d6eade5fd7352b444c4c91ce562a2d188716d6995155c2ed5d1e337"
   },
-  "cpython-3.9.11-linux-x86_64_v3": {
+  "cpython-3.9.11-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "6ce18f9b6808aece6e45f2859cd12e0420c2a3372b9a9130503d8f5689d68f89"
+  },
+  "cpython-3.9.11-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "19d87980827f146e7eb6f276ec2fb5d99c26cc0a5e11120a533fbcda75498c98"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ea43a4a473ebf99af4f7b9ae1d00e3bd6c5a2a329096e5657590ed5d823903dd"
   },
-  "cpython-3.9.11-linux-x86_64_v4": {
+  "cpython-3.9.11-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "48452b551065ae3040967cc47c36fe7eb42ea4f8be07c3c19a47ceab9a5957ea"
+  },
+  "cpython-3.9.11-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "c21c52e659d54177b69cb939129ae20e22d00aa754d2883445fc60baa750f430"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a1e7c4554d200d4fa50dc43cda6db020df99f75bb105dd7c44139c44d5040fae"
   },
-  "cpython-3.9.10-darwin-arm64": {
+  "cpython-3.9.11-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "395a2c3b64446af61100ccf8fdce7dfa3cff91fd72ca0b0a1147a5aac5f7aa9c"
+  },
+  "cpython-3.9.10-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 10,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "ba1b63600ed8d9f3b8d739657bd8e7f5ca167de29a1a58d04b2cd9940b289464"
   },
-  "cpython-3.9.10-linux-arm64": {
+  "cpython-3.9.10-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 10,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "a40dc3f12bbcaeb487d2ece8c5415f94f3856b400f78202b6055cd514c5e9a24"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8bf7ac2cd5825b8fde0a6e535266a57c97e82fd5a97877940920b403ca5e53d7"
   },
-  "cpython-3.9.10-linux-i686": {
+  "cpython-3.9.10-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 10,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "218a79ef09d599d95a04819311ee27ab0fd34dd80d3722347003fec0139dca7b"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3e3bf4d3e71a2131e6c064d1e5019f58cb9c58fdceae4b76b26ac978a6d49aad"
   },
-  "cpython-3.9.10-windows-i686": {
+  "cpython-3.9.10-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 10,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "7f3ca15f89775f76a32e6ea9b2c9778ebf0cde753c5973d4493959e75dd92488"
   },
-  "cpython-3.9.10-darwin-x86_64": {
+  "cpython-3.9.10-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 10,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "ef2f090ff920708b4b9aa5d6adf0dc930c09a4bf638d71e6883091f9e629193d"
   },
-  "cpython-3.9.10-linux-x86_64": {
+  "cpython-3.9.10-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 10,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "de0a1b11f56cd6acdbc4b369a023377fd830946726f3abbbce8fc11dcb56cac0"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d453abf741c3196ffc8470f3ea6404a3e2b55b2674a501bb79162f06122423e5"
   },
-  "cpython-3.9.10-windows-x86_64": {
+  "cpython-3.9.10-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "2744b817f249c0563b844cddd5aba4cc2fd449489b8bd59980d7a31de3a4ece1"
+  },
+  "cpython-3.9.10-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 10,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "56b2738599131d03b39b914ea0597862fd9096e5e64816bf19466bf026e74f0c"
   },
-  "cpython-3.9.10-linux-x86_64_v2": {
+  "cpython-3.9.10-linux-x86_64_v2-gnu": {
     "name": "cpython",
     "arch": "x86_64_v2",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 10,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "b06b7ca295b5a838a4fbc2bf67c43e28b761a0548b8b6181ddfa61bc1deaf0b9"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8317251d7480b9fc8b4f0b76dbb91b339bc55760cc92715e66f91a3055396497"
   },
-  "cpython-3.9.10-linux-x86_64_v3": {
+  "cpython-3.9.10-linux-x86_64_v2-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v2",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v2-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "8aca72895482f0730ac20f829fd47ce004bb0f52fc99fdd500cf22a2b1288d9a"
+  },
+  "cpython-3.9.10-linux-x86_64_v3-gnu": {
     "name": "cpython",
     "arch": "x86_64_v3",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 10,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "7a912ec0220da389b6d3b9a2373aee2a9fb9f24e975c358292c266ab6e775150"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c2a8ef2fd0f2c033371e931c2588444c5872b3c1fe7c787e0139e9ee03177ea6"
   },
-  "cpython-3.9.10-linux-x86_64_v4": {
+  "cpython-3.9.10-linux-x86_64_v3-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v3",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v3-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "c6d9c35ac9e3553eb1f56a955c24487f1910c58827efee846b38ee8dbfef6390"
+  },
+  "cpython-3.9.10-linux-x86_64_v4-gnu": {
     "name": "cpython",
     "arch": "x86_64_v4",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 10,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "eb8fa11710f6fbdb3e3c1323068fbcce1296d862eed30216946b1d573ce989b4"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "162da56c07f3bec783c3c202b274c89ab115dae82ab7783b04404c7e315b819f"
   },
-  "cpython-3.9.7-darwin-arm64": {
+  "cpython-3.9.10-linux-x86_64_v4-musl": {
+    "name": "cpython",
+    "arch": "x86_64_v4",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64_v4-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "e9c51af9f3e684349a8b2f3422849520d64e1a6b8c3546367fe0e239c2ff7399"
+  },
+  "cpython-3.9.7-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.7-linux-arm64": {
+  "cpython-3.9.7-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-unknown-linux-gnu-lto-20211017T1616.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-unknown-linux-gnu-debug-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.7-linux-i686": {
+  "cpython-3.9.7-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-unknown-linux-gnu-debug-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.7-windows-i686": {
+  "cpython-3.9.7-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.7-darwin-x86_64": {
+  "cpython-3.9.7-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.7-linux-x86_64": {
+  "cpython-3.9.7-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-gnu-debug-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.7-windows-x86_64": {
+  "cpython-3.9.7-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.6-darwin-arm64": {
+  "cpython-3.9.6-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.6-linux-arm64": {
+  "cpython-3.9.6-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-unknown-linux-gnu-lto-20210724T1424.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-unknown-linux-gnu-debug-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.6-linux-i686": {
+  "cpython-3.9.6-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-unknown-linux-gnu-debug-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.6-windows-i686": {
+  "cpython-3.9.6-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.6-darwin-x86_64": {
+  "cpython-3.9.6-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.6-linux-x86_64": {
+  "cpython-3.9.6-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-gnu-debug-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.6-windows-x86_64": {
+  "cpython-3.9.6-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.5-darwin-arm64": {
+  "cpython-3.9.5-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-aarch64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.5-linux-i686": {
+  "cpython-3.9.5-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-unknown-linux-gnu-debug-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.5-windows-i686": {
+  "cpython-3.9.5-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.5-darwin-x86_64": {
+  "cpython-3.9.5-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.5-linux-x86_64": {
+  "cpython-3.9.5-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-gnu-debug-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.5-windows-x86_64": {
+  "cpython-3.9.5-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.4-darwin-arm64": {
+  "cpython-3.9.4-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-aarch64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.4-linux-i686": {
+  "cpython-3.9.4-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-unknown-linux-gnu-debug-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.4-windows-i686": {
+  "cpython-3.9.4-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.4-darwin-x86_64": {
+  "cpython-3.9.4-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.4-linux-x86_64": {
+  "cpython-3.9.4-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-gnu-debug-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.4-windows-x86_64": {
+  "cpython-3.9.4-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.3-darwin-arm64": {
+  "cpython-3.9.3-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-aarch64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.3-windows-i686": {
+  "cpython-3.9.3-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-i686-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.3-darwin-x86_64": {
+  "cpython-3.9.3-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.3-linux-x86_64": {
+  "cpython-3.9.3-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-gnu-pgo%2Blto-20210413T2055.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-gnu-debug-20210413T2055.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.3-windows-x86_64": {
+  "cpython-3.9.3-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-musl-lto-20210413T2055.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.2-darwin-arm64": {
+  "cpython-3.9.2-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-aarch64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.2-linux-i686": {
+  "cpython-3.9.2-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-unknown-linux-gnu-debug-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.2-windows-i686": {
+  "cpython-3.9.2-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.2-darwin-x86_64": {
+  "cpython-3.9.2-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.2-linux-x86_64": {
+  "cpython-3.9.2-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-gnu-debug-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.2-windows-x86_64": {
+  "cpython-3.9.2-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 2,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.2-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.1-windows-i686": {
+  "cpython-3.9.1-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.1-darwin-x86_64": {
+  "cpython-3.9.1-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.1-linux-x86_64": {
+  "cpython-3.9.1-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-gnu-pgo-20210103T1125.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-gnu-debug-20210103T1125.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.1-windows-x86_64": {
+  "cpython-3.9.1-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.1-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.0-windows-i686": {
+  "cpython-3.9.0-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-i686-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.0-darwin-x86_64": {
+  "cpython-3.9.0-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.0-linux-x86_64": {
+  "cpython-3.9.0-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 9,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-gnu-pgo-20201020T0627.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-gnu-debug-20201020T0627.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.0-windows-x86_64": {
+  "cpython-3.9.0-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 0,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.0-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.18-darwin-arm64": {
+  "cpython-3.8.18-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 18,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "f426349265897fb3715f19f474f45e17406d77701eb1b60953f9b32e51c779b9"
   },
-  "cpython-3.8.18-linux-arm64": {
+  "cpython-3.8.18-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "a3d6f2dcaf43b7549e6c0965debdc8ccb958e662b4a3d95b506816dc99624e68"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8aeb623f50866c9ee0260471a664e048b31836ce8793490895d2f7b5b5792e84"
   },
-  "cpython-3.8.18-windows-i686": {
+  "cpython-3.8.18-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 18,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "875983fccf91310805164528150adfde1ac63564d0c3967d48086c6fdb9f568b"
   },
-  "cpython-3.8.18-darwin-x86_64": {
+  "cpython-3.8.18-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 18,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "bfcd4a61998e105a78dbac2b68f1f264cd7bedc5ef11f89ec10911f23b445616"
   },
-  "cpython-3.8.18-linux-x86_64": {
+  "cpython-3.8.18-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "954b52b1d93a1f4f016b5e5f1f9683617f7de112ff0cf53ca3002dcd45eff4ef"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ff02848c574ccc581d21433f20eef333faf06f4fcd35bf2c6264553bec3f1643"
   },
-  "cpython-3.8.18-windows-x86_64": {
+  "cpython-3.8.18-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 18,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "a0f8f26137b9971bfa7fc657b55362dd23a69d9df6d39e35bdae211834350f62"
+  },
+  "cpython-3.8.18-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 18,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.8.18%2B20240107-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "0675bf51ad66c149c311e8da4a358b0e0fc28801770163d8053d9aadf6bdb556"
   },
-  "cpython-3.8.17-darwin-arm64": {
+  "cpython-3.8.17-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 17,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "d08a542bed35fc74ac6e8f6884c8aa29a77ff2f4ed04a06dcf91578dea622f9a"
   },
-  "cpython-3.8.17-linux-arm64": {
+  "cpython-3.8.17-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "efdf69695af469da13f86d5be23556fee6c03f417f8810fca55307a63aabf08d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "eaee5a0b79cc28943e19df54f314634795aee43a6670ce99c0306893a18fa784"
   },
-  "cpython-3.8.17-linux-i686": {
+  "cpython-3.8.17-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "aaf4b15bdc35674dbe25d4538c9e75e243796a0cc8841fd31d7bbbee6703342a"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "61ac08680c022f180a32dc82d84548aeb92c7194a489e3b3c532dc48f999d757"
   },
-  "cpython-3.8.17-windows-i686": {
+  "cpython-3.8.17-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 17,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "0931d8ca0e060c6ac1dfcf6bb9b6dea0ac3a9d95daf7906a88128045f4464bf8"
   },
-  "cpython-3.8.17-darwin-x86_64": {
+  "cpython-3.8.17-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 17,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "2c4925f5cf37d498e0d8cfe7b10591cc5f0cd80d2582f566b12006e6f96958b1"
   },
-  "cpython-3.8.17-linux-x86_64": {
+  "cpython-3.8.17-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "4bfe1055dee03d4357b3dca5b334df3076b8aab066cdd84596199b9712ee3632"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f499750ab0019f36ccb4d964e222051d0d49a1d1e8dbada98abae738cf48c9dc"
   },
-  "cpython-3.8.17-windows-x86_64": {
+  "cpython-3.8.17-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "a316ba0b1f425b04c8dfd7a8a18a05d72ae5852732d401b16d7439bdf25caec3"
+  },
+  "cpython-3.8.17-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 17,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "68c7d03de5283c4812f2706c797b2139999a28cec647bc662d1459a922059318"
   },
-  "cpython-3.8.16-darwin-arm64": {
+  "cpython-3.8.16-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 16,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "bfc91d0a1d6d6dfaa5a31c925aa6adae82bd1ae5eb17813a9f0a50bf9d3e6305"
   },
-  "cpython-3.8.16-linux-arm64": {
+  "cpython-3.8.16-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "62c3e7b417a9c11fb7d251ee6f763c7dd2ae681017a82686122a8167f1b8c081"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "423d43d93e2fe33b41ad66d35426f16541f09fee9d7272ae5decf5474ebbc225"
   },
-  "cpython-3.8.16-linux-i686": {
+  "cpython-3.8.16-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "e8d832f16548e199e7c622eec9e06f746ba9dbbdf562dac8810c4e64e1f5115a"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9aa3e559130a47c33ee2b67f6ca69e2f10d8f70c1fd1e2871763b892372a6d9e"
   },
-  "cpython-3.8.16-windows-i686": {
+  "cpython-3.8.16-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 16,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "5de953621402c11cc7db65ba15d45779e838d7ce78e7aa8d43c7d78fff177f13"
   },
-  "cpython-3.8.16-darwin-x86_64": {
+  "cpython-3.8.16-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 16,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "21c0f4a0fa6ee518b9f2f1901c9667e3baf45d9f84235408b7ca50499d19f56d"
   },
-  "cpython-3.8.16-linux-x86_64": {
+  "cpython-3.8.16-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "446a1f600698167a3e70448787f61dd8b1e6fb8f50f50558c901a0f4d3c7a6d6"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f12f5cb38f796ca48dc73262c05506a6f21f59d24e709ea0390b18bf71c2e1f9"
   },
-  "cpython-3.8.16-windows-x86_64": {
+  "cpython-3.8.16-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "f7d46196b44d12a26209ac74061200aac478b96c253eea93a0b9734efa642779"
+  },
+  "cpython-3.8.16-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 16,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "6316713c2dcb30127b38ced249fa9608830a33459580b71275a935aaa8cd5d5f"
   },
-  "cpython-3.8.15-darwin-arm64": {
+  "cpython-3.8.15-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 15,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "fc0f944e6f01ed649f79c873af1c317db61d2136b82081b4d7cbb7755f878035"
   },
-  "cpython-3.8.15-linux-arm64": {
+  "cpython-3.8.15-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "3a4975f1b0c196c98b4867ad41d2f1ba211b52dc6a2965c56acbb00eb7f69aa7"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2e80025eda686c14a9a0618ced40043c1d577a754b904fd7a382cd41abf9ca00"
   },
-  "cpython-3.8.15-linux-i686": {
+  "cpython-3.8.15-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "f76c0d13f600e819696035851ec47cf5a233cf053d2de85fbd8e5e12a8146f5f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b8436415ea9bd9970fb766f791a14b0e14ce6351fc4604eb158f1425e8bb4a33"
   },
-  "cpython-3.8.15-windows-i686": {
+  "cpython-3.8.15-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 15,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "98bb2315c3567316c30b060d613c8d6067b368b64f08ef8fe6196341637c1d78"
   },
-  "cpython-3.8.15-darwin-x86_64": {
+  "cpython-3.8.15-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 15,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "e4fd2fa2255295fbdcfadb8b48014fa80810305eccb246d355880aabb45cbe93"
   },
-  "cpython-3.8.15-linux-x86_64": {
+  "cpython-3.8.15-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "1fd71062d9b7d632af202972c4488fa9c2255d2ef072b80766ab059b37473ea5"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c3c8c23e34bddb4a2b90333ff17041f344401775d505700f1ceddb3ad9d589e0"
   },
-  "cpython-3.8.15-windows-x86_64": {
+  "cpython-3.8.15-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "231b35d3c2cff0372d17cea7ff5168c0684a920b94a912ffc965c2518cacb694"
+  },
+  "cpython-3.8.15-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 15,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "59beac5610e6da0848ebaccd72f91f6aaaeed65ef59606d006af909e9e79beba"
   },
-  "cpython-3.8.14-darwin-arm64": {
+  "cpython-3.8.14-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 14,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "d17a3fcc161345efa2ec0b4ab9c9ed6c139d29128f2e34bb636338a484aa7b72"
   },
-  "cpython-3.8.14-linux-arm64": {
+  "cpython-3.8.14-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "650821c45386e7727b6e682620007d2532d9ee599b2caf4b4356575bee3c77a0"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a14d8b5cbd8e1ca45cbcb49f4bf0b0440dc86eb95b7c3da3c463a704a3b4593c"
   },
-  "cpython-3.8.14-linux-i686": {
+  "cpython-3.8.14-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "adb5a08f8dd700bc2d8260226354137349939e9bc5ccfdb8c16493e97b593a19"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "631bb90fe8f2965d03400b268de90fe155ce51961296360d6578b7151aa9ef4c"
   },
-  "cpython-3.8.14-windows-i686": {
+  "cpython-3.8.14-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 14,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "e43f7a5044eac91e95df59fd08bf96f13245898876fc2afd90a081cfcd847e35"
   },
-  "cpython-3.8.14-darwin-x86_64": {
+  "cpython-3.8.14-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 14,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "62edfea77b42e87ca2d85c482319211cd2dd68d55ba85c99f1834f7b64a60133"
   },
-  "cpython-3.8.14-linux-x86_64": {
+  "cpython-3.8.14-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "5ca1c591ffb019fad3978018f68d69d4b6c73ce629fb7e42bc2c594cd8344d4f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bd1e8e09edccaab82fbd75b457205a076847d62e3354c3d9b5abe985181047fc"
   },
-  "cpython-3.8.14-windows-x86_64": {
+  "cpython-3.8.14-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "c6da442aaea160179a9379b297ccb3ba09b825fc27d84577fc28e62911451e7d"
+  },
+  "cpython-3.8.14-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 14,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "6986b3e6edf7b37f96ea940b7ccba7b767ed3ea9b3faec2a2a60e5b2c4443314"
   },
-  "cpython-3.8.13-darwin-arm64": {
+  "cpython-3.8.13-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "a204e5f9e1566bdc170b163300a29fc9580d5c65cd6e896caf6500cd64471373"
   },
-  "cpython-3.8.13-linux-arm64": {
+  "cpython-3.8.13-linux-arm64-gnu": {
     "name": "cpython",
     "arch": "arm64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-lto-full.tar.zst",
-    "sha256": "ad2b859fb502491f72f8d74ed3410bfb78a8886f8a1baa6908faea6128d91265"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3a927205db4686c182b5e8f3fc7fd7d82ec8f61c70d5b2bfddd9673c7ddc07ba"
   },
-  "cpython-3.8.13-linux-i686": {
+  "cpython-3.8.13-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "9191ac9858eddfc727fa5ebadc654a57a719ac96b9dee4e1e48e6498a27499f4"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6daf0405beae6d127a2dcae61d51a719236b861b4cabc220727e48547fd6f045"
   },
-  "cpython-3.8.13-windows-i686": {
+  "cpython-3.8.13-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "5630739d1c6fcfbf90311d236c5e46314fc4b439364429bee12d0ffc95e134fb"
   },
-  "cpython-3.8.13-darwin-x86_64": {
+  "cpython-3.8.13-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "f706a62de8582bf84b8b693c993314cd786f3e78639892cfd9a7283a526696f9"
   },
-  "cpython-3.8.13-linux-x86_64": {
+  "cpython-3.8.13-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "31c98d8329746c19739558f164e6374a2cd9c5c93c9e213d2548c993566a593c"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "891b5d7b0e936b98a62f65bc0b28fff61ca9002125a2fc1ebb9c72f6b0056712"
   },
-  "cpython-3.8.13-windows-x86_64": {
+  "cpython-3.8.13-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "410f3223021d1b439cf8e4da699f868adada2066e354d88a00b5f365dc66c4bf"
+  },
+  "cpython-3.8.13-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "c36b703b8b806a047ba71e5e85734ac78d204d3a2b7ebc2efcdc7d4af6f6c263"
   },
-  "cpython-3.8.12-darwin-arm64": {
+  "cpython-3.8.12-darwin-arm64-none": {
     "name": "cpython",
     "arch": "arm64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "386f667f8d49b6c34aee1910cdc0b5b41883f9406f98e7d59a3753990b1cdbac"
   },
-  "cpython-3.8.12-linux-i686": {
+  "cpython-3.8.12-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "61024acdfe5aef07ba4246ea07dba9962770ec1f3d137c54835c0e5b6e040149"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7cfac9a57e262be3e889036d7fc570293e6d3d74411ee23e1fa9aa470d387e6a"
   },
-  "cpython-3.8.12-windows-i686": {
+  "cpython-3.8.12-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "3e2e6c7de78b1924aad37904fed7bfbac6efa2bef05348e9be92180b2f2b1ae1"
   },
-  "cpython-3.8.12-darwin-x86_64": {
+  "cpython-3.8.12-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "cf614d96e2001d526061b3ce0569c79057fd0074ace472ff4f5f601262e08cdb"
   },
-  "cpython-3.8.12-linux-x86_64": {
+  "cpython-3.8.12-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-gnu-pgo%2Blto-full.tar.zst",
-    "sha256": "a014cf132a642a5d585f37da0c56f7e6672699811726af18e8905d652b261a3f"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9ad20c520c291d08087e9afb4390f389d2b66c7fc97f23fffc1313ebafc5fee0"
   },
-  "cpython-3.8.12-windows-x86_64": {
+  "cpython-3.8.12-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-musl-lto-full.tar.zst",
+    "sha256": "3d958e3f984637d8ca4a90a2e068737b268f87fc615121a6f1808cd46ccacc48"
+  },
+  "cpython-3.8.12-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "33f278416ba8074f2ca6d7f8c17b311b60537c9e6431fd47948784c2a78ea227"
   },
-  "cpython-3.8.11-linux-i686": {
+  "cpython-3.8.11-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-unknown-linux-gnu-debug-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.11-windows-i686": {
+  "cpython-3.8.11-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.11-darwin-x86_64": {
+  "cpython-3.8.11-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.11-linux-x86_64": {
+  "cpython-3.8.11-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-gnu-debug-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.11-windows-x86_64": {
+  "cpython-3.8.11-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.11-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.10-linux-i686": {
+  "cpython-3.8.10-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 10,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-unknown-linux-gnu-debug-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.10-windows-i686": {
+  "cpython-3.8.10-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 10,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.10-darwin-x86_64": {
+  "cpython-3.8.10-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 10,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.10-linux-x86_64": {
+  "cpython-3.8.10-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 10,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-gnu-debug-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.10-windows-x86_64": {
+  "cpython-3.8.10-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 10,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.10-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 10,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.9-linux-i686": {
+  "cpython-3.8.9-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-unknown-linux-gnu-debug-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.9-windows-i686": {
+  "cpython-3.8.9-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.9-darwin-x86_64": {
+  "cpython-3.8.9-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.9-linux-x86_64": {
+  "cpython-3.8.9-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-gnu-debug-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.9-windows-x86_64": {
+  "cpython-3.8.9-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 9,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.9-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.8-linux-i686": {
+  "cpython-3.8.8-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-unknown-linux-gnu-debug-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.8-windows-i686": {
+  "cpython-3.8.8-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 8,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.8-darwin-x86_64": {
+  "cpython-3.8.8-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 8,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.8-linux-x86_64": {
+  "cpython-3.8.8-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-gnu-debug-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.8-windows-x86_64": {
+  "cpython-3.8.8-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 8,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.8-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 8,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.7-windows-i686": {
+  "cpython-3.8.7-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.7-darwin-x86_64": {
+  "cpython-3.8.7-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.7-linux-x86_64": {
+  "cpython-3.8.7-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-gnu-pgo-20210103T1125.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-gnu-debug-20210103T1125.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.7-windows-x86_64": {
+  "cpython-3.8.7-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.6-windows-i686": {
+  "cpython-3.8.6-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-i686-pc-windows-msvc-shared-pgo-20201021T0233.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.6-darwin-x86_64": {
+  "cpython-3.8.6-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.6-linux-x86_64": {
+  "cpython-3.8.6-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-gnu-pgo-20201020T0627.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-gnu-debug-20201020T0627.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.6-windows-x86_64": {
+  "cpython-3.8.6-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-pc-windows-msvc-shared-pgo-20201021T0232.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.5-windows-i686": {
+  "cpython-3.8.5-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-i686-pc-windows-msvc-shared-pgo-20200830T2311.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.5-darwin-x86_64": {
+  "cpython-3.8.5-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.8.5-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.5-linux-x86_64": {
+  "cpython-3.8.5-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-gnu-pgo-20200823T0036.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-gnu-debug-20200823T0036.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.5-windows-x86_64": {
+  "cpython-3.8.5-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-x86_64-pc-windows-msvc-shared-pgo-20200830T2254.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.3-windows-i686": {
+  "cpython-3.8.3-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-i686-pc-windows-msvc-shared-pgo-20200518T0154.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.3-darwin-x86_64": {
+  "cpython-3.8.3-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.8.3-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.3-linux-x86_64": {
+  "cpython-3.8.3-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-gnu-pgo-20200518T0040.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-gnu-debug-20200518T0040.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.3-windows-x86_64": {
+  "cpython-3.8.3-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-pc-windows-msvc-shared-pgo-20200517T2207.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.2-windows-i686": {
+  "cpython-3.8.2-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-i686-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.2-darwin-x86_64": {
+  "cpython-3.8.2-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-apple-darwin-pgo-20200418T2238.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.2-linux-x86_64": {
+  "cpython-3.8.2-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 8,
     "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-unknown-linux-gnu-pgo-20200418T2243.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-unknown-linux-gnu-debug-20200418T2305.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.2-windows-x86_64": {
+  "cpython-3.8.2-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.9-windows-i686": {
+  "cpython-3.7.9-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-i686-pc-windows-msvc-shared-pgo-20200823T0159.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.9-darwin-x86_64": {
+  "cpython-3.7.9-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.7.9-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.9-linux-x86_64": {
+  "cpython-3.7.9-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 7,
     "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-gnu-pgo-20200823T0036.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-gnu-debug-20200823T0036.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.9-windows-x86_64": {
+  "cpython-3.7.9-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 7,
+    "patch": 9,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.7.9-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-pc-windows-msvc-shared-pgo-20200823T0118.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.7-windows-i686": {
+  "cpython-3.7.7-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-i686-pc-windows-msvc-shared-pgo-20200517T2153.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.7-shared-windows": {
+  "cpython-3.7.7-shared-windows-none": {
     "name": "cpython",
     "arch": "windows",
     "os": "shared",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200408/cpython-3.7.7-windows-amd64-shared-20200409T0108.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.7-darwin-x86_64": {
+  "cpython-3.7.7-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.7.7-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.7-linux-x86_64": {
+  "cpython-3.7.7-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 7,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-gnu-pgo-20200518T0040.tar.zst",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-gnu-debug-20200518T0040.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.7-windows-x86_64": {
+  "cpython-3.7.7-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 7,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.7.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-pc-windows-msvc-shared-pgo-20200517T2128.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.6-windows-i686": {
+  "cpython-3.7.6-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-x86-shared-pgo-20200217T0110.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.6-shared-windows": {
+  "cpython-3.7.6-shared-windows-none": {
     "name": "cpython",
     "arch": "windows",
     "os": "shared",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-amd64-shared-20200216T2324.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.6-darwin-x86_64": {
+  "cpython-3.7.6-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-macos-20200216T2344.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.6-linux-x86_64": {
+  "cpython-3.7.6-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 7,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-linux64-20200216T2303.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.6-windows-x86_64": {
+  "cpython-3.7.6-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 7,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200217/cpython-3.7.6-linux64-musl-20200218T0557.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.7.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-amd64-shared-pgo-20200217T0022.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.5-windows-i686": {
+  "cpython-3.7.5-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-x86-20191025T0549.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.5-darwin-x86_64": {
+  "cpython-3.7.5-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-macos-20191026T0535.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.5-linux-x86_64": {
+  "cpython-3.7.5-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 7,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-linux64-20191025T0506.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.5-windows-x86_64": {
+  "cpython-3.7.5-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 7,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-linux64-musl-20191026T0603.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.7.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-amd64-20191025T0540.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.4-windows-i686": {
+  "cpython-3.7.4-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-x86-20190817T0235.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.4-darwin-x86_64": {
+  "cpython-3.7.4-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-macos-20190817T0220.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.4-linux-x86_64": {
+  "cpython-3.7.4-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 7,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-linux64-20190817T0224.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.4-windows-x86_64": {
+  "cpython-3.7.4-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 7,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-linux64-musl-20190817T0227.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.7.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-amd64-20190817T0227.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.3-windows-i686": {
+  "cpython-3.7.3-windows-i686-none": {
     "name": "cpython",
     "arch": "i686",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-x86-20190709T0348.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.3-darwin-x86_64": {
+  "cpython-3.7.3-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "darwin",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-macos-20190618T0523.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.3-linux-x86_64": {
+  "cpython-3.7.3-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 7,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-linux64-20190618T0324.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.3-windows-x86_64": {
+  "cpython-3.7.3-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 7,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-linux64-musl-20190618T0400.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.7.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "windows",
+    "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-amd64-20190618T0516.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.1-linux-x86_64": {
+  "cpython-3.7.1-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
     "os": "linux",
+    "libc": "gnu",
     "major": 3,
     "minor": 7,
     "patch": 1,


### PR DESCRIPTION
Previously, only glibc builds were tracked in the bootstrap script. A new field `libc` tracks if `gnu` or `musl` are used on linux, while it is `"none"` everywhere else. I've confirmed that the updated script works on ubuntu and alpine.
