### PR TITLE
Remove `Cache` argument from `DistributionDatabase`

### DIFF
--- a/crates/uv-installer/src/downloader.rs
+++ b/crates/uv-installer/src/downloader.rs
@@ -54,7 +54,7 @@ impl<'a, Context: BuildContext + Send + Sync> Downloader<'a, Context> {
         Self {
             tags,
             cache,
-            database: DistributionDatabase::new(cache, client, build_context),
+            database: DistributionDatabase::new(client, build_context),
             reporter: None,
         }
     }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -140,7 +140,7 @@ impl<
     ) -> Result<Self, ResolveError> {
         let provider = DefaultResolverProvider::new(
             client,
-            DistributionDatabase::new(build_context.cache(), client, build_context),
+            DistributionDatabase::new(client, build_context),
             flat_index,
             tags,
             PythonRequirement::new(interpreter, markers),


### PR DESCRIPTION
## Summary

We can access cache from `BuildContext`. This mirrors `SourceDistCachedBuilder`, which doesn't accept `Cache` as an argument and always accesses it through `BuildContext`.
