### PR TITLE
Respect non-`sysconfig`-based system Pythons

### DIFF
--- a/.github/workflows/system-install.yml
+++ b/.github/workflows/system-install.yml
@@ -18,6 +18,30 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
+  install-debian:
+    name: "Install Python on Debian"
+    runs-on: ubuntu-latest
+    container: debian:bullseye
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Install Python"
+        run: apt-get update && apt-get install -y python3.9 python3-pip python3.9-venv
+
+      - name: "Install Rust toolchain"
+        run: apt-get update && apt-get install -y curl build-essential && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: "Build"
+        run: $HOME/.cargo/bin/cargo build --no-default-features
+
+      - name: "Print Python path"
+        run: echo $(which python3.9)
+
+      - name: "Validate global Python install"
+        run: python3.9 scripts/check_system_python.py --uv ./target/debug/uv
+
   install-ubuntu:
     name: "Install Python on Ubuntu"
     runs-on: ubuntu-latest

--- a/.github/workflows/system-install.yml
+++ b/.github/workflows/system-install.yml
@@ -90,6 +90,27 @@ jobs:
       - name: "Validate global Python install"
         run: pypy scripts/check_system_python.py --uv ./target/debug/uv
 
+  install-pyston:
+    name: "Install Pyston"
+    runs-on: ubuntu-latest
+    container: pyston/pyston:2.3.5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Install Rust toolchain"
+        run: apt-get update && apt-get install -y curl build-essential && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: "Build"
+        run: $HOME/.cargo/bin/cargo build --no-default-features
+
+      - name: "Print Python path"
+        run: echo $(which pyston)
+
+      - name: "Validate global Python install"
+        run: pyston scripts/check_system_python.py --uv ./target/debug/uv
+
   install-macos:
     name: "Install Python on macOS"
     runs-on: macos-14

--- a/crates/platform-tags/src/lib.rs
+++ b/crates/platform-tags/src/lib.rs
@@ -256,6 +256,7 @@ impl TryFrom<usize> for TagPriority {
 pub enum Implementation {
     CPython,
     PyPy,
+    Pyston,
 }
 
 impl Implementation {
@@ -267,6 +268,8 @@ impl Implementation {
             Self::CPython => format!("cp{}{}", python_version.0, python_version.1),
             // Ex) `pp39`
             Self::PyPy => format!("pp{}{}", python_version.0, python_version.1),
+            // Ex) `pt38``
+            Self::Pyston => format!("pt{}{}", python_version.0, python_version.1),
         }
     }
 
@@ -288,6 +291,14 @@ impl Implementation {
                 implementation_version.0,
                 implementation_version.1
             ),
+            // Ex) `pyston38-pyston_23`
+            Self::Pyston => format!(
+                "pyston{}{}-pyston_{}{}",
+                python_version.0,
+                python_version.1,
+                implementation_version.0,
+                implementation_version.1
+            ),
         }
     }
 }
@@ -300,6 +311,7 @@ impl FromStr for Implementation {
             // Known and supported implementations.
             "cpython" => Ok(Self::CPython),
             "pypy" => Ok(Self::PyPy),
+            "pyston" => Ok(Self::Pyston),
             // Known but unsupported implementations.
             "python" => Err(TagsError::UnsupportedImplementation(s.to_string())),
             "ironpython" => Err(TagsError::UnsupportedImplementation(s.to_string())),


### PR DESCRIPTION
## Summary

`pip` uses `sysconfig` for Python 3.10 and later by default; however, it falls back to `distutils` for earlier Python versions, and distros can actually tell `pip` to continue falling back to `distutils` via the `_PIP_USE_SYSCONFIG` variable.

By _always_ using `sysconfig`, we're doing the wrong then when installing into some system Pythons, e.g., on Debian prior to Python 3.10.

This PR modifies our logic to mirror `pip` exactly, which is what's been recommended to me as the right thing to do.

Closes https://github.com/astral-sh/uv/issues/2113.

## Test Plan

Most notably, the new Debian tests pass here (which fail on main: https://github.com/astral-sh/uv/pull/2144).

I also added Pyston as a second stress-test.