### PR TITLE
Do not bump the minor version on breaking changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ include = ["rust-toolchain.toml"]
 
 [tool.rooster]
 major_labels = []  # We do not use the major version number
-minor_labels = ["breaking"]   # Bump the minor version on breaking changes
+minor_labels = []  # Normally we'd bump the minor version on breaking changes, but we're waiting
 changelog_ignore_labels = ["internal", "ci", "testing"]
 changelog_sections.breaking = "Breaking changes"
 changelog_sections.enhancement = "Enhancements"


### PR DESCRIPTION
... yet.

I think we're not quite ready for a versioning policy over here. Now that we have a "labeled" breaking change in #2362 we need to decide if it should be a minor or patch version.