### PR TITLE
Use dense formatting for requirement version specifiers in diagnostics

### DIFF
--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -243,7 +243,7 @@ impl Display for Requirement {
                 VersionOrUrl::VersionSpecifier(version_specifier) => {
                     let version_specifier: Vec<String> =
                         version_specifier.iter().map(ToString::to_string).collect();
-                    write!(f, " {}", version_specifier.join(", "))?;
+                    write!(f, "{}", version_specifier.join(","))?;
                 }
                 VersionOrUrl::Url(url) => {
                     // We add the space for markers later if necessary

--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -1627,7 +1627,7 @@ mod tests {
 
     #[test]
     fn basic_examples() {
-        let input = r"requests[security,tests] >=2.8.1, ==2.8.* ; python_version < '2.7'";
+        let input = r"requests[security,tests]>=2.8.1,==2.8.* ; python_version < '2.7'";
         let requests = Requirement::from_str(input).unwrap();
         assert_eq!(input, requests.to_string());
         let expected = Requirement {

--- a/crates/uv/tests/pip_check.rs
+++ b/crates/uv/tests/pip_check.rs
@@ -136,7 +136,7 @@ fn check_incompatible_packages() -> Result<()> {
     Installed 1 package in [TIME]
      - idna==3.4
      + idna==2.4
-    warning: The package `requests` requires `idna <4, >=2.5`, but `2.4` is installed.
+    warning: The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed.
     "###
     );
 
@@ -148,7 +148,7 @@ fn check_incompatible_packages() -> Result<()> {
     ----- stderr -----
     Checked 5 packages in [TIME]
     Found 1 incompatibility
-    The package `requests` requires `idna <4, >=2.5`, but `2.4` is installed.
+    The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed.
     "###
     );
 
@@ -206,8 +206,8 @@ fn check_multiple_incompatible_packages() -> Result<()> {
      + idna==2.4
      - urllib3==2.1.0
      + urllib3==1.20
-    warning: The package `requests` requires `idna <4, >=2.5`, but `2.4` is installed.
-    warning: The package `requests` requires `urllib3 <3, >=1.21.1`, but `1.20` is installed.
+    warning: The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed.
+    warning: The package `requests` requires `urllib3<3,>=1.21.1`, but `1.20` is installed.
     "###
     );
 
@@ -219,8 +219,8 @@ fn check_multiple_incompatible_packages() -> Result<()> {
     ----- stderr -----
     Checked 5 packages in [TIME]
     Found 2 incompatibilities
-    The package `requests` requires `idna <4, >=2.5`, but `2.4` is installed.
-    The package `requests` requires `urllib3 <3, >=1.21.1`, but `1.20` is installed.
+    The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed.
+    The package `requests` requires `urllib3<3,>=1.21.1`, but `1.20` is installed.
     "###
     );
 

--- a/crates/uv/tests/pip_freeze.rs
+++ b/crates/uv/tests/pip_freeze.rs
@@ -168,8 +168,8 @@ fn freeze_url() -> Result<()> {
     iniconfig @ https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
 
     ----- stderr -----
-    warning: The package `anyio` requires `idna >=2.8`, but it's not installed.
-    warning: The package `anyio` requires `sniffio >=1.1`, but it's not installed.
+    warning: The package `anyio` requires `idna>=2.8`, but it's not installed.
+    warning: The package `anyio` requires `sniffio>=1.1`, but it's not installed.
     "###
     );
 

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -552,7 +552,7 @@ fn allow_incompatibilities() -> Result<()> {
     Installed 1 package in [TIME]
      - jinja2==3.1.2
      + jinja2==2.11.3
-    warning: The package `flask` requires `jinja2 >=3.1.2`, but `2.11.3` is installed.
+    warning: The package `flask` requires `jinja2>=3.1.2`, but `2.11.3` is installed.
     "###
     );
 
@@ -1375,11 +1375,11 @@ fn no_deps() {
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
      + flask==3.0.0
-    warning: The package `flask` requires `werkzeug >=3.0.0`, but it's not installed.
-    warning: The package `flask` requires `jinja2 >=3.1.2`, but it's not installed.
-    warning: The package `flask` requires `itsdangerous >=2.1.2`, but it's not installed.
-    warning: The package `flask` requires `click >=8.1.3`, but it's not installed.
-    warning: The package `flask` requires `blinker >=1.6.2`, but it's not installed.
+    warning: The package `flask` requires `werkzeug>=3.0.0`, but it's not installed.
+    warning: The package `flask` requires `jinja2>=3.1.2`, but it's not installed.
+    warning: The package `flask` requires `itsdangerous>=2.1.2`, but it's not installed.
+    warning: The package `flask` requires `click>=8.1.3`, but it's not installed.
+    warning: The package `flask` requires `blinker>=1.6.2`, but it's not installed.
     "###
     );
 

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -2351,11 +2351,11 @@ fn sync_editable_and_registry() -> Result<()> {
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==24.1.0
-    warning: The package `black` requires `click >=8.0.0`, but it's not installed.
-    warning: The package `black` requires `mypy-extensions >=0.4.3`, but it's not installed.
-    warning: The package `black` requires `packaging >=22.0`, but it's not installed.
-    warning: The package `black` requires `pathspec >=0.9.0`, but it's not installed.
-    warning: The package `black` requires `platformdirs >=2`, but it's not installed.
+    warning: The package `black` requires `click>=8.0.0`, but it's not installed.
+    warning: The package `black` requires `mypy-extensions>=0.4.3`, but it's not installed.
+    warning: The package `black` requires `packaging>=22.0`, but it's not installed.
+    warning: The package `black` requires `pathspec>=0.9.0`, but it's not installed.
+    warning: The package `black` requires `platformdirs>=2`, but it's not installed.
     "###
     );
 
@@ -2455,11 +2455,11 @@ fn sync_editable_and_registry() -> Result<()> {
     Installed 1 package in [TIME]
      - black==0.1.0 (from file://[WORKSPACE_DIR]/scripts/editable-installs/black_editable)
      + black==23.10.0
-    warning: The package `black` requires `click >=8.0.0`, but it's not installed.
-    warning: The package `black` requires `mypy-extensions >=0.4.3`, but it's not installed.
-    warning: The package `black` requires `packaging >=22.0`, but it's not installed.
-    warning: The package `black` requires `pathspec >=0.9.0`, but it's not installed.
-    warning: The package `black` requires `platformdirs >=2`, but it's not installed.
+    warning: The package `black` requires `click>=8.0.0`, but it's not installed.
+    warning: The package `black` requires `mypy-extensions>=0.4.3`, but it's not installed.
+    warning: The package `black` requires `packaging>=22.0`, but it's not installed.
+    warning: The package `black` requires `pathspec>=0.9.0`, but it's not installed.
+    warning: The package `black` requires `platformdirs>=2`, but it's not installed.
     "###
     );
 


### PR DESCRIPTION
For consistency with the output in "no solution" errors
