### PR TITLE
Resolve versions appearing in multiple extra indexes

### DIFF
--- a/crates/uv-dev/src/resolve_many.rs
+++ b/crates/uv-dev/src/resolve_many.rs
@@ -48,10 +48,15 @@ async fn find_latest_version(
     client: &RegistryClient,
     package_name: &PackageName,
 ) -> Option<Version> {
-    let (_, raw_simple_metadata) = client.simple(package_name).await.ok()?;
-    let simple_metadata = OwnedArchive::deserialize(&raw_simple_metadata);
-    let version = simple_metadata.into_iter().next()?.version;
-    Some(version)
+    let results = client.simple(package_name).await.ok()?;
+
+    results
+        .into_iter()
+        .filter_map(|(_index, raw_simple_metadata)| {
+            let simple_metadata = OwnedArchive::deserialize(&raw_simple_metadata);
+            Some(simple_metadata.into_iter().next()?.version)
+        })
+        .max()
 }
 
 pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -206,14 +206,16 @@ impl NoSolutionError {
                     // we represent the state of the resolver at the time of failure.
                     if visited.contains(name) {
                         if let Some(response) = package_versions.get(name) {
-                            if let VersionsResponse::Found(ref version_map) = *response {
-                                available_versions.insert(
-                                    package.clone(),
-                                    version_map
-                                        .iter()
-                                        .map(|(version, _)| version.clone())
-                                        .collect(),
-                                );
+                            if let VersionsResponse::Found(ref version_maps) = *response {
+                                for version_map in version_maps {
+                                    available_versions.insert(
+                                        package.clone(),
+                                        version_map
+                                            .iter()
+                                            .map(|(version, _)| version.clone())
+                                            .collect(),
+                                    );
+                                }
                             }
                         }
                     }

--- a/crates/uv-resolver/src/resolution.rs
+++ b/crates/uv-resolver/src/resolution.rs
@@ -86,12 +86,14 @@ impl ResolutionGraph {
 
                     // Add its hashes to the index.
                     if let Some(versions_response) = packages.get(package_name) {
-                        if let VersionsResponse::Found(ref version_map) = *versions_response {
-                            hashes.insert(package_name.clone(), {
-                                let mut hashes = version_map.hashes(version);
-                                hashes.sort_unstable();
-                                hashes
-                            });
+                        if let VersionsResponse::Found(ref version_maps) = *versions_response {
+                            for version_map in version_maps {
+                                hashes.insert(package_name.clone(), {
+                                    let mut hashes = version_map.hashes(version);
+                                    hashes.sort_unstable();
+                                    hashes
+                                });
+                            }
                         }
                     }
 
@@ -113,12 +115,14 @@ impl ResolutionGraph {
 
                     // Add its hashes to the index.
                     if let Some(versions_response) = packages.get(package_name) {
-                        if let VersionsResponse::Found(ref version_map) = *versions_response {
-                            hashes.insert(package_name.clone(), {
-                                let mut hashes = version_map.hashes(version);
-                                hashes.sort_unstable();
-                                hashes
-                            });
+                        if let VersionsResponse::Found(ref version_maps) = *versions_response {
+                            for version_map in version_maps {
+                                hashes.insert(package_name.clone(), {
+                                    let mut hashes = version_map.hashes(version);
+                                    hashes.sort_unstable();
+                                    hashes
+                                });
+                            }
                         }
                     }
 

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -646,7 +646,8 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                 }
 
                 // Find a version.
-                let Some(candidate) = self.selector.select(package_name, range, version_maps) else {
+                let Some(candidate) = self.selector.select(package_name, range, version_maps)
+                else {
                     // Short circuit: we couldn't find _any_ versions for a package.
                     return Ok(None);
                 };

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -614,8 +614,8 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                     .ok_or(ResolveError::Unregistered)?;
                 self.visited.insert(package_name.clone());
 
-                let version_map = match *versions_response {
-                    VersionsResponse::Found(ref version_map) => version_map,
+                let version_maps = match *versions_response {
+                    VersionsResponse::Found(ref version_maps) => version_maps,
                     // Short-circuit if we do not find any versions for the package
                     VersionsResponse::NoIndex => {
                         self.unavailable_packages
@@ -646,7 +646,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                 }
 
                 // Find a version.
-                let Some(candidate) = self.selector.select(package_name, range, version_map) else {
+                let Some(candidate) = self.selector.select(package_name, range, version_maps) else {
                     // Short circuit: we couldn't find _any_ versions for a package.
                     return Ok(None);
                 };
@@ -1008,8 +1008,8 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                     .await
                     .ok_or(ResolveError::Unregistered)?;
 
-                let version_map = match *versions_response {
-                    VersionsResponse::Found(ref version_map) => version_map,
+                let version_maps = match *versions_response {
+                    VersionsResponse::Found(ref version_maps) => version_maps,
                     // Short-circuit if we did not find any versions for the package
                     VersionsResponse::NoIndex => {
                         self.unavailable_packages
@@ -1033,7 +1033,7 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
 
                 // Try to find a compatible version. If there aren't any compatible versions,
                 // short-circuit and return `None`.
-                let Some(candidate) = self.selector.select(&package_name, &range, version_map)
+                let Some(candidate) = self.selector.select(&package_name, &range, version_maps)
                 else {
                     return Ok(None);
                 };


### PR DESCRIPTION
## Summary

This is intended to fix an issue similar to https://github.com/astral-sh/uv/issues/1451 and https://github.com/astral-sh/uv/pull/2083 for a case where there are multiple private extra-index-urls. afaik they're all equally trusted, so there shouldn't be any security issue.

## Test Plan

I really don't know how to test this properly.
