### PR TITLE
Enable `freeze` and `list` to introspect non-virtualenv Pythons

### DIFF
--- a/crates/uv-interpreter/src/python_query.rs
+++ b/crates/uv-interpreter/src/python_query.rs
@@ -68,7 +68,7 @@ pub fn find_requested_python(
     }
 }
 
-/// Pick a sensible default for the python a user wants when they didn't specify a version.
+/// Pick a sensible default for the Python a user wants when they didn't specify a version.
 ///
 /// We prefer the test overwrite `UV_TEST_PYTHON_PATH` if it is set, otherwise `python3`/`python` or
 /// `python.exe` respectively.

--- a/crates/uv-interpreter/src/virtual_env.rs
+++ b/crates/uv-interpreter/src/virtual_env.rs
@@ -9,7 +9,7 @@ use uv_fs::{LockedFile, Normalized};
 
 use crate::cfg::PyVenvConfiguration;
 use crate::python_platform::PythonPlatform;
-use crate::{find_requested_python, Error, Interpreter};
+use crate::{find_default_python, find_requested_python, Error, Interpreter};
 
 /// A Python executable and its associated platform markers.
 #[derive(Debug, Clone)]
@@ -59,6 +59,15 @@ impl Virtualenv {
         let Some(interpreter) = find_requested_python(python, platform, cache)? else {
             return Err(Error::RequestedPythonNotFound(python.to_string()));
         };
+        Ok(Self {
+            root: interpreter.base_prefix().to_path_buf(),
+            interpreter,
+        })
+    }
+
+    /// Create a [`Virtualenv`] for the default Python interpreter.
+    pub fn from_default_python(platform: &Platform, cache: &Cache) -> Result<Self, Error> {
+        let interpreter = find_default_python(platform, cache)?;
         Ok(Self {
             root: interpreter.base_prefix().to_path_buf(),
             interpreter,

--- a/crates/uv/src/commands/cache_clean.rs
+++ b/crates/uv/src/commands/cache_clean.rs
@@ -12,8 +12,8 @@ use crate::printer::Printer;
 
 /// Clear the cache.
 pub(crate) fn cache_clean(
-    cache: &Cache,
     packages: &[PackageName],
+    cache: &Cache,
     mut printer: Printer,
 ) -> Result<ExitStatus> {
     if !cache.root().exists() {


### PR DESCRIPTION
## Summary

Now that we have the ability to introspect the installed packages for arbitrary Pythons, we can allow `pip freeze` and `pip list` to fall back to the "default" Python, if no virtualenv is present.

Closes https://github.com/astral-sh/uv/issues/2005.
