### PR TITLE
Ignore Python 2 installations when querying for interpreters

### DIFF
--- a/crates/uv-interpreter/src/get_interpreter_info.py
+++ b/crates/uv-interpreter/src/get_interpreter_info.py
@@ -1,3 +1,13 @@
+""""
+Queries information about the current Python interpreter and prints it as JSON.
+
+Exit Codes:
+    0: Success
+    1: General failure
+    3: Python version 3 or newer is required
+"""
+
+
 import json
 import os
 import platform
@@ -11,6 +21,10 @@ def format_full_version(info):
     if kind != "final":
         version += kind[0] + str(info.serial)
     return version
+
+
+if sys.version_info[0] < 3:
+    sys.exit(3)
 
 
 if hasattr(sys, "implementation"):

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -59,6 +59,8 @@ pub enum Error {
         stdout: String,
         stderr: String,
     },
+    #[error("Python 2 or older is not supported. Please use Python 3 or newer.")]
+    Python2OrOlder,
     #[error("Failed to write to cache")]
     Encode(#[from] rmp_serde::encode::Error),
     #[error("Broken virtualenv: Failed to parse pyvenv.cfg")]


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/uv/issues/1693

`uv` currently fails when a user has `python` 2 or older installed on their system without a `python3` or `python3.exe` on their path because
the `get_interpreter_info.py` script fails executing (it uses some Python 3+ APIs).

This PR fixes this by:

* Returning an explicit error code in `get_interpreter_info` if the Python version isn't supported
* Skipping over this error in `python_query` if the user requested ANY python version or a version >= 3. 
* Error if the user requested a Python 2 version. 

## Test Plan

Error if the user requests a legacy python version. 

```
uv venv -p 2
  × Python 2 or older is not supported. Please use Python 3 or newer.
```


Ignore any python 2 installation when querying newer python installations (using v4 here because I have python3 on the path and that takes precedence over querying python)
```
 uv_interpreter::python_query::find_python selector=Major(4)
      0.005541s   0ms DEBUG uv_interpreter::interpreter Detecting markers for: /home/micha/.pyenv/shims/python
      0.059730s  54ms DEBUG uv_interpreter::python_query Found a Python 2 installation that isn't supported by uv, skipping.
      0.059983s  54ms DEBUG uv_interpreter::interpreter Using cached markers for: /usr/bin/python
  × No Python 4 In `PATH`. Is Python 4 installed?

```
