### PR TITLE
Add `rustc-hash` to `uv` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4336,6 +4336,7 @@ dependencies = [
  "regex",
  "requirements-txt",
  "reqwest",
+ "rustc-hash",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -48,6 +48,7 @@ itertools = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
 owo-colors = { workspace = true }
 regex = { workspace = true }
+rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/uv/tests/pip_show.rs
+++ b/crates/uv/tests/pip_show.rs
@@ -549,12 +549,12 @@ fn show_required_by_multiple() -> Result<()> {
     Downloaded 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + anyio==4.0.0
-     + certifi==2023.11.17
+     + certifi==2024.2.2
      + charset-normalizer==3.3.2
-     + idna==3.4
+     + idna==3.6
      + requests==2.31.0
-     + sniffio==1.3.0
-     + urllib3==2.1.0
+     + sniffio==1.3.1
+     + urllib3==2.2.1
     "###
     );
 
@@ -578,7 +578,7 @@ fn show_required_by_multiple() -> Result<()> {
     exit_code: 0
     ----- stdout -----
     Name: idna
-    Version: 3.4
+    Version: 3.6
     Location: [WORKSPACE_DIR]/site-packages
     Requires:
     Required-by: anyio, requests


### PR DESCRIPTION
## Summary

This is required as of https://github.com/astral-sh/uv/pull/2589, but isn't a direct dependency. I'm not sure how that PR passed CI exactly.

Edit: it looks like the dependency was removed between the time the PR was opened and merged (https://github.com/astral-sh/uv/pull/2609).
