### PR TITLE
feat: expose uv_normalize types

### DIFF
--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -43,6 +43,7 @@ pub use marker::{
 };
 use pep440_rs::{Version, VersionSpecifier, VersionSpecifiers};
 use uv_fs::normalize_url_path;
+// Parity with the crates.io version of pep508_rs
 pub use uv_normalize::{ExtraName, InvalidNameError, PackageName};
 pub use verbatim_url::{split_scheme, Scheme, VerbatimUrl};
 

--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -43,9 +43,7 @@ pub use marker::{
 };
 use pep440_rs::{Version, VersionSpecifier, VersionSpecifiers};
 use uv_fs::normalize_url_path;
-#[cfg(feature = "pyo3")]
-use uv_normalize::InvalidNameError;
-use uv_normalize::{ExtraName, PackageName};
+pub use uv_normalize::{ExtraName, InvalidNameError, PackageName};
 pub use verbatim_url::{split_scheme, Scheme, VerbatimUrl};
 
 mod marker;


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Expose the uv_normalize types from pep508, so that these can be used with a crates.io version.

