### PR TITLE
Add empty gitignore during source distribution builds

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -815,8 +815,8 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
         // Download and unzip the source distribution into a temporary directory.
         let span =
             info_span!("download_source_dist", filename = filename, source_dist = %source_dist);
-        let temp_dir =
-            tempfile::tempdir_in(self.build_context.cache().root()).map_err(Error::CacheWrite)?;
+        let temp_dir = tempfile::tempdir_in(self.build_context.cache().bucket(CacheBucket::Build))
+            .map_err(Error::CacheWrite)?;
         let reader = response
             .bytes_stream()
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))
@@ -896,8 +896,9 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
         } else {
             debug!("Unpacking for build: {source_dist}");
 
-            let temp_dir = tempfile::tempdir_in(self.build_context.cache().root())
-                .map_err(Error::CacheWrite)?;
+            let temp_dir =
+                tempfile::tempdir_in(self.build_context.cache().bucket(CacheBucket::Build))
+                    .map_err(Error::CacheWrite)?;
 
             // Unzip the archive into the temporary directory.
             let reader = fs_err::tokio::File::open(&path)

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -815,8 +815,9 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
         // Download and unzip the source distribution into a temporary directory.
         let span =
             info_span!("download_source_dist", filename = filename, source_dist = %source_dist);
-        let temp_dir = tempfile::tempdir_in(self.build_context.cache().bucket(CacheBucket::Build))
-            .map_err(Error::CacheWrite)?;
+        let temp_dir =
+            tempfile::tempdir_in(self.build_context.cache().bucket(CacheBucket::BuiltWheels))
+                .map_err(Error::CacheWrite)?;
         let reader = response
             .bytes_stream()
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))
@@ -897,7 +898,7 @@ impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
             debug!("Unpacking for build: {source_dist}");
 
             let temp_dir =
-                tempfile::tempdir_in(self.build_context.cache().bucket(CacheBucket::Build))
+                tempfile::tempdir_in(self.build_context.cache().bucket(CacheBucket::BuiltWheels))
                     .map_err(Error::CacheWrite)?;
 
             // Unzip the archive into the temporary directory.


### PR DESCRIPTION
## Summary

It's not clear _why_ it matters in this case, but Hatchling respecting the `.gitignore` in our cache is causing certain builds to fail. This PR adds an empty `.gitignore` to the `built-wheels-v0` bucket and ensures that all unzipped distributions are stored in temporary folders within that bucket.

## Test Plan

Run `cargo run pip install "local_not_used_with_sdist_a @ file:///Users/crmarsh/Downloads/local_not_used_with_sdist_a-1.2.3" --reinstall --verbose --verbose -n`.

Then:

```
❯ ls .venv/lib/python3.12/site-packages/
__pycache__                                 _virtualenv.pth                             _virtualenv.py                              local_not_used_with_sdist_a                 local_not_used_with_sdist_a-1.2.3.dist-info
```
