### PR TITLE
Warn when trying many versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,6 +4420,7 @@ dependencies = [
  "uv-git",
  "uv-normalize",
  "uv-traits",
+ "uv-warnings",
  "zip",
 ]
 

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -105,20 +105,18 @@ impl<'a> BuildContext for BuildDispatch<'a> {
     }
 
     async fn resolve<'data>(&'data self, requirements: &'data [Requirement]) -> Result<Resolution> {
-        let markers = self.interpreter.markers();
-        let tags = self.interpreter.tags()?;
         let resolver = Resolver::new(
             Manifest::simple(requirements.to_vec()),
             self.options,
-            markers,
+            self.interpreter.markers(),
             self.interpreter,
-            tags,
+            self.interpreter.tags()?,
             self.client,
             self.flat_index,
             self.index,
             self,
         )?;
-        let graph = resolver.resolve().await.with_context(|| {
+        let graph = resolver.resolve().boxed().await.with_context(|| {
             format!(
                 "No solution found when resolving: {}",
                 requirements.iter().map(ToString::to_string).join(", "),

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -18,7 +18,7 @@ distribution-filename = { path = "../distribution-filename", features = ["serde"
 distribution-types = { path = "../distribution-types" }
 install-wheel-rs = { path = "../install-wheel-rs" }
 pep440_rs = { path = "../pep440-rs" }
-pep508_rs = { path =     "../pep508-rs" }
+pep508_rs = { path = "../pep508-rs" }
 platform-tags = { path = "../platform-tags" }
 uv-cache = { path = "../uv-cache" }
 uv-client = { path = "../uv-client" }
@@ -27,6 +27,7 @@ uv-fs = { path = "../uv-fs", features = ["tokio"] }
 uv-git = { path = "../uv-git", features = ["vendored-openssl"] }
 uv-normalize = { path = "../uv-normalize" }
 uv-traits = { path = "../uv-traits" }
+uv-warnings = { path = "../uv-warnings" }
 pypi-types = { path = "../pypi-types" }
 
 anyhow = { workspace = true }
@@ -36,7 +37,7 @@ nanoid = { workspace = true }
 reqwest = { workspace = true }
 rmp-serde = { workspace = true }
 rustc-hash = { workspace = true }
-serde = { workspace = true , features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
In pathological cases, it's hard to follow why the resolution is slow. This is an attempt to give the user an indication what is slow (boto3) and how to fix this (add a manual boto3 constraint). This also helps to determine if this is a pathological case or a server that doesn't support range requests.

I picked the download function as point-of-counting so we can potentially ignore selection versions that we immediately discard, while network requests (both cached and uncached) are what makes the resolution slow. The threasholds i picked are somewhat arbitrary.

```
$ uv pip install bio_embeddings
  ⠸ pytest==8.0.2
warning: Downloading metadata for more than 50 different versions of boto3. Consider adding a stricter version constraint for this package to speed up resolution.
warning: Downloading metadata for more than 50 different versions of botocore. Consider adding a stricter version constraint for this package to speed up resolution.
  ⠼ boto3==1.26.85
```

`warn_user!` interacts badly with the `Reporter`, do we have a way to pause-and-restart the restart the reporter when showing our own messages, similar to tqdm or `IndicatifLayer`?
