### PR TITLE
Uv tests fail when path contains size/time-like strings

### DIFF
--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -27,9 +27,9 @@ pub static EXCLUDE_NEWER: &str = "2023-11-18T12:00:00Z";
 pub const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"--cache-dir [^\s]+", "--cache-dir [CACHE_DIR]"),
     // Operation times
-    (r"(\s)(\d+m )?(\d+\.)?\d+(ms|s)", "$1[TIME]"),
+    (r"(\s|\()(\d+m )?(\d+\.)?\d+(ms|s)", "$1[TIME]"),
     // File sizes
-    (r"(\s)(\d+\.)?\d+([KM]i)?B", "$1[SIZE]"),
+    (r"(\s|\()(\d+\.)?\d+([KM]i)?B", "$1[SIZE]"),
     // Rewrite Windows output to Unix output
     (r"\\([\w\d])", "/$1"),
     (r"uv.exe", "uv"),

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -27,9 +27,9 @@ pub static EXCLUDE_NEWER: &str = "2023-11-18T12:00:00Z";
 pub const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"--cache-dir [^\s]+", "--cache-dir [CACHE_DIR]"),
     // Operation times
-    (r"(\d+m )?(\d+\.)?\d+(ms|s)", "[TIME]"),
+    (r"(\s)(\d+m )?(\d+\.)?\d+(ms|s)", "$1[TIME]"),
     // File sizes
-    (r"(\d+\.)?\d+([KM]i)?B", "[SIZE]"),
+    (r"(\s)(\d+\.)?\d+([KM]i)?B", "$1[SIZE]"),
     // Rewrite Windows output to Unix output
     (r"\\([\w\d])", "/$1"),
     (r"uv.exe", "uv"),


### PR DESCRIPTION
The test suite for `uv` fails when the user path contains substrings that are incorrectly identified as `[TIME]` or `[SIZE]`, e.g.

`/Users/AB10BA/Documents/uv/` => `/Users/AB[SIZE]A/Documents/uv/`

Proposed change expects whitespace in front of the search string.