### PR TITLE
Make an empty string behave like the default

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -201,6 +201,17 @@ fn date_or_datetime(input: &str) -> Result<DateTime<Utc>, String> {
     ))
 }
 
+/// Clap parser for the index url
+fn parse_index_url(mut arg: &str) -> Result<IndexUrl, String> {
+    if arg.is_empty() {
+        arg = "https://pypi.org/simple";
+    }
+    match IndexUrl::from_str(arg) {
+        Ok(url) => Ok(url),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 struct PipCompileArgs {
@@ -291,7 +302,7 @@ struct PipCompileArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, short, env = "UV_INDEX_URL")]
+    #[clap(long, short, env = "UV_INDEX_URL", value_parser = parse_index_url)]
     index_url: Option<IndexUrl>,
 
     /// Extra URLs of package indexes to use, in addition to `--index-url`.
@@ -443,7 +454,7 @@ struct PipSyncArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, short, env = "UV_INDEX_URL")]
+    #[clap(long, short, env = "UV_INDEX_URL", value_parser = parse_index_url)]
     index_url: Option<IndexUrl>,
 
     /// Extra URLs of package indexes to use, in addition to `--index-url`.
@@ -656,7 +667,7 @@ struct PipInstallArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, short, env = "UV_INDEX_URL")]
+    #[clap(long, short, env = "UV_INDEX_URL", value_parser = parse_index_url)]
     index_url: Option<IndexUrl>,
 
     /// Extra URLs of package indexes to use, in addition to `--index-url`.
@@ -954,7 +965,7 @@ struct VenvArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, short, env = "UV_INDEX_URL")]
+    #[clap(long, short, env = "UV_INDEX_URL", value_parser = parse_index_url)]
     index_url: Option<IndexUrl>,
 
     /// Extra URLs of package indexes to use, in addition to `--index-url`.

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -201,14 +201,32 @@ fn date_or_datetime(input: &str) -> Result<DateTime<Utc>, String> {
     ))
 }
 
