### PR TITLE
Re-add support for pyenv shims

### DIFF
--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -372,7 +372,8 @@ impl InterpreterInfo {
         let output = Command::new(interpreter)
             .arg("-m")
             .arg("python.get_interpreter_info")
-            .current_dir(tempdir.path().simplified())
+            .env("PYTHONPATH", tempdir.path())
+            .env("PYTHONSAFEPATH", "1")
             .output()
             .map_err(|err| Error::PythonSubcommandLaunch {
                 interpreter: interpreter.to_path_buf(),


### PR DESCRIPTION
## Summary

By running `get_interpreter_info.py` outside of the current working directory, we seem to have broken pyenv shims.

Closes https://github.com/astral-sh/uv/issues/2488.

## Test Plan

Without this change (resolving to the Homebrew Python, even though we start with a shim):

```
DEBUG Starting interpreter discovery for Python @ `python3.11`
DEBUG Probing interpreter info for: /Users/crmarsh/.pyenv/shims/python3.11
DEBUG Found Python 3.11.7 for: /Users/crmarsh/.pyenv/shims/python3.11
Using Python 3.11.7 interpreter at: /opt/homebrew/opt/python@3.11/bin/python3.11
Creating virtualenv at: .venv
INFO Removing existing directory
Activate with: source .venv/bin/activate
```

With this change:

```
DEBUG Starting interpreter discovery for Python @ `python3.11`
DEBUG Probing interpreter info for: /Users/crmarsh/.pyenv/shims/python3.11
DEBUG Found Python 3.11.1 for: /Users/crmarsh/.pyenv/shims/python3.11
Using Python 3.11.1 interpreter at: /Users/crmarsh/.pyenv/versions/3.11.1/bin/python3.11
Creating virtualenv at: .venv
INFO Removing existing directory
Activate with: source .venv/bin/activate
```
