### PR TITLE
Add fast build profile without debuginfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,11 @@ rest_pat_in_fully_bound_structs = "warn"
 inherits = "release"
 debug = true
 
+[profile.fast-build]
+inherits = "dev"
+debug = 0
+strip = "debuginfo"
+
 # The profile that 'cargo dist' will build with.
 [profile.dist]
 inherits = "release"


### PR DESCRIPTION
Add a compile option `-p fast-build` for a 16% incremental compile speedup (linux) at the cost of having no debuginfo.

After trying various rust compiler speedup suggestions, setting mold as my default linker and removing debuginfo are the only ones showing a speedup.

```
hyperfine --warmup 1 --runs 3 --prepare "touch crates/uv-resolver/src/resolver/mod.rs" \
    "cargo +nightly build --bin uv" \
    "cargo +nightly build --bin uv --profile fast-build"
Benchmark 1: cargo +nightly build --bin uv
  Time (mean ± σ):      1.569 s ±  0.008 s    [User: 1.179 s, System: 0.369 s]
  Range (min … max):    1.560 s …  1.576 s    3 runs

Benchmark 2: cargo +nightly build --bin uv --profile fast-build
  Time (mean ± σ):      1.353 s ±  0.020 s    [User: 1.109 s, System: 0.301 s]
  Range (min … max):    1.338 s …  1.375 s    3 runs

Summary
  cargo +nightly build --bin uv --profile fast-build ran
    1.16 ± 0.02 times faster than cargo +nightly build --bin uv
```