### PR TITLE
Added ability to select bytecode invalidation mode of generated .pyc

### DIFF
--- a/crates/uv-installer/src/compile.rs
+++ b/crates/uv-installer/src/compile.rs
@@ -32,7 +32,7 @@ pub enum CompileError {
     PythonSubcommand(#[source] io::Error),
     #[error("Failed to create temporary script file")]
     TempFile(#[source] io::Error),
-    #[error("Bytecode compilation failed, expected {0:?}, received: {1:?}")]
+    #[error(r#"Bytecode compilation failed, expected "{0}", received: "{1}""#)]
     WrongPath(String, String),
     #[error("Failed to write to Python {device}")]
     ChildStdio {

--- a/crates/uv-installer/src/pip_compileall.py
+++ b/crates/uv-installer/src/pip_compileall.py
@@ -9,6 +9,8 @@ which contains some vendored Python 2 code which fails to compile.
 """
 
 import compileall
+import os
+import py_compile
 import sys
 import warnings
 
@@ -17,6 +19,12 @@ with warnings.catch_warnings():
 
     # Successful launch check
     print("Ready")
+
+    # https://docs.python.org/3/library/py_compile.html#py_compile.PycInvalidationMode
+    # TIMESTAMP, CHECKED_HASH, UNCHECKED_HASH
+    mode = os.environ.get("PYC_INVALIDATION_MODE")
+    if mode is not None:
+        mode = py_compile.PycInvalidationMode[mode]
 
     # In rust, we provide one line per file to compile.
     for path in sys.stdin:
@@ -27,6 +35,6 @@ with warnings.catch_warnings():
         # Unlike pip, we set quiet=2, so we don't have to capture stdout.
         # We'd like to show those errors, but given that pip thinks that's totally fine,
         # we can't really change that.
-        success = compileall.compile_file(path, force=True, quiet=2)
+        success = compileall.compile_file(path, invalidation_mode=mode, force=True, quiet=2)
         # We're ready for the next file.
         print(path)

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -174,6 +174,20 @@ impl TestContext {
     pub fn python_kind(&self) -> &str {
         "python"
     }
+
+    /// Returns the site-packages folder inside the venv.
+    pub fn site_packages(&self) -> PathBuf {
+        if cfg!(unix) {
+            self.venv
+                .join("lib")
+                .join(format!("{}{}", self.python_kind(), self.python_version))
+                .join("site-packages")
+        } else if cfg!(windows) {
+            self.venv.join("Lib").join("site-packages")
+        } else {
+            unimplemented!("Only Windows and Unix are supported")
+        }
+    }
 }
 
 pub fn venv_to_interpreter(venv: &Path) -> PathBuf {

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -2950,7 +2950,7 @@ fn compile_invalid_pyc_invalidation_mode() -> Result<()> {
     requirements_txt.write_str("MarkupSafe==2.1.3")?;
 
     let mut filters = INSTA_FILTERS.to_vec();
-    let site_packages = context.site_packages().display().to_string();
+    let site_packages = regex::escape(&context.site_packages().display().to_string());
     filters.push((&site_packages, "[SITE-PACKAGES]"));
     filters.push((
         r#"\[SITE-PACKAGES\]/.*.py", received: "#,

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -2954,12 +2954,12 @@ fn compile_invalid_pyc_invalidation_mode() -> Result<()> {
         (site_packages.as_str(), "[SITE-PACKAGES]"),
         (
             r#"\[SITE-PACKAGES\].*.py", received: "#,
-            r#"[SITE-PACKAGES]/[FIRST-FILE]", received: "#
+            r#"[SITE-PACKAGES]/[FIRST-FILE]", received: "#,
         ),
     ]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
+    .into_iter()
+    .chain(INSTA_FILTERS.to_vec())
+    .collect();
 
     uv_snapshot!(filters, command(&context)
         .arg("requirements.txt")

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -2,7 +2,7 @@
 
 use fs_err as fs;
 use std::env::consts::EXE_SUFFIX;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 use anyhow::Result;
@@ -71,25 +71,6 @@ fn uninstall_command(context: &TestContext) -> Command {
     }
 
     command
-}
-
-/// Returns the site-packages folder inside the venv.
-fn site_packages(context: &TestContext) -> PathBuf {
-    if cfg!(unix) {
-        context
-            .venv
-            .join("lib")
-            .join(format!(
-                "{}{}",
-                context.python_kind(),
-                context.python_version
-            ))
-            .join("site-packages")
-    } else if cfg!(windows) {
-        context.venv.join("Lib").join("site-packages")
-    } else {
-        unimplemented!("Only Windows and Unix are supported")
-    }
 }
 
 #[test]
@@ -186,7 +167,8 @@ fn install() -> Result<()> {
     );
 
     // Counterpart for the `compile()` test.
-    assert!(!site_packages(&context)
+    assert!(!context
+        .site_packages()
         .join("markupsafe")
         .join("__pycache__")
         .join("__init__.cpython-312.pyc")
@@ -2946,13 +2928,54 @@ fn compile() -> Result<()> {
     "###
     );
 
-    assert!(site_packages(&context)
+    assert!(context
+        .site_packages()
         .join("markupsafe")
         .join("__pycache__")
         .join("__init__.cpython-312.pyc")
         .exists());
 
     context.assert_command("import markupsafe").success();
+
+    Ok(())
+}
+
+/// Test that the `PYC_INVALIDATION_MODE` option is recognized and that the error handling works.
+#[test]
+fn compile_invalid_pyc_invalidation_mode() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.touch()?;
+    requirements_txt.write_str("MarkupSafe==2.1.3")?;
+
+    let mut filters = INSTA_FILTERS.to_vec();
+    let site_packages = context.site_packages().display().to_string();
+    filters.push((&site_packages, "[SITE-PACKAGES]"));
+    filters.push((
+        r#"\[SITE-PACKAGES\]/.*.py", received: "#,
+        r#"[SITE-PACKAGES]/[FIRST-FILE]", received: "#,
+    ));
+
+    uv_snapshot!(filters, command(&context)
+        .arg("requirements.txt")
+        .arg("--compile")
+        .arg("--strict")
+        .env("PYC_INVALIDATION_MODE", "bogus"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Downloaded 1 package in [TIME]
+    Installed 1 package in [TIME]
+    error: Failed to bytecode compile [SITE-PACKAGES]
+      Caused by: Python process stderr:
+    Invalid value for PYC_INVALIDATION_MODE "bogus", valid are "TIMESTAMP", "CHECKED_HASH", "UNCHECKED_HASH":
+      Caused by: Bytecode compilation failed, expected "[SITE-PACKAGES]/[FIRST-FILE]", received: ""
+    "###
+    );
 
     Ok(())
 }

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -2949,13 +2949,17 @@ fn compile_invalid_pyc_invalidation_mode() -> Result<()> {
     requirements_txt.touch()?;
     requirements_txt.write_str("MarkupSafe==2.1.3")?;
 
-    let mut filters = INSTA_FILTERS.to_vec();
-    let site_packages = regex::escape(&context.site_packages().display().to_string());
-    filters.push((&site_packages, "[SITE-PACKAGES]"));
-    filters.push((
-        r#"\[SITE-PACKAGES\]/.*.py", received: "#,
-        r#"[SITE-PACKAGES]/[FIRST-FILE]", received: "#,
-    ));
+    let site_packages = regex::escape(&context.site_packages().simplified_display().to_string());
+    let filters: Vec<_> = [
+        (site_packages.as_str(), "[SITE-PACKAGES]"),
+        (
+            r#"\[SITE-PACKAGES\].*.py", received: "#,
+            r#"[SITE-PACKAGES]/[FIRST-FILE]", received: "#
+        ),
+    ]
+        .into_iter()
+        .chain(INSTA_FILTERS.to_vec())
+        .collect();
 
     uv_snapshot!(filters, command(&context)
         .arg("requirements.txt")

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -2949,7 +2949,14 @@ fn compile_invalid_pyc_invalidation_mode() -> Result<()> {
     requirements_txt.touch()?;
     requirements_txt.write_str("MarkupSafe==2.1.3")?;
 
-    let site_packages = regex::escape(&context.site_packages().simplified_display().to_string());
+    let site_packages = regex::escape(
+        &context
+            .site_packages()
+            .canonicalize()
+            .unwrap()
+            .simplified_display()
+            .to_string(),
+    );
     let filters: Vec<_> = [
         (site_packages.as_str(), "[SITE-PACKAGES]"),
         (


### PR DESCRIPTION
Since Python 3.7, deterministic pycs are possible (see [PEP 552](https://peps.python.org/pep-0552/))
To select the bytecode invalidation mode explicitly by env var:

    PYC_INVALIDATION_MODE=UNCHECKED_HASH uv pip install --compile ...

Valid values are TIMESTAMP (default), CHECKED_HASH, and UNCHECKED_HASH.
The latter options are useful for reproducible builds.
