### PR TITLE
Wrap unsafe script shebangs in `/bin/sh`

### DIFF
--- a/crates/install-wheel-rs/src/lib.rs
+++ b/crates/install-wheel-rs/src/lib.rs
@@ -24,6 +24,7 @@ mod uninstall;
 mod wheel;
 
 /// The layout of the target environment into which a wheel can be installed.
+#[derive(Debug, Clone)]
 pub struct Layout {
     /// The Python interpreter, as returned by `sys.executable`.
     pub sys_executable: PathBuf,
@@ -39,6 +40,8 @@ pub struct Layout {
     pub data: PathBuf,
     /// The Python version, as returned by `sys.version_info`.
     pub python_version: (u8, u8),
+    /// The `os.name` value for the current platform.
+    pub os_name: String,
 }
 
 /// Note: The caller is responsible for adding the path of the wheel we're installing.

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -419,6 +419,7 @@ impl Interpreter {
             } else {
                 self.include().to_path_buf()
             },
+            os_name: self.markers.os_name.clone(),
         }
     }
 }


### PR DESCRIPTION
## Summary

This is based on Pradyun's installer branch (https://github.com/pradyunsg/installer/blob/d01624e5f20963f046e67d58f5319e21a07aa03e/src/installer/scripts.py#L54), which is itself based on pip (https://github.com/pypa/pip/blob/0ad4c94be74cc24874c6feb5bb3c2152c398a18e/src/pip/_vendor/distlib/scripts.py#L136).

The gist of it is: on Posix platforms, if a path contains a space (or is too long), we wrap the shebang in a `/bin/sh` invocation.

Closes https://github.com/astral-sh/uv/issues/2076.

## Test Plan

```
❯ cargo run venv "foo"
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/uv venv foo`
Using Python 3.12.0 interpreter at: /Users/crmarsh/.local/share/rtx/installs/python/3.12.0/bin/python3
Creating virtualenv at: foo
Activate with: source foo/bin/activate

❯ source "foo bar/bin/activate"

❯ which black
black not found

❯ cargo run pip install black
Resolved 6 packages in 177ms
Installed 6 packages in 17ms
 + black==24.2.0
 + click==8.1.7
 + mypy-extensions==1.0.0
 + packaging==23.2
 + pathspec==0.12.1
 + platformdirs==4.2.0

❯ which black
/Users/crmarsh/workspace/uv/foo bar/bin/black

❯ black
Usage: black [OPTIONS] SRC ...

One of 'SRC' or 'code' is required.

❯ cat "foo bar/bin/black"
#!/bin/sh
'''exec' '/Users/crmarsh/workspace/uv/foo bar/bin/python' "$0" "$@"
' '''
# -*- coding: utf-8 -*-
import re
import sys
from black import patched_main
if __name__ == "__main__":
    sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
    sys.exit(patched_main())
```