### PR TITLE
Add support for `--no-build-isolation`

### DIFF
--- a/PIP_COMPATIBILITY.md
+++ b/PIP_COMPATIBILITY.md
@@ -307,7 +307,6 @@ the implementation, and tend to be tracked in individual issues. For example:
 
 - [`--trusted-host`](https://github.com/astral-sh/uv/issues/1339)
 - [`--user`](https://github.com/astral-sh/uv/issues/2077)
-- [`--no-build-isolation`](https://github.com/astral-sh/uv/issues/1715)
 
 If you encounter a missing option or subcommand, please search the issue tracker to see if it has
 already been reported, and if not, consider opening a new issue. Feel free to upvote any existing

--- a/crates/uv-dev/src/build.rs
+++ b/crates/uv-dev/src/build.rs
@@ -15,7 +15,9 @@ use uv_dispatch::BuildDispatch;
 use uv_installer::NoBinary;
 use uv_interpreter::PythonEnvironment;
 use uv_resolver::InMemoryIndex;
-use uv_traits::{BuildContext, BuildKind, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
+use uv_traits::{
+    BuildContext, BuildIsolation, BuildKind, ConfigSettings, InFlight, NoBuild, SetupPyStrategy,
+};
 
 #[derive(Parser)]
 pub(crate) struct BuildArgs {
@@ -74,6 +76,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
         &in_flight,
         setup_py,
         &config_settings,
+        BuildIsolation::Isolated,
         &NoBuild::None,
         &NoBinary::None,
     );
@@ -87,6 +90,7 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
         args.sdist.display().to_string(),
         setup_py,
         config_settings.clone(),
+        BuildIsolation::Isolated,
         build_kind,
         FxHashMap::default(),
     )

--- a/crates/uv-dev/src/install_many.rs
+++ b/crates/uv-dev/src/install_many.rs
@@ -24,7 +24,7 @@ use uv_installer::{Downloader, NoBinary};
 use uv_interpreter::PythonEnvironment;
 use uv_normalize::PackageName;
 use uv_resolver::{DistFinder, InMemoryIndex};
-use uv_traits::{BuildContext, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
+use uv_traits::{BuildContext, BuildIsolation, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
 
 #[derive(Parser)]
 pub(crate) struct InstallManyArgs {
@@ -81,6 +81,7 @@ pub(crate) async fn install_many(args: InstallManyArgs) -> Result<()> {
         &in_flight,
         setup_py,
         &config_settings,
+        BuildIsolation::Isolated,
         &no_build,
         &NoBinary::None,
     );

--- a/crates/uv-dev/src/resolve_cli.rs
+++ b/crates/uv-dev/src/resolve_cli.rs
@@ -18,7 +18,7 @@ use uv_dispatch::BuildDispatch;
 use uv_installer::NoBinary;
 use uv_interpreter::PythonEnvironment;
 use uv_resolver::{InMemoryIndex, Manifest, Options, Resolver};
-use uv_traits::{ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
+use uv_traits::{BuildIsolation, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
 
 #[derive(ValueEnum, Default, Clone)]
 pub(crate) enum ResolveCliFormat {
@@ -85,6 +85,7 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
         &in_flight,
         SetupPyStrategy::default(),
         &config_settings,
+        BuildIsolation::Isolated,
         &no_build,
         &NoBinary::None,
     );

--- a/crates/uv-dev/src/resolve_many.rs
+++ b/crates/uv-dev/src/resolve_many.rs
@@ -21,7 +21,7 @@ use uv_installer::NoBinary;
 use uv_interpreter::PythonEnvironment;
 use uv_normalize::PackageName;
 use uv_resolver::InMemoryIndex;
-use uv_traits::{BuildContext, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
+use uv_traits::{BuildContext, BuildIsolation, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
 
 #[derive(Parser)]
 pub(crate) struct ResolveManyArgs {
@@ -109,6 +109,7 @@ pub(crate) async fn resolve_many(args: ResolveManyArgs) -> Result<()> {
                     &in_flight,
                     setup_py,
                     &config_settings,
+                    BuildIsolation::Isolated,
                     &no_build,
                     &NoBinary::None,
                 );

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -20,7 +20,9 @@ use uv_client::{FlatIndex, RegistryClient};
 use uv_installer::{Downloader, Installer, NoBinary, Plan, Planner, Reinstall, SitePackages};
 use uv_interpreter::{Interpreter, PythonEnvironment};
 use uv_resolver::{InMemoryIndex, Manifest, Options, Resolver};
-use uv_traits::{BuildContext, BuildKind, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
+use uv_traits::{
+    BuildContext, BuildIsolation, BuildKind, ConfigSettings, InFlight, NoBuild, SetupPyStrategy,
+};
 
 /// The main implementation of [`BuildContext`], used by the CLI, see [`BuildContext`]
 /// documentation.
@@ -33,6 +35,7 @@ pub struct BuildDispatch<'a> {
     index: &'a InMemoryIndex,
     in_flight: &'a InFlight,
     setup_py: SetupPyStrategy,
+    build_isolation: BuildIsolation<'a>,
     no_build: &'a NoBuild,
     no_binary: &'a NoBinary,
     config_settings: &'a ConfigSettings,
@@ -53,6 +56,7 @@ impl<'a> BuildDispatch<'a> {
         in_flight: &'a InFlight,
         setup_py: SetupPyStrategy,
         config_settings: &'a ConfigSettings,
+        build_isolation: BuildIsolation<'a>,
         no_build: &'a NoBuild,
         no_binary: &'a NoBinary,
     ) -> Self {
@@ -66,6 +70,7 @@ impl<'a> BuildDispatch<'a> {
             in_flight,
             setup_py,
             config_settings,
+            build_isolation,
             no_build,
             no_binary,
             source_build_context: SourceBuildContext::default(),
@@ -105,6 +110,10 @@ impl<'a> BuildContext for BuildDispatch<'a> {
 
     fn interpreter(&self) -> &Interpreter {
         self.interpreter
+    }
+
+    fn build_isolation(&self) -> BuildIsolation {
+        self.build_isolation
     }
 
     fn no_build(&self) -> &NoBuild {
@@ -180,7 +189,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
                 local,
                 remote,
                 reinstalls,
-                extraneous,
+                extraneous: _,
             } = Planner::with_requirements(&resolution.requirements()).build(
                 site_packages,
                 &Reinstall::None,
@@ -190,6 +199,12 @@ impl<'a> BuildContext for BuildDispatch<'a> {
                 venv,
                 tags,
             )?;
+
+            // Nothing to do.
+            if remote.is_empty() && local.is_empty() && reinstalls.is_empty() {
+                debug!("No build requirements to install for build");
+                return Ok(());
+            }
 
             // Resolve any registry-based requirements.
             let remote = remote
@@ -221,8 +236,8 @@ impl<'a> BuildContext for BuildDispatch<'a> {
             };
 
             // Remove any unnecessary packages.
-            if !extraneous.is_empty() || !reinstalls.is_empty() {
-                for dist_info in extraneous.iter().chain(reinstalls.iter()) {
+            if !reinstalls.is_empty() {
+                for dist_info in reinstalls.iter() {
                     let summary = uv_installer::uninstall(dist_info)
                         .await
                         .context("Failed to uninstall build dependencies")?;
@@ -295,6 +310,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
             package_id.to_string(),
             self.setup_py,
             self.config_settings.clone(),
+            self.build_isolation,
             build_kind,
             self.build_extra_env_vars.clone(),
         )

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -857,11 +857,6 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
             return Err(Error::NoBuild);
         }
 
-        // Lock the build context.
-        println!("Locking build context");
-        let mutex = self.build_context.mutex();
-        let lock = mutex.lock().await;
-
         // Build the wheel.
         fs::create_dir_all(&cache_shard)
             .await
@@ -880,8 +875,6 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
             .wheel(cache_shard)
             .await
             .map_err(|err| Error::Build(dist.to_string(), err))?;
-
-        drop(lock);
 
         // Read the metadata from the wheel.
         let filename = WheelFilename::from_str(&disk_filename)?;
@@ -908,16 +901,6 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
         subdirectory: Option<&Path>,
     ) -> Result<Option<Metadata21>, Error> {
         debug!("Preparing metadata for: {dist}");
-
-        // Lock the build context.
-        // let mutex;
-        // let _lock;
-        // if self.build_context.build_isolation().is_shared() {
-        //     mutex = self.build_context.mutex();
-        //     _lock = mutex.lock().await;
-        // }
-
-        // let _lock = self.build_context.lock().await;
 
         // Setup the builder.
         let mut builder = self

--- a/crates/uv-interpreter/src/python_environment.rs
+++ b/crates/uv-interpreter/src/python_environment.rs
@@ -1,6 +1,5 @@
 use std::env;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
 
 use tracing::debug;
 
@@ -16,7 +15,6 @@ use crate::{find_default_python, find_requested_python, Error, Interpreter};
 pub struct PythonEnvironment {
     root: PathBuf,
     interpreter: Interpreter,
-    lock: Arc<Mutex<()>>,
 }
 
 impl PythonEnvironment {
@@ -39,7 +37,6 @@ impl PythonEnvironment {
         Ok(Self {
             root: venv,
             interpreter,
-            lock: Arc::new(Mutex::default()),
         })
     }
 
@@ -55,7 +52,6 @@ impl PythonEnvironment {
         Ok(Self {
             root: interpreter.prefix().to_path_buf(),
             interpreter,
-            lock: Arc::new(Mutex::default()),
         })
     }
 
@@ -65,16 +61,14 @@ impl PythonEnvironment {
         Ok(Self {
             root: interpreter.prefix().to_path_buf(),
             interpreter,
-            lock: Arc::new(Mutex::default()),
         })
     }
 
     /// Create a [`PythonEnvironment`] from an existing [`Interpreter`] and root directory.
-    pub fn from_interpreter(interpreter: Interpreter, root: PathBuf) -> Self {
+    pub fn from_interpreter(interpreter: Interpreter) -> Self {
         Self {
-            root,
+            root: interpreter.prefix().to_path_buf(),
             interpreter,
-            lock: Arc::new(Mutex::default()),
         }
     }
 
@@ -107,11 +101,6 @@ impl PythonEnvironment {
     /// Returns the path to the `bin` directory inside a virtual environment.
     pub fn scripts(&self) -> &Path {
         self.interpreter.scripts()
-    }
-
-    /// Grab an in-memory lock for the virtual environment to prevent concurrent writes across threads.
-    pub fn acquire(&self) -> Arc<Mutex<()>> {
-        self.lock.clone()
     }
 
     /// Grab a file lock for the virtual environment to prevent concurrent writes across processes.

--- a/crates/uv-resolver/tests/resolver.rs
+++ b/crates/uv-resolver/tests/resolver.rs
@@ -21,7 +21,9 @@ use uv_resolver::{
     DisplayResolutionGraph, InMemoryIndex, Manifest, Options, OptionsBuilder, PreReleaseMode,
     ResolutionGraph, ResolutionMode, Resolver,
 };
-use uv_traits::{BuildContext, BuildKind, NoBinary, NoBuild, SetupPyStrategy, SourceBuildTrait};
+use uv_traits::{
+    BuildContext, BuildIsolation, BuildKind, NoBinary, NoBuild, SetupPyStrategy, SourceBuildTrait,
+};
 
 // Exclude any packages uploaded after this date.
 static EXCLUDE_NEWER: Lazy<DateTime<Utc>> = Lazy::new(|| {
@@ -55,6 +57,10 @@ impl BuildContext for DummyContext {
 
     fn interpreter(&self) -> &Interpreter {
         &self.interpreter
+    }
+
+    fn build_isolation(&self) -> BuildIsolation {
+        BuildIsolation::Isolated
     }
 
     fn no_build(&self) -> &NoBuild {

--- a/crates/uv-traits/src/lib.rs
+++ b/crates/uv-traits/src/lib.rs
@@ -6,10 +6,8 @@ use std::fmt::{Display, Formatter};
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
 
 use anyhow::Result;
-use tokio::sync::{Mutex, MutexGuard};
 
 use distribution_types::{CachedDist, DistributionId, IndexLocations, Resolution, SourceDist};
 use once_map::OnceMap;
@@ -56,14 +54,8 @@ use uv_normalize::PackageName;
 /// `uv-build` to depend on `uv-resolver` which having actual crate dependencies between
 /// them.
 
-// TODO(konstin): Proper error types
 pub trait BuildContext: Sync {
     type SourceDistBuilder: SourceBuildTrait + Send + Sync;
-
-    /// Return a mutex that can be used to lock the build context.
-    fn mutex(&self) -> Arc<Mutex<()>>;
-
-    fn lock(&self) -> impl Future<Output = Option<MutexGuard<'_, ()>>> + Send;
 
     /// Return a reference to the cache.
     fn cache(&self) -> &Cache;
@@ -156,9 +148,9 @@ pub enum BuildIsolation<'a> {
 }
 
 impl<'a> BuildIsolation<'a> {
-    /// Returns `true` if build isolation is not enforced.
-    pub fn is_shared(&self) -> bool {
-        matches!(self, Self::Shared(_))
+    /// Returns `true` if build isolation is enforced.
+    pub fn is_isolated(&self) -> bool {
+        matches!(self, Self::Isolated)
     }
 }
 

--- a/crates/uv-traits/src/lib.rs
+++ b/crates/uv-traits/src/lib.rs
@@ -64,6 +64,9 @@ pub trait BuildContext: Sync {
     /// it's metadata (e.g. wheel compatibility tags).
     fn interpreter(&self) -> &Interpreter;
 
+    /// Whether to enforce build isolation when building source distributions.
+    fn build_isolation(&self) -> BuildIsolation;
+
     /// Whether source distribution building is disabled. This [`BuildContext::setup_build`] calls
     /// will fail in this case. This method exists to avoid fetching source distributions if we know
     /// we can't build them
@@ -135,6 +138,13 @@ pub trait SourceBuildTrait {
 pub struct InFlight {
     /// The in-flight distribution downloads.
     pub downloads: OnceMap<DistributionId, Result<CachedDist, String>>,
+}
+
+/// Whether to enforce build isolation when building source distributions.
+#[derive(Debug, Copy, Clone)]
+pub enum BuildIsolation<'a> {
+    Isolated,
+    Shared(&'a PythonEnvironment),
 }
 
 /// The strategy to use when building source distributions that lack a `pyproject.toml`.

--- a/crates/uv-virtualenv/src/lib.rs
+++ b/crates/uv-virtualenv/src/lib.rs
@@ -64,6 +64,5 @@ pub fn create_venv(
 
     // Create the corresponding `PythonEnvironment`.
     let interpreter = interpreter.with_virtualenv(virtualenv);
-    let root = interpreter.prefix().to_path_buf();
-    Ok(PythonEnvironment::from_interpreter(interpreter, root))
+    Ok(PythonEnvironment::from_interpreter(interpreter))
 }

--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -30,7 +30,7 @@ use uv_resolver::{
     AnnotationStyle, DependencyMode, DisplayResolutionGraph, InMemoryIndex, Manifest,
     OptionsBuilder, PreReleaseMode, PythonRequirement, ResolutionMode, Resolver,
 };
-use uv_traits::{ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
+use uv_traits::{BuildIsolation, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
 use uv_warnings::warn_user;
 
 use crate::commands::reporters::{DownloadReporter, ResolverReporter};
@@ -213,6 +213,7 @@ pub(crate) async fn pip_compile(
         &in_flight,
         setup_py,
         &config_settings,
+        BuildIsolation::Isolated,
         no_build,
         &NoBinary::None,
     )

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -59,6 +59,7 @@ pub(crate) async fn pip_install(
     setup_py: SetupPyStrategy,
     connectivity: Connectivity,
     config_settings: &ConfigSettings,
+    no_build_isolation: bool,
     no_build: &NoBuild,
     no_binary: &NoBinary,
     strict: bool,
@@ -190,6 +191,13 @@ pub(crate) async fn pip_install(
         FlatIndex::from_entries(entries, tags)
     };
 
+    // Determine whether to enable build isolation.
+    let build_isolation = if no_build_isolation {
+        BuildIsolation::Shared(&venv)
+    } else {
+        BuildIsolation::Isolated
+    };
+
     // Create a shared in-memory index.
     let index = InMemoryIndex::default();
 
@@ -206,7 +214,7 @@ pub(crate) async fn pip_install(
         &in_flight,
         setup_py,
         config_settings,
-        BuildIsolation::Shared(&venv),
+        build_isolation,
         no_build,
         no_binary,
     )
@@ -290,7 +298,7 @@ pub(crate) async fn pip_install(
             &in_flight,
             setup_py,
             config_settings,
-            BuildIsolation::Shared(&venv),
+            build_isolation,
             no_build,
             no_binary,
         )

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -32,7 +32,7 @@ use uv_resolver::{
     DependencyMode, InMemoryIndex, Manifest, Options, OptionsBuilder, PreReleaseMode,
     ResolutionGraph, ResolutionMode, Resolver,
 };
-use uv_traits::{ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
+use uv_traits::{BuildIsolation, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
 
 use crate::commands::reporters::{DownloadReporter, InstallReporter, ResolverReporter};
 use crate::commands::{compile_bytecode, elapsed, ChangeEvent, ChangeEventKind, ExitStatus};
@@ -206,6 +206,7 @@ pub(crate) async fn pip_install(
         &in_flight,
         setup_py,
         config_settings,
+        BuildIsolation::Shared(&venv),
         no_build,
         no_binary,
     )
@@ -289,6 +290,7 @@ pub(crate) async fn pip_install(
             &in_flight,
             setup_py,
             config_settings,
+            BuildIsolation::Shared(&venv),
             no_build,
             no_binary,
         )

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -38,6 +38,7 @@ pub(crate) async fn pip_sync(
     setup_py: SetupPyStrategy,
     connectivity: Connectivity,
     config_settings: &ConfigSettings,
+    no_build_isolation: bool,
     no_build: &NoBuild,
     no_binary: &NoBinary,
     strict: bool,
@@ -135,6 +136,13 @@ pub(crate) async fn pip_sync(
     // Track in-flight downloads, builds, etc., across resolutions.
     let in_flight = InFlight::default();
 
+    // Determine whether to enable build isolation.
+    let build_isolation = if no_build_isolation {
+        BuildIsolation::Shared(&venv)
+    } else {
+        BuildIsolation::Isolated
+    };
+
     // Prep the build context.
     let build_dispatch = BuildDispatch::new(
         &client,
@@ -146,7 +154,7 @@ pub(crate) async fn pip_sync(
         &in_flight,
         setup_py,
         config_settings,
-        BuildIsolation::Isolated,
+        build_isolation,
         no_build,
         no_binary,
     );

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -20,7 +20,7 @@ use uv_installer::{
 };
 use uv_interpreter::{Interpreter, PythonEnvironment};
 use uv_resolver::InMemoryIndex;
-use uv_traits::{ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
+use uv_traits::{BuildIsolation, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
 
 use crate::commands::reporters::{DownloadReporter, FinderReporter, InstallReporter};
 use crate::commands::{compile_bytecode, elapsed, ChangeEvent, ChangeEventKind, ExitStatus};
@@ -146,6 +146,7 @@ pub(crate) async fn pip_sync(
         &in_flight,
         setup_py,
         config_settings,
+        BuildIsolation::Isolated,
         no_build,
         no_binary,
     );

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -21,7 +21,7 @@ use uv_fs::Simplified;
 use uv_installer::NoBinary;
 use uv_interpreter::{find_default_python, find_requested_python, Error};
 use uv_resolver::{InMemoryIndex, OptionsBuilder};
-use uv_traits::{BuildContext, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
+use uv_traits::{BuildContext, BuildIsolation, ConfigSettings, InFlight, NoBuild, SetupPyStrategy};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -172,6 +172,7 @@ async fn venv_impl(
             &in_flight,
             SetupPyStrategy::default(),
             &config_settings,
+            BuildIsolation::Isolated,
             &NoBuild::All,
             &NoBinary::None,
         )

--- a/crates/uv/src/compat/mod.rs
+++ b/crates/uv/src/compat/mod.rs
@@ -31,9 +31,6 @@ pub(crate) struct PipCompileCompatArgs {
     build_isolation: bool,
 
     #[clap(long, hide = true)]
-    no_build_isolation: bool,
-
-    #[clap(long, hide = true)]
     resolver: Option<Resolver>,
 
     #[clap(long, hide = true)]
@@ -115,12 +112,6 @@ impl CompatArgs for PipCompileCompatArgs {
             warn_user!(
                 "pip-compile's `--build-isolation` has no effect (uv always uses build isolation)."
             );
-        }
-
-        if self.no_build_isolation {
-            return Err(anyhow!(
-                "pip-compile's `--no-build-isolation` is unsupported (uv always uses build isolation)."
-            ));
         }
 
         if let Some(resolver) = self.resolver {

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -370,6 +370,12 @@ struct PipCompileArgs {
     #[clap(long)]
     legacy_setup_py: bool,
 
+    /// Disable isolation when building source distributions.
+    ///
+    /// Assumes that build dependencies specified by PEP 518 are already installed.
+    #[clap(long)]
+    no_build_isolation: bool,
+
     /// Don't build source distributions.
     ///
     /// When enabled, resolving will not run arbitrary code. The cached wheels of already-built
@@ -549,6 +555,12 @@ struct PipSyncArgs {
     /// `pyproject.toml`.
     #[clap(long)]
     legacy_setup_py: bool,
+
+    /// Disable isolation when building source distributions.
+    ///
+    /// Assumes that build dependencies specified by PEP 518 are already installed.
+    #[clap(long)]
+    no_build_isolation: bool,
 
     /// Don't build source distributions.
     ///
@@ -789,6 +801,12 @@ struct PipInstallArgs {
     /// `pyproject.toml`.
     #[clap(long)]
     legacy_setup_py: bool,
+
+    /// Disable isolation when building source distributions.
+    ///
+    /// Assumes that build dependencies specified by PEP 518 are already installed.
+    #[clap(long)]
+    no_build_isolation: bool,
 
     /// Don't build source distributions.
     ///
@@ -1358,6 +1376,7 @@ async fn run() -> Result<ExitStatus> {
                 } else {
                     Connectivity::Online
                 },
+                args.no_build_isolation,
                 &no_build,
                 args.python_version,
                 args.exclude_newer,
@@ -1411,6 +1430,7 @@ async fn run() -> Result<ExitStatus> {
                     Connectivity::Online
                 },
                 &config_settings,
+                args.no_build_isolation,
                 &no_build,
                 &no_binary,
                 args.strict,
@@ -1504,6 +1524,7 @@ async fn run() -> Result<ExitStatus> {
                     Connectivity::Online
                 },
                 &config_settings,
+                args.no_build_isolation,
                 &no_build,
                 &no_binary,
                 args.strict,


### PR DESCRIPTION
## Summary

This PR adds support for pip's `--no-build-isolation`. When enabled, build requirements won't be installed during PEP 517-style builds, but the source environment _will_ be used when executing the build steps themselves.

Closes https://github.com/astral-sh/uv/issues/1715.
