### PR TITLE
Fix windows py spurious stderr failure

### DIFF
--- a/crates/uv-interpreter/src/python_query.rs
+++ b/crates/uv-interpreter/src/python_query.rs
@@ -344,8 +344,8 @@ mod windows {
             .in_scope(|| Command::new("py").arg("--list-paths").output())
             .map_err(Error::PyList)?;
 
-        // There shouldn't be any output on stderr.
-        if !output.status.success() || !output.stderr.is_empty() {
+        // `py` sometimes prints "Installed Pythons found by py Launcher for Windows" to stderr which we ignore.
+        if !output.status.success() {
             return Err(Error::PythonSubcommandOutput {
                 message: format!(
                     "Running `py --list-paths` failed with status {}",


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

On Windows `10.0.19045` the `py` command prints to `stderr` even when working correctly.  This means that uv should not treat this as a failure.

Fixes https://github.com/astral-sh/uv/issues/1904

## Test Plan

I ran the modified code and it worked. I expect the pull request to run automated tests.
