### PR TITLE
Only use compile timeout for critical section

### DIFF
--- a/crates/uv-installer/Cargo.toml
+++ b/crates/uv-installer/Cargo.toml
@@ -43,7 +43,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["process"] }
 toml = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }


### PR DESCRIPTION
Follow-up to #2086: Don't use timeouts for the entire workers, but only for the section that's about communicating with the (potentially broken) `python` subprocess. I've also raised the timeout to 60s.
