### PR TITLE
Skip prefetching when `--no-deps` is specified

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -255,8 +255,12 @@ impl<'a, Provider: ResolverProvider> Resolver<'a, Provider> {
             // Run unit propagation.
             state.unit_propagation(next)?;
 
-            // Pre-visit all candidate packages, to allow metadata to be fetched in parallel.
-            Self::pre_visit(state.partial_solution.prioritized_packages(), request_sink).await?;
+            // Pre-visit all candidate packages, to allow metadata to be fetched in parallel. If
+            // the dependency mode is direct, we only need to visit the root package.
+            if self.dependency_mode.is_transitive() {
+                Self::pre_visit(state.partial_solution.prioritized_packages(), request_sink)
+                    .await?;
+            }
 
             // Choose a package version.
             let Some(highest_priority_pkg) =


### PR DESCRIPTION
## Summary

When running under `--no-deps`, we don't need to pre-fetch, because pre-fetching fetches the _distribution_ metadata. But with `--no-deps`, we only need the package metadata for the top-level requirements. We never need distribution metadata.

Incidentally, this will fix https://github.com/astral-sh/uv/issues/2300.

## Test Plan

- `cargo test`
- `./target/debug/uv  pip install --verbose --no-cache-dir --no-deps --reinstall ddtrace==2.6.2 debugpy==1.8.1 ecdsa==0.18.0 editorconfig==0.12.4 --verbose` in a Python 3.10 Docker contain repeatedly.
