### PR TITLE
Use space as delimiter for `UV_EXTRA_INDEX_URL`

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -303,7 +303,7 @@ struct PipCompileArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, env = "UV_EXTRA_INDEX_URL")]
+    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ')]
     extra_index_url: Vec<IndexUrl>,
 
     /// Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those
@@ -455,7 +455,7 @@ struct PipSyncArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, env = "UV_EXTRA_INDEX_URL")]
+    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ')]
     extra_index_url: Vec<IndexUrl>,
 
     /// Locations to search for candidate distributions, beyond those found in the indexes.
@@ -668,7 +668,7 @@ struct PipInstallArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, env = "UV_EXTRA_INDEX_URL")]
+    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ')]
     extra_index_url: Vec<IndexUrl>,
 
     /// Locations to search for candidate distributions, beyond those found in the indexes.
@@ -966,7 +966,7 @@ struct VenvArgs {
     /// Unlike `pip`, `uv` will stop looking for versions of a package as soon
     /// as it finds it in an index. That is, it isn't possible for `uv` to
     /// consider versions of the same package across multiple indexes.
-    #[clap(long, env = "UV_EXTRA_INDEX_URL")]
+    #[clap(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ')]
     extra_index_url: Vec<IndexUrl>,
 
     /// Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those


### PR DESCRIPTION
## Summary

I was looking at something unrelated and saw this in the Clap docs.

Closes https://github.com/astral-sh/uv/issues/1702.

## Test Plan

```shell
❯ UV_EXTRA_INDEX_URL="https://google.com https://foo.com" cargo run pip compile -
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/uv pip compile -`
index: None
extra_index_url: [Url(VerbatimUrl { url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("google.com")), port: None, path: "/", query: None, fragment: None }, given: Some("https://google.com") }), Url(VerbatimUrl { url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("foo.com")), port: None, path: "/", query: None, fragment: None }, given: Some("https://foo.com") })]
```
