### PR TITLE
feat: keep backwards compatibility with `SSL_CERT_FILE` without requiring `--native-tls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,8 +435,8 @@ system's certificate store. To instruct uv to use the system's trust store, run 
 `--native-tls` command-line flag.
 
 If a direct path to the certificate is required (e.g., in CI), set the `SSL_CERT_FILE` environment
-variable to the path of the certificate bundle (alongside the `--native-tls` flag), to instruct uv
-to use that file instead of the system's trust store.
+variable to the path of the certificate bundle, to instruct uv to use that file instead of the
+system's trust store.
 
 ## Acknowledgements
 

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -120,7 +120,7 @@ impl RegistryClientBuilder {
         // Initialize the base client.
         let client = self.client.unwrap_or_else(|| {
             // Load the TLS configuration.
-            let tls = tls::load(if self.native_tls {
+            let tls = tls::load(if self.native_tls || env::var("SSL_CERT_FILE").is_ok() {
                 Roots::Native
             } else {
                 Roots::Webpki


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Small follow up to https://github.com/astral-sh/uv/pull/2362 to check if `SSL_CERT_FILE` is set to enable `--native-tls` functionality. This maintains backwards compatibility with `0.1.17` and below users leveraging only `SSL_CERT_FILE`.

Closes https://github.com/astral-sh/uv/issues/2400

## Test Plan

<!-- How was it tested? -->
Assuming `SSL_CERT_FILE` is already working via `--native-tls`, this is simply a shortcut to enable `--native-tls` functionality implicitly while still being able to let `rustls-native-certs` handle the loading of `SSL_CERT_FILE` instead of ourselves.

Edit: Manually tested by setting up own self-signed CA certificate bundle and set `SSL_CERT_FILE` to this and confirmed the loading happens without having to specify `--native-tls`.