### PR TITLE
Ignore inverse dependencies when building graph

### DIFF
--- a/crates/uv-resolver/src/resolution.rs
+++ b/crates/uv-resolver/src/resolution.rs
@@ -213,6 +213,14 @@ impl ResolutionGraph {
                     dependency_range,
                 ) = &state.incompatibility_store[*id].kind
                 {
+                    // `Kind::FromDependencyOf` will include inverse dependencies. That is, if we're
+                    // looking for a package `A`, this list will include incompatibilities of
+                    // package `B` _depending on_ `A`. We're only interested in packages that `A`
+                    // depends on.
+                    if package != self_package {
+                        continue;
+                    }
+
                     let PubGrubPackage::Package(self_package, _, _) = self_package else {
                         continue;
                     };


### PR DESCRIPTION
## Summary

It turns out that when we iterate over the incompatibilities of a package, PubGrub will _also_ show us the inverse dependencies. I suspect this was rare, because we have a version check at the bottom... So, this specifically required that you had some dependency that didn't end up appearing in the output resolution, but that matched the version constraints of the package you care about.

In this case, `langchain-community` depends on `langchain-core`. So we were seeing an incompatibility like:

```rust
FromDependencyOf(Package(PackageName("langchain-community"), None, None), Range { segments: [(Included("0.0.10"), Included("0.0.10")), (Included("0.0.11"), Included("0.0.11"))] }, Package(PackageName("langchain-core"), None, None), Range { segments: [(Included("0.1.8"), Excluded("0.2"))] })
```

Where we were iterating over `langchain-core`, and looking for version `0.0.11`... which happens to match `langchain-community`. (`langchain-community was omitted from the resolution; hence, it didn't exist in the map.)

Closes https://github.com/astral-sh/uv/issues/2358.
