### PR TITLE
Allow empty extras in `pep508-rs` and add more corner case to tests

### DIFF
--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -634,7 +634,7 @@ fn parse_extras(cursor: &mut Cursor) -> Result<Vec<ExtraName>, Pep508Error> {
             (Some((pos, ',')), true) => {
                 return Err(Pep508Error {
                     message: Pep508ErrorSource::String(
-                        "Expected either alphanumerical character (starting the extra name) ']' (ending the extras section), found ','".to_string()
+                        "Expected either alphanumerical character (starting the extra name) or ']' (ending the extras section), found ','".to_string()
                     ),
                     start: pos,
                     len: 1,

--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -623,14 +623,15 @@ fn parse_extras(cursor: &mut Cursor) -> Result<Vec<ExtraName>, Pep508Error> {
     loop {
         cursor.eat_whitespace();
 
-        // end of the extras section
+        // End of the extras section
         if let Some(']') = cursor.peek_char() {
             cursor.next();
             break;
         }
 
-        // comma separator, except for the first iteration
+        // Comma separator
         match (cursor.peek(), is_first_iteration) {
+            // For the first iteration, we don't expect a comma
             (Some((pos, ',')), true) => {
                 return Err(Pep508Error {
                     message: Pep508ErrorSource::String(
@@ -641,6 +642,7 @@ fn parse_extras(cursor: &mut Cursor) -> Result<Vec<ExtraName>, Pep508Error> {
                     input: cursor.to_string(),
                 });
             }
+            // For the other iterations, the comma is required
             (Some((_, ',')), false) => {
                 cursor.next();
             }
@@ -708,8 +710,9 @@ fn parse_extras(cursor: &mut Cursor) -> Result<Vec<ExtraName>, Pep508Error> {
             }
             _ => {}
         };
-        cursor.eat_whitespace();
         // wsp* after the identifier
+        cursor.eat_whitespace();
+        // Add the parsed extra
         extras.push(
             ExtraName::new(buffer).expect("`ExtraName` validation should match PEP 508 parsing"),
         );

--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -1205,7 +1205,7 @@ mod test {
         }, {
             insta::assert_display_snapshot!(errors, @r###"
             Couldn't parse requirement in `<REQUIREMENTS_TXT>` at position 6
-            Expected either alphanumerical character (starting the extra name) ']' (ending the extras section), found ','
+            Expected either alphanumerical character (starting the extra name) or ']' (ending the extras section), found ','
             black[,abcdef]
                   ^
             "###);

--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -1205,7 +1205,7 @@ mod test {
         }, {
             insta::assert_display_snapshot!(errors, @r###"
             Couldn't parse requirement in `<REQUIREMENTS_TXT>` at position 6
-            Expected an alphanumeric character starting the extra name, found ','
+            Expected either alphanumerical character (starting the extra name) ']' (ending the extras section), found ','
             black[,abcdef]
                   ^
             "###);


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixes #2127, allow empty extras, and add more corner case to tests

## References

- [PEP 508 grammar](https://peps.python.org/pep-0508/#complete-grammar)