### PR TITLE
Fix uv-fs extras by removing dead code

### DIFF
--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -18,7 +18,7 @@ distribution-filename = { path = "../distribution-filename", features = ["serde"
 distribution-types = { path = "../distribution-types" }
 install-wheel-rs = { path = "../install-wheel-rs" }
 pep440_rs = { path = "../pep440-rs" }
-pep508_rs = { path =     "../pep508-rs" }
+pep508_rs = { path = "../pep508-rs" }
 platform-tags = { path = "../platform-tags" }
 uv-cache = { path = "../uv-cache" }
 uv-client = { path = "../uv-client" }
@@ -36,7 +36,7 @@ nanoid = { workspace = true }
 reqwest = { workspace = true }
 rmp-serde = { workspace = true }
 rustc-hash = { workspace = true }
-serde = { workspace = true , features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -13,20 +13,6 @@ pub use crate::path::*;
 
 mod path;
 
-/// Reads the contents of the file path into memory.
-///
-/// If the file path is `-`, then contents are read from stdin instead.
-pub async fn read(path: impl AsRef<Path>) -> std::io::Result<Vec<u8>> {
-    let path = path.as_ref();
-    if path == Path::new("-") {
-        let mut buf = Vec::with_capacity(1024);
-        std::io::stdin().read_to_end(&mut buf)?;
-        Ok(buf)
-    } else {
-        fs_err::tokio::read(path).await
-    }
-}
-
 /// Reads the contents of the file path into memory as a `String`.
 ///
 /// If the file path is `-`, then contents are read from stdin instead.


### PR DESCRIPTION
Running the pep508_rs tests was failing due to uv-fs depending on `fs_err::tokio` even when not selected. But the function that used it is unused anyway, so i removed it.