### PR TITLE
Use reparse points to detect Windows installer shims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4604,6 +4604,7 @@ dependencies = [
  "uv-cache",
  "uv-fs",
  "which",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ url = { version = "2.5.0" }
 urlencoding = { version = "2.1.3" }
 walkdir = { version = "2.4.0" }
 which = { version = "6.0.0" }
+winapi = { version = "0.3.9" }
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 
 [patch.crates-io]

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -94,10 +94,90 @@ pub fn canonicalize_executable(path: impl AsRef<Path>) -> std::io::Result<PathBu
     }
 }
 
-/// Returns `true` if this is a Python executable installed via the Windows Store, like:
+/// Returns `true` if this is a Python executable or shim installed via the Windows Store, based on
+/// the path.
 ///
-///     `C:\Users\crmar\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.11_qbs5n2kfra8p0\python.exe`.
+/// This method does _not_ introspect the filesystem to determine if the shim is a redirect to the
+/// Windows Store installer. In other words, it assumes that the path represents a Python
+/// executable, not a redirect.
 fn is_windows_store_python(path: &Path) -> bool {
+    /// Returns `true` if this is a Python executable shim installed via the Windows Store, like:
+    ///
+    ///     `C:\Users\crmar\AppData\Local\Microsoft\WindowsApps\python3.exe`
+    fn is_windows_store_python_shim(path: &Path) -> bool {
+        let mut components = path.components().rev();
+
+        // Ex) `python.exe`, or `python3.exe`, or `python3.12.exe`
+        if !components
+            .next()
+            .and_then(|component| component.as_os_str().to_str())
+            .is_some_and(|component| component.starts_with("python"))
+        {
+            return false;
+        }
+
+        // Ex) `WindowsApps`
+        if !components
+            .next()
+            .is_some_and(|component| component.as_os_str() == "WindowsApps")
+        {
+            return false;
+        }
+
+        // Ex) `Microsoft`
+        if !components
+            .next()
+            .is_some_and(|component| component.as_os_str() == "Microsoft")
+        {
+            return false;
+        }
+
+        true
+    }
+
+    /// Returns `true` if this is a Python executable installed via the Windows Store, like:
+    ///
+    ///     `C:\Users\crmar\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.11_qbs5n2kfra8p0\python.exe`
+    fn is_windows_store_python_executable(path: &Path) -> bool {
+        let mut components = path.components().rev();
+
+        // Ex) `python.exe`
+        if !components
+            .next()
+            .and_then(|component| component.as_os_str().to_str())
+            .is_some_and(|component| component.starts_with("python"))
+        {
+            return false;
+        }
+
+        // Ex) `PythonSoftwareFoundation.Python.3.11_qbs5n2kfra8p0`
+        if !components
+            .next()
+            .and_then(|component| component.as_os_str().to_str())
+            .is_some_and(|component| component.starts_with("PythonSoftwareFoundation.Python.3."))
+        {
+            return false;
+        }
+
+        // Ex) `WindowsApps`
+        if !components
+            .next()
+            .is_some_and(|component| component.as_os_str() == "WindowsApps")
+        {
+            return false;
+        }
+
+        // Ex) `Microsoft`
+        if !components
+            .next()
+            .is_some_and(|component| component.as_os_str() == "Microsoft")
+        {
+            return false;
+        }
+
+        true
+    }
+
     if !cfg!(windows) {
         return false;
     }
@@ -106,43 +186,7 @@ fn is_windows_store_python(path: &Path) -> bool {
         return false;
     }
 
-    let mut components = path.components().rev();
-
-    // Ex) `python.exe`
-    if !components
-        .next()
-        .and_then(|component| component.as_os_str().to_str())
-        .is_some_and(|component| component.starts_with("python"))
-    {
-        return false;
-    }
-
-    // Ex) `PythonSoftwareFoundation.Python.3.11_qbs5n2kfra8p0`
-    if !components
-        .next()
-        .and_then(|component| component.as_os_str().to_str())
-        .is_some_and(|component| component.starts_with("PythonSoftwareFoundation.Python.3."))
-    {
-        return false;
-    }
-
-    // Ex) `WindowsApps`
-    if !components
-        .next()
-        .is_some_and(|component| component.as_os_str() == "WindowsApps")
-    {
-        return false;
-    }
-
-    // Ex) `Microsoft`
-    if !components
-        .next()
-        .is_some_and(|component| component.as_os_str() == "Microsoft")
-    {
-        return false;
-    }
-
-    true
+    is_windows_store_python_shim(path) || is_windows_store_python_executable(path)
 }
 
 #[cfg(test)]

--- a/crates/uv-interpreter/Cargo.toml
+++ b/crates/uv-interpreter/Cargo.toml
@@ -35,6 +35,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 which = { workspace = true}
+winapi = { workspace = true }
 
 [dev-dependencies]
 anyhow = { version = "1.0.80" }


### PR DESCRIPTION
## Summary

This PR enables use of the Windows Store Pythons even with `py` is not installed. Specifically, we need to ensure that the `python.exe` and `python3.exe` executables installed into the `C:\Users\crmar\AppData\Local\Microsoft\WindowsApp` directory _are_ used when they're not "App execution aliases" (which merely open the Windows Store, to help you install Python).

When `py` is installed, this isn't strictly necessary, since the "resolved" executables are discovered via `py`. These look like `C:\Users\crmar\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.11_qbs5n2kfra8p0\python.exe`.

Closes https://github.com/astral-sh/uv/issues/2264.

## Test Plan

- Removed all Python installations from my Windows machine.
- Uninstalled `py`.
- Enabled "App execution aliases".
- Verified that for both `cargo run venv --python python.exe` and `cargo run venv --python python3.exe`, `uv` exited with a failure that no Python could be found.
- Installed Python 3.10 via the Windows Store.
- Verified that the above commands succeeded without error.
- Verified that `cargo run venv --python python3.10.exe` _also_ succeeded.
