### PR TITLE
Renovate: only look for cargo dependencies in the `crates/` directory

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,9 @@
   "cargo": {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy
     "rangeStrategy": "update-lockfile",
+    "fileMatch": [
+      "^crates/.*Cargo\\.toml$",
+    ],
   },
   "pre-commit": {
     "enabled": true,


### PR DESCRIPTION
As discussed on Discord, we probably don't want Renovate trying to bump "dependency pins" such as https://github.com/astral-sh/uv/blob/f97f47a67b9113d2ca52813ee9b7778a126d6ef3/scripts/packages/maturin_editable/Cargo.toml#L1-L4