### PR TITLE
Update minimum rust version (cargo) to 1.76

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.76"
 homepage = "https://pypi.org/project/uv/"
 documentation = "https://pypi.org/project/uv/"
 repository = "https://github.com/astral-sh/uv"


### PR DESCRIPTION
This should address (fix?) #2442, it blocks building with a version that doesn't support return type impl trait.

```
$ cargo +1.74 check
  error: package `pep508_rs v0.4.2 (/home/konsti/projects/uv/crates/pep508-rs)` cannot be built because it requires rustc 1.76 or newer, while the currently active rustc version is 1.74.1
```

While we should encourage our dependencies to set a msrv, if we set our rust-toolchain.toml version as cargo msrv our users on no-wheel no-installer platforms will also be fine (or at least get helpful error messages).