### PR TITLE
Don't install `pydantic_core` on Python 3.13

### DIFF
--- a/scripts/check_system_python.py
+++ b/scripts/check_system_python.py
@@ -174,6 +174,7 @@ if __name__ == "__main__":
         # This ensures that we can successfully install and recognize a package that may
         # be installed into `platlib`.
         #
-        # `pydantic_core` doesn't distribute wheels for non-CPython interpreters.
-        if sys.implementation.name == "cpython":
+        # `pydantic_core` doesn't distribute wheels for non-CPython interpreters, nor
+        # for Python 3.13 (at time of writing).
+        if sys.version_info < (3, 13) and sys.implementation.name == "cpython":
             install_package(uv=uv, package="pydantic_core")


### PR DESCRIPTION
See: https://github.com/astral-sh/uv/actions/runs/8379602011/job/22947128453?pr=1217

![Screenshot 2024-03-21 at 2 06 40 PM](https://github.com/astral-sh/uv/assets/1309177/227d9e76-7b5d-4730-8f13-cc8bb4a7ac33)
