### PR TITLE
Fix wheel builds and uploads for musl ARM

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -272,10 +272,6 @@ jobs:
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: armv7-unknown-linux-gnueabihf
             arch: armv7
-          - target: armv7-unknown-linux-musleabihf
-            arch: armv7
-          - target: arm-unknown-linux-musleabihf
-            arch: arm
 
     steps:
       - uses: actions/checkout@v4
@@ -306,8 +302,6 @@ jobs:
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             ${{ env.MODULE_NAME }} --help
       - name: "Upload wheels"
-        # Skip for `arm`, which is not supported by PyPI.
-        if: ${{ matrix.platform.arch != 'arm' }}
         uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.platform.target }}
@@ -540,6 +534,10 @@ jobs:
           - target: aarch64-unknown-linux-musl
             arch: aarch64
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
+          - target: armv7-unknown-linux-musleabihf
+            arch: armv7
+          - target: arm-unknown-linux-musleabihf
+            arch: arm
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -272,6 +272,8 @@ jobs:
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: armv7-unknown-linux-gnueabihf
             arch: armv7
+          - target: arm-unknown-linux-musleabihf
+            arch: arm
 
     steps:
       - uses: actions/checkout@v4
@@ -536,8 +538,6 @@ jobs:
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: armv7-unknown-linux-musleabihf
             arch: armv7
-          - target: arm-unknown-linux-musleabihf
-            arch: arm
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
If you look at https://pypi.org/project/uv/0.1.22/#files...

- We didn't upload the ARMv6 wheel (I thought I had removed the `# Skip for `arm`, which is not supported by PyPI.`), it must've gotten re-added in a rebase or something.
- We lost the musllinux builds for ARM. I think this is because I built them as manylinux.