### PR TITLE
Add `Accept-Encoding: identity` to remaining stream paths

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -549,6 +549,13 @@ impl RegistryClient {
             .client
             .uncached()
             .get(url.clone())
+            .header(
+                // `reqwest` defaults to accepting compressed responses.
+                // Specify identity encoding to get consistent .whl downloading
+                // behavior from servers. ref: https://github.com/pypa/pip/pull/1688
+                "accept-encoding",
+                reqwest::header::HeaderValue::from_static("identity"),
+            )
             .build()
             .map_err(ErrorKind::from)?;
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -259,6 +259,13 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                     .cached_client()
                     .uncached()
                     .get(wheel.url.raw().clone())
+                    .header(
+                        // `reqwest` defaults to accepting compressed responses.
+                        // Specify identity encoding to get consistent .whl downloading
+                        // behavior from servers. ref: https://github.com/pypa/pip/pull/1688
+                        "accept-encoding",
+                        reqwest::header::HeaderValue::from_static("identity"),
+                    )
                     .build()?;
                 let cache_control = match self.client.connectivity() {
                     Connectivity::Online => CacheControl::from(

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -307,6 +307,13 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
             .cached_client()
             .uncached()
             .get(url.clone())
+            .header(
+                // `reqwest` defaults to accepting compressed responses.
+                // Specify identity encoding to get consistent .whl downloading
+                // behavior from servers. ref: https://github.com/pypa/pip/pull/1688
+                "accept-encoding",
+                reqwest::header::HeaderValue::from_static("identity"),
+            )
             .build()?;
         let manifest = self
             .client
@@ -410,6 +417,13 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
             .cached_client()
             .uncached()
             .get(url.clone())
+            .header(
+                // `reqwest` defaults to accepting compressed responses.
+                // Specify identity encoding to get consistent .whl downloading
+                // behavior from servers. ref: https://github.com/pypa/pip/pull/1688
+                "accept-encoding",
+                reqwest::header::HeaderValue::from_static("identity"),
+            )
             .build()?;
         let manifest = self
             .client


### PR DESCRIPTION
## Summary

Like #2319, there are a few other places where we attempt to stream a file.
