### PR TITLE
Avoid truncating EXTERNALLY-MANAGED error message

### DIFF
--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -279,13 +279,16 @@ impl Interpreter {
             return None;
         };
 
-        let Ok(mut ini) = Ini::new_cs().read(contents) else {
+        let mut ini = Ini::new_cs();
+        ini.set_multiline(true);
+
+        let Ok(mut sections) = ini.read(contents) else {
             // If a file exists but is not a valid INI file, we assume the environment is
             // externally managed.
             return Some(ExternallyManaged::default());
         };
 
-        let Some(section) = ini.get_mut("externally-managed") else {
+        let Some(section) = sections.get_mut("externally-managed") else {
             // If the file exists but does not contain an "externally-managed" section, we assume
             // the environment is externally managed.
             return Some(ExternallyManaged::default());


### PR DESCRIPTION
## Summary

This is still imperfect, since the INI parser seems to strip empty lines, but at least the content is preserved.

Closes https://github.com/astral-sh/uv/issues/2061.

## Test Plan

![Screenshot 2024-02-28 at 9 48 24 PM](https://github.com/astral-sh/uv/assets/1309177/66224e94-0500-4634-83cb-33981443b8a3)
