### PR TITLE
pep440: remove redundant `without_local()`

### DIFF
--- a/crates/pep440-rs/src/version_specifier.rs
+++ b/crates/pep440-rs/src/version_specifier.rs
@@ -417,10 +417,7 @@ impl VersionSpecifier {
             (self.version.clone(), version.clone())
         } else {
             // self is already without local
-            (
-                self.version.clone().without_local(),
-                version.clone().without_local(),
-            )
+            (self.version.clone(), version.clone().without_local())
         };
 
         match self.operator {


### PR DESCRIPTION
In this context, we already know (as the comment says) that `self` does
not have a local segment, so we don't need to strip it.

This change isn't motivated by anything other than making the code and
comment in sync. For example, when I first looked at it, I wondered
whether the extra stripping was somehow necessary. But it isn't.
