### PR TITLE
Add env UV_SYSTEM as alias to --system

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,10 +399,10 @@ uv accepts the following command-line arguments as environment variables:
   cache for any operations.
 - `UV_PRERELEASE`: Equivalent to the `--prerelease` command-line argument. If set to `allow`, uv
   will allow pre-release versions for all dependencies.
-- `UV_SYSTEM`:  Equivalent to the `--system` command-line argument. If set to `true`, uv
-  will  use the first Python found in the system `PATH`. WARNING: `UV_SYSTEM=true` is intended 
-  for use in continuous integration (CI) environments and should be used with caution, as it can 
-  modify the system Python installation.
+- `UV_SYSTEM_PYTHON`:  Equivalent to the `--system` command-line argument. If set to `true`, uv
+  will use the first Python interpreter found in the system `PATH`.
+  WARNING: `UV_SYSTEM=true` is intended for use in continuous integration (CI) environments and
+  should be used with caution, as it can modify the system Python installation.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 

--- a/README.md
+++ b/README.md
@@ -399,6 +399,10 @@ uv accepts the following command-line arguments as environment variables:
   cache for any operations.
 - `UV_PRERELEASE`: Equivalent to the `--prerelease` command-line argument. If set to `allow`, uv
   will allow pre-release versions for all dependencies.
+- `UV_SYSTEM`:  Equivalent to the `--system` command-line argument. If set to `true`, uv
+  will  use the first Python found in the system `PATH`. WARNING: `UV_SYSTEM=true` is intended 
+  for use in continuous integration (CI) environments and should be used with caution, as it can 
+  modify the system Python installation.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -542,7 +542,12 @@ struct PipSyncArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
+    #[clap(
+        long,
+        conflicts_with = "python",
+        env = "UV_SYSTEM",
+        group = "discovery"
+    )]
     system: bool,
 
     /// Allow `uv` to modify an `EXTERNALLY-MANAGED` Python installation.
@@ -788,7 +793,12 @@ struct PipInstallArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
+    #[clap(
+        long,
+        conflicts_with = "python",
+        env = "UV_SYSTEM",
+        group = "discovery"
+    )]
     system: bool,
 
     /// Allow `uv` to modify an `EXTERNALLY-MANAGED` Python installation.
@@ -916,7 +926,12 @@ struct PipUninstallArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
+    #[clap(
+        long,
+        conflicts_with = "python",
+        env = "UV_SYSTEM",
+        group = "discovery"
+    )]
     system: bool,
 
     /// Allow `uv` to modify an `EXTERNALLY-MANAGED` Python installation.
@@ -970,7 +985,12 @@ struct PipFreezeArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution.
-    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
+    #[clap(
+        long,
+        conflicts_with = "python",
+        env = "UV_SYSTEM",
+        group = "discovery"
+    )]
     system: bool,
 }
 
@@ -1027,7 +1047,12 @@ struct PipListArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution.
-    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
+    #[clap(
+        long,
+        conflicts_with = "python",
+        env = "UV_SYSTEM",
+        group = "discovery"
+    )]
     system: bool,
 }
 
@@ -1071,7 +1096,12 @@ struct PipShowArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution.
-    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
+    #[clap(
+        long,
+        conflicts_with = "python",
+        env = "UV_SYSTEM",
+        group = "discovery"
+    )]
     system: bool,
 }
 
@@ -1105,7 +1135,12 @@ struct VenvArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
+    #[clap(
+        long,
+        conflicts_with = "python",
+        env = "UV_SYSTEM",
+        group = "discovery"
+    )]
     system: bool,
 
     /// Install seed packages (`pip`, `setuptools`, and `wheel`) into the virtual environment.

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -545,7 +545,7 @@ struct PipSyncArgs {
     #[clap(
         long,
         conflicts_with = "python",
-        env = "UV_SYSTEM",
+        env = "UV_SYSTEM_PYTHON",
         group = "discovery"
     )]
     system: bool,
