### PR TITLE
Fix uv-created venv detection

### DIFF
--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -378,7 +378,7 @@ impl<'a> Planner<'a> {
         if !site_packages.is_empty() {
             // If uv created the virtual environment, then remove all packages, regardless of
             // whether they're considered "seed" packages.
-            let seed_packages = !venv.cfg().is_ok_and(|cfg| cfg.is_gourgeist());
+            let seed_packages = !venv.cfg().is_ok_and(|cfg| cfg.is_uv());
             for dist_info in site_packages {
                 if seed_packages
                     && matches!(

--- a/crates/uv-interpreter/src/cfg.rs
+++ b/crates/uv-interpreter/src/cfg.rs
@@ -3,19 +3,20 @@ use std::path::Path;
 use fs_err as fs;
 use thiserror::Error;
 
+/// A parsed `pyvenv.cfg`
 #[derive(Debug, Clone)]
-pub struct Configuration {
+pub struct PyVenvConfiguration {
     /// The version of the `virtualenv` package used to create the virtual environment, if any.
     pub(crate) virtualenv: bool,
-    /// The version of the `gourgeist` package used to create the virtual environment, if any.
-    pub(crate) gourgeist: bool,
+    /// The version of the `uv` package used to create the virtual environment, if any.
+    pub(crate) uv: bool,
 }
 
-impl Configuration {
-    /// Parse a `pyvenv.cfg` file into a [`Configuration`].
+impl PyVenvConfiguration {
+    /// Parse a `pyvenv.cfg` file into a [`PyVenvConfiguration`].
     pub fn parse(cfg: impl AsRef<Path>) -> Result<Self, Error> {
         let mut virtualenv = false;
-        let mut gourgeist = false;
+        let mut uv = false;
 
         // Per https://snarky.ca/how-virtual-environments-work/, the `pyvenv.cfg` file is not a
         // valid INI file, and is instead expected to be parsed by partitioning each line on the
@@ -29,17 +30,14 @@ impl Configuration {
                 "virtualenv" => {
                     virtualenv = true;
                 }
-                "gourgeist" => {
-                    gourgeist = true;
+                "uv" => {
+                    uv = true;
                 }
                 _ => {}
             }
         }
 
-        Ok(Self {
-            virtualenv,
-            gourgeist,
-        })
+        Ok(Self { virtualenv, uv })
     }
 
     /// Returns true if the virtual environment was created with the `virtualenv` package.
@@ -47,9 +45,9 @@ impl Configuration {
         self.virtualenv
     }
 
-    /// Returns true if the virtual environment was created with the `gourgeist` package.
-    pub fn is_gourgeist(&self) -> bool {
-        self.gourgeist
+    /// Returns true if the virtual environment was created with the `uv` package.
+    pub fn is_uv(&self) -> bool {
+        self.uv
     }
 }
 

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
-pub use crate::cfg::Configuration;
+pub use crate::cfg::PyVenvConfiguration;
 pub use crate::interpreter::Interpreter;
 pub use crate::python_query::{find_default_python, find_requested_python};
 pub use crate::python_version::PythonVersion;

--- a/crates/uv-interpreter/src/virtual_env.rs
+++ b/crates/uv-interpreter/src/virtual_env.rs
@@ -8,7 +8,7 @@ use platform_host::Platform;
 use uv_cache::Cache;
 use uv_fs::{LockedFile, Normalized};
 
-use crate::cfg::Configuration;
+use crate::cfg::PyVenvConfiguration;
 use crate::python_platform::PythonPlatform;
 use crate::{Error, Interpreter};
 
@@ -65,10 +65,10 @@ impl Virtualenv {
         &self.interpreter
     }
 
-    /// Return the [`Configuration`] for this virtual environment, as extracted from the
+    /// Return the [`PyVenvConfiguration`] for this virtual environment, as extracted from the
     /// `pyvenv.cfg` file.
-    pub fn cfg(&self) -> Result<Configuration, Error> {
-        Ok(Configuration::parse(self.root.join("pyvenv.cfg"))?)
+    pub fn cfg(&self) -> Result<PyVenvConfiguration, Error> {
+        Ok(PyVenvConfiguration::parse(self.root.join("pyvenv.cfg"))?)
     }
 
     /// Returns the path to the `site-packages` directory inside a virtual environment.


### PR DESCRIPTION
Read the key read for uv from `pyenv.cfg` from `gourgeist` instead of `uv`. I missed that we're also reading pyenv.cfg when reviewing #1852. We could check for gourgeist for backwards compatibility, but i think it's fine this way.