### PR TITLE
Don't write pip compile output to stdout with `-q`

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -932,6 +932,7 @@ async fn run() -> Result<ExitStatus> {
                 args.python_version,
                 args.exclude_newer,
                 args.annotation_style,
+                cli.quiet,
                 cache,
                 printer,
             )

--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,0 @@
-apache-airflow[otel]
-opentelemetry-exporter-prometheus<0.44


### PR DESCRIPTION
## Summary

When the user provides an output file, avoid writing the `pip compile` output to `stdout` when `-q` is specified. (We still write to `stdout` if no output file is provided, since otherwise, the resolution won't be printed _anywhere_.)