### PR TITLE
Rename `Virtualenv` and `PythonPlatform` structs

### DIFF
--- a/crates/gourgeist/src/lib.rs
+++ b/crates/gourgeist/src/lib.rs
@@ -5,7 +5,7 @@ use camino::{FromPathError, Utf8Path};
 use thiserror::Error;
 
 use platform_host::PlatformError;
-use uv_interpreter::{Interpreter, Virtualenv};
+use uv_interpreter::{Interpreter, PythonEnvironment};
 
 pub use crate::bare::create_bare_venv;
 
@@ -52,12 +52,12 @@ pub fn create_venv(
     interpreter: Interpreter,
     prompt: Prompt,
     extra_cfg: Vec<(String, String)>,
-) -> Result<Virtualenv, Error> {
+) -> Result<PythonEnvironment, Error> {
     let location: &Utf8Path = location
         .try_into()
         .map_err(|err: FromPathError| err.into_io_error())?;
     let paths = create_bare_venv(location, &interpreter, prompt, extra_cfg)?;
-    Ok(Virtualenv::from_interpreter(
+    Ok(PythonEnvironment::from_interpreter(
         interpreter,
         paths.root.as_std_path(),
     ))

--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -29,7 +29,7 @@ use tracing::{debug, info_span, instrument, Instrument};
 use distribution_types::Resolution;
 use pep508_rs::Requirement;
 use uv_fs::Normalized;
-use uv_interpreter::{Interpreter, Virtualenv};
+use uv_interpreter::{Interpreter, PythonEnvironment};
 use uv_traits::{BuildContext, BuildKind, ConfigSettings, SetupPyStrategy, SourceBuildTrait};
 
 /// e.g. `pygraphviz/graphviz_wrap.c:3020:10: fatal error: graphviz/cgraph.h: No such file or directory`
@@ -316,7 +316,7 @@ pub struct SourceBuild {
     /// If performing a PEP 517 build, the backend to use.
     pep517_backend: Option<Pep517Backend>,
     /// The virtual environment in which to build the source distribution.
-    venv: Virtualenv,
+    venv: PythonEnvironment,
     /// Populated if `prepare_metadata_for_build_wheel` was called.
     ///
     /// > If the build frontend has previously called prepare_metadata_for_build_wheel and depends
@@ -757,7 +757,7 @@ fn escape_path_for_python(path: &Path) -> String {
 /// Not a method because we call it before the builder is completely initialized
 async fn create_pep517_build_environment(
     source_tree: &Path,
-    venv: &Virtualenv,
+    venv: &PythonEnvironment,
     pep517_backend: &Pep517Backend,
     build_context: &impl BuildContext,
     package_id: &str,
@@ -846,7 +846,7 @@ async fn create_pep517_build_environment(
 
 /// It is the caller's responsibility to create an informative span.
 async fn run_python_script(
-    venv: &Virtualenv,
+    venv: &PythonEnvironment,
     script: &str,
     source_tree: &Path,
 ) -> Result<Output, Error> {

--- a/crates/uv-dev/src/build.rs
+++ b/crates/uv-dev/src/build.rs
@@ -12,7 +12,7 @@ use uv_cache::{Cache, CacheArgs};
 use uv_client::{FlatIndex, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
 use uv_installer::NoBinary;
-use uv_interpreter::Virtualenv;
+use uv_interpreter::PythonEnvironment;
 use uv_resolver::InMemoryIndex;
 use uv_traits::{BuildContext, BuildKind, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
 
@@ -54,7 +54,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
     let cache = Cache::try_from(args.cache_args)?;
 
     let platform = Platform::current()?;
-    let venv = Virtualenv::from_env(platform, &cache)?;
+    let venv = PythonEnvironment::from_virtualenv(platform, &cache)?;
     let client = RegistryClientBuilder::new(cache.clone()).build();
     let index_urls = IndexLocations::default();
     let flat_index = FlatIndex::default();

--- a/crates/uv-dev/src/install_many.rs
+++ b/crates/uv-dev/src/install_many.rs
@@ -21,7 +21,7 @@ use uv_client::{FlatIndex, RegistryClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
 use uv_distribution::RegistryWheelIndex;
 use uv_installer::{Downloader, NoBinary};
-use uv_interpreter::Virtualenv;
+use uv_interpreter::PythonEnvironment;
 use uv_normalize::PackageName;
 use uv_resolver::{DistFinder, InMemoryIndex};
 use uv_traits::{BuildContext, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
@@ -56,7 +56,7 @@ pub(crate) async fn install_many(args: InstallManyArgs) -> Result<()> {
 
     let cache = Cache::try_from(args.cache_args)?;
     let platform = Platform::current()?;
-    let venv = Virtualenv::from_env(platform, &cache)?;
+    let venv = PythonEnvironment::from_virtualenv(platform, &cache)?;
     let client = RegistryClientBuilder::new(cache.clone()).build();
     let index_locations = IndexLocations::default();
     let flat_index = FlatIndex::default();
@@ -112,7 +112,7 @@ async fn install_chunk(
     build_dispatch: &BuildDispatch<'_>,
     tags: &Tags,
     client: &RegistryClient,
-    venv: &Virtualenv,
+    venv: &PythonEnvironment,
     index_locations: &IndexLocations,
 ) -> Result<()> {
     let resolution: Vec<_> = DistFinder::new(

--- a/crates/uv-dev/src/resolve_cli.rs
+++ b/crates/uv-dev/src/resolve_cli.rs
@@ -16,7 +16,7 @@ use uv_cache::{Cache, CacheArgs};
 use uv_client::{FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
 use uv_installer::NoBinary;
-use uv_interpreter::Virtualenv;
+use uv_interpreter::PythonEnvironment;
 use uv_resolver::{InMemoryIndex, Manifest, Options, Resolver};
 use uv_traits::{ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
 
@@ -55,7 +55,7 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
     let cache = Cache::try_from(args.cache_args)?;
 
     let platform = Platform::current()?;
-    let venv = Virtualenv::from_env(platform, &cache)?;
+    let venv = PythonEnvironment::from_virtualenv(platform, &cache)?;
     let index_locations = IndexLocations::new(
         Some(args.index_url),
         args.extra_index_url,

--- a/crates/uv-dev/src/resolve_many.rs
+++ b/crates/uv-dev/src/resolve_many.rs
@@ -18,7 +18,7 @@ use uv_cache::{Cache, CacheArgs};
 use uv_client::{FlatIndex, OwnedArchive, RegistryClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
 use uv_installer::NoBinary;
-use uv_interpreter::Virtualenv;
+use uv_interpreter::PythonEnvironment;
 use uv_normalize::PackageName;
 use uv_resolver::InMemoryIndex;
 use uv_traits::{BuildContext, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
@@ -73,7 +73,7 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
     let total = requirements.len();
 
     let platform = Platform::current()?;
-    let venv = Virtualenv::from_env(platform, &cache)?;
+    let venv = PythonEnvironment::from_virtualenv(platform, &cache)?;
     let in_flight = InFlight::default();
     let client = RegistryClientBuilder::new(cache.clone()).build();
 

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -16,7 +16,7 @@ use uv_build::{SourceBuild, SourceBuildContext};
 use uv_cache::Cache;
 use uv_client::{FlatIndex, RegistryClient};
 use uv_installer::{Downloader, Installer, NoBinary, Plan, Planner, Reinstall, SitePackages};
-use uv_interpreter::{Interpreter, Virtualenv};
+use uv_interpreter::{Interpreter, PythonEnvironment};
 use uv_resolver::{InMemoryIndex, Manifest, Options, Resolver};
 use uv_traits::{BuildContext, BuildKind, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
 
@@ -138,7 +138,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
     fn install<'data>(
         &'data self,
         resolution: &'data Resolution,
-        venv: &'data Virtualenv,
+        venv: &'data PythonEnvironment,
     ) -> impl Future<Output = Result<()>> + Send + 'data {
         async move {
             debug!(

--- a/crates/uv-installer/src/installer.rs
+++ b/crates/uv-installer/src/installer.rs
@@ -3,17 +3,17 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use tracing::instrument;
 
 use distribution_types::CachedDist;
-use uv_interpreter::Virtualenv;
+use uv_interpreter::PythonEnvironment;
 
 pub struct Installer<'a> {
-    venv: &'a Virtualenv,
+    venv: &'a PythonEnvironment,
     link_mode: install_wheel_rs::linker::LinkMode,
     reporter: Option<Box<dyn Reporter>>,
 }
 
 impl<'a> Installer<'a> {
     /// Initialize a new installer.
-    pub fn new(venv: &'a Virtualenv) -> Self {
+    pub fn new(venv: &'a PythonEnvironment) -> Self {
         Self {
             venv,
             link_mode: install_wheel_rs::linker::LinkMode::default(),

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -16,7 +16,7 @@ use platform_tags::Tags;
 use uv_cache::{ArchiveTimestamp, Cache, CacheBucket, CacheEntry, Timestamp, WheelCache};
 use uv_distribution::{BuiltWheelIndex, RegistryWheelIndex};
 use uv_fs::Normalized;
-use uv_interpreter::Virtualenv;
+use uv_interpreter::PythonEnvironment;
 use uv_normalize::PackageName;
 use uv_traits::NoBinary;
 
@@ -63,7 +63,7 @@ impl<'a> Planner<'a> {
         no_binary: &NoBinary,
         index_locations: &IndexLocations,
         cache: &Cache,
-        venv: &Virtualenv,
+        venv: &PythonEnvironment,
         tags: &Tags,
     ) -> Result<Plan> {
         // Index all the already-downloaded wheels in the cache.

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -11,7 +11,7 @@ use distribution_types::{InstalledDist, InstalledMetadata, InstalledVersion, Nam
 use pep440_rs::{Version, VersionSpecifiers};
 use pep508_rs::{Requirement, VerbatimUrl};
 use requirements_txt::EditableRequirement;
-use uv_interpreter::Virtualenv;
+use uv_interpreter::PythonEnvironment;
 use uv_normalize::PackageName;
 
 use crate::{is_dynamic, not_modified};
@@ -21,7 +21,7 @@ use crate::{is_dynamic, not_modified};
 /// Packages are indexed by both name and (for editable installs) URL.
 #[derive(Debug)]
 pub struct SitePackages<'a> {
-    venv: &'a Virtualenv,
+    venv: &'a PythonEnvironment,
     /// The vector of all installed distributions. The `by_name` and `by_url` indices index into
     /// this vector. The vector may contain `None` values, which represent distributions that were
     /// removed from the virtual environment.
@@ -36,7 +36,7 @@ pub struct SitePackages<'a> {
 
 impl<'a> SitePackages<'a> {
     /// Build an index of installed packages from the given Python executable.
-    pub fn from_executable(venv: &'a Virtualenv) -> Result<SitePackages<'a>> {
+    pub fn from_executable(venv: &'a PythonEnvironment) -> Result<SitePackages<'a>> {
         let mut distributions: Vec<Option<InstalledDist>> = Vec::new();
         let mut by_name = FxHashMap::default();
         let mut by_url = FxHashMap::default();

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -6,16 +6,16 @@ use thiserror::Error;
 
 pub use crate::cfg::PyVenvConfiguration;
 pub use crate::interpreter::Interpreter;
+pub use crate::python_environment::PythonEnvironment;
 pub use crate::python_query::{find_default_python, find_requested_python};
 pub use crate::python_version::PythonVersion;
-pub use crate::virtual_env::Virtualenv;
 
 mod cfg;
 mod interpreter;
-mod python_platform;
+mod python_environment;
 mod python_query;
 mod python_version;
-mod virtual_env;
+mod virtualenv_layout;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/crates/uv-resolver/tests/resolver.rs
+++ b/crates/uv-resolver/tests/resolver.rs
@@ -16,7 +16,7 @@ use platform_host::{Arch, Os, Platform};
 use platform_tags::Tags;
 use uv_cache::Cache;
 use uv_client::{FlatIndex, RegistryClientBuilder};
-use uv_interpreter::{Interpreter, Virtualenv};
+use uv_interpreter::{Interpreter, PythonEnvironment};
 use uv_resolver::{
     DisplayResolutionGraph, InMemoryIndex, Manifest, Options, OptionsBuilder, PreReleaseMode,
     ResolutionGraph, ResolutionMode, Resolver,
@@ -77,7 +77,7 @@ impl BuildContext for DummyContext {
         panic!("The test should not need to build source distributions")
     }
 
-    async fn install<'a>(&'a self, _: &'a Resolution, _: &'a Virtualenv) -> Result<()> {
+    async fn install<'a>(&'a self, _: &'a Resolution, _: &'a PythonEnvironment) -> Result<()> {
         panic!("The test should not need to build source distributions")
     }
 

--- a/crates/uv-traits/src/lib.rs
+++ b/crates/uv-traits/src/lib.rs
@@ -14,7 +14,7 @@ use distribution_types::{CachedDist, DistributionId, IndexLocations, Resolution,
 use once_map::OnceMap;
 use pep508_rs::Requirement;
 use uv_cache::Cache;
-use uv_interpreter::{Interpreter, Virtualenv};
+use uv_interpreter::{Interpreter, PythonEnvironment};
 use uv_normalize::PackageName;
 
 /// Avoid cyclic crate dependencies between resolver, installer and builder.
@@ -90,7 +90,7 @@ pub trait BuildContext: Sync {
     fn install<'a>(
         &'a self,
         resolution: &'a Resolution,
-        venv: &'a Virtualenv,
+        venv: &'a PythonEnvironment,
     ) -> impl Future<Output = Result<()>> + Send + 'a;
 
     /// Setup a source distribution build by installing the required dependencies. A wrapper for

--- a/crates/uv/src/commands/pip_freeze.rs
+++ b/crates/uv/src/commands/pip_freeze.rs
@@ -11,7 +11,7 @@ use platform_host::Platform;
 use uv_cache::Cache;
 use uv_fs::Normalized;
 use uv_installer::SitePackages;
-use uv_interpreter::Virtualenv;
+use uv_interpreter::PythonEnvironment;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -26,12 +26,12 @@ pub(crate) fn pip_freeze(
     // Detect the current Python interpreter.
     let platform = Platform::current()?;
     let venv = if let Some(python) = python {
-        Virtualenv::from_requested_python(python, &platform, cache)?
+        PythonEnvironment::from_requested_python(python, &platform, cache)?
     } else {
-        match Virtualenv::from_env(platform.clone(), cache) {
+        match PythonEnvironment::from_virtualenv(platform.clone(), cache) {
             Ok(venv) => venv,
             Err(uv_interpreter::Error::VenvNotFound) => {
-                Virtualenv::from_default_python(&platform, cache)?
+                PythonEnvironment::from_default_python(&platform, cache)?
             }
             Err(err) => return Err(err.into()),
         }

--- a/crates/uv/src/commands/pip_list.rs
+++ b/crates/uv/src/commands/pip_list.rs
@@ -13,7 +13,7 @@ use platform_host::Platform;
 use uv_cache::Cache;
 use uv_fs::Normalized;
 use uv_installer::SitePackages;
-use uv_interpreter::Virtualenv;
+use uv_interpreter::PythonEnvironment;
 use uv_normalize::PackageName;
 
 use crate::commands::ExitStatus;
@@ -32,12 +32,12 @@ pub(crate) fn pip_list(
     // Detect the current Python interpreter.
     let platform = Platform::current()?;
     let venv = if let Some(python) = python {
-        Virtualenv::from_requested_python(python, &platform, cache)?
+        PythonEnvironment::from_requested_python(python, &platform, cache)?
     } else {
-        match Virtualenv::from_env(platform.clone(), cache) {
+        match PythonEnvironment::from_virtualenv(platform.clone(), cache) {
             Ok(venv) => venv,
             Err(uv_interpreter::Error::VenvNotFound) => {
-                Virtualenv::from_default_python(&platform, cache)?
+                PythonEnvironment::from_default_python(&platform, cache)?
             }
             Err(err) => return Err(err.into()),
         }

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -19,7 +19,7 @@ use uv_installer::{
     is_dynamic, not_modified, Downloader, NoBinary, Plan, Planner, Reinstall, ResolvedEditable,
     SitePackages,
 };
-use uv_interpreter::Virtualenv;
+use uv_interpreter::PythonEnvironment;
 use uv_resolver::InMemoryIndex;
 use uv_traits::{ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
 
@@ -74,9 +74,9 @@ pub(crate) async fn pip_sync(
     // Detect the current Python interpreter.
     let platform = Platform::current()?;
     let venv = if let Some(python) = python.as_ref() {
-        Virtualenv::from_requested_python(python, &platform, &cache)?
+        PythonEnvironment::from_requested_python(python, &platform, &cache)?
     } else {
-        Virtualenv::from_env(platform, &cache)?
+        PythonEnvironment::from_virtualenv(platform, &cache)?
     };
     debug!(
         "Using Python {} environment at {}",
@@ -406,7 +406,7 @@ async fn resolve_editables(
     editables: Vec<EditableRequirement>,
     site_packages: &SitePackages<'_>,
     reinstall: &Reinstall,
-    venv: &Virtualenv,
+    venv: &PythonEnvironment,
     tags: &Tags,
     cache: &Cache,
     client: &RegistryClient,

--- a/crates/uv/src/commands/pip_uninstall.rs
+++ b/crates/uv/src/commands/pip_uninstall.rs
@@ -8,7 +8,7 @@ use distribution_types::{InstalledMetadata, Name};
 use platform_host::Platform;
 use uv_cache::Cache;
 use uv_fs::Normalized;
-use uv_interpreter::Virtualenv;
+use uv_interpreter::PythonEnvironment;
 
 use crate::commands::{elapsed, ExitStatus};
 use crate::printer::Printer;
@@ -40,9 +40,9 @@ pub(crate) async fn pip_uninstall(
     // Detect the current Python interpreter.
     let platform = Platform::current()?;
     let venv = if let Some(python) = python.as_ref() {
-        Virtualenv::from_requested_python(python, &platform, &cache)?
+        PythonEnvironment::from_requested_python(python, &platform, &cache)?
     } else {
-        Virtualenv::from_env(platform, &cache)?
+        PythonEnvironment::from_virtualenv(platform, &cache)?
     };
     debug!(
         "Using Python {} environment at {}",


### PR DESCRIPTION
## Summary

`PythonPlatform` only exists to format paths to directories within virtual environments based on a root and an OS, so it's now `VirtualenvLayout`.

`Virtualenv` is now used for non-virtual environment Pythons, so it's now `PythonEnvironment`.