### PR TITLE
Remove `camino` from `uv-virtualenv`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,15 +422,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "cargo-util"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4613,7 +4604,6 @@ version = "0.0.4"
 dependencies = [
  "anstream",
  "cachedir",
- "camino",
  "clap",
  "directories",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ async_http_range_reader = { version = "0.7.0" }
 async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "d76801da0943de985254fc6255c0e476b57c5836", features = ["deflate"] }
 base64 = { version = "0.21.7" }
 cachedir = { version = "0.3.1" }
-camino = { version = "1.1.6", features = ["serde1"] }
 cargo-util = { version = "0.2.8" }
 chrono = { version = "0.4.31" }
 clap = { version = "4.4.13" }

--- a/crates/uv-virtualenv/Cargo.toml
+++ b/crates/uv-virtualenv/Cargo.toml
@@ -28,7 +28,6 @@ uv-interpreter = { path = "../uv-interpreter" }
 
 anstream = { workspace = true }
 cachedir = { workspace = true }
-camino = { workspace = true }
 clap = { workspace = true, features = ["derive"], optional = true }
 directories = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/uv-virtualenv/src/lib.rs
+++ b/crates/uv-virtualenv/src/lib.rs
@@ -1,7 +1,6 @@
 use std::io;
 use std::path::Path;
 
-use camino::{FromPathError, Utf8Path};
 use thiserror::Error;
 
 use platform_host::PlatformError;
@@ -55,9 +54,6 @@ pub fn create_venv(
     extra_cfg: Vec<(String, String)>,
 ) -> Result<PythonEnvironment, Error> {
     // Create the virtualenv at the given location.
-    let location: &Utf8Path = location
-        .try_into()
-        .map_err(|err: FromPathError| err.into_io_error())?;
     let virtualenv = create_bare_venv(
         location,
         &interpreter,

--- a/crates/uv-virtualenv/src/main.rs
+++ b/crates/uv-virtualenv/src/main.rs
@@ -1,9 +1,9 @@
 use std::error::Error;
+use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::Instant;
 
 use anstream::eprintln;
-use camino::Utf8PathBuf;
 use clap::Parser;
 use directories::ProjectDirs;
 use tracing::info;
@@ -18,7 +18,7 @@ use uv_virtualenv::{create_bare_venv, Prompt};
 
 #[derive(Parser, Debug)]
 struct Cli {
-    path: Option<Utf8PathBuf>,
+    path: Option<PathBuf>,
     #[clap(short, long)]
     python: Option<String>,
     #[clap(long)]
@@ -29,7 +29,7 @@ struct Cli {
 
 fn run() -> Result<(), uv_virtualenv::Error> {
     let cli = Cli::parse();
-    let location = cli.path.unwrap_or(Utf8PathBuf::from(".venv"));
+    let location = cli.path.unwrap_or(PathBuf::from(".venv"));
     let platform = Platform::current()?;
     let cache = if let Some(project_dirs) = ProjectDirs::from("", "", "uv-virtualenv") {
         Cache::from_path(project_dirs.cache_dir())?


### PR DESCRIPTION
## Summary

I think Camino is nice but it makes it much harder to work in `uv-virtualenv`, since it's the _only_ crate that uses it. If we want to use Camino, we should use it everywhere IMO.
