### PR TITLE
Configurable bootstrap dir

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ Alternatively, you can install `zstandard` from PyPI, then run:
 python3.12 scripts/bootstrap/install.py
 ```
 
+You can configure the bootstrapping directory with `PUFFIN_BOOTSTRAP_DIR`.
+
 ### Local testing
 
 You can invoke your development version of uv with `cargo run -- <args>`. For example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Alternatively, you can install `zstandard` from PyPI, then run:
 python3.12 scripts/bootstrap/install.py
 ```
 
-You can configure the bootstrapping directory with `PUFFIN_BOOTSTRAP_DIR`.
+You can configure the bootstrapping directory with `UV_BOOTSTRAP_DIR`.
 
 ### Local testing
 

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -115,7 +115,7 @@ pub fn bootstrapped_pythons() -> Option<Vec<PathBuf>> {
         .parent()
         .unwrap()
         .to_path_buf();
-    let boostrap_dir = if let Some(boostrap_dir) = env::var_os("PUFFIN_BOOTSTRAP_DIR") {
+    let boostrap_dir = if let Some(boostrap_dir) = env::var_os("UV_BOOTSTRAP_DIR") {
         let boostrap_dir = PathBuf::from(boostrap_dir);
         if boostrap_dir.is_absolute() {
             boostrap_dir

--- a/scripts/bootstrap/install.py
+++ b/scripts/bootstrap/install.py
@@ -30,6 +30,7 @@
 
 import hashlib
 import json
+import os
 import platform
 import shutil
 import sys
@@ -48,7 +49,10 @@ except ImportError:
 # Setup some file paths
 THIS_DIR = Path(__file__).parent
 ROOT_DIR = THIS_DIR.parent.parent
-BIN_DIR = ROOT_DIR / "bin"
+if bin_dir := os.environ.get("PUFFIN_BOOTSTRAP_DIR"):
+    BIN_DIR = Path(bin_dir)
+else:
+    BIN_DIR = ROOT_DIR / "bin"
 INSTALL_DIR = BIN_DIR / "versions"
 VERSIONS_FILE = ROOT_DIR / ".python-versions"
 VERSIONS_METADATA_FILE = THIS_DIR / "versions.json"

--- a/scripts/bootstrap/install.py
+++ b/scripts/bootstrap/install.py
@@ -49,7 +49,7 @@ except ImportError:
 # Setup some file paths
 THIS_DIR = Path(__file__).parent
 ROOT_DIR = THIS_DIR.parent.parent
-if bin_dir := os.environ.get("PUFFIN_BOOTSTRAP_DIR"):
+if bin_dir := os.environ.get("UV_BOOTSTRAP_DIR"):
     BIN_DIR = Path(bin_dir)
 else:
     BIN_DIR = ROOT_DIR / "bin"


### PR DESCRIPTION
Add a `UV_BOOTSTRAP_DIR` option to configure the python bootstrap directory. This is helpful when working across multiple platforms in a single IDE session.