### PR TITLE
Add Homebrew system check test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,12 +477,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Install Python"
-        run: |
-          brew install python@3.8
-
-          # The system provides `python3` and brew only adds `python3.8` to the path so
-          # we need to link it to take precedence over the the default system python
-          ln -s "/opt/homebrew/bin/python3.8" "/opt/homebrew/bin/python3.3"
+        run: brew install python3
 
       - name: "Download binary"
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,6 +469,35 @@ jobs:
       - name: "Validate global Python install"
         run: python3 scripts/check_system_python.py --uv ./uv --externally-managed
 
+  system-test-macos-aarch64-homebrew:
+    needs: build-binary-macos-aarch64
+    name: "check system | homebrew python on macos aarch64"
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Install Python"
+        run: |
+          brew install python@3.8
+
+          # The system provides `python3` and brew only adds `python3.8` to the path so
+          # we need to link it to take precedence over the the default system python
+          ln -s "/opt/homebrew/bin/python3.8" "/opt/homebrew/bin/python3.3"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-macos-aarch64-${{ github.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Print Python path"
+        run: echo $(which python3)
+
+      - name: "Validate global Python install"
+        run: python3 scripts/check_system_python.py --uv ./uv --externally-managed
+
   system-test-macos-x86_64:
     needs: build-binary-macos-x86_64
     name: "check system | python on macos x86_64"


### PR DESCRIPTION
Following #2735 adds a system check that uses Homebrew. I think we were never were actually using Homebrew's Python in the past, we were mislead or something changed in the runners recently that broke it.