### PR TITLE
Resolve non-determistic behavior in preferences due to site-packages ordering

### DIFF
--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -50,7 +50,7 @@ impl<'a> SitePackages<'a> {
                     let mut entries = site_packages.collect::<Result<Vec<_>, std::io::Error>>()?;
                     // TODO(zanieb): Consider filtering to just directories to reduce the size of the sort
                     // Sort for determinism, `read_dir` is different per-platform
-                    entries.sort_by_key(|entry| entry.path());
+                    entries.sort_by_key(fs_err::DirEntry::path);
                     entries
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -46,7 +46,13 @@ impl<'a> SitePackages<'a> {
         for site_packages in venv.site_packages() {
             // Read the site-packages directory.
             let site_packages = match fs::read_dir(site_packages) {
-                Ok(site_packages) => site_packages,
+                Ok(site_packages) => {
+                    let mut entries = site_packages.collect::<Result<Vec<_>, std::io::Error>>()?;
+                    // TODO(zanieb): Consider filtering to just directories to reduce the size of the sort
+                    // Sort for determinism, `read_dir` is different per-platform
+                    entries.sort_by_key(|entry| entry.path());
+                    entries
+                }
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                     return Ok(Self {
                         venv,
@@ -60,7 +66,6 @@ impl<'a> SitePackages<'a> {
 
             // Index all installed packages by name.
             for entry in site_packages {
-                let entry = entry?;
                 if entry.file_type()?.is_dir() {
                     let path = entry.path();
 

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -101,7 +101,7 @@ impl CandidateSelector {
                         // We do not consider installed distributions with multiple versions because
                         // during installation these must be reinstalled from the remote
                         _ => {
-                            debug!("Ignoring installed versions of {package_name}: multiple distributions found")
+                            debug!("Ignoring installed versions of {package_name}: multiple distributions found");
                         }
                     }
                 }
@@ -133,7 +133,7 @@ impl CandidateSelector {
                 // We do not consider installed distributions with multiple versions because
                 // during installation these must be reinstalled from the remote
                 _ => {
-                    debug!("Ignoring installed versions of {package_name}: multiple distributions found")
+                    debug!("Ignoring installed versions of {package_name}: multiple distributions found");
                 }
             }
         }

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -100,7 +100,9 @@ impl CandidateSelector {
                         }
                         // We do not consider installed distributions with multiple versions because
                         // during installation these must be reinstalled from the remote
-                        _ => {}
+                        _ => {
+                            debug!("Ignoring installed versions of {package_name}: multiple distributions found")
+                        }
                     }
                 }
 
@@ -130,7 +132,9 @@ impl CandidateSelector {
                 }
                 // We do not consider installed distributions with multiple versions because
                 // during installation these must be reinstalled from the remote
-                _ => {}
+                _ => {
+                    debug!("Ignoring installed versions of {package_name}: multiple distributions found")
+                }
             }
         }
 

--- a/crates/uv-resolver/src/preferences.rs
+++ b/crates/uv-resolver/src/preferences.rs
@@ -79,6 +79,9 @@ impl Preferences {
         markers: &MarkerEnvironment,
     ) -> Self {
         Self(
+            // TODO(zanieb): We should explicitly ensure that when a package name is seen multiple times
+            // that the newest or oldest version is preferred dependning on the resolution strategy;
+            // right now, the order is dependent on the given iterator.
             preferences
                 .into_iter()
                 .filter_map(|preference| {

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -3554,8 +3554,43 @@ fn already_installed_multiple_versions() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    INFO Found a virtualenv through VIRTUAL_ENV at: [VENV]/
+    DEBUG Cached interpreter info for Python 3.12.1, skipping probing: [VENV]/bin/python
+    DEBUG Using Python 3.12.1 environment at [36m[VENV]/bin/python[39m
+    DEBUG Using registry request timeout of [TIME]
+    DEBUG Solving with target Python version 3.12.1
+    DEBUG Adding direct dependency: anyio==4.0.0
+    DEBUG Found fresh response for: https://pypi.org/simple/anyio/
+    DEBUG Ignoring installed versions of anyio: multiple distributions found
+    DEBUG Searching for a compatible version of anyio (==4.0.0)
+    DEBUG Ignoring installed versions of anyio: multiple distributions found
+    DEBUG Selecting: anyio==4.0.0 (anyio-4.0.0-py3-none-any.whl)
+    DEBUG No cache entry for: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl.metadata
+    DEBUG No credentials found for: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl.metadata
+    DEBUG Adding transitive dependency: idna>=2.8
+    DEBUG Adding transitive dependency: sniffio>=1.1
+    DEBUG Found fresh response for: https://pypi.org/simple/idna/
+    DEBUG Found fresh response for: https://pypi.org/simple/sniffio/
+    DEBUG Found installed version of idna==3.6 that satisfies preference in >=2.8
+    DEBUG Found installed version of sniffio==1.3.1 that satisfies preference in >=1.1
+    DEBUG Searching for a compatible version of idna (>=2.8)
+    DEBUG Found installed version of idna==3.6 that satisfies preference in >=2.8
+    DEBUG Selecting: idna==3.6 (installed)
+    DEBUG Searching for a compatible version of sniffio (>=1.1)
+    DEBUG Found installed version of sniffio==1.3.1 that satisfies preference in >=1.1
+    DEBUG Selecting: sniffio==1.3.1 (installed)
     Resolved 3 packages in [TIME]
+    DEBUG Identified uncached requirement: anyio==4.0.0
+    DEBUG Requirement already satisfied: idna==3.6
+    DEBUG Requirement already installed: idna==3.6
+    DEBUG Requirement already satisfied: sniffio==1.3.1
+    DEBUG Requirement already installed: sniffio==1.3.1
+    DEBUG No cache entry for: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
+    DEBUG No credentials found for already-seen URL: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
+    DEBUG No credentials found for: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
     Downloaded 1 package in [TIME]
+    DEBUG Uninstalled anyio (45 files, 4 directories)
+    DEBUG Uninstalled anyio (9 files, 3 directories)
     Installed 1 package in [TIME]
      - anyio==3.7.0
      - anyio==4.0.0
@@ -3574,7 +3609,38 @@ fn already_installed_multiple_versions() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    INFO Found a virtualenv through VIRTUAL_ENV at: [VENV]/
+    DEBUG Cached interpreter info for Python 3.12.1, skipping probing: [VENV]/bin/python
+    DEBUG Using Python 3.12.1 environment at [36m[VENV]/bin/python[39m
+    DEBUG Using registry request timeout of [TIME]
+    DEBUG Solving with target Python version 3.12.1
+    DEBUG Adding direct dependency: anyio*
+    DEBUG Found fresh response for: https://pypi.org/simple/anyio/
+    DEBUG Ignoring installed versions of anyio: multiple distributions found
+    DEBUG Searching for a compatible version of anyio (*)
+    DEBUG Ignoring installed versions of anyio: multiple distributions found
+    DEBUG Selecting: anyio==3.7.0 (anyio-3.7.0-py3-none-any.whl)
+    DEBUG Found fresh response for: https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl.metadata
+    DEBUG Adding transitive dependency: idna>=2.8
+    DEBUG Adding transitive dependency: sniffio>=1.1
+    DEBUG Found fresh response for: https://pypi.org/simple/idna/
+    DEBUG Found fresh response for: https://pypi.org/simple/sniffio/
+    DEBUG Found installed version of idna==3.6 that satisfies preference in >=2.8
+    DEBUG Found installed version of sniffio==1.3.1 that satisfies preference in >=1.1
+    DEBUG Searching for a compatible version of idna (>=2.8)
+    DEBUG Found installed version of idna==3.6 that satisfies preference in >=2.8
+    DEBUG Selecting: idna==3.6 (installed)
+    DEBUG Searching for a compatible version of sniffio (>=1.1)
+    DEBUG Found installed version of sniffio==1.3.1 that satisfies preference in >=1.1
+    DEBUG Selecting: sniffio==1.3.1 (installed)
     Resolved 3 packages in [TIME]
+    DEBUG Requirement already cached: anyio==3.7.0
+    DEBUG Requirement already satisfied: idna==3.6
+    DEBUG Requirement already installed: idna==3.6
+    DEBUG Requirement already satisfied: sniffio==1.3.1
+    DEBUG Requirement already installed: sniffio==1.3.1
+    DEBUG Uninstalled anyio (45 files, 4 directories)
+    DEBUG Uninstalled anyio (9 files, 3 directories)
     Installed 1 package in [TIME]
      - anyio==3.7.0
      - anyio==4.0.0

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -3589,8 +3589,8 @@ fn already_installed_multiple_versions() -> Result<()> {
     DEBUG No credentials found for already-seen URL: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
     DEBUG No credentials found for: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
     Downloaded 1 package in [TIME]
-    DEBUG Uninstalled anyio (45 files, 4 directories)
-    DEBUG Uninstalled anyio (9 files, 3 directories)
+    DEBUG Uninstalled anyio (46 files, 6 directories)
+    DEBUG Uninstalled anyio (8 files, 1 directory)
     Installed 1 package in [TIME]
      - anyio==3.7.0
      - anyio==4.0.0
@@ -3619,8 +3619,8 @@ fn already_installed_multiple_versions() -> Result<()> {
     DEBUG Ignoring installed versions of anyio: multiple distributions found
     DEBUG Searching for a compatible version of anyio (*)
     DEBUG Ignoring installed versions of anyio: multiple distributions found
-    DEBUG Selecting: anyio==3.7.0 (anyio-3.7.0-py3-none-any.whl)
-    DEBUG Found fresh response for: https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl.metadata
+    DEBUG Selecting: anyio==4.0.0 (anyio-4.0.0-py3-none-any.whl)
+    DEBUG Found fresh response for: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl.metadata
     DEBUG Adding transitive dependency: idna>=2.8
     DEBUG Adding transitive dependency: sniffio>=1.1
     DEBUG Found fresh response for: https://pypi.org/simple/idna/
@@ -3634,17 +3634,17 @@ fn already_installed_multiple_versions() -> Result<()> {
     DEBUG Found installed version of sniffio==1.3.1 that satisfies preference in >=1.1
     DEBUG Selecting: sniffio==1.3.1 (installed)
     Resolved 3 packages in [TIME]
-    DEBUG Requirement already cached: anyio==3.7.0
+    DEBUG Requirement already cached: anyio==4.0.0
     DEBUG Requirement already satisfied: idna==3.6
     DEBUG Requirement already installed: idna==3.6
     DEBUG Requirement already satisfied: sniffio==1.3.1
     DEBUG Requirement already installed: sniffio==1.3.1
-    DEBUG Uninstalled anyio (45 files, 4 directories)
-    DEBUG Uninstalled anyio (9 files, 3 directories)
+    DEBUG Uninstalled anyio (46 files, 6 directories)
+    DEBUG Uninstalled anyio (8 files, 1 directory)
     Installed 1 package in [TIME]
      - anyio==3.7.0
      - anyio==4.0.0
-     + anyio==3.7.0
+     + anyio==4.0.0
     "###
     );
 

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -3548,49 +3548,14 @@ fn already_installed_multiple_versions() -> Result<()> {
 
     // Request the second anyio version again
     // Should remove both previous versions and reinstall the second one
-    uv_snapshot!(context.filters(), context.install().arg("anyio==4.0.0").arg("-v"), @r###"
+    uv_snapshot!(context.filters(), context.install().arg("anyio==4.0.0"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    INFO Found a virtualenv through VIRTUAL_ENV at: [VENV]/
-    DEBUG Cached interpreter info for Python 3.12.1, skipping probing: [VENV]/bin/python
-    DEBUG Using Python 3.12.1 environment at [36m[VENV]/bin/python[39m
-    DEBUG Using registry request timeout of [TIME]
-    DEBUG Solving with target Python version 3.12.1
-    DEBUG Adding direct dependency: anyio==4.0.0
-    DEBUG Found fresh response for: https://pypi.org/simple/anyio/
-    DEBUG Ignoring installed versions of anyio: multiple distributions found
-    DEBUG Searching for a compatible version of anyio (==4.0.0)
-    DEBUG Ignoring installed versions of anyio: multiple distributions found
-    DEBUG Selecting: anyio==4.0.0 (anyio-4.0.0-py3-none-any.whl)
-    DEBUG No cache entry for: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl.metadata
-    DEBUG No credentials found for: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl.metadata
-    DEBUG Adding transitive dependency: idna>=2.8
-    DEBUG Adding transitive dependency: sniffio>=1.1
-    DEBUG Found fresh response for: https://pypi.org/simple/idna/
-    DEBUG Found fresh response for: https://pypi.org/simple/sniffio/
-    DEBUG Found installed version of idna==3.6 that satisfies preference in >=2.8
-    DEBUG Found installed version of sniffio==1.3.1 that satisfies preference in >=1.1
-    DEBUG Searching for a compatible version of idna (>=2.8)
-    DEBUG Found installed version of idna==3.6 that satisfies preference in >=2.8
-    DEBUG Selecting: idna==3.6 (installed)
-    DEBUG Searching for a compatible version of sniffio (>=1.1)
-    DEBUG Found installed version of sniffio==1.3.1 that satisfies preference in >=1.1
-    DEBUG Selecting: sniffio==1.3.1 (installed)
     Resolved 3 packages in [TIME]
-    DEBUG Identified uncached requirement: anyio==4.0.0
-    DEBUG Requirement already satisfied: idna==3.6
-    DEBUG Requirement already installed: idna==3.6
-    DEBUG Requirement already satisfied: sniffio==1.3.1
-    DEBUG Requirement already installed: sniffio==1.3.1
-    DEBUG No cache entry for: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
-    DEBUG No credentials found for already-seen URL: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
-    DEBUG No credentials found for: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
     Downloaded 1 package in [TIME]
-    DEBUG Uninstalled anyio (46 files, 6 directories)
-    DEBUG Uninstalled anyio (8 files, 1 directory)
     Installed 1 package in [TIME]
      - anyio==3.7.0
      - anyio==4.0.0
@@ -3602,45 +3567,15 @@ fn already_installed_multiple_versions() -> Result<()> {
     prepare(&context)?;
 
     // Request the anyio without a version specifier
-    // Should remove both previous versions and reinstall
-    uv_snapshot!(context.filters(), context.install().arg("anyio").arg("-v"), @r###"
+    // This is loosely a regression test for the ordering of the installation preferences
+    // from existing site-packages
+    uv_snapshot!(context.filters(), context.install().arg("anyio"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    INFO Found a virtualenv through VIRTUAL_ENV at: [VENV]/
-    DEBUG Cached interpreter info for Python 3.12.1, skipping probing: [VENV]/bin/python
-    DEBUG Using Python 3.12.1 environment at [36m[VENV]/bin/python[39m
-    DEBUG Using registry request timeout of [TIME]
-    DEBUG Solving with target Python version 3.12.1
-    DEBUG Adding direct dependency: anyio*
-    DEBUG Found fresh response for: https://pypi.org/simple/anyio/
-    DEBUG Ignoring installed versions of anyio: multiple distributions found
-    DEBUG Searching for a compatible version of anyio (*)
-    DEBUG Ignoring installed versions of anyio: multiple distributions found
-    DEBUG Selecting: anyio==4.0.0 (anyio-4.0.0-py3-none-any.whl)
-    DEBUG Found fresh response for: https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl.metadata
-    DEBUG Adding transitive dependency: idna>=2.8
-    DEBUG Adding transitive dependency: sniffio>=1.1
-    DEBUG Found fresh response for: https://pypi.org/simple/idna/
-    DEBUG Found fresh response for: https://pypi.org/simple/sniffio/
-    DEBUG Found installed version of idna==3.6 that satisfies preference in >=2.8
-    DEBUG Found installed version of sniffio==1.3.1 that satisfies preference in >=1.1
-    DEBUG Searching for a compatible version of idna (>=2.8)
-    DEBUG Found installed version of idna==3.6 that satisfies preference in >=2.8
-    DEBUG Selecting: idna==3.6 (installed)
-    DEBUG Searching for a compatible version of sniffio (>=1.1)
-    DEBUG Found installed version of sniffio==1.3.1 that satisfies preference in >=1.1
-    DEBUG Selecting: sniffio==1.3.1 (installed)
     Resolved 3 packages in [TIME]
-    DEBUG Requirement already cached: anyio==4.0.0
-    DEBUG Requirement already satisfied: idna==3.6
-    DEBUG Requirement already installed: idna==3.6
-    DEBUG Requirement already satisfied: sniffio==1.3.1
-    DEBUG Requirement already installed: sniffio==1.3.1
-    DEBUG Uninstalled anyio (46 files, 6 directories)
-    DEBUG Uninstalled anyio (8 files, 1 directory)
     Installed 1 package in [TIME]
      - anyio==3.7.0
      - anyio==4.0.0

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -3548,7 +3548,7 @@ fn already_installed_multiple_versions() -> Result<()> {
 
     // Request the second anyio version again
     // Should remove both previous versions and reinstall the second one
-    uv_snapshot!(context.filters(), context.install().arg("anyio==4.0.0"), @r###"
+    uv_snapshot!(context.filters(), context.install().arg("anyio==4.0.0").arg("-v"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3568,7 +3568,7 @@ fn already_installed_multiple_versions() -> Result<()> {
 
     // Request the anyio without a version specifier
     // Should remove both previous versions and reinstall
-    uv_snapshot!(context.filters(), context.install().arg("anyio"), @r###"
+    uv_snapshot!(context.filters(), context.install().arg("anyio").arg("-v"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -3517,11 +3517,9 @@ fn already_installed_local_version_of_remote_package() {
 #[test]
 #[cfg(unix)]
 fn already_installed_multiple_versions() -> Result<()> {
-    use crate::common::copy_dir_all;
-
-    let context = TestContext::new("3.12");
-
     fn prepare(context: &TestContext) -> Result<()> {
+        use crate::common::copy_dir_all;
+
         // Install into the base environment
         context.install().arg("anyio==3.7.0").assert().success();
 
@@ -3543,6 +3541,8 @@ fn already_installed_multiple_versions() -> Result<()> {
 
         Ok(())
     }
+
+    let context = TestContext::new("3.12");
 
     prepare(&context)?;
 


### PR DESCRIPTION
Originally a regression test for #2779 but we found out that there's some weird behavior where different `anyio` versions were preferred based on the platform.