### PR TITLE
Use `libgit2` first then fallback to the `git` command on failure

### DIFF
--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -1002,6 +1002,7 @@ pub(crate) fn fetch(
             tags,
         )
         .or_else(|_| {
+            debug!("fetching with libgit2 failed, trying the git command");
             fetch_with_strategy(
                 repo,
                 remote_url,

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -1086,7 +1086,7 @@ fn fetch_with_strategy(
                     debug!("initiating fetch of {refspecs:?} from {remote_url}");
                     let res =
                         repo.remote_anonymous(remote_url)?
-                            .fetch(&refspecs, Some(&mut opts), None);
+                            .fetch(refspecs, Some(&mut opts), None);
                     let err = match res {
                         Ok(()) => break,
                         Err(e) => e,

--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -19,8 +19,6 @@ pub struct GitSource {
     git: GitUrl,
     /// The HTTP client to use for fetching.
     client: Client,
-    /// The fetch strategy to use when cloning.
-    strategy: FetchStrategy,
     /// The path to the Git source database.
     cache: PathBuf,
     /// The reporter to use for this source.
@@ -33,7 +31,6 @@ impl GitSource {
         Self {
             git,
             client: Client::new(),
-            strategy: FetchStrategy::Cli,
             cache: cache.into(),
             reporter: None,
         }
@@ -49,7 +46,25 @@ impl GitSource {
     }
 
     /// Fetch the underlying Git repository at the given revision.
+    ///
+    /// Uses the Libgit2 backend first, then falls back to the CLI which supports
+    /// more authentication schemes.
     pub fn fetch(self) -> Result<Fetch> {
+        self.fetch_with_strategy(FetchStrategy::Libgit2)
+            .or_else(|_| {
+                debug!("fetch with libgit2 failed, trying git cli");
+                self.fetch_with_strategy(FetchStrategy::Cli)
+            })
+            .map(|(actual_rev, checkout_path)| Fetch {
+                git: self.git.with_precise(actual_rev),
+                path: checkout_path,
+            })
+    }
+
+    /// Fetch the underlying Git repository at the given revision.
+    ///
+    /// Callers **should** update `self.git.with_precise` with the given SHA.
+    fn fetch_with_strategy(&self, strategy: FetchStrategy) -> Result<(GitSha, PathBuf)> {
         // The path to the repo, within the Git database.
         let ident = digest(&RepositoryUrl::new(&self.git.repository));
         let db_path = self.cache.join("db").join(&ident);
@@ -77,7 +92,7 @@ impl GitSource {
                     db,
                     &self.git.reference,
                     locked_rev.map(git2::Oid::from),
-                    self.strategy,
+                    strategy,
                     &self.client,
                 )?;
 
@@ -97,12 +112,7 @@ impl GitSource {
             .join("checkouts")
             .join(&ident)
             .join(short_id.as_str());
-        db.copy_to(
-            actual_rev.into(),
-            &checkout_path,
-            self.strategy,
-            &self.client,
-        )?;
+        db.copy_to(actual_rev.into(), &checkout_path, strategy, &self.client)?;
 
         // Report the checkout operation to the reporter.
         if let Some(task) = task {
@@ -111,10 +121,7 @@ impl GitSource {
             }
         }
 
-        Ok(Fetch {
-            git: self.git.with_precise(actual_rev),
-            path: checkout_path,
-        })
+        Ok((actual_rev, checkout_path))
     }
 }
 

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -829,8 +829,7 @@ fn install_git_public_https_missing_ref() {
     ----- stderr -----
     error: Failed to download and build: uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@2.0.0
       Caused by: Git operation failed
-      Caused by: failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
-      Caused by: failed to fetch all refspecs
+      Caused by: failed to find branch or tag `2.0.0`
     "###);
 }
 


### PR DESCRIPTION
Some necessary context in https://github.com/astral-sh/uv/pull/1781.

This should be faster in the happy path but robust to less common authentication schemes. Cargo uses an environment variable to toggle instead of this "fallback" approach. I'm hesitant to require that from our users.

The downside of this is that we will always retry with the `git` command even if the failure is not related to authentication. This could result in confusing logs and is, of course, slower. In practice, I think the error messages from the `git` command are better as they give you something reproducible to test with and have more context, the `libgit2` errors are very opaque.

I've also added a rough way to reuse the discovered correct strategy for fetching (https://github.com/astral-sh/uv/pull/1786/commits/df4382f4d1b415d3c86cd119876734b2596cb311) we could extend this to avoid unnecessary calls to `libgit2` in the future.

We can definitely say this is overkill and just drop fetching with libgit2 entirely in favor of the git CLI. We could also only use the `git` command if we detect authentication via some heuristic?