### PR TITLE
Avoid duplicating authorization header with netrc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,16 +2893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-netrc"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca0c58cd4b2978f9697dea94302e772399f559cd175356eb631cb6daaa0b6db"
-dependencies = [
- "reqwest-middleware",
- "rust-netrc",
-]
-
-[[package]]
 name = "reqwest-retry"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4328,6 +4318,7 @@ dependencies = [
  "async-trait",
  "async_http_range_reader",
  "async_zip",
+ "base64 0.21.7",
  "cache-key",
  "chrono",
  "distribution-filename",
@@ -4345,10 +4336,10 @@ dependencies = [
  "pypi-types",
  "reqwest",
  "reqwest-middleware",
- "reqwest-netrc",
  "reqwest-retry",
  "rkyv",
  "rmp-serde",
+ "rust-netrc",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,10 +78,10 @@ reflink-copy = { version = "0.1.14" }
 regex = { version = "1.10.2" }
 reqwest = { version = "0.11.23", default-features = false, features = ["json", "gzip", "brotli", "stream", "rustls-tls-native-roots"] }
 reqwest-middleware = { version = "0.2.4" }
-reqwest-netrc = { version = "0.1.1" }
 reqwest-retry = { version = "0.3.0" }
 rkyv = { version = "0.7.43", features = ["strict", "validation"] }
 rmp-serde = { version = "1.1.2" }
+rust-netrc = { version = "0.1.1" }
 rustc-hash = { version = "1.1.0" }
 same-file = { version = "1.0.6" }
 seahash = { version = "4.1.0" }

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 async_http_range_reader = { workspace = true }
 async_zip = { workspace = true, features = ["tokio"] }
+base64 = { workspace = true }
 chrono = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
@@ -30,10 +31,10 @@ html-escape = { workspace = true }
 http = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
-reqwest-netrc = { workspace = true }
 reqwest-retry = { workspace = true }
 rkyv = { workspace = true, features = ["strict", "validation"] }
 rmp-serde = { workspace = true }
+rust-netrc = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -8,7 +8,6 @@ use async_http_range_reader::AsyncHttpRangeReader;
 use futures::{FutureExt, TryStreamExt};
 use http::HeaderMap;
 use reqwest::{Client, ClientBuilder, Response, StatusCode};
-use reqwest_netrc::NetrcMiddleware;
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::RetryTransientMiddleware;
 use serde::{Deserialize, Serialize};
@@ -30,7 +29,7 @@ use uv_warnings::warn_user_once;
 
 use crate::cached_client::CacheControl;
 use crate::html::SimpleHtml;
-use crate::middleware::OfflineMiddleware;
+use crate::middleware::{NetrcMiddleware, OfflineMiddleware};
 use crate::remote_metadata::wheel_metadata_from_remote_zip;
 use crate::rkyvutil::OwnedArchive;
 use crate::{CachedClient, CachedClientError, Error, ErrorKind};
@@ -133,7 +132,7 @@ impl RegistryClientBuilder {
 
                 // Initialize the netrc middleware.
                 let client = if let Ok(netrc) = NetrcMiddleware::new() {
-                    client.with_init(netrc)
+                    client.with(netrc)
                 } else {
                     client
                 };


### PR DESCRIPTION
## Summary

The netrc middleware we added in https://github.com/astral-sh/uv/pull/2241 has a slight problem. If you include credentials in your index URL, _and_ in the netrc file, the crate blindly adds the netrc credentials as a header. And given the `ReqwestBuilder` API, this means you end up with _two_ `Authorization` headers, which always leads to an invalid request, though the exact failure can take different forms.

This PR removes the middleware crate in favor of our own middleware. Instead of using the `RequestInitialiser` API, we have to use the `Middleware` API, so that we can remove the header on the request itself.

Closes https://github.com/astral-sh/uv/issues/2323.

## Test Plan

- Verified that running against a private index with credentials in the URL (but no netrc file) worked without error.
- Verified that running against a private index with credentials in the netrc file (but not the URL) worked without error.
- Verified that running against a private index with a mix of credentials in  both _also_ worked without error.
