### PR TITLE
Enable TLS native root toggling at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4361,6 +4361,8 @@ dependencies = [
  "rmp-serde",
  "rust-netrc",
  "rustc-hash",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2",
@@ -4379,6 +4381,7 @@ dependencies = [
  "uv-normalize",
  "uv-version",
  "uv-warnings",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,6 +2880,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -4934,6 +4935,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "weezl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ rand = { version = "0.8.5" }
 rayon = { version = "1.8.0" }
 reflink-copy = { version = "0.1.15" }
 regex = { version = "1.10.2" }
-reqwest = { version = "0.11.23", default-features = false, features = ["json", "gzip", "brotli", "stream", "rustls-tls-native-roots"] }
+reqwest = { version = "0.11.23", default-features = false, features = ["json", "gzip", "brotli", "stream", "rustls-tls", "rustls-tls-native-roots"] }
 reqwest-middleware = { version = "0.2.4" }
 reqwest-retry = { version = "0.3.0" }
 rkyv = { version = "0.7.43", features = ["strict", "validation"] }

--- a/README.md
+++ b/README.md
@@ -425,13 +425,18 @@ In addition, uv respects the following environment variables:
 
 ## Custom CA Certificates
 
-uv supports custom CA certificates (such as those needed by corporate proxies) by utilizing the
-system's trust store. To ensure this works out of the box, ensure your certificates are added to the
-system's trust store.
+By default, uv loads certificates from the bundled `webpki-roots` crate. The `webpki-roots` are a
+reliable set of trust roots from Mozilla, and including them in uv improves portability and
+performance (especially on macOS, where reading the system trust store incurs a significant delay).
+
+However, in some cases, you may want to use the platform's native certificate store, especially if
+you're relying on a corporate trust root (e.g., for a mandatory proxy) that's included in your
+system's certificate store. To instruct uv to use the system's trust store, run uv with the
+`--native-tls` command-line flag.
 
 If a direct path to the certificate is required (e.g., in CI), set the `SSL_CERT_FILE` environment
-variable to the path of the certificate bundle, to instruct uv to use that file instead of the
-system's trust store.
+variable to the path of the certificate bundle (alongside the `--native-tls` flag), to instruct uv
+to use that file instead of the system's trust store.
 
 ## Acknowledgements
 

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -48,6 +48,8 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
+
+# These must be kept in-sync with those used by `reqwest`.
 rustls = { version = "0.21.10" }
 rustls-native-certs = { version = "0.6.3" }
 webpki-roots = { version = "0.25.4" }

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -48,6 +48,9 @@ tokio-util = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
+rustls = { version = "0.21.10" }
+rustls-native-certs = { version = "0.6.3" }
+webpki-roots = { version = "0.25.4" }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -16,3 +16,4 @@ mod middleware;
 mod registry_client;
 mod remote_metadata;
 mod rkyvutil;
+mod tls;

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -87,6 +87,138 @@ impl RegistryClientBuilder {
         self
     }
 
+    fn tls(&self) {
+        use crate::tls::NoVerifier;
+
+        // Set root certificates.
+        let mut root_cert_store = rustls::RootCertStore::empty();
+        for cert in config.root_certs {
+            cert.add_to_rustls(&mut root_cert_store)?;
+        }
+
+        #[cfg(feature = "rustls-tls-webpki-roots")]
+        if config.tls_built_in_root_certs {
+            use rustls::OwnedTrustAnchor;
+
+            let trust_anchors = webpki_roots::TLS_SERVER_ROOTS.iter().map(|trust_anchor| {
+                OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    trust_anchor.subject,
+                    trust_anchor.spki,
+                    trust_anchor.name_constraints,
+                )
+            });
+
+            root_cert_store.add_trust_anchors(trust_anchors);
+        }
+
+        #[cfg(feature = "rustls-tls-native-roots")]
+        if config.tls_built_in_root_certs {
+            let mut valid_count = 0;
+            let mut invalid_count = 0;
+            for cert in rustls_native_certs::load_native_certs().map_err(crate::error::builder)? {
+                let cert = rustls::Certificate(cert.0);
+                // Continue on parsing errors, as native stores often include ancient or syntactically
+                // invalid certificates, like root certificates without any X509 extensions.
+                // Inspiration: https://github.com/rustls/rustls/blob/633bf4ba9d9521a95f68766d04c22e2b01e68318/rustls/src/anchors.rs#L105-L112
+                match root_cert_store.add(&cert) {
+                    Ok(_) => valid_count += 1,
+                    Err(err) => {
+                        invalid_count += 1;
+                        log::warn!(
+                            "rustls failed to parse DER certificate {:?} {:?}",
+                            &err,
+                            &cert
+                        );
+                    }
+                }
+            }
+            if valid_count == 0 && invalid_count > 0 {
+                return Err(crate::error::builder(
+                    "zero valid certificates found in native root store",
+                ));
+            }
+        }
+
+        // Set TLS versions.
+        let mut versions = rustls::ALL_VERSIONS.to_vec();
+
+        if let Some(min_tls_version) = config.min_tls_version {
+            versions.retain(|&supported_version| {
+                match tls::Version::from_rustls(supported_version.version) {
+                    Some(version) => version >= min_tls_version,
+                    // Assume it's so new we don't know about it, allow it
+                    // (as of writing this is unreachable)
+                    None => true,
+                }
+            });
+        }
+
+        if let Some(max_tls_version) = config.max_tls_version {
+            versions.retain(|&supported_version| {
+                match tls::Version::from_rustls(supported_version.version) {
+                    Some(version) => version <= max_tls_version,
+                    None => false,
+                }
+            });
+        }
+
+        // Build TLS config
+        let config_builder = rustls::ClientConfig::builder()
+            .with_safe_default_cipher_suites()
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&versions)
+            .map_err(crate::error::builder)?
+            .with_root_certificates(root_cert_store);
+
+        // Finalize TLS config
+        let mut tls = if let Some(id) = config.identity {
+            id.add_to_rustls(config_builder)?
+        } else {
+            config_builder.with_no_client_auth()
+        };
+
+        // Certificate verifier
+        if !config.certs_verification {
+            tls.dangerous()
+                .set_certificate_verifier(Arc::new(NoVerifier));
+        }
+
+        tls.enable_sni = config.tls_sni;
+
+        // ALPN protocol
+        match config.http_version_pref {
+            HttpVersionPref::Http1 => {
+                tls.alpn_protocols = vec!["http/1.1".into()];
+            }
+            HttpVersionPref::Http2 => {
+                tls.alpn_protocols = vec!["h2".into()];
+            }
+            #[cfg(feature = "http3")]
+            HttpVersionPref::Http3 => {
+                tls.alpn_protocols = vec!["h3".into()];
+            }
+            HttpVersionPref::All => {
+                tls.alpn_protocols = vec!["h2".into(), "http/1.1".into()];
+            }
+        }
+
+        #[cfg(feature = "http3")]
+        {
+            tls.enable_early_data = config.tls_enable_early_data;
+
+            h3_connector = build_h3_connector(
+                resolver,
+                tls.clone(),
+                config.quic_max_idle_timeout,
+                config.quic_stream_receive_window,
+                config.quic_receive_window,
+                config.quic_send_window,
+                config.local_address,
+                &config.http_version_pref,
+            )?;
+        }
+    }
+
     pub fn build(self) -> RegistryClient {
         // Create user agent.
         let user_agent_string = format!("uv/{}", version());
@@ -114,7 +246,8 @@ impl RegistryClientBuilder {
             let client_core = ClientBuilder::new()
                 .user_agent(user_agent_string)
                 .pool_max_idle_per_host(20)
-                .timeout(std::time::Duration::from_secs(timeout));
+                .timeout(std::time::Duration::from_secs(timeout))
+                .tls_built_in_root_certs(false);
 
             client_core.build().expect("Failed to build HTTP client.")
         });