-/// Clap parser for the index url
-fn parse_index_url(mut arg: &str) -> Result<IndexUrl, String> {
-    if arg.is_empty() {
-        arg = "https://pypi.org/simple";
+/// A re-implementation of `Option`, used to avoid Clap's automatic `Option` flattening in
+/// [`parse_index_url`].
+#[derive(Debug, Clone)]
+enum Maybe<T> {
+    Some(T),
+    None,
+}
+
+impl<T> Maybe<T> {
+    fn into_option(self) -> Option<T> {
+        match self {
+            Maybe::Some(value) => Some(value),
+            Maybe::None => None,
+        }
     }
-    match IndexUrl::from_str(arg) {
-        Ok(url) => Ok(url),
-        Err(err) => Err(err.to_string()),
+}
+
+/// Parse a string into an [`IndexUrl`], mapping the empty string to `None`.
+fn parse_index_url(input: &str) -> Result<Maybe<IndexUrl>, String> {
+    if input.is_empty() {
+        Ok(Maybe::None)
+    } else {
+        match IndexUrl::from_str(input) {
+            Ok(url) => Ok(Maybe::Some(url)),
+            Err(err) => Err(err.to_string()),
+        }
     }
 }
 
@@ -303,7 +321,7 @@ struct PipCompileArgs {
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
     #[clap(long, short, env = "UV_INDEX_URL", value_parser = parse_index_url)]
-    index_url: Option<IndexUrl>,
+    index_url: Option<Maybe<IndexUrl>>,
 
     /// Extra URLs of package indexes to use, in addition to `--index-url`.
     ///
@@ -314,8 +332,8 @@ struct PipCompileArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ')]
-    extra_index_url: Vec<IndexUrl>,
+    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ', value_parser = parse_index_url)]
+    extra_index_url: Vec<Maybe<IndexUrl>>,
 
     /// Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those
     /// discovered via `--find-links`.
@@ -455,7 +473,7 @@ struct PipSyncArgs {
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
     #[clap(long, short, env = "UV_INDEX_URL", value_parser = parse_index_url)]
-    index_url: Option<IndexUrl>,
+    index_url: Option<Maybe<IndexUrl>>,
 
     /// Extra URLs of package indexes to use, in addition to `--index-url`.
     ///
@@ -466,8 +484,8 @@ struct PipSyncArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ')]
-    extra_index_url: Vec<IndexUrl>,
+    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ', value_parser = parse_index_url)]
+    extra_index_url: Vec<Maybe<IndexUrl>>,
 
     /// Locations to search for candidate distributions, beyond those found in the indexes.
     ///
@@ -668,7 +686,7 @@ struct PipInstallArgs {
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
     #[clap(long, short, env = "UV_INDEX_URL", value_parser = parse_index_url)]
-    index_url: Option<IndexUrl>,
+    index_url: Option<Maybe<IndexUrl>>,
 
     /// Extra URLs of package indexes to use, in addition to `--index-url`.
     ///
@@ -679,8 +697,8 @@ struct PipInstallArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ')]
-    extra_index_url: Vec<IndexUrl>,
+    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ', value_parser = parse_index_url)]
+    extra_index_url: Vec<Maybe<IndexUrl>>,
 
     /// Locations to search for candidate distributions, beyond those found in the indexes.
     ///
@@ -966,7 +984,7 @@ struct VenvArgs {
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
     #[clap(long, short, env = "UV_INDEX_URL", value_parser = parse_index_url)]
-    index_url: Option<IndexUrl>,
+    index_url: Option<Maybe<IndexUrl>>,
 
     /// Extra URLs of package indexes to use, in addition to `--index-url`.
     ///
@@ -977,8 +995,8 @@ struct VenvArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ')]
-    extra_index_url: Vec<IndexUrl>,
+    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ', value_parser = parse_index_url)]
+    extra_index_url: Vec<Maybe<IndexUrl>>,
 
     /// Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those
     /// discovered via `--find-links`.
@@ -1135,8 +1153,11 @@ async fn run() -> Result<ExitStatus> {
                 .map(RequirementsSource::from_path)
                 .collect::<Vec<_>>();
             let index_urls = IndexLocations::new(
-                args.index_url,
-                args.extra_index_url,
+                args.index_url.and_then(Maybe::into_option),
+                args.extra_index_url
+                    .into_iter()
+                    .filter_map(Maybe::into_option)
+                    .collect(),
                 args.find_links,
                 args.no_index,
             );
@@ -1206,8 +1227,11 @@ async fn run() -> Result<ExitStatus> {
 
             let cache = cache.with_refresh(Refresh::from_args(args.refresh, args.refresh_package));
             let index_urls = IndexLocations::new(
-                args.index_url,
-                args.extra_index_url,
+                args.index_url.and_then(Maybe::into_option),
+                args.extra_index_url
+                    .into_iter()
+                    .filter_map(Maybe::into_option)
+                    .collect(),
                 args.find_links,
                 args.no_index,
             );
@@ -1274,8 +1298,11 @@ async fn run() -> Result<ExitStatus> {
                 .map(RequirementsSource::from_path)
                 .collect::<Vec<_>>();
             let index_urls = IndexLocations::new(
-                args.index_url,
-                args.extra_index_url,
+                args.index_url.and_then(Maybe::into_option),
+                args.extra_index_url
+                    .into_iter()
+                    .filter_map(Maybe::into_option)
+                    .collect(),
                 args.find_links,
                 args.no_index,
             );
@@ -1388,8 +1415,11 @@ async fn run() -> Result<ExitStatus> {
             args.compat_args.validate()?;
 
             let index_locations = IndexLocations::new(
-                args.index_url,
-                args.extra_index_url,
+                args.index_url.and_then(Maybe::into_option),
+                args.extra_index_url
+                    .into_iter()
+                    .filter_map(Maybe::into_option)
+                    .collect(),
                 // No find links for the venv subcommand, to keep things simple
                 Vec::new(),
                 args.no_index,


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Resolve  #2129

I changed the behavior to parse an empty string for `--index-url` to be the same as the default.
