### PR TITLE
fixed uv can't create .venv for cpython-x86 on Windows 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,6 +475,32 @@ jobs:
       - name: "Validate global Python install"
         run: py -3.10 ./scripts/check_system_python.py --uv ./uv.exe
 
+  system-test-windows-x86-python-310:
+    needs: build-binary-windows
+    name: "check system | python3.10 on windows x86"
+    runs-on: windows-latest
+    env:
+      # Avoid debug build stack overflows.
+      UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          architecture: "x86"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-windows-${{ github.sha }}
+
+      - name: "Print Python path"
+        run: echo $(which python)
+
+      - name: "Validate global Python install"
+        run: py -3.10 ./scripts/check_system_python.py --uv ./uv.exe
+
   system-test-windows-python-313:
     needs: build-binary-windows
     name: "check system | python3.13 on windows"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,7 @@ jobs:
         run: echo $(which python)
 
       - name: "Validate global Python install"
-        run: py -3.10 ./scripts/check_system_python.py --uv ./uv.exe
+        run: python ./scripts/check_system_python.py --uv ./uv.exe
 
   system-test-windows-python-313:
     needs: build-binary-windows

--- a/crates/uv-interpreter/python/get_interpreter_info.py
+++ b/crates/uv-interpreter/python/get_interpreter_info.py
@@ -415,12 +415,15 @@ def get_operating_system_and_architecture():
     """
     # https://github.com/pypa/packaging/blob/cc938f984bbbe43c5734b9656c9837ab3a28191f/src/packaging/_musllinux.py#L84
     # Note that this is not `os.name`.
+    # https://docs.python.org/3/library/sysconfig.html#sysconfig.get_platform
+    # windows x86 will return win32
     platform_info = sysconfig.get_platform().split("-", 1)
     if len(platform_info) == 1:
         if platform_info[0] == "win32":
             operating_system, version_arch = "win", "i386"
         else:
-            raise ValueError(f"Unsupported Platform: {platform_info[0]}")
+            # unknown_operating_system will flow to the final error print
+            operating_system, version_arch = platform_info[0], ""
     else:
         [operating_system, version_arch] = platform_info
     if "-" in version_arch:

--- a/crates/uv-interpreter/python/get_interpreter_info.py
+++ b/crates/uv-interpreter/python/get_interpreter_info.py
@@ -415,7 +415,14 @@ def get_operating_system_and_architecture():
     """
     # https://github.com/pypa/packaging/blob/cc938f984bbbe43c5734b9656c9837ab3a28191f/src/packaging/_musllinux.py#L84
     # Note that this is not `os.name`.
-    [operating_system, version_arch] = sysconfig.get_platform().split("-", 1)
+    platform_info = sysconfig.get_platform().split("-", 1)
+    if len(platform_info) == 1:
+        if platform_info[0] == "win32":
+            operating_system, version_arch = "win", "i386"
+        else:
+            raise ValueError(f"Unsupported Platform: {platform_info[0]}")
+    else:
+        [operating_system, version_arch] = platform_info
     if "-" in version_arch:
         # Ex: macosx-11.2-arm64
         version, architecture = version_arch.rsplit("-", 1)


### PR DESCRIPTION
Adaptation to the win32 platform is added.

https://docs.python.org/3/library/sysconfig.html#sysconfig.get_platform


## Summary

fixed uv can't create .venv for cpython-x86 on Windows 

[uv can't create .venv for cpython-x86 on Windows ](https://github.com/astral-sh/rye/issues/952)

