### PR TITLE
Take `setup.cfg` timestamp into account for cache invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ The specifics of uv's caching semantics vary based on the nature of the dependen
 - **For Git dependencies**, uv caches based on the fully-resolved Git commit hash. As such,
   `uv pip compile` will pin Git dependencies to a specific commit hash when writing the resolved
   dependency set.
-- **For local dependencies**, uv caches based on the last-modified time of the `setup.py` or
-  `pyproject.toml` file.
+- **For local dependencies**, uv caches based on the last-modified time of the `setup.cfg`,
+  `setup.py` or `pyproject.toml` file.
 
 If you're running into caching issues, uv includes a few escape hatches:
 

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -630,7 +630,7 @@ pub enum ArchiveTimestamp {
     /// The archive consists of a single file with the given modification time.
     Exact(Timestamp),
     /// The archive consists of a directory. The modification time is the latest modification time
-    /// of the `pyproject.toml` or `setup.py` file in the directory.
+    /// of the `pyproject.toml`, `setup.cfg` or `setup.py` file in the directory.
     Approximate(Timestamp),
 }
 
@@ -638,8 +638,8 @@ impl ArchiveTimestamp {
     /// Return the modification timestamp for an archive, which could be a file (like a wheel or a zip
     /// archive) or a directory containing a Python package.
     ///
-    /// If the path is to a directory with no entrypoint (i.e., no `pyproject.toml` or `setup.py`),
-    /// returns `None`.
+    /// If the path is to a directory with no entrypoint (i.e., no `pyproject.toml`, `setup.cfg` or
+    /// `setup.py`), returns `None`.
     pub fn from_path(path: impl AsRef<Path>) -> Result<Option<Self>, io::Error> {
         let metadata = fs_err::metadata(path.as_ref())?;
         if metadata.is_file() {
@@ -648,6 +648,14 @@ impl ArchiveTimestamp {
             if let Some(metadata) = path
                 .as_ref()
                 .join("pyproject.toml")
+                .metadata()
+                .ok()
+                .filter(std::fs::Metadata::is_file)
+            {
+                Ok(Some(Self::Approximate(Timestamp::from_metadata(&metadata))))
+            } else if let Some(metadata) = path
+                .as_ref()
+                .join("setup.cfg")
                 .metadata()
                 .ok()
                 .filter(std::fs::Metadata::is_file)


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This patch adds `setup.cfg` timestamp metadata to the list of files to process for cache invalidation.

Partially related to #1913.

---

Thanks bye :wave:
