### PR TITLE
Make > operator exclude post and local releases

### DIFF
--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -398,6 +398,19 @@ impl Version {
         }
     }
 
+    /// Returns the max-release part of this version, if it exists.
+    ///
+    /// The "max" component is internal-only, and does not exist in PEP 440.
+    /// The version `1.0max0` is larger than all other `1.0` versions,
+    /// like `1.0.post1`, `1.0+local`, etc.
+    #[inline]
+    pub fn max(&self) -> Option<u64> {
+        match *self.inner {
+            VersionInner::Small { ref small } => small.max(),
+            VersionInner::Full { ref full } => full.max,
+        }
+    }
+
     /// Set the release numbers and return the updated version.
     ///
     /// Usually one can just use `Version::new` to create a new version with
@@ -541,6 +554,23 @@ impl Version {
         self
     }
 
+    /// Set the max-release component and return the updated version.
+    ///
+    /// The "max" component is internal-only, and does not exist in PEP 440.
+    /// The version `1.0max0` is larger than all other `1.0` versions,
+    /// like `1.0.post1`, `1.0+local`, etc.
+    #[inline]
+    pub fn with_max(mut self, value: Option<u64>) -> Self {
+        if let VersionInner::Small { ref mut small } = Arc::make_mut(&mut self.inner) {
+            if small.set_max(value) {
+                return self;
+            }
+        }
+        self.make_full().max = value;
+        self
+    }
+
+
     /// Convert this version to a "full" representation in-place and return a
     /// mutable borrow to the full type.
     fn make_full(&mut self) -> &mut VersionFull {
@@ -549,6 +579,7 @@ impl Version {
                 epoch: small.epoch(),
                 release: small.release().to_vec(),
                 min: small.min(),
+                max: small.max(),
                 pre: small.pre(),
                 post: small.post(),
                 dev: small.dev(),
@@ -774,13 +805,15 @@ impl FromStr for Version {
 /// * Bytes 5, 4 and 3 correspond to the second, third and fourth release
 /// segments, respectively.
 /// * Bytes 2, 1 and 0 represent *one* of the following:
-///   `min, .devN, aN, bN, rcN, <no suffix>, .postN`.
+///   `min, .devN, aN, bN, rcN, <no suffix>, .postN, max`.
 ///   Its representation is thus:
 ///   * The most significant 3 bits of Byte 2 corresponds to a value in
 ///   the range 0-6 inclusive, corresponding to min, dev, pre-a, pre-b, pre-rc,
 ///   no-suffix or post releases, respectively. `min` is a special version that
 ///   does not exist in PEP 440, but is used here to represent the smallest
-///   possible version, preceding any `dev`, `pre`, `post` or releases.
+///   possible version, preceding any `dev`, `pre`, `post` or releases. `max` is
+///   an analogous concept for the largest possible version, following any `post`
+///   or local releases.
 ///   * The low 5 bits combined with the bits in bytes 1 and 0 correspond
 ///   to the release number of the suffix, if one exists. If there is no
 ///   suffix, then this bits are always 0.
@@ -789,7 +822,7 @@ impl FromStr for Version {
 /// encoded at a less significant location than the release numbers, so that
 /// `1.2.3 < 1.2.3.post4`.
 ///
-/// In a previous representation, we tried to enocode the suffixes in different
+/// In a previous representation, we tried to encode the suffixes in different
 /// locations so that, in theory, you could represent `1.2.3.dev2.post3` in the
 /// packed form. But getting the ordering right for this is difficult (perhaps
 /// impossible without extra space?). So we limited to only storing one suffix.
@@ -850,6 +883,7 @@ impl VersionSmall {
     const SUFFIX_PRE_RC: u64 = 4;
     const SUFFIX_NONE: u64 = 5;
     const SUFFIX_POST: u64 = 6;
+    const SUFFIX_MAX: u64 = 7;
     const SUFFIX_MAX_VERSION: u64 = 0x1FFFFF;
 
     #[inline]
@@ -922,7 +956,7 @@ impl VersionSmall {
 
     #[inline]
     fn set_post(&mut self, value: Option<u64>) -> bool {
-        if self.min().is_some() || self.pre().is_some() || self.dev().is_some() {
+        if self.min().is_some() || self.pre().is_some() || self.dev().is_some() || self.max().is_some() {
             return value.is_none();
         }
         match value {
@@ -965,7 +999,7 @@ impl VersionSmall {
 
     #[inline]
     fn set_pre(&mut self, value: Option<PreRelease>) -> bool {
-        if self.min().is_some() || self.dev().is_some() || self.post().is_some() {
+        if self.min().is_some() || self.dev().is_some() || self.post().is_some() || self.max().is_some() {
             return value.is_none();
         }
         match value {
@@ -1004,7 +1038,7 @@ impl VersionSmall {
 
     #[inline]
     fn set_dev(&mut self, value: Option<u64>) -> bool {
-        if self.min().is_some() || self.pre().is_some() || self.post().is_some() {
+        if self.min().is_some() || self.pre().is_some() || self.post().is_some() || self.max().is_some() {
             return value.is_none();
         }
         match value {
@@ -1033,7 +1067,7 @@ impl VersionSmall {
 
     #[inline]
     fn set_min(&mut self, value: Option<u64>) -> bool {
-        if self.dev().is_some() || self.pre().is_some() || self.post().is_some() {
+        if self.dev().is_some() || self.pre().is_some() || self.post().is_some() || self.max().is_some() {
             return value.is_none();
         }
         match value {
@@ -1052,6 +1086,35 @@ impl VersionSmall {
     }
 
     #[inline]
+    fn max(&self) -> Option<u64> {
+        if self.suffix_kind() == Self::SUFFIX_MAX {
+            Some(self.suffix_version())
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn set_max(&mut self, value: Option<u64>) -> bool {
+        if self.dev().is_some() || self.pre().is_some() || self.post().is_some() || self.min().is_some() {
+            return value.is_none();
+        }
+        match value {
+            None => {
+                self.set_suffix_kind(Self::SUFFIX_NONE);
+            }
+            Some(number) => {
+                if number > Self::SUFFIX_MAX_VERSION {
+                    return false;
+                }
+                self.set_suffix_kind(Self::SUFFIX_MAX);
+                self.set_suffix_version(number);
+            }
+        }
+        true
+    }
+
+    #[inline]
     fn local(&self) -> &[LocalSegment] {
         // A "small" version is never used if the version has a non-zero number
         // of local segments.
@@ -1061,13 +1124,13 @@ impl VersionSmall {
     #[inline]
     fn suffix_kind(&self) -> u64 {
         let kind = (self.repr >> 21) & 0b111;
-        debug_assert!(kind <= Self::SUFFIX_POST);
+        debug_assert!(kind <= Self::SUFFIX_MAX);
         kind
     }
 
     #[inline]
     fn set_suffix_kind(&mut self, kind: u64) {
-        debug_assert!(kind <= Self::SUFFIX_POST);
+        debug_assert!(kind <= Self::SUFFIX_MAX);
         self.repr &= !0xE00000;
         self.repr |= kind << 21;
         if kind == Self::SUFFIX_NONE {
@@ -1146,6 +1209,10 @@ struct VersionFull {
     /// represent the smallest possible version of a release, preceding any
     /// `dev`, `pre`, `post` or releases.
     min: Option<u64>,
+    /// An internal-only segment that does not exist in PEP 440, used to
+    /// represent the largest possible version of a release, following any
+    /// `post` or local releases.
+    max: Option<u64>,
 }
 
 /// A version number pattern.
@@ -2319,12 +2386,12 @@ pub(crate) fn compare_release(this: &[u64], other: &[u64]) -> Ordering {
 /// implementation
 ///
 /// [pep440-suffix-ordering]: https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering
-fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, u64, &[LocalSegment]) {
+fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, Option<u64>, u64, &[LocalSegment]) {
     match (version.pre(), version.post(), version.dev(), version.min()) {
         // min release
-        (_pre, post, _dev, Some(n)) => (0, 0, post, n, version.local()),
+        (_pre, _post, _dev, Some(_), _max) => (0, 0, None, None, 0, version.local()),
         // dev release
-        (None, None, Some(n), None) => (1, 0, None, n, version.local()),
+        (None, None, Some(n), None, max) => (1, 0, max, None, n, version.local()),
         // alpha release
         (
             Some(PreRelease {
@@ -2334,7 +2401,8 @@ fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, u64, &[LocalSegm
             post,
             dev,
             None,
-        ) => (2, n, post, dev.unwrap_or(u64::MAX), version.local()),
+            max
+        ) => (2, n, max, post, dev.unwrap_or(u64::MAX), version.local()),
         // beta release
         (
             Some(PreRelease {
@@ -2344,7 +2412,8 @@ fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, u64, &[LocalSegm
             post,
             dev,
             None,
-        ) => (3, n, post, dev.unwrap_or(u64::MAX), version.local()),
+            max,
+        ) => (3, n, max, post, dev.unwrap_or(u64::MAX), version.local()),
         // alpha release
         (
             Some(PreRelease {
@@ -2354,12 +2423,13 @@ fn sortable_tuple(version: &Version) -> (u64, u64, Option<u64>, u64, &[LocalSegm
             post,
             dev,
             None,
-        ) => (4, n, post, dev.unwrap_or(u64::MAX), version.local()),
+            max,
+        ) => (4, n, max, post, dev.unwrap_or(u64::MAX), version.local()),
         // final release
-        (None, None, None, None) => (5, 0, None, 0, version.local()),
+        (None, None, None, None, max) => (5, 0, max, None, 0, version.local()),
         // post release
-        (None, Some(post), dev, None) => {
-            (6, 0, Some(post), dev.unwrap_or(u64::MAX), version.local())
+        (None, Some(post), dev, None, max) => {
+            (6, 0, max, Some(post), dev.unwrap_or(u64::MAX), version.local())
         }
     }
 }
@@ -3616,6 +3686,65 @@ mod tests {
 
         for greater in versions.iter() {
             let greater = greater.parse::<Version>().unwrap();
+            assert_eq!(
+                less.cmp(&greater),
+                Ordering::Less,
+                "less: {:?}\ngreater: {:?}",
+                less.as_bloated_debug(),
+                greater.as_bloated_debug()
+            );
+        }
+    }
+
+    #[test]
+    fn max_version() {
+        // Ensure that the `.max` suffix succeeds all other suffixes.
+        let greater = Version::new([1, 0]).with_max(Some(0));
+
+        let versions = &[
+            "1.dev0",
+            // "1.0.dev456",
+            // "1.0a1",
+            // "1.0a2.dev456",
+            // "1.0a12.dev456",
+            // "1.0a12",
+            // "1.0b1.dev456",
+            // "1.0b2",
+            // "1.0b2.post345.dev456",
+            // "1.0b2.post345",
+            // "1.0rc1.dev456",
+            // "1.0rc1",
+            // "1.0",
+            // "1.0+abc.5",
+            // "1.0+abc.7",
+            // "1.0+5",
+            // "1.0.post456.dev34",
+            // "1.0.post456",
+            // "1.0",
+        ];
+
+        for less in versions.iter() {
+            let less = less.parse::<Version>().unwrap();
+            assert_eq!(
+                less.cmp(&greater),
+                Ordering::Less,
+                "less: {:?}\ngreater: {:?}",
+                less.as_bloated_debug(),
+                greater.as_bloated_debug()
+            );
+        }
+
+        // Ensure that the `.max` suffix plays nicely with dev versions.
+        let greater = Version::new([1, 0]).with_dev(Some(5)).with_max(Some(0));
+
+        let versions = &[
+            "1.dev5",
+            "1.dev5+local",
+            "1.0",
+        ];
+
+        for less in versions.iter() {
+            let less = less.parse::<Version>().unwrap();
             assert_eq!(
                 less.cmp(&greater),
                 Ordering::Less,

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -537,7 +537,7 @@ impl CacheBucket {
             Self::FlatIndex => "flat-index-v0",
             Self::Git => "git-v0",
             Self::Interpreter => "interpreter-v0",
-            Self::Simple => "simple-v3",
+            Self::Simple => "simple-v4",
             Self::Wheels => "wheels-v0",
             Self::Archive => "archive-v0",
         }

--- a/crates/uv-resolver/src/pubgrub/specifier.rs
+++ b/crates/uv-resolver/src/pubgrub/specifier.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use pubgrub::range::Range;
 
-use pep440_rs::{LocalSegment, Operator, PreRelease, Version, VersionSpecifier};
+use pep440_rs::{Operator, PreRelease, Version, VersionSpecifier};
 
 use crate::ResolveError;
 
@@ -63,10 +63,12 @@ impl TryFrom<&VersionSpecifier> for PubGrubSpecifier {
                 // Per PEP 440: "The exclusive ordered comparison >V MUST NOT allow a post-release of
                 // the given version unless V itself is a post release."
                 let version = specifier.version().clone();
-                if version.is_post() {
-                    Range::strictly_higher_than(version.with_local(vec![LocalSegment::Number(u64::MAX)]))
+                if let Some(dev) = version.dev() {
+                    Range::higher_than(version.with_dev(Some(dev + 1)))
+                } else if let Some(post) = version.post() {
+                    Range::higher_than(version.with_post(Some(post + 1)))
                 } else {
-                    Range::strictly_higher_than(version.with_post(Some(u64::MAX)).with_local(vec![LocalSegment::Number(u64::MAX)]))
+                    Range::strictly_higher_than(version.with_max(Some(0)))
                 }
             }
             Operator::GreaterThanEqual => {

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -46,7 +46,7 @@ fn command(context: &TestContext) -> Command {
         .arg("pip")
         .arg("install")
         .arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.10/simple-html/")
+        .arg("http://localhost:3141")
         .arg("--find-links")
         .arg("https://raw.githubusercontent.com/zanieb/packse/0.3.10/vendor/links.html")
         .arg("--cache-dir")
@@ -2127,15 +2127,13 @@ fn post_greater_than() {
     uv_snapshot!(filters, command(&context)
         .arg("post-greater-than-a>1.2.3")
         , @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + package-a==1.2.3.post1
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only package-a<=1.2.3.post18446744073709551615+18446744073709551615 is available and you require package-a>1.2.3.post18446744073709551615+18446744073709551615, we can conclude that the requirements are unsatisfiable.
     "###);
 
     assert_installed(
@@ -2336,15 +2334,13 @@ fn post_local_greater_than() {
     uv_snapshot!(filters, command(&context)
         .arg("post-local-greater-than-a>1.2.3")
         , @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + package-a==1.2.3.post1+local
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only package-a<=1.2.3.post18446744073709551615+18446744073709551615 is available and you require package-a>1.2.3.post18446744073709551615+18446744073709551615, we can conclude that the requirements are unsatisfiable.
     "###);
 
     assert_installed(
@@ -2379,17 +2375,15 @@ fn post_local_greater_than_post() {
     filters.push((r"post-local-greater-than-post-", "package-"));
 
     uv_snapshot!(filters, command(&context)
-        .arg("post-local-greater-than-post-a>1.2.3.post0")
+        .arg("post-local-greater-than-post-a>1.2.3.post1")
         , @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
-    Installed 1 package in [TIME]
-     + package-a==1.2.3.post1
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only package-a<=1.2.3.post1+18446744073709551615 is available and you require package-a>1.2.3.post1+18446744073709551615, we can conclude that the requirements are unsatisfiable.
     "###);
 
     // The version '1.2.3.post1' satisfies the constraint '>1.2.3.post0'.

--- a/scripts/scenarios/generate.py
+++ b/scripts/scenarios/generate.py
@@ -152,59 +152,6 @@ def main(scenarios: list[Path], snapshot_update: bool = True):
             expected[
                 "explanation"
             ] = "We do not have correct behavior for local version identifiers yet"
-        elif scenario["name"] == "local-greater-than":
-            expected["satisfiable"] = True
-            expected["packages"] = [
-                {
-                    "name": "local-greater-than-a",
-                    "version": "1.2.3+foo",
-                    "module_name": "local_greater_than_a",
-                }
-            ]
-            expected["explanation"] = (
-                "We do not have correct behavior for local version identifiers yet"
-            )
-        elif scenario["name"] == "local-transitive-greater-than":
-            expected["satisfiable"] = True
-            expected["packages"] = [
-                {
-                    "name": "local-transitive-greater-than-a",
-                    "version": "1.0.0",
-                    "module_name": "local_transitive_greater_than_a",
-                },
-                {
-                    "name": "local-transitive-greater-than-b",
-                    "version": "2.0.0+foo",
-                    "module_name": "local_transitive_greater_than_b",
-                }
-            ]
-            expected["explanation"] = (
-                "We do not have correct behavior for local version identifiers yet"
-            )
-        elif scenario["name"] == 'post-greater-than':
-            expected["satisfiable"] = True
-            expected["packages"] = [
-                {
-                    "name": "post-greater-than-a",
-                    "version": "1.2.3.post1",
-                    "module_name": "post_greater_than_a",
-                }
-            ]
-            expected["explanation"] = (
-                "We do not have correct behavior for local version identifiers yet"
-            )
-        elif scenario["name"] == 'post-local-greater-than':
-            expected["satisfiable"] = True
-            expected["packages"] = [
-                {
-                    "name": "post-local-greater-than-a",
-                    "version": "1.2.3.post1+local",
-                    "module_name": "post_local_greater_than_a",
-                }
-            ]
-            expected["explanation"] = (
-                "We do not have correct behavior for local version identifiers yet"
-            )
 
     # Split scenarios into `install` and `compile` cases
     install_scenarios = []

--- a/scripts/scenarios/requirements.in
+++ b/scripts/scenarios/requirements.in
@@ -1,2 +1,2 @@
 chevron-blue
-packse>=0.3.10
+packse>=0.3.11


### PR DESCRIPTION
## Summary

This PR attempts to use a similar trick to that we added in https://github.com/astral-sh/uv/pull/1878, but for post-releases.

In https://github.com/astral-sh/uv/pull/1878, we added a fake "minimum" version to enable us to treat `< 1.0.0` as _excluding_ pre-releases of 1.0.0.

Today, on `main`, we accept post-releases and local versions in `> 1.0.0`. But per PEP 440, that should _exclude_ post-releases and local versions, unless the specifier is itself a pre-release, in which case, pre-releases are allowed (e.g., `> 1.0.0.post0` should allow `> 1.0.0.post1`).

To support this, we add a fake "maximum" version that's greater than all the post and local releases for a given version. This leverages our last remaining free bit in the compact representation.
