### PR TITLE
Remove current directory from PATH in PEP 517 hooks

### DIFF
--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -285,6 +285,10 @@ impl Pep517Backend {
         // > backend hooks.
         formatdoc! {r#"
             import sys
+
+            if sys.path[0] == "":
+                sys.path.pop(0)
+
             sys.path = [{backend_path}] + sys.path
 
             {import}
@@ -552,7 +556,8 @@ impl SourceBuild {
             pep517_backend.backend
         );
         let script = formatdoc! {
-            r#"{}
+            r#"
+            {}
             import json
 
             prepare_metadata_for_build_wheel = getattr(backend, "prepare_metadata_for_build_wheel", None)
@@ -686,7 +691,9 @@ impl SourceBuild {
         );
         let escaped_wheel_dir = escape_path_for_python(wheel_dir);
         let script = formatdoc! {
-            r#"{}
+            r#"
+            {}
+
             print(backend.build_{}("{}", metadata_directory={}, config_settings={}))
             "#,
             pep517_backend.backend_import(),


### PR DESCRIPTION
## Summary

When you invoke `python -c`, an empty string is prepended to `sys.path`, which allows loading modules in the current directory (https://docs.python.org/3/using/cmdline.html#cmdoption-P). However, in PEP 517 builds, the current directory should _not_ be part of the path. There's a flag we can use to disable this behavior (`-P`), but it's only available in Python 3.11 and later, so instead, I'm doing something similar to pip's `__main__.py`, which avoids this for `python -m pip` invocations.

Closes https://github.com/astral-sh/uv/issues/1972.
