### PR TITLE
fix: make query method of interpreter public

### DIFF
--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -35,11 +35,7 @@ pub struct Interpreter {
 
 impl Interpreter {
     /// Detect the interpreter info for the given Python executable.
-    pub(crate) fn query(
-        executable: &Path,
-        platform: &Platform,
-        cache: &Cache,
-    ) -> Result<Self, Error> {
+    pub fn query(executable: &Path, platform: &Platform, cache: &Cache) -> Result<Self, Error> {
         let info = InterpreterInfo::query_cached(executable, cache)?;
 
         debug_assert!(


### PR DESCRIPTION
## Summary

Made the `query` method public again, as I believe this currently the only way to query a intepreter with a custom location.

Closes: #2015 