### PR TITLE
docs: update venv activation for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To activate the virtual environment:
 source .venv/bin/activate
 
 # On Windows.
-.\.venv\Scripts\activate.ps1
+.venv\Scripts\activate
 ```
 
 To install a package into the virtual environment:


### PR DESCRIPTION
## Summary

Follow on to PR https://github.com/astral-sh/uv/pull/1811 as part of issue https://github.com/astral-sh/uv/issues/1750. This change updates the windows venv activation to work for both Powershell and Command Prompt instead of just Powershell. This also aligns with what `uv venv` displays.

