### PR TITLE
Update badge to current CI status. Remove the link to `/actions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![image](https://img.shields.io/pypi/v/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/l/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/pyversions/uv.svg)](https://pypi.python.org/pypi/uv)
-[![Actions status](https://github.com/astral-sh/uv/workflows/ci.yaml/badge.svg)](https://github.com/astral-sh/uv/actions)
+[![Actions status](https://github.com/astral-sh/uv/workflows/ci.yaml/badge.svg)](https://github.com/astral-sh/uv/workflows/ci.yaml/badge.svg)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/astral-sh)
 
 An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in

--- a/README.md
+++ b/README.md
@@ -4,11 +4,8 @@
 [![image](https://img.shields.io/pypi/v/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/l/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/pyversions/uv.svg)](https://pypi.python.org/pypi/uv)
-[![Actions status](https://github.com/astral-sh/uv/actions/workflows/ci/badge.svg)](https://github.com/astral-sh/uv/actions)
+![Actions status](https://github.com/astral-sh/uv/actions/workflows/ci/badge.svg)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/astral-sh)
-
-![example workflow](https://github.com/github/docs/actions/workflows/main.yml/badge.svg)
-![Action Status](https://github.com/astral-sh/uv/actions/workflows/ci.yml/badge.svg)
 
 An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in
 replacement for common `pip` and `pip-tools` workflows.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![image](https://img.shields.io/pypi/v/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/l/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/pyversions/uv.svg)](https://pypi.python.org/pypi/uv)
-[![Actions status](https://github.com/astral-sh/uv/actions/workflows/ci.yaml/badge.svg)](https://github.com/astral-sh/uv/actions/workflows/ci.yaml/badge.svg)
+[![Actions status](https://github.com/astral-sh/uv/actions/workflows/ci/badge.svg)](https://github.com/astral-sh/uv/actions/workflows/ci/badge.svg)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/astral-sh)
 
-![example workflow](https://github.com/astral-sh/uv/actions/workflows/main.yml/badge.svg)
+![example workflow](https://github.com/astral-sh/uv/actions/workflows/main/badge.svg)
 
 An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in
 replacement for common `pip` and `pip-tools` workflows.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 [![image](https://img.shields.io/pypi/v/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/l/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/pyversions/uv.svg)](https://pypi.python.org/pypi/uv)
-[![Actions status](https://github.com/astral-sh/uv/workflows/ci.yaml/badge.svg)](https://github.com/astral-sh/uv/workflows/ci.yaml/badge.svg)
+[![Actions status](https://github.com/astral-sh/uv/actions/workflows/ci.yaml/badge.svg)](https://github.com/astral-sh/uv/actions/workflows/ci.yaml/badge.svg)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/astral-sh)
+
+![example workflow](https://github.com/astral-sh/uv/actions/workflows/main.yml/badge.svg)
 
 An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in
 replacement for common `pip` and `pip-tools` workflows.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 [![Actions status](https://github.com/astral-sh/uv/actions/workflows/ci/badge.svg)](https://github.com/astral-sh/uv/actions/workflows/ci/badge.svg)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/astral-sh)
 
-![example workflow](https://github.com/astral-sh/uv/actions/workflows/main/badge.svg)
+![example workflow](https://github.com/github/docs/actions/workflows/main.yml/badge.svg)
+![example2 workflow](https://github.com/astral-sh/uv/actions/workflows/ci.yml/badge.svg)
 
 An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in
 replacement for common `pip` and `pip-tools` workflows.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![image](https://img.shields.io/pypi/v/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/l/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/pyversions/uv.svg)](https://pypi.python.org/pypi/uv)
-[![Actions status](https://github.com/astral-sh/uv/actions/workflows/ci/badge.svg)](https://github.com/astral-sh/uv/actions/workflows/ci/badge.svg)
+[![Actions status](https://github.com/astral-sh/uv/actions/workflows/ci/badge.svg)](https://github.com/astral-sh/uv/actions)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/astral-sh)
 
 ![example workflow](https://github.com/github/docs/actions/workflows/main.yml/badge.svg)
-![example2 workflow](https://github.com/astral-sh/uv/actions/workflows/ci.yml/badge.svg)
+![Action Status](https://github.com/astral-sh/uv/actions/workflows/ci.yml/badge.svg)
 
 An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in
 replacement for common `pip` and `pip-tools` workflows.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![image](https://img.shields.io/pypi/v/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/l/uv.svg)](https://pypi.python.org/pypi/uv)
 [![image](https://img.shields.io/pypi/pyversions/uv.svg)](https://pypi.python.org/pypi/uv)
-[![Actions status](https://github.com/astral-sh/uv/workflows/CI/badge.svg)](https://github.com/astral-sh/uv/actions)
+[![Actions status](https://github.com/astral-sh/uv/workflows/ci.yaml/badge.svg)](https://github.com/astral-sh/uv/actions)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/astral-sh)
 
 An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in


### PR DESCRIPTION
## Summary

Hi! I noticed the badge in the `README.md` says CI it's failing

[![Actions status](https://github.com/astral-sh/uv/workflows/CI/badge.svg)](https://github.com/astral-sh/uv/actions)

But current main CI is okay. The problem is that badge is bringing the latest actions ran in the repo. Even if it's from a PR
So I changed to this link:

![Action Status](https://github.com/astral-sh/uv/actions/workflows/ci.yml/badge.svg)

It shows the current main branch CI status, but _I couldn't get the link to work (go into `uv/actions`)_. Is it acceptable to lose some functionality in order to display the correct information?

I investigated with google but only found a sample that github is not rendering correctly the badge with the link
[medium post](https://nklya.medium.com/useful-status-badges-for-github-actions-16e658d52ba2), [similar repo with the same badge](https://github.com/Nklya/test-actions)

## Test Plan

manually
