### PR TITLE
Populate the in-memory index when resolving lookahead URLs

### DIFF
--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -345,6 +345,7 @@ pub(crate) async fn pip_compile(
         &editables,
         &build_dispatch,
         &client,
+        &top_level_index,
     )
     .with_reporter(ResolverReporter::from(printer))
     .resolve(&markers)

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -546,6 +546,7 @@ async fn resolve(
         &editables,
         build_dispatch,
         client,
+        index,
     )
     .with_reporter(ResolverReporter::from(printer))
     .resolve(markers)

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -1584,8 +1584,8 @@ fn conflicting_transitive_url_dependency() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because flask==3.0.0 depends on werkzeug>=3.0.0 and only werkzeug<3.0.0
-          is available, we can conclude that flask==3.0.0 cannot be used.
+      ╰─▶ Because only werkzeug<3.0.0 is available and flask==3.0.0 depends on
+          werkzeug>=3.0.0, we can conclude that flask==3.0.0 cannot be used.
           And because you require flask==3.0.0, we can conclude that the
           requirements are unsatisfiable.
     "###


### PR DESCRIPTION
## Summary

Just ensures that we don't have to go back to the cache when resolving.