### PR TITLE
Limit overrides and constraints to `requirements.txt` format

### DIFF
--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -4,6 +4,7 @@ use console::Term;
 
 use uv_fs::Simplified;
 use uv_normalize::ExtraName;
+use uv_warnings::warn_user;
 
 use crate::confirm;
 
@@ -20,13 +21,34 @@ pub enum RequirementsSource {
 }
 
 impl RequirementsSource {
-    /// Parse a [`RequirementsSource`] from a [`PathBuf`].
-    pub fn from_path(path: PathBuf) -> Self {
+    /// Parse a [`RequirementsSource`] from a [`PathBuf`]. The file type is determined by the file
+    /// extension.
+    pub fn from_requirements_file(path: PathBuf) -> Self {
         if path.ends_with("pyproject.toml") {
             Self::PyprojectToml(path)
         } else {
             Self::RequirementsTxt(path)
         }
+    }
+
+    /// Parse a [`RequirementsSource`] from a constraints file.
+    pub fn from_constraints_file(path: PathBuf) -> Self {
+        if path.ends_with("pyproject.toml") {
+            warn_user!(
+                "The file `{}` appears to be a `pyproject.toml` file, but constraints must be specified in `requirements.txt` format.", path.user_display()
+            );
+        }
+        Self::RequirementsTxt(path)
+    }
+
+    /// Parse a [`RequirementsSource`] from an overrides file.
+    pub fn from_overrides_file(path: PathBuf) -> Self {
+        if path.ends_with("pyproject.toml") {
+            warn_user!(
+                "The file `{}` appears to be a `pyproject.toml` file, but overrides must be specified in `requirements.txt` format.", path.user_display()
+            );
+        }
+        Self::RequirementsTxt(path)
     }
 
     /// Parse a [`RequirementsSource`] from a user-provided string, assumed to be a package.

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -1464,17 +1464,17 @@ async fn run() -> Result<ExitStatus> {
             let requirements = args
                 .src_file
                 .into_iter()
-                .map(RequirementsSource::from_path)
+                .map(RequirementsSource::from_requirements_file)
                 .collect::<Vec<_>>();
             let constraints = args
                 .constraint
                 .into_iter()
-                .map(RequirementsSource::from_path)
+                .map(RequirementsSource::from_constraints_file)
                 .collect::<Vec<_>>();
             let overrides = args
                 .r#override
                 .into_iter()
-                .map(RequirementsSource::from_path)
+                .map(RequirementsSource::from_overrides_file)
                 .collect::<Vec<_>>();
             let index_urls = IndexLocations::new(
                 args.index_url.and_then(Maybe::into_option),
@@ -1567,7 +1567,7 @@ async fn run() -> Result<ExitStatus> {
             let sources = args
                 .src_file
                 .into_iter()
-                .map(RequirementsSource::from_path)
+                .map(RequirementsSource::from_requirements_file)
                 .collect::<Vec<_>>();
             let reinstall = Reinstall::from_args(args.reinstall, args.reinstall_package);
             let no_binary = NoBinary::from_args(args.no_binary);
@@ -1618,18 +1618,18 @@ async fn run() -> Result<ExitStatus> {
                 .chain(
                     args.requirement
                         .into_iter()
-                        .map(RequirementsSource::from_path),
+                        .map(RequirementsSource::from_requirements_file),
                 )
                 .collect::<Vec<_>>();
             let constraints = args
                 .constraint
                 .into_iter()
-                .map(RequirementsSource::from_path)
+                .map(RequirementsSource::from_constraints_file)
                 .collect::<Vec<_>>();
             let overrides = args
                 .r#override
                 .into_iter()
-                .map(RequirementsSource::from_path)
+                .map(RequirementsSource::from_overrides_file)
                 .collect::<Vec<_>>();
             let index_urls = IndexLocations::new(
                 args.index_url.and_then(Maybe::into_option),
@@ -1714,7 +1714,7 @@ async fn run() -> Result<ExitStatus> {
                 .chain(
                     args.requirement
                         .into_iter()
-                        .map(RequirementsSource::from_path),
+                        .map(RequirementsSource::from_requirements_file),
                 )
                 .collect::<Vec<_>>();
             commands::pip_uninstall(


### PR DESCRIPTION
## Summary

I don't see a great reason to allow this, and it adds a lot of complexity, so `pyproject.toml` files are now limited to `pip compile` and `pip install -r` -- they can't be passed as `-c` or `--override`.
