### PR TITLE
test: pip_list: Fix replacement pattern computation

### DIFF
--- a/crates/uv/tests/pip_list.rs
+++ b/crates/uv/tests/pip_list.rs
@@ -98,13 +98,11 @@ fn list_editable() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let current_dir = std::env::current_dir()?;
-    let workspace_dir = regex::escape(
-        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?)
-            .unwrap()
-            .as_str(),
-    );
+    let workspace_dir =
+        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?).unwrap();
+    let workspace_dir_re = regex::escape(workspace_dir.as_str());
 
-    let filters = [(workspace_dir.as_str(), "file://[WORKSPACE_DIR]/")]
+    let filters = [(workspace_dir_re.as_str(), "file://[WORKSPACE_DIR]/")]
         .into_iter()
         .chain(INSTA_FILTERS.to_vec())
         .collect::<Vec<_>>();
@@ -159,7 +157,7 @@ fn list_editable() -> Result<()> {
     let find_whitespace = " ".repeat(25 + workspace_len_difference);
     let replace_whitespace = " ".repeat(57);
 
-    let search_workspace = workspace_dir.as_str().strip_prefix(prefix).unwrap();
+    let search_workspace = workspace_dir_re.as_str().strip_prefix(prefix).unwrap();
     let replace_workspace = "[WORKSPACE_DIR]/";
 
     let filters = INSTA_FILTERS
@@ -200,13 +198,11 @@ fn list_editable_only() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let current_dir = std::env::current_dir()?;
-    let workspace_dir = regex::escape(
-        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?)
-            .unwrap()
-            .as_str(),
-    );
+    let workspace_dir =
+        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?).unwrap();
+    let workspace_dir_re = regex::escape(workspace_dir.as_str());
 
-    let filters = [(workspace_dir.as_str(), "file://[WORKSPACE_DIR]/")]
+    let filters = [(workspace_dir_re.as_str(), "file://[WORKSPACE_DIR]/")]
         .into_iter()
         .chain(INSTA_FILTERS.to_vec())
         .collect::<Vec<_>>();
@@ -254,7 +250,7 @@ fn list_editable_only() -> Result<()> {
     let find_whitespace = " ".repeat(25 + workspace_len_difference);
     let replace_whitespace = " ".repeat(57);
 
-    let search_workspace = workspace_dir.as_str().strip_prefix(prefix).unwrap();
+    let search_workspace = workspace_dir_re.as_str().strip_prefix(prefix).unwrap();
     let replace_workspace = "[WORKSPACE_DIR]/";
 
     let filters = INSTA_FILTERS
@@ -331,13 +327,11 @@ fn list_exclude() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let current_dir = std::env::current_dir()?;
-    let workspace_dir = regex::escape(
-        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?)
-            .unwrap()
-            .as_str(),
-    );
+    let workspace_dir =
+        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?).unwrap();
+    let workspace_dir_re = regex::escape(workspace_dir.as_str());
 
-    let filters = [(workspace_dir.as_str(), "file://[WORKSPACE_DIR]/")]
+    let filters = [(workspace_dir_re.as_str(), "file://[WORKSPACE_DIR]/")]
         .into_iter()
         .chain(INSTA_FILTERS.to_vec())
         .collect::<Vec<_>>();
@@ -385,7 +379,7 @@ fn list_exclude() -> Result<()> {
     let find_whitespace = " ".repeat(25 + workspace_len_difference);
     let replace_whitespace = " ".repeat(57);
 
-    let search_workspace = workspace_dir.as_str().strip_prefix(prefix).unwrap();
+    let search_workspace = workspace_dir_re.as_str().strip_prefix(prefix).unwrap();
     let replace_workspace = "[WORKSPACE_DIR]/";
 
     let filters = INSTA_FILTERS


### PR DESCRIPTION
## Summary

Fix computing replacements pattern for pip_list tests to count characters in the original directory string rather than the regex::escape'd string.  The latter yields incorrect results if the workspace path contains characters such as `-` or `.`.

Fixes #2232

## Test Plan

`cargo test --test pip_list` in a directory named `uv-test` to provoke the bug.
