### PR TITLE
Enable install audits without resolving named requirements

### DIFF
--- a/crates/uv/src/commands/pip_uninstall.rs
+++ b/crates/uv/src/commands/pip_uninstall.rs
@@ -81,7 +81,8 @@ pub(crate) async fn pip_uninstall(
     // Index the current `site-packages` directory.
     let site_packages = uv_installer::SitePackages::from_executable(&venv)?;
 
-    // Sort and deduplicate the packages, which are keyed by name.
+    // Sort and deduplicate the packages, which are keyed by name. Like `pip`, we ignore the
+    // dependency specifier (even if it's a URL).
     let packages = {
         let mut packages = requirements
             .into_iter()


### PR DESCRIPTION
## Summary

This PR ensures that if a package is already satisfied by the current environment, we don't bother resolving the named requirement.

Part of: https://github.com/astral-sh/uv/issues/313.

## Test Plan

- `cargo run pip install ./scripts/editable-installs/black_editable`
- `cargo run pip install black --verbose`
