### PR TITLE
Avoid assuming `RECORD` file is in `platlib`

### DIFF
--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -125,11 +125,7 @@ pub fn install_wheel(
     let mut record_writer = csv::WriterBuilder::new()
         .has_headers(false)
         .escape(b'"')
-        .from_path(
-            layout
-                .platlib
-                .join(format!("{dist_info_prefix}.dist-info/RECORD")),
-        )?;
+        .from_path(site_packages.join(format!("{dist_info_prefix}.dist-info/RECORD")))?;
     record.sort();
     for entry in record {
         record_writer.serialize(entry)?;


### PR DESCRIPTION
## Summary

This was a missed find-and-replace. We shouldn't assume `layout.platlib` here, since `RECORD` will be written to `site_packages` (which could be `layout.purelib`).

This is hard to reproduce. You need a _fresh_ environment where `purelib` and `platlib` differ (which isn't the case for virtualenvs, at least typically), and you need to be installing a new package that is a purelib. I tested it by manually changing `platlib` to point to a different path.

Closes https://github.com/astral-sh/uv/issues/2064.
