### PR TITLE
fix: expose DefaultResolverProvider

### DIFF
--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -7,7 +7,8 @@ pub use prerelease_mode::PreReleaseMode;
 pub use resolution::{Diagnostic, DisplayResolutionGraph, ResolutionGraph};
 pub use resolution_mode::ResolutionMode;
 pub use resolver::{
-    BuildId, InMemoryIndex, Reporter as ResolverReporter, Resolver, ResolverProvider,
+    BuildId, DefaultResolverProvider, InMemoryIndex, Reporter as ResolverReporter, Resolver,
+    ResolverProvider,
 };
 
 mod candidate_selector;

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -46,7 +46,7 @@ use crate::python_requirement::PythonRequirement;
 use crate::resolution::ResolutionGraph;
 use crate::resolver::allowed_urls::AllowedUrls;
 pub use crate::resolver::index::InMemoryIndex;
-use crate::resolver::provider::DefaultResolverProvider;
+pub use crate::resolver::provider::DefaultResolverProvider;
 pub use crate::resolver::provider::ResolverProvider;
 pub(crate) use crate::resolver::provider::VersionsResponse;
 use crate::resolver::reporter::Facade;


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The `DefaultResolverProvider` struct was not public. This PR exposes it so we can build our own and use this as a fallback.

## Test Plan

I did not explicitly test this trivial change. 