### PR TITLE
ci: maturing version uses env var

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -31,6 +31,7 @@ env:
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
+  MATURIN_VERSION: "1.4.0"
 
 jobs:
   sdist:
@@ -46,7 +47,7 @@ jobs:
       - name: "Build sdist"
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.4.0
+          maturin-version: ${{ env.MATURIN_VERSION }}
           command: sdist
           args: --out dist
       - name: "Test sdist"
@@ -74,7 +75,7 @@ jobs:
       - name: "Build wheels - x86_64"
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.4.0
+          maturin-version: ${{ env.MATURIN_VERSION }}
           target: x86_64
           args: --release --locked --out dist
       - name: "Upload wheels"
@@ -114,7 +115,7 @@ jobs:
       - name: "Build wheels - universal2"
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.4.0
+          maturin-version: ${{ env.MATURIN_VERSION }}
           args: --release --locked --target universal2-apple-darwin --out dist
       - name: "Test wheel - universal2"
         run: |
@@ -165,7 +166,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.4.0
+          maturin-version: ${{ env.MATURIN_VERSION }}
           target: ${{ matrix.platform.target }}
           args: --release --locked --out dist
       - name: "Test wheel"
@@ -213,7 +214,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.4.0
+          maturin-version: ${{ env.MATURIN_VERSION }}
           target: ${{ matrix.target }}
           manylinux: auto
           args: --release --locked --out dist
@@ -288,7 +289,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.4.0
+          maturin-version: ${{ env.MATURIN_VERSION }}
           target: ${{ matrix.platform.target }}
           manylinux: 2_28
           docker-options: ${{ matrix.platform.maturin_docker_options }}
@@ -354,7 +355,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.4.0
+          maturin-version: ${{ env.MATURIN_VERSION }}
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
@@ -422,7 +423,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.4.0
+          maturin-version: ${{ env.MATURIN_VERSION }}
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
@@ -493,7 +494,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.4.0
+          maturin-version: ${{ env.MATURIN_VERSION }}
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
           args: --release --locked --out dist
@@ -556,7 +557,7 @@ jobs:
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.4.0
+          maturin-version: ${{ env.MATURIN_VERSION }}
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
           args: --release --locked --out dist


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Adjust maturing version to use env var for reusability in the workflow.


## Test Plan

<!-- How was it tested? -->
CI `Build binaries` workflow uses correct version and passes