### PR TITLE
Rename and document venv discoveries

### DIFF
--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -6,7 +6,7 @@ use configparser::ini::Ini;
 use fs_err as fs;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, instrument, warn};
+use tracing::{debug, warn};
 
 use cache_key::digest;
 use install_wheel_rs::Layout;
@@ -18,9 +18,8 @@ use pypi_types::Scheme;
 use uv_cache::{Cache, CacheBucket, CachedByTimestamp, Freshness, Timestamp};
 use uv_fs::write_atomic_sync;
 
-use crate::python_environment::{detect_python_executable, detect_virtual_env};
-use crate::python_query::try_find_default_python;
-use crate::{find_requested_python, Error, PythonVersion, Virtualenv};
+use crate::Error;
+use crate::Virtualenv;
 
 /// A Python executable and its associated platform markers.
 #[derive(Debug, Clone)]
@@ -40,8 +39,12 @@ pub struct Interpreter {
 
 impl Interpreter {
     /// Detect the interpreter info for the given Python executable.
-    pub fn query(executable: &Path, platform: Platform, cache: &Cache) -> Result<Self, Error> {
-        let info = InterpreterInfo::query_cached(executable, cache)?;
+    pub fn query(
+        executable: impl AsRef<Path>,
+        platform: Platform,
+        cache: &Cache,
+    ) -> Result<Self, Error> {
+        let info = InterpreterInfo::query_cached(executable.as_ref(), cache)?;
 
         debug_assert!(
             info.sys_executable.is_absolute(),
@@ -101,112 +104,6 @@ impl Interpreter {
             sys_executable: virtualenv.executable,
             prefix: virtualenv.root,
             ..self
-        }
-    }
-
-    /// Find the best available Python interpreter to use.
-    ///
-    /// If no Python version is provided, we will use the first available interpreter.
-    ///
-    /// If a Python version is provided, we will first try to find an exact match. If
-    /// that cannot be found and a patch version was requested, we will look for a match
-    /// without comparing the patch version number. If that cannot be found, we fall back to
-    /// the first available version.
-    ///
-    /// See [`Self::find_version`] for details on the precedence of Python lookup locations.
-    #[instrument(skip_all, fields(?python_version))]
-    pub fn find_best(
-        python_version: Option<&PythonVersion>,
-        platform: &Platform,
-        cache: &Cache,
-    ) -> Result<Self, Error> {
-        if let Some(python_version) = python_version {
-            debug!(
-                "Starting interpreter discovery for Python {}",
-                python_version
-            );
-        } else {
-            debug!("Starting interpreter discovery for active Python");
-        }
-
-        // First, check for an exact match (or the first available version if no Python version was provided)
-        if let Some(interpreter) = Self::find_version(python_version, platform, cache)? {
-            return Ok(interpreter);
-        }
-
-        if let Some(python_version) = python_version {
-            // If that fails, and a specific patch version was requested try again allowing a
-            // different patch version
-            if python_version.patch().is_some() {
-                if let Some(interpreter) =
-                    Self::find_version(Some(&python_version.without_patch()), platform, cache)?
-                {
-                    return Ok(interpreter);
-                }
-            }
-
-            // If a Python version was requested but cannot be fulfilled, just take any version
-            if let Some(interpreter) = Self::find_version(None, platform, cache)? {
-                return Ok(interpreter);
-            }
-        }
-
-        Err(Error::PythonNotFound)
-    }
-
-    /// Find a Python interpreter.
-    ///
-    /// We check, in order, the following locations:
-    ///
-    /// - `VIRTUAL_ENV` and `CONDA_PREFIX`
-    /// - A `.venv` folder
-    /// - If a python version is given: `pythonx.y`
-    /// - `python3` (unix) or `python.exe` (windows)
-    ///
-    /// If `UV_TEST_PYTHON_PATH` is set, we will not check for Python versions in the
-    /// global PATH, instead we will search using the provided path. Virtual environments
-    /// will still be respected.
-    ///
-    /// If a version is provided and an interpreter cannot be found with the given version,
-    /// we will return [`None`].
-    pub(crate) fn find_version(
-        python_version: Option<&PythonVersion>,
-        platform: &Platform,
-        cache: &Cache,
-    ) -> Result<Option<Self>, Error> {
-        let version_matches = |interpreter: &Self| -> bool {
-            if let Some(python_version) = python_version {
-                // If a patch version was provided, check for an exact match
-                python_version.is_satisfied_by(interpreter)
-            } else {
-                // The version always matches if one was not provided
-                true
-            }
-        };
-
-        // Check if the venv Python matches.
-        if let Some(venv) = detect_virtual_env()? {
-            let executable = detect_python_executable(venv);
-            let interpreter = Self::query(&executable, platform.clone(), cache)?;
-
-            if version_matches(&interpreter) {
-                return Ok(Some(interpreter));
-            }
-        };
-
-        // Look for the requested version with by search for `python{major}.{minor}` in `PATH` on
-        // Unix and `py --list-paths` on Windows.
-        let interpreter = if let Some(python_version) = python_version {
-            find_requested_python(&python_version.string, platform, cache)?
-        } else {
-            try_find_default_python(platform, cache)?
-        };
-
-        if let Some(interpreter) = interpreter {
-            debug_assert!(version_matches(&interpreter));
-            Ok(Some(interpreter))
-        } else {
-            Ok(None)
         }
     }
 

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -1,3 +1,12 @@
+//! Find matching Python interpreter and query information about python interpreter.
+//!
+//! * The `venv` subcommand uses [`find_requested_python`] if `-p`/`--python` is used and
+//!   `find_default_python` otherwise.
+//! * The `compile` subcommand uses [`find_best_python`].
+//! * The `sync`, `install`, `uninstall`, `freeze`, `list` and `show` subcommands use
+//!   [`find_default_python`] when `--python` is used, [`find_default_python`] when `--system` is used
+//!   and the current venv by default.
+
 use std::ffi::OsString;
 use std::io;
 use std::path::PathBuf;
@@ -6,16 +15,16 @@ use std::process::ExitStatus;
 use thiserror::Error;
 
 pub use crate::cfg::PyVenvConfiguration;
+pub use crate::find_python::{find_best_python, find_default_python, find_requested_python};
 pub use crate::interpreter::Interpreter;
 pub use crate::python_environment::PythonEnvironment;
-pub use crate::python_query::{find_default_python, find_requested_python};
 pub use crate::python_version::PythonVersion;
 pub use crate::virtualenv::Virtualenv;
 
 mod cfg;
+mod find_python;
 mod interpreter;
 mod python_environment;
-mod python_query;
 mod python_version;
 mod virtualenv;
 

--- a/crates/uv-interpreter/src/python_environment.rs
+++ b/crates/uv-interpreter/src/python_environment.rs
@@ -10,7 +10,7 @@ use uv_fs::{LockedFile, Simplified};
 use crate::cfg::PyVenvConfiguration;
 use crate::{find_default_python, find_requested_python, Error, Interpreter};
 
-/// A Python environment, consisting of a Python [`Interpreter`] and a root directory.
+/// A Python environment, consisting of a Python [`Interpreter`] and its associated paths.
 #[derive(Debug, Clone)]
 pub struct PythonEnvironment {
     root: PathBuf,

--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -24,7 +24,7 @@ use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClientBuilder}
 use uv_dispatch::BuildDispatch;
 use uv_fs::Simplified;
 use uv_installer::{Downloader, NoBinary};
-use uv_interpreter::{Interpreter, PythonEnvironment, PythonVersion};
+use uv_interpreter::{find_best_python, PythonEnvironment, PythonVersion};
 use uv_normalize::{ExtraName, PackageName};
 use uv_resolver::{
     AnnotationStyle, DependencyMode, DisplayResolutionGraph, InMemoryIndex, Manifest,
@@ -132,7 +132,7 @@ pub(crate) async fn pip_compile(
 
     // Find an interpreter to use for building distributions
     let platform = Platform::current()?;
-    let interpreter = Interpreter::find_best(python_version.as_ref(), &platform, &cache)?;
+    let interpreter = find_best_python(python_version.as_ref(), &platform, &cache)?;
     debug!(
         "Using Python {} interpreter at {} for builds",
         interpreter.python_version(),


### PR DESCRIPTION
Preparing for #2058, i found it hard to follow where which discovery function gets called. I moved all the discovery functions to a `find_python` module (some exposed through `PythonEnvironment`) and documented which subcommand uses which python discovery strategy.

No functional changes.

![new uv-virtualenv docs page](https://github.com/astral-sh/uv/assets/6826232/cd56df8a-754d-4640-9e7a-e1f9baf6441c)
