### PR TITLE
Use async unzip for local source distributions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3489,17 +3489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tar"
-version = "0.4.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4424,7 +4413,6 @@ dependencies = [
  "futures",
  "rayon",
  "rustc-hash",
- "tar",
  "thiserror",
  "tokio",
  "tokio-tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,6 @@ serde = { version = "1.0.194" }
 serde_json = { version = "1.0.111" }
 sha1 = { version = "0.10.6" }
 sha2 = { version = "0.10.8" }
-tar = { version = "0.4.40" }
 target-lexicon = { version = "0.12.13" }
 task-local-extensions = { version = "0.1.4" }
 tempfile = { version = "3.9.0" }

--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -301,7 +301,9 @@ impl SourceBuild {
             let extracted = temp_dir.path().join("extracted");
 
             // Unzip the archive into the temporary directory.
-            uv_extract::archive(source, &extracted)
+            let reader = fs_err::tokio::File::open(source).await?;
+            uv_extract::stream::archive(tokio::io::BufReader::new(reader), source, &extracted)
+                .await
                 .map_err(|err| Error::Extraction(extracted.clone(), err))?;
 
             // Extract the top-level directory from the archive.

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -20,7 +20,6 @@ fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
-tar = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util"] }
 tokio-tar = { workspace = true }


### PR DESCRIPTION
## Summary

We currently maintain separate untar methods for sync and async, but we only use the sync version when the user provides a local source distribution. (Otherwise, we untar as we download the distribution.) In my testing, this is actually slower anyway:

```
❯ python -m scripts.bench \
        --uv-path ./target/release/main \
        --uv-path ./target/release/uv \
        ./requirements.in --benchmark resolve-cold --min-runs 50
Benchmark 1: ./target/release/main (resolve-cold)
  Time (mean ± σ):     835.2 ms ± 107.4 ms    [User: 346.0 ms, System: 151.3 ms]
  Range (min … max):   639.2 ms … 1051.0 ms    50 runs

Benchmark 2: ./target/release/uv (resolve-cold)
  Time (mean ± σ):     750.7 ms ±  91.9 ms    [User: 345.7 ms, System: 149.4 ms]
  Range (min … max):   637.9 ms … 905.7 ms    50 runs

Summary
  './target/release/uv (resolve-cold)' ran
    1.11 ± 0.20 times faster than './target/release/main (resolve-cold)'
```
