### PR TITLE
Retry on python interpreter launch failures

### DIFF
--- a/crates/uv-installer/src/pip_compileall.py
+++ b/crates/uv-installer/src/pip_compileall.py
@@ -14,6 +14,10 @@ import warnings
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore")
+
+    # Successful launch check
+    print("Ready")
+
     # In rust, we provide one line per file to compile.
     for path in sys.stdin:
         # Remove trailing newlines.


### PR DESCRIPTION
Sometimes, the first time we read from the stdout of the bytecode compiler python subprocess, we get an empty string back (no newline). If we try to write to stdin, it will often be a broken pipe (#2245). After we got an empty string the first time, we will get the same empty string if we read a line again.

The details of this behavior are mysterious to me, but it seems that it can be identified by the first empty string. We check by inserting starting with a `Ready` message on the Python side. When we encounter the broken state, we discard the interpreter and try again.

We have to introduce a third timeout check for the interpreter launch itself.

Minimized test script:

```bash
#!/usr/bin/env bash

set -euo pipefail

while true; do
  date --iso-8601=seconds # Progress indicator
  rm -rf testenv
  target/profiling/uv venv testenv -q --python 3.12
  VIRTUAL_ENV=$PWD/testenv target/profiling/uv pip install -q --compile wheel==0.42.0
done
```

Run as

```
cargo build --profile profiling && bash compile_bug.sh
```

Fixes #2245