### PR TITLE
Avoid repeating paths of workspace packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,37 @@ authors = ["uv"]
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
+cache-key = { path = "crates/cache-key" }
+distribution-filename = { path = "crates/distribution-filename" }
+distribution-types = { path = "crates/distribution-types" }
+install-wheel-rs = { path = "crates/install-wheel-rs" }
+once-map = { path = "crates/once-map" }
+pep440_rs = { path = "crates/pep440-rs" }
+pep508_rs = { path = "crates/pep508-rs" }
+platform-tags = { path = "crates/platform-tags" }
+pypi-types = { path = "crates/pypi-types" }
+requirements-txt = { path = "crates/requirements-txt" }
+uv = { path = "crates/uv" }
+uv-auth = { path = "crates/uv-auth" }
+uv-build = { path = "crates/uv-build" }
+uv-cache = { path = "crates/uv-cache" }
+uv-client = { path = "crates/uv-client" }
+uv-dev = { path = "crates/uv-dev" }
+uv-dispatch = { path = "crates/uv-dispatch" }
+uv-distribution = { path = "crates/uv-distribution" }
+uv-extract = { path = "crates/uv-extract" }
+uv-fs = { path = "crates/uv-fs" }
+uv-git = { path = "crates/uv-git" }
+uv-installer = { path = "crates/uv-installer" }
+uv-interpreter = { path = "crates/uv-interpreter" }
+uv-normalize = { path = "crates/uv-normalize" }
+uv-resolver = { path = "crates/uv-resolver" }
+uv-traits = { path = "crates/uv-traits" }
+uv-trampoline = { path = "crates/uv-trampoline" }
+uv-version = { path = "crates/uv-version" }
+uv-virtualenv = { path = "crates/uv-virtualenv" }
+uv-warnings = { path = "crates/uv-warnings" }
+
 anstream = { version = "0.6.13" }
 anyhow = { version = "1.0.80" }
 async-channel = { version = "2.2.0" }

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -23,7 +23,7 @@ path = "benches/distribution_filename.rs"
 harness = false
 
 [dependencies]
-distribution-filename = { path = "../distribution-filename" }
-platform-tags = { path = "../platform-tags" }
+distribution-filename = { workspace = true }
+platform-tags = { workspace = true }
 
 criterion = { version = "0.5.1", default-features = false }

--- a/crates/distribution-filename/Cargo.toml
+++ b/crates/distribution-filename/Cargo.toml
@@ -16,9 +16,9 @@ workspace = true
 rkyv = ["dep:rkyv", "pep440_rs/rkyv"]
 
 [dependencies]
