### PR TITLE
Fix Conda Python detection on Windows

### DIFF
--- a/crates/uv-interpreter/src/python_environment.rs
+++ b/crates/uv-interpreter/src/python_environment.rs
@@ -181,7 +181,7 @@ pub(crate) fn detect_python_executable(venv: impl AsRef<Path>) -> PathBuf {
         }
 
         // Fallback for Conda environments.
-        venv.to_path_buf()
+        venv.join("python.exe")
     } else {
         // Search for `python` in the `bin` directory.
         venv.join("bin").join("python")


### PR DESCRIPTION
## Summary

In #2102, I did some refactor, and changed a method to return the Python executable path rather than the parent directory path. But I missed this one codepath for Conda on Windows.

Closes https://github.com/astral-sh/uv/issues/2269.

## Test Plan

- Installed micromamba on my Windows machine.
- Reproduced the failure in the linked issue.
- Verified that `python.exe` exists at `${CONDA_PREFIX}\python.exe`.
- Ran with this change; installed successfully.
