### PR TITLE
Show appropriate activation command based on shell detection

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -50,6 +50,7 @@ mod confirm;
 mod logging;
 mod printer;
 mod requirements;
+mod shell;
 mod version;
 
 const DEFAULT_VENV_NAME: &str = ".venv";

--- a/crates/uv/src/shell.rs
+++ b/crates/uv/src/shell.rs
@@ -1,0 +1,69 @@
+use std::path::Path;
+
+/// Shells for which virtualenv activation scripts are available.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum Shell {
+    /// Bourne Again SHell (bash)
+    Bash,
+    /// Friendly Interactive SHell (fish)
+    Fish,
+    /// PowerShell
+    Powershell,
+    /// Z SHell (zsh)
+    Zsh,
+    /// Nushell
+    Nushell,
+    /// C SHell (csh)
+    Csh,
+}
+
+impl Shell {
+    /// Determine the user's current shell from the environment.
+    ///
+    /// This will read the `SHELL` environment variable and try to determine which shell is in use
+    /// from that.
+    ///
+    /// If `SHELL` is not set, then on windows, it will default to powershell, and on
+    /// other `OSes` it will return `None`.
+    ///
+    /// If `SHELL` is set, but contains a value that doesn't correspond to one of the supported
+    /// shell types, then return `None`.
+    pub(crate) fn from_env() -> Option<Shell> {
+        if std::env::var_os("NU_VERSION").is_some() {
+            Some(Shell::Nushell)
+        } else if let Some(env_shell) = std::env::var_os("SHELL") {
+            Shell::from_shell_path(env_shell)
+        } else if cfg!(windows) {
+            Some(Shell::Powershell)
+        } else {
+            None
+        }
+    }
+
+    /// Parse a shell from a path to the executable for the shell.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crate::shells::Shell;
+    ///
+    /// assert_eq!(Shell::from_shell_path("/bin/bash"), Some(Shell::Bash));
+    /// assert_eq!(Shell::from_shell_path("/usr/bin/zsh"), Some(Shell::Zsh));
+    /// assert_eq!(Shell::from_shell_path("/opt/my_custom_shell"), None);
+    /// ```
+    pub(crate) fn from_shell_path<P: AsRef<Path>>(path: P) -> Option<Shell> {
+        parse_shell_from_path(path.as_ref())
+    }
+}
+
+fn parse_shell_from_path(path: &Path) -> Option<Shell> {
+    let name = path.file_stem()?.to_str()?;
+    match name {
+        "bash" => Some(Shell::Bash),
+        "zsh" => Some(Shell::Zsh),
+        "fish" => Some(Shell::Fish),
+        "csh" => Some(Shell::Csh),
+        "powershell" | "powershell_ise" => Some(Shell::Powershell),
+        _ => None,
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Closes https://github.com/astral-sh/uv/issues/2174.

## Test Plan

On Nushell:

```
(uv) ~/workspace/uv> cargo run venv                                                                                                                                                                                      
Using Python 3.12.0 interpreter at: /Users/crmarsh/workspace/uv/.venv/bin/python3
Creating virtualenv at: .venv
Activate with: overlay use .venv/bin/activate.nu
```

On Bash:

```
❯ cargo run venv "foo bar"
Using Python 3.12.0 interpreter at: /Users/crmarsh/.local/share/rtx/installs/python/3.12.0/bin/python3
Creating virtualenv at: foo bar
Activate with: source 'foo bar/bin/activate'
```
