### PR TITLE
Make self-update an opt-in Cargo feature

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -74,7 +74,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
-          args: --release --locked --out dist
+          args: --release --locked --out dist --features self-update
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4
         with:
@@ -112,7 +112,7 @@ jobs:
       - name: "Build wheels - universal2"
         uses: PyO3/maturin-action@v1
         with:
-          args: --release --locked --target universal2-apple-darwin --out dist
+          args: --release --locked --target universal2-apple-darwin --out dist --features self-update
       - name: "Test wheel - universal2"
         run: |
           pip install dist/${{ env.PACKAGE_NAME }}-*universal2.whl --force-reinstall
@@ -163,7 +163,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --locked --out dist
+          args: --release --locked --out dist --features self-update
       - name: "Test wheel"
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
@@ -211,7 +211,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: auto
-          args: --release --locked --out dist
+          args: --release --locked --out dist --features self-update
           # See: https://github.com/sfackler/rust-openssl/issues/2036#issuecomment-1724324145
           before-script-linux: |
             # If we're running on rhel centos, install needed packages.
@@ -289,7 +289,7 @@ jobs:
           # On `aarch64`, use `manylinux: 2_28`; otherwise, use `manylinux: auto`.
           manylinux: ${{ matrix.platform.arch == 'aarch64' && '2_28' || 'auto' }}
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release --locked --out dist
+          args: --release --locked --out dist --features self-update
       - uses: uraimo/run-on-arch-action@v2
         name: Test wheel
         with:
@@ -353,7 +353,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release --locked --out dist --no-default-features --features flate2/rust_backend
+          args: --release --locked --out dist --no-default-features --features flate2/rust_backend --features self-update
       - uses: uraimo/run-on-arch-action@v2
         if: matrix.platform.arch != 'ppc64'
         name: Test wheel
@@ -420,7 +420,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release --locked --out dist --no-default-features --features flate2/rust_backend
+          args: --release --locked --out dist --no-default-features --features flate2/rust_backend --features self-update
           before-script-linux: |
             if command -v yum &> /dev/null; then
                 yum update -y
@@ -489,7 +489,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
-          args: --release --locked --out dist
+          args: --release --locked --out dist --features self-update
       - name: "Test wheel"
         if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: addnab/docker-run-action@v3
@@ -551,7 +551,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
-          args: --release --locked --out dist
+          args: --release --locked --out dist --features self-update
           docker-options: ${{ matrix.platform.maturin_docker_options }}
       - uses: uraimo/run-on-arch-action@v2
         name: Test wheel

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -36,7 +36,7 @@ uv-warnings = { workspace = true }
 
 anstream = { workspace = true }
 anyhow = { workspace = true }
-axoupdater = { workspace = true, features = ["github_releases", "tokio"] }
+axoupdater = { workspace = true, features = ["github_releases", "tokio"], optional = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "string"] }
 clap_complete_command = { workspace = true }
@@ -93,6 +93,8 @@ pypi = []
 git = []
 # Introduces a dependency on Maturin.
 maturin = []
+# Adds self-update functionality.
+self-update = ["axoupdater"]
 
 [build-dependencies]
 fs-err = { workspace = true }

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub(crate) use pip_list::pip_list;
 pub(crate) use pip_show::pip_show;
 pub(crate) use pip_sync::pip_sync;
 pub(crate) use pip_uninstall::pip_uninstall;
+#[cfg(feature = "self-update")]
 pub(crate) use self_update::self_update;
 use uv_cache::Cache;
 use uv_fs::Simplified;
@@ -39,6 +40,7 @@ mod pip_show;
 mod pip_sync;
 mod pip_uninstall;
 mod reporters;
+#[cfg(feature = "self-update")]
 mod self_update;
 mod venv;
 mod version;

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -136,6 +136,7 @@ enum Commands {
     Cache(CacheNamespace),
     /// Manage the `uv` executable.
     #[clap(name = "self")]
+    #[cfg(feature = "self-update")]
     Self_(SelfNamespace),
     /// Clear the cache, removing all entries or those linked to specific packages.
     #[clap(hide = true)]
@@ -151,12 +152,14 @@ enum Commands {
 }
 
 #[derive(Args)]
+#[cfg(feature = "self-update")]
 struct SelfNamespace {
     #[clap(subcommand)]
     command: SelfCommand,
 }
 
 #[derive(Subcommand)]
+#[cfg(feature = "self-update")]
 enum SelfCommand {
     /// Update `uv` to the latest version.
     Update,
@@ -1822,6 +1825,7 @@ async fn run() -> Result<ExitStatus> {
             )
             .await
         }
+        #[cfg(feature = "self-update")]
         Commands::Self_(SelfNamespace {
             command: SelfCommand::Update,
         }) => commands::self_update(printer).await,


### PR DESCRIPTION
## Summary

Ensures that (e.g.) installs from conda-forge, Homebrew, and other distributions don't expose `uv self update` at all.

We'll still show `uv self update` for `pip install uv`, but it will fail with a good error. Removing the `uv self update` from `pip`-installed `uv` is more complicated, since we'd need to build separately for the installer vs. for PyPI.

Closes #2588.