@@ -796,7 +796,7 @@ struct PipInstallArgs {
     #[clap(
         long,
         conflicts_with = "python",
-        env = "UV_SYSTEM",
+        env = "UV_SYSTEM_PYTHON",
         group = "discovery"
     )]
     system: bool,
@@ -929,7 +929,7 @@ struct PipUninstallArgs {
     #[clap(
         long,
         conflicts_with = "python",
-        env = "UV_SYSTEM",
+        env = "UV_SYSTEM_PYTHON",
         group = "discovery"
     )]
     system: bool,
@@ -988,7 +988,7 @@ struct PipFreezeArgs {
     #[clap(
         long,
         conflicts_with = "python",
-        env = "UV_SYSTEM",
+        env = "UV_SYSTEM_PYTHON",
         group = "discovery"
     )]
     system: bool,
@@ -1050,7 +1050,7 @@ struct PipListArgs {
     #[clap(
         long,
         conflicts_with = "python",
-        env = "UV_SYSTEM",
+        env = "UV_SYSTEM_PYTHON",
         group = "discovery"
     )]
     system: bool,
@@ -1099,7 +1099,7 @@ struct PipShowArgs {
     #[clap(
         long,
         conflicts_with = "python",
-        env = "UV_SYSTEM",
+        env = "UV_SYSTEM_PYTHON",
         group = "discovery"
     )]
     system: bool,
@@ -1138,7 +1138,7 @@ struct VenvArgs {
     #[clap(
         long,
         conflicts_with = "python",
-        env = "UV_SYSTEM",
+        env = "UV_SYSTEM_PYTHON",
         group = "discovery"
     )]
     system: bool,

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -542,7 +542,7 @@ struct PipSyncArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[clap(long, conflicts_with = "python", group = "discovery")]
+    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
     system: bool,
 
     /// Allow `uv` to modify an `EXTERNALLY-MANAGED` Python installation.
@@ -788,7 +788,7 @@ struct PipInstallArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[clap(long, conflicts_with = "python", group = "discovery")]
+    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
     system: bool,
 
     /// Allow `uv` to modify an `EXTERNALLY-MANAGED` Python installation.
@@ -916,7 +916,7 @@ struct PipUninstallArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[clap(long, conflicts_with = "python", group = "discovery")]
+    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
     system: bool,
 
     /// Allow `uv` to modify an `EXTERNALLY-MANAGED` Python installation.
@@ -970,7 +970,7 @@ struct PipFreezeArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution.
-    #[clap(long, conflicts_with = "python", group = "discovery")]
+    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
     system: bool,
 }
 
@@ -1027,7 +1027,7 @@ struct PipListArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution.
-    #[clap(long, conflicts_with = "python", group = "discovery")]
+    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
     system: bool,
 }
 
@@ -1071,7 +1071,7 @@ struct PipShowArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution.
-    #[clap(long, conflicts_with = "python", group = "discovery")]
+    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
     system: bool,
 }
 
@@ -1105,7 +1105,7 @@ struct VenvArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[clap(long, conflicts_with = "python", group = "discovery")]
+    #[clap(long, conflicts_with = "python", env="UV_SYSTEM", group = "discovery")]
     system: bool,
 
     /// Install seed packages (`pip`, `setuptools`, and `wheel`) into the virtual environment.


### PR DESCRIPTION
## Summary

Add a new env variable `UV_SYSTEM` as alias for the cli argument
`--system`.
Use cases:
- No need to specify on each uv call inside the docker container the
`--system` flag
- It allows installing and configuring uv in a base container and in the
child containers nobody needs to know if you need the `--system` cli
flag
- The Home Assistant development env can be set up via devcontainer or a
venv. Both use some common scripts. Instead of adding duplicate or
special code to identify the dev container to set the `--system` flag,
it would be nicer to set it via an env variable.

I'm unfamiliar with Rust and tried to add the support by looking at the
code.

## Test Plan

I did test it manually
`UV_SYSTEM_PYTHON=true uv pip install requests`
