### PR TITLE
Avoid Windows Store shims in `--python python3`-like invocations

### DIFF
--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -1,4 +1,3 @@
-use std::ffi::{OsStr, OsString};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -197,25 +196,6 @@ impl Interpreter {
             Ok(Some(interpreter))
         } else {
             Ok(None)
-        }
-    }
-
-    /// Find the Python interpreter in `PATH`, respecting `UV_PYTHON_PATH`.
-    ///
-    /// Returns `Ok(None)` if not found.
-    pub(crate) fn find_executable<R: AsRef<OsStr> + Into<OsString> + Copy>(
-        requested: R,
-    ) -> Result<Option<PathBuf>, Error> {
-        let result = if let Some(isolated) = std::env::var_os("UV_TEST_PYTHON_PATH") {
-            which::which_in(requested, Some(isolated), std::env::current_dir()?)
-        } else {
-            which::which(requested)
-        };
-
-        match result {
-            Err(which::Error::CannotFindBinaryPath) => Ok(None),
-            Err(err) => Err(Error::WhichError(requested.into(), err)),
-            Ok(path) => Ok(Some(path)),
         }
     }
 


### PR DESCRIPTION
## Summary

We have logic in `python_query.rs` to filter out Windows Store shims when you use invocations like `-p 3.10`, but not `--python python3`, which is uncommon but allowed on Windows.

Closes #2211.
