### PR TITLE
Add numpy to system import tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,6 +418,9 @@ jobs:
     needs: build-binary-windows
     name: "check system | python3.10 on windows"
     runs-on: windows-latest
+    env:
+      # Avoid debug build stack overflows.
+      UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
     steps:
       - uses: actions/checkout@v4
 
@@ -440,6 +443,9 @@ jobs:
     needs: build-binary-windows
     name: "check system | python3.13 on windows"
     runs-on: windows-latest
+    env:
+      # Avoid debug build stack overflows.
+      UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
     steps:
       - uses: actions/checkout@v4
 
@@ -464,6 +470,9 @@ jobs:
     needs: build-binary-windows
     name: "check system | python3.12 via chocolatey"
     runs-on: windows-latest
+    env:
+      # Avoid debug build stack overflows.
+      UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
     steps:
       - uses: actions/checkout@v4
 

--- a/scripts/check_system_python.py
+++ b/scripts/check_system_python.py
@@ -17,7 +17,7 @@ def numpy():
     """sys.version_info"""
     logging.info("Installing the package `numpy`.")
     subprocess.run(
-        [uv, "pip", "install", "numpy", "--system"],
+        [uv, "pip", "install", "numpy", "--system"] + allow_externally_managed,
         cwd=temp_dir,
         check=True,
     )

--- a/scripts/check_system_python.py
+++ b/scripts/check_system_python.py
@@ -11,6 +11,25 @@ import subprocess
 import sys
 import tempfile
 
+
+def numpy():
+    """sys.version_info"""
+    logging.info("Installing the package `numpy`.")
+    subprocess.run(
+        [uv, "pip", "install", "numpy", "--system"],
+        cwd=temp_dir,
+        check=True,
+    )
+    # Check that the native libraries of numpy work.
+    logging.info("Checking that `numpy` can be imported.")
+    code = subprocess.run(
+        [sys.executable, "-c", "import numpy"],
+        cwd=temp_dir,
+    )
+    if code.returncode != 0:
+        raise Exception("Could not import numpy.")
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
@@ -138,19 +157,6 @@ if __name__ == "__main__":
                 "The package `pylint` isn't installed in the virtual environment."
             )
 
-        # Install the package (`numpy`).
-        logging.info("Installing the package `numpy`.")
-        subprocess.run(
-            [uv, "pip", "install", "numpy", "--system"],
-            cwd=temp_dir,
-            check=True,
-        )
-
-        # Check that the native libraries of numpy work.
-        logging.info("Checking that `numpy` can be imported.")
-        code = subprocess.run(
-            [sys.executable, "-c", "import numpy"],
-            cwd=temp_dir,
-        )
-        if code.returncode != 0:
-            raise Exception("Could not import numpy.")
+        # Numpy doesn't have wheels for python 3.13 (at the time of writing)
+        if sys.version_info < (3, 13):
+            numpy()

--- a/scripts/check_system_python.py
+++ b/scripts/check_system_python.py
@@ -2,7 +2,8 @@
 
 """Install `pylint` and `numpy` into the system Python.
 
-To run locally, create a venv with seed packages."""
+To run locally, create a venv with seed packages.
+"""
 
 import argparse
 import logging

--- a/scripts/check_system_python.py
+++ b/scripts/check_system_python.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
-"""Install `pylint` into the system Python."""
+"""Install `pylint` and `numpy` into the system Python.
+
+To run locally, create a venv with seed packages."""
 
 import argparse
 import logging
@@ -135,3 +137,20 @@ if __name__ == "__main__":
             raise Exception(
                 "The package `pylint` isn't installed in the virtual environment."
             )
+
+        # Install the package (`numpy`).
+        logging.info("Installing the package `numpy`.")
+        subprocess.run(
+            [uv, "pip", "install", "numpy", "--system"],
+            cwd=temp_dir,
+            check=True,
+        )
+
+        # Check that the native libraries of numpy work.
+        logging.info("Checking that `numpy` can be imported.")
+        code = subprocess.run(
+            [sys.executable, "-c", "import numpy"],
+            cwd=temp_dir,
+        )
+        if code.returncode != 0:
+            raise Exception("Could not import numpy.")


### PR DESCRIPTION
Installing and importing numpy tests for two cases:

* The python architecture and the package architecture don't match (https://github.com/astral-sh/uv/issues/2326)
* The libc of python and that of the package don't match on linux (musllinux vs manylinux, picking a compatible manylinux version)

All pylint deps are py3-none-any, so they don't catch those cases.
