### PR TITLE
Retain authentication attached to URLs when making requests to the same host

### DIFF
--- a/crates/uv-client/src/auth.rs
+++ b/crates/uv-client/src/auth.rs
@@ -48,15 +48,9 @@ fn should_retain_auth(request_url: &Url, response_url: &Url) -> bool {
 
     // Check the port.
     // The port is only allowed to differ if it it matches the "default port" for the scheme.
-    let default_port = match request_url.scheme() {
-        "http" => Some(80),
-        "https" => Some(443),
-        _ => None,
-    };
-    if request_url.port() != response_url.port()
-        && request_url.port() != default_port
-        && response_url.port() != default_port
-    {
+    // However, `reqwest` sets the `port` to `None` if it matches the default port so we do
+    // not need any special handling here.
+    if request_url.port() != response_url.port() {
         return false;
     }
 

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -19,6 +19,7 @@ use pypi_types::{Hashes, Yanked};
 use uv_cache::{Cache, CacheBucket};
 use uv_normalize::PackageName;
 
+use crate::auth::safe_copy_auth;
 use crate::cached_client::{CacheControl, CachedClientError};
 use crate::html::SimpleHtml;
 use crate::{Connectivity, Error, ErrorKind, RegistryClient};
@@ -155,7 +156,7 @@ impl<'a> FlatIndexClient<'a> {
             async {
                 // Use the response URL, rather than the request URL, as the base for relative URLs.
                 // This ensures that we handle redirects and other URL transformations correctly.
-                let url = response.url().clone();
+                let url = safe_copy_auth(url, response.url().clone());
 
                 let text = response.text().await.map_err(ErrorKind::RequestError)?;
                 let SimpleHtml { base, files } = SimpleHtml::parse(&text, &url)

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -7,6 +7,7 @@ pub use registry_client::{
 };
 pub use rkyvutil::OwnedArchive;
 
+mod auth;
 mod cached_client;
 mod error;
 mod flat_index;

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -247,7 +247,21 @@ impl RegistryClient {
             async {
                 // Use the response URL, rather than the request URL, as the base for relative URLs.
                 // This ensures that we handle redirects and other URL transformations correctly.
-                let url = response.url().clone();
+                let request_url = url;
+                let mut url = response.url().clone();
+
+                // We must ensure authentication is retained for hosts
+                if request_url.host() == url.host() {
+                    // These shouldn't fail, but we'll log if they do in case it's relevant for debugging
+                    url.set_username(request_url.username())
+                        .unwrap_or_else(|_| {
+                            warn!("Failed to transfer username to response URL: {url}")
+                        });
+                    url.set_password(request_url.password())
+                        .unwrap_or_else(|_| {
+                            warn!("Failed to transfer password to response URL: {url}")
+                        });
+                }
 
                 let content_type = response
                     .headers()

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -530,6 +530,48 @@ impl RegistryClient {
                 .into_async_read(),
         ))
     }
+
+    /// Determine if authentication information should be retained on a new URL.
+    /// Implements the specification defined in RFC 7235 and 7230.
+    ///
+    /// <https://datatracker.ietf.org/doc/html/rfc7235#section-2.2>
+    /// <https://datatracker.ietf.org/doc/html/rfc7230#section-5.5>
+    fn should_retain_auth(request_url: &Url, response_url: &Url) -> bool {
+        // The "scheme" and "authority" components must match to retain authentication
+
+        // Check the scheme.
+        // Note some clients such as Python's `requests` library allow an upgrade
+        // from `http` to `https` but this is not spec-compliant.
+        // <https://github.com/pypa/pip/blob/75f54cae9271179b8cc80435f92336c97e349f9d/src/pip/_vendor/requests/sessions.py#L133-L136>
+        if request_url.scheme() != response_url.scheme() {
+            return false;
+        }
+
+        // Check the authority, which is composed of the host and port.
+        if request_url.host() != response_url.host() {
+            return false;
+        }
+
+        let default_port = match request_url.scheme() {
+            "http" => Some(80),
+            "https" => Some(443),
+            _ => None,
+        };
+
+        // Check the port
+        if request_url.port() != response_url.port() {
+            if (request_url.port() == default_port || request_url.port().is_none())
+                && (response_url.port() == default_port || response_url.port().is_none())
+            {
+                // Allow the ports to be different if they are the default port for the scheme
+                // or null
+            } else {
+                return false;
+            }
+        }
+
+        true
+    }
 }
 
 /// Read a wheel's `METADATA` file from a zip file.
@@ -779,12 +821,12 @@ pub enum Connectivity {
 mod tests {
     use std::str::FromStr;
 
-    use url::Url;
+    use url::{ParseError, Url};
 
     use pypi_types::{JoinRelativeError, SimpleJson};
     use uv_normalize::PackageName;
 
-    use crate::{html::SimpleHtml, SimpleMetadata, SimpleMetadatum};
+    use crate::{html::SimpleHtml, RegistryClient, SimpleMetadata, SimpleMetadatum};
 
     #[test]
     fn ignore_failing_files() {
@@ -875,6 +917,89 @@ mod tests {
             "https://account.d.codeartifact.us-west-2.amazonaws.com/pypi/shared-packages-pypi/simple/3.0.1/flask-3.0.1.tar.gz#sha256=6489f51bb3666def6f314e15f19d50a1869a19ae0e8c9a3641ffe66c77d42403",
         ]
         "###);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_should_retain_auth() -> Result<(), ParseError> {
+        // Exact match (https)
+        assert!(RegistryClient::should_retain_auth(
+            &Url::parse("https://example.com")?,
+            &Url::parse("https://example.com")?,
+        ));
+
+        // Exact match (with port)
+        assert!(RegistryClient::should_retain_auth(
+            &Url::parse("https://example.com:1234")?,
+            &Url::parse("https://example.com:1234")?,
+        ));
+
+        // Exact match (http)
+        assert!(RegistryClient::should_retain_auth(
+            &Url::parse("http://example.com")?,
+            &Url::parse("http://example.com")?,
+        ));
+
+        // Okay, path differs
+        assert!(RegistryClient::should_retain_auth(
+            &Url::parse("http://example.com/foo")?,
+            &Url::parse("http://example.com/bar")?,
+        ));
+
+        // Okay, default port differs (https)
+        assert!(RegistryClient::should_retain_auth(
+            &Url::parse("https://example.com:443")?,
+            &Url::parse("https://example.com")?,
+        ));
+        assert!(RegistryClient::should_retain_auth(
+            &Url::parse("https://example.com")?,
+            &Url::parse("https://example.com:443")?,
+        ));
+
+        // Okay, default port differs (http)
+        assert!(RegistryClient::should_retain_auth(
+            &Url::parse("http://example.com:80")?,
+            &Url::parse("http://example.com")?,
+        ));
+        assert!(RegistryClient::should_retain_auth(
+            &Url::parse("http://example.com")?,
+            &Url::parse("http://example.com:80")?,
+        ));
+
+        // Mismatched scheme
+        assert!(!RegistryClient::should_retain_auth(
+            &Url::parse("https://example.com")?,
+            &Url::parse("http://example.com")?,
+        ));
+
+        // Mismatched scheme, we explicitly do not allow upgrade to https
+        assert!(!RegistryClient::should_retain_auth(
+            &Url::parse("http://example.com")?,
+            &Url::parse("https://example.com")?,
+        ));
+
+        // Mismatched host
+        assert!(!RegistryClient::should_retain_auth(
+            &Url::parse("https://foo.com")?,
+            &Url::parse("https://bar.com")?,
+        ));
+
+        // Mismatched port
+        assert!(!RegistryClient::should_retain_auth(
+            &Url::parse("https://example.com:1234")?,
+            &Url::parse("https://example.com:5678")?,
+        ));
+
+        // Mismatched port, with one as default for scheme
+        assert!(!RegistryClient::should_retain_auth(
+            &Url::parse("https://example.com:443")?,
+            &Url::parse("https://example.com:5678")?,
+        ));
+        assert!(!RegistryClient::should_retain_auth(
+            &Url::parse("https://example.com:1234")?,
+            &Url::parse("https://example.com:443")?,
+        ));
 
         Ok(())
     }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -767,7 +767,7 @@ pub enum Connectivity {
 mod tests {
     use std::str::FromStr;
 
-    use url::{Url};
+    use url::Url;
 
     use pypi_types::{JoinRelativeError, SimpleJson};
     use uv_normalize::PackageName;


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/1860


In https://github.com/astral-sh/uv/pull/1816, we started using the URL attached to a response instead of the request URL for subsequent requests — this fixes various bugs but has the side-effect of dropping credentials from the URL. Here, we transfer credentials from the request URL to the response URL. We perform RFC compliant checks for safety.