### PR TITLE
Use the right marker for the `implementation` field of `pyvenv.cfg`

### DIFF
--- a/crates/gourgeist/src/bare.rs
+++ b/crates/gourgeist/src/bare.rs
@@ -220,7 +220,10 @@ pub fn create_bare_venv(
     };
     let pyvenv_cfg_data = &[
         ("home", python_home),
-        ("implementation", "CPython".to_string()),
+        (
+            "implementation",
+            interpreter.markers().platform_python_implementation.clone(),
+        ),
         (
             "version_info",
             interpreter.markers().python_version.string.clone(),


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The generated `pyvenv.cfg` file hardcodes `implementation = CPython` even for PyPy venvs, created with `uv venv venv --python pypy3.10`, for example.

```ini
home = /path/to/.pyenv/versions/pypy3.10-7.3.15/bin
implementation = CPython
version_info = 3.10
gourgeist = 0.0.4
include-system-site-packages = false
base-prefix = /path/to/.pyenv/versions/pypy3.10-7.3.15
base-exec-prefix = /path/to/.pyenv/versions/pypy3.10-7.3.15
base-executable = /path/to/.pyenv/versions/pypy3.10-7.3.15/bin/pypy3.10
```

## Test Plan

<!-- How was it tested? -->

Manually verified that `pyvenv.cfg` now contains `implementation = PyPy`. I can try refactoring `create_bare_venv` to make it more easily testable, though.
