### PR TITLE
uv-fs: transparently support reading UTF-16 files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,6 +973,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4186,6 +4195,7 @@ dependencies = [
  "assert_cmd",
  "assert_fs",
  "base64 0.21.7",
+ "byteorder",
  "chrono",
  "clap",
  "clap_complete_command",
@@ -4499,10 +4509,12 @@ name = "uv-fs"
 version = "0.0.1"
 dependencies = [
  "dunce",
+ "encoding_rs_io",
  "fs-err",
  "fs2",
  "junction",
  "tempfile",
+ "tokio",
  "tracing",
  "urlencoding",
  "uv-warnings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ derivative = { version = "2.2.0" }
 directories = { version = "5.0.1" }
 dunce = { version = "1.0.4" }
 either = { version = "1.9.0" }
+encoding_rs_io = { version = "0.1.7" }
 flate2 = { version = "1.0.28", default-features = false }
 fs-err = { version = "2.11.0" }
 fs2 = { version = "0.4.3" }

--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -359,7 +359,7 @@ impl RequirementsTxt {
                     read_url_to_string(&requirements_txt, client).await
                 }
             } else {
-                uv_fs::read_to_string(&requirements_txt)
+                uv_fs::read_to_string_transcode(&requirements_txt)
                     .await
                     .map_err(RequirementsTxtParserError::IO)
             }

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -16,13 +16,15 @@ workspace = true
 uv-warnings = { path = "../uv-warnings" }
 
 dunce = { workspace = true }
+encoding_rs_io = { workspace = true }
 fs-err = { workspace = true }
 fs2 = { workspace = true }
 junction = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true, optional = true }
 tracing = { workspace = true }
 urlencoding = { workspace = true }
 
 [features]
 default = []
-tokio = ["fs-err/tokio"]
+tokio = ["fs-err/tokio", "dep:tokio"]

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -82,7 +82,9 @@ pub fn normalize_path(path: impl AsRef<Path>) -> PathBuf {
 /// Windows Store. For example, if you install Python via the Windows Store, then run `python`
 /// and print the `sys.executable` path, you'll get a path like:
 ///
-///     `C:\Users\crmar\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.11_qbs5n2kfra8p0\python.exe`.
+/// ```text
+/// C:\Users\crmar\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.11_qbs5n2kfra8p0\python.exe
+/// ```
 ///
 /// Attempting to canonicalize this path will fail with `ErrorKind::Uncategorized`.
 pub fn canonicalize_executable(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
@@ -103,7 +105,9 @@ pub fn canonicalize_executable(path: impl AsRef<Path>) -> std::io::Result<PathBu
 fn is_windows_store_python(path: &Path) -> bool {
     /// Returns `true` if this is a Python executable shim installed via the Windows Store, like:
     ///
-    ///     `C:\Users\crmar\AppData\Local\Microsoft\WindowsApps\python3.exe`
+    /// ```text
+    /// C:\Users\crmar\AppData\Local\Microsoft\WindowsApps\python3.exe
+    /// ```
     fn is_windows_store_python_shim(path: &Path) -> bool {
         let mut components = path.components().rev();
 
@@ -137,7 +141,9 @@ fn is_windows_store_python(path: &Path) -> bool {
 
     /// Returns `true` if this is a Python executable installed via the Windows Store, like:
     ///
-    ///     `C:\Users\crmar\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.11_qbs5n2kfra8p0\python.exe`
+    /// ```text
+    /// C:\Users\crmar\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.11_qbs5n2kfra8p0\python.exe
+    /// ```
     fn is_windows_store_python_executable(path: &Path) -> bool {
         let mut components = path.components().rev();
 

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -82,6 +82,7 @@ tikv-jemallocator = { version = "0.5.4" }
 [dev-dependencies]
 assert_cmd = { version = "2.0.14" }
 assert_fs = { version = "1.1.0" }
+byteorder = { version = "1.5.0" }
 filetime = { version = "0.2.23" }
 indoc = { version = "2.0.4" }
 insta = { version = "1.36.1", features = ["filters", "json"] }


### PR DESCRIPTION
This PR tweaks uv to support reading `requirements.txt` regardless of
whether it is encoded as UTF-8 or UTF-16. This is particularly relevant
on Windows where `uv pip freeze > requirements.txt` will likely write a
UTF-16 encoded `requirements.txt` file.

There is some discussion on #1666 where it's suggested that perhaps
we should explicitly not support this. I didn't see that until I
had already put this PR together, but even so, I think it's worth
considering this. UTF-16 is predominant on Windows. It is very easy
to produce a UTF-16 encoded file. Moreover, there is an easy and well
specified way to recognize and transcode UTF-16 encoded data to UTF-8.

I think the downside of this is that it could encourage the use UTF-16
encoded `requirements.txt` files *in addition* to UTF-8 encoded
files, and it would probably be nice to converge and standardize on
one encoding. One possible alternative to this PR is that we provide
a better error message. Another alternative is to ensure that a
`-o/--output` flag exists for all commands (neither `uv pip freeze` nor
`pip freeze` have such a flag) so that users can always write output
to a file without relying on their environment's piping behavior.
(Although this last alternative seems a little sad to me.)

It's also worth noting the [PEP-0508] doesn't seem to mention file
encoding at all. So I think from a "do the standards allow this"
perspective, this change is OK.

Finally, `pip` itself seems to work with UTF-16 encoded
`requirements.txt` files.

I think I personally overall lean towards supporting UTF-16 for
`requirements.txt` files. In part because I think it smoothes out the
UX a little bit, in part because there is no obvious specification
(that I'm aware of) that mandates that these files are UTF-8, and
finally in part because `pip` supports it too.

Fixes #1666, Fixes #2276

[PEP-0508]: https://peps.python.org/pep-0508/
