### PR TITLE
`VIRTUAL_ENV` takes precedence over `CONDA_PREFIX`

### DIFF
--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -33,8 +33,6 @@ mod virtualenv;
 pub enum Error {
     #[error("Expected `{0}` to be a virtualenv, but `pyvenv.cfg` is missing")]
     MissingPyVenvCfg(PathBuf),
-    #[error("Both VIRTUAL_ENV and CONDA_PREFIX are set. Please unset one of them.")]
-    Conflict,
     #[error("No versions of Python could be found. Is Python installed?")]
     PythonNotFound,
     #[error("Failed to locate a virtualenv or Conda environment (checked: `VIRTUAL_ENV`, `CONDA_PREFIX`, and `.venv`). Run `uv venv` to create a virtualenv.")]


### PR DESCRIPTION
It is a common pattern to have an active conda base env (that sets `CONDA_PREFIX`) and then create a venv on top of that (setting `VIRTUAL_ENV`).

Previously, we would error when both `VIRTUAL_ENV` and `CONDA_PREFIX` were set, now `VIRTUAL_ENV` takes precedence over `CONDA_PREFIX`.

Fixes #2028