### PR TITLE
Fix uv tokio extra, part 2

### DIFF
--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -1,5 +1,4 @@
 use std::fmt::Display;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 
 use fs2::FileExt;
@@ -13,24 +12,13 @@ pub use crate::path::*;
 
 mod path;
 
-/// Reads the contents of the file path into memory.
-///
-/// If the file path is `-`, then contents are read from stdin instead.
-pub async fn read(path: impl AsRef<Path>) -> std::io::Result<Vec<u8>> {
-    let path = path.as_ref();
-    if path == Path::new("-") {
-        let mut buf = Vec::with_capacity(1024);
-        std::io::stdin().read_to_end(&mut buf)?;
-        Ok(buf)
-    } else {
-        fs_err::tokio::read(path).await
-    }
-}
-
 /// Reads the contents of the file path into memory as a `String`.
 ///
 /// If the file path is `-`, then contents are read from stdin instead.
+#[cfg(feature = "tokio")]
 pub async fn read_to_string(path: impl AsRef<Path>) -> std::io::Result<String> {
+    use std::io::Read;
+
     let path = path.as_ref();
     if path == Path::new("-") {
         let mut buf = String::with_capacity(1024);


### PR DESCRIPTION
Follow to #2272 by adding the tokio gate to `read_to_string`.