### PR TITLE
Detect Fish via `FISH_VERSION`

### DIFF
--- a/crates/uv/src/shell.rs
+++ b/crates/uv/src/shell.rs
@@ -33,6 +33,12 @@ impl Shell {
     pub(crate) fn from_env() -> Option<Shell> {
         if std::env::var_os("NU_VERSION").is_some() {
             Some(Shell::Nushell)
+        } else if std::env::var_os("FISH_VERSION").is_some() {
+            Some(Shell::Fish)
+        } else if std::env::var_os("BASH_VERSION").is_some() {
+            Some(Shell::Bash)
+        } else if std::env::var_os("ZSH_VERSION").is_some() {
+            Some(Shell::Zsh)
         } else if let Some(env_shell) = std::env::var_os("SHELL") {
             Shell::from_shell_path(env_shell)
         } else if cfg!(windows) {


### PR DESCRIPTION
## Summary

Apparently `SHELL` isn't always set to Fish: https://github.com/fish-shell/fish-shell/issues/374.

## Test Plan

`uv venv` after running `fish` in macOS.
