### PR TITLE
Use canonical URL to key redirect map

### DIFF
--- a/crates/uv-resolver/src/resolver/index.rs
+++ b/crates/uv-resolver/src/resolver/index.rs
@@ -1,3 +1,4 @@
+use cache_key::CanonicalUrl;
 use dashmap::DashMap;
 use url::Url;
 
@@ -21,5 +22,5 @@ pub struct InMemoryIndex {
     /// A map from source URL to precise URL. For example, the source URL
     /// `git+https://github.com/pallets/flask.git` could be redirected to
     /// `git+https://github.com/pallets/flask.git@c2f65dd1cfff0672b902fd5b30815f0b4137214c`.
-    pub(crate) redirects: DashMap<Url, Url>,
+    pub(crate) redirects: DashMap<CanonicalUrl, Url>,
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -6,6 +6,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use anyhow::Result;
+use cache_key::CanonicalUrl;
 use dashmap::{DashMap, DashSet};
 use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
@@ -949,13 +950,19 @@ impl<
                     if let Some(precise) = precise {
                         match distribution {
                             SourceDist::DirectUrl(sdist) => {
-                                self.index.redirects.insert(sdist.url.to_url(), precise);
+                                self.index
+                                    .redirects
+                                    .insert(CanonicalUrl::new(&sdist.url), precise);
                             }
                             SourceDist::Git(sdist) => {
-                                self.index.redirects.insert(sdist.url.to_url(), precise);
+                                self.index
+                                    .redirects
+                                    .insert(CanonicalUrl::new(&sdist.url), precise);
                             }
                             SourceDist::Path(sdist) => {
-                                self.index.redirects.insert(sdist.url.to_url(), precise);
+                                self.index
+                                    .redirects
+                                    .insert(CanonicalUrl::new(&sdist.url), precise);
                             }
                             SourceDist::Registry(_) => {}
                         }


### PR DESCRIPTION
## Summary

This fixes a potential bug that revealed itself in https://github.com/astral-sh/uv/pull/2761. We don't run into this now because we always use "allowed URLs", stores the "last" compatible URL in the map. But the use of the "raw" URL (rather than the "canonical" URL) means that other writers have to follow that same assumption and iterate over dependencies in-order.
