### PR TITLE
Add support for `--system-site-packages` in `uv venv`

### DIFF
--- a/crates/gourgeist/src/bare.rs
+++ b/crates/gourgeist/src/bare.rs
@@ -66,6 +66,7 @@ pub fn create_bare_venv(
     location: &Utf8Path,
     interpreter: &Interpreter,
     prompt: Prompt,
+    system_site_packages: bool,
     extra_cfg: Vec<(String, String)>,
 ) -> Result<VenvPaths, Error> {
     // We have to canonicalize the interpreter path, otherwise the home is set to the venv dir instead of the real root.
@@ -251,7 +252,11 @@ pub fn create_bare_venv(
         ),
         (
             "include-system-site-packages".to_string(),
-            "false".to_string(),
+            if system_site_packages {
+                "true".to_string()
+            } else {
+                "false".to_string()
+            },
         ),
         (
             "base-prefix".to_string(),

--- a/crates/gourgeist/src/lib.rs
+++ b/crates/gourgeist/src/lib.rs
@@ -51,12 +51,19 @@ pub fn create_venv(
     location: &Path,
     interpreter: Interpreter,
     prompt: Prompt,
+    system_site_packages: bool,
     extra_cfg: Vec<(String, String)>,
 ) -> Result<PythonEnvironment, Error> {
     let location: &Utf8Path = location
         .try_into()
         .map_err(|err: FromPathError| err.into_io_error())?;
-    let paths = create_bare_venv(location, &interpreter, prompt, extra_cfg)?;
+    let paths = create_bare_venv(
+        location,
+        &interpreter,
+        prompt,
+        system_site_packages,
+        extra_cfg,
+    )?;
     Ok(PythonEnvironment::from_interpreter(
         interpreter,
         paths.root.as_std_path(),

--- a/crates/gourgeist/src/main.rs
+++ b/crates/gourgeist/src/main.rs
@@ -23,6 +23,8 @@ struct Cli {
     python: Option<String>,
     #[clap(long)]
     prompt: Option<String>,
+    #[clap(long)]
+    system_site_packages: bool,
 }
 
 fn run() -> Result<(), gourgeist::Error> {
@@ -45,6 +47,7 @@ fn run() -> Result<(), gourgeist::Error> {
         &location,
         &interpreter,
         Prompt::from_args(cli.prompt),
+        cli.system_site_packages,
         Vec::new(),
     )?;
     Ok(())

--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -402,6 +402,7 @@ impl SourceBuild {
             &temp_dir.path().join(".venv"),
             interpreter.clone(),
             gourgeist::Prompt::None,
+            false,
             Vec::new(),
         )?;
 

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -34,6 +34,7 @@ pub(crate) async fn venv(
     python_request: Option<&str>,
     index_locations: &IndexLocations,
     prompt: Prompt,
+    system_site_packages: bool,
     connectivity: Connectivity,
     seed: bool,
     exclude_newer: Option<DateTime<Utc>>,
@@ -45,6 +46,7 @@ pub(crate) async fn venv(
         python_request,
         index_locations,
         prompt,
+        system_site_packages,
         connectivity,
         seed,
         exclude_newer,
@@ -87,6 +89,7 @@ async fn venv_impl(
     python_request: Option<&str>,
     index_locations: &IndexLocations,
     prompt: Prompt,
+    system_site_packages: bool,
     connectivity: Connectivity,
     seed: bool,
     exclude_newer: Option<DateTime<Utc>>,
@@ -123,7 +126,7 @@ async fn venv_impl(
     let extra_cfg = vec![("uv".to_string(), env!("CARGO_PKG_VERSION").to_string())];
 
     // Create the virtual environment.
-    let venv = gourgeist::create_venv(path, interpreter, prompt, extra_cfg)
+    let venv = gourgeist::create_venv(path, interpreter, prompt, system_site_packages, extra_cfg)
         .map_err(VenvError::Creation)?;
 
     // Install seed packages.

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -936,6 +936,16 @@ struct VenvArgs {
     #[clap(long, verbatim_doc_comment)]
     prompt: Option<String>,
 
+    /// Give the virtual environment access to the system site packages directory.
+    ///
+    /// Unlike `pip`, when a virtual environment is created with `--system-site-packages`, `uv` will
+    /// _not_ take system site packages into account when running commands like `uv pip list` or
+    /// `uv pip install`. The `--system-site-packages` flag will provide the virtual environment
+    /// with access to the system site packages directory at runtime, but it will not affect the
+    /// behavior of `uv` commands.
+    #[clap(long)]
+    system_site_packages: bool,
+
     /// The URL of the Python package index (by default: <https://pypi.org/simple>).
     ///
     /// The index given by this flag is given lower priority than all other
@@ -1388,6 +1398,7 @@ async fn run() -> Result<ExitStatus> {
                 args.python.as_deref(),
                 &index_locations,
                 gourgeist::Prompt::from_args(prompt),
+                args.system_site_packages,
                 if args.offline {
                     Connectivity::Offline
                 } else {


### PR DESCRIPTION
## Summary

Adds support for `--system-site-packages`. Unlike `pip`, we won't take the system site packages into account in subsequent commands. I think this is ok.

Closes https://github.com/astral-sh/uv/issues/1483.
