### PR TITLE
Use redirected URL as base for relative paths

### DIFF
--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -153,7 +153,10 @@ impl<'a> FlatIndexClient<'a> {
             .map_err(ErrorKind::RequestError)?;
         let parse_simple_response = |response: Response| {
             async {
+                // Use the response URL, rather than the request URL, as the base for relative URLs.
+                // This ensures that we handle redirects and other URL transformations correctly.
                 let url = response.url().clone();
+
                 let text = response.text().await.map_err(ErrorKind::RequestError)?;
                 let SimpleHtml { base, files } = SimpleHtml::parse(&text, &url)
                     .map_err(|err| Error::from_html_err(err, url.clone()))?;

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -245,6 +245,10 @@ impl RegistryClient {
             .map_err(ErrorKind::RequestError)?;
         let parse_simple_response = |response: Response| {
             async {
+                // Use the response URL, rather than the request URL, as the base for relative URLs.
+                // This ensures that we handle redirects and other URL transformations correctly.
+                let url = response.url().clone();
+
                 let content_type = response
                     .headers()
                     .get("content-type")


### PR DESCRIPTION
## Summary

If you review the setup in https://github.com/astral-sh/uv/issues/1747, when we fetch `http://localhost:8000/simple/wheel/`, it gets redirected to `http://localhost:8000/index/wheel/`. So any relative paths returned need to be resolved relative to `http://localhost:8000/index/wheel/`.

Closes https://github.com/astral-sh/uv/issues/1747.

## Test Plan

- Install `proxpi gunicorn pypiserver`
- `gunicorn proxpi.server:app --bind 0.0.0.0:8000`
- `pypi-server run -p 8080 ~/packages --fallback-url "http://localhost:8000/index" --verbose`
- `echo "wheel" | cargo run pip compile - --index-url http://localhost:8080/simple --verbose --no-cache`
