### PR TITLE
Log build output

### DIFF
--- a/crates/uv/src/logging.rs
+++ b/crates/uv/src/logging.rs
@@ -167,7 +167,7 @@ pub(crate) fn setup_logging(
                     HierarchicalLayer::default()
                         .with_targets(true)
                         .with_timer(Uptime::default())
-                        .with_writer(std::io::stderr),
+                        .with_writer(anstream::stderr),
                 )
                 .init();
         }

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -2397,7 +2397,7 @@ fn no_build_isolation() -> Result<()> {
     ----- stderr -----
     error: Failed to download and build: anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz
       Caused by: Failed to build: anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz
-      Caused by: Build backend failed to determine metadata through `prepare_metadata_for_build_wheel` with exit status: 1
+      Caused by: Build backend failed when calling `prepare_metadata_for_build_wheel()` with exit status: 1
     --- stdout:
 
     --- stderr:


### PR DESCRIPTION
Show source distribution build output in debug (`-v`) logging.

Example output for `uv pip install --no-cache-dir --no-binary :all: -v tqdm 2> stderr.txt`: [gist](https://gist.github.com/konstin/61758c6bd5f4294cfc048fea18d5cca3).

I'd suggest taking hierarchical layer out of the default `-v`, i find the indentation makes it hard to read and the spans are generally not that informative compare to the actual log messages.

I've also added anstream filtering to the log output after seeing ansi codes in my log files.

Fixes #2146
Partially addresses #1567 - It doesn't show output while compiling but only after. We can consider i meanwhile but this is a much larger project due to complexity around pipes.