### PR TITLE
fix: do not error when there are warnings on stderr

### DIFF
--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -386,8 +386,6 @@ impl InterpreterInfo {
                 err,
             })?;
 
-        // stderr isn't technically a criterion for success, but i don't know of any cases where there
-        // should be stderr output and if there is, we want to know
         if !output.status.success() {
             return Err(Error::PythonSubcommandOutput {
                 message: format!(

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -388,7 +388,7 @@ impl InterpreterInfo {
 
         // stderr isn't technically a criterion for success, but i don't know of any cases where there
         // should be stderr output and if there is, we want to know
-        if !output.status.success() || !output.stderr.is_empty() {
+        if !output.status.success() {
             return Err(Error::PythonSubcommandOutput {
                 message: format!(
                     "Querying Python at `{}` failed with status {}",


### PR DESCRIPTION
## Summary

We had some users report bugs because the Python querying failed due to warnings in `stderr`. I don't think this should fail on any `stderr` output.

E.g.

```
  × Querying Python at `USER/.pixi/envs/default/bin/python3.10` failed with status exit status: 0 with exit status: 0
  │ --- stdout:
  │ {"markers": {"implementation_name": "cpython", "implementation_version": "3.10.0", "os_name": "posix", "platform_machine": "x86_64", "platform_python_implementation": "CPython", "platform_release": "5.15.146.1-microsoft-standard-WSL2",
  │ "platform_system": "Linux", "platform_version": "#1 SMP Thu Jan 11 04:09:03 UTC 2024", "python_full_version": "3.10.0", "python_version": "3.10", "sys_platform": "linux"}, "base_prefix": "USER/.pixi/
  │ envs/default", "base_exec_prefix": "USER/.pixi/envs/default", "prefix": "USER/.pixi/envs/default", "base_executable": "USER/.pixi/envs/default/
  │ bin/python3.10", "sys_executable": "USER/.pixi/envs/default/bin/python3.10", "stdlib": "USER/.pixi/envs/default/lib/python3.10", "scheme": {"platlib": "/home/mvanniekerk/
  │ code/vice-python/.pixi/envs/default/lib/python3.10/site-packages", "purelib": "USER/.pixi/envs/default/lib/python3.10/site-packages", "include": "USER/.pixi/envs/default/
  │ include/python3.10", "scripts": "USER/.pixi/envs/default/bin", "data": "USER/.pixi/envs/default"}, "virtualenv": {"purelib": "lib/python3.10/site-packages", "platlib": "lib/
  │ python3.10/site-packages", "include": "include/site/python3.10", "scripts": "bin", "data": ""}}
  │ --- stderr:
  │ [03/21/24 15:59:48] WARNING  pyproject.toml does not contain a setuptools.py:119
  │                              tool.setuptools_scm section
  │ ---
```