### PR TITLE
HTML-decode URLs in HTML indexes

### DIFF
--- a/crates/uv-client/src/html.rs
+++ b/crates/uv-client/src/html.rs
@@ -188,7 +188,7 @@ impl SimpleHtml {
             requires_python,
             hashes,
             filename: filename.to_string(),
-            url: href.to_string(),
+            url: decoded.to_string(),
             size: None,
             upload_time: None,
         })
@@ -443,7 +443,7 @@ mod tests {
                     requires_python: None,
                     size: None,
                     upload_time: None,
-                    url: "/whl/Jinja2-3.1.2&#43;233fca715f49-py3-none-any.whl#sha256=6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61",
+                    url: "/whl/Jinja2-3.1.2+233fca715f49-py3-none-any.whl#sha256=6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61",
                     yanked: None,
                 },
             ],


### PR DESCRIPTION
## Summary

If the index lists a URL like `https://buf.build/gen/python/hashb-foxglove-protocolbuffers-python/hashb_foxglove_protocolbuffers_python-25.3.0.1.20240226043130&#43;465630478360-py3-none-any.whl`, we need to decode that to `https://buf.build/gen/python/hashb-foxglove-protocolbuffers-python/hashb_foxglove_protocolbuffers_python-25.3.0.1.20240226043130+465630478360-py3-none-any.whl`.

Closes https://github.com/astral-sh/uv/issues/2202.
