### PR TITLE
Centralize up-to-date checking for path installations

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -6,6 +6,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use distribution_types::InstalledDist;
 use fs_err as fs;
 use tempfile::{tempdir, TempDir};
 
@@ -692,6 +693,36 @@ impl ArchiveTimestamp {
             Self::Approximate(timestamp) => *timestamp,
         }
     }
+
+    /// Returns `true` if the `target` (an installed or cached distribution) is up-to-date with the
+    /// source archive (`source`).
+    ///
+    /// The `target` should be an installed package in a virtual environment, or an unzipped
+    /// package in the cache.
+    ///
+    /// The `source` is a source archive, i.e., a path to a built wheel or a Python package directory.
+    pub fn up_to_date_with(source: &Path, target: ArchiveTarget) -> Result<bool, io::Error> {
+        let Some(modified_at) = Self::from_path(source)? else {
+            // If there's no entrypoint, we can't determine the modification time, so we assume that the
+            // target is not up-to-date.
+            return Ok(false);
+        };
+        let created_at = match target {
+            ArchiveTarget::Install(installed) => {
+                Timestamp::from_path(installed.path().join("METADATA"))?
+            }
+            ArchiveTarget::Cache(cache) => Timestamp::from_path(cache)?,
+        };
+        Ok(modified_at.timestamp() <= created_at)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ArchiveTarget<'a> {
+    /// The target is an installed package in a virtual environment.
+    Install(&'a InstalledDist),
+    /// The target is an unzipped package in the cache.
+    Cache(&'a Path),
 }
 
 impl PartialOrd for ArchiveTimestamp {

--- a/crates/uv-distribution/src/index/built_wheel_index.rs
+++ b/crates/uv-distribution/src/index/built_wheel_index.rs
@@ -48,7 +48,8 @@ impl BuiltWheelIndex {
         );
 
         // Determine the last-modified time of the source distribution.
-        let Some(modified) = ArchiveTimestamp::from_path(&source_dist.path).expect("archived")
+        let Some(modified) =
+            ArchiveTimestamp::from_path(&source_dist.path).map_err(Error::CacheRead)?
         else {
             return Err(Error::DirWithoutEntrypoint);
         };

--- a/crates/uv-installer/src/editable.rs
+++ b/crates/uv-installer/src/editable.rs
@@ -6,7 +6,7 @@ use distribution_types::{
 };
 use pypi_types::Metadata21;
 use requirements_txt::EditableRequirement;
-use uv_cache::ArchiveTimestamp;
+
 use uv_normalize::PackageName;
 
 /// An editable distribution that has been built.
@@ -67,18 +67,6 @@ impl std::fmt::Display for ResolvedEditable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}{}", self.name(), self.installed_version())
     }
-}
-
-/// Returns `true` if the installed distribution is up-to-date with the [`EditableRequirement`].
-pub fn not_modified(editable: &EditableRequirement, installed: &InstalledDist) -> bool {
-    let Ok(Some(installed_at)) = ArchiveTimestamp::from_path(installed.path().join("METADATA"))
-    else {
-        return false;
-    };
-    let Ok(Some(modified_at)) = ArchiveTimestamp::from_path(&editable.path) else {
-        return false;
-    };
-    installed_at > modified_at
 }
 
 /// Returns `true` if the [`EditableRequirement`] contains dynamic metadata.

--- a/crates/uv-installer/src/lib.rs
+++ b/crates/uv-installer/src/lib.rs
@@ -1,5 +1,5 @@
 pub use downloader::{Downloader, Reporter as DownloadReporter};
-pub use editable::{is_dynamic, not_modified, BuiltEditable, ResolvedEditable};
+pub use editable::{is_dynamic, BuiltEditable, ResolvedEditable};
 pub use installer::{Installer, Reporter as InstallReporter};
 pub use plan::{Plan, Planner, Reinstall};
 pub use site_packages::SitePackages;

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -11,10 +11,11 @@ use distribution_types::{InstalledDist, InstalledMetadata, InstalledVersion, Nam
 use pep440_rs::{Version, VersionSpecifiers};
 use pep508_rs::{Requirement, VerbatimUrl};
 use requirements_txt::EditableRequirement;
+use uv_cache::{ArchiveTarget, ArchiveTimestamp};
 use uv_interpreter::PythonEnvironment;
 use uv_normalize::PackageName;
 
-use crate::{is_dynamic, not_modified};
+use crate::is_dynamic;
 
 /// An index over the packages installed in an environment.
 ///
@@ -276,7 +277,10 @@ impl<'a> SitePackages<'a> {
                 }
                 [distribution] => {
                     // Is the editable out-of-date?
-                    if !not_modified(requirement, distribution) {
+                    if !ArchiveTimestamp::up_to_date_with(
+                        &requirement.path,
+                        ArchiveTarget::Install(distribution),
+                    )? {
                         return Ok(false);
                     }
 

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -11,13 +11,12 @@ use platform_host::Platform;
 use platform_tags::Tags;
 use pypi_types::Yanked;
 use requirements_txt::EditableRequirement;
-use uv_cache::Cache;
+use uv_cache::{ArchiveTarget, ArchiveTimestamp, Cache};
 use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
 use uv_fs::Simplified;
 use uv_installer::{
-    is_dynamic, not_modified, Downloader, NoBinary, Plan, Planner, Reinstall, ResolvedEditable,
-    SitePackages,
+    is_dynamic, Downloader, NoBinary, Plan, Planner, Reinstall, ResolvedEditable, SitePackages,
 };
 use uv_interpreter::PythonEnvironment;
 use uv_resolver::InMemoryIndex;
@@ -426,7 +425,11 @@ async fn resolve_editables(
                 match existing.as_slice() {
                     [] => uninstalled.push(editable),
                     [dist] => {
-                        if not_modified(&editable, dist) && !is_dynamic(&editable) {
+                        if ArchiveTimestamp::up_to_date_with(
+                            &editable.path,
+                            ArchiveTarget::Install(dist),
+                        )? && !is_dynamic(&editable)
+                        {
                             installed.push((*dist).clone());
                         } else {
                             uninstalled.push(editable);
@@ -447,7 +450,11 @@ async fn resolve_editables(
                     [dist] => {
                         if packages.contains(dist.name()) {
                             uninstalled.push(editable);
-                        } else if not_modified(&editable, dist) && !is_dynamic(&editable) {
+                        } else if ArchiveTimestamp::up_to_date_with(
+                            &editable.path,
+                            ArchiveTarget::Install(dist),
+                        )? && !is_dynamic(&editable)
+                        {
                             installed.push((*dist).clone());
                         } else {
                             uninstalled.push(editable);


### PR DESCRIPTION
## Summary

Internal-only refactor to consolidate multiple codepaths we have for checking whether a cached or installed entry is up-to-date with a local requirement.