### PR TITLE
Allow `UV_PRERELEASE` to be set via environment variable

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -280,7 +280,7 @@ struct PipCompileArgs {
     #[clap(long, value_enum, default_value_t = ResolutionMode::default())]
     resolution: ResolutionMode,
 
-    #[clap(long, value_enum, default_value_t = PreReleaseMode::default(), conflicts_with = "pre")]
+    #[clap(long, value_enum, default_value_t = PreReleaseMode::default(), conflicts_with = "pre", env = "UV_PRERELEASE")]
     prerelease: PreReleaseMode,
 
     #[clap(long, hide = true, conflicts_with = "prerelease")]
@@ -682,7 +682,7 @@ struct PipInstallArgs {
     #[clap(long, value_enum, default_value_t = ResolutionMode::default())]
     resolution: ResolutionMode,
 
-    #[clap(long, value_enum, default_value_t = PreReleaseMode::default(), conflicts_with = "pre")]
+    #[clap(long, value_enum, default_value_t = PreReleaseMode::default(), conflicts_with = "pre", env = "UV_PRERELEASE")]
     prerelease: PreReleaseMode,
 
     #[clap(long, hide = true, conflicts_with = "prerelease")]


### PR DESCRIPTION
## Summary

This is useful as it tends to be "system-wide" configuration, and configuration that differs from pip. See https://github.com/astral-sh/uv/issues/1641#issuecomment-1980934954.