### PR TITLE
Loosen `.dist-info` validation to accept arbitrary versions

### DIFF
--- a/crates/install-wheel-rs/src/lib.rs
+++ b/crates/install-wheel-rs/src/lib.rs
@@ -86,6 +86,16 @@ pub enum Error {
     MissingRecord(PathBuf),
     #[error("Multiple .dist-info directories found: {0}")]
     MultipleDistInfo(String),
+    #[error(
+        "The .dist-info directory {0} does not consist of the normalized package name and version"
+    )]
+    MissingDistInfoSegments(String),
+    #[error("The .dist-info directory {0} does not start with the normalized package name: {0}")]
+    MissingDistInfoPackageName(String, String),
+    #[error("The .dist-info directory {0} does not start with the normalized version: {0}")]
+    MissingDistInfoVersion(String, String),
+    #[error("The .dist-info directory name contains invalid characters")]
+    InvalidDistInfoPrefix,
     #[error("Invalid wheel size")]
     InvalidSize,
     #[error("Invalid package name")]

--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -137,6 +137,8 @@ pub fn install_wheel(
 /// Find the `dist-info` directory in an unzipped wheel.
 ///
 /// See: <https://github.com/PyO3/python-pkginfo-rs>
+///
+/// See: <https://github.com/pypa/pip/blob/36823099a9cdd83261fdbc8c1d2a24fa2eea72ca/src/pip/_internal/utils/wheel.py#L38>
 fn find_dist_info(path: impl AsRef<Path>) -> Result<String, Error> {
     // Iterate over `path` to find the `.dist-info` directory. It should be at the top-level.
     let Some(dist_info) = fs::read_dir(path.as_ref())?.find_map(|entry| {


### PR DESCRIPTION
## Summary

It turns out that pip does _not_ validate the normalization of the version specifier in the `.dist-info` directory. In particular, it seems that some tools replace the `+` in a local version segment with a `_`.

Closes https://github.com/astral-sh/uv/issues/2424.
