### PR TITLE
Rework --clear flag for venv command

### DIFF
--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -38,6 +38,7 @@ pub(crate) async fn venv(
     exclude_newer: Option<DateTime<Utc>>,
     cache: &Cache,
     printer: Printer,
+    clear: bool,
 ) -> Result<ExitStatus> {
     match venv_impl(
         path,
@@ -49,6 +50,7 @@ pub(crate) async fn venv(
         exclude_newer,
         cache,
         printer,
+        clear,
     )
     .await
     {
@@ -91,6 +93,7 @@ async fn venv_impl(
     exclude_newer: Option<DateTime<Utc>>,
     cache: &Cache,
     mut printer: Printer,
+    clear: bool,
 ) -> miette::Result<ExitStatus> {
     // Locate the Python interpreter.
     let platform = Platform::current().into_diagnostic()?;
@@ -110,6 +113,16 @@ async fn venv_impl(
         interpreter.sys_executable().normalized_display().cyan()
     )
     .into_diagnostic()?;
+
+    if path.exists() && !clear {
+        writeln!(
+            printer,
+            "Virtualenv already exists at {}. Use --clear option to recreate",
+            path.normalized_display().cyan()
+        )
+        .into_diagnostic()?;
+        return Ok(ExitStatus::Success);
+    }
 
     writeln!(
         printer,

--- a/crates/uv/src/compat/mod.rs
+++ b/crates/uv/src/compat/mod.rs
@@ -334,8 +334,8 @@ enum Resolver {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct VenvCompatArgs {
-    #[clap(long, hide = true)]
-    clear: bool,
+    #[clap(long)]
+    pub clear: bool,
 
     #[clap(long, hide = true)]
     no_seed: bool,
@@ -357,12 +357,12 @@ impl CompatArgs for VenvCompatArgs {
     /// behavior. If an argument is passed that does _not_ match uv's behavior, this method will
     /// return an error.
     fn validate(&self) -> Result<()> {
-        if self.clear {
-            warn_user!(
-                "virtualenv's `--clear` has no effect (uv always clears the virtual environment)."
-            );
-        }
-
+        // if self.clear {
+        //     warn_user!(
+        //         "virtualenv's `--clear` has no effect (uv always clears the virtual environment)."
+        //     );
+        // }
+        //
         if self.no_seed {
             warn_user!(
                 "virtualenv's `--no-seed` has no effect (uv omits seed packages by default)."

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -1092,6 +1092,7 @@ async fn run() -> Result<ExitStatus> {
                 args.exclude_newer,
                 &cache,
                 printer,
+                args.compat_args.clear,
             )
             .await
         }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Reworked the --clear flag for venv command for it not to recreate the existing virtualenv unless --clear flag is set.

Based on this discussion https://github.com/astral-sh/uv/issues/1472

## Test Plan

Create venv using `uv venv` command. Then use `uv venv` command again without flag. Check that virtualenv is not cleared. Then use `uv venv --clear`, check that it is recreated.

```bash
$ uv venv
Using Python 3.10.12 interpreter at /usr/bin/python3.10
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
$ uv pip install ruff # fill virtualenv with something
Resolved 1 package in 141ms
Installed 1 package in 21ms
 + ruff==0.2.2
$ uv pip freeze # memorize the previous state of virtualenv
ruff==0.2.2
$ uv venv # without flag
Using Python 3.10.12 interpreter at /usr/bin/python3.10
Virtualenv already exists at .venv. Use --clear option to recreate
$ uv pip freeze # check that virtualenv is not cleared
ruff==0.2.2
$ uv venv --clear # with flag
Using Python 3.10.12 interpreter at /usr/bin/python3.10
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
$ uv pip freeze # check virtualenv is cleared
$
```
