### PR TITLE
Add backoff for transient Windows failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom",
+ "instant",
+ "pin-project-lite",
+ "rand",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,6 +4400,7 @@ dependencies = [
 name = "uv-fs"
 version = "0.0.1"
 dependencies = [
+ "backoff",
  "dunce",
  "encoding_rs_io",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ async-trait = { version = "0.1.77" }
 async-recursion = { version = "1.0.5" }
 async_http_range_reader = { version = "0.7.0" }
 async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "d76801da0943de985254fc6255c0e476b57c5836", features = ["deflate"] }
+backoff = { version = "0.4.0" }
 base64 = { version = "0.21.7" }
 cachedir = { version = "0.3.1" }
 cargo-util = { version = "0.2.8" }

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -206,7 +206,7 @@ impl Cache {
     }
 
     /// Persist a temporary directory to the artifact store.
-    pub fn persist(
+    pub async fn persist(
         &self,
         temp_dir: impl AsRef<Path>,
         path: impl AsRef<Path>,
@@ -218,7 +218,7 @@ impl Cache {
         // Move the temporary directory into the directory store.
         let archive_entry = self.entry(CacheBucket::Archive, "", id);
         fs_err::create_dir_all(archive_entry.dir())?;
-        fs_err::rename(temp_dir.as_ref(), archive_entry.path())?;
+        uv_fs::rename_with_retry(temp_dir.as_ref(), archive_entry.path()).await?;
 
         // Create a symlink to the directory store.
         fs_err::create_dir_all(path.as_ref().parent().expect("Cache entry to have parent"))?;

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -451,6 +451,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                 let archive = self
                     .cache
                     .persist(temp_dir.into_path(), wheel_entry.path())
+                    .await
                     .map_err(Error::CacheRead)?;
                 Ok(archive)
             }
@@ -532,6 +533,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                 let archive = self
                     .cache
                     .persist(temp_dir.into_path(), wheel_entry.path())
+                    .await
                     .map_err(Error::CacheRead)?;
                 Ok(archive)
             }

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 uv-warnings = { path = "../uv-warnings" }
 
+backoff = { workspace = true }
 dunce = { workspace = true }
 encoding_rs_io = { workspace = true }
 fs-err = { workspace = true }
@@ -27,4 +28,4 @@ urlencoding = { workspace = true }
 
 [features]
 default = []
-tokio = ["fs-err/tokio", "dep:tokio"]
+tokio = ["dep:tokio", "fs-err/tokio", "backoff/tokio"]


### PR DESCRIPTION
## Summary

This may be required elsewhere, but all the traces in that issue are related to persisting the temporary directory to our persistent cache, so lets start there.

See: https://github.com/astral-sh/uv/issues/1491.
