### PR TITLE
Normalize `VIRTUAL_ENV` path in activation scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uv-cache",
+ "uv-fs",
  "uv-interpreter",
  "which",
 ]

--- a/crates/gourgeist/Cargo.toml
+++ b/crates/gourgeist/Cargo.toml
@@ -23,6 +23,7 @@ workspace = true
 [dependencies]
 platform-host = { path = "../platform-host" }
 uv-cache = { path = "../uv-cache" }
+uv-fs = { path = "../uv-fs" }
 uv-interpreter = { path = "../uv-interpreter" }
 
 anstream = { workspace = true }

--- a/crates/gourgeist/src/bare.rs
+++ b/crates/gourgeist/src/bare.rs
@@ -9,6 +9,7 @@ use camino::{FromPathBufError, Utf8Path, Utf8PathBuf};
 use fs_err as fs;
 use fs_err::File;
 use tracing::info;
+use uv_fs::Normalized;
 
 use uv_interpreter::Interpreter;
 
@@ -183,9 +184,16 @@ pub fn create_bare_venv(
     // cross-platform.
     for (name, template) in ACTIVATE_TEMPLATES {
         let activator = template
-            .replace("{{ VIRTUAL_ENV_DIR }}", location.as_str())
+            .replace(
+                "{{ VIRTUAL_ENV_DIR }}",
+                // SAFETY: `unwrap` is guaranteed to succeed because `location` is an `Utf8PathBuf`.
+                location.normalized().to_str().unwrap(),
+            )
             .replace("{{ BIN_NAME }}", bin_name)
-            .replace("{{ VIRTUAL_PROMPT }}", prompt.as_deref().unwrap_or(""))
+            .replace(
+                "{{ VIRTUAL_PROMPT }}",
+                prompt.as_deref().unwrap_or_default(),
+            )
             .replace(
                 "{{ RELATIVE_SITE_PACKAGES }}",
                 &format!(


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/uv/issues/1763

This PR fixes the issue where the Path to the virtual environment used NT Paths thar are unsupported in CMD on Win 10 (I can't repro on win11) by normalizing the path. 

## Test Plan

I can't reproduce the mentioned issue locally because it works fine under Win 11 and I don't have access to Win 10. 

But I verified that the path in the generated `activation.bat` isn't an NT Path. 

![grafik](https://github.com/astral-sh/uv/assets/1203881/0b7f1a9b-eb66-4685-9a40-ea5e96aab040)

I verified that I can activate the virtual env in CMD and Powershell by running the activation scripts.
