### PR TITLE
feat: make direct_url public

### DIFF
--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -101,7 +101,7 @@ impl InstalledDist {
     }
 
     /// Read the `direct_url.json` file from a `.dist-info` directory.
-    fn direct_url(path: &Path) -> Result<Option<pypi_types::DirectUrl>> {
+    pub fn direct_url(path: &Path) -> Result<Option<pypi_types::DirectUrl>> {
         let path = path.join("direct_url.json");
         let Ok(file) = fs_err::File::open(path) else {
             return Ok(None);


### PR DESCRIPTION

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Made the `direct_url` method public because it was not :) Can be merged instead of in addition to: https://github.com/astral-sh/uv/pull/2510

## Test Plan

<!-- How was it tested? -->
