### PR TITLE
Avoid panicking on cannot-be-a-base URLs

### DIFF
--- a/crates/cache-key/src/canonical_url.rs
+++ b/crates/cache-key/src/canonical_url.rs
@@ -21,6 +21,11 @@ impl CanonicalUrl {
     pub fn new(url: &Url) -> Self {
         let mut url = url.clone();
 
+        // If the URL cannot be a base, then it's not a valid URL anyway.
+        if url.cannot_be_a_base() {
+            return Self(url);
+        }
+
         // Strip a trailing slash.
         if url.path().ends_with('/') {
             url.path_segments_mut().unwrap().pop_if_empty();
@@ -192,6 +197,12 @@ mod tests {
             CanonicalUrl::parse(
                 "git+https://github.com/pypa/sample-namespace-packages.git@v2.0.0"
             )?,
+        );
+
+        // Two URLs that cannot be a base should be considered equal.
+        assert_eq!(
+            CanonicalUrl::parse("git+https:://github.com/pypa/sample-namespace-packages.git")?,
+            CanonicalUrl::parse("git+https:://github.com/pypa/sample-namespace-packages.git")?,
         );
 
         Ok(())


### PR DESCRIPTION
`path_segments_mut` returns an `Err` for cannot-be-a-base URLs. These won't be valid when we try to fetch them anyway, but we need to avoid a panic.

Closes https://github.com/astral-sh/uv/issues/2460.