### PR TITLE
add tests for versions with local segments

### DIFF
--- a/crates/uv/tests/pip_compile_scenarios.rs
+++ b/crates/uv/tests/pip_compile_scenarios.rs
@@ -1,7 +1,7 @@
 //! DO NOT EDIT
 //!
-//! Generated with scripts/scenarios/update.py
-//! Scenarios from <https://github.com/zanieb/packse/tree/4f39539c1b858e28268554604e75c69e25272e5a/scenarios>
+//! Generated with ./scripts/scenarios/update.py
+//! Scenarios from <https://github.com/zanieb/packse/tree/da7e83b5a6f44fb8851a8bfdb6822b07d75635a0/scenarios>
 //!
 #![cfg(all(feature = "python", feature = "pypi"))]
 
@@ -29,7 +29,7 @@ fn command(context: &TestContext, python_versions: &[&str]) -> Command {
         .arg("--index-url")
         .arg("https://test.pypi.org/simple")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/zanieb/packse/4f39539c1b858e28268554604e75c69e25272e5a/vendor/links.html")
+        .arg("https://raw.githubusercontent.com/zanieb/packse/da7e83b5a6f44fb8851a8bfdb6822b07d75635a0/vendor/links.html")
         .arg("--cache-dir")
         .arg(context.cache_dir.path())
         .env("VIRTUAL_ENV", context.venv.as_os_str())

--- a/scripts/scenarios/templates/install.mustache
+++ b/scripts/scenarios/templates/install.mustache
@@ -79,6 +79,9 @@ fn command(context: &TestContext) -> Command {
 /// {{.}}
 {{/tree}}
 /// ```
+{{#skip}}
+#[ignore]
+{{/skip}}
 #[test]
 fn {{module_name}}() {
     let context = TestContext::new("{{environment.python}}");

--- a/scripts/scenarios/update.py
+++ b/scripts/scenarios/update.py
@@ -67,6 +67,18 @@ CUTE_NAMES = {
     "h": "heron",
 }
 
+# Scenarios to skip testing. That is, these scenarios are marked with
+# `#[ignore]`. This is useful for keeping track of scenarios that `uv`
+# doesn't pass, but perhaps one day will.
+SKIP = {
+    'local-simple',
+    'local-not-used-with-sdist',
+    'local-used-without-sdist',
+    'local-not-latest',
+    'local-transitive',
+    'local-transitive-confounding',
+}
+
 try:
     import packse
 except ImportError:
@@ -164,6 +176,15 @@ data["scenarios"] = [
     # Drop the example scenario
     if scenario["name"] != "example"
 ]
+
+
+# Mark selected scenarios as skipped.
+for scenario in data["scenarios"]:
+    # Assert that we aren't trampling on anything from packse.
+    # i.e., In case a new 'skip' field is added to packse's schema.
+    assert "skip" not in scenario, "expect 'skip' key to be available"
+    scenario["skip"] = scenario["name"] in SKIP
+
 
 # Wrap the description onto multiple lines
 for scenario in data["scenarios"]:

--- a/scripts/scenarios/update.py
+++ b/scripts/scenarios/update.py
@@ -20,11 +20,10 @@ Usage:
 
         $ packse index up --bg
         $ packse build scenarios/*
-        $ packse publish dist/* --index-url http://localhost:3141/packages/local --anonymous
 
         Override the default PyPI index for uv and update the scenarios
 
-        $ UV_INDEX_URL="http://localhost:3141/packages/all/+simple" ./scripts/scenarios/update.py
+        $ UV_INDEX_URL="http://localhost:3141" ./scripts/scenarios/update.py
 
 Requirements:
 


### PR DESCRIPTION
While trying to fix #1855, I came up with a few tests that improve
our coverage of versions with local segments. Those tests were added
to packse here: https://github.com/zanieb/packse/pull/132

None of these tests pass yet, so they are marked as ignored.
