### PR TITLE
Initialize client lazily for remote requirements files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,7 +2816,6 @@ dependencies = [
  "pep508_rs",
  "regex",
  "reqwest",
- "reqwest-middleware",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/requirements-txt/Cargo.toml
+++ b/crates/requirements-txt/Cargo.toml
@@ -25,7 +25,6 @@ fs-err = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, optional = true }
-reqwest-middleware = { workspace = true, optional = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
@@ -42,7 +41,3 @@ serde_json = { version = "1.0.114" }
 tempfile = { version = "3.9.0" }
 test-case = { version = "3.3.1" }
 tokio = { version = "1.35.1", features = ["macros"] }
-
-[features]
-default = []
-reqwest = ["dep:reqwest", "dep:reqwest-middleware"]

--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -84,11 +84,6 @@ pub(crate) async fn pip_compile(
         ));
     }
 
-    // Initialize the registry client.
-    let client = RegistryClientBuilder::new(cache.clone())
-        .connectivity(connectivity)
-        .build();
-
     // Read all requirements from the provided sources.
     let RequirementsSpecification {
         project,
@@ -106,7 +101,7 @@ pub(crate) async fn pip_compile(
         constraints,
         overrides,
         &extras,
-        &client,
+        connectivity,
     )
     .await?;
 
@@ -191,9 +186,11 @@ pub(crate) async fn pip_compile(
     let index_locations =
         index_locations.combine(index_url, extra_index_urls, find_links, no_index);
 
-    // Update the index URLs on the client, to take into account any index URLs added by the
-    // sources (e.g., `--index-url` in a `requirements.txt` file).
-    let client = client.with_index_url(index_locations.index_urls());
+    // Initialize the registry client.
+    let client = RegistryClientBuilder::new(cache.clone())
+        .connectivity(connectivity)
+        .index_urls(index_locations.index_urls())
+        .build();
 
     // Resolve the flat indexes from `--find-links`.
     let flat_index = {

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -50,11 +50,6 @@ pub(crate) async fn pip_sync(
 ) -> Result<ExitStatus> {
     let start = std::time::Instant::now();
 
-    // Initialize the registry client.
-    let client = RegistryClientBuilder::new(cache.clone())
-        .connectivity(connectivity)
-        .build();
-
     // Read all requirements from the provided sources.
     let RequirementsSpecification {
         project: _project,
@@ -67,7 +62,7 @@ pub(crate) async fn pip_sync(
         no_index,
         find_links,
         extras: _extras,
-    } = RequirementsSpecification::from_simple_sources(sources, &client).await?;
+    } = RequirementsSpecification::from_simple_sources(sources, connectivity).await?;
 
     let num_requirements = requirements.len() + editables.len();
     if num_requirements == 0 {
@@ -119,9 +114,11 @@ pub(crate) async fn pip_sync(
     let index_locations =
         index_locations.combine(index_url, extra_index_urls, find_links, no_index);
 
-    // Update the index URLs on the client, to take into account any index URLs added by the
-    // sources (e.g., `--index-url` in a `requirements.txt` file).
-    let client = client.with_index_url(index_locations.index_urls());
+    // Initialize the registry client.
+    let client = RegistryClientBuilder::new(cache.clone())
+        .connectivity(connectivity)
+        .index_urls(index_locations.index_urls())
+        .build();
 
     // Resolve the flat indexes from `--find-links`.
     let flat_index = {

--- a/crates/uv/src/commands/pip_uninstall.rs
+++ b/crates/uv/src/commands/pip_uninstall.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 use distribution_types::{InstalledMetadata, Name};
 use platform_host::Platform;
 use uv_cache::Cache;
-use uv_client::{Connectivity, RegistryClientBuilder};
+use uv_client::Connectivity;
 use uv_fs::Simplified;
 use uv_interpreter::PythonEnvironment;
 
@@ -27,11 +27,6 @@ pub(crate) async fn pip_uninstall(
 ) -> Result<ExitStatus> {
     let start = std::time::Instant::now();
 
-    // Initialize the registry client.
-    let client: uv_client::RegistryClient = RegistryClientBuilder::new(cache.clone())
-        .connectivity(connectivity)
-        .build();
-
     // Read all requirements from the provided sources.
     let RequirementsSpecification {
         project: _project,
@@ -44,7 +39,7 @@ pub(crate) async fn pip_uninstall(
         no_index: _no_index,
         find_links: _find_links,
         extras: _extras,
-    } = RequirementsSpecification::from_simple_sources(sources, &client).await?;
+    } = RequirementsSpecification::from_simple_sources(sources, connectivity).await?;
 
     // Detect the current Python interpreter.
     let platform = Platform::current()?;

--- a/crates/uv/src/requirements.rs
+++ b/crates/uv/src/requirements.rs
@@ -12,7 +12,7 @@ use tracing::{instrument, Level};
 use distribution_types::{FlatIndexLocation, IndexUrl};
 use pep508_rs::Requirement;
 use requirements_txt::{EditableRequirement, FindLink, RequirementsTxt};
-use uv_client::RegistryClient;
+use uv_client::Connectivity;
 use uv_fs::Simplified;
 use uv_normalize::{ExtraName, PackageName};
 use uv_warnings::warn_user;
@@ -142,7 +142,7 @@ impl RequirementsSpecification {
     pub(crate) async fn from_source(
         source: &RequirementsSource,
         extras: &ExtrasSpecification<'_>,
-        client: &RegistryClient,
+        connectivity: Connectivity,
     ) -> Result<Self> {
         Ok(match source {
             RequirementsSource::Package(name) => {
@@ -179,7 +179,7 @@ impl RequirementsSpecification {
             }
             RequirementsSource::RequirementsTxt(path) => {
                 let requirements_txt =
-                    RequirementsTxt::parse(path, std::env::current_dir()?, Some(client)).await?;
+                    RequirementsTxt::parse(path, std::env::current_dir()?, connectivity).await?;
                 Self {
                     project: None,
                     requirements: requirements_txt
@@ -281,7 +281,7 @@ impl RequirementsSpecification {
         constraints: &[RequirementsSource],
         overrides: &[RequirementsSource],
         extras: &ExtrasSpecification<'_>,
-        client: &RegistryClient,
+        connectivity: Connectivity,
     ) -> Result<Self> {
         let mut spec = Self::default();
 
@@ -289,7 +289,7 @@ impl RequirementsSpecification {
         // A `requirements.txt` can contain a `-c constraints.txt` directive within it, so reading
         // a requirements file can also add constraints.
         for source in requirements {
-            let source = Self::from_source(source, extras, client).await?;
+            let source = Self::from_source(source, extras, connectivity).await?;
             spec.requirements.extend(source.requirements);
             spec.constraints.extend(source.constraints);
             spec.overrides.extend(source.overrides);
@@ -316,7 +316,7 @@ impl RequirementsSpecification {
 
         // Read all constraints, treating _everything_ as a constraint.
         for source in constraints {
-            let source = Self::from_source(source, extras, client).await?;
+            let source = Self::from_source(source, extras, connectivity).await?;
             spec.constraints.extend(source.requirements);
             spec.constraints.extend(source.constraints);
             spec.constraints.extend(source.overrides);
@@ -336,7 +336,7 @@ impl RequirementsSpecification {
 
         // Read all overrides, treating both requirements _and_ constraints as overrides.
         for source in overrides {
-            let source = Self::from_source(source, extras, client).await?;
+            let source = Self::from_source(source, extras, connectivity).await?;
             spec.overrides.extend(source.requirements);
             spec.overrides.extend(source.constraints);
             spec.overrides.extend(source.overrides);
@@ -360,9 +360,16 @@ impl RequirementsSpecification {
     /// Read the requirements from a set of sources.
     pub(crate) async fn from_simple_sources(
         requirements: &[RequirementsSource],
-        client: &RegistryClient,
+        connectivity: Connectivity,
     ) -> Result<Self> {
-        Self::from_sources(requirements, &[], &[], &ExtrasSpecification::None, client).await
+        Self::from_sources(
+            requirements,
+            &[],
+            &[],
+            &ExtrasSpecification::None,
+            connectivity,
+        )
+        .await
     }
 }
 
@@ -449,7 +456,8 @@ pub(crate) async fn read_lockfile(
 
     // Parse the requirements from the lockfile.
     let requirements_txt =
-        RequirementsTxt::parse(output_file, std::env::current_dir()?, None).await?;
+        RequirementsTxt::parse(output_file, std::env::current_dir()?, Connectivity::Offline)
+            .await?;
     let requirements = requirements_txt
         .requirements
         .into_iter()

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1499,8 +1499,7 @@ fn install_constraints_respects_offline_mode() {
     ----- stdout -----
 
     ----- stderr -----
-    error: Error while accessing remote requirements file http://example.com/requirements.txt: Middleware error: Network connectivity is disabled, but the requested data wasn't found in the cache for: `http://example.com/requirements.txt`
-      Caused by: Network connectivity is disabled, but the requested data wasn't found in the cache for: `http://example.com/requirements.txt`
+    error: Network connectivity is disabled, but a remote requirements file was requested: http://example.com/requirements.txt
     "###
     );
 }


### PR DESCRIPTION
## Summary

We now initialize an HTTP client in advance for remote requirements files. It turns out this adds a significant overhead, even for operations like auditing the environment (at least on macOS).

This PR makes initialization lazy. After a lot of evaluation, I took the easiest route, which is: we just pass in `Connectivity`, and then use the default HTTP client. So we won't respect netrc files and anything else that we get from our registry client. If we want to keep using the registry client, we _can_, it's just way more ceremony to pass down a closure.

See: https://github.com/astral-sh/uv/issues/2346.

## Test Plan

- Verified that `cargo run pip compile https://raw.githubusercontent.com/ansible/ansible/f1ded0f41759235eb15a7d13dbc3c95dce5d5acd/requirements.txt` completed without error.
- Verified that `cargo run pip compile https://raw.githubusercontent.com/ansible/ansible/f1ded0f41759235eb15a7d13dbc3c95dce5d5acd/requirements.txt --offline` failed with an error.
- Verified that `./target/release/uv pip install requests` completed in 0-2ms, rather than hundreds.
