### PR TITLE
docs: add brand-centric badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # uv
 
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-[![image](https://img.shields.io/pypi/v/uv?logo=python&logoColor=D7FF64&color=261230)](https://pypi.python.org/pypi/uv)
-[![image](https://img.shields.io/pypi/l/uv?logo=python&logoColor=D7FF64&color=261230)](https://pypi.python.org/pypi/uv)
-[![image](https://img.shields.io/pypi/pyversions/uv?logo=python&logoColor=D7FF64&color=261230)](https://pypi.python.org/pypi/uv)
-[![Actions status](https://img.shields.io/github/actions/workflow/status/astral-sh/uv/ci.yml?logo=github&logoColor=D7FF64&label=CI&color=261230)](https://github.com/astral-sh/uv/actions)
+[![PyPI Version](https://img.shields.io/pypi/v/uv?logo=python&logoColor=D7FF64&color=261230&label=Verson)](https://pypi.python.org/pypi/uv)
+[![License](https://img.shields.io/pypi/l/uv?logo=python&logoColor=D7FF64&color=261230&label=License)](https://pypi.python.org/pypi/uv)
+[![Python Versions](https://img.shields.io/pypi/pyversions/uv?logo=python&logoColor=D7FF64&color=261230&label=Python)](https://pypi.python.org/pypi/uv)
+[![Actions Status](https://img.shields.io/github/actions/workflow/status/astral-sh/uv/ci.yml?logo=github&logoColor=D7FF64&label=CI&color=261230)](https://github.com/astral-sh/uv/actions)
 [![Astral Discord](https://img.shields.io/discord/1039017663004942429?logo=discord&logoColor=D7FF64&label=Astral%20Discord&color=261230)](https://discord.gg/astral-sh)
 
 An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # uv
 
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
-[![image](https://img.shields.io/pypi/v/uv.svg)](https://pypi.python.org/pypi/uv)
-[![image](https://img.shields.io/pypi/l/uv.svg)](https://pypi.python.org/pypi/uv)
-[![image](https://img.shields.io/pypi/pyversions/uv.svg)](https://pypi.python.org/pypi/uv)
-[![Actions status](https://github.com/astral-sh/uv/workflows/CI/badge.svg)](https://github.com/astral-sh/uv/actions)
-[![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/astral-sh)
+[![image](https://img.shields.io/pypi/v/uv?logo=python&logoColor=D7FF64&color=261230)](https://pypi.python.org/pypi/uv)
+[![image](https://img.shields.io/pypi/l/uv?logo=python&logoColor=D7FF64&color=261230)](https://pypi.python.org/pypi/uv)
+[![image](https://img.shields.io/pypi/pyversions/uv?logo=python&logoColor=D7FF64&color=261230)](https://pypi.python.org/pypi/uv)
+[![Actions status](https://img.shields.io/github/actions/workflow/status/astral-sh/uv/ci.yml?logo=github&logoColor=D7FF64&label=CI&color=261230)](https://github.com/astral-sh/uv/actions)
+[![Astral Discord](https://img.shields.io/discord/1039017663004942429?logo=discord&logoColor=D7FF64&label=Astral%20Discord&color=261230)](https://discord.gg/astral-sh)
 
 An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in
 replacement for `pip` and `pip-compile`.


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
<!-- What's the purpose of the change? What does it do, and why? -->
- Updates badges to have brand-centric style
<img width="300" alt="image" src="https://github.com/astral-sh/uv/assets/45884264/d97a2a25-82db-4f4b-9f78-5aa2b5ed97de">


See Also:
- https://github.com/astral-sh/ruff/pull/10123
- https://github.com/astral-sh/rye/pull/769

## Test Plan

<!-- How was it tested? -->
