### PR TITLE
Use `git` command to fetch repositories instead of `libgit2` for robust SSH support

### DIFF
--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -1057,7 +1057,11 @@ fn fetch_with_cli(
         .env_remove("GIT_OBJECT_DIRECTORY")
         .env_remove("GIT_ALTERNATE_OBJECT_DIRECTORIES")
         .cwd(repo.path());
-    cmd.exec()?;
+
+    // We capture the output to avoid streaming it to the user's console during clones.
+    // The required `on...line` callbacks currently do nothing.
+    // The output appears to be included in error messages by default.
+    cmd.exec_with_streaming(&mut |_| Ok(()), &mut |_| Ok(()), true)?;
     Ok(())
 }
 

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -11,7 +11,7 @@ use cargo_util::{paths, ProcessBuilder};
 use git2::{self, ErrorClass, ObjectType};
 use reqwest::Client;
 use reqwest::StatusCode;
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 use url::Url;
 use uv_fs::Normalized;
 
@@ -904,10 +904,18 @@ pub(crate) fn fetch(
 
     clean_repo_temp_files(repo);
 
+    enum RefspecStrategy {
+        // All refspecs should be fetched, if any fail then the fetch will fail
+        All,
+        // Stop after the first successful fetch, if none suceed then the fetch will fail
+        First,
+    }
+
     // Translate the reference desired here into an actual list of refspecs
     // which need to get fetched. Additionally record if we're fetching tags.
     let mut refspecs = Vec::new();
     let mut tags = false;
+    let mut refspec_strategy = RefspecStrategy::All;
     // The `+` symbol on the refspec means to allow a forced (fast-forward)
     // update which is needed if there is ever a force push that requires a
     // fast-forward.
@@ -929,6 +937,7 @@ pub(crate) fn fetch(
             refspecs.push(format!(
                 "+refs/tags/{branch_or_tag}:refs/remotes/origin/tags/{branch_or_tag}"
             ));
+            refspec_strategy = RefspecStrategy::First;
         }
 
         GitReference::DefaultBranch => {
@@ -970,27 +979,42 @@ pub(crate) fn fetch(
     debug!("Performing a Git fetch for: {remote_url}");
     match strategy {
         FetchStrategy::Cli => {
-            // Try each refspec
-            let results = refspecs
-                .into_iter()
-                .map(|refspec| fetch_with_cli(repo, remote_url, &[refspec], tags))
-                .collect::<Vec<_>>();
+            match refspec_strategy {
+                RefspecStrategy::All => fetch_with_cli(repo, remote_url, refspecs.as_slice(), tags),
+                RefspecStrategy::First => {
+                    let num_refspecs = refspecs.len();
 
-            // Only fail if _all_ refspecs cannot be found
-            // This matches the Libgit2 behavior
-            if results.iter().all(Result::is_err) {
-                let mut combined_err = anyhow!("failed to fetch all refspecs");
-                for err in results {
-                    if let Err(err) = err {
-                        combined_err = combined_err.context(err.to_string());
+                    // Try each refspec
+                    let errors = refspecs
+                        .into_iter()
+                        .map(|refspec| {
+                            (
+                                refspec.clone(),
+                                fetch_with_cli(repo, remote_url, &[refspec], tags),
+                            )
+                        })
+                        // Stop after the first success
+                        .take_while(|(_, result)| result.is_err())
+                        .collect::<Vec<_>>();
+
+                    if errors.len() == num_refspecs {
+                        // If all of the fetches failed, report to the user
+                        for (refspec, err) in errors {
+                            if let Err(err) = err {
+                                error!("failed to fetch refspec `{refspec}`: {err}");
+                            }
+                        }
+                        Err(anyhow!("failed to fetch all refspecs"))
+                    } else {
+                        Ok(())
                     }
                 }
-                Err(combined_err)
-            } else {
-                Ok(())
             }
         }
         FetchStrategy::Libgit2 => {
+            // Libgit2 does not fail if a refspec is missing, so the `refspec_strategy`
+            // is not handled here
+
             let git_config = git2::Config::open_default()?;
             with_fetch_options(&git_config, remote_url, &mut |mut opts| {
                 if tags {

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -907,10 +907,6 @@ pub(crate) fn fetch(
     // Translate the reference desired here into an actual list of refspecs
     // which need to get fetched. Additionally record if we're fetching tags.
     let mut refspecs = Vec::new();
-    // Track a secondary refspec list to include if the first fetch fails,
-    // this is important when using [`FetchStrategy::Cli`] as it will not
-    // succeed if _any_ given refspec cannot be found.
-    let mut secondary_refspecs = Vec::new();
     let mut tags = false;
     // The `+` symbol on the refspec means to allow a forced (fast-forward)
     // update which is needed if there is ever a force push that requires a
@@ -930,7 +926,7 @@ pub(crate) fn fetch(
             refspecs.push(format!(
                 "+refs/heads/{branch_or_tag}:refs/remotes/origin/{branch_or_tag}"
             ));
-            secondary_refspecs.push(format!(
+            refspecs.push(format!(
                 "+refs/tags/{branch_or_tag}:refs/remotes/origin/tags/{branch_or_tag}"
             ));
         }
@@ -974,16 +970,25 @@ pub(crate) fn fetch(
     debug!("Performing a Git fetch for: {remote_url}");
     match strategy {
         FetchStrategy::Cli => {
-            fetch_with_cli(repo, remote_url, &refspecs, tags).or_else(|err| {
-                // If secondary refspecs are populated i.e. from [`GitReference::BranchOrTag`],
-                // then ignore the first error and try again; ideally we'd only retry if the
-                // error was due to a missing ref but this is already not the fast path
-                if secondary_refspecs.is_empty() {
-                    Err(err)
-                } else {
-                    fetch_with_cli(repo, remote_url, &secondary_refspecs, tags)
+            // Try each refspec
+            let results = refspecs
+                .into_iter()
+                .map(|refspec| fetch_with_cli(repo, remote_url, &[refspec], tags))
+                .collect::<Vec<_>>();
+
+            // Only fail if _all_ refspecs cannot be found
+            // This matches the Libgit2 behavior
+            if results.iter().all(Result::is_err) {
+                let mut combined_err = anyhow!("failed to fetch all refspecs");
+                for err in results {
+                    if let Err(err) = err {
+                        combined_err = combined_err.context(err.to_string());
+                    }
                 }
-            })
+                Err(combined_err)
+            } else {
+                Ok(())
+            }
         }
         FetchStrategy::Libgit2 => {
             let git_config = git2::Config::open_default()?;
@@ -991,9 +996,6 @@ pub(crate) fn fetch(
                 if tags {
                     opts.download_tags(git2::AutotagOption::All);
                 }
-
-                // When using libgit2, missing refspecs are okay
-                refspecs.append(&mut secondary_refspecs);
 
                 // The `fetch` operation here may fail spuriously due to a corrupt
                 // repository. It could also fail, however, for a whole slew of other

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -43,6 +43,14 @@ pub(crate) enum GitReference {
     DefaultBranch,
 }
 
+/// Strategy when fetching refspecs for a [`GitReference`]
+enum RefspecStrategy {
+    // All refspecs should be fetched, if any fail then the fetch will fail
+    All,
+    // Stop after the first successful fetch, if none suceed then the fetch will fail
+    First,
+}
+
 impl GitReference {
     pub(crate) fn from_rev(rev: &str) -> Self {
         if rev.starts_with("refs/") {
@@ -903,13 +911,6 @@ pub(crate) fn fetch(
     maybe_gc_repo(repo)?;
 
     clean_repo_temp_files(repo);
-
-    enum RefspecStrategy {
-        // All refspecs should be fetched, if any fail then the fetch will fail
-        All,
-        // Stop after the first successful fetch, if none suceed then the fetch will fail
-        First,
-    }
 
     // Translate the reference desired here into an actual list of refspecs
     // which need to get fetched. Additionally record if we're fetching tags.

--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -33,7 +33,7 @@ impl GitSource {
         Self {
             git,
             client: Client::new(),
-            strategy: FetchStrategy::Libgit2,
+            strategy: FetchStrategy::Cli,
             cache: cache.into(),
             reporter: None,
         }

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -152,11 +152,9 @@ impl TestContext {
     pub fn filters(&self) -> Vec<(&str, &str)> {
         let mut filters = INSTA_FILTERS.to_vec();
 
-        for (pattern, replacement) in self.filters.iter() {
+        for (pattern, replacement) in &self.filters {
             filters.push((pattern, replacement));
         }
-
-        dbg!(&filters);
 
         filters
     }

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -112,13 +112,18 @@ impl TestContext {
 
     /// Generate an escaped regex pattern for the given path.
     fn path_pattern(path: impl AsRef<Path>) -> String {
-        regex::escape(
-            &path
-                .as_ref()
-                .canonicalize()
-                .expect("Failed to create canonical path")
-                .normalized()
-                .to_string_lossy(),
+        format!(
+            // Remove the trailing `\` or `/` from directories for cross-platform filters
+            r"{}\\?/?",
+            regex::escape(
+                &path
+                    .as_ref()
+                    .canonicalize()
+                    .expect("Failed to create canonical path")
+                    // Normalize the path to match display and remove UNC prefixes on Windows
+                    .normalized()
+                    .to_string_lossy(),
+            )
         )
     }
 

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -136,6 +136,8 @@ impl TestContext {
         // Note the temporary directoy comes last because the others are nested within
         filters.push((&self.temp_dir_pattern, "[TEMP DIR]"));
 
+        dbg!(&filters);
+
         filters
     }
 }

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -96,6 +96,31 @@ impl TestContext {
         .success()
         .stdout(version);
     }
+
+    pub fn filters(&self) -> std::io::Result<Vec<(String, String)>> {
+        let cache_dir = self.cache_dir.canonicalize()?;
+        let venv_dir = self.venv.canonicalize()?;
+        let temp_dir = self.temp_dir.canonicalize()?;
+
+        let mut filters = INSTA_FILTERS
+            .iter()
+            .map(|(pattern, replacement)| (pattern.to_string(), replacement.to_string()))
+            .collect::<Vec<_>>();
+        filters.push((
+            cache_dir.to_str().unwrap().to_string(),
+            "[CACHE DIR]".to_string(),
+        ));
+        filters.push((
+            venv_dir.to_str().unwrap().to_string(),
+            "[VENV DIR]".to_string(),
+        ));
+        filters.push((
+            temp_dir.to_str().unwrap().to_string(),
+            "[TEMP DIR]".to_string(),
+        ));
+
+        Ok(filters)
+    }
 }
 
 pub fn venv_to_interpreter(venv: &Path) -> PathBuf {

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -132,13 +132,14 @@ impl TestContext {
                         .expect("Failed to create canonical path")
                         // Normalize the path to match display and remove UNC prefixes on Windows
                         .normalized()
-                        .to_string_lossy(),
+                        .display()
+                        .to_string(),
                 )
             ),
             // Include a non-canonicalized version
             format!(
                 r"{}\\?/?",
-                regex::escape(&path.as_ref().normalized().as_os_str().to_string_lossy())
+                regex::escape(&path.as_ref().normalized().display().to_string())
             ),
         ]
     }

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -123,7 +123,7 @@ impl TestContext {
     fn path_patterns(path: impl AsRef<Path>) -> Vec<String> {
         vec![
             format!(
-                // Remove the trailing `\` or `/` from directories for cross-platform filters
+                // Trim the trailing separator for cross-platform directories filters
                 r"{}\\?/?",
                 regex::escape(
                     &path
@@ -135,11 +135,15 @@ impl TestContext {
                         .display()
                         .to_string(),
                 )
+                // Make seprators platform agnostic because on Windows we will display
+                // paths with Unix-style separators sometimes
+                .replace(r"\\", r"(\\|\/)")
             ),
             // Include a non-canonicalized version
             format!(
                 r"{}\\?/?",
                 regex::escape(&path.as_ref().normalized().display().to_string())
+                    .replace(r"\\", r"(\\|\/)")
             ),
         ]
     }

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -131,10 +131,10 @@ impl TestContext {
     pub fn filters(&self) -> Vec<(&str, &str)> {
         let mut filters = INSTA_FILTERS.to_vec();
 
-        filters.push((&self.cache_dir_pattern, "[CACHE DIR]"));
-        filters.push((&self.venv_pattern, "[VENV DIR]"));
+        filters.push((&self.cache_dir_pattern, "[CACHE DIR]/"));
+        filters.push((&self.venv_pattern, "[VENV DIR]/"));
         // Note the temporary directoy comes last because the others are nested within
-        filters.push((&self.temp_dir_pattern, "[TEMP DIR]"));
+        filters.push((&self.temp_dir_pattern, "[TEMP DIR]/"));
 
         dbg!(&filters);
 

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -276,7 +276,7 @@ pub fn create_bin_with_executables(
 /// This function is derived from `insta_cmd`s `spawn_with_info`.
 pub fn run_and_format<'a>(
     mut command: impl BorrowMut<std::process::Command>,
-    filters: impl AsRef<[(&'a str, &'a str)]>,
+    filters: impl AsRef<[(AsRef<str>, AsRef<str>)]>,
     windows_filters: bool,
 ) -> (String, Output) {
     let program = command

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -123,7 +123,7 @@ impl TestContext {
     }
 
     /// Canonical snapshot filters for this test context.
-    pub fn filters<'a>(&'a self) -> Vec<(&'a str, &'a str)> {
+    pub fn filters(&self) -> Vec<(&str, &str)> {
         let mut filters = INSTA_FILTERS.to_vec();
 
         filters.push((&self.cache_dir_pattern, "[CACHE DIR]"));

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -829,7 +829,7 @@ fn install_git_public_https_missing_ref() {
     ----- stderr -----
     error: Failed to download and build: uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@2.0.0
       Caused by: Git operation failed
-      Caused by: failed to clone into: [CACHE DIR]/git-v0/db/8dab139913c4b566
+      Caused by: failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
       Caused by: failed to fetch all refspecs
     "###);
 }
@@ -908,7 +908,6 @@ fn install_git_private_https_pat_and_username() {
 
     let mut filters = INSTA_FILTERS.to_vec();
     filters.insert(0, (&token, "***"));
-    filters.push(("failed to clone into: .*", "failed to clone into: [PATH]"));
 
     uv_snapshot!(filters, command(&context)
         .arg(format!("uv-private-pypackage @ git+https://{user}:{token}@github.com/astral-test/uv-private-pypackage"))
@@ -951,7 +950,7 @@ fn install_git_private_https_pat_not_authorized() {
     ----- stderr -----
     error: Failed to download and build: uv-private-pypackage @ git+https://git:***@github.com/astral-test/uv-private-pypackage
       Caused by: Git operation failed
-      Caused by: failed to clone into: [CACHE DIR]/git-v0/db/2496970ed6fdf08f
+      Caused by: failed to clone into: [CACHE_DIR]/git-v0/db/2496970ed6fdf08f
       Caused by: process didn't exit successfully: `git fetch --force --update-head-ok 'https://git:***@github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
     --- stderr
     remote: Support for password authentication was removed on August 13, 2021.

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -812,13 +812,19 @@ fn install_git_public_https() {
     context.assert_installed("uv_public_pypackage", "0.1.0");
 }
 
-/// Install a package from a public GitHub repository at  
+/// Install a package from a public GitHub repository at a ref that does not exist
 #[test]
 #[cfg(feature = "git")]
-fn install_git_public_https_missing_ref() {
+fn install_git_public_https_missing_ref() -> Result<()> {
     let context = TestContext::new("3.8");
 
-    uv_snapshot!(command(&context)
+    let filters = context.filters()?;
+    let filters: Vec<(&str, &str)> = filters
+        .iter()
+        .map(|(a, b)| (a.as_str(), b.as_str()))
+        .collect();
+
+    uv_snapshot!(filters, command(&context)
         // 2.0.0 does not exist
         .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@2.0.0")
         , @r###"
@@ -829,10 +835,13 @@ fn install_git_public_https_missing_ref() {
     ----- stderr -----
     error: Failed to download and build: uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@2.0.0
       Caused by: Git operation failed
-      Caused by: failed to find branch or tag `2.0.0`
+      Caused by: failed to clone into: [CACHE DIR]/git-v0/db/8dab139913c4b566
+      Caused by: failed to fetch all refspecs
     "###);
 
     context.assert_installed("uv_public_pypackage", "0.1.0");
+
+    Ok(())
 }
 
 /// Install a package from a private GitHub repository using a PAT
@@ -931,14 +940,18 @@ fn install_git_private_https_pat_and_username() {
 /// Install a package from a private GitHub repository using a PAT
 #[test]
 #[cfg(all(not(windows), feature = "git"))]
-fn install_git_private_https_pat_not_authorizd() {
+fn install_git_private_https_pat_not_authorized() -> Result<()> {
     let context = TestContext::new("3.8");
 
     // A revoked token
     let token = "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";
 
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.insert(0, (&token, "***"));
+    let mut filters = context.filters()?;
+    filters.insert(0, (token.to_string(), "***".to_string()));
+    let filters: Vec<(&str, &str)> = filters
+        .iter()
+        .map(|(a, b)| (a.as_str(), b.as_str()))
+        .collect();
 
     // We provide a username otherwise (since the token is invalid), the git cli will prompt for a password
     // and hang the test
@@ -952,15 +965,16 @@ fn install_git_private_https_pat_not_authorizd() {
     ----- stderr -----
     error: Failed to download and build: uv-private-pypackage @ git+https://git:***@github.com/astral-test/uv-private-pypackage
       Caused by: Git operation failed
-      Caused by: failed to clone into: /private/var/folders/bc/qlsk3t6x7c9fhhbvvcg68k9c0000gp/T/.tmp9ciF4C/git-v0/db/2496970ed6fdf08f
+      Caused by: failed to clone into: [CACHE DIR]/git-v0/db/2496970ed6fdf08f
       Caused by: process didn't exit successfully: `git fetch --force --update-head-ok 'https://git:***@github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
     --- stderr
     remote: Support for password authentication was removed on August 13, 2021.
     remote: Please see https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls for information on currently recommended modes of authentication.
     fatal: Authentication failed for 'https://github.com/astral-test/uv-private-pypackage/'
 
-      Caused by: failed to fetch all refspecs
     "###);
+
+    Ok(())
 }
 
 /// Install a package without using pre-built wheels.

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -812,6 +812,29 @@ fn install_git_public_https() {
     context.assert_installed("uv_public_pypackage", "0.1.0");
 }
 
+/// Install a package from a public GitHub repository at  
+#[test]
+#[cfg(feature = "git")]
+fn install_git_public_https_missing_ref() {
+    let context = TestContext::new("3.8");
+
+    uv_snapshot!(command(&context)
+        // 2.0.0 does not exist
+        .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@2.0.0")
+        , @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to download and build: uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@2.0.0
+      Caused by: Git operation failed
+      Caused by: failed to find branch or tag `2.0.0`
+    "###);
+
+    context.assert_installed("uv_public_pypackage", "0.1.0");
+}
+
 /// Install a package from a private GitHub repository using a PAT
 #[test]
 #[cfg(all(not(windows), feature = "git"))]

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -815,16 +815,10 @@ fn install_git_public_https() {
 /// Install a package from a public GitHub repository at a ref that does not exist
 #[test]
 #[cfg(feature = "git")]
-fn install_git_public_https_missing_ref() -> Result<()> {
+fn install_git_public_https_missing_ref() {
     let context = TestContext::new("3.8");
 
-    let filters = context.filters()?;
-    let filters: Vec<(&str, &str)> = filters
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
-        .collect();
-
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         // 2.0.0 does not exist
         .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@2.0.0")
         , @r###"
@@ -838,10 +832,6 @@ fn install_git_public_https_missing_ref() -> Result<()> {
       Caused by: failed to clone into: [CACHE DIR]/git-v0/db/8dab139913c4b566
       Caused by: failed to fetch all refspecs
     "###);
-
-    context.assert_installed("uv_public_pypackage", "0.1.0");
-
-    Ok(())
 }
 
 /// Install a package from a private GitHub repository using a PAT
@@ -940,18 +930,14 @@ fn install_git_private_https_pat_and_username() {
 /// Install a package from a private GitHub repository using a PAT
 #[test]
 #[cfg(all(not(windows), feature = "git"))]
-fn install_git_private_https_pat_not_authorized() -> Result<()> {
+fn install_git_private_https_pat_not_authorized() {
     let context = TestContext::new("3.8");
 
     // A revoked token
     let token = "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";
 
-    let mut filters = context.filters()?;
-    filters.insert(0, (token.to_string(), "***".to_string()));
-    let filters: Vec<(&str, &str)> = filters
-        .iter()
-        .map(|(a, b)| (a.as_str(), b.as_str()))
-        .collect();
+    let mut filters = context.filters();
+    filters.insert(0, (&token, "***"));
 
     // We provide a username otherwise (since the token is invalid), the git cli will prompt for a password
     // and hang the test
@@ -973,8 +959,6 @@ fn install_git_private_https_pat_not_authorized() -> Result<()> {
     fatal: Authentication failed for 'https://github.com/astral-test/uv-private-pypackage/'
 
     "###);
-
-    Ok(())
 }
 
 /// Install a package without using pre-built wheels.


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/1775
Closes https://github.com/astral-sh/uv/issues/1452
Closes https://github.com/astral-sh/uv/issues/1514
Follows https://github.com/astral-sh/uv/pull/1717

libgit2 does not support host names with extra identifiers during SSH lookup (e.g. [`github.com-some_identifier`](
https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#using-multiple-repositories-on-one-server)) so we use the `git` command instead for fetching. This is required for `pip` parity.

See the [Cargo documentation](https://doc.rust-lang.org/nightly/cargo/reference/config.html#netgit-fetch-with-cli) for more details on using the `git` CLI instead of libgit2. We may want to try to use libgit2 first in the future, as it is more performant (#1786).

We now support authentication with:

```
git+ssh://git@<hostname>/...
git+ssh://git@<hostname>-<identifier>/...
```

Tested with a deploy key e.g.

```
cargo run -- \
    pip install uv-private-pypackage@git+ssh://git@github.com-test-uv-private-pypackage/astral-test/uv-private-pypackage.git \
    --reinstall --no-cache -v
```

and

```
cargo run -- \
    pip install uv-private-pypackage@git+ssh://git@github.com/astral-test/uv-private-pypackage.git \
    --reinstall --no-cache -v     
```

with a ssh config like

```
Host github.com
        Hostname github.com
        IdentityFile=/Users/mz/.ssh/id_ed25519

Host github.com-test-uv-private-pypackage
        Hostname github.com
        IdentityFile=/Users/mz/.ssh/id_ed25519
```

It seems quite hard to add test coverage for this to the test suite, as we'd need to add the SSH key and I don't know how to isolate that from affecting other developer's machines.