### PR TITLE
Fix parsing requirement where a variable follows an operator without a space

### DIFF
--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -1710,4 +1710,10 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn no_space_after_operator() {
+        let requirement = Requirement::from_str("pytest;'4.0'>=python_version").unwrap();
+        assert_eq!(requirement.to_string(), "pytest ; '4.0' >= python_version");
+    }
 }


### PR DESCRIPTION
Fix parsing `pytest;'4.0'>=python_version`, where previously the operator and the variable were incorrectly tokenized as one invalid operator.

Fixes #2247