### PR TITLE
Stop looking for `-p` in PATH

### DIFF
--- a/crates/platform-tags/src/lib.rs
+++ b/crates/platform-tags/src/lib.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{cmp, num::NonZeroU32};
@@ -252,8 +253,9 @@ impl TryFrom<usize> for TagPriority {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum Implementation {
+    #[default]
     CPython,
     PyPy,
     Pyston,
@@ -318,6 +320,16 @@ impl FromStr for Implementation {
             "jython" => Err(TagsError::UnsupportedImplementation(s.to_string())),
             // Unknown implementations.
             _ => Err(TagsError::UnknownImplementation(s.to_string())),
+        }
+    }
+}
+
+impl Display for Implementation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Implementation::CPython => f.write_str("cpython"),
+            Implementation::PyPy => f.write_str("pypy"),
+            Implementation::Pyston => f.write_str("pyston"),
         }
     }
 }

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -12,6 +12,7 @@ use std::io;
 use std::path::PathBuf;
 use std::process::ExitStatus;
 
+use platform_tags::TagsError;
 use thiserror::Error;
 
 pub use crate::cfg::PyVenvConfiguration;
@@ -79,4 +80,12 @@ pub enum Error {
     Cfg(#[from] cfg::Error),
     #[error("Error finding `{}` in PATH", _0.to_string_lossy())]
     WhichError(OsString, #[source] which::Error),
+    #[error(
+        "Unrecognized python specifier: `{0}`. You can use a version (e.g. `3.12`), \
+        an implementation and a version (e.g. `pypy3.10`) or \
+        the path to a python interpreter (e.g. `/usr/bin/python`)"
+    )]
+    UnrecognizedPython(String),
+    #[error(transparent)]
+    UnrecognizedImplementation(TagsError),
 }


### PR DESCRIPTION
See #2386 for the motivation and semantics. We keep only two behaviours for `-p`, we have an absolute or relative path (containing a system path separator) or `-p <implementation><version>`.

Open question: Should `python3.10` or `3.10` force cpython 3.10 or is any python implementation acceptable? My assumption right now is that i assume that a user specifying nothing wouldn't like it if we picked pypy, rather we should force cpython and make pypy explicit.

I will add tests tomorrow, please already give the semantics a look.