### PR TITLE
Treat ARM wheels as higher-priority than universal

### DIFF
--- a/crates/platform-tags/src/lib.rs
+++ b/crates/platform-tags/src/lib.rs
@@ -154,7 +154,6 @@ impl Tags {
             "none".to_string(),
             "any".to_string(),
         ));
-        tags.sort();
         Ok(Self::new(tags))
     }
 
@@ -236,32 +235,20 @@ impl Tags {
 
 /// The priority of a platform tag.
 ///
-/// A wrapper around [`NonZeroU32`]. Lower values indicate higher priority.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// A wrapper around [`NonZeroU32`]. Higher values indicate higher priority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TagPriority(NonZeroU32);
 
 impl TryFrom<usize> for TagPriority {
     type Error = TagsError;
 
-    /// Create a [`TagPriority`] from a `usize`, where lower `usize` values are given higher
+    /// Create a [`TagPriority`] from a `usize`, where higher `usize` values are given higher
     /// priority.
     fn try_from(priority: usize) -> Result<Self, TagsError> {
         match u32::try_from(priority).and_then(|priority| NonZeroU32::try_from(1 + priority)) {
             Ok(priority) => Ok(Self(priority)),
             Err(err) => Err(TagsError::InvalidPriority(priority, err)),
         }
-    }
-}
-
-impl Ord for TagPriority {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.0.cmp(&other.0).reverse()
-    }
-}
-
-impl PartialOrd for TagPriority {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/crates/platform-tags/src/lib.rs
+++ b/crates/platform-tags/src/lib.rs
@@ -236,20 +236,32 @@ impl Tags {
 
 /// The priority of a platform tag.
 ///
-/// A wrapper around [`NonZeroU32`]. Higher values indicate higher priority.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// A wrapper around [`NonZeroU32`]. Lower values indicate higher priority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TagPriority(NonZeroU32);
 
 impl TryFrom<usize> for TagPriority {
     type Error = TagsError;
 
-    /// Create a [`TagPriority`] from a `usize`, where higher `usize` values are given higher
+    /// Create a [`TagPriority`] from a `usize`, where lower `usize` values are given higher
     /// priority.
     fn try_from(priority: usize) -> Result<Self, TagsError> {
         match u32::try_from(priority).and_then(|priority| NonZeroU32::try_from(1 + priority)) {
             Ok(priority) => Ok(Self(priority)),
             Err(err) => Err(TagsError::InvalidPriority(priority, err)),
         }
+    }
+}
+
+impl Ord for TagPriority {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        self.0.cmp(&other.0).reverse()
+    }
+}
+
+impl PartialOrd for TagPriority {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
## Summary

We need to take care to keep wheel tags in "priority order" (e.g., we should prefer ARM wheels over universal wheels). However... it looks like we've had a `.sort()` in here all along, that risks throwing off the ordering?

Closes https://github.com/astral-sh/uv/issues/1840.

## Test Plan

ensure that `rlax` uses the ARM wheel rather than the universal wheel:

- `cargo run venv`
- `cargo run pip install rlax`
- `import rlax`
