### PR TITLE
Better offline error message

### DIFF
--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -18,6 +18,7 @@ uv-normalize = { path = "../uv-normalize" }
 uv-warnings = { path = "../uv-warnings" }
 pypi-types = { path = "../pypi-types" }
 
+anyhow = { workspace = true }
 async-trait = { workspace = true }
 async_http_range_reader = { workspace = true }
 async_zip = { workspace = true, features = ["tokio"] }

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -421,9 +421,9 @@ impl CachedClient {
             .execute(req)
             .instrument(info_span!("revalidation_request", url = url.as_str()))
             .await
-            .map_err(ErrorKind::from_middleware)?
+            .map_err(ErrorKind::from)?
             .error_for_status()
-            .map_err(ErrorKind::RequestError)?;
+            .map_err(ErrorKind::from)?;
         match cached
             .cache_policy
             .after_response(new_cache_policy_builder, &response)
@@ -459,9 +459,9 @@ impl CachedClient {
             .0
             .execute(req)
             .await
-            .map_err(ErrorKind::from_middleware)?
+            .map_err(ErrorKind::from)?
             .error_for_status()
-            .map_err(ErrorKind::RequestError)?;
+            .map_err(ErrorKind::from)?;
         let cache_policy = cache_policy_builder.build(&response);
         let cache_policy = if cache_policy.to_archived().is_storable() {
             Some(Box::new(cache_policy))

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -152,14 +152,14 @@ impl<'a> FlatIndexClient<'a> {
             .header("Accept-Encoding", "gzip")
             .header("Accept", "text/html")
             .build()
-            .map_err(ErrorKind::RequestError)?;
+            .map_err(ErrorKind::from)?;
         let parse_simple_response = |response: Response| {
             async {
                 // Use the response URL, rather than the request URL, as the base for relative URLs.
                 // This ensures that we handle redirects and other URL transformations correctly.
                 let url = safe_copy_url_auth(url, response.url().clone());
 
-                let text = response.text().await.map_err(ErrorKind::RequestError)?;
+                let text = response.text().await.map_err(ErrorKind::from)?;
                 let SimpleHtml { base, files } = SimpleHtml::parse(&text, &url)
                     .map_err(|err| Error::from_html_err(err, url.clone()))?;
 

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -1,5 +1,5 @@
 pub use cached_client::{CacheControl, CachedClient, CachedClientError, DataWithCachePolicy};
-pub use error::{Error, ErrorKind};
+pub use error::{BetterReqwestError, Error, ErrorKind};
 pub use flat_index::{FlatDistributions, FlatIndex, FlatIndexClient, FlatIndexError};
 pub use registry_client::{
     Connectivity, RegistryClient, RegistryClientBuilder, SimpleMetadata, SimpleMetadatum,

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -2,6 +2,7 @@ use tokio::task::JoinError;
 use zip::result::ZipError;
 
 use distribution_filename::WheelFilenameError;
+use uv_client::BetterReqwestError;
 use uv_normalize::PackageName;
 
 #[derive(Debug, thiserror::Error)]
@@ -19,7 +20,7 @@ pub enum Error {
     #[error("Git operation failed")]
     Git(#[source] anyhow::Error),
     #[error(transparent)]
-    Request(#[from] reqwest::Error),
+    Reqwest(#[from] BetterReqwestError),
     #[error(transparent)]
     Client(#[from] uv_client::Error),
 
@@ -59,4 +60,10 @@ pub enum Error {
     /// Should not occur; only seen when another task panicked.
     #[error("The task executor is broken, did some other task panic?")]
     Join(#[from] JoinError),
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(error: reqwest::Error) -> Self {
+        Self::Reqwest(BetterReqwestError::from(error))
+    }
 }


### PR DESCRIPTION
Error for `uv pip compile scripts/requirements/jupyter.in` without internet:

**Before**

```
error: error sending request for url (https://pypi.org/simple/jupyter/): error trying to connect: dns error: failed to lookup address information: No such host is known. (os error 11001)
  Caused by: error trying to connect: dns error: failed to lookup address information: No such host is known. (os error 11001)
  Caused by: dns error: failed to lookup address information: No such host is known. (os error 11001)
  Caused by: failed to lookup address information:  No such host is known. (os error 11001)
```

**After**

```
error: Could not connect, are you offline?
  Caused by: error sending request for url (https://pypi.org/simple/django/): error trying to connect: dns error: failed to lookup address information: Temporary failure in name resolution
  Caused by: error trying to connect: dns error: failed to lookup address information: Temporary failure in name resolution
  Caused by: dns error: failed to lookup address information: Temporary failure in name resolution
  Caused by: failed to lookup address information: Temporary failure in name resolution
```

On linux, it would be "Temporary failure in name resolution" instead of "No such host is known. (os error 11001)".

The implementation checks for "dne error" stringly as hyper errors are opaque. The danger is that this breaks with a hyper update. We still get the complete error trace since reqwest eagerly inlines errors (https://github.com/seanmonstar/reqwest/issues/2147).

No test since i wouldn't know how to simulate this in cargo test.

Fixes #1971
