### PR TITLE
Move source distribution unpacking out of `build`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4282,7 +4282,6 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
- "uv-extract",
  "uv-fs",
  "uv-interpreter",
  "uv-traits",

--- a/crates/uv-build/Cargo.toml
+++ b/crates/uv-build/Cargo.toml
@@ -18,7 +18,6 @@ distribution-types = { path = "../distribution-types" }
 pep508_rs = { path = "../pep508-rs" }
 platform-host = { path = "../platform-host" }
 pypi-types = { path = "../pypi-types" }
-uv-extract = { path = "../uv-extract" }
 uv-fs = { path = "../uv-fs" }
 uv-interpreter = { path = "../uv-interpreter" }
 uv-traits = { path = "../uv-traits", features = ["serde"] }

--- a/crates/uv-dev/src/build.rs
+++ b/crates/uv-dev/src/build.rs
@@ -28,7 +28,7 @@ pub(crate) struct BuildArgs {
     /// Directory to story the built wheel in
     #[clap(short, long)]
     wheels: Option<PathBuf>,
-    /// The source distribution to build, either a directory or a source archive.
+    /// The source distribution to build, as a directory.
     sdist: PathBuf,
     /// The subdirectory to build within the source distribution.
     subdirectory: Option<PathBuf>,

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use tokio::task::JoinError;
 use zip::result::ZipError;
 
@@ -56,6 +57,8 @@ pub enum Error {
     DirWithoutEntrypoint,
     #[error("Failed to extract source distribution")]
     Extract(#[from] uv_extract::Error),
+    #[error("Source distribution not found at: {0}")]
+    NotFound(PathBuf),
 
     /// Should not occur; only seen when another task panicked.
     #[error("The task executor is broken, did some other task panic?")]

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -3283,7 +3283,6 @@ fn missing_editable_requirement() -> Result<()> {
 
     ----- stderr -----
     error: Failed to build editables
-      Caused by: Failed to build editable: file://[TEMP_DIR]/django-3.2.8.tar.gz
       Caused by: Source distribution not found at: /[TEMP_DIR]/django-3.2.8.tar.gz
     "###);
 


### PR DESCRIPTION
## Summary

If a user provides a source distribution via a direct path, it can either be an archive (like a `.tar.gz` or `.zip` file) or a directory. If the former, we need to extract (e.g., unzip) the contents at some point. Previously, this extraction was in `uv-build`; this PR lifts it up to the distribution database.

The first benefit here is that various methods that take the distribution are now simpler, as they can assume a directory.

The second benefit is that we no longer extract _multiple times_ when working with a source distribution. (Previously, if we tried to get the metadata, then fell back and built the wheel, we'd extract the wheel _twice_.)
