### PR TITLE
Use more universal windows install instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,6 @@ jobs:
     name: "check windows trampoline"
     steps:
       - uses: actions/checkout@v4
-      - run: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
       - name: "Install Rust toolchain"
         working-directory: crates/uv-trampoline
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
     name: "check windows trampoline"
     steps:
       - uses: actions/checkout@v4
+      - run: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
       - name: "Install Rust toolchain"
         working-directory: crates/uv-trampoline
         run: |

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Install uv with our standalone installers, or from [PyPI](https://pypi.org/proje
 # On macOS and Linux.
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# On Windows (with PowerShell).
-irm https://astral.sh/uv/install.ps1 | iex
+# On Windows.
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 
 # With pip.
 pip install uv


### PR DESCRIPTION
Recommend installing uv on windows with

```
powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
```

instead of

```
irm https://astral.sh/uv/install.ps1 | iex
```

to support installing on cmd.exe, the classic non-powershell windows command prompt.

See https://github.com/axodotdev/cargo-dist/issues/458 for background. This will also be included in the next cargo-dist release.

I have confirmed this passes on
 * Command Prompt
 * Windows PowerShell
 * PowerShell
 * git bash

Closes #1750

CC @12932 this fixes the uv command prompt installation.