### PR TITLE
Use URL-encoded username for keyring if no URL-encoded password

### DIFF
--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -262,6 +262,7 @@ mod tests {
     #[tokio::test]
     async fn test_with_keyring_no_username() -> Result<(), Box<dyn std::error::Error>> {
         let server = MockServer::start().await;
+        // this shouldn't save anything because there's no username in the URL
         GLOBAL_AUTH_STORE.save_from_url(&Url::parse(&server.uri()).expect("valid URL"));
 
         Mock::given(method("GET"))

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -68,7 +68,9 @@ impl Middleware for AuthMiddleware {
         };
 
         // Try auth strategies in order of precedence:
-        if stored_auth.is_some() && !matches!(stored_auth, Some(Some(Credential::UrlEncoded(_)))) {
+        if matches!(stored_auth, Some(Some(Credential::Basic(_))))
+            || (stored_auth.is_some() && original_header.is_none())
+        {
             // If we've already seen this URL, we can use the stored credentials
             if let Some(auth) = stored_auth.flatten() {
                 debug!("Adding authentication to already-seen URL: {url}");


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Currently, the middleware will not check keyring or netrc if there is any URL-encoded credentials.  `pip` will check keyring and netrc if there is no URL-encoded password, and use the URL-encoded username for keyring.  This updates the middleware to match `pip` functionality in this way.

See issue:
- #2563 

## Test Plan

<!-- How was it tested? -->

See included unit tests

Note:  Introduced `cfg`-branching functionality to `get_keyring_subprocess_auth` in order to bypass subprocess calls in unit tests.