-pep440_rs = { path = "../pep440-rs" }
-platform-tags = { path = "../platform-tags" }
-uv-normalize = { path = "../uv-normalize" }
+pep440_rs = { workspace = true }
+platform-tags = { workspace = true }
+uv-normalize = { workspace = true }
 
 rkyv = { workspace = true, features = ["strict", "validation"], optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/distribution-types/Cargo.toml
+++ b/crates/distribution-types/Cargo.toml
@@ -13,15 +13,15 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-cache-key = { path = "../cache-key" }
-distribution-filename = { path = "../distribution-filename", features = ["serde"] }
-pep440_rs = { path = "../pep440-rs" }
-pep508_rs = { path = "../pep508-rs" }
-platform-tags = { path = "../platform-tags" }
-uv-fs = { path = "../uv-fs" }
-uv-git = { path = "../uv-git", features = ["vendored-openssl"] }
-uv-normalize = { path = "../uv-normalize" }
-pypi-types = { path = "../pypi-types" }
+cache-key = { workspace = true }
+distribution-filename = { workspace = true, features = ["serde"] }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
+platform-tags = { workspace = true }
+uv-fs = { workspace = true }
+uv-git = { workspace = true, features = ["vendored-openssl"] }
+uv-normalize = { workspace = true }
+pypi-types = { workspace = true }
 
 anyhow = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/install-wheel-rs/Cargo.toml
+++ b/crates/install-wheel-rs/Cargo.toml
@@ -20,12 +20,12 @@ workspace = true
 name = "install_wheel_rs"
 
 [dependencies]
-distribution-filename = { path = "../distribution-filename" }
-pep440_rs = { path = "../pep440-rs" }
-platform-tags = { path = "../platform-tags" }
-uv-normalize = { path = "../uv-normalize" }
-uv-fs = { path = "../uv-fs" }
-pypi-types = { path = "../pypi-types" }
+distribution-filename = { workspace = true }
+pep440_rs = { workspace = true }
+platform-tags = { workspace = true }
+uv-normalize = { workspace = true }
+uv-fs = { workspace = true }
+pypi-types = { workspace = true }
 
 clap = { workspace = true, optional = true, features = ["derive"] }
 configparser = { workspace = true }

--- a/crates/pep508-rs/Cargo.toml
+++ b/crates/pep508-rs/Cargo.toml
@@ -17,9 +17,9 @@ name = "pep508_rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pep440_rs = { path = "../pep440-rs" }
-uv-fs = { path = "../uv-fs" }
-uv-normalize = { path = "../uv-normalize" }
+pep440_rs = { workspace = true }
+uv-fs = { workspace = true }
+uv-normalize = { workspace = true }
 
 derivative = { workspace = true }
 once_cell = { workspace = true }

--- a/crates/pypi-types/Cargo.toml
+++ b/crates/pypi-types/Cargo.toml
@@ -13,9 +13,9 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-pep440_rs = { path = "../pep440-rs", features = ["rkyv", "serde"] }
-pep508_rs = { path = "../pep508-rs", features = ["rkyv", "serde"] }
-uv-normalize = { path = "../uv-normalize" }
+pep440_rs = { workspace = true, features = ["rkyv", "serde"] }
+pep508_rs = { workspace = true, features = ["rkyv", "serde"] }
+uv-normalize = { workspace = true }
 
 chrono = { workspace = true, features = ["serde"] }
 mailparse = { workspace = true }

--- a/crates/requirements-txt/Cargo.toml
+++ b/crates/requirements-txt/Cargo.toml
@@ -13,11 +13,11 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-pep508_rs = { path = "../pep508-rs", features = ["rkyv", "serde", "non-pep508-extensions"] }
-uv-client = { path = "../uv-client" }
-uv-fs = { path = "../uv-fs" }
-uv-normalize = { path = "../uv-normalize" }
-uv-warnings = { path = "../uv-warnings" }
+pep508_rs = { workspace = true, features = ["rkyv", "serde", "non-pep508-extensions"] }
+uv-client = { workspace = true }
+uv-fs = { workspace = true }
+uv-normalize = { workspace = true }
+uv-warnings = { workspace = true }
 
 async-recursion = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/uv-build/Cargo.toml
+++ b/crates/uv-build/Cargo.toml
@@ -14,13 +14,13 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-distribution-types = { path = "../distribution-types" }
-pep440_rs = { path = "../pep440-rs" }
-pep508_rs = { path = "../pep508-rs" }
-uv-fs = { path = "../uv-fs" }
-uv-interpreter = { path = "../uv-interpreter" }
-uv-traits = { path = "../uv-traits", features = ["serde"] }
-uv-virtualenv = { path = "../uv-virtualenv" }
+distribution-types = { workspace = true }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
+uv-fs = { workspace = true }
+uv-interpreter = { workspace = true }
+uv-traits = { workspace = true, features = ["serde"] }
+uv-virtualenv = { workspace = true }
 
 anyhow = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/uv-cache/Cargo.toml
+++ b/crates/uv-cache/Cargo.toml
@@ -14,10 +14,10 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-cache-key = { path = "../cache-key" }
-distribution-types = { path = "../distribution-types" }
-uv-fs = { path = "../uv-fs" }
-uv-normalize = { path = "../uv-normalize" }
+cache-key = { workspace = true }
+distribution-types = { workspace = true }
+uv-fs = { workspace = true }
+uv-normalize = { workspace = true }
 
 cachedir = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"], optional = true }

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -4,20 +4,20 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-cache-key = { path = "../cache-key" }
-distribution-filename = { path = "../distribution-filename", features = ["rkyv", "serde"] }
-distribution-types = { path = "../distribution-types" }
-install-wheel-rs = { path = "../install-wheel-rs" }
-pep440_rs = { path = "../pep440-rs" }
-pep508_rs = { path = "../pep508-rs" }
-platform-tags = { path = "../platform-tags" }
-uv-auth = { path = "../uv-auth" }
-uv-cache = { path = "../uv-cache" }
-uv-fs = { path = "../uv-fs", features = ["tokio"] }
-uv-normalize = { path = "../uv-normalize" }
-uv-version = { path = "../uv-version" }
-uv-warnings = { path = "../uv-warnings" }
-pypi-types = { path = "../pypi-types" }
+cache-key = { workspace = true }
+distribution-filename = { workspace = true, features = ["rkyv", "serde"] }
+distribution-types = { workspace = true }
+install-wheel-rs = { workspace = true }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
+platform-tags = { workspace = true }
+uv-auth = { workspace = true }
+uv-cache = { workspace = true }
+uv-fs = { workspace = true, features = ["tokio"] }
+uv-normalize = { workspace = true }
+uv-version = { workspace = true }
+uv-warnings = { workspace = true }
+pypi-types = { workspace = true }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -16,22 +16,22 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-distribution-filename = { path = "../distribution-filename" }
-distribution-types = { path = "../distribution-types" }
-install-wheel-rs = { path = "../install-wheel-rs" }
-pep440_rs = { path = "../pep440-rs" }
-pep508_rs = { path = "../pep508-rs" }
-platform-tags = { path = "../platform-tags" }
-uv-build = { path = "../uv-build" }
-uv-cache = { path = "../uv-cache", features = ["clap"] }
-uv-client = { path = "../uv-client" }
-uv-dispatch = { path = "../uv-dispatch" }
-uv-distribution = { path = "../uv-distribution" }
-uv-installer = { path = "../uv-installer" }
-uv-interpreter = { path = "../uv-interpreter" }
-uv-normalize = { path = "../uv-normalize" }
-uv-resolver = { path = "../uv-resolver" }
-uv-traits = { path = "../uv-traits" }
+distribution-filename = { workspace = true }
+distribution-types = { workspace = true }
+install-wheel-rs = { workspace = true }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
+platform-tags = { workspace = true }
+uv-build = { workspace = true }
+uv-cache = { workspace = true, features = ["clap"] }
+uv-client = { workspace = true }
+uv-dispatch = { workspace = true }
+uv-distribution = { workspace = true }
+uv-installer = { workspace = true }
+uv-interpreter = { workspace = true }
+uv-normalize = { workspace = true }
+uv-resolver = { workspace = true }
+uv-traits = { workspace = true }
 
 # Any dependencies that are exclusively used in `uv-dev` should be listed as non-workspace
 # dependencies, to ensure that we're forced to think twice before including them in other crates.

--- a/crates/uv-dispatch/Cargo.toml
+++ b/crates/uv-dispatch/Cargo.toml
@@ -14,15 +14,15 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-distribution-types = { path = "../distribution-types" }
-pep508_rs = { path = "../pep508-rs" }
-uv-build = { path = "../uv-build" }
-uv-cache = { path = "../uv-cache" }
-uv-client = { path = "../uv-client" }
-uv-installer = { path = "../uv-installer" }
-uv-interpreter = { path = "../uv-interpreter" }
-uv-resolver = { path = "../uv-resolver" }
-uv-traits = { path = "../uv-traits" }
+distribution-types = { workspace = true }
+pep508_rs = { workspace = true }
+uv-build = { workspace = true }
+uv-cache = { workspace = true }
+uv-client = { workspace = true }
+uv-installer = { workspace = true }
+uv-interpreter = { workspace = true }
+uv-resolver = { workspace = true }
+uv-traits = { workspace = true }
 
 anyhow = { workspace = true }
 futures = { workspace = true }

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -13,21 +13,21 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-cache-key = { path = "../cache-key" }
-distribution-filename = { path = "../distribution-filename", features = ["serde"] }
-distribution-types = { path = "../distribution-types" }
-install-wheel-rs = { path = "../install-wheel-rs" }
-pep440_rs = { path = "../pep440-rs" }
-pep508_rs = { path = "../pep508-rs" }
-platform-tags = { path = "../platform-tags" }
-uv-cache = { path = "../uv-cache" }
-uv-client = { path = "../uv-client" }
-uv-extract = { path = "../uv-extract" }
-uv-fs = { path = "../uv-fs", features = ["tokio"] }
-uv-git = { path = "../uv-git", features = ["vendored-openssl"] }
-uv-normalize = { path = "../uv-normalize" }
-uv-traits = { path = "../uv-traits" }
-pypi-types = { path = "../pypi-types" }
+cache-key = { workspace = true }
+distribution-filename = { workspace = true, features = ["serde"] }
+distribution-types = { workspace = true }
+install-wheel-rs = { workspace = true }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
+platform-tags = { workspace = true }
+uv-cache = { workspace = true }
+uv-client = { workspace = true }
+uv-extract = { workspace = true }
+uv-fs = { workspace = true, features = ["tokio"] }
+uv-git = { workspace = true, features = ["vendored-openssl"] }
+uv-normalize = { workspace = true }
+uv-traits = { workspace = true }
+pypi-types = { workspace = true }
 
 anyhow = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -13,7 +13,7 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-uv-warnings = { path = "../uv-warnings" }
+uv-warnings = { workspace = true }
 
 backoff = { workspace = true }
 dunce = { workspace = true }

--- a/crates/uv-git/Cargo.toml
+++ b/crates/uv-git/Cargo.toml
@@ -13,8 +13,8 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-cache-key = { path = "../cache-key" }
-uv-fs = { path = "../uv-fs" }
+cache-key = { workspace = true }
+uv-fs = { workspace = true }
 
 anyhow = { workspace = true }
 base64 = { workspace = true }

--- a/crates/uv-installer/Cargo.toml
+++ b/crates/uv-installer/Cargo.toml
@@ -13,22 +13,22 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-distribution-types = { path = "../distribution-types" }
-install-wheel-rs = { path = "../install-wheel-rs", default-features = false }
-pep440_rs = { path = "../pep440-rs" }
-pep508_rs = { path = "../pep508-rs" }
-platform-tags = { path = "../platform-tags" }
-pypi-types = { path = "../pypi-types" }
-requirements-txt = { path = "../requirements-txt" }
-uv-cache = { path = "../uv-cache" }
-uv-client = { path = "../uv-client" }
-uv-distribution = { path = "../uv-distribution" }
-uv-extract = { path = "../uv-extract" }
-uv-fs = { path = "../uv-fs" }
-uv-interpreter = { path = "../uv-interpreter" }
-uv-normalize = { path = "../uv-normalize" }
-uv-traits = { path = "../uv-traits" }
-uv-warnings = { path = "../uv-warnings" }
+distribution-types = { workspace = true }
+install-wheel-rs = { workspace = true, default-features = false }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
+platform-tags = { workspace = true }
+pypi-types = { workspace = true }
+requirements-txt = { workspace = true }
+uv-cache = { workspace = true }
+uv-client = { workspace = true }
+uv-distribution = { workspace = true }
+uv-extract = { workspace = true }
+uv-fs = { workspace = true }
+uv-interpreter = { workspace = true }
+uv-normalize = { workspace = true }
+uv-traits = { workspace = true }
+uv-warnings = { workspace = true }
 
 anyhow = { workspace = true }
 async-channel = { workspace = true }

--- a/crates/uv-interpreter/Cargo.toml
+++ b/crates/uv-interpreter/Cargo.toml
@@ -13,14 +13,14 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-cache-key = { path = "../cache-key" }
-install-wheel-rs = { path = "../install-wheel-rs" }
-pep440_rs = { path = "../pep440-rs" }
-pep508_rs = { path = "../pep508-rs", features = ["serde"] }
-platform-tags = { path = "../platform-tags" }
-pypi-types = { path = "../pypi-types" }
-uv-cache = { path = "../uv-cache" }
-uv-fs = { path = "../uv-fs" }
+cache-key = { workspace = true }
+install-wheel-rs = { workspace = true }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true, features = ["serde"] }
+platform-tags = { workspace = true }
+pypi-types = { workspace = true }
+uv-cache = { workspace = true }
+uv-fs = { workspace = true }
 
 configparser = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -13,22 +13,22 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-cache-key = { path = "../cache-key" }
