### PR TITLE
Update pubgrub to use a dependency provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,7 +2444,6 @@ version = "0.5.0"
 dependencies = [
  "indoc",
  "once_cell",
- "pubgrub",
  "pyo3",
  "rkyv",
  "serde",
@@ -2663,7 +2662,7 @@ dependencies = [
 [[package]]
 name = "pubgrub"
 version = "0.2.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=e981e4dfe315582e84e2fd724832fb0e0c50b7aa#e981e4dfe315582e84e2fd724832fb0e0c50b7aa"
+source = "git+https://github.com/astral-sh/pubgrub?rev=c26e485213e39582c6f2e4d45c0328422670e7a7#c26e485213e39582c6f2e4d45c0328422670e7a7"
 dependencies = [
  "indexmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ owo-colors = { version = "4.0.0" }
 pathdiff = { version = "0.2.1" }
 petgraph = { version = "0.6.4" }
 platform-info = { version = "2.0.2" }
-pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "e981e4dfe315582e84e2fd724832fb0e0c50b7aa" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "c26e485213e39582c6f2e4d45c0328422670e7a7" }
 pyo3 = { version = "0.20.3" }
 pyo3-log = { version = "0.9.0" }
 pyproject-toml = { version = "0.10.0" }

--- a/crates/pep440-rs/Cargo.toml
+++ b/crates/pep440-rs/Cargo.toml
@@ -18,7 +18,6 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 once_cell = { workspace = true }
-pubgrub = { workspace = true, optional = true }
 pyo3 = { workspace = true, optional = true, features = ["extension-module", "abi3-py37"] }
 serde = { workspace = true, features = ["derive"], optional = true }
 rkyv = { workspace = true, optional = true }

--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -2509,25 +2509,6 @@ fn parse_u64(bytes: &[u8]) -> Result<u64, VersionParseError> {
 pub static MIN_VERSION: once_cell::sync::Lazy<Version> =
     once_cell::sync::Lazy::new(|| Version::from_str("0a0.dev0").unwrap());
 
-#[cfg(feature = "pubgrub")]
-impl pubgrub::version::Version for Version {
-    fn lowest() -> Self {
-        MIN_VERSION.to_owned()
-    }
-
-    fn bump(&self) -> Self {
-        let mut next = self.clone();
-        if let Some(dev) = next.dev() {
-            next = next.with_dev(Some(dev + 1));
-        } else if let Some(post) = next.post() {
-            next = next.with_post(Some(post + 1));
-        } else {
-            next = next.with_post(Some(0)).with_dev(Some(0));
-        }
-        next
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -17,7 +17,7 @@ cache-key = { workspace = true }
 distribution-filename = { workspace = true, features = ["serde"] }
 distribution-types = { workspace = true }
 once-map = { workspace = true }
-pep440_rs = { workspace = true, features = ["pubgrub"] }
+pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
 platform-tags = { workspace = true }
 pypi-types = { workspace = true }

--- a/crates/uv-resolver/src/dependency_provider.rs
+++ b/crates/uv-resolver/src/dependency_provider.rs
@@ -1,0 +1,40 @@
+use std::convert::Infallible;
+
+use pubgrub::range::Range;
+use pubgrub::solver::{Dependencies, DependencyProvider};
+
+use pep440_rs::Version;
+
+use crate::pubgrub::{PubGrubPackage, PubGrubPriority};
+
+/// We don't use a dependency provider, we interact with state directly, but we still need this one
+/// for type
+pub(crate) struct UvDependencyProvider;
+
+impl DependencyProvider for UvDependencyProvider {
+    type P = PubGrubPackage;
+    type V = Version;
+    type VS = Range<Version>;
+    fn prioritize(&self, _package: &Self::P, _range: &Self::VS) -> Self::Priority {
+        unimplemented!()
+    }
+    type Priority = PubGrubPriority;
+
+    type Err = Infallible;
+
+    fn choose_version(
+        &self,
+        _package: &Self::P,
+        _range: &Self::VS,
+    ) -> Result<Option<Self::V>, Self::Err> {
+        unimplemented!()
+    }
+
+    fn get_dependencies(
+        &self,
+        _package: &Self::P,
+        _version: &Self::V,
+    ) -> Result<Dependencies<Vec<(Self::P, Self::VS)>>, Self::Err> {
+        unimplemented!()
+    }
+}

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeSet;
-use std::convert::Infallible;
 use std::fmt::Formatter;
 use std::ops::Deref;
 
@@ -16,6 +15,7 @@ use pep508_rs::Requirement;
 use uv_normalize::PackageName;
 
 use crate::candidate_selector::CandidateSelector;
+use crate::dependency_provider::UvDependencyProvider;
 use crate::pubgrub::{PubGrubPackage, PubGrubPython, PubGrubReportFormatter};
 use crate::python_requirement::PythonRequirement;
 use crate::resolver::{UnavailablePackage, VersionsResponse};
@@ -100,12 +100,8 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for ResolveError {
     }
 }
 
-impl From<pubgrub::error::PubGrubError<PubGrubPackage, Range<Version>, Infallible>>
-    for ResolveError
-{
-    fn from(
-        value: pubgrub::error::PubGrubError<PubGrubPackage, Range<Version>, Infallible>,
-    ) -> Self {
+impl From<pubgrub::error::PubGrubError<UvDependencyProvider>> for ResolveError {
+    fn from(value: pubgrub::error::PubGrubError<UvDependencyProvider>) -> Self {
         match value {
             // These are all never type variant that can never match, but never is experimental
             pubgrub::error::PubGrubError::ErrorChoosingPackageVersion(_)

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -20,6 +20,7 @@ mod bare;
 mod candidate_selector;
 mod constraints;
 mod dependency_mode;
+mod dependency_provider;
 mod editables;
 mod error;
 mod finder;

--- a/crates/uv-resolver/src/resolution.rs
+++ b/crates/uv-resolver/src/resolution.rs
@@ -13,6 +13,7 @@ use pubgrub::type_aliases::SelectedDependencies;
 use rustc_hash::FxHashMap;
 use url::Url;
 
+use crate::dependency_provider::UvDependencyProvider;
 use distribution_types::{Dist, DistributionMetadata, LocalEditable, Name, PackageId, Verbatim};
 use once_map::OnceMap;
 use pep440_rs::Version;
@@ -22,7 +23,7 @@ use uv_normalize::{ExtraName, PackageName};
 use crate::editables::Editables;
 use crate::pins::FilePins;
 use crate::preferences::Preferences;
-use crate::pubgrub::{PubGrubDistribution, PubGrubPackage, PubGrubPriority};
+use crate::pubgrub::{PubGrubDistribution, PubGrubPackage};
 use crate::redirect::apply_redirect;
 use crate::resolver::VersionsResponse;
 use crate::ResolveError;
@@ -59,12 +60,12 @@ impl ResolutionGraph {
     /// Create a new graph from the resolved `PubGrub` state.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_state(
-        selection: &SelectedDependencies<PubGrubPackage, Version>,
+        selection: &SelectedDependencies<UvDependencyProvider>,
         pins: &FilePins,
         packages: &OnceMap<PackageName, VersionsResponse>,
         distributions: &OnceMap<PackageId, Metadata23>,
         redirects: &DashMap<Url, Url>,
-        state: &State<PubGrubPackage, Range<Version>, PubGrubPriority>,
+        state: &State<UvDependencyProvider>,
         preferences: &Preferences,
         editables: Editables,
     ) -> Result<Self, ResolveError> {


### PR DESCRIPTION
With https://github.com/pubgrub-rs/pubgrub/pull/190, pubgrub attaches all types to a dependency provider to reduce the number of generics. We need a dummy dependency provider now to emulate this. On the plus side, pep440_rs drops its pubgrub dependency.