### PR TITLE
Store choco cache in GitHub Actions cache

### DIFF
--- a/.github/workflows/system-install.yml
+++ b/.github/workflows/system-install.yml
@@ -251,6 +251,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: "Configure choco cache"
+        run: choco config set cacheLocation ./.choco-cache
+
+      - uses: actions/cache@v4
+        with:
+          path: ./.choco-cache
+          key: choco-cache
+
       - name: "Install Python"
         run: choco install python3 --verbose --version=3.9.13
 


### PR DESCRIPTION
This step is weirdly slow, perhaps it will go faster if we stash the download in GitHub.

Related unresolved issues in choco do not bode well:

- https://github.com/chocolatey/choco/issues/2015
- https://github.com/chocolatey/choco/issues/1390
- https://github.com/chocolatey/choco/issues/2134