-distribution-filename = { path = "../distribution-filename", features = ["serde"] }
-distribution-types = { path = "../distribution-types" }
-once-map = { path = "../once-map" }
-pep440_rs = { path = "../pep440-rs", features = ["pubgrub"] }
-pep508_rs = { path = "../pep508-rs" }
-platform-tags = { path = "../platform-tags" }
-pypi-types = { path = "../pypi-types" }
-requirements-txt = { path = "../requirements-txt" }
-uv-cache = { path = "../uv-cache" }
-uv-client = { path = "../uv-client" }
-uv-distribution = { path = "../uv-distribution" }
-uv-interpreter = { path = "../uv-interpreter" }
-uv-normalize = { path = "../uv-normalize" }
-uv-traits = { path = "../uv-traits" }
-uv-warnings = { path = "../uv-warnings" }
+cache-key = { workspace = true }
+distribution-filename = { workspace = true, features = ["serde"] }
+distribution-types = { workspace = true }
+once-map = { workspace = true }
+pep440_rs = { workspace = true, features = ["pubgrub"] }
+pep508_rs = { workspace = true }
+platform-tags = { workspace = true }
+pypi-types = { workspace = true }
+requirements-txt = { workspace = true }
+uv-cache = { workspace = true }
+uv-client = { workspace = true }
+uv-distribution = { workspace = true }
+uv-interpreter = { workspace = true }
+uv-normalize = { workspace = true }
+uv-traits = { workspace = true }
+uv-warnings = { workspace = true }
 
 anstream = { workspace = true }
 anyhow = { workspace = true }