--- a/crates/uv-client/src/tls.rs
+++ b/crates/uv-client/src/tls.rs
@@ -19,86 +19,84 @@ pub(crate) enum Roots {
     Native,
 }
 
-impl Roots {
-    /// Initialize a TLS configuration for the client.
-    ///
-    /// This is equivalent to the TLS initialization `reqwest` when `rustls-tls` is enabled,
-    /// with two notable changes:
-    ///
-    /// 1. It enables _either_ the `webpki-roots` or the `native-certs` feature, but not both.
-    /// 2. It assumes the following builder settings (which match the defaults):
-    ///    - `root_certs: vec![]`
-    ///    - `min_tls_version: None`
-    ///    - `max_tls_version: None`
-    ///    - `identity: None`
-    ///    - `certs_verification: false`
-    ///    - `tls_sni: true`
-    ///    - `http_version_pref: HttpVersionPref::All`
-    ///
-    /// See: <https://github.com/seanmonstar/reqwest/blob/e3192638518d577759dd89da489175b8f992b12f/src/async_impl/client.rs#L498>
-    pub(crate) fn load(self) -> Result<ClientConfig, TlsError> {
-        // Set root certificates.
-        let mut root_cert_store = rustls::RootCertStore::empty();
+/// Initialize a TLS configuration for the client.
+///
+/// This is equivalent to the TLS initialization `reqwest` when `rustls-tls` is enabled,
+/// with two notable changes:
+///
+/// 1. It enables _either_ the `webpki-roots` or the `native-certs` feature, but not both.
+/// 2. It assumes the following builder settings (which match the defaults):
+///    - `root_certs: vec![]`
+///    - `min_tls_version: None`
+///    - `max_tls_version: None`
+///    - `identity: None`
+///    - `certs_verification: false`
+///    - `tls_sni: true`
+///    - `http_version_pref: HttpVersionPref::All`
+///
+/// See: <https://github.com/seanmonstar/reqwest/blob/e3192638518d577759dd89da489175b8f992b12f/src/async_impl/client.rs#L498>
+pub(crate) fn load(roots: Roots) -> Result<ClientConfig, TlsError> {
+    // Set root certificates.
+    let mut root_cert_store = rustls::RootCertStore::empty();
 
-        match self {
-            Self::Webpki => {
-                // Use `rustls-tls-webpki-roots`
-                use rustls::OwnedTrustAnchor;
+    match roots {
+        Roots::Webpki => {
+            // Use `rustls-tls-webpki-roots`
+            use rustls::OwnedTrustAnchor;
 
-                let trust_anchors = webpki_roots::TLS_SERVER_ROOTS.iter().map(|trust_anchor| {
-                    OwnedTrustAnchor::from_subject_spki_name_constraints(
-                        trust_anchor.subject,
-                        trust_anchor.spki,
-                        trust_anchor.name_constraints,
-                    )
-                });
+            let trust_anchors = webpki_roots::TLS_SERVER_ROOTS.iter().map(|trust_anchor| {
+                OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    trust_anchor.subject,
+                    trust_anchor.spki,
+                    trust_anchor.name_constraints,
+                )
+            });
 
-                root_cert_store.add_trust_anchors(trust_anchors);
-            }
-            Self::Native => {
-                // Use: `rustls-tls-native-roots`
-                let mut valid_count = 0;
-                let mut invalid_count = 0;
-                for cert in rustls_native_certs::load_native_certs()
-                    .map_err(TlsError::NativeCertificates)?
-                {
-                    let cert = rustls::Certificate(cert.0);
-                    // Continue on parsing errors, as native stores often include ancient or syntactically
-                    // invalid certificates, like root certificates without any X509 extensions.
-                    // Inspiration: https://github.com/rustls/rustls/blob/633bf4ba9d9521a95f68766d04c22e2b01e68318/rustls/src/anchors.rs#L105-L112
-                    match root_cert_store.add(&cert) {
-                        Ok(_) => valid_count += 1,
-                        Err(err) => {
-                            invalid_count += 1;
-                            warn!(
-                                "rustls failed to parse DER certificate {:?} {:?}",
-                                &err, &cert
-                            );
-                        }
+            root_cert_store.add_trust_anchors(trust_anchors);
+        }
+        Roots::Native => {
+            // Use: `rustls-tls-native-roots`
+            let mut valid_count = 0;
+            let mut invalid_count = 0;
+            for cert in
+                rustls_native_certs::load_native_certs().map_err(TlsError::NativeCertificates)?
+            {
+                let cert = rustls::Certificate(cert.0);
+                // Continue on parsing errors, as native stores often include ancient or syntactically
+                // invalid certificates, like root certificates without any X509 extensions.
+                // Inspiration: https://github.com/rustls/rustls/blob/633bf4ba9d9521a95f68766d04c22e2b01e68318/rustls/src/anchors.rs#L105-L112
+                match root_cert_store.add(&cert) {
+                    Ok(_) => valid_count += 1,
+                    Err(err) => {
+                        invalid_count += 1;
+                        warn!(
+                            "rustls failed to parse DER certificate {:?} {:?}",
+                            &err, &cert
+                        );
                     }
                 }
-                if valid_count == 0 && invalid_count > 0 {
-                    return Err(TlsError::ZeroCertificates);
-                }
+            }
+            if valid_count == 0 && invalid_count > 0 {
+                return Err(TlsError::ZeroCertificates);
             }
         }
-
-        // Build TLS config
-        let config_builder = rustls::ClientConfig::builder()
-            .with_safe_default_cipher_suites()
-            .with_safe_default_kx_groups()
-            .with_protocol_versions(&rustls::ALL_VERSIONS)?
-            .with_root_certificates(root_cert_store);
-
-        // Finalize TLS config
-        let mut tls = config_builder.with_no_client_auth();
-
-        // Enable SNI
-        tls.enable_sni = true;
-
-        // ALPN protocol
-        tls.alpn_protocols = vec!["h2".into(), "http/1.1".into()];
-
-        Ok(tls)
     }
+
+    // Build TLS config
+    let config_builder = ClientConfig::builder()
+        .with_safe_default_cipher_suites()
+        .with_safe_default_kx_groups()
+        .with_protocol_versions(rustls::ALL_VERSIONS)?
+        .with_root_certificates(root_cert_store);
+
+    // Finalize TLS config
+    let mut tls = config_builder.with_no_client_auth();
+
+    // Enable SNI
+    tls.enable_sni = true;
+
+    // ALPN protocol
+    tls.alpn_protocols = vec!["h2".into(), "http/1.1".into()];
+
+    Ok(tls)
 }

--- a/crates/uv-client/src/tls.rs
+++ b/crates/uv-client/src/tls.rs
@@ -1,0 +1,104 @@
+use rustls::ClientConfig;
+use tracing::warn;
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum TlsError {
+    #[error(transparent)]
+    Rustls(#[from] rustls::Error),
+    #[error("zero valid certificates found in native root store")]
+    ZeroCertificates,
+    #[error("failed to load native root certificates")]
+    NativeCertificates(#[source] std::io::Error),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Roots {
+    /// Use reqwest's `rustls-tls-webpki-roots` behavior for loading root certificates.
+    Webpki,
+    /// Use reqwest's `rustls-tls-native-roots` behavior for loading root certificates.
+    Native,
+}
+
+impl Roots {
+    /// Initialize a TLS configuration for the client.
+    ///
+    /// This is equivalent to the TLS initialization `reqwest` when `rustls-tls` is enabled,
+    /// with two notable changes:
+    ///
+    /// 1. It enables _either_ the `webpki-roots` or the `native-certs` feature, but not both.
+    /// 2. It assumes the following builder settings (which match the defaults):
+    ///    - `root_certs: vec![]`
+    ///    - `min_tls_version: None`
+    ///    - `max_tls_version: None`
+    ///    - `identity: None`
+    ///    - `certs_verification: false`
+    ///    - `tls_sni: true`
+    ///    - `http_version_pref: HttpVersionPref::All`
+    ///
+    /// See: <https://github.com/seanmonstar/reqwest/blob/e3192638518d577759dd89da489175b8f992b12f/src/async_impl/client.rs#L498>
+    pub(crate) fn load(self) -> Result<ClientConfig, TlsError> {
+        // Set root certificates.
+        let mut root_cert_store = rustls::RootCertStore::empty();
+
+        match self {
+            Self::Webpki => {
+                // Use `rustls-tls-webpki-roots`
+                use rustls::OwnedTrustAnchor;
+
+                let trust_anchors = webpki_roots::TLS_SERVER_ROOTS.iter().map(|trust_anchor| {
+                    OwnedTrustAnchor::from_subject_spki_name_constraints(
+                        trust_anchor.subject,
+                        trust_anchor.spki,
+                        trust_anchor.name_constraints,
+                    )
+                });
+
+                root_cert_store.add_trust_anchors(trust_anchors);
+            }
+            Self::Native => {
+                // Use: `rustls-tls-native-roots`
+                let mut valid_count = 0;
+                let mut invalid_count = 0;
+                for cert in rustls_native_certs::load_native_certs()
+                    .map_err(TlsError::NativeCertificates)?
+                {
+                    let cert = rustls::Certificate(cert.0);
+                    // Continue on parsing errors, as native stores often include ancient or syntactically
+                    // invalid certificates, like root certificates without any X509 extensions.
+                    // Inspiration: https://github.com/rustls/rustls/blob/633bf4ba9d9521a95f68766d04c22e2b01e68318/rustls/src/anchors.rs#L105-L112
+                    match root_cert_store.add(&cert) {
+                        Ok(_) => valid_count += 1,
+                        Err(err) => {
+                            invalid_count += 1;
+                            warn!(
+                                "rustls failed to parse DER certificate {:?} {:?}",
+                                &err, &cert
+                            );
+                        }
+                    }
+                }
+                if valid_count == 0 && invalid_count > 0 {
+                    return Err(TlsError::ZeroCertificates);
+                }
+            }
+        }
+
+        // Build TLS config
+        let config_builder = rustls::ClientConfig::builder()
+            .with_safe_default_cipher_suites()
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(&rustls::ALL_VERSIONS)?
+            .with_root_certificates(root_cert_store);
+
+        // Finalize TLS config
+        let mut tls = config_builder.with_no_client_auth();
+
+        // Enable SNI
+        tls.enable_sni = true;
+
+        // ALPN protocol
+        tls.alpn_protocols = vec!["h2".into(), "http/1.1".into()];
+
+        Ok(tls)
+    }
+}

--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -67,6 +67,7 @@ pub(crate) async fn pip_compile(
     python_version: Option<PythonVersion>,
     exclude_newer: Option<DateTime<Utc>>,
     annotation_style: AnnotationStyle,
+    native_tls: bool,
     quiet: bool,
     cache: Cache,
     printer: Printer,
@@ -188,6 +189,7 @@ pub(crate) async fn pip_compile(
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())
+        .native_tls(native_tls)
         .connectivity(connectivity)
         .index_urls(index_locations.index_urls())
         .build();

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -67,6 +67,7 @@ pub(crate) async fn pip_install(
     python: Option<String>,
     system: bool,
     break_system_packages: bool,
+    native_tls: bool,
     cache: Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -177,6 +178,7 @@ pub(crate) async fn pip_install(
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())
+        .native_tls(native_tls)
         .connectivity(connectivity)
         .index_urls(index_locations.index_urls())
         .build();

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -45,6 +45,7 @@ pub(crate) async fn pip_sync(
     python: Option<String>,
     system: bool,
     break_system_packages: bool,
+    native_tls: bool,
     cache: Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -116,6 +117,7 @@ pub(crate) async fn pip_sync(
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())
+        .native_tls(native_tls)
         .connectivity(connectivity)
         .index_urls(index_locations.index_urls())
         .build();

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -88,6 +88,18 @@ struct Cli {
     )]
     color: ColorChoice,
 
+    /// Whether to load TLS certificates from the platform's native certificate store.
+    ///
+    /// By default, `uv` loads certificates from the bundled `webpki-roots` crate. The
+    /// `webpki-roots` are a reliable set of trust roots from Mozilla, and including them in `uv`
+    /// improves portability and performance (especially on macOS).
+    ///
+    /// However, in some cases, you may want to use the platform's native certificate store,
+    /// especially if you're relying on a corporate trust root (e.g., for a mandatory proxy) that's
+    /// included in your system's certificate store.
+    #[arg(global = true, long)]
+    native_tls: bool,
+
     #[command(flatten)]
     cache_args: CacheArgs,
 }
@@ -1419,6 +1431,7 @@ async fn run() -> Result<ExitStatus> {
                 args.python_version,
                 args.exclude_newer,
                 args.annotation_style,
+                cli.native_tls,
                 cli.quiet,
                 cache,
                 printer,
@@ -1475,6 +1488,7 @@ async fn run() -> Result<ExitStatus> {
                 args.python,
                 args.system,
                 args.break_system_packages,
+                cli.native_tls,
                 cache,
                 printer,
             )
@@ -1570,6 +1584,7 @@ async fn run() -> Result<ExitStatus> {
                 args.python,
                 args.system,
                 args.break_system_packages,
+                cli.native_tls,
                 cache,
                 printer,
             )


### PR DESCRIPTION
## Summary

It turns out that on macOS, reading the native certificates can add hundreds of milliseconds to client initialization. This PR makes `--native-tls` a command-line flag, to toggle (at runtime) the choice of the `webpki` roots or the native system roots.

You can't accomplish this kind of configuration with the `reqwest` builder API, so instead, I pulled out the heart of that logic from the crate (https://github.com/seanmonstar/reqwest/blob/e3192638518d577759dd89da489175b8f992b12f/src/async_impl/client.rs#L498), and modified it to allow toggling a choice of root.

Note that there's an open PR for this in reqwest (https://github.com/seanmonstar/reqwest/pull/1848), along with an issue (https://github.com/seanmonstar/reqwest/issues/1843), which I may ping, but it's been around for a while and I believe reqwest is focused on its next major release.

Closes https://github.com/astral-sh/uv/issues/2346.
