### PR TITLE
Split `get_or_build_wheel_metadata` into distinct methods

### DIFF
--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -424,10 +424,6 @@ impl SourceDist {
     #[must_use]
     pub fn with_url(self, url: Url) -> Self {
         match self {
-            Self::DirectUrl(dist) => Self::DirectUrl(DirectUrlSourceDist {
-                url: VerbatimUrl::unknown(url),
-                ..dist
-            }),
             Self::Git(dist) => Self::Git(GitSourceDist {
                 url: VerbatimUrl::unknown(url),
                 ..dist
@@ -992,6 +988,70 @@ impl Identifier for Dist {
         match self {
             Self::Built(dist) => dist.resource_id(),
             Self::Source(dist) => dist.resource_id(),
+        }
+    }
+}
+
+impl Identifier for DirectSourceUrl<'_> {
+    fn distribution_id(&self) -> DistributionId {
+        self.url.distribution_id()
+    }
+
+    fn resource_id(&self) -> ResourceId {
+        self.url.resource_id()
+    }
+}
+
+impl Identifier for GitSourceUrl<'_> {
+    fn distribution_id(&self) -> DistributionId {
+        self.url.distribution_id()
+    }
+
+    fn resource_id(&self) -> ResourceId {
+        self.url.resource_id()
+    }
+}
+
+impl Identifier for PathSourceUrl<'_> {
+    fn distribution_id(&self) -> DistributionId {
+        self.url.distribution_id()
+    }
+
+    fn resource_id(&self) -> ResourceId {
+        self.url.resource_id()
+    }
+}
+
+impl Identifier for SourceUrl<'_> {
+    fn distribution_id(&self) -> DistributionId {
+        match self {
+            Self::Direct(url) => url.distribution_id(),
+            Self::Git(url) => url.distribution_id(),
+            Self::Path(url) => url.distribution_id(),
+        }
+    }
+
+    fn resource_id(&self) -> ResourceId {
+        match self {
+            Self::Direct(url) => url.resource_id(),
+            Self::Git(url) => url.resource_id(),
+            Self::Path(url) => url.resource_id(),
+        }
+    }
+}
+
+impl Identifier for BuildableSource<'_> {
+    fn distribution_id(&self) -> DistributionId {
+        match self {
+            BuildableSource::Dist(source) => source.distribution_id(),
+            BuildableSource::Url(source) => source.distribution_id(),
+        }
+    }
+
+    fn resource_id(&self) -> ResourceId {
+        match self {
+            BuildableSource::Dist(source) => source.resource_id(),
+            BuildableSource::Url(source) => source.resource_id(),
         }
     }
 }

--- a/crates/uv-distribution/src/git.rs
+++ b/crates/uv-distribution/src/git.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashMap;
 use tracing::debug;
 use url::Url;
 
-use distribution_types::{DirectGitUrl, SourceDist};
+use distribution_types::DirectGitUrl;
 use uv_cache::{Cache, CacheBucket};
 use uv_fs::LockedFile;
 use uv_git::{Fetch, GitSource, GitUrl};
@@ -87,17 +87,13 @@ pub(crate) async fn fetch_git_archive(
 /// layer. For example: removing `#subdirectory=pkg_dir`-like fragments, and removing `git+`
 /// prefix kinds.
 pub(crate) async fn resolve_precise(
-    dist: &SourceDist,
+    url: &Url,
     cache: &Cache,
     reporter: Option<&Arc<dyn Reporter>>,
 ) -> Result<Option<Url>, Error> {
-    let SourceDist::Git(source_dist) = dist else {
-        return Ok(None);
-    };
     let git_dir = cache.bucket(CacheBucket::Git);
 
-    let DirectGitUrl { url, subdirectory } =
-        DirectGitUrl::try_from(source_dist.url.raw()).map_err(Error::Git)?;
+    let DirectGitUrl { url, subdirectory } = DirectGitUrl::try_from(url).map_err(Error::Git)?;
 
     // If the Git reference already contains a complete SHA, short-circuit.
     if url.precise().is_some() {


### PR DESCRIPTION
## Summary

Internal refactor which makes `DistributionDatabase` for unnamed requirements (or, at least, source distributions).
