### PR TITLE
Pin maturin version in CI for now

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -46,6 +46,7 @@ jobs:
       - name: "Build sdist"
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.4.0
           command: sdist
           args: --out dist
       - name: "Test sdist"
@@ -73,6 +74,7 @@ jobs:
       - name: "Build wheels - x86_64"
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.4.0
           target: x86_64
           args: --release --locked --out dist
       - name: "Upload wheels"
@@ -112,6 +114,7 @@ jobs:
       - name: "Build wheels - universal2"
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.4.0
           args: --release --locked --target universal2-apple-darwin --out dist
       - name: "Test wheel - universal2"
         run: |
@@ -162,6 +165,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.4.0
           target: ${{ matrix.platform.target }}
           args: --release --locked --out dist
       - name: "Test wheel"
@@ -209,6 +213,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.4.0
           target: ${{ matrix.target }}
           manylinux: auto
           args: --release --locked --out dist
@@ -283,6 +288,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.4.0
           target: ${{ matrix.platform.target }}
           manylinux: 2_28
           docker-options: ${{ matrix.platform.maturin_docker_options }}
@@ -348,6 +354,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.4.0
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
@@ -415,6 +422,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.4.0
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
@@ -485,6 +493,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.4.0
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
           args: --release --locked --out dist
@@ -547,6 +556,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.4.0
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
           args: --release --locked --out dist


### PR DESCRIPTION
## Summary

In v1.5.0, Maturin now produces Metadata 2.3.0, which isn't supported in the GitHub Action: https://github.com/pypa/gh-action-pypi-publish/pull/219.