### PR TITLE
feat: added method to get direct url json from dist

### DIFF
--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -190,3 +190,12 @@ impl InstalledMetadata for InstalledDist {
         }
     }
 }
+
+impl InstalledDirectUrlDist {
+    /// Get the direct url json for a direct url dist
+    /// useful function for installers that want to check the
+    /// `direct_url.json` metadata
+    pub fn direct_url(&self) -> Result<Option<pypi_types::DirectUrl>, anyhow::Error> {
+        InstalledDist::direct_url(&self.path)
+    }
+}


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
We want to use this in `pixi` to check the installed info against the lock file.

## Test Plan

<!-- How was it tested? -->
Not added any tests yet. I know uv writes the `direct_url.json`. I can add a test if advised :)