### PR TITLE
Add failing python-build-standalone alpine test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,41 +138,20 @@ jobs:
 
       - uses: rui314/setup-mold@v1
 
+      - name: "Setup musl"
+        run: |
+          sudo apt-get install musl-tools
+          rustup target add x86_64-unknown-linux-musl
+
       - uses: Swatinem/rust-cache@v2
       - name: "Build"
-        run: cargo build
+        run: cargo build --target x86_64-unknown-linux-musl
 
       - name: "Upload binary"
         uses: actions/upload-artifact@v4
         with:
           name: uv-linux-${{ github.sha }}
-          path: ./target/debug/uv
-          retention-days: 1
-
-  build-binary-debian:
-    runs-on:
-      labels: ubuntu-latest-large
-    container: debian:bullseye
-    name: "build binary | debian"
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: "Install Rust toolchain"
-        run: |
-          apt-get update
-          apt-get install -y curl build-essential cmake
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          echo "PATH=$PATH:$HOME/.cargo/bin" >> "$GITHUB_ENV"
-
-      - uses: Swatinem/rust-cache@v2
-      - name: "Build"
-        run: cargo build
-
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v4
-        with:
-          name: uv-debian-${{ github.sha }}
-          path: ./target/debug/uv
+          path: ./target/x86_64-unknown-linux-musl/debug/uv
           retention-days: 1
 
   build-binary-macos-aarch64:
@@ -216,7 +195,7 @@ jobs:
           retention-days: 1
 
   system-test-debian:
-    needs: build-binary-debian
+    needs: build-binary-linux
     name: "check system | python on debian"
     runs-on: ubuntu-latest
     container: debian:bullseye
@@ -229,7 +208,7 @@ jobs:
       - name: "Download binary"
         uses: actions/download-artifact@v4
         with:
-          name: uv-debian-${{ github.sha }}
+          name: uv-linux-${{ github.sha }}
 
       - name: "Prepare binary"
         run: chmod +x ./uv
@@ -291,7 +270,7 @@ jobs:
         run: pypy scripts/check_system_python.py --uv ./uv
 
   system-test-pyston:
-    needs: build-binary-debian
+    needs: build-binary-linux
     name: "check system | pyston"
     runs-on: ubuntu-latest
     container: pyston/pyston:2.3.5
@@ -301,7 +280,7 @@ jobs:
       - name: "Download binary"
         uses: actions/download-artifact@v4
         with:
-          name: uv-debian-${{ github.sha }}
+          name: uv-linux-${{ github.sha }}
 
       - name: "Prepare binary"
         run: chmod +x ./uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,31 @@ jobs:
       - name: "Validate global Python install"
         run: pyston scripts/check_system_python.py --uv ./uv
 
+  system-test-alpine:
+    needs: build-binary-linux
+    name: "check system | alpine"
+    runs-on: ubuntu-latest
+    container: alpine:latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Install Python"
+        run: apk add --update --no-cache python3 py3-pip
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-linux-${{ github.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Print Python path"
+        run: echo $(which python3)
+
+      - name: "Validate global Python install"
+        run: python3 scripts/check_system_python.py --uv ./uv
+
   system-test-macos:
     needs: build-binary-macos-aarch64
     name: "check system | python on macos"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
         run: echo $(which python3)
 
       - name: "Validate global Python install"
-        run: python3 scripts/check_system_python.py --uv ./uv
+        run: python3 scripts/check_system_python.py --uv ./uv --externally-managed
 
   system-test-macos:
     needs: build-binary-macos-aarch64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
 
@@ -32,7 +32,7 @@ jobs:
     name: "cargo clippy"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ ubuntu-latest, windows-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -300,7 +300,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Install Python"
-        run: apk add --update --no-cache python3 py3-pip
+        run: apk add --update --no-cache python3 py3-pip pipx
 
       - name: "Download binary"
         uses: actions/download-artifact@v4
@@ -315,6 +315,18 @@ jobs:
 
       - name: "Validate global Python install"
         run: python3 scripts/check_system_python.py --uv ./uv --externally-managed
+
+      - name: "Download Python build standalone"
+        run: pipx run /io/scripts/bootstrap/install.py python-build-standalone
+        env:
+          UV_BOOTSTRAP_DIR: python-build-standalone
+
+      - name: "Test Python build standalone"
+        run: |
+          python-build-standalone/versions/cpython@3.12.1/install/bin/python3 -m venv venv3.12
+          venv3.12/bin/python scripts/check_system_python.py --uv ./uv
+          python-build-standalone/versions/cpython@3.8.18/install/bin/python3 -m venv venv3.8
+          venv3.8/bin/python scripts/check_system_python.py --uv ./uv
 
   system-test-macos:
     needs: build-binary-macos-aarch64
@@ -435,14 +447,14 @@ jobs:
 
   system-test-conda:
     needs:
-      [build-binary-windows, build-binary-macos-aarch64, build-binary-linux]
+      [ build-binary-windows, build-binary-macos-aarch64, build-binary-linux ]
     name: check system | conda${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        os: ["linux", "windows", "macos"]
-        python-version: ["3.8", "3.11"]
+        os: [ "linux", "windows", "macos" ]
+        python-version: [ "3.8", "3.11" ]
         include:
           - { os: "linux", target: "linux", runner: "ubuntu-latest" }
           - { os: "windows", target: "windows", runner: "windows-latest" }

--- a/scripts/check_system_python.py
+++ b/scripts/check_system_python.py
@@ -14,9 +14,17 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Check a Python interpreter.")
     parser.add_argument("--uv", help="Path to a uv binary.")
+    parser.add_argument(
+        "--externally-managed",
+        action="store_true",
+        help="Set if the Python installation has an EXTERNALLY-MANAGED marker.",
+    )
     args = parser.parse_args()
 
     uv: str = os.path.abspath(args.uv) if args.uv else "uv"
+    allow_externally_managed = (
+        ["--break-system-packages"] if args.externally_managed else []
+    )
 
     # Create a temporary directory.
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -32,7 +40,7 @@ if __name__ == "__main__":
         # Install the package (`pylint`).
         logging.info("Installing the package `pylint`.")
         subprocess.run(
-            [uv, "pip", "install", "pylint", "--system"],
+            [uv, "pip", "install", "pylint", "--system"] + allow_externally_managed,
             cwd=temp_dir,
             check=True,
         )
@@ -57,7 +65,7 @@ if __name__ == "__main__":
         # Uninstall the package (`pylint`).
         logging.info("Uninstalling the package `pylint`.")
         subprocess.run(
-            [uv, "pip", "uninstall", "pylint", "--system"],
+            [uv, "pip", "uninstall", "pylint", "--system"] + allow_externally_managed,
             cwd=temp_dir,
             check=True,
         )


### PR DESCRIPTION
Currently, python-build-standalone is failing on alpine (musl) with the following error:

> OSError: Dynamic loading not supported

iirc this is something that gregory mentioned, but it means that as of now, we can't adopt bootstrapping python-build-standalone as default when we want to support alpine.