### PR TITLE
 Use python from `python -m uv` as default 

### DIFF
--- a/crates/uv-interpreter/src/python_environment.rs
+++ b/crates/uv-interpreter/src/python_environment.rs
@@ -51,8 +51,8 @@ impl PythonEnvironment {
     }
 
     /// Create a [`PythonEnvironment`] for the default Python interpreter.
-    pub fn from_default_python(cache: &Cache) -> Result<Self, Error> {
-        let interpreter = find_default_python(cache)?;
+    pub fn from_default_python(cache: &Cache, system: bool) -> Result<Self, Error> {
+        let interpreter = find_default_python(cache, system)?;
         Ok(Self {
             root: interpreter.prefix().to_path_buf(),
             interpreter,

--- a/crates/uv-resolver/tests/resolver.rs
+++ b/crates/uv-resolver/tests/resolver.rs
@@ -120,8 +120,8 @@ async fn resolve(
     let flat_index = FlatIndex::default();
     let index = InMemoryIndex::default();
     // TODO(konstin): Should we also use the bootstrapped pythons here?
-    let real_interpreter =
-        find_default_python(&Cache::temp().unwrap()).expect("Expected a python to be installed");
+    let real_interpreter = find_default_python(&Cache::temp().unwrap(), false)
+        .expect("Expected a python to be installed");
     let interpreter = Interpreter::artificial(real_interpreter.platform().clone(), markers.clone());
     let build_context = DummyContext::new(Cache::temp()?, interpreter.clone());
     let resolver = Resolver::new(

--- a/crates/uv-virtualenv/src/main.rs
+++ b/crates/uv-virtualenv/src/main.rs
@@ -39,7 +39,7 @@ fn run() -> Result<(), uv_virtualenv::Error> {
             uv_interpreter::Error::NoSuchPython(python_request.to_string()),
         )?
     } else {
-        find_default_python(&cache)?
+        find_default_python(&cache, false)?
     };
     create_bare_venv(
         &location,

--- a/crates/uv/src/commands/pip_freeze.rs
+++ b/crates/uv/src/commands/pip_freeze.rs
@@ -26,12 +26,12 @@ pub(crate) fn pip_freeze(
     let venv = if let Some(python) = python {
         PythonEnvironment::from_requested_python(python, cache)?
     } else if system {
-        PythonEnvironment::from_default_python(cache)?
+        PythonEnvironment::from_default_python(cache, true)?
     } else {
         match PythonEnvironment::from_virtualenv(cache) {
             Ok(venv) => venv,
             Err(uv_interpreter::Error::VenvNotFound) => {
-                PythonEnvironment::from_default_python(cache)?
+                PythonEnvironment::from_default_python(cache, false)?
             }
             Err(err) => return Err(err.into()),
         }

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -110,7 +110,7 @@ pub(crate) async fn pip_install(
     let venv = if let Some(python) = python.as_ref() {
         PythonEnvironment::from_requested_python(python, &cache)?
     } else if system {
-        PythonEnvironment::from_default_python(&cache)?
+        PythonEnvironment::from_default_python(&cache, true)?
     } else {
         PythonEnvironment::from_virtualenv(&cache)?
     };

--- a/crates/uv/src/commands/pip_list.rs
+++ b/crates/uv/src/commands/pip_list.rs
@@ -37,12 +37,12 @@ pub(crate) fn pip_list(
     let venv = if let Some(python) = python {
         PythonEnvironment::from_requested_python(python, cache)?
     } else if system {
-        PythonEnvironment::from_default_python(cache)?
+        PythonEnvironment::from_default_python(cache, true)?
     } else {
         match PythonEnvironment::from_virtualenv(cache) {
             Ok(venv) => venv,
             Err(uv_interpreter::Error::VenvNotFound) => {
-                PythonEnvironment::from_default_python(cache)?
+                PythonEnvironment::from_default_python(cache, false)?
             }
             Err(err) => return Err(err.into()),
         }

--- a/crates/uv/src/commands/pip_show.rs
+++ b/crates/uv/src/commands/pip_show.rs
@@ -42,12 +42,12 @@ pub(crate) fn pip_show(
     let venv = if let Some(python) = python {
         PythonEnvironment::from_requested_python(python, cache)?
     } else if system {
-        PythonEnvironment::from_default_python(cache)?
+        PythonEnvironment::from_default_python(cache, true)?
     } else {
         match PythonEnvironment::from_virtualenv(cache) {
             Ok(venv) => venv,
             Err(uv_interpreter::Error::VenvNotFound) => {
-                PythonEnvironment::from_default_python(cache)?
+                PythonEnvironment::from_default_python(cache, false)?
             }
             Err(err) => return Err(err.into()),
         }

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -74,7 +74,7 @@ pub(crate) async fn pip_sync(
     let venv = if let Some(python) = python.as_ref() {
         PythonEnvironment::from_requested_python(python, &cache)?
     } else if system {
-        PythonEnvironment::from_default_python(&cache)?
+        PythonEnvironment::from_default_python(&cache, true)?
     } else {
         PythonEnvironment::from_virtualenv(&cache)?
     };

--- a/crates/uv/src/commands/pip_uninstall.rs
+++ b/crates/uv/src/commands/pip_uninstall.rs
@@ -44,7 +44,7 @@ pub(crate) async fn pip_uninstall(
     let venv = if let Some(python) = python.as_ref() {
         PythonEnvironment::from_requested_python(python, &cache)?
     } else if system {
-        PythonEnvironment::from_default_python(&cache)?
+        PythonEnvironment::from_default_python(&cache, true)?
     } else {
         PythonEnvironment::from_virtualenv(&cache)?
     };

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -102,7 +102,7 @@ async fn venv_impl(
             .ok_or(Error::NoSuchPython(python_request.to_string()))
             .into_diagnostic()?
     } else {
-        find_default_python(cache).into_diagnostic()?
+        find_default_python(cache, false).into_diagnostic()?
     };
 
     writeln!(

--- a/python/uv/__main__.py
+++ b/python/uv/__main__.py
@@ -22,6 +22,7 @@ def _detect_virtualenv() -> str:
 
     return ""
 
+
 def _run() -> None:
     uv = os.fsdecode(find_uv_bin())
 
@@ -30,6 +31,9 @@ def _run() -> None:
     if venv:
         env.setdefault("VIRTUAL_ENV", venv)
 
+    # When running with `python -m uv`, use this `python` as default.
+    env.setdefault("UV_DEFAULT_PYTHON", sys.executable)
+
     if sys.platform == "win32":
         import subprocess
 
@@ -37,7 +41,6 @@ def _run() -> None:
         sys.exit(completed_process.returncode)
     else:
         os.execvpe(uv, [uv, *sys.argv[1:]], env=env)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Python tools run with `python -m <tool>` will use this `python` as their default python, including pip, virtualenv and the built-in venv. Calling Python tools this way is common, the [pip docs](https://pip.pypa.io/en/stable/user_guide/) use `python -m pip` exclusively, the built-in venv can only be called this way and certain project layouts require `python -m pytest` over `pytest`. This python interpreter takes precedence over the currently active (v)env.

These tools are all written in python and read `sys.executable`. To emulate this, we're setting `UV_DEFAULT_PYTHON` in the python module-launcher shim and read it in the default python discovery, prioritizing it over the active venv. User can also set `UV_DEFAULT_PYTHON` for their own purposes.

The test covers only half of the feature since we don't build the python package before running the tests.

Fixes https://github.com/astral-sh/uv/issues/2058
Fixes https://github.com/astral-sh/uv/issues/2222