### PR TITLE
Remove `spawn_blocking` from version map

### DIFF
--- a/crates/uv-distribution/src/unzip.rs
+++ b/crates/uv-distribution/src/unzip.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use tracing::instrument;
+
 use uv_extract::Error;
 
 use crate::download::BuiltWheel;
@@ -23,6 +25,7 @@ impl Unzip for BuiltWheel {
 }
 
 impl Unzip for LocalWheel {
+    #[instrument(skip_all, fields(filename=self.filename().to_string()))]
     fn unzip(&self, target: &Path) -> Result<(), Error> {
         match self {
             Self::Unzipped(_) => Ok(()),

--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use reqwest::Client;
-use tracing::debug;
+use tracing::{debug, instrument};
 use url::Url;
 
 use cache_key::{digest, RepositoryUrl};
@@ -49,6 +49,7 @@ impl GitSource {
     }
 
     /// Fetch the underlying Git repository at the given revision.
+    #[instrument(skip(self))]
     pub fn fetch(self) -> Result<Fetch> {
         // The path to the repo, within the Git database.
         let ident = digest(&RepositoryUrl::new(&self.git.repository));

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -808,8 +808,15 @@ fn install_no_index_version() {
 fn install_git_public_https() {
     let context = TestContext::new("3.8");
 
-    uv_snapshot!(command(&context)
-        .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage")
+    let mut command = command(&context);
+    command.arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage");
+    if cfg!(all(windows, debug_assertions)) {
+        // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
+        // default windows stack of 1MB
+        command.env("UV_STACK_SIZE", (2 * 1024 * 1024).to_string());
+    }
+
+    uv_snapshot!(command
         , @r###"
     success: true
     exit_code: 0
@@ -838,8 +845,7 @@ fn install_git_public_https_missing_branch_or_tag() {
 
     uv_snapshot!(filters, command(&context)
         // 2.0.0 does not exist
-        .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@2.0.0")
-        , @r###"
+        .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@2.0.0"), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -897,8 +903,15 @@ fn install_git_private_https_pat() {
     let mut filters = INSTA_FILTERS.to_vec();
     filters.insert(0, (&token, "***"));
 
-    uv_snapshot!(filters, command(&context)
-        .arg(format!("uv-private-pypackage @ git+https://{token}@github.com/astral-test/uv-private-pypackage"))
+    let mut command = command(&context);
+    command.arg(format!("uv-private-pypackage @ git+https://{token}@github.com/astral-test/uv-private-pypackage"));
+    if cfg!(all(windows, debug_assertions)) {
+        // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
+        // default windows stack of 1MB
+        command.env("UV_STACK_SIZE", (2 * 1024 * 1024).to_string());
+    }
+
+    uv_snapshot!(filters, command
         , @r###"
     success: true
     exit_code: 0
@@ -933,8 +946,15 @@ fn install_git_private_https_pat_at_ref() {
         ""
     };
 
-    uv_snapshot!(filters, command(&context)
-        .arg(format!("uv-private-pypackage @ git+https://{user}{token}@github.com/astral-test/uv-private-pypackage@6c09ce9ae81f50670a60abd7d95f30dd416d00ac"))
+    let mut command = command(&context);
+    command.arg(format!("uv-private-pypackage @ git+https://{user}{token}@github.com/astral-test/uv-private-pypackage@6c09ce9ae81f50670a60abd7d95f30dd416d00ac"));
+    if cfg!(all(windows, debug_assertions)) {
+        // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
+        // default windows stack of 1MB
+        command.env("UV_STACK_SIZE", (2 * 1024 * 1024).to_string());
+    }
+
+    uv_snapshot!(filters, command,
         , @r###"
     success: true
     exit_code: 0
@@ -1476,7 +1496,14 @@ fn direct_url_zip_file_bunk_permissions() -> Result<()> {
         "opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v2023.11.06.145820.zip",
     )?;
 
-    uv_snapshot!(command(&context)
+    let mut command = command(&context);
+    if cfg!(all(windows, debug_assertions)) {
+        // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
+        // default windows stack of 1MB
+        command.env("UV_STACK_SIZE", (2 * 1024 * 1024).to_string());
+    }
+
+    uv_snapshot!(command
         .arg("-r")
         .arg("requirements.txt")
         .arg("--strict"), @r###"

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -904,7 +904,9 @@ fn install_git_private_https_pat() {
     filters.insert(0, (&token, "***"));
 
     let mut command = command(&context);
-    command.arg(format!("uv-private-pypackage @ git+https://{token}@github.com/astral-test/uv-private-pypackage"));
+    command.arg(format!(
+        "uv-private-pypackage @ git+https://{token}@github.com/astral-test/uv-private-pypackage"
+    ));
     if cfg!(all(windows, debug_assertions)) {
         // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
         // default windows stack of 1MB
@@ -954,8 +956,7 @@ fn install_git_private_https_pat_at_ref() {
         command.env("UV_STACK_SIZE", (2 * 1024 * 1024).to_string());
     }
 
-    uv_snapshot!(filters, command,
-        , @r###"
+    uv_snapshot!(filters, command, @r###"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
I previously add `spawn_blocking` to the version map construction as it had become a bottleneck (https://github.com/astral-sh/uv/pull/1163/files#diff-704ceeaedada99f90369eac535713ec82e19550bff166cd44745d7277ecae527R116). With the zero copy deserialization, this has become so fast we don't need to move it to the thread pool anymore. I've also checked `DataWithCachePolicy` but it seems to still take a significant amount of time. Span visualization:

Resolving jupyter warm:

![image](https://github.com/astral-sh/uv/assets/6826232/692b03da-61c5-4f96-b413-199c14aa47c4)

Resolving jupyter cold:

![image](https://github.com/astral-sh/uv/assets/6826232/a6893155-d327-40c9-a83a-7c537b7c99c4)
![image](https://github.com/astral-sh/uv/assets/6826232/213556a3-a331-42db-aaf5-bdef5e0205dd)

I've also updated the instrumentation a little.

We don't seem cpu bound for the cold cache (top) and refresh case (bottom) from jupyter:

![image](https://github.com/astral-sh/uv/assets/6826232/cb976add-3d30-465a-a470-8490b7b6caea)

![image](https://github.com/astral-sh/uv/assets/6826232/d7ecb745-dd2d-4f91-939c-2e46b7c812dd)

