### PR TITLE
Use full python version in `pyvenv.cfg`

### DIFF
--- a/crates/gourgeist/src/bare.rs
+++ b/crates/gourgeist/src/bare.rs
@@ -246,7 +246,7 @@ pub fn create_bare_venv(
         ),
         (
             "version_info".to_string(),
-            interpreter.markers().python_version.string.clone(),
+            interpreter.markers().python_full_version.string.clone(),
         ),
         (
             "include-system-site-packages".to_string(),


### PR DESCRIPTION
## Summary

For a venv created by `virtualenv`, the `pyvenv.cfg` file specifies the full version string in the `version_info` field:

```
home = /Users/x/.rye/py/cpython@3.12.1/install/bin
implementation = CPython
version_info = 3.12.1.final.0
virtualenv = 20.25.0
include-system-site-packages = false
base-prefix = /Users/x/.rye/py/cpython@3.12.1/install
base-exec-prefix = /Users/x/.rye/py/cpython@3.12.1/install
base-executable = /Users/x/.rye/py/cpython@3.12.1/install/bin/python3
```

The relevant code can be found here: 
https://github.com/pypa/virtualenv/blob/4ca8a20c179a03e649ce696a0df3e6e3344a18c9/src/virtualenv/create/creator.py#L167

This PR changes `pyvenv.cfg` created by uv for better compatibility with `virtualenv`.

## Test Plan

```sh
uv venv
cat .venv/pyvenv.cfg
```
