### PR TITLE
Add a `-vv` log level and make `-v` more readable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3981,6 +3981,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3990,12 +4000,15 @@ dependencies = [
  "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ toml = { version = "0.8.8" }
 tracing = { version = "0.1.40" }
 tracing-durations-export = { version = "0.2.0", features = ["plot"] }
 tracing-indicatif = { version = "0.3.6" }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 tracing-tree = { version = "0.3.0" }
 unicode-width = { version = "0.1.11" }
 unscanny = { version = "0.1.0" }

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -16,7 +16,7 @@ use platform_host::Platform;
 use platform_tags::{Tags, TagsError};
 use pypi_types::Scheme;
 use uv_cache::{Cache, CacheBucket, CachedByTimestamp, Freshness, Timestamp};
-use uv_fs::write_atomic_sync;
+use uv_fs::{write_atomic_sync, Simplified};
 
 use crate::Error;
 use crate::Virtualenv;
@@ -453,20 +453,20 @@ impl InterpreterInfo {
                             debug!(
                                 "Cached interpreter info for Python {}, skipping probing: {}",
                                 cached.data.markers.python_full_version,
-                                executable.display()
+                                executable.simplified_display()
                             );
                             return Ok(cached.data);
                         }
 
                         debug!(
                             "Ignoring stale cached markers for: {}",
-                            executable.display()
+                            executable.simplified_display()
                         );
                     }
                     Err(err) => {
                         warn!(
                             "Broken cache entry at {}, removing: {err}",
-                            cache_entry.path().display()
+                            cache_entry.path().simplified_display()
                         );
                         let _ = fs_err::remove_file(cache_entry.path());
                     }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -809,11 +809,11 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
                         self.markers,
                     )?;
 
-                    for (package, version) in constraints.iter() {
-                        debug!("Adding transitive dependency: {package}{version}");
+                    for (dep_package, dep_version) in constraints.iter() {
+                        debug!("Adding transitive dependency for {package}{version}: {dep_package}{dep_version}");
 
                         // Emit a request to fetch the metadata for this package.
-                        self.visit_package(package, priorities, request_sink)
+                        self.visit_package(dep_package, priorities, request_sink)
                             .await?;
                     }
 

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -67,7 +67,7 @@ tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 tracing-durations-export = { workspace = true, features = ["plot"], optional = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["json"] }
 tracing-tree = { workspace = true }
 unicode-width = { workspace = true }
 url = { workspace = true }

--- a/crates/uv/src/logging.rs
+++ b/crates/uv/src/logging.rs
@@ -40,7 +40,7 @@ pub(crate) fn setup_logging(level: Level, duration: impl Layer<Registry> + Send 
                     tracing_subscriber::fmt::layer()
                         .without_time()
                         .with_target(false)
-                        .with_writer(std::io::sink),
+                        .with_writer(std::io::stderr),
                 )
                 .init();
         }

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -1261,7 +1261,7 @@ async fn run() -> Result<ExitStatus> {
             logging::Level::Default
         },
         duration_layer,
-    );
+    )?;
 
     // Configure the `Printer`, which controls user-facing output in the CLI.
     let printer = if cli.quiet {

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -68,6 +68,9 @@ struct Cli {
     quiet: bool,
 
     /// Use verbose output.
+    ///
+    /// You can configure fine-grained logging using the `RUST_LOG` environment variable.
+    /// (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
     #[arg(global = true, long, short, conflicts_with = "quiet")]
     verbose: bool,
 


### PR DESCRIPTION
Behind error messages, the debug log is the second most important resource to finding out what and why went wrong when there was a problem with uv. It is important to see which paths it has found and how the decisions in the resolver were made. I'm trying to improve the experience interacting with the debug log.

The hierarchical layer is verbose and hard to follow, so it's moved to the `-vv` extra verbose setting, while `-v` works like `RUST_LOG=uv=debug`.

For installing jupyter with a warm cache:

* Default: https://gist.github.com/konstin/4de6e466127311c5a5fc2f99c56a8e11
* `-v`: https://gist.github.com/konstin/e7bafe0ec7d07e47ba98a3865ae2ef3e
* `-vv`: https://gist.github.com/konstin/3ee1aaff37f91cceb6275dd5525f180e
Ideally, we would have `-v`, `-vv` and `-vvv`, but we're lacking the the `info!` layer for `-v`, so there's only two layers for now.

The `tracing_subcriber` formatter always print the current span, so i replaced it with a custom formatter.

![image](https://github.com/astral-sh/uv/assets/6826232/75f5cfd1-da7b-432e-b090-2f3916930dd1)

Best read commit-by-commit.
