### PR TITLE
Unhide `--emit-index-url` and `--emit-find-links`

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -469,11 +469,11 @@ struct PipCompileArgs {
     no_emit_package: Vec<PackageName>,
 
     /// Include `--index-url` and `--extra-index-url` entries in the generated output file.
-    #[clap(long, hide = true)]
+    #[clap(long)]
     emit_index_url: bool,
 
     /// Include `--find-links` entries in the generated output file.
-    #[clap(long, hide = true)]
+    #[clap(long)]
     emit_find_links: bool,
 
     /// Choose the style of the annotation comments, which indicate the source of each package.


### PR DESCRIPTION
## Summary

I don't know why I hid these in the first place. Maybe I copied these over from the `compat.rs` version.

Closes https://github.com/astral-sh/uv/issues/1502.
