### PR TITLE
Surface the `EXTERNALLY-MANAGED` message to users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4524,6 +4524,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "cache-key",
+ "configparser",
  "fs-err",
  "indoc",
  "insta",

--- a/crates/uv-interpreter/Cargo.toml
+++ b/crates/uv-interpreter/Cargo.toml
@@ -22,6 +22,7 @@ uv-cache = { path = "../uv-cache" }
 uv-fs = { path = "../uv-fs" }
 install-wheel-rs = { path = "../install-wheel-rs" }
 
+configparser = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 once_cell = { workspace = true }
 regex = { workspace = true }

--- a/crates/uv-interpreter/src/python_query.rs
+++ b/crates/uv-interpreter/src/python_query.rs
@@ -121,9 +121,7 @@ fn find_python(
             }
             Err(Error::PyList(error)) => {
                 if error.kind() == std::io::ErrorKind::NotFound {
-                    tracing::debug!(
-                        "`py` is not installed. Falling back to searching Python on the path"
-                    );
+                    debug!("`py` is not installed. Falling back to searching Python on the path");
                     // Continue searching for python installations on the path.
                 }
             }
@@ -156,7 +154,7 @@ fn find_python(
                                 return Err(Error::Python2OrOlder);
                             }
                             // Skip over Python 2 or older installation when querying for a recent python installation.
-                            tracing::debug!("Found a Python 2 installation that isn't supported by uv, skipping.");
+                            debug!("Found a Python 2 installation that isn't supported by uv, skipping.");
                             continue;
                         }
                         Err(error) => return Err(error),

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -118,12 +118,19 @@ pub(crate) async fn pip_install(
     );
 
     // If the environment is externally managed, abort.
-    // TODO(charlie): Surface the error from the `EXTERNALLY-MANAGED` file.
-    if venv.interpreter().externally_managed() {
-        return Err(anyhow::anyhow!(
-            "The environment at {} is externally managed",
-            venv.root().normalized_display()
-        ));
+    if let Some(externally_managed) = venv.interpreter().is_externally_managed() {
+        return if let Some(error) = externally_managed.into_error() {
+            Err(anyhow::anyhow!(
+                "The interpreter at {} is externally managed, and indicates the following:\n\n{}\n\nConsider creating a virtual environment with `uv venv`.",
+                venv.root().normalized_display().cyan(),
+                textwrap::indent(&error, "  ").green(),
+            ))
+        } else {
+            Err(anyhow::anyhow!(
+                "The interpreter at {} is externally managed. Instead, create a virtual environment with `uv venv`.",
+                venv.root().normalized_display().cyan()
+            ))
+        };
     }
 
     let _lock = venv.lock()?;

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -86,12 +86,19 @@ pub(crate) async fn pip_sync(
     );
 
     // If the environment is externally managed, abort.
-    // TODO(charlie): Surface the error from the `EXTERNALLY-MANAGED` file.
-    if venv.interpreter().externally_managed() {
-        return Err(anyhow::anyhow!(
-            "The environment at {} is externally managed",
-            venv.root().normalized_display()
-        ));
+    if let Some(externally_managed) = venv.interpreter().is_externally_managed() {
+        return if let Some(error) = externally_managed.into_error() {
+            Err(anyhow::anyhow!(
+                "The interpreter at {} is externally managed, and indicates the following:\n\n{}\n\nConsider creating a virtual environment with `uv venv`.",
+                venv.root().normalized_display().cyan(),
+                textwrap::indent(&error, "  ").green(),
+            ))
+        } else {
+            Err(anyhow::anyhow!(
+                "The interpreter at {} is externally managed. Instead, create a virtual environment with `uv venv`.",
+                venv.root().normalized_display().cyan()
+            ))
+        };
     }
 
     let _lock = venv.lock()?;


### PR DESCRIPTION
## Summary

Per the [spec](https://packaging.python.org/en/latest/specifications/externally-managed-environments/), this message should be surfaced to users:

![Screenshot 2024-02-27 at 10 42 52 PM](https://github.com/astral-sh/uv/assets/1309177/dac3bd6b-dd05-4146-8faa-f046492e8a26)
