### PR TITLE
Add in-URL credentials to store prior to creating requests

### DIFF
--- a/crates/distribution-types/src/file.rs
+++ b/crates/distribution-types/src/file.rs
@@ -53,11 +53,13 @@ impl File {
             size: file.size,
             upload_time_utc_ms: file.upload_time.map(|dt| dt.timestamp_millis()),
             url: if file.url.contains("://") {
+                // Copy over any credentials from the global store.
                 let url = Url::parse(&file.url)
                     .map_err(|err| FileConversionError::Url(file.url.clone(), err))?;
                 let url = GLOBAL_AUTH_STORE.with_url_encoded_auth(url);
                 FileLocation::AbsoluteUrl(url.to_string())
             } else {
+                // It's assumed that the base URL already contains any necessary credentials.
                 FileLocation::RelativeUrl(base.to_string(), file.url)
             },
             yanked: file.yanked,

--- a/crates/distribution-types/src/index_url.rs
+++ b/crates/distribution-types/src/index_url.rs
@@ -26,6 +26,16 @@ pub enum IndexUrl {
     Url(VerbatimUrl),
 }
 
+impl IndexUrl {
+    /// Return the raw URL for the index.
+    pub(crate) fn url(&self) -> &Url {
+        match self {
+            Self::Pypi(url) => url.raw(),
+            Self::Url(url) => url.raw(),
+        }
+    }
+}
+
 impl Display for IndexUrl {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -267,6 +277,16 @@ impl<'a> IndexLocations {
             extra_index: self.extra_index.clone(),
             no_index: self.no_index,
         }
+    }
+
+    /// Return an iterator over all [`Url`] entries.
+    pub fn urls(&'a self) -> impl Iterator<Item = &'a Url> + 'a {
+        self.indexes()
+            .map(IndexUrl::url)
+            .chain(self.flat_index.iter().filter_map(|index| match index {
+                FlatIndexLocation::Path(_) => None,
+                FlatIndexLocation::Url(url) => Some(url),
+            }))
     }
 }
 

--- a/crates/pypi-types/src/base_url.rs
+++ b/crates/pypi-types/src/base_url.rs
@@ -57,21 +57,6 @@ pub struct BaseUrl(
 );
 
 impl BaseUrl {
-    /// Parse the given URL. If it's relative, join it to the current [`BaseUrl`]. Allows for
-    /// parsing URLs that may be absolute or relative, with a known base URL.
-    pub fn join_relative(&self, url: &str) -> Result<Url, url::ParseError> {
-        match Url::parse(url) {
-            Ok(url) => Ok(url),
-            Err(err) => {
-                if err == url::ParseError::RelativeUrlWithoutBase {
-                    self.0.join(url)
-                } else {
-                    Err(err)
-                }
-            }
-        }
-    }
-
     /// Return the underlying [`Url`].
     pub fn as_url(&self) -> &Url {
         &self.0

--- a/crates/uv-auth/src/store.rs
+++ b/crates/uv-auth/src/store.rs
@@ -102,6 +102,7 @@ impl AuthenticationStore {
         }
     }
 
+    /// Store in-URL credentials for future use.
     pub fn save_from_url(&self, url: &Url) {
         let netloc = NetLoc::from(url);
         let mut credentials = self.credentials.lock().unwrap();

--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -18,7 +18,7 @@ use tracing::debug;
 use distribution_types::{IndexLocations, LocalEditable, Verbatim};
 use platform_tags::Tags;
 use requirements_txt::EditableRequirement;
-use uv_auth::KeyringProvider;
+use uv_auth::{KeyringProvider, GLOBAL_AUTH_STORE};
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
@@ -186,6 +186,11 @@ pub(crate) async fn pip_compile(
     // Incorporate any index locations from the provided sources.
     let index_locations =
         index_locations.combine(index_url, extra_index_urls, find_links, no_index);
+
+    // Add all authenticated sources to the store.
+    for url in index_locations.urls() {
+        GLOBAL_AUTH_STORE.save_from_url(url);
+    }
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -20,7 +20,7 @@ use pep508_rs::{MarkerEnvironment, Requirement};
 use platform_tags::Tags;
 use pypi_types::Yanked;
 use requirements_txt::EditableRequirement;
-use uv_auth::KeyringProvider;
+use uv_auth::{KeyringProvider, GLOBAL_AUTH_STORE};
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
@@ -180,6 +180,11 @@ pub(crate) async fn pip_install(
     // Incorporate any index locations from the provided sources.
     let index_locations =
         index_locations.combine(index_url, extra_index_urls, find_links, no_index);
+
+    // Add all authenticated sources to the store.
+    for url in index_locations.urls() {
+        GLOBAL_AUTH_STORE.save_from_url(url);
+    }
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -10,7 +10,7 @@ use install_wheel_rs::linker::LinkMode;
 use platform_tags::Tags;
 use pypi_types::Yanked;
 use requirements_txt::EditableRequirement;
-use uv_auth::KeyringProvider;
+use uv_auth::{KeyringProvider, GLOBAL_AUTH_STORE};
 use uv_cache::{ArchiveTarget, ArchiveTimestamp, Cache};
 use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
@@ -114,6 +114,11 @@ pub(crate) async fn pip_sync(
     // Incorporate any index locations from the provided sources.
     let index_locations =
         index_locations.combine(index_url, extra_index_urls, find_links, no_index);
+
+    // Add all authenticated sources to the store.
+    for url in index_locations.urls() {
+        GLOBAL_AUTH_STORE.save_from_url(url);
+    }
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 
 use distribution_types::{DistributionMetadata, IndexLocations, Name};
 use pep508_rs::Requirement;
-use uv_auth::KeyringProvider;
+use uv_auth::{KeyringProvider, GLOBAL_AUTH_STORE};
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
@@ -139,6 +139,11 @@ async fn venv_impl(
     if seed {
         // Extract the interpreter.
         let interpreter = venv.interpreter();
+
+        // Add all authenticated sources to the store.
+        for url in index_locations.urls() {
+            GLOBAL_AUTH_STORE.save_from_url(url);
+        }
 
         // Instantiate a client.
         let client = RegistryClientBuilder::new(cache.clone())


### PR DESCRIPTION
## Summary

The authentication middleware extracts in-URL credentials from URLs that pass through it; however, by the time a request reaches the store, the credentials will have already been removed, and relocated to the header. So we were never propagating in-URL credentials.

This PR adds an explicit pass wherein we pass in-URL credentials to the store prior to doing any work.

Closes https://github.com/astral-sh/uv/issues/2444.

## Test Plan

`cargo run pip install` against an authenticated AWS registry.
