### PR TITLE
Search in both `purelib` and `platlib` for site-packages population

### DIFF
--- a/crates/uv-interpreter/src/python_environment.rs
+++ b/crates/uv-interpreter/src/python_environment.rs
@@ -88,9 +88,18 @@ impl PythonEnvironment {
         self.interpreter.sys_executable()
     }
 
-    /// Returns the path to the `site-packages` directory inside a virtual environment.
-    pub fn site_packages(&self) -> &Path {
-        self.interpreter.purelib()
+    /// Returns an iterator over the `site-packages` directories inside a virtual environment.
+    ///
+    /// In most cases, `purelib` and `platlib` will be the same, and so the iterator will contain
+    /// a single element; however, in some distributions, they may be different.
+    pub fn site_packages(&self) -> impl Iterator<Item = &Path> {
+        std::iter::once(self.interpreter.purelib()).chain(
+            if self.interpreter.purelib() == self.interpreter.platlib() {
+                None
+            } else {
+                Some(self.interpreter.platlib())
+            },
+        )
     }
 
     /// Returns the path to the `bin` directory inside a virtual environment.

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -129,14 +129,17 @@ pub(super) async fn compile_bytecode(
     printer: Printer,
 ) -> anyhow::Result<()> {
     let start = std::time::Instant::now();
-    let files = compile_tree(venv.site_packages(), venv.python_executable(), cache.root())
-        .await
-        .with_context(|| {
-            format!(
-                "Failed to bytecode compile {}",
-                venv.site_packages().simplified_display()
-            )
-        })?;
+    let mut files = 0;
+    for site_packages in venv.site_packages() {
+        files += compile_tree(site_packages, venv.python_executable(), cache.root())
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to bytecode-compile Python file in: {}",
+                    site_packages.simplified_display()
+                )
+            })?;
+    }
     let s = if files == 1 { "" } else { "s" };
     writeln!(
         printer.stderr(),

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -2948,7 +2948,7 @@ fn compile_invalid_pyc_invalidation_mode() -> Result<()> {
     Resolved 1 package in [TIME]
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
-    error: Failed to bytecode compile [SITE-PACKAGES]
+    error: Failed to bytecode-compile Python file in: [SITE-PACKAGES]
       Caused by: Python process stderr:
     Invalid value for PYC_INVALIDATION_MODE "bogus", valid are "TIMESTAMP", "CHECKED_HASH", "UNCHECKED_HASH":
       Caused by: Bytecode compilation failed, expected "[SITE-PACKAGES]/[FIRST-FILE]", received: ""


### PR DESCRIPTION
## Summary

In reality, there's no such thing as the `site-packages` directory for a given virtualenv. Rather, Python defines both `purelib` and `platlib`, where the former is for pure-Python packages and the latter is for packages that contain native code. These are almost always set to the same thing... but they don't _have_ to be, and in fact of Fedora they are not.

This PR changes the `site_packages` method to return an iterator of directories.

Note that the system tests introduced in https://github.com/astral-sh/uv/pull/2535, which failed on the PR itself, now pass.

Closes https://github.com/astral-sh/uv/issues/2527.
