### PR TITLE
Bring harmony to the test snapshot filtering situation

### DIFF
--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -3,7 +3,12 @@ use std::path::{Component, Path, PathBuf};
 
 use once_cell::sync::Lazy;
 
-pub static CWD: Lazy<PathBuf> = Lazy::new(|| std::env::current_dir().unwrap());
+pub static CWD: Lazy<PathBuf> = Lazy::new(|| {
+    std::env::current_dir()
+        .unwrap()
+        .canonicalize()
+        .expect("The current directory must exist")
+});
 
 pub trait Simplified {
     /// Simplify a [`Path`].
@@ -34,7 +39,9 @@ impl<T: AsRef<Path>> Simplified for T {
 
     fn user_display(&self) -> std::path::Display {
         let path = dunce::simplified(self.as_ref());
-        path.strip_prefix(&*CWD).unwrap_or(path).display()
+        path.strip_prefix(CWD.simplified())
+            .unwrap_or(path)
+            .display()
     }
 }
 

--- a/crates/uv/build.rs
+++ b/crates/uv/build.rs
@@ -5,8 +5,11 @@ fn main() {
     // The workspace root directory is not available without walking up the tree
     // https://github.com/rust-lang/cargo/issues/3946
     let workspace_root = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
-        .join("..")
-        .join("..");
+        .parent()
+        .expect("CARGO_MANIFEST_DIR should be nested in workspace")
+        .parent()
+        .expect("CARGO_MANIFEST_DIR should be doubly nested in workspace")
+        .to_path_buf();
 
     commit_info(&workspace_root);
 

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -12,7 +12,7 @@ use assert_fs::TempDir;
 use indoc::indoc;
 use url::Url;
 
-use common::{uv_snapshot, TestContext, INSTA_FILTERS};
+use common::{uv_snapshot, TestContext};
 use uv_fs::Simplified;
 
 use crate::common::{get_bin, EXCLUDE_NEWER};
@@ -629,13 +629,7 @@ dependencies = [
 "#,
     )?;
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filters: Vec<_> = [(r"file://.*/", "file://[TEMP_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg("pyproject.toml"), @r###"
     success: false
     exit_code: 2
@@ -862,7 +856,7 @@ fn compile_python_37() -> Result<()> {
         ),
     ]
         .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
+        .chain(context.filters())
         .collect();
 
     uv_snapshot!(filters, context.compile()
@@ -1083,7 +1077,7 @@ fn compile_git_https_dependency() -> Result<()> {
     // In addition to the standard filters, remove the `main` commit, which will change frequently.
     let filters: Vec<_> = [(r"@(\d|\w){40}", "@[COMMIT]")]
         .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
+        .chain(context.filters())
         .collect();
 
     uv_snapshot!(filters, context.compile()
@@ -2096,13 +2090,7 @@ fn compile_wheel_path_dependency() -> Result<()> {
         Url::from_file_path(flask_wheel.path()).unwrap()
     ))?;
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filters: Vec<_> = [(r"file://.*/", "file://[TEMP_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg("requirements.in"), @r###"
     success: true
     exit_code: 0
@@ -2229,14 +2217,7 @@ fn compile_wheel_path_dependency() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str(&format!("flask @ {}", flask_wheel.path().display()))?;
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filter_path = regex::escape(&flask_wheel.user_display().to_string());
-    let filters: Vec<_> = [(filter_path.as_str(), "/[TEMP_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg("requirements.in"), @r###"
     success: true
     exit_code: 0
@@ -2247,7 +2228,7 @@ fn compile_wheel_path_dependency() -> Result<()> {
         # via flask
     click==8.1.7
         # via flask
-    flask @ /[TEMP_DIR]/
+    flask @ [TEMP_DIR]/flask-3.0.0-py3-none-any.whl
     itsdangerous==2.1.2
         # via flask
     jinja2==3.1.3
@@ -2269,14 +2250,7 @@ fn compile_wheel_path_dependency() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str(&format!("flask @ file://{}", flask_wheel.path().display()))?;
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filter_path = regex::escape(&flask_wheel.user_display().to_string());
-    let filters: Vec<_> = [(filter_path.as_str(), "/[TEMP_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg("requirements.in"), @r###"
     success: true
     exit_code: 0
@@ -2287,7 +2261,7 @@ fn compile_wheel_path_dependency() -> Result<()> {
         # via flask
     click==8.1.7
         # via flask
-    flask @ file:///[TEMP_DIR]/
+    flask @ file://[TEMP_DIR]/flask-3.0.0-py3-none-any.whl
     itsdangerous==2.1.2
         # via flask
     jinja2==3.1.3
@@ -2312,14 +2286,7 @@ fn compile_wheel_path_dependency() -> Result<()> {
         flask_wheel.path().display()
     ))?;
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filter_path = regex::escape(&flask_wheel.user_display().to_string());
-    let filters: Vec<_> = [(filter_path.as_str(), "/[TEMP_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg("requirements.in"), @r###"
     success: true
     exit_code: 0
@@ -2330,7 +2297,7 @@ fn compile_wheel_path_dependency() -> Result<()> {
         # via flask
     click==8.1.7
         # via flask
-    flask @ file://localhost//[TEMP_DIR]/
+    flask @ file://localhost/[TEMP_DIR]/flask-3.0.0-py3-none-any.whl
     itsdangerous==2.1.2
         # via flask
     jinja2==3.1.3
@@ -2366,13 +2333,7 @@ fn compile_source_distribution_path_dependency() -> Result<()> {
         Url::from_file_path(flask_wheel.path()).unwrap()
     ))?;
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filters: Vec<_> = [(r"file://.*/", "file://[TEMP_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg("requirements.in"), @r###"
     success: true
     exit_code: 0
@@ -2407,15 +2368,15 @@ fn compile_source_distribution_path_dependency() -> Result<()> {
 fn compile_wheel_path_dependency_missing() -> Result<()> {
     let context = TestContext::new("3.12");
     let requirements_in = context.temp_dir.child("requirements.in");
-    requirements_in.write_str("flask @ file:///path/to/flask-3.0.0-py3-none-any.whl")?;
+    requirements_in.write_str(&format!(
+        "flask @ {}",
+        context
+            .temp_dir
+            .join("flask-3.0.0-py3-none-any.whl")
+            .simplified_display()
+    ))?;
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filters: Vec<_> = [(r"file://.*/", "file://[TEMP_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg("requirements.in"), @r###"
     success: false
     exit_code: 2
@@ -2892,20 +2853,14 @@ fn compile_editable() -> Result<()> {
         "
     })?;
 
-    let filter_path = regex::escape(&requirements_in.user_display().to_string());
-    let filters: Vec<_> = [(filter_path.as_str(), "requirements.in")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
         .arg(requirements_in.path())
         .current_dir(current_dir()?), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     # This file was autogenerated by uv via the following command:
-    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z requirements.in
+    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z [TEMP_DIR]/requirements.in
     -e ${PROJECT_ROOT}/../../scripts/packages/maturin_editable
     -e ../../scripts/packages/poetry_editable
     -e file://../../scripts/packages/black_editable
@@ -2951,12 +2906,6 @@ fn recursive_extras_direct_url() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("black[dev] @ ../../scripts/packages/black_editable")?;
 
-    let filter_path = regex::escape(&requirements_in.user_display().to_string());
-    let filters: Vec<_> = [(filter_path.as_str(), "requirements.in")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
     let mut command = Command::new(get_bin());
     if cfg!(all(windows, debug_assertions)) {
         // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
@@ -2964,7 +2913,7 @@ fn recursive_extras_direct_url() -> Result<()> {
         command.env("UV_STACK_SIZE", (2 * 1024 * 1024).to_string());
     }
 
-    uv_snapshot!(filters, command
+    uv_snapshot!(context.filters(), command
             .arg("pip")
             .arg("compile")
             .arg(requirements_in.path())
@@ -2977,7 +2926,7 @@ fn recursive_extras_direct_url() -> Result<()> {
     exit_code: 0
     ----- stdout -----
     # This file was autogenerated by uv via the following command:
-    #    uv pip compile requirements.in --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z
+    #    uv pip compile [TEMP_DIR]/requirements.in --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z
     aiohttp==3.9.3
         # via black
     aiosignal==1.3.1
@@ -3014,20 +2963,14 @@ fn compile_editable_url_requirement() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("-e ../../scripts/packages/hatchling_editable")?;
 
-    let filter_path = regex::escape(&requirements_in.user_display().to_string());
-    let filters: Vec<_> = [(filter_path.as_str(), "requirements.in")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
         .arg(requirements_in.path())
         .current_dir(current_dir()?), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     # This file was autogenerated by uv via the following command:
-    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z requirements.in
+    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z [TEMP_DIR]/requirements.in
     -e ../../scripts/packages/hatchling_editable
     iniconfig @ git+https://github.com/pytest-dev/iniconfig@9cae43103df70bac6fde7b9f35ad11a9f1be0cb4
         # via hatchling-editable
@@ -3296,7 +3239,7 @@ fn generate_hashes() -> Result<()> {
         vec![]
     }
     .into_iter()
-    .chain(INSTA_FILTERS.to_vec())
+    .chain(context.filters())
     .collect();
 
     uv_snapshot!(filters, context.compile()
@@ -3414,24 +3357,10 @@ fn find_links_directory() -> Result<()> {
         werkzeug @ https://files.pythonhosted.org/packages/c3/fc/254c3e9b5feb89ff5b9076a23218dafbc99c96ac5941e900b71206e6313b/werkzeug-3.0.1-py3-none-any.whl
     "})?;
 
-    let project_root = fs_err::canonicalize(std::env::current_dir()?.join("..").join(".."))?;
-    let project_root_string = regex::escape(&project_root.user_display().to_string());
-    let filters: Vec<_> = [
-        (project_root_string.as_str(), "[PROJECT_ROOT]"),
-        // Unify trailing (back)slash between Windows and Unix.
-        (
-            "[PROJECT_ROOT]/scripts/wheels/",
-            "[PROJECT_ROOT]/scripts/wheels",
-        ),
-    ]
-    .into_iter()
-    .chain(INSTA_FILTERS.to_vec())
-    .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg("requirements.in")
             .arg("--find-links")
-            .arg(project_root.join("scripts").join("wheels")), @r###"
+            .arg(context.workspace_root.join("scripts").join("wheels")), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3708,7 +3637,7 @@ fn missing_path_requirement() -> Result<()> {
 
     let filters: Vec<_> = [(r"/C:/", "/")]
         .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
+        .chain(context.filters())
         .collect();
 
     uv_snapshot!(filters, context.compile()
@@ -3718,7 +3647,7 @@ fn missing_path_requirement() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Distribution not found at: file:///tmp/anyio-3.7.0.tar.gz
+    error: Distribution not found at: file://tmp/anyio-3.7.0.tar.gz
     "###);
 
     Ok(())
@@ -3729,19 +3658,9 @@ fn missing_path_requirement() -> Result<()> {
 fn missing_editable_requirement() -> Result<()> {
     let context = TestContext::new("3.12");
     let requirements_in = context.temp_dir.child("requirements.in");
-    requirements_in.write_str("-e ../tmp/anyio-3.7.0.tar.gz")?;
+    requirements_in.write_str("-e foo/anyio-3.7.0.tar.gz")?;
 
-    // File url, absolute Unix path or absolute Windows path
-    let filters: Vec<_> = [
-        (r" file://.*/", " file://[TEMP_DIR]/"),
-        (r" /.*/", " /[TEMP_DIR]/"),
-        (r" [A-Z]:\\.*\\", " /[TEMP_DIR]/"),
-    ]
-    .into_iter()
-    .chain(INSTA_FILTERS.to_vec())
-    .collect::<Vec<_>>();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg("requirements.in"), @r###"
     success: false
     exit_code: 2
@@ -3749,7 +3668,7 @@ fn missing_editable_requirement() -> Result<()> {
 
     ----- stderr -----
     error: Failed to build editables
-      Caused by: Source distribution not found at: /[TEMP_DIR]/anyio-3.7.0.tar.gz
+      Caused by: Source distribution not found at: [TEMP_DIR]/foo/anyio-3.7.0.tar.gz
     "###);
 
     Ok(())
@@ -4612,29 +4531,20 @@ fn editable_invalid_extra() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("-e ../../scripts/packages/black_editable[empty]")?;
 
-    let requirements_path = regex::escape(&requirements_in.user_display().to_string());
-    let filters: Vec<_> = [
-        (r" file://.*/", " file://[TEMP_DIR]/"),
-        (requirements_path.as_str(), "requirements.in"),
-    ]
-    .into_iter()
-    .chain(INSTA_FILTERS.to_vec())
-    .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg(requirements_in.path())
             .current_dir(current_dir()?), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     # This file was autogenerated by uv via the following command:
-    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z requirements.in
+    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z [TEMP_DIR]/requirements.in
     -e ../../scripts/packages/black_editable
 
     ----- stderr -----
     Built 1 editable in [TIME]
     Resolved 1 package in [TIME]
-    warning: The package `black @ file://[TEMP_DIR]/black_editable` does not have an extra named `empty`.
+    warning: The package `black @ file://[WORKSPACE]/scripts/packages/black_editable` does not have an extra named `empty`.
     "###);
 
     Ok(())
@@ -4930,17 +4840,7 @@ fn override_editable() -> Result<()> {
     let overrides_txt = context.temp_dir.child("overrides.txt");
     overrides_txt.write_str("black==23.10.1")?;
 
-    let requirements_path = regex::escape(&requirements_in.user_display().to_string());
-    let overrides_path = regex::escape(&overrides_txt.user_display().to_string());
-    let filters: Vec<_> = [
-        (requirements_path.as_str(), "requirements.in"),
-        (overrides_path.as_str(), "overrides.txt"),
-    ]
-    .into_iter()
-    .chain(INSTA_FILTERS.to_vec())
-    .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg(requirements_in.path())
             .arg("--override")
             .arg(overrides_txt.path())
@@ -4949,7 +4849,7 @@ fn override_editable() -> Result<()> {
     exit_code: 0
     ----- stdout -----
     # This file was autogenerated by uv via the following command:
-    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z requirements.in --override overrides.txt
+    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z [TEMP_DIR]/requirements.in --override [TEMP_DIR]/overrides.txt
     -e ../../scripts/packages/black_editable
 
     ----- stderr -----
@@ -5278,16 +5178,7 @@ fn editable_direct_dependency() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("-e ../../scripts/packages/setuptools_editable")?;
 
-    let requirements_path = regex::escape(&requirements_in.user_display().to_string());
-    let filters: Vec<_> = [
-        (r" file://.*/", " file://[TEMP_DIR]/"),
-        (requirements_path.as_str(), "requirements.in"),
-    ]
-    .into_iter()
-    .chain(INSTA_FILTERS.to_vec())
-    .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
             .arg(requirements_in.path())
             .arg("--resolution")
             .arg("lowest-direct")
@@ -5296,7 +5187,7 @@ fn editable_direct_dependency() -> Result<()> {
     exit_code: 0
     ----- stdout -----
     # This file was autogenerated by uv via the following command:
-    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z requirements.in --resolution lowest-direct
+    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z [TEMP_DIR]/requirements.in --resolution lowest-direct
     -e ../../scripts/packages/setuptools_editable
     iniconfig==0.1
         # via setuptools-editable
@@ -5468,7 +5359,8 @@ fn requires_python_editable() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Create an editable package with a `Requires-Python` constraint that is not met.
-    let editable_dir = TempDir::new()?;
+    let editable_dir = context.temp_dir.child("editable");
+    editable_dir.create_dir_all()?;
     let pyproject_toml = editable_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"[project]
@@ -5505,7 +5397,8 @@ fn requires_python_editable_target_version() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Create an editable package with a `Requires-Python` constraint that is not met.
-    let editable_dir = TempDir::new()?;
+    let editable_dir = context.temp_dir.child("editable");
+    editable_dir.create_dir_all()?;
     let pyproject_toml = editable_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"[project]
@@ -5530,7 +5423,7 @@ requires-python = "<=3.8"
         ),
     ]
         .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
+        .chain(context.filters())
         .collect();
 
     uv_snapshot!(filters, context.compile()
@@ -5720,7 +5613,8 @@ fn requires_python_direct_url() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Create an editable package with a `Requires-Python` constraint that is not met.
-    let editable_dir = TempDir::new()?;
+    let editable_dir = context.temp_dir.child("editable");
+    editable_dir.create_dir_all()?;
     let pyproject_toml = editable_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"[project]
@@ -5764,14 +5658,8 @@ fn compile_root_uri_editable() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("-e ${ROOT_PATH}")?;
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filters: Vec<_> = [(r"file://.*/", "file://[TEMP_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
     let root_path = current_dir()?.join("../../scripts/packages/root_editable");
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
         .arg("requirements.in")
         .env("ROOT_PATH", root_path.as_os_str()), @r###"
     success: true
@@ -5780,7 +5668,7 @@ fn compile_root_uri_editable() -> Result<()> {
     # This file was autogenerated by uv via the following command:
     #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z requirements.in
     -e ${ROOT_PATH}
-    black @ file://[TEMP_DIR]/black_editable
+    black @ file://[WORKSPACE]/scripts/packages/root_editable/../black_editable
         # via root-editable
 
     ----- stderr -----
@@ -5800,15 +5688,9 @@ fn compile_root_uri_non_editable() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("${ROOT_PATH}\n${BLACK_PATH}")?;
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filters: Vec<_> = [(r"file://.*/", "file://[TEMP_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
     let root_path = current_dir()?.join("../../scripts/packages/root_editable");
     let black_path = current_dir()?.join("../../scripts/packages/black_editable");
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
         .arg("requirements.in")
         .env("ROOT_PATH", root_path.as_os_str())
         .env("BLACK_PATH", black_path.as_os_str()), @r###"
@@ -6098,20 +5980,14 @@ fn unnamed_path_requirement() -> Result<()> {
         "
     })?;
 
-    let filter_path = regex::escape(&requirements_in.user_display().to_string());
-    let filters: Vec<_> = [(filter_path.as_str(), "requirements.in")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
         .arg(requirements_in.path())
         .current_dir(current_dir()?), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     # This file was autogenerated by uv via the following command:
-    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z requirements.in
+    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z [TEMP_DIR]/requirements.in
     anyio==4.3.0
         # via
         #   httpx
@@ -6236,20 +6112,14 @@ fn dynamic_dependencies() -> Result<()> {
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("hatchling-dynamic @ ../../scripts/packages/hatchling_dynamic")?;
 
-    let filter_path = regex::escape(&requirements_in.user_display().to_string());
-    let filters: Vec<_> = [(filter_path.as_str(), "requirements.in")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
-    uv_snapshot!(filters, context.compile()
+    uv_snapshot!(context.filters(), context.compile()
         .arg(requirements_in.path())
         .current_dir(current_dir()?), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
     # This file was autogenerated by uv via the following command:
-    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z requirements.in
+    #    uv pip compile --cache-dir [CACHE_DIR] --exclude-newer 2024-03-25T00:00:00Z [TEMP_DIR]/requirements.in
     anyio==4.3.0
         # via hatchling-dynamic
     hatchling-dynamic @ ../../scripts/packages/hatchling_dynamic

--- a/crates/uv/tests/pip_compile_scenarios.rs
+++ b/crates/uv/tests/pip_compile_scenarios.rs
@@ -13,7 +13,7 @@ use assert_cmd::assert::OutputAssertExt;
 use assert_fs::fixture::{FileWriteStr, PathChild};
 use predicates::prelude::predicate;
 
-use common::{create_bin_with_executables, get_bin, uv_snapshot, TestContext, INSTA_FILTERS};
+use common::{create_bin_with_executables, get_bin, uv_snapshot, TestContext};
 
 mod common;
 
@@ -67,7 +67,7 @@ fn incompatible_python_compatible_override() -> Result<()> {
     let python_versions = &[];
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"incompatible-python-compatible-override-", "package-"));
 
     let requirements_in = context.temp_dir.child("requirements.in");
@@ -116,7 +116,7 @@ fn compatible_python_incompatible_override() -> Result<()> {
     let python_versions = &[];
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"compatible-python-incompatible-override-", "package-"));
 
     let requirements_in = context.temp_dir.child("requirements.in");
@@ -163,7 +163,7 @@ fn incompatible_python_compatible_override_unavailable_no_wheels() -> Result<()>
     let python_versions = &[];
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"incompatible-python-compatible-override-unavailable-no-wheels-",
         "package-",
@@ -219,7 +219,7 @@ fn incompatible_python_compatible_override_available_no_wheels() -> Result<()> {
     let python_versions = &["3.11"];
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"incompatible-python-compatible-override-available-no-wheels-",
         "package-",
@@ -274,7 +274,7 @@ fn incompatible_python_compatible_override_no_compatible_wheels() -> Result<()> 
     let python_versions = &[];
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"incompatible-python-compatible-override-no-compatible-wheels-",
         "package-",
@@ -332,7 +332,7 @@ fn incompatible_python_compatible_override_other_wheel() -> Result<()> {
     let python_versions = &[];
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"incompatible-python-compatible-override-other-wheel-",
         "package-",
@@ -392,7 +392,7 @@ fn python_patch_override_no_patch() -> Result<()> {
     let python_versions = &[];
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"python-patch-override-no-patch-", "package-"));
 
     let requirements_in = context.temp_dir.child("requirements.in");
@@ -439,7 +439,7 @@ fn python_patch_override_patch_compatible() -> Result<()> {
     let python_versions = &[];
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"python-patch-override-patch-compatible-", "package-"));
 
     let requirements_in = context.temp_dir.child("requirements.in");

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -6,11 +6,10 @@ use assert_fs::prelude::*;
 use base64::{prelude::BASE64_STANDARD as base64, Engine};
 use indoc::indoc;
 use itertools::Itertools;
-use std::env::current_dir;
-use std::process::Command;
-use url::Url;
 
-use common::{uv_snapshot, TestContext, EXCLUDE_NEWER, INSTA_FILTERS};
+use std::process::Command;
+
+use common::{uv_snapshot, TestContext, EXCLUDE_NEWER};
 use uv_fs::Simplified;
 
 use crate::common::get_bin;
@@ -215,14 +214,10 @@ dependencies = ["flask==1.0.x"]
 "#,
     )?;
 
-    let filters = [
-        (r"file://.*", "[SOURCE_DIR]"),
-        (r#"File ".*[/\\]site-packages"#, "File \"[SOURCE_DIR]"),
-        ("exit status", "exit code"),
-    ]
-    .into_iter()
-    .chain(INSTA_FILTERS.to_vec())
-    .collect::<Vec<_>>();
+    let filters = [("exit status", "exit code")]
+        .into_iter()
+        .chain(context.filters())
+        .collect::<Vec<_>>();
 
     uv_snapshot!(filters, command(&context)
         .arg("-r")
@@ -232,7 +227,7 @@ dependencies = ["flask==1.0.x"]
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to build: [SOURCE_DIR]
+    error: Failed to build: file://[TEMP_DIR]/
       Caused by: Build backend failed to determine extra requires with `build_wheel()` with exit code: 1
     --- stdout:
     configuration error: `project.dependencies[0]` must be pep508
@@ -254,32 +249,32 @@ dependencies = ["flask==1.0.x"]
     --- stderr:
     Traceback (most recent call last):
       File "<string>", line 14, in <module>
-      File "[SOURCE_DIR]/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
+      File "[CACHE_DIR]/[TMP]/build_meta.py", line 325, in get_requires_for_build_wheel
         return self._get_build_requires(config_settings, requirements=['wheel'])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      File "[SOURCE_DIR]/setuptools/build_meta.py", line 295, in _get_build_requires
+      File "[CACHE_DIR]/[TMP]/build_meta.py", line 295, in _get_build_requires
         self.run_setup()
-      File "[SOURCE_DIR]/setuptools/build_meta.py", line 487, in run_setup
+      File "[CACHE_DIR]/[TMP]/build_meta.py", line 487, in run_setup
         super().run_setup(setup_script=setup_script)
-      File "[SOURCE_DIR]/setuptools/build_meta.py", line 311, in run_setup
+      File "[CACHE_DIR]/[TMP]/build_meta.py", line 311, in run_setup
         exec(code, locals())
       File "<string>", line 1, in <module>
-      File "[SOURCE_DIR]/setuptools/__init__.py", line 104, in setup
+      File "[CACHE_DIR]/[TMP]/__init__.py", line 104, in setup
         return distutils.core.setup(**attrs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      File "[SOURCE_DIR]/setuptools/_distutils/core.py", line 159, in setup
+      File "[CACHE_DIR]/[TMP]/core.py", line 159, in setup
         dist.parse_config_files()
-      File "[SOURCE_DIR]/_virtualenv.py", line 22, in parse_config_files
+      File "[CACHE_DIR]/[TMP]/_virtualenv.py", line 22, in parse_config_files
         result = old_parse_config_files(self, *args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      File "[SOURCE_DIR]/setuptools/dist.py", line 631, in parse_config_files
+      File "[CACHE_DIR]/[TMP]/dist.py", line 631, in parse_config_files
         pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
-      File "[SOURCE_DIR]/setuptools/config/pyprojecttoml.py", line 68, in apply_configuration
+      File "[CACHE_DIR]/[TMP]/pyprojecttoml.py", line 68, in apply_configuration
         config = read_configuration(filepath, True, ignore_option_errors, dist)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      File "[SOURCE_DIR]/setuptools/config/pyprojecttoml.py", line 129, in read_configuration
+      File "[CACHE_DIR]/[TMP]/pyprojecttoml.py", line 129, in read_configuration
         validate(subset, filepath)
-      File "[SOURCE_DIR]/setuptools/config/pyprojecttoml.py", line 57, in validate
+      File "[CACHE_DIR]/[TMP]/pyprojecttoml.py", line 57, in validate
         raise ValueError(f"{error}/n{summary}") from None
     ValueError: invalid pyproject.toml config: `project.dependencies[0]`.
     configuration error: `project.dependencies[0]` must be pep508
@@ -458,13 +453,13 @@ fn respect_installed_and_reinstall() -> Result<()> {
 
     let filters = if cfg!(windows) {
         // Remove the colorama count on windows
-        INSTA_FILTERS
-            .iter()
-            .copied()
+        context
+            .filters()
+            .into_iter()
             .chain([("Resolved 8 packages", "Resolved 7 packages")])
             .collect()
     } else {
-        INSTA_FILTERS.to_vec()
+        context.filters()
     };
     uv_snapshot!(filters, command(&context)
         .arg("-r")
@@ -596,7 +591,6 @@ fn reinstall_extras() -> Result<()> {
 
 /// Warn, but don't fail, when uninstalling incomplete packages.
 #[test]
-#[cfg(unix)]
 fn reinstall_incomplete() -> Result<()> {
     let context = TestContext::new("3.12");
 
@@ -623,23 +617,14 @@ fn reinstall_incomplete() -> Result<()> {
     );
 
     // Manually remove the `RECORD` file.
-    fs_err::remove_file(
-        context
-            .venv
-            .join("lib/python3.12/site-packages/anyio-3.7.0.dist-info/RECORD"),
-    )?;
+    fs_err::remove_file(context.site_packages().join("anyio-3.7.0.dist-info/RECORD"))?;
 
     // Re-install anyio.
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.touch()?;
     requirements_txt.write_str("anyio==4.0.0")?;
 
-    let filters = [(r"Failed to uninstall package at .* due to missing RECORD", "Failed to uninstall package at .venv/lib/python3.12/site-packages/anyio-3.7.0.dist-info due to missing RECORD")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect::<Vec<_>>();
-
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("-r")
         .arg("requirements.txt"), @r###"
     success: true
@@ -649,7 +634,7 @@ fn reinstall_incomplete() -> Result<()> {
     ----- stderr -----
     Resolved 3 packages in [TIME]
     Downloaded 1 package in [TIME]
-    warning: Failed to uninstall package at .venv/lib/python3.12/site-packages/anyio-3.7.0.dist-info due to missing RECORD file. Installation may result in an incomplete environment.
+    warning: Failed to uninstall package at [SITE_PACKAGES]/anyio-3.7.0.dist-info due to missing RECORD file. Installation may result in an incomplete environment.
     Installed 1 package in [TIME]
      - anyio==3.7.0
      + anyio==4.0.0
@@ -723,28 +708,13 @@ fn allow_incompatibilities() -> Result<()> {
 }
 
 #[test]
-#[cfg(feature = "maturin")]
-fn install_editable() -> Result<()> {
+fn install_editable() {
     let context = TestContext::new("3.12");
 
-    let current_dir = std::env::current_dir()?;
-    let workspace_dir = regex::escape(
-        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?)
-            .unwrap()
-            .as_str(),
-    );
-
-    let filters = [(workspace_dir.as_str(), "file://[WORKSPACE_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect::<Vec<_>>();
-
     // Install the editable package.
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("-e")
-        .arg("../../scripts/packages/poetry_editable")
-        .current_dir(&current_dir)
-        .env("CARGO_TARGET_DIR", "../../../target/target_install_editable"), @r###"
+        .arg(context.workspace_root.join("scripts/packages/poetry_editable")), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -756,24 +726,15 @@ fn install_editable() -> Result<()> {
     Installed 4 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
-     + poetry-editable==0.1.0 (from file://[WORKSPACE_DIR]/scripts/packages/poetry_editable)
+     + poetry-editable==0.1.0 (from file://[WORKSPACE]/scripts/packages/poetry_editable)
      + sniffio==1.3.1
     "###
     );
 
     // Install it again (no-op).
-    uv_snapshot!(filters, Command::new(get_bin())
-        .arg("pip")
-        .arg("install")
+    uv_snapshot!(context.filters(), command(&context)
         .arg("-e")
-        .arg("../../scripts/packages/poetry_editable")
-        .arg("--strict")
-        .arg("--cache-dir")
-        .arg(context.cache_dir.path())
-        .arg("--exclude-newer")
-        .arg(EXCLUDE_NEWER)
-        .env("VIRTUAL_ENV", context.venv.as_os_str())
-        .env("CARGO_TARGET_DIR", "../../../target/target_install_editable"), @r###"
+        .arg(context.workspace_root.join("scripts/packages/poetry_editable")), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -784,19 +745,10 @@ fn install_editable() -> Result<()> {
     );
 
     // Add another, non-editable dependency.
-    uv_snapshot!(filters, Command::new(get_bin())
-        .arg("pip")
-        .arg("install")
+    uv_snapshot!(context.filters(), command(&context)
         .arg("-e")
-        .arg("../../scripts/packages/poetry_editable")
-        .arg("black")
-        .arg("--strict")
-        .arg("--cache-dir")
-        .arg(context.cache_dir.path())
-        .arg("--exclude-newer")
-        .arg(EXCLUDE_NEWER)
-        .env("VIRTUAL_ENV", context.venv.as_os_str())
-        .env("CARGO_TARGET_DIR", "../../../target/target_install_editable"), @r###"
+        .arg(context.workspace_root.join("scripts/packages/poetry_editable"))
+        .arg("black"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -812,35 +764,19 @@ fn install_editable() -> Result<()> {
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
-     - poetry-editable==0.1.0 (from file://[WORKSPACE_DIR]/scripts/packages/poetry_editable)
-     + poetry-editable==0.1.0 (from file://[WORKSPACE_DIR]/scripts/packages/poetry_editable)
+     - poetry-editable==0.1.0 (from file://[WORKSPACE]/scripts/packages/poetry_editable)
+     + poetry-editable==0.1.0 (from file://[WORKSPACE]/scripts/packages/poetry_editable)
     "###
     );
-
-    Ok(())
 }
 
 #[test]
-fn install_editable_and_registry() -> Result<()> {
+fn install_editable_and_registry() {
     let context = TestContext::new("3.12");
 
-    let current_dir = std::env::current_dir()?;
-    let workspace_dir = regex::escape(
-        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?)
-            .unwrap()
-            .as_str(),
-    );
-
-    let filters: Vec<_> = [(workspace_dir.as_str(), "file://[WORKSPACE_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
-
     // Install the registry-based version of Black.
-    uv_snapshot!(filters, command(&context)
-        .arg("black")
-        .current_dir(&current_dir)
-        .env("CARGO_TARGET_DIR", "../../../target/target_install_editable"), @r###"
+    uv_snapshot!(context.filters(), command(&context)
+        .arg("black"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -859,11 +795,9 @@ fn install_editable_and_registry() -> Result<()> {
     );
 
     // Install the editable version of Black. This should remove the registry-based version.
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("-e")
-        .arg("../../scripts/packages/black_editable")
-        .current_dir(&current_dir)
-        .env("CARGO_TARGET_DIR", "../../../target/target_install_editable"), @r###"
+        .arg(context.workspace_root.join("scripts/packages/black_editable")), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -873,17 +807,15 @@ fn install_editable_and_registry() -> Result<()> {
     Resolved 1 package in [TIME]
     Installed 1 package in [TIME]
      - black==24.3.0
-     + black==0.1.0 (from file://[WORKSPACE_DIR]/scripts/packages/black_editable)
+     + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
     "###
     );
 
     // Re-install the registry-based version of Black. This should be a no-op, since we have a
     // version of Black installed (the editable version) that satisfies the requirements.
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("black")
-        .arg("--strict")
-        .current_dir(&current_dir)
-        .env("CARGO_TARGET_DIR", "../../../target/target_install_editable"), @r###"
+        .arg("--strict"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -893,7 +825,8 @@ fn install_editable_and_registry() -> Result<()> {
     "###
     );
 
-    let filters2: Vec<_> = filters
+    let filters: Vec<_> = context
+        .filters()
         .into_iter()
         .chain([
             // Remove colorama
@@ -902,10 +835,8 @@ fn install_editable_and_registry() -> Result<()> {
         .collect();
 
     // Re-install Black at a specific version. This should replace the editable version.
-    uv_snapshot!(filters2, command(&context)
-        .arg("black==23.10.0")
-        .current_dir(&current_dir)
-        .env("CARGO_TARGET_DIR", "../../../target/target_install_editable"), @r###"
+    uv_snapshot!(filters, command(&context)
+        .arg("black==23.10.0"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -914,38 +845,22 @@ fn install_editable_and_registry() -> Result<()> {
     Resolved 6 packages in [TIME]
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
-     - black==0.1.0 (from file://[WORKSPACE_DIR]/scripts/packages/black_editable)
+     - black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
      + black==23.10.0
     "###
     );
-
-    Ok(())
 }
 
 #[test]
-fn install_editable_no_binary() -> Result<()> {
+fn install_editable_no_binary() {
     let context = TestContext::new("3.12");
 
-    let current_dir = std::env::current_dir()?;
-    let workspace_dir = regex::escape(
-        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?)
-            .unwrap()
-            .as_str(),
-    );
-
-    let filters = [(workspace_dir.as_str(), "file://[WORKSPACE_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect::<Vec<_>>();
-
     // Install the editable package with no-binary enabled
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("-e")
-        .arg("../../scripts/packages/black_editable")
+        .arg(context.workspace_root.join("scripts/packages/black_editable"))
         .arg("--no-binary")
-        .arg(":all:")
-        .current_dir(&current_dir)
-        .env("CARGO_TARGET_DIR", "../../../target/target_install_editable"), @r###"
+        .arg(":all:"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -954,11 +869,9 @@ fn install_editable_no_binary() -> Result<()> {
     Built 1 editable in [TIME]
     Resolved 1 package in [TIME]
     Installed 1 package in [TIME]
-     + black==0.1.0 (from file://[WORKSPACE_DIR]/scripts/packages/black_editable)
+     + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
     "###
     );
-
-    Ok(())
 }
 
 /// Install a source distribution that uses the `flit` build system, along with `flit`
@@ -1198,15 +1111,16 @@ fn install_git_private_https_pat() {
     let context = TestContext::new("3.8");
     let token = decode_token(READ_ONLY_GITHUB_TOKEN);
 
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.insert(0, (&token, "***"));
+    let filters: Vec<_> = [(token.as_str(), "***")]
+        .into_iter()
+        .chain(context.filters())
+        .collect();
 
-    let mut command = command(&context);
-    command.arg(format!(
+    let package = format!(
         "uv-private-pypackage @ git+https://{token}@github.com/astral-test/uv-private-pypackage"
-    ));
+    );
 
-    uv_snapshot!(filters, command
+    uv_snapshot!(filters, command(&context).arg(package)
         , @r###"
     success: true
     exit_code: 0
@@ -1229,8 +1143,11 @@ fn install_git_private_https_pat_at_ref() {
     let context = TestContext::new("3.8");
     let token = decode_token(READ_ONLY_GITHUB_TOKEN);
 
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.insert(0, (&token, "***"));
+    let mut filters: Vec<_> = [(token.as_str(), "***")]
+        .into_iter()
+        .chain(context.filters())
+        .collect();
+
     filters.push((r"git\+https://", ""));
 
     // A user is _required_ on Windows
@@ -1241,10 +1158,9 @@ fn install_git_private_https_pat_at_ref() {
         ""
     };
 
-    let mut command = command(&context);
-    command.arg(format!("uv-private-pypackage @ git+https://{user}{token}@github.com/astral-test/uv-private-pypackage@6c09ce9ae81f50670a60abd7d95f30dd416d00ac"));
-
-    uv_snapshot!(filters, command, @r###"
+    let package = format!("uv-private-pypackage @ git+https://{user}{token}@github.com/astral-test/uv-private-pypackage@6c09ce9ae81f50670a60abd7d95f30dd416d00ac");
+    uv_snapshot!(filters, command(&context)
+        .arg(package), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1272,13 +1188,12 @@ fn install_git_private_https_pat_and_username() {
     let token = decode_token(READ_ONLY_GITHUB_TOKEN);
     let user = "astral-test-bot";
 
-    let mut filters = INSTA_FILTERS.to_vec();
-    filters.insert(0, (&token, "***"));
+    let filters: Vec<_> = [(token.as_str(), "***")]
+        .into_iter()
+        .chain(context.filters())
+        .collect();
 
-    let mut command = command(&context);
-    command.arg(format!("uv-private-pypackage @ git+https://{user}:{token}@github.com/astral-test/uv-private-pypackage"));
-
-    uv_snapshot!(filters, command
+    uv_snapshot!(filters, command(&context).arg(format!("uv-private-pypackage @ git+https://{user}:{token}@github.com/astral-test/uv-private-pypackage"))
         , @r###"
     success: true
     exit_code: 0
@@ -1376,14 +1291,15 @@ fn reinstall_no_binary() {
     // With `--reinstall`, `--no-binary` should have an affect
     let filters = if cfg!(windows) {
         // Remove the colorama count on windows
-        INSTA_FILTERS
-            .iter()
-            .copied()
+        context
+            .filters()
+            .into_iter()
             .chain([("Resolved 8 packages", "Resolved 7 packages")])
             .collect()
     } else {
-        INSTA_FILTERS.to_vec()
+        context.filters()
     };
+
     let mut command = crate::command(&context);
     command
         .arg("anyio")
@@ -1980,34 +1896,13 @@ fn launcher_with_symlink() -> Result<()> {
 }
 
 #[test]
-#[cfg(unix)]
-fn config_settings() -> Result<()> {
+fn config_settings() {
     let context = TestContext::new("3.12");
 
-    let current_dir = std::env::current_dir()?;
-    let workspace_dir = regex::escape(
-        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?)
-            .unwrap()
-            .as_str(),
-    );
-
-    let filters = [(workspace_dir.as_str(), "file://[WORKSPACE_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect::<Vec<_>>();
-
     // Install the editable package.
-    uv_snapshot!(filters, Command::new(get_bin())
-        .arg("pip")
-        .arg("install")
+    uv_snapshot!(context.filters(), command(&context)
         .arg("-e")
-        .arg("../../scripts/packages/setuptools_editable")
-        .arg("--cache-dir")
-        .arg(context.cache_dir.path())
-        .arg("--exclude-newer")
-        .arg(EXCLUDE_NEWER)
-        .env("VIRTUAL_ENV", context.venv.as_os_str())
-        .env("CARGO_TARGET_DIR", "../../../target/target_install_editable"), @r###"
+        .arg(context.workspace_root.join("scripts/packages/setuptools_editable")), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2018,45 +1913,25 @@ fn config_settings() -> Result<()> {
     Downloaded 1 package in [TIME]
     Installed 2 packages in [TIME]
      + iniconfig==2.0.0
-     + setuptools-editable==0.1.0 (from file://[WORKSPACE_DIR]/scripts/packages/setuptools_editable)
+     + setuptools-editable==0.1.0 (from file://[WORKSPACE]/scripts/packages/setuptools_editable)
     "###
     );
 
     // When installed without `--editable_mode=compat`, the `finder.py` file should be present.
     let finder = context
-        .venv
-        .join("lib/python3.12/site-packages")
+        .site_packages()
         .join("__editable___setuptools_editable_0_1_0_finder.py");
     assert!(finder.exists());
 
     // Install the editable package with `--editable_mode=compat`.
     let context = TestContext::new("3.12");
 
-    let current_dir = std::env::current_dir()?;
-    let workspace_dir = regex::escape(
-        Url::from_directory_path(current_dir.join("..").join("..").canonicalize()?)
-            .unwrap()
-            .as_str(),
-    );
-
-    let filters = [(workspace_dir.as_str(), "file://[WORKSPACE_DIR]/")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect::<Vec<_>>();
-
-    uv_snapshot!(filters, Command::new(get_bin())
-        .arg("pip")
-        .arg("install")
+    uv_snapshot!(context.filters(), command(&context)
         .arg("-e")
-        .arg("../../scripts/packages/setuptools_editable")
+        .arg(context.workspace_root.join("scripts/packages/setuptools_editable"))
         .arg("-C")
         .arg("editable_mode=compat")
-        .arg("--cache-dir")
-        .arg(context.cache_dir.path())
-        .arg("--exclude-newer")
-        .arg(EXCLUDE_NEWER)
-        .env("VIRTUAL_ENV", context.venv.as_os_str())
-        .env("CARGO_TARGET_DIR", "../../../target/target_install_editable"), @r###"
+        , @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2067,23 +1942,19 @@ fn config_settings() -> Result<()> {
     Downloaded 1 package in [TIME]
     Installed 2 packages in [TIME]
      + iniconfig==2.0.0
-     + setuptools-editable==0.1.0 (from file://[WORKSPACE_DIR]/scripts/packages/setuptools_editable)
+     + setuptools-editable==0.1.0 (from file://[WORKSPACE]/scripts/packages/setuptools_editable)
     "###
     );
 
     // When installed without `--editable_mode=compat`, the `finder.py` file should _not_ be present.
     let finder = context
-        .venv
-        .join("lib/python3.12/site-packages")
+        .site_packages()
         .join("__editable___setuptools_editable_0_1_0_finder.py");
     assert!(!finder.exists());
-
-    Ok(())
 }
 
 /// Reinstall a duplicate package in a virtual environment.
 #[test]
-#[cfg(unix)]
 fn reinstall_duplicate() -> Result<()> {
     use crate::common::copy_dir_all;
 
@@ -2121,12 +1992,8 @@ fn reinstall_duplicate() -> Result<()> {
 
     // Copy the virtual environment to a new location.
     copy_dir_all(
-        context2
-            .venv
-            .join("lib/python3.12/site-packages/pip-22.1.1.dist-info"),
-        context1
-            .venv
-            .join("lib/python3.12/site-packages/pip-22.1.1.dist-info"),
+        context2.site_packages().join("pip-22.1.1.dist-info"),
+        context1.site_packages().join("pip-22.1.1.dist-info"),
     )?;
 
     // Run `pip install`.
@@ -2191,7 +2058,8 @@ fn invalidate_editable_on_change() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Create an editable package.
-    let editable_dir = assert_fs::TempDir::new()?;
+    let editable_dir = context.temp_dir.child("editable");
+    editable_dir.create_dir_all()?;
     let pyproject_toml = editable_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"[project]
@@ -2204,12 +2072,7 @@ requires-python = ">=3.8"
 "#,
     )?;
 
-    let filters = [(r"\(from file://.*\)", "(from [WORKSPACE_DIR])")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect::<Vec<_>>();
-
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("--editable")
         .arg(editable_dir.path()), @r###"
     success: true
@@ -2222,14 +2085,14 @@ requires-python = ">=3.8"
     Downloaded 3 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.0.0
-     + example==0.0.0 (from [WORKSPACE_DIR])
+     + example==0.0.0 (from file://[TEMP_DIR]/editable)
      + idna==3.6
      + sniffio==1.3.1
     "###
     );
 
     // Re-installing should be a no-op.
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("--editable")
         .arg(editable_dir.path()), @r###"
     success: true
@@ -2254,7 +2117,7 @@ requires-python = ">=3.8"
     )?;
 
     // Re-installing should update the package.
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("--editable")
         .arg(editable_dir.path()), @r###"
     success: true
@@ -2268,8 +2131,8 @@ requires-python = ">=3.8"
     Installed 2 packages in [TIME]
      - anyio==4.0.0
      + anyio==3.7.1
-     - example==0.0.0 (from [WORKSPACE_DIR])
-     + example==0.0.0 (from [WORKSPACE_DIR])
+     - example==0.0.0 (from file://[TEMP_DIR]/editable)
+     + example==0.0.0 (from file://[TEMP_DIR]/editable)
     "###
     );
 
@@ -2281,7 +2144,8 @@ fn invalidate_editable_dynamic() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Create an editable package with dynamic metadata
-    let editable_dir = assert_fs::TempDir::new()?;
+    let editable_dir = context.temp_dir.child("editable");
+    editable_dir.create_dir_all()?;
     let pyproject_toml = editable_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"
@@ -2299,12 +2163,7 @@ dependencies = {file = ["requirements.txt"]}
     let requirements_txt = editable_dir.child("requirements.txt");
     requirements_txt.write_str("anyio==4.0.0")?;
 
-    let filters = [(r"\(from file://.*\)", "(from [WORKSPACE_DIR])")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect::<Vec<_>>();
-
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("--editable")
         .arg(editable_dir.path()), @r###"
     success: true
@@ -2317,14 +2176,14 @@ dependencies = {file = ["requirements.txt"]}
     Downloaded 3 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.0.0
-     + example==0.1.0 (from [WORKSPACE_DIR])
+     + example==0.1.0 (from file://[TEMP_DIR]/editable)
      + idna==3.6
      + sniffio==1.3.1
     "###
     );
 
     // Re-installing should re-install.
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("--editable")
         .arg(editable_dir.path()), @r###"
     success: true
@@ -2335,8 +2194,8 @@ dependencies = {file = ["requirements.txt"]}
     Built 1 editable in [TIME]
     Resolved 4 packages in [TIME]
     Installed 1 package in [TIME]
-     - example==0.1.0 (from [WORKSPACE_DIR])
-     + example==0.1.0 (from [WORKSPACE_DIR])
+     - example==0.1.0 (from file://[TEMP_DIR]/editable)
+     + example==0.1.0 (from file://[TEMP_DIR]/editable)
     "###
     );
 
@@ -2344,7 +2203,7 @@ dependencies = {file = ["requirements.txt"]}
     requirements_txt.write_str("anyio==3.7.1")?;
 
     // Re-installing should update the package.
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("--editable")
         .arg(editable_dir.path()), @r###"
     success: true
@@ -2358,8 +2217,8 @@ dependencies = {file = ["requirements.txt"]}
     Installed 2 packages in [TIME]
      - anyio==4.0.0
      + anyio==3.7.1
-     - example==0.1.0 (from [WORKSPACE_DIR])
-     + example==0.1.0 (from [WORKSPACE_DIR])
+     - example==0.1.0 (from file://[TEMP_DIR]/editable)
+     + example==0.1.0 (from file://[TEMP_DIR]/editable)
     "###
     );
 
@@ -2371,7 +2230,8 @@ fn invalidate_path_on_change() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Create a local package.
-    let editable_dir = assert_fs::TempDir::new()?;
+    let editable_dir = context.temp_dir.child("editable");
+    editable_dir.create_dir_all()?;
     let pyproject_toml = editable_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"[project]
@@ -2384,12 +2244,7 @@ requires-python = ">=3.8"
 "#,
     )?;
 
-    let filters = [(r"\(from file://.*\)", "(from [WORKSPACE_DIR])")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect::<Vec<_>>();
-
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("example @ .")
         .current_dir(editable_dir.path()), @r###"
     success: true
@@ -2401,14 +2256,14 @@ requires-python = ">=3.8"
     Downloaded 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.0.0
-     + example==0.0.0 (from [WORKSPACE_DIR])
+     + example==0.0.0 (from file://[TEMP_DIR]/editable)
      + idna==3.6
      + sniffio==1.3.1
     "###
     );
 
     // Re-installing should be a no-op.
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("example @ .")
         .current_dir(editable_dir.path()), @r###"
     success: true
@@ -2433,7 +2288,7 @@ requires-python = ">=3.8"
     )?;
 
     // Re-installing should update the package.
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("example @ .")
         .current_dir(editable_dir.path()), @r###"
     success: true
@@ -2446,8 +2301,8 @@ requires-python = ">=3.8"
     Installed 2 packages in [TIME]
      - anyio==4.0.0
      + anyio==3.7.1
-     - example==0.0.0 (from [WORKSPACE_DIR])
-     + example==0.0.0 (from [WORKSPACE_DIR])
+     - example==0.0.0 (from file://[TEMP_DIR]/editable)
+     + example==0.0.0 (from file://[TEMP_DIR]/editable)
     "###
     );
 
@@ -2459,7 +2314,8 @@ requires-python = ">=3.8"
 fn editable_url_with_marker() -> Result<()> {
     let context = TestContext::new("3.12");
 
-    let editable_dir = assert_fs::TempDir::new()?;
+    let editable_dir = context.temp_dir.child("editable");
+    editable_dir.create_dir_all()?;
     let pyproject_toml = editable_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"
@@ -2474,12 +2330,7 @@ requires-python = ">=3.11,<3.13"
 "#,
     )?;
 
-    let filters = [(r"\(from file://.*\)", "(from [WORKSPACE_DIR])")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect::<Vec<_>>();
-
-    uv_snapshot!(filters, command(&context)
+    uv_snapshot!(context.filters(), command(&context)
         .arg("--editable")
         .arg(editable_dir.path()), @r###"
     success: true
@@ -2492,7 +2343,7 @@ requires-python = ">=3.11,<3.13"
     Downloaded 3 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.0.0
-     + example==0.1.0 (from [WORKSPACE_DIR])
+     + example==0.1.0 (from file://[TEMP_DIR]/editable)
      + idna==3.6
      + sniffio==1.3.1
     "###
@@ -2507,7 +2358,8 @@ fn requires_python_editable() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Create an editable package with a `Requires-Python` constraint that is not met.
-    let editable_dir = assert_fs::TempDir::new()?;
+    let editable_dir = context.temp_dir.child("editable");
+    editable_dir.create_dir_all()?;
     let pyproject_toml = editable_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"[project]
@@ -2544,7 +2396,7 @@ fn no_build_isolation() -> Result<()> {
 
     // We expect the build to fail, because `setuptools` is not installed.
     let filters = std::iter::once((r"exit code: 1", "exit status: 1"))
-        .chain(INSTA_FILTERS.to_vec())
+        .chain(context.filters())
         .collect::<Vec<_>>();
     uv_snapshot!(filters, command(&context)
         .arg("-r")
@@ -2955,7 +2807,8 @@ fn requires_python_direct_url() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Create an editable package with a `Requires-Python` constraint that is not met.
-    let editable_dir = assert_fs::TempDir::new()?;
+    let editable_dir = context.temp_dir.child("editable");
+    editable_dir.create_dir_all()?;
     let pyproject_toml = editable_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"[project]
@@ -3117,32 +2970,15 @@ fn install_site_packages_mtime_updated() -> Result<()> {
 /// entry (because we want to ignore the entire cache from outside), ignoring all python source
 /// files.
 #[test]
-fn deptry_gitignore() -> Result<()> {
+fn deptry_gitignore() {
     let context = TestContext::new("3.12");
 
-    let project_root = current_dir()?
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .to_path_buf();
-    let source_dist_dir = project_root
-        .join("scripts")
-        .join("packages")
-        .join("deptry_reproducer");
-    let filter_path = regex::escape(
-        Url::from_directory_path(source_dist_dir.simplified_display().to_string())
-            .unwrap()
-            .to_string()
-            .trim_end_matches('/'),
-    );
-    let filters: Vec<_> = [(filter_path.as_str(), "[SOURCE_DIST_DIR]")]
-        .into_iter()
-        .chain(INSTA_FILTERS.to_vec())
-        .collect();
+    let source_dist_dir = context
+        .workspace_root
+        .join("scripts/packages/deptry_reproducer");
 
-    uv_snapshot!(filters, command(&context)
-        .arg(format!("deptry_reproducer @ {}/deptry_reproducer-0.1.0.tar.gz", source_dist_dir.simplified_display()))
+    uv_snapshot!(context.filters(), command(&context)
+        .arg(format!("deptry_reproducer @ {}", source_dist_dir.join("deptry_reproducer-0.1.0.tar.gz").simplified_display()))
         .arg("--strict")
         .current_dir(source_dist_dir), @r###"
     success: true
@@ -3154,7 +2990,7 @@ fn deptry_gitignore() -> Result<()> {
     Downloaded 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + cffi==1.16.0
-     + deptry-reproducer==0.1.0 (from [SOURCE_DIST_DIR]/deptry_reproducer-0.1.0.tar.gz)
+     + deptry-reproducer==0.1.0 (from file://[WORKSPACE]/scripts/packages/deptry_reproducer/deptry_reproducer-0.1.0.tar.gz)
      + pycparser==2.21
     "###
     );
@@ -3163,6 +2999,4 @@ fn deptry_gitignore() -> Result<()> {
     context
         .assert_command("import deptry_reproducer.foo")
         .success();
-
-    Ok(())
 }

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -11,7 +11,7 @@ use std::process::Command;
 use assert_cmd::assert::Assert;
 use assert_cmd::prelude::*;
 
-use common::{venv_to_interpreter, INSTA_FILTERS};
+use common::venv_to_interpreter;
 
 use crate::common::{get_bin, uv_snapshot, TestContext};
 
@@ -79,7 +79,7 @@ fn requires_package_does_not_exist() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"requires-package-does-not-exist-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -118,7 +118,7 @@ fn requires_exact_version_does_not_exist() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"requires-exact-version-does-not-exist-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -159,7 +159,7 @@ fn requires_greater_version_does_not_exist() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"requires-greater-version-does-not-exist-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -201,7 +201,7 @@ fn requires_less_version_does_not_exist() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"requires-less-version-does-not-exist-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -242,7 +242,7 @@ fn transitive_requires_package_does_not_exist() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"transitive-requires-package-does-not-exist-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -283,7 +283,7 @@ fn excluded_only_version() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"excluded-only-version-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -338,7 +338,7 @@ fn excluded_only_compatible_version() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"excluded-only-compatible-version-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -440,7 +440,7 @@ fn dependency_excludes_range_of_compatible_versions() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"dependency-excludes-range-of-compatible-versions-",
         "package-",
@@ -501,7 +501,7 @@ fn dependency_excludes_range_of_compatible_versions() {
 /// There is a non-contiguous range of compatible versions for the requested package
 /// `a`, but another dependency `c` excludes the range. This is the same as
 /// `dependency-excludes-range-of-compatible-versions` but some of the versions of
-/// `a` are incompatible for another reason e.g. dependency on non-existent package
+/// `a` are incompatible for another reason e.g. dependency on non-existant package
 /// `d`.
 ///
 /// ```text
@@ -565,7 +565,7 @@ fn dependency_excludes_non_contiguous_range_of_compatible_versions() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"dependency-excludes-non-contiguous-range-of-compatible-versions-",
         "package-",
@@ -646,7 +646,7 @@ fn extra_required() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"extra-required-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -696,7 +696,7 @@ fn missing_extra() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"missing-extra-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -746,7 +746,7 @@ fn multiple_extras_required() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"multiple-extras-required-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -826,7 +826,7 @@ fn all_extras_required() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"all-extras-required-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -894,7 +894,7 @@ fn extra_incompatible_with_extra() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"extra-incompatible-with-extra-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -948,7 +948,7 @@ fn extra_incompatible_with_extra_not_requested() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"extra-incompatible-with-extra-not-requested-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1009,7 +1009,7 @@ fn extra_incompatible_with_root() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"extra-incompatible-with-root-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1068,7 +1068,7 @@ fn extra_does_not_exist_backtrack() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"extra-does-not-exist-backtrack-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1115,7 +1115,7 @@ fn direct_incompatible_versions() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"direct-incompatible-versions-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1168,7 +1168,7 @@ fn transitive_incompatible_with_root_version() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"transitive-incompatible-with-root-version-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1226,7 +1226,7 @@ fn transitive_incompatible_with_transitive() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"transitive-incompatible-with-transitive-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1274,7 +1274,7 @@ fn local_simple() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-simple-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1313,7 +1313,7 @@ fn local_not_used_with_sdist() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-not-used-with-sdist-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1360,7 +1360,7 @@ fn local_used_without_sdist() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-used-without-sdist-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1405,7 +1405,7 @@ fn local_not_latest() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-not-latest-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1454,7 +1454,7 @@ fn local_transitive() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-transitive-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1512,7 +1512,7 @@ fn local_transitive_greater_than() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-transitive-greater-than-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1565,7 +1565,7 @@ fn local_transitive_greater_than_or_equal() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-transitive-greater-than-or-equal-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1623,7 +1623,7 @@ fn local_transitive_less_than() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-transitive-less-than-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1676,7 +1676,7 @@ fn local_transitive_less_than_or_equal() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-transitive-less-than-or-equal-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1734,7 +1734,7 @@ fn local_transitive_confounding() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-transitive-confounding-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1782,7 +1782,7 @@ fn local_transitive_conflicting() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-transitive-conflicting-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1841,7 +1841,7 @@ fn local_transitive_backtrack() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-transitive-backtrack-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1892,7 +1892,7 @@ fn local_greater_than() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-greater-than-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1927,7 +1927,7 @@ fn local_greater_than_or_equal() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-greater-than-or-equal-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -1970,7 +1970,7 @@ fn local_less_than() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-less-than-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2005,7 +2005,7 @@ fn local_less_than_or_equal() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"local-less-than-or-equal-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2045,7 +2045,7 @@ fn post_simple() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-simple-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2080,7 +2080,7 @@ fn post_greater_than_or_equal() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-greater-than-or-equal-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2123,7 +2123,7 @@ fn post_greater_than() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-greater-than-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2160,7 +2160,7 @@ fn post_greater_than_post() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-greater-than-post-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2206,7 +2206,7 @@ fn post_greater_than_or_equal_post() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-greater-than-or-equal-post-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2249,7 +2249,7 @@ fn post_less_than_or_equal() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-less-than-or-equal-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2288,7 +2288,7 @@ fn post_less_than() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-less-than-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2325,7 +2325,7 @@ fn post_local_greater_than() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-local-greater-than-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2366,7 +2366,7 @@ fn post_local_greater_than_post() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-local-greater-than-post-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2407,7 +2407,7 @@ fn post_equal_not_available() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-equal-not-available-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2448,7 +2448,7 @@ fn post_equal_available() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-equal-available-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2494,7 +2494,7 @@ fn post_greater_than_post_not_available() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"post-greater-than-post-not-available-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2534,7 +2534,7 @@ fn package_only_prereleases() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-only-prereleases-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2580,7 +2580,7 @@ fn package_only_prereleases_in_range() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-only-prereleases-in-range-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2626,7 +2626,7 @@ fn requires_package_only_prereleases_in_range_global_opt_in() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"requires-package-only-prereleases-in-range-global-opt-in-",
         "package-",
@@ -2674,7 +2674,7 @@ fn requires_package_prerelease_and_final_any() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"requires-package-prerelease-and-final-any-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2723,7 +2723,7 @@ fn package_prerelease_specified_only_final_available() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"package-prerelease-specified-only-final-available-",
         "package-",
@@ -2774,7 +2774,7 @@ fn package_prerelease_specified_only_prerelease_available() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"package-prerelease-specified-only-prerelease-available-",
         "package-",
@@ -2827,7 +2827,7 @@ fn package_prerelease_specified_mixed_available() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-prerelease-specified-mixed-available-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2876,7 +2876,7 @@ fn package_multiple_prereleases_kinds() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-multiple-prereleases-kinds-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2923,7 +2923,7 @@ fn package_multiple_prereleases_numbers() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-multiple-prereleases-numbers-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -2971,7 +2971,7 @@ fn transitive_package_only_prereleases() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"transitive-package-only-prereleases-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3028,7 +3028,7 @@ fn transitive_package_only_prereleases_in_range() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"transitive-package-only-prereleases-in-range-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3082,7 +3082,7 @@ fn transitive_package_only_prereleases_in_range_opt_in() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"transitive-package-only-prereleases-in-range-opt-in-",
         "package-",
@@ -3149,7 +3149,7 @@ fn transitive_prerelease_and_stable_dependency() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"transitive-prerelease-and-stable-dependency-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3214,7 +3214,7 @@ fn transitive_prerelease_and_stable_dependency_opt_in() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"transitive-prerelease-and-stable-dependency-opt-in-",
         "package-",
@@ -3313,7 +3313,7 @@ fn transitive_prerelease_and_stable_dependency_many_versions() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"transitive-prerelease-and-stable-dependency-many-versions-",
         "package-",
@@ -3397,7 +3397,7 @@ fn transitive_prerelease_and_stable_dependency_many_versions_holes() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"transitive-prerelease-and-stable-dependency-many-versions-holes-",
         "package-",
@@ -3465,7 +3465,7 @@ fn package_only_prereleases_boundary() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-only-prereleases-boundary-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3483,7 +3483,7 @@ fn package_only_prereleases_boundary() {
     "###);
 
     // Since there are only prerelease versions of `a` available, a prerelease is
-    // allowed. Since the user did not explicitly request a pre-release, pre-releases at
+    // allowed. Since the user did not explictly request a pre-release, pre-releases at
     // the boundary should not be selected.
     assert_installed(
         &context.venv,
@@ -3513,7 +3513,7 @@ fn package_prereleases_boundary() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-prereleases-boundary-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3561,7 +3561,7 @@ fn package_prereleases_global_boundary() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-prereleases-global-boundary-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3612,7 +3612,7 @@ fn package_prereleases_specifier_boundary() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-prereleases-specifier-boundary-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3657,7 +3657,7 @@ fn python_version_does_not_exist() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"python-version-does-not-exist-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3699,7 +3699,7 @@ fn python_less_than_current() {
     let context = TestContext::new("3.9");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"python-less-than-current-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3741,7 +3741,7 @@ fn python_greater_than_current() {
     let context = TestContext::new("3.9");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"python-greater-than-current-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3783,7 +3783,7 @@ fn python_greater_than_current_patch() {
     let context = TestContext::new("3.8.12");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"python-greater-than-current-patch-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3847,7 +3847,7 @@ fn python_greater_than_current_many() {
     let context = TestContext::new("3.9");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"python-greater-than-current-many-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3896,7 +3896,7 @@ fn python_greater_than_current_backtrack() {
     let context = TestContext::new("3.9");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"python-greater-than-current-backtrack-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -3947,7 +3947,7 @@ fn python_greater_than_current_excluded() {
     let context = TestContext::new("3.9");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"python-greater-than-current-excluded-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4003,7 +4003,7 @@ fn specific_tag_and_default() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"specific-tag-and-default-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4038,7 +4038,7 @@ fn only_wheels() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"only-wheels-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4073,7 +4073,7 @@ fn no_wheels() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"no-wheels-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4108,7 +4108,7 @@ fn no_wheels_with_matching_platform() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"no-wheels-with-matching-platform-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4144,7 +4144,7 @@ fn no_sdist_no_wheels_with_matching_platform() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"no-sdist-no-wheels-with-matching-platform-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4185,7 +4185,7 @@ fn no_sdist_no_wheels_with_matching_python() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"no-sdist-no-wheels-with-matching-python-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4226,7 +4226,7 @@ fn no_sdist_no_wheels_with_matching_abi() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"no-sdist-no-wheels-with-matching-abi-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4267,7 +4267,7 @@ fn no_wheels_no_build() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"no-wheels-no-build-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4306,7 +4306,7 @@ fn only_wheels_no_binary() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"only-wheels-no-binary-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4345,7 +4345,7 @@ fn no_build() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"no-build-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4385,7 +4385,7 @@ fn no_binary() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"no-binary-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4425,7 +4425,7 @@ fn package_only_yanked() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-only-yanked-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4464,7 +4464,7 @@ fn package_only_yanked_in_range() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-only-yanked-in-range-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4511,7 +4511,7 @@ fn requires_package_yanked_and_unyanked_any() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"requires-package-yanked-and-unyanked-any-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4559,7 +4559,7 @@ fn package_yanked_specified_mixed_available() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"package-yanked-specified-mixed-available-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4607,7 +4607,7 @@ fn transitive_package_only_yanked() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"transitive-package-only-yanked-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4656,7 +4656,7 @@ fn transitive_package_only_yanked_in_range() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"transitive-package-only-yanked-in-range-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4711,7 +4711,7 @@ fn transitive_package_only_yanked_in_range_opt_in() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"transitive-package-only-yanked-in-range-opt-in-",
         "package-",
@@ -4779,7 +4779,7 @@ fn transitive_yanked_and_unyanked_dependency() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"transitive-yanked-and-unyanked-dependency-", "package-"));
 
     uv_snapshot!(filters, command(&context)
@@ -4841,7 +4841,7 @@ fn transitive_yanked_and_unyanked_dependency_opt_in() {
     let context = TestContext::new("3.8");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((
         r"transitive-yanked-and-unyanked-dependency-opt-in-",
         "package-",

--- a/crates/uv/tests/pip_show.rs
+++ b/crates/uv/tests/pip_show.rs
@@ -85,14 +85,7 @@ fn show_requires_multiple() -> Result<()> {
     );
 
     context.assert_command("import requests").success();
-    let filters = [(
-        r"Location:.*site-packages",
-        "Location: [WORKSPACE_DIR]/site-packages",
-    )]
-    .to_vec();
-
-    // Guards against the package names being sorted.
-    uv_snapshot!(filters, Command::new(get_bin())
+    uv_snapshot!(context.filters(), Command::new(get_bin())
         .arg("pip")
         .arg("show")
         .arg("requests")
@@ -105,7 +98,7 @@ fn show_requires_multiple() -> Result<()> {
     ----- stdout -----
     Name: requests
     Version: 2.31.0
-    Location: [WORKSPACE_DIR]/site-packages
+    Location: [SITE_PACKAGES]/
     Requires: certifi, charset-normalizer, idna, urllib3
     Required-by:
 
@@ -144,10 +137,7 @@ fn show_python_version_marker() -> Result<()> {
 
     context.assert_command("import click").success();
 
-    let mut filters = vec![(
-        r"Location:.*site-packages",
-        "Location: [WORKSPACE_DIR]/site-packages",
-    )];
+    let mut filters = context.filters();
     if cfg!(windows) {
         filters.push(("Requires: colorama", "Requires:"));
     }
@@ -165,7 +155,7 @@ fn show_python_version_marker() -> Result<()> {
     ----- stdout -----
     Name: click
     Version: 8.1.7
-    Location: [WORKSPACE_DIR]/site-packages
+    Location: [SITE_PACKAGES]/
     Requires:
     Required-by:
 
@@ -202,12 +192,7 @@ fn show_found_single_package() -> Result<()> {
 
     context.assert_command("import markupsafe").success();
 
-    let filters = vec![(
-        r"Location:.*site-packages",
-        "Location: [WORKSPACE_DIR]/site-packages",
-    )];
-
-    uv_snapshot!(filters, Command::new(get_bin())
+    uv_snapshot!(context.filters(), Command::new(get_bin())
         .arg("pip")
         .arg("show")
         .arg("markupsafe")
@@ -220,7 +205,7 @@ fn show_found_single_package() -> Result<()> {
     ----- stdout -----
     Name: markupsafe
     Version: 2.1.3
-    Location: [WORKSPACE_DIR]/site-packages
+    Location: [SITE_PACKAGES]/
     Requires:
     Required-by:
 
@@ -262,14 +247,7 @@ fn show_found_multiple_packages() -> Result<()> {
 
     context.assert_command("import markupsafe").success();
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filters = [(
-        r"Location:.*site-packages",
-        "Location: [WORKSPACE_DIR]/site-packages",
-    )]
-    .to_vec();
-
-    uv_snapshot!(filters, Command::new(get_bin())
+    uv_snapshot!(context.filters(), Command::new(get_bin())
         .arg("pip")
         .arg("show")
         .arg("markupsafe")
@@ -283,13 +261,13 @@ fn show_found_multiple_packages() -> Result<()> {
     ----- stdout -----
     Name: markupsafe
     Version: 2.1.3
-    Location: [WORKSPACE_DIR]/site-packages
+    Location: [SITE_PACKAGES]/
     Requires:
     Required-by:
     ---
     Name: pip
     Version: 21.3.1
-    Location: [WORKSPACE_DIR]/site-packages
+    Location: [SITE_PACKAGES]/
     Requires:
     Required-by:
 
@@ -331,14 +309,7 @@ fn show_found_one_out_of_three() -> Result<()> {
 
     context.assert_command("import markupsafe").success();
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filters = [(
-        r"Location:.*site-packages",
-        "Location: [WORKSPACE_DIR]/site-packages",
-    )]
-    .to_vec();
-
-    uv_snapshot!(filters, Command::new(get_bin())
+    uv_snapshot!(context.filters(), Command::new(get_bin())
         .arg("pip")
         .arg("show")
         .arg("markupsafe")
@@ -353,7 +324,7 @@ fn show_found_one_out_of_three() -> Result<()> {
     ----- stdout -----
     Name: markupsafe
     Version: 2.1.3
-    Location: [WORKSPACE_DIR]/site-packages
+    Location: [SITE_PACKAGES]/
     Requires:
     Required-by:
 
@@ -486,20 +457,7 @@ fn show_editable() -> Result<()> {
         .assert()
         .success();
 
-    // In addition to the standard filters, remove the temporary directory from the snapshot.
-    let filters = [
-        (
-            r"Location:.*site-packages",
-            "Location: [WORKSPACE_DIR]/site-packages",
-        ),
-        (
-            r"Editable project location:.*poetry_editable",
-            "Editable project location: [EDITABLE_INSTALLS_PREFIX]poetry_editable",
-        ),
-    ]
-    .to_vec();
-
-    uv_snapshot!(filters, Command::new(get_bin())
+    uv_snapshot!(context.filters(), Command::new(get_bin())
         .arg("pip")
         .arg("show")
         .arg("poetry-editable")
@@ -512,8 +470,8 @@ fn show_editable() -> Result<()> {
     ----- stdout -----
     Name: poetry-editable
     Version: 0.1.0
-    Location: [WORKSPACE_DIR]/site-packages
-    Editable project location: [EDITABLE_INSTALLS_PREFIX]poetry_editable
+    Location: [SITE_PACKAGES]/
+    Editable project location: [WORKSPACE]/scripts/packages/poetry_editable
     Requires: anyio
     Required-by:
 
@@ -559,14 +517,9 @@ fn show_required_by_multiple() -> Result<()> {
     );
 
     context.assert_command("import requests").success();
-    let filters = [(
-        r"Location:.*site-packages",
-        "Location: [WORKSPACE_DIR]/site-packages",
-    )]
-    .to_vec();
 
     // idna is required by anyio and requests
-    uv_snapshot!(filters, Command::new(get_bin())
+    uv_snapshot!(context.filters(), Command::new(get_bin())
         .arg("pip")
         .arg("show")
         .arg("idna")
@@ -579,7 +532,7 @@ fn show_required_by_multiple() -> Result<()> {
     ----- stdout -----
     Name: idna
     Version: 3.6
-    Location: [WORKSPACE_DIR]/site-packages
+    Location: [SITE_PACKAGES]/
     Requires:
     Required-by: anyio, requests
 

--- a/scripts/scenarios/templates/compile.mustache
+++ b/scripts/scenarios/templates/compile.mustache
@@ -64,7 +64,7 @@ fn {{module_name}}() -> Result<()> {
     let python_versions = &[{{#environment.additional_python}}"{{.}}", {{/environment.additional_python}}];
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"{{name}}-", "package-"));
 
     let requirements_in = context.temp_dir.child("requirements.in");

--- a/scripts/scenarios/templates/install.mustache
+++ b/scripts/scenarios/templates/install.mustache
@@ -82,7 +82,7 @@ fn {{module_name}}() {
     let context = TestContext::new("{{environment.python}}");
 
     // In addition to the standard filters, swap out package names for shorter messages
-    let mut filters = INSTA_FILTERS.to_vec();
+    let mut filters = context.filters();
     filters.push((r"{{name}}-", "package-"));
 
     uv_snapshot!(filters, command(&context)


### PR DESCRIPTION
The snapshot filtering situation has gotten way out of hand, with each test hand-rolling it's own filters on top of copied cruft from previous tests.

I've attempted to address this holistically:

- `TestContext.filters()` has everything you should need 
    - This was introduced a while ago, but needed a few more filters for it to be generalized everywhere
    - Using `INSTA_FILTERS` is **not recommended** unless you do not want the context filters
    - It is okay to extend these filters for things unrelated to paths
    - If you have to write a custom path filter, please highlight it in review so we can address it in the common module
- `TestContext.site_packages()` gives cross-platform access to the site-packages directory
    - Do not manually construct the path to site-packages from the venv
    - Do not turn off tests on Windows because you manually constructed a Unix path to site-packages
- `TestContext.workspace_root` gives access to uv's repository directory
    - Use this for installing from `scripts/packages/`
    - If you need coverage for relative paths, copy the test package into the `temp_dir` don't change the working directory of the test fixture

There is additional work that can be done here, such as:

- Auditing and removing additional uses of `INSTA_FILTERS`
- Updating manual construction of `Command` instances to use a utility
- The `venv` tests are particularly frightening in their lack of a test context and could use some love
- Improving the developer experience i.e. apply context filters to snapshots by default