### PR TITLE
Future-proof pip entrypoints special case

### DIFF
--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 
 use anyhow::Result;
 use assert_cmd::prelude::*;
+use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
 use indoc::indoc;
 use url::Url;
@@ -2766,36 +2767,32 @@ fn set_read_permissions() -> Result<()> {
 fn pip_entrypoints() -> Result<()> {
     let context = TestContext::new("3.12");
 
-    let requirements_txt = context.temp_dir.child("requirements.txt");
-    requirements_txt.touch()?;
-    requirements_txt.write_str("pip==24.0")?;
+    // TODO(konstin): Remove git dep when the next pip version is released.
+    for pip_requirement in ["pip==24.0", "pip @ git+https://github.com/pypa/pip"] {
+        let requirements_txt = context.temp_dir.child("requirements.txt");
+        requirements_txt.touch()?;
+        requirements_txt.write_str(pip_requirement)?;
 
-    uv_snapshot!(command(&context)
-        .arg("requirements.txt")
-        .arg("--strict"), @r###"
-    success: true
-    exit_code: 0
-    ----- stdout -----
+        command(&context)
+            .arg("requirements.txt")
+            .arg("--strict")
+            .output()
+            .expect("Failed to install pip");
 
-    ----- stderr -----
-    Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + pip==24.0
-    "###
-    );
-
-    let bin_dir = context.venv.join(if cfg!(unix) {
-        "bin"
-    } else if cfg!(windows) {
-        "Scripts"
-    } else {
-        unimplemented!("Only Windows and Unix are supported")
-    });
-    // Pip 24.0 contains a pip3.10 launcher.
-    // https://inspector.pypi.io/project/pip/24.0/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl/pip-24.0.dist-info/entry_points.txt
-    assert!(!bin_dir.join(format!("pip3.10{EXE_SUFFIX}")).exists());
-    assert!(bin_dir.join(format!("pip3.12{EXE_SUFFIX}")).exists());
+        let bin_dir = context.venv.join(if cfg!(unix) {
+            "bin"
+        } else if cfg!(windows) {
+            "Scripts"
+        } else {
+            unimplemented!("Only Windows and Unix are supported")
+        });
+        // Pip 24.0 contains a pip3.10 launcher.
+        // https://inspector.pypi.io/project/pip/24.0/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl/pip-24.0.dist-info/entry_points.txt
+        ChildPath::new(bin_dir.join(format!("pip3.10{EXE_SUFFIX}")))
+            .assert(predicates::path::missing());
+        ChildPath::new(bin_dir.join(format!("pip3.12{EXE_SUFFIX}")))
+            .assert(predicates::path::exists());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Update #1918 to handle https://github.com/pypa/pip/pull/12536, where pip removed their python minor entrypoint. The pip test is semi-functional since it builds pip from source instead of using a wheel with the wrong entrypoint, we have to update it when this pip version has a release.

Closes #1593.
