### PR TITLE
Preserve `.git` suffixes and casing in Git dependencies

### DIFF
--- a/crates/cache-key/src/canonical_url.rs
+++ b/crates/cache-key/src/canonical_url.rs
@@ -165,6 +165,12 @@ impl Deref for RepositoryUrl {
     }
 }
 
+impl std::fmt::Display for RepositoryUrl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/distribution-types/src/direct_url.rs
+++ b/crates/distribution-types/src/direct_url.rs
@@ -164,7 +164,7 @@ impl TryFrom<&DirectGitUrl> for pypi_types::DirectUrl {
             vcs_info: pypi_types::VcsInfo {
                 vcs: pypi_types::VcsKind::Git,
                 commit_id: value.url.precise().as_ref().map(ToString::to_string),
-                requested_revision: value.url.reference().map(ToString::to_string),
+                requested_revision: value.url.reference().as_str().map(ToString::to_string),
             },
             subdirectory: value.subdirectory.clone(),
         })

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -24,7 +24,7 @@ const CHECKOUT_READY_LOCK: &str = ".ok";
 
 /// A reference to commit or commit-ish.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) enum GitReference {
+pub enum GitReference {
     /// From a branch.
     #[allow(unused)]
     Branch(String),
@@ -66,8 +66,29 @@ impl GitReference {
         }
     }
 
-    /// Views the short ID as a `str`.
-    pub(crate) fn as_str(&self) -> &str {
+    pub fn precise(&self) -> Option<&str> {
+        match self {
+            Self::FullCommit(rev) => Some(rev),
+            Self::ShortCommit(rev) => Some(rev),
+            _ => None,
+        }
+    }
+
+    /// Converts the [`GitReference`] to a `str`.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::Branch(rev) => Some(rev),
+            Self::Tag(rev) => Some(rev),
+            Self::BranchOrTag(rev) => Some(rev),
+            Self::FullCommit(rev) => Some(rev),
+            Self::ShortCommit(rev) => Some(rev),
+            Self::Ref(rev) => Some(rev),
+            Self::DefaultBranch => None,
+        }
+    }
+
+    /// Converts the [`GitReference`] to a `str` that can be used as a revision.
+    pub(crate) fn as_rev(&self) -> &str {
         match self {
             Self::Branch(rev)
             | Self::Tag(rev)
@@ -79,6 +100,7 @@ impl GitReference {
         }
     }
 
+    /// Returns the kind of this reference.
     pub(crate) fn kind_str(&self) -> &str {
         match self {
             Self::Branch(_) => "branch",
@@ -1034,7 +1056,7 @@ pub(crate) fn fetch(
                     format!(
                         "failed to fetch {} `{}`",
                         reference.kind_str(),
-                        reference.as_str()
+                        reference.as_rev()
                     )
                 }),
             }

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 use url::Url;
 
-use crate::git::GitReference;
+pub use crate::git::GitReference;
 pub use crate::sha::GitSha;
 pub use crate::source::{Fetch, GitSource, Reporter};
 
@@ -24,7 +24,7 @@ pub struct GitUrl {
 
 impl GitUrl {
     #[must_use]
-    pub(crate) fn with_precise(mut self, precise: GitSha) -> Self {
+    pub fn with_precise(mut self, precise: GitSha) -> Self {
         self.precise = Some(precise);
         self
     }
@@ -35,16 +35,8 @@ impl GitUrl {
     }
 
     /// Return the reference to the commit to use, which could be a branch, tag or revision.
-    pub fn reference(&self) -> Option<&str> {
-        match &self.reference {
-            GitReference::Branch(rev)
-            | GitReference::Tag(rev)
-            | GitReference::BranchOrTag(rev)
-            | GitReference::Ref(rev)
-            | GitReference::FullCommit(rev)
-            | GitReference::ShortCommit(rev) => Some(rev),
-            GitReference::DefaultBranch => None,
-        }
+    pub fn reference(&self) -> &GitReference {
+        &self.reference
     }
 
     /// Returns `true` if the reference is a full commit.

--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -70,7 +70,7 @@ impl GitSource {
 
                 // Report the checkout operation to the reporter.
                 let task = self.reporter.as_ref().map(|reporter| {
-                    reporter.on_checkout_start(remote.url(), self.git.reference.as_str())
+                    reporter.on_checkout_start(remote.url(), self.git.reference.as_rev())
                 });
 
                 let (db, actual_rev) = remote.checkout(

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -569,7 +569,7 @@ fn install_git_tag() -> Result<()> {
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.touch()?;
-    requirements_txt.write_str("werkzeug @ git+https://github.com/pallets/werkzeug.git@2.0.0")?;
+    requirements_txt.write_str("werkzeug @ git+https://github.com/pallets/WerkZeug.git@2.0.0")?;
 
     uv_snapshot!(command(&context)
         .arg("requirements.txt")
@@ -582,7 +582,7 @@ fn install_git_tag() -> Result<()> {
     Resolved 1 package in [TIME]
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
-     + werkzeug==2.0.0 (from git+https://github.com/pallets/werkzeug@af160e0b6b7ddd81c22f1652c728ff5ac72d5c74)
+     + werkzeug==2.0.0 (from git+https://github.com/pallets/WerkZeug.git@af160e0b6b7ddd81c22f1652c728ff5ac72d5c74)
     "###
     );
 


### PR DESCRIPTION
## Summary

I noticed in #2769 that I was now stripping `.git` suffixes from Git URLs after resolving to a precise commit. This PR cleans up the internal caching to use a better canonical representation: a `RepositoryUrl` along with a `GitReference`, instead of a `GitUrl` which can contain non-canonical data. This gives us both better fidelity (preserving the `.git`, along with any casing that the user provided when defining the URL) and is overall cleaner and more robust.
