### PR TITLE
docs(readme): add instructions for installing on Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ pipx install uv
 
 # With Homebrew.
 brew install uv
+
+# With Pacman.
+pacman -S uv
 ```
 
 To create a virtual environment:


### PR DESCRIPTION
## Summary

I packaged `uv` in the official repositories: https://archlinux.org/packages/extra/x86_64/uv/

This PR simply updates README.md to add the instructions to install the package.

## Test Plan

None.
