### PR TITLE
Track source incompatibilities in prioritized distribution

### DIFF
--- a/crates/platform-tags/src/lib.rs
+++ b/crates/platform-tags/src/lib.rs
@@ -18,7 +18,7 @@ pub enum TagsError {
     InvalidPriority(usize, #[source] std::num::TryFromIntError),
 }
 
-#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, Clone)]
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd, Clone, Copy)]
 pub enum IncompatibleTag {
     Invalid,
     Python,

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -11,7 +11,7 @@ use url::Url;
 use distribution_filename::DistFilename;
 use distribution_types::{
     BuiltDist, Dist, File, FileLocation, FlatIndexLocation, IndexUrl, PrioritizedDist,
-    RegistryBuiltDist, RegistrySourceDist, SourceDist,
+    RegistryBuiltDist, RegistrySourceDist, SourceCompatibility, SourceDist,
 };
 use pep440_rs::Version;
 use pep508_rs::VerbatimUrl;
@@ -334,9 +334,13 @@ impl FlatIndex {
                 }));
                 match distributions.0.entry(filename.version) {
                     Entry::Occupied(mut entry) => {
-                        entry
-                            .get_mut()
-                            .insert_source(dist, None, Yanked::default(), None);
+                        entry.get_mut().insert_source(
+                            dist,
+                            None,
+                            Yanked::default(),
+                            None,
+                            SourceCompatibility::Compatible,
+                        );
                     }
                     Entry::Vacant(entry) => {
                         entry.insert(PrioritizedDist::from_source(
@@ -344,6 +348,7 @@ impl FlatIndex {
                             None,
                             Yanked::default(),
                             None,
+                            SourceCompatibility::Compatible,
                         ));
                     }
                 }

--- a/crates/uv-dev/src/install_many.rs
+++ b/crates/uv-dev/src/install_many.rs
@@ -121,6 +121,7 @@ async fn install_chunk(
         venv.interpreter(),
         &FlatIndex::default(),
         &NoBinary::None,
+        &NoBuild::None,
     )
     .resolve_stream(requirements)
     .collect()

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -10,7 +10,7 @@ use pypi_types::Metadata21;
 use uv_client::{FlatIndex, RegistryClient};
 use uv_distribution::DistributionDatabase;
 use uv_normalize::PackageName;
-use uv_traits::{BuildContext, NoBinary};
+use uv_traits::{BuildContext, NoBinary, NoBuild};
 
 use crate::python_requirement::PythonRequirement;
 use crate::version_map::VersionMap;
@@ -68,6 +68,7 @@ pub struct DefaultResolverProvider<'a, Context: BuildContext + Send + Sync> {
     python_requirement: PythonRequirement,
     exclude_newer: Option<DateTime<Utc>>,
     no_binary: NoBinary,
+    no_build: NoBuild,
 }
 
 impl<'a, Context: BuildContext + Send + Sync> DefaultResolverProvider<'a, Context> {
@@ -81,6 +82,7 @@ impl<'a, Context: BuildContext + Send + Sync> DefaultResolverProvider<'a, Contex
         python_requirement: PythonRequirement,
         exclude_newer: Option<DateTime<Utc>>,
         no_binary: &'a NoBinary,
+        no_build: &'a NoBuild,
     ) -> Self {
         Self {
             fetcher,
@@ -90,6 +92,7 @@ impl<'a, Context: BuildContext + Send + Sync> DefaultResolverProvider<'a, Contex
             python_requirement,
             exclude_newer,
             no_binary: no_binary.clone(),
+            no_build: no_build.clone(),
         }
     }
 }
@@ -116,6 +119,7 @@ impl<'a, Context: BuildContext + Send + Sync> ResolverProvider
                 self.exclude_newer.as_ref(),
                 self.flat_index.get(package_name).cloned(),
                 &self.no_binary,
+                &self.no_build,
             ))),
             Err(err) => match err.into_kind() {
                 uv_client::ErrorKind::PackageNotFound(_) => {

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -203,9 +203,15 @@ pub(crate) async fn pip_sync(
     } else {
         let start = std::time::Instant::now();
 
-        let wheel_finder =
-            uv_resolver::DistFinder::new(tags, &client, venv.interpreter(), &flat_index, no_binary)
-                .with_reporter(FinderReporter::from(printer).with_length(remote.len() as u64));
+        let wheel_finder = uv_resolver::DistFinder::new(
+            tags,
+            &client,
+            venv.interpreter(),
+            &flat_index,
+            no_binary,
+            no_build,
+        )
+        .with_reporter(FinderReporter::from(printer).with_length(remote.len() as u64));
         let resolution = wheel_finder.resolve(&remote).await?;
 
         let s = if resolution.len() == 1 { "" } else { "s" };

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -2870,12 +2870,13 @@ fn no_wheels_no_build() {
         .arg("a-662cbd94")
         , @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download and build: albatross==1.0.0
-      Caused by: Building source distributions is disabled
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only albatross==1.0.0 is available and albatross==1.0.0 is unusable because building from source is disabled, we can conclude that all versions of albatross cannot be used.
+          And because you require albatross, we can conclude that the requirements are unsatisfiable.
     "###);
 
     assert_not_installed(&context.venv, "a_662cbd94", &context.temp_dir);


### PR DESCRIPTION
## Summary

Like with wheels, we can track the compatibility of source distributions in `PrioritizedDist` and use those to both backtrack _and_ surface better error messages to users.

Closes https://github.com/astral-sh/uv/issues/2003.
