### PR TITLE
Fallback to fresh request on non-validating 304

### DIFF
--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -283,7 +283,7 @@ impl CachedClient {
                 // If we got a modified response, but it's a 304, then a validator failed (e.g., the
                 // ETag didn't match). We need to make a fresh request.
                 if response.status() == http::StatusCode::NOT_MODIFIED {
-                    debug!("Server returned invalid 304 for: {}", fresh_req.url());
+                    warn!("Server returned unusable 304 for: {}", fresh_req.url());
                     self.resend_and_heal_cache(fresh_req, cache_entry, response_callback)
                         .await
                 } else {


### PR DESCRIPTION
## Summary

We're seeing reports that Sonatype Nexus isn't working with cached data. Users are reporting 304 responses that show "Found modified response..." path in the logs. I can't reproduce this on latest Sonatype Nexus, but my best guess is that there's a 304 response that is failing our validators, and we try to use that as if it's a "complete" response?

Closes https://github.com/astral-sh/uv/issues/1754.