### PR TITLE
`--exclude-editable` and `--exclude` args for `uv pip list`

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -698,6 +698,14 @@ struct PipListArgs {
     /// List editable projects.
     #[clap(short, long)]
     editable: bool,
+
+    // Exclude editable package from output.
+    #[clap(long)]
+    exclude_editable: bool,
+
+    // Exclude specified package from the output.
+    #[clap(long)]
+    r#exclude: Vec<PackageName>,
 }
 
 #[derive(Args)]
@@ -1109,7 +1117,14 @@ async fn run() -> Result<ExitStatus> {
         }) => commands::pip_freeze(&cache, args.strict, printer),
         Commands::Pip(PipNamespace {
             command: PipCommand::List(args),
-        }) => commands::pip_list(&cache, args.strict, args.editable, printer),
+        }) => commands::pip_list(
+            &cache,
+            args.strict,
+            args.editable,
+            args.exclude_editable,
+            &args.exclude,
+            printer,
+        ),
         Commands::Cache(CacheNamespace {
             command: CacheCommand::Clean(args),
         })

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -695,15 +695,15 @@ struct PipListArgs {
     #[clap(long)]
     strict: bool,
 
-    /// List editable projects.
+    /// Only include editable projects.
     #[clap(short, long)]
     editable: bool,
 
-    // Exclude editable package from output.
+    /// Exclude any editable packages from output.
     #[clap(long)]
     exclude_editable: bool,
 
-    // Exclude specified package from the output.
+    /// Exclude the specified package(s) from the output.
     #[clap(long)]
     r#exclude: Vec<PackageName>,
 }

--- a/crates/uv/tests/pip_list.rs
+++ b/crates/uv/tests/pip_list.rs
@@ -287,5 +287,176 @@ fn editable_only() -> Result<()> {
     "###
     );
 
+    uv_snapshot!(filters, Command::new(get_bin())
+    .arg("pip")
+    .arg("list")
+    .arg("--exclude-editable")
+    .arg("--cache-dir")
+    .arg(context.cache_dir.path())
+    .env("VIRTUAL_ENV", context.venv.as_os_str())
+    .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Package Version
+    ------- -------
+    numpy   1.26.2 
+
+    ----- stderr -----
+    "###
+    );
+
+    uv_snapshot!(filters, Command::new(get_bin())
+    .arg("pip")
+    .arg("list")
+    .arg("--editable")
+    .arg("--exclude-editable")
+    .arg("--cache-dir")
+    .arg(context.cache_dir.path())
+    .env("VIRTUAL_ENV", context.venv.as_os_str())
+    .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "###
+    );
+
+    Ok(())
+}
+
+#[test]
+fn exclude() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let current_dir = std::env::current_dir()?;
+    let workspace_dir = regex::escape(
+        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?)
+            .unwrap()
+            .as_str(),
+    );
+
+    let filters = [(workspace_dir.as_str(), "file://[WORKSPACE_DIR]/")]
+        .into_iter()
+        .chain(INSTA_FILTERS.to_vec())
+        .collect::<Vec<_>>();
+
+    // Install the editable package.
+    uv_snapshot!(filters, Command::new(get_bin())
+        .arg("pip")
+        .arg("install")
+        .arg("-e")
+        .arg("../../scripts/editable-installs/poetry_editable")
+        .arg("--strict")
+        .arg("--cache-dir")
+        .arg(context.cache_dir.path())
+        .arg("--exclude-newer")
+        .arg(EXCLUDE_NEWER)
+        .env("VIRTUAL_ENV", context.venv.as_os_str())
+        .env("CARGO_TARGET_DIR", "../../../target/target_install_editable"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Built 1 editable in [TIME]
+    Resolved 2 packages in [TIME]
+    Downloaded 1 package in [TIME]
+    Installed 2 packages in [TIME]
+     + numpy==1.26.2
+     + poetry-editable==0.1.0 (from file://[WORKSPACE_DIR]/scripts/editable-installs/poetry_editable)
+    "###
+    );
+
+    // Account for difference length workspace dir
+    let prefix = if cfg!(windows) { "file:///" } else { "file://" };
+
+    let workspace_len_difference = workspace_dir.as_str().len() + 32 - 16 - prefix.len();
+    let find_divider = "-".repeat(25 + workspace_len_difference);
+    let replace_divider = "-".repeat(57);
+
+    let find_header = format!(
+        "Editable project location{0}",
+        " ".repeat(workspace_len_difference)
+    );
+    let replace_header = format!("Editable project location{0}", " ".repeat(32));
+
+    let find_whitespace = " ".repeat(25 + workspace_len_difference);
+    let replace_whitespace = " ".repeat(57);
+
+    let search_workspace = workspace_dir.as_str().strip_prefix(prefix).unwrap();
+    let replace_workspace = "[WORKSPACE_DIR]/";
+
+    let filters = INSTA_FILTERS
+        .iter()
+        .copied()
+        .chain(vec![
+            (search_workspace, replace_workspace),
+            (find_divider.as_str(), replace_divider.as_str()),
+            (find_header.as_str(), replace_header.as_str()),
+            (find_whitespace.as_str(), replace_whitespace.as_str()),
+        ])
+        .collect::<Vec<_>>();
+
+    uv_snapshot!(filters, Command::new(get_bin())
+    .arg("pip")
+    .arg("list")
+    .arg("--exclude")
+    .arg("numpy")
+    .arg("--cache-dir")
+    .arg(context.cache_dir.path())
+    .env("VIRTUAL_ENV", context.venv.as_os_str())
+    .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Package         Version Editable project location                                
+    --------------- ------- ---------------------------------------------------------
+    poetry-editable 0.1.0   [WORKSPACE_DIR]/scripts/editable-installs/poetry_editable
+
+    ----- stderr -----
+    "###
+    );
+
+    uv_snapshot!(filters, Command::new(get_bin())
+    .arg("pip")
+    .arg("list")
+    .arg("--exclude")
+    .arg("poetry-editable")
+    .arg("--cache-dir")
+    .arg(context.cache_dir.path())
+    .env("VIRTUAL_ENV", context.venv.as_os_str())
+    .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Package Version
+    ------- -------
+    numpy   1.26.2 
+
+    ----- stderr -----
+    "###
+    );
+
+    uv_snapshot!(filters, Command::new(get_bin())
+    .arg("pip")
+    .arg("list")
+    .arg("--exclude")
+    .arg("numpy")
+    .arg("--exclude")
+    .arg("poetry-editable")
+    .arg("--cache-dir")
+    .arg(context.cache_dir.path())
+    .env("VIRTUAL_ENV", context.venv.as_os_str())
+    .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "###
+    );
+
     Ok(())
 }


### PR DESCRIPTION
Allows filtering out editable (`--exclude-editable`) and explicitly provided packages (`--exclude setuptools`) from `uv pip list`.

https://pip.pypa.io/en/stable/cli/pip_list/

Continuation of https://github.com/astral-sh/uv/issues/1401

## Test Plan

Extended existing tests to cover these new arguments.