@@ -53,7 +53,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-uv-interpreter = { path = "../uv-interpreter" }
+uv-interpreter = { workspace = true }
 
 once_cell = { version = "1.19.0" }
 insta = { version = "1.36.1" }

--- a/crates/uv-traits/Cargo.toml
+++ b/crates/uv-traits/Cargo.toml
@@ -13,12 +13,12 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-distribution-types = { path = "../distribution-types" }
-once-map = { path = "../once-map" }
-pep508_rs = { path = "../pep508-rs" }
-uv-cache = { path = "../uv-cache" }
-uv-interpreter = { path = "../uv-interpreter" }
-uv-normalize = { path = "../uv-normalize" }
+distribution-types = { workspace = true }
+once-map = { workspace = true }
+pep508_rs = { workspace = true }
+uv-cache = { workspace = true }
+uv-interpreter = { workspace = true }
+uv-normalize = { workspace = true }
 
 anyhow = { workspace = true }
 serde = { workspace = true, optional = true }

--- a/crates/uv-virtualenv/Cargo.toml
+++ b/crates/uv-virtualenv/Cargo.toml
@@ -21,11 +21,11 @@ required-features = ["cli"]
 workspace = true
 
 [dependencies]
-platform-tags = { path = "../platform-tags" }
-pypi-types = { path = "../pypi-types" }
-uv-cache = { path = "../uv-cache" }
-uv-fs = { path = "../uv-fs" }
-uv-interpreter = { path = "../uv-interpreter" }
+platform-tags = { workspace = true }
+pypi-types = { workspace = true }
+uv-cache = { workspace = true }
+uv-fs = { workspace = true }
+uv-interpreter = { workspace = true }
 
 anstream = { workspace = true }
 cachedir = { workspace = true }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -14,24 +14,24 @@ default-run = "uv"
 workspace = true
 
 [dependencies]
