### PR TITLE
Rename to `SourceDistributionBuilder`

### DIFF
--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -22,7 +22,7 @@ use uv_types::{BuildContext, NoBinary, NoBuild};
 use crate::download::{BuiltWheel, UnzippedWheel};
 use crate::git::resolve_precise;
 use crate::locks::Locks;
-use crate::{DiskWheel, Error, LocalWheel, Reporter, SourceDistCachedBuilder};
+use crate::{DiskWheel, Error, LocalWheel, Reporter, SourceDistributionBuilder};
 
 /// A cached high-level interface to convert distributions (a requirement resolved to a location)
 /// to a wheel or wheel metadata.
@@ -39,7 +39,7 @@ use crate::{DiskWheel, Error, LocalWheel, Reporter, SourceDistCachedBuilder};
 pub struct DistributionDatabase<'a, Context: BuildContext + Send + Sync> {
     client: &'a RegistryClient,
     build_context: &'a Context,
-    builder: SourceDistCachedBuilder<'a, Context>,
+    builder: SourceDistributionBuilder<'a, Context>,
     locks: Arc<Locks>,
     reporter: Option<Arc<dyn Reporter>>,
 }
@@ -49,7 +49,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
         Self {
             client,
             build_context,
-            builder: SourceDistCachedBuilder::new(build_context, client),
+            builder: SourceDistributionBuilder::new(client, build_context),
             locks: Arc::new(Locks::default()),
             reporter: None,
         }

--- a/crates/uv-distribution/src/lib.rs
+++ b/crates/uv-distribution/src/lib.rs
@@ -3,7 +3,7 @@ pub use download::{BuiltWheel, DiskWheel, LocalWheel};
 pub use error::Error;
 pub use index::{BuiltWheelIndex, RegistryWheelIndex};
 pub use reporter::Reporter;
-pub use source::{download_and_extract_archive, SourceDistCachedBuilder};
+pub use source::{download_and_extract_archive, SourceDistributionBuilder};
 pub use unzip::Unzip;
 
 mod distribution_database;

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -44,9 +44,9 @@ mod built_wheel_metadata;
 mod manifest;
 
 /// Fetch and build a source distribution from a remote source, or from a local cache.
-pub struct SourceDistCachedBuilder<'a, T: BuildContext> {
-    build_context: &'a T,
+pub struct SourceDistributionBuilder<'a, T: BuildContext> {
     client: &'a RegistryClient,
+    build_context: &'a T,
     reporter: Option<Arc<dyn Reporter>>,
 }
 
@@ -56,13 +56,13 @@ pub(crate) const MANIFEST: &str = "manifest.msgpack";
 /// The name of the file that contains the cached distribution metadata, encoded via `MsgPack`.
 pub(crate) const METADATA: &str = "metadata.msgpack";
 
-impl<'a, T: BuildContext> SourceDistCachedBuilder<'a, T> {
-    /// Initialize a [`SourceDistCachedBuilder`] from a [`BuildContext`].
-    pub fn new(build_context: &'a T, client: &'a RegistryClient) -> Self {
+impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
+    /// Initialize a [`SourceDistributionBuilder`] from a [`BuildContext`].
+    pub fn new(client: &'a RegistryClient, build_context: &'a T) -> Self {
         Self {
+            client,
             build_context,
             reporter: None,
-            client,
         }
     }
 

--- a/crates/uv-requirements/src/lookahead.rs
+++ b/crates/uv-requirements/src/lookahead.rs
@@ -9,7 +9,7 @@ use distribution_types::{BuildableSource, Dist, LocalEditable};
 use pep508_rs::{MarkerEnvironment, Requirement, VersionOrUrl};
 use pypi_types::Metadata23;
 use uv_client::RegistryClient;
-use uv_distribution::{Reporter, SourceDistCachedBuilder};
+use uv_distribution::{Reporter, SourceDistributionBuilder};
 use uv_types::{BuildContext, Constraints, Overrides, RequestedRequirements};
 
 /// A resolver for resolving lookahead requirements from local dependencies.
@@ -134,9 +134,9 @@ impl<'a> LookaheadResolver<'a> {
 
         // Run the PEP 517 build process to extract metadata from the source distribution.
         let builder = if let Some(reporter) = self.reporter.clone() {
-            SourceDistCachedBuilder::new(context, client).with_reporter(reporter)
+            SourceDistributionBuilder::new(client, context).with_reporter(reporter)
         } else {
-            SourceDistCachedBuilder::new(context, client)
+            SourceDistributionBuilder::new(client, context)
         };
 
         let metadata = builder

--- a/crates/uv-requirements/src/resolver.rs
+++ b/crates/uv-requirements/src/resolver.rs
@@ -18,7 +18,7 @@ use pep508_rs::{
 };
 use pypi_types::Metadata10;
 use uv_client::RegistryClient;
-use uv_distribution::{Reporter, SourceDistCachedBuilder};
+use uv_distribution::{Reporter, SourceDistributionBuilder};
 use uv_normalize::PackageName;
 use uv_types::BuildContext;
 
@@ -233,9 +233,9 @@ impl NamedRequirementsResolver {
 
         // Run the PEP 517 build process to extract metadata from the source distribution.
         let builder = if let Some(reporter) = reporter {
-            SourceDistCachedBuilder::new(context, client).with_reporter(reporter)
+            SourceDistributionBuilder::new(client, context).with_reporter(reporter)
         } else {
-            SourceDistCachedBuilder::new(context, client)
+            SourceDistributionBuilder::new(client, context)
         };
 
         let metadata = builder

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -9,7 +9,7 @@ use url::Url;
 use distribution_types::{BuildableSource, PathSourceUrl, SourceUrl};
 use pep508_rs::Requirement;
 use uv_client::RegistryClient;
-use uv_distribution::{Reporter, SourceDistCachedBuilder};
+use uv_distribution::{Reporter, SourceDistributionBuilder};
 use uv_types::BuildContext;
 
 use crate::ExtrasSpecification;
@@ -87,9 +87,9 @@ impl<'a> SourceTreeResolver<'a> {
 
         // Run the PEP 517 build process to extract metadata from the source distribution.
         let builder = if let Some(reporter) = self.reporter.clone() {
-            SourceDistCachedBuilder::new(context, client).with_reporter(reporter)
+            SourceDistributionBuilder::new(client, context).with_reporter(reporter)
         } else {
-            SourceDistCachedBuilder::new(context, client)
+            SourceDistributionBuilder::new(client, context)
         };
 
         let metadata = builder.download_and_build_metadata(&source).await?;


### PR DESCRIPTION
## Summary

This is more consistent with `DistributionDatabase`. The order of the arguments is also now consistent between the two structs.
