### PR TITLE
Use `rustls-tls-native-roots` in `uv` crate

### DIFF
--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -82,7 +82,7 @@ indoc = { version = "2.0.4" }
 insta = { version = "1.34.0", features = ["filters"] }
 predicates = { version = "3.0.4" }
 regex = { version = "1.10.3" }
-reqwest = { version = "0.11.23", features = ["blocking", "rustls"], default-features = false }
+reqwest = { version = "0.11.23", features = ["blocking", "rustls-tls-native-roots"], default-features = false }
 
 [features]
 default = ["flate2/zlib-ng", "python", "pypi", "git", "maturin"]

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -82,7 +82,7 @@ indoc = { version = "2.0.4" }
 insta = { version = "1.34.0", features = ["filters"] }
 predicates = { version = "3.0.4" }
 regex = { version = "1.10.3" }
-reqwest = { version = "0.11.23", features = ["blocking", "rustls-tls-native-roots"], default-features = false }
+reqwest = { version = "0.11.23", features = ["blocking"], default-features = false }
 
 [features]
 default = ["flate2/zlib-ng", "python", "pypi", "git", "maturin"]


### PR DESCRIPTION
I'm confused that we have this separate specification of `reqwests`? I'm not sure this has any effect, but it seems like it should be done for correctness.

Follows #1512 