### PR TITLE
Read package metadata from `pyproject.toml` when statically defined

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,6 +2750,7 @@ name = "pypi-types"
 version = "0.0.1"
 dependencies = [
  "chrono",
+ "indexmap",
  "mailparse",
  "once_cell",
  "pep440_rs",
@@ -2758,6 +2759,7 @@ dependencies = [
  "rkyv",
  "serde",
  "thiserror",
+ "toml",
  "tracing",
  "url",
  "uv-normalize",

--- a/crates/pypi-types/Cargo.toml
+++ b/crates/pypi-types/Cargo.toml
@@ -18,12 +18,14 @@ pep508_rs = { workspace = true, features = ["rkyv", "serde"] }
 uv-normalize = { workspace = true }
 
 chrono = { workspace = true, features = ["serde"] }
+indexmap = { workspace = true, features = ["serde"] }
 mailparse = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 rkyv = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
+toml = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 

--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -18,7 +18,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::de::{value, SeqAccess, Visitor};
-use serde::{de, Deserialize, Deserializer, Serialize};
+use serde::{de, Deserialize, Deserializer};
 use tempfile::{tempdir_in, TempDir};
 use thiserror::Error;
 use tokio::process::Command;
@@ -26,7 +26,7 @@ use tokio::sync::Mutex;
 use tracing::{debug, info_span, instrument, Instrument};
 
 use distribution_types::Resolution;
-use pep440_rs::{Version, VersionSpecifiers};
+use pep440_rs::Version;
 use pep508_rs::{PackageName, Requirement};
 use uv_fs::{PythonExt, Simplified};
 use uv_interpreter::{Interpreter, PythonEnvironment};
@@ -193,8 +193,8 @@ impl Error {
     }
 }
 
-/// A pyproject.toml as specified in PEP 517.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+/// A `pyproject.toml` as specified in PEP 517.
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct PyProjectToml {
     /// Build-related data
@@ -204,22 +204,23 @@ pub struct PyProjectToml {
 }
 
 /// The `[project]` section of a pyproject.toml as specified in PEP 621.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+///
+/// This representation only includes a subset of the fields defined in PEP 621 necessary for
+/// informing wheel builds.
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct Project {
     /// The name of the project
     pub name: PackageName,
     /// The version of the project as supported by PEP 440
     pub version: Option<Version>,
-    /// The Python version requirements of the project
-    pub requires_python: Option<VersionSpecifiers>,
     /// Specifies which fields listed by PEP 621 were intentionally unspecified so another tool
     /// can/will provide such metadata dynamically.
     pub dynamic: Option<Vec<String>>,
 }
 
 /// The `[build-system]` section of a pyproject.toml as specified in PEP 517.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct BuildSystem {
     /// PEP 508 dependencies required to execute the build system.
@@ -237,8 +238,7 @@ impl BackendPath {
     }
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BackendPath(Vec<String>);
 
 impl<'de> Deserialize<'de> for BackendPath {

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -61,8 +61,12 @@ pub enum Error {
     NotFound(PathBuf),
     #[error("The source distribution is missing a `PKG-INFO` file")]
     MissingPkgInfo,
-    #[error("The source distribution does not support static metadata")]
+    #[error("The source distribution does not support static metadata in `PKG-INFO`")]
     DynamicPkgInfo(#[source] pypi_types::Error),
+    #[error("The source distribution is missing a `pyproject.toml` file")]
+    MissingPyprojectToml,
+    #[error("The source distribution does not support static metadata in `pyproject.toml`")]
+    DynamicPyprojectToml(#[source] pypi_types::Error),
     #[error("Unsupported scheme in URL: {0}")]
     UnsupportedScheme(String),
 

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -881,7 +881,6 @@ fn install_editable_no_binary() {
 fn reinstall_build_system() -> Result<()> {
     let context = TestContext::new("3.12");
 
-    // Install devpi.
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(indoc! {r"
         flit_core<4.0.0
@@ -900,7 +899,7 @@ fn reinstall_build_system() -> Result<()> {
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Downloaded 8 packages in [TIME]
     Installed 8 packages in [TIME]
      + blinker==1.7.0
      + click==8.1.7


### PR DESCRIPTION
## Summary

Now that we're resolving metadata more aggressively for local sources, it's worth doing this. We now pull metadata from the `pyproject.toml` directly if it's statically-defined.

Closes https://github.com/astral-sh/uv/issues/2629.
