### PR TITLE
WIP: feat: uv pip list --outdated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,12 +2384,12 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_info"
-version = "3.7.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+checksum = "6cbb46d5d01695d7a1fb8be5f0d1968bd2b2b8ba1d1b3e7062ce2a0593e57af1"
 dependencies = [
  "log",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -30,7 +30,7 @@ pub struct SitePackages<'a> {
     /// The installed distributions, keyed by name. Although the Python runtime does not support it,
     /// it is possible to have multiple distributions with the same name to be present in the
     /// virtual environment, which we handle gracefully.
-    by_name: FxHashMap<PackageName, Vec<usize>>,
+    pub by_name: FxHashMap<PackageName, Vec<usize>>,
     /// The installed editable distributions, keyed by URL.
     by_url: FxHashMap<Url, Vec<usize>>,
 }

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -910,7 +910,7 @@ async fn install(
 }
 
 /// Validate the installed packages in the virtual environment.
-pub(crate) fn validate(
+fn validate(
     resolution: &Resolution,
     venv: &PythonEnvironment,
     printer: Printer,

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -336,7 +336,7 @@ pub(crate) async fn pip_install(
 }
 
 /// Consolidate the requirements for an installation.
-async fn read_requirements(
+pub(crate) async fn read_requirements(
     requirements: &[RequirementsSource],
     constraints: &[RequirementsSource],
     overrides: &[RequirementsSource],
@@ -385,7 +385,7 @@ async fn read_requirements(
 
 /// Build a set of editable distributions.
 #[allow(clippy::too_many_arguments)]
-async fn build_editables(
+pub(crate) async fn build_editables(
     editables: &[EditableRequirement],
     editable_wheel_dir: &Path,
     cache: &Cache,
@@ -451,7 +451,7 @@ async fn build_editables(
 
 /// Resolve a set of requirements, similar to running `pip compile`.
 #[allow(clippy::too_many_arguments)]
-async fn resolve(
+pub(crate) async fn resolve(
     requirements: Vec<Requirement>,
     constraints: Vec<Requirement>,
     overrides: Vec<Requirement>,
@@ -910,7 +910,7 @@ async fn install(
 }
 
 /// Validate the installed packages in the virtual environment.
-fn validate(
+pub(crate) fn validate(
     resolution: &Resolution,
     venv: &PythonEnvironment,
     printer: Printer,
@@ -936,7 +936,7 @@ fn validate(
 }
 
 #[derive(thiserror::Error, Debug)]
-enum Error {
+pub(crate) enum Error {
     #[error(transparent)]
     Resolve(#[from] uv_resolver::ResolveError),
 

--- a/crates/uv/src/commands/pip_list.rs
+++ b/crates/uv/src/commands/pip_list.rs
@@ -2,28 +2,37 @@ use std::cmp::max;
 use std::fmt::Write;
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 use serde::Serialize;
 use tracing::debug;
 use unicode_width::UnicodeWidthStr;
+use uv_dispatch::BuildDispatch;
 
-use distribution_types::{InstalledDist, Name};
+use crate::commands::pip_install::{build_editables, read_requirements, resolve, Error};
+use crate::commands::{ExitStatus, Upgrade};
+use crate::printer::Printer;
+use crate::requirements::{ExtrasSpecification, NamedRequirements, RequirementsSource};
+use distribution_types::{IndexLocations, InstalledDist, Name, Resolution};
+use tempfile::tempdir_in;
+use uv_auth::{KeyringProvider, GLOBAL_AUTH_STORE};
 use uv_cache::Cache;
+use uv_client::{Connectivity, FlatIndex, FlatIndexClient, RegistryClientBuilder};
 use uv_fs::Simplified;
-use uv_installer::SitePackages;
+use uv_installer::{Reinstall, SitePackages};
 use uv_interpreter::PythonEnvironment;
 use uv_normalize::PackageName;
-
-use crate::commands::ExitStatus;
-use crate::printer::Printer;
+use uv_resolver::{DependencyMode, InMemoryIndex, OptionsBuilder, PreReleaseMode, ResolutionMode};
+use uv_traits::{BuildIsolation, ConfigSettings, InFlight, NoBinary, NoBuild, SetupPyStrategy};
 
 use super::ListFormat;
 
 /// Enumerate the installed packages in the current environment.
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
-pub(crate) fn pip_list(
+pub(crate) async fn pip_list(
     strict: bool,
+    outdated: bool,
     editable: bool,
     exclude_editable: bool,
     exclude: &[PackageName],
@@ -58,7 +67,7 @@ pub(crate) fn pip_list(
     let site_packages = SitePackages::from_executable(&venv)?;
 
     // Filter if `--editable` is specified; always sort by name.
-    let results = site_packages
+    let mut results = site_packages
         .iter()
         .filter(|dist| {
             (!dist.is_editable() && !editable) || (dist.is_editable() && !exclude_editable)
@@ -68,6 +77,205 @@ pub(crate) fn pip_list(
         .collect_vec();
     if results.is_empty() {
         return Ok(ExitStatus::Success);
+    }
+
+    if outdated {
+        let constraints: &[RequirementsSource] = Default::default();
+        let overrides: &[RequirementsSource] = Default::default();
+        let extras: ExtrasSpecification<'_> = ExtrasSpecification::default();
+        let connectivity: Connectivity = Connectivity::Online;
+
+        let resolution_mode: ResolutionMode = ResolutionMode::Highest;
+        let prerelease_mode: PreReleaseMode = PreReleaseMode::default();
+        let dependency_mode: DependencyMode = DependencyMode::default();
+        let upgrade: Upgrade = Upgrade::All;
+        let index_locations: IndexLocations = IndexLocations::default();
+        let keyring_provider: KeyringProvider = KeyringProvider::default();
+        let reinstall: Reinstall = Reinstall::All;
+        let setup_py: SetupPyStrategy = SetupPyStrategy::default();
+        let config_settings: ConfigSettings = ConfigSettings::default();
+        let no_build: NoBuild = NoBuild::None;
+        let no_binary: NoBinary = NoBinary::None;
+        let exclude_newer: Option<DateTime<Utc>> = None;
+        let break_system_packages: bool = false;
+        let native_tls: bool = false;
+
+        let _lock = venv.lock()?;
+
+        // Determine the set of installed packages.
+        let site_packages = SitePackages::from_executable(&venv)?;
+
+        let requirements = &site_packages
+            .by_name
+            .keys()
+            .map(|p| RequirementsSource::Package(p.as_dist_info_name().to_string()))
+            .collect::<Vec<_>>();
+
+        // Read all requirements from the provided sources.
+        let spec =
+            read_requirements(requirements, constraints, overrides, &extras, connectivity).await?;
+
+        // If the environment is externally managed, abort.
+        if let Some(externally_managed) = venv.interpreter().is_externally_managed() {
+            if break_system_packages {
+                debug!("Ignoring externally managed environment due to `--break-system-packages`");
+            } else {
+                return if let Some(error) = externally_managed.into_error() {
+                    Err(anyhow::anyhow!(
+                        "The interpreter at {} is externally managed, and indicates the following:\n\n{}\n\nConsider creating a virtual environment with `uv venv`.",
+                        venv.root().simplified_display().cyan(),
+                        textwrap::indent(&error, "  ").green(),
+                    ))
+                } else {
+                    Err(anyhow::anyhow!(
+                        "The interpreter at {} is externally managed. Instead, create a virtual environment with `uv venv`.",
+                        venv.root().simplified_display().cyan()
+                    ))
+                };
+            }
+        }
+
+        // Convert from unnamed to named requirements.
+        let NamedRequirements {
+            project,
+            requirements,
+            constraints,
+            overrides,
+            editables,
+            index_url,
+            extra_index_urls,
+            no_index,
+            find_links,
+        } = NamedRequirements::from_spec(spec)?;
+
+        // Determine the tags, markers, and interpreter to use for resolution.
+        let interpreter = venv.interpreter().clone();
+        let tags = venv.interpreter().tags()?;
+        let markers = venv.interpreter().markers();
+
+        // Incorporate any index locations from the provided sources.
+        let index_locations =
+            index_locations.combine(index_url, extra_index_urls, find_links, no_index);
+
+        // Add all authenticated sources to the store.
+        for url in index_locations.urls() {
+            GLOBAL_AUTH_STORE.save_from_url(url);
+        }
+
+        // Initialize the registry client.
+        let client = RegistryClientBuilder::new(cache.clone())
+            .native_tls(native_tls)
+            .connectivity(connectivity)
+            .index_urls(index_locations.index_urls())
+            .keyring_provider(keyring_provider)
+            .markers(markers)
+            .platform(interpreter.platform())
+            .build();
+
+        // Resolve the flat indexes from `--find-links`.
+        let flat_index = {
+            let client = FlatIndexClient::new(&client, cache);
+            let entries = client.fetch(index_locations.flat_index()).await?;
+            FlatIndex::from_entries(entries, tags)
+        };
+
+        let build_isolation = BuildIsolation::Isolated;
+
+        // Create a shared in-memory index.
+        let index = InMemoryIndex::default();
+
+        // Track in-flight downloads, builds, etc., across resolutions.
+        let in_flight = InFlight::default();
+
+        let resolve_dispatch = BuildDispatch::new(
+            &client,
+            cache,
+            &interpreter,
+            &index_locations,
+            &flat_index,
+            &index,
+            &in_flight,
+            setup_py,
+            &config_settings,
+            build_isolation,
+            &no_build,
+            &no_binary,
+        )
+        .with_options(OptionsBuilder::new().exclude_newer(exclude_newer).build());
+
+        // Build all editable distributions. The editables are shared between resolution and
+        // installation, and should live for the duration of the command. If an editable is already
+        // installed in the environment, we'll still re-build it here.
+        let editable_wheel_dir;
+        let editables = if editables.is_empty() {
+            vec![]
+        } else {
+            editable_wheel_dir = tempdir_in(venv.root())?;
+            build_editables(
+                &editables,
+                editable_wheel_dir.path(),
+                cache,
+                &interpreter,
+                tags,
+                &client,
+                &resolve_dispatch,
+                printer,
+            )
+            .await?
+        };
+
+        let options = OptionsBuilder::new()
+            .resolution_mode(resolution_mode)
+            .prerelease_mode(prerelease_mode)
+            .dependency_mode(dependency_mode)
+            .exclude_newer(exclude_newer)
+            .build();
+
+        // Resolve the requirements.
+        let resolution = match resolve(
+            requirements,
+            constraints,
+            overrides,
+            project,
+            &editables,
+            &site_packages,
+            &reinstall,
+            &upgrade,
+            &interpreter,
+            tags,
+            markers,
+            &client,
+            &flat_index,
+            &index,
+            &resolve_dispatch,
+            options,
+            printer,
+        )
+        .await
+        {
+            Ok(resolution) => Resolution::from(resolution),
+            Err(Error::Resolve(uv_resolver::ResolveError::NoSolution(err))) => {
+                let report = miette::Report::msg(format!("{err}"))
+                    .context("No solution found when resolving dependencies:");
+                eprint!("{report:?}");
+                return Ok(ExitStatus::Failure);
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        results = results
+            .into_iter()
+            .filter(|result| {
+                let current_version = result.version();
+                match resolution.get(result.name()) {
+                    Some(dist) => {
+                        let available_version = dist.version().unwrap_or(current_version);
+                        available_version > current_version
+                    }
+                    _ => false,
+                }
+            })
+            .collect::<Vec<_>>()
     }
 
     match format {

--- a/crates/uv/src/commands/pip_list.rs
+++ b/crates/uv/src/commands/pip_list.rs
@@ -275,7 +275,7 @@ pub(crate) async fn pip_list(
                     _ => false,
                 }
             })
-            .collect::<Vec<_>>()
+            .collect::<Vec<_>>();
     }
 
     match format {

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -1065,6 +1065,10 @@ struct PipListArgs {
     #[clap(long)]
     strict: bool,
 
+    /// Only include outdated projects.
+    #[clap(short, long)]
+    outdated: bool,
+
     /// Only include editable projects.
     #[clap(short, long)]
     editable: bool,
@@ -1736,6 +1740,7 @@ async fn run() -> Result<ExitStatus> {
             command: PipCommand::List(args),
         }) => commands::pip_list(
             args.strict,
+            args.outdated,
             args.editable,
             args.exclude_editable,
             &args.exclude,
@@ -1744,7 +1749,7 @@ async fn run() -> Result<ExitStatus> {
             args.system,
             &cache,
             printer,
-        ),
+        ).await,
         Commands::Pip(PipNamespace {
             command: PipCommand::Show(args),
         }) => commands::pip_show(

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -1738,18 +1738,21 @@ async fn run() -> Result<ExitStatus> {
         ),
         Commands::Pip(PipNamespace {
             command: PipCommand::List(args),
-        }) => commands::pip_list(
-            args.strict,
-            args.outdated,
-            args.editable,
-            args.exclude_editable,
-            &args.exclude,
-            &args.format,
-            args.python.as_deref(),
-            args.system,
-            &cache,
-            printer,
-        ).await,
+        }) => {
+            commands::pip_list(
+                args.strict,
+                args.outdated,
+                args.editable,
+                args.exclude_editable,
+                &args.exclude,
+                &args.format,
+                args.python.as_deref(),
+                args.system,
+                &cache,
+                printer,
+            )
+            .await
+        }
         Commands::Pip(PipNamespace {
             command: PipCommand::Show(args),
         }) => commands::pip_show(


### PR DESCRIPTION
## Summary

This PR adds support for `uv pip list --outdated`

https://pip.pypa.io/en/stable/cli/pip_list/#cmdoption-o

Fixes https://github.com/astral-sh/uv/issues/2150

## WIP

This PR is currently a work in progress, and I am seeking feedback on the approach 🙏

I have left some comments in the code and would appreciate feedback on both the large scale approach and also any small-scale implementation details.

I have got to the point where running the command correctly identifies those packages which have an update available.

```sh
➜  uv git:(feat/pip-list-outdated) cargo r --bin uv -- pip list --outdated
Resolved 370 packages in 2.33s
Package                           Version
--------------------------------- --------------
aenum                             3.1.11
aiodns                            3.0.0
...
```

* [ ] The output formatting needs updating in order to match `pip`

```sh
➜  uv git:(timl/pip-list-outdated) pip list --outdated                    
Package                           Version        Latest         Type
--------------------------------- -------------- -------------- -----
aenum                             3.1.11         3.1.15         wheel
aiodns                            3.0.0          3.1.1          wheel
...
```

## Test Plan

WIP