### PR TITLE
Add example for compile current env packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,17 @@ To install a package into the virtual environment:
 uv pip install flask                # Install Flask.
 uv pip install -r requirements.txt  # Install from a requirements.txt file.
 uv pip install -e .                 # Install the current project in editable mode.
-uv pip install "package @ ."        # Install the current project from disk
+uv pip install "package @ ."        # Install the current project from disk.
 uv pip install "flask[dotenv]"      # Install Flask with "dotenv" extra.
 ```
 
-To generate a set of locked dependencies from an input file:
+To generate a set of locked dependencies:
 
 ```shell
 uv pip compile pyproject.toml -o requirements.txt   # Read a pyproject.toml file.
 uv pip compile requirements.in -o requirements.txt  # Read a requirements.in file.
+uv pip compile - -o requirements.txt  # Read from stdin.
+uv pip freeze | uv pip compile - -o requirements.txt  # Read from env packages.
 ```
 
 To sync a set of locked dependencies with the virtual environment:

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ To generate a set of locked dependencies:
 ```shell
 uv pip compile pyproject.toml -o requirements.txt   # Read a pyproject.toml file.
 uv pip compile requirements.in -o requirements.txt  # Read a requirements.in file.
-uv pip compile - -o requirements.txt  # Read from stdin.
-uv pip freeze | uv pip compile - -o requirements.txt  # Read from env packages.
+echo flask | uv pip compile - -o requirements.txt  # Read from stdin.
+uv pip freeze | uv pip compile - -o requirements.txt  # Lock the current environment.
 ```
 
 To sync a set of locked dependencies with the virtual environment:


### PR DESCRIPTION

## Summary
I was going to create a feature-request issue for adding graph like showing of currently installed dependencies in venv, but then I found `uv pip freeze | uv pip compile` is what I'm looking for.

As one who manually pip-installs packages every once in a while (instead of edit `requirements.in` each time), after a while I would need to have graph of installed packages (e.g. to see how uninstallinga packages effects on others).

I found this command is so useful and wondered if we could have this in docs as one of `uv` features.
## Test Plan

<!-- How was it tested? -->
