### PR TITLE
Linker copies files as a fallback when ref-linking fails

### DIFF
--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -302,7 +302,7 @@ fn clone_recursive(site_packages: &Path, wheel: &Path, entry: &DirEntry) -> Resu
     debug!("Cloning {} to {}", from.display(), to.display());
 
     // Attempt to copy the file or directory
-    let reflink = reflink_copy::reflink(&from, &to);
+    let reflink = reflink_copy::reflink_or_copy(&from, &to);
 
     if reflink
         .as_ref()
@@ -317,7 +317,7 @@ fn clone_recursive(site_packages: &Path, wheel: &Path, entry: &DirEntry) -> Resu
             // If file already exists, overwrite it.
             let tempdir = tempdir_in(site_packages)?;
             let tempfile = tempdir.path().join(from.file_name().unwrap());
-            reflink_copy::reflink(from, &tempfile)?;
+            reflink_copy::reflink_or_copy(from, &tempfile)?;
             fs::rename(&tempfile, to)?;
         }
     } else {

--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -306,9 +306,10 @@ fn clone_recursive(site_packages: &Path, wheel: &Path, entry: &DirEntry) -> Resu
 
     let entry_file_type = entry.file_type()?;
 
-    // `reflink_or_copy` returns `InvalidInput` on macOS when reflinking a directory that already exists
-    // at the source destination. We need to properly fallback in this case as well, so we re-run `reflink`
-    // and check if that gives us an `AlreadyExists` error.
+    // `reflink_or_copy` returns `InvalidInput` on macOS when reflinking a directory/symlink that already exists
+    // at the destination - macOS has the capability to reflink those, but `reflink_or_copy` doesn't make an exception
+    // and obscures the underlying `AlreadyExists` error. We need to properly fallback in this case,
+    // so we run `reflink` and check if that gives us an `AlreadyExists` error.
     if reflink
         .as_ref()
         .is_err_and(|err| err.kind() == std::io::ErrorKind::InvalidInput)


### PR DESCRIPTION
## Summary

Fixes #1444.

In situations where the installer fails to perform a reflink, a regular file copy is also attempted, as a fallback. This circumvents issues with linking files across filesystems or volumes.

## Test Plan
N/A