### PR TITLE
fix: expose types to implement custom `ResolverProvider`

### DIFF
--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -4,12 +4,15 @@ pub use finder::{DistFinder, Reporter as FinderReporter};
 pub use manifest::Manifest;
 pub use options::{Options, OptionsBuilder};
 pub use prerelease_mode::PreReleaseMode;
+pub use python_requirement::PythonRequirement;
 pub use resolution::{AnnotationStyle, Diagnostic, DisplayResolutionGraph, ResolutionGraph};
 pub use resolution_mode::ResolutionMode;
 pub use resolver::{
-    BuildId, DefaultResolverProvider, InMemoryIndex, Reporter as ResolverReporter, Resolver,
-    ResolverProvider,
+    BuildId, DefaultResolverProvider, InMemoryIndex, PackageVersionsResult,
+    Reporter as ResolverReporter, Resolver, ResolverProvider, VersionsResponse,
+    WheelMetadataResult,
 };
+pub use version_map::VersionMap;
 
 mod candidate_selector;
 mod constraints;

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -47,9 +47,10 @@ use crate::pubgrub::{
 use crate::python_requirement::PythonRequirement;
 use crate::resolution::ResolutionGraph;
 pub use crate::resolver::index::InMemoryIndex;
-pub use crate::resolver::provider::DefaultResolverProvider;
-pub use crate::resolver::provider::ResolverProvider;
-pub(crate) use crate::resolver::provider::VersionsResponse;
+pub use crate::resolver::provider::{
+    DefaultResolverProvider, PackageVersionsResult, ResolverProvider, VersionsResponse,
+    WheelMetadataResult,
+};
 use crate::resolver::reporter::Facade;
 pub use crate::resolver::reporter::{BuildId, Reporter};
 use crate::yanks::AllowedYanks;

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -17,8 +17,8 @@ use uv_traits::{BuildContext, NoBinary};
 use crate::python_requirement::PythonRequirement;
 use crate::version_map::VersionMap;
 
-type PackageVersionsResult = Result<VersionsResponse, uv_client::Error>;
-type WheelMetadataResult = Result<(Metadata21, Option<Url>), uv_distribution::Error>;
+pub type PackageVersionsResult = Result<VersionsResponse, uv_client::Error>;
+pub type WheelMetadataResult = Result<(Metadata21, Option<Url>), uv_distribution::Error>;
 
 /// The response when requesting versions for a package
 #[derive(Debug)]

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -181,6 +181,14 @@ impl From<FlatDistributions> for VersionMap {
     }
 }
 
+impl From<BTreeMap<Version, PrioritizedDist>> for VersionMap {
+    fn from(value: BTreeMap<Version, PrioritizedDist>) -> Self {
+        Self {
+            inner: VersionMapInner::Eager(value),
+        }
+    }
+}
+
 /// A lazily initialized distribution.
 ///
 /// This permits access to a handle that can be turned into a resolvable


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

To integrate `uv` into `pixi` I need to specify a custom `ResolverProvider` to be able to specify that some packages are already installed by conda and should not be touched. However, some of the types required to implement your own `ResolverProvider` were not accessible through the public API. This PR basically adds them.

## Test Plan

I didnt add an explicit test for this.
