### PR TITLE
feat: add installer to `InstalledDist`

### DIFF
--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -117,7 +117,7 @@ impl InstalledDist {
         match fs::read_to_string(path) {
             Ok(installer) => Ok(Some(installer)),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(err) => Err(err.into())
+            Err(err) => Err(err.into()),
         }
     }
 

--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -114,7 +114,7 @@ impl InstalledDist {
     /// Return the `INSTALLER` of the distribution.
     pub fn installer(&self) -> Option<String> {
         let path = self.path().join("INSTALLER");
-        let Ok(installer) = fs_err::read_to_string(&path) else {
+        let Ok(installer) = fs_err::read_to_string(path) else {
             return None;
         };
         Some(installer)

--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -112,12 +112,13 @@ impl InstalledDist {
     }
 
     /// Return the `INSTALLER` of the distribution.
-    pub fn installer(&self) -> Option<String> {
+    pub fn installer(&self) -> Result<Option<String>> {
         let path = self.path().join("INSTALLER");
-        let Ok(installer) = fs::read_to_string(path) else {
-            return None;
-        };
-        Some(installer)
+        match fs::read_to_string(path) {
+            Ok(installer) => Ok(Some(installer)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err.into())
+        }
     }
 
     /// Return the [`Url`] of the distribution, if it is editable.

--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -114,7 +114,7 @@ impl InstalledDist {
     /// Return the `INSTALLER` of the distribution.
     pub fn installer(&self) -> Option<String> {
         let path = self.path().join("INSTALLER");
-        let Ok(installer) = fs_err::read_to_string(path) else {
+        let Ok(installer) = fs::read_to_string(path) else {
             return None;
         };
         Some(installer)

--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -111,6 +111,15 @@ impl InstalledDist {
         })
     }
 
+    /// Return the `INSTALLER` of the distribution.
+    pub fn installer(&self) -> Option<String> {
+        let path = self.path().join("INSTALLER");
+        let Ok(installer) = fs_err::read_to_string(&path) else {
+            return None;
+        };
+        Some(installer)
+    }
+
     /// Return the [`Url`] of the distribution, if it is editable.
     pub fn as_editable(&self) -> Option<&Url> {
         match self {


### PR DESCRIPTION
## Summary

Add `installer` method to `InstalledDist` to distinguish between different installers. Might be nice to add an enum for all possible installers, but this might be too hard to keep up to date :).

The `INSTALLER` file is a file that can be added to the `.dist-info` folder with the installer name.

Closes: #1759 

## Test Plan

Not sure if there is a place I can automatically test it, if you have a pointer I would be happy to add a test.