-distribution-types = { path = "../distribution-types" }
-install-wheel-rs = { path = "../install-wheel-rs", features = ["clap"], default-features = false }
-pep508_rs = { path = "../pep508-rs" }
-platform-tags = { path = "../platform-tags" }
-pypi-types = { path = "../pypi-types" }
-requirements-txt = { path = "../requirements-txt", features = ["reqwest"] }
-uv-auth = { path = "../uv-auth", features = ["clap"] }
-uv-cache = { path = "../uv-cache", features = ["clap"] }
-uv-client = { path = "../uv-client" }
-uv-dispatch = { path = "../uv-dispatch" }
-uv-fs = { path = "../uv-fs" }
-uv-installer = { path = "../uv-installer" }
-uv-interpreter = { path = "../uv-interpreter" }
-uv-normalize = { path = "../uv-normalize" }
-uv-resolver = { path = "../uv-resolver", features = ["clap"] }
-uv-traits = { path = "../uv-traits" }
-uv-virtualenv = { path = "../uv-virtualenv" }
-uv-warnings = { path = "../uv-warnings" }
+distribution-types = { workspace = true }
+install-wheel-rs = { workspace = true, features = ["clap"], default-features = false }
+pep508_rs = { workspace = true }
+platform-tags = { workspace = true }
+pypi-types = { workspace = true }
+requirements-txt = { workspace = true, features = ["reqwest"] }
+uv-auth = { workspace = true, features = ["clap"] }
+uv-cache = { workspace = true, features = ["clap"] }
+uv-client = { workspace = true }
+uv-dispatch = { workspace = true }
+uv-fs = { workspace = true }
+uv-installer = { workspace = true }
+uv-interpreter = { workspace = true }
+uv-normalize = { workspace = true }
+uv-resolver = { workspace = true, features = ["clap"] }
+uv-traits = { workspace = true }
+uv-virtualenv = { workspace = true }
+uv-warnings = { workspace = true }
 
 anstream = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
Scott schafer got me the idea: We can avoid repeating the path for workspaces dependencies everywhere if we declare them in the virtual package once and treat them as workspace dependencies from there on.