### PR TITLE
feature:  Support custom commands for keyring

### DIFF
--- a/crates/uv-auth/src/lib.rs
+++ b/crates/uv-auth/src/lib.rs
@@ -2,7 +2,7 @@ mod keyring;
 mod middleware;
 mod store;
 
-pub use keyring::KeyringProvider;
+pub use keyring::{KeyringConfig, KeyringProvider};
 pub use middleware::AuthMiddleware;
 use once_cell::sync::Lazy;
 pub use store::AuthenticationStore;

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -7,7 +7,7 @@ use tracing::{debug, warn};
 use url::Url;
 
 use crate::{
-    keyring::{get_keyring_subprocess_auth, KeyringProvider, KeyringConfig},
+    keyring::{get_keyring_subprocess_auth, KeyringConfig, KeyringProvider},
     store::Credential,
     GLOBAL_AUTH_STORE,
 };
@@ -65,7 +65,7 @@ impl Middleware for AuthMiddleware {
                 self.keyring_conf.provider,
                 KeyringProvider::Subprocess | KeyringProvider::CustomSubprocess
             ) {
-                match get_keyring_subprocess_auth(&url, &self.keyring_conf) {
+                match get_keyring_subprocess_auth(url, &self.keyring_conf) {
                     Ok(Some(auth)) => Some(auth),
                     Ok(None) => {
                         debug!("No keyring credentials found for {url}");

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -7,7 +7,7 @@ use tracing::{debug, warn};
 use url::Url;
 
 use crate::{
-    keyring::{get_keyring_subprocess_auth, KeyringConfig, KeyringProvider},
+    keyring::{get_keyring_subprocess_auth, KeyringConfig},
     store::Credential,
     GLOBAL_AUTH_STORE,
 };
@@ -61,23 +61,16 @@ impl Middleware for AuthMiddleware {
         };
 
         let keyring_auth = move |url: &Url| {
-            if matches!(
-                self.keyring_conf.provider,
-                KeyringProvider::Subprocess | KeyringProvider::CustomSubprocess
-            ) {
-                match get_keyring_subprocess_auth(url, &self.keyring_conf) {
-                    Ok(Some(auth)) => Some(auth),
-                    Ok(None) => {
-                        debug!("No keyring credentials found for {url}");
-                        None
-                    }
-                    Err(e) => {
-                        warn!("Failed to get keyring credentials for {url}: {e}");
-                        None
-                    }
+            match get_keyring_subprocess_auth(url, &self.keyring_conf) {
+                Ok(Some(auth)) => Some(auth),
+                Ok(None) => {
+                    debug!("No keyring credentials found for {url}");
+                    None
                 }
-            } else {
-                None
+                Err(e) => {
+                    warn!("Failed to get keyring credentials for {url}: {e}");
+                    None
+                }
             }
         };
 

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -60,8 +60,8 @@ impl Middleware for AuthMiddleware {
             })
         };
 
-        let keyring_auth = move |url: &Url| {
-            match get_keyring_subprocess_auth(url, &self.keyring_conf) {
+        let keyring_auth =
+            move |url: &Url| match get_keyring_subprocess_auth(url, &self.keyring_conf) {
                 Ok(Some(auth)) => Some(auth),
                 Ok(None) => {
                     debug!("No keyring credentials found for {url}");
@@ -71,8 +71,7 @@ impl Middleware for AuthMiddleware {
                     warn!("Failed to get keyring credentials for {url}: {e}");
                     None
                 }
-            }
-        };
+            };
 
         // Try auth strategies in order of precedence:
         if let Some(stored_auth) = GLOBAL_AUTH_STORE.get(&url) {

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -21,7 +21,7 @@ use distribution_types::{BuiltDist, File, FileLocation, IndexUrl, IndexUrls, Nam
 use install_wheel_rs::metadata::{find_archive_dist_info, is_metadata_entry};
 use pep440_rs::Version;
 use pypi_types::{Metadata23, SimpleJson};
-use uv_auth::{AuthMiddleware, KeyringProvider, GLOBAL_AUTH_STORE};
+use uv_auth::{AuthMiddleware, KeyringConfig, GLOBAL_AUTH_STORE};
 use uv_cache::{Cache, CacheBucket, WheelCache};
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
@@ -40,7 +40,7 @@ use crate::{tls, CachedClient, CachedClientError, Error, ErrorKind};
 #[derive(Debug, Clone)]
 pub struct RegistryClientBuilder {
     index_urls: IndexUrls,
-    keyring_provider: KeyringProvider,
+    keyring_conf: KeyringConfig,
     native_tls: bool,
     retries: u32,
     connectivity: Connectivity,
@@ -52,7 +52,7 @@ impl RegistryClientBuilder {
     pub fn new(cache: Cache) -> Self {
         Self {
             index_urls: IndexUrls::default(),
-            keyring_provider: KeyringProvider::default(),
+            keyring_conf: KeyringConfig::default(),
             native_tls: false,
             cache,
             connectivity: Connectivity::Online,
@@ -70,8 +70,8 @@ impl RegistryClientBuilder {
     }
 
     #[must_use]
-    pub fn keyring_provider(mut self, keyring_provider: KeyringProvider) -> Self {
-        self.keyring_provider = keyring_provider;
+    pub fn keyring_conf(mut self, keyring_conf: KeyringConfig) -> Self {
+        self.keyring_conf = keyring_conf;
         self
     }
 
@@ -168,7 +168,7 @@ impl RegistryClientBuilder {
                 let client = client.with(retry_strategy);
 
                 // Initialize the authentication middleware to set headers.
-                let client = client.with(AuthMiddleware::new(self.keyring_provider));
+                let client = client.with(AuthMiddleware::new(self.keyring_conf));
 
                 client.build()
             }

--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -18,7 +18,7 @@ use tracing::debug;
 use distribution_types::{IndexLocations, LocalEditable, Verbatim};
 use platform_tags::Tags;
 use requirements_txt::EditableRequirement;
-use uv_auth::{KeyringProvider, GLOBAL_AUTH_STORE};
+use uv_auth::{KeyringConfig, GLOBAL_AUTH_STORE};
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
@@ -59,7 +59,7 @@ pub(crate) async fn pip_compile(
     include_index_url: bool,
     include_find_links: bool,
     index_locations: IndexLocations,
-    keyring_provider: KeyringProvider,
+    keyring_conf: KeyringConfig,
     setup_py: SetupPyStrategy,
     config_settings: ConfigSettings,
     connectivity: Connectivity,
@@ -197,7 +197,7 @@ pub(crate) async fn pip_compile(
         .native_tls(native_tls)
         .connectivity(connectivity)
         .index_urls(index_locations.index_urls())
-        .keyring_provider(keyring_provider)
+        .keyring_conf(keyring_conf)
         .build();
 
     // Resolve the flat indexes from `--find-links`.

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -20,7 +20,7 @@ use pep508_rs::{MarkerEnvironment, Requirement};
 use platform_tags::Tags;
 use pypi_types::Yanked;
 use requirements_txt::EditableRequirement;
-use uv_auth::{KeyringProvider, GLOBAL_AUTH_STORE};
+use uv_auth::{KeyringConfig, GLOBAL_AUTH_STORE};
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
@@ -55,7 +55,7 @@ pub(crate) async fn pip_install(
     dependency_mode: DependencyMode,
     upgrade: Upgrade,
     index_locations: IndexLocations,
-    keyring_provider: KeyringProvider,
+    keyring_conf: KeyringConfig,
     reinstall: &Reinstall,
     link_mode: LinkMode,
     compile: bool,
@@ -191,7 +191,7 @@ pub(crate) async fn pip_install(
         .native_tls(native_tls)
         .connectivity(connectivity)
         .index_urls(index_locations.index_urls())
-        .keyring_provider(keyring_provider)
+        .keyring_conf(keyring_conf)
         .build();
 
     // Resolve the flat indexes from `--find-links`.

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -10,7 +10,7 @@ use install_wheel_rs::linker::LinkMode;
 use platform_tags::Tags;
 use pypi_types::Yanked;
 use requirements_txt::EditableRequirement;
-use uv_auth::{KeyringProvider, GLOBAL_AUTH_STORE};
+use uv_auth::{KeyringConfig, GLOBAL_AUTH_STORE};
 use uv_cache::{ArchiveTarget, ArchiveTimestamp, Cache};
 use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
@@ -35,7 +35,7 @@ pub(crate) async fn pip_sync(
     link_mode: LinkMode,
     compile: bool,
     index_locations: IndexLocations,
-    keyring_provider: KeyringProvider,
+    keyring_conf: KeyringConfig,
     setup_py: SetupPyStrategy,
     connectivity: Connectivity,
     config_settings: &ConfigSettings,
@@ -125,7 +125,7 @@ pub(crate) async fn pip_sync(
         .native_tls(native_tls)
         .connectivity(connectivity)
         .index_urls(index_locations.index_urls())
-        .keyring_provider(keyring_provider)
+        .keyring_conf(keyring_conf)
         .build();
 
     // Resolve the flat indexes from `--find-links`.

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 
 use distribution_types::{DistributionMetadata, IndexLocations, Name};
 use pep508_rs::Requirement;
-use uv_auth::{KeyringProvider, GLOBAL_AUTH_STORE};
+use uv_auth::{KeyringConfig, GLOBAL_AUTH_STORE};
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
@@ -33,7 +33,7 @@ pub(crate) async fn venv(
     path: &Path,
     python_request: Option<&str>,
     index_locations: &IndexLocations,
-    keyring_provider: KeyringProvider,
+    keyring_conf: KeyringConfig,
     prompt: uv_virtualenv::Prompt,
     system_site_packages: bool,
     connectivity: Connectivity,
@@ -47,7 +47,7 @@ pub(crate) async fn venv(
         path,
         python_request,
         index_locations,
-        keyring_provider,
+        keyring_conf,
         prompt,
         system_site_packages,
         connectivity,
@@ -92,7 +92,7 @@ async fn venv_impl(
     path: &Path,
     python_request: Option<&str>,
     index_locations: &IndexLocations,
-    keyring_provider: KeyringProvider,
+    keyring_conf: KeyringConfig,
     prompt: uv_virtualenv::Prompt,
     system_site_packages: bool,
     connectivity: Connectivity,
@@ -149,7 +149,7 @@ async fn venv_impl(
         let client = RegistryClientBuilder::new(cache.clone())
             .native_tls(native_tls)
             .index_urls(index_locations.index_urls())
-            .keyring_provider(keyring_provider)
+            .keyring_conf(keyring_conf)
             .connectivity(connectivity)
             .build();
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Adds ability to use a script or program other than `keyring` with the same interface as `keyring` to get password.

Based on suggestion/request from https://github.com/vlad-ivanov-name in #2254 

## Test Plan

<!-- How was it tested? -->

I created a script: `my-keyring.sh` with a couple variants
First:  Wrap actual keyring
```
#!/bin/bash
keyring get $2 $3
```
Second:  Wrap gcloud auth command
```
#!/bin/bash
# should verify domain here
gcloud auth application-default print-access-token --scopes="https://www.googleapis.com/auth/cloud-platform" --quiet
```
and tested on a project I knew to be working by replacing `--keyring-provider subprocess` with `--keyring-provider custom --custom-keyring-command ./my-keyring.sh` for both variants