### PR TITLE
feat: allow setting installer name other than `uv`

### DIFF
--- a/crates/uv-installer/src/installer.rs
+++ b/crates/uv-installer/src/installer.rs
@@ -9,6 +9,7 @@ pub struct Installer<'a> {
     venv: &'a PythonEnvironment,
     link_mode: install_wheel_rs::linker::LinkMode,
     reporter: Option<Box<dyn Reporter>>,
+    installer_name: Option<String>,
 }
 
 impl<'a> Installer<'a> {
@@ -18,6 +19,7 @@ impl<'a> Installer<'a> {
             venv,
             link_mode: install_wheel_rs::linker::LinkMode::default(),
             reporter: None,
+            installer_name: Some("uv".to_string()),
         }
     }
 
@@ -32,6 +34,15 @@ impl<'a> Installer<'a> {
     pub fn with_reporter(self, reporter: impl Reporter + 'static) -> Self {
         Self {
             reporter: Some(Box::new(reporter)),
+            ..self
+        }
+    }
+
+    /// Set the `installer_name` to something other than `"uv"`.
+    #[must_use]
+    pub fn with_installer_name(self, installer_name: Option<&str>) -> Self {
+        Self {
+            installer_name: installer_name.map(str::to_string),
             ..self
         }
     }
@@ -52,7 +63,7 @@ impl<'a> Installer<'a> {
                         .map(pypi_types::DirectUrl::try_from)
                         .transpose()?
                         .as_ref(),
-                    Some("uv"),
+                    self.installer_name.as_deref(),
                     self.link_mode,
                 )
                 .with_context(|| format!("Failed to install: {} ({wheel})", wheel.filename()))?;

--- a/crates/uv-installer/src/installer.rs
+++ b/crates/uv-installer/src/installer.rs
@@ -40,9 +40,9 @@ impl<'a> Installer<'a> {
 
     /// Set the `installer_name` to something other than `"uv"`.
     #[must_use]
-    pub fn with_installer_name(self, installer_name: Option<&str>) -> Self {
+    pub fn with_installer_name(self, installer_name: Option<String>) -> Self {
         Self {
-            installer_name: installer_name.map(str::to_string),
+            installer_name,
             ..self
         }
     }


### PR DESCRIPTION
## Summary

We would like to be able to configure the installer-name so that other tools can co-exist with `uv`. In `pixi` we would like to use `pixi-uv` as the installer name, for example, to be able to distinguish them from packages installed by pure `uv`.