### PR TITLE
WIP: add-colab-badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![image](https://img.shields.io/pypi/pyversions/uv.svg)](https://pypi.python.org/pypi/uv)
 [![Actions status](https://github.com/astral-sh/uv/workflows/CI/badge.svg)](https://github.com/astral-sh/uv/actions)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/astral-sh)
+[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1Lt2mw6zsqcvzmHxcqyp26EX-W5ARt1FZ#scrollTo=HNK4nQpn31BO)|
 
 An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in
 replacement for common `pip` and `pip-tools` workflows.


### PR DESCRIPTION
In writing https://github.com/astral-sh/uv/issues/2469 I created this. You are more than well to copy to you own notebook so you are the owner.

https://colab.research.google.com/drive/1Lt2mw6zsqcvzmHxcqyp26EX-W5ARt1FZ#scrollTo=HNK4nQpn31BO 

nevermind below think I got it now, clunky but useable

```
!curl -LsSf https://astral.sh/uv/install.sh | sh 
import os
os.environ['PATH'] = '/root/.cargo/bin:' + os.environ['PATH']
!uv venv
!uv pip install ruff
import sys
sys.path.append(".venv/lib/python3.10/site-packages")
import ruff
```