### PR TITLE
Fix authentication with JFrog artifactories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4424,6 +4424,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "urlencoding",
  "wiremock",
 ]
 

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -14,6 +14,7 @@ task-local-extensions = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+urlencoding = { workspace = true }
 once_cell = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Closes #2566 

We were storing the username e.g. `charlie@astral.sh` as a percent-encoded string `charlie%40astral.sh` which resulted in different headers and broke JFrog's artifactory which apparently does not decode usernames.

Tested with a JFrog artifactory and AWS CodeArtifact although it is worth noting that AWS does _not_ have a username with an `@` — it'd be nice to test another artifactory with percent-encoded characters in the username and/or password.