### PR TITLE
Remove redirects from the resolver

### DIFF
--- a/crates/uv-distribution/src/lib.rs
+++ b/crates/uv-distribution/src/lib.rs
@@ -1,7 +1,7 @@
 pub use distribution_database::DistributionDatabase;
 pub use download::{BuiltWheel, DiskWheel, LocalWheel};
 pub use error::Error;
-pub use git::is_same_reference;
+pub use git::{is_same_reference, to_precise};
 pub use index::{BuiltWheelIndex, RegistryWheelIndex};
 pub use reporter::Reporter;
 pub use source::SourceDistributionBuilder;

--- a/crates/uv-requirements/src/lookahead.rs
+++ b/crates/uv-requirements/src/lookahead.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use anyhow::{Context, Result};
-use cache_key::CanonicalUrl;
+
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use rustc_hash::FxHashSet;
@@ -139,7 +139,7 @@ impl<'a, Context: BuildContext + Send + Sync> LookaheadResolver<'a, Context> {
                 metadata.requires_dist.clone()
             } else {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
-                let (metadata, precise) = self
+                let metadata = self
                     .database
                     .get_or_build_wheel_metadata(&dist)
                     .await
@@ -152,11 +152,6 @@ impl<'a, Context: BuildContext + Send + Sync> LookaheadResolver<'a, Context> {
 
                 // Insert the metadata into the index.
                 self.index.insert_metadata(id, metadata);
-
-                // Insert the redirect into the index.
-                if let Some(precise) = precise {
-                    self.index.insert_redirect(CanonicalUrl::new(url), precise);
-                }
 
                 requires_dist
             }

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -6,7 +6,6 @@ use anyhow::{Context, Result};
 use futures::{StreamExt, TryStreamExt};
 use url::Url;
 
-use cache_key::CanonicalUrl;
 use distribution_types::{BuildableSource, PackageId, PathSourceUrl, SourceUrl};
 use pep508_rs::Requirement;
 use uv_client::RegistryClient;
@@ -94,15 +93,10 @@ impl<'a, Context: BuildContext + Send + Sync> SourceTreeResolver<'a, Context> {
             } else {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let source = BuildableSource::Url(source);
-                let (metadata, precise) = self.database.build_wheel_metadata(&source).await?;
+                let metadata = self.database.build_wheel_metadata(&source).await?;
 
                 // Insert the metadata into the index.
                 self.index.insert_metadata(id, metadata.clone());
-
-                // Insert the redirect into the index.
-                if let Some(precise) = precise {
-                    self.index.insert_redirect(CanonicalUrl::new(&url), precise);
-                }
 
                 metadata
             }

--- a/crates/uv-requirements/src/unnamed.rs
+++ b/crates/uv-requirements/src/unnamed.rs
@@ -8,7 +8,6 @@ use futures::{StreamExt, TryStreamExt};
 use serde::Deserialize;
 use tracing::debug;
 
-use cache_key::CanonicalUrl;
 use distribution_filename::{SourceDistFilename, WheelFilename};
 use distribution_types::{
     BuildableSource, DirectSourceUrl, GitSourceUrl, PackageId, PathSourceUrl, RemoteSource,
@@ -243,17 +242,12 @@ impl<'a, Context: BuildContext + Send + Sync> NamedRequirementsResolver<'a, Cont
             } else {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let source = BuildableSource::Url(source);
-                let (metadata, precise) = database.build_wheel_metadata(&source).await?;
+                let metadata = database.build_wheel_metadata(&source).await?;
 
                 let name = metadata.name.clone();
 
                 // Insert the metadata into the index.
                 index.insert_metadata(id, metadata);
-
-                // Insert the redirect into the index.
-                if let Some(precise) = precise {
-                    index.insert_redirect(CanonicalUrl::new(&requirement.url), precise);
-                }
 
                 name
             }

--- a/crates/uv-resolver/src/redirect.rs
+++ b/crates/uv-resolver/src/redirect.rs
@@ -4,8 +4,8 @@ use pep508_rs::VerbatimUrl;
 
 /// Given a [`VerbatimUrl`] and a redirect, apply the redirect to the URL while preserving as much
 /// of the verbatim representation as possible.
-pub(crate) fn apply_redirect(url: &VerbatimUrl, redirect: &Url) -> VerbatimUrl {
-    let redirect = VerbatimUrl::from_url(redirect.clone());
+pub(crate) fn apply_redirect(url: &VerbatimUrl, redirect: Url) -> VerbatimUrl {
+    let redirect = VerbatimUrl::from_url(redirect);
 
     // The redirect should be the "same" URL, but with a specific commit hash added after the `@`.
     // We take advantage of this to preserve as much of the verbatim representation as possible.
@@ -53,7 +53,7 @@ mod tests {
             "https://github.com/flask.git@b90a4f1f4a370e92054b9cc9db0efcb864f87ebe",
         )?
         .with_given("https://github.com/flask.git@b90a4f1f4a370e92054b9cc9db0efcb864f87ebe");
-        assert_eq!(apply_redirect(&verbatim, &redirect), expected);
+        assert_eq!(apply_redirect(&verbatim, redirect), expected);
 
         // If there's an `@` in the original representation, and it's stable between the parsed and
         // given representations, we preserve everything that precedes the `@` in the precise
@@ -67,7 +67,7 @@ mod tests {
             "https://github.com/flask.git@b90a4f1f4a370e92054b9cc9db0efcb864f87ebe",
         )?
         .with_given("https://${DOMAIN}.com/flask.git@b90a4f1f4a370e92054b9cc9db0efcb864f87ebe");
-        assert_eq!(apply_redirect(&verbatim, &redirect), expected);
+        assert_eq!(apply_redirect(&verbatim, redirect), expected);
 
         // If there's a conflict after the `@`, discard the original representation.
         let verbatim = VerbatimUrl::parse_url("https://github.com/flask.git@main")?
@@ -78,7 +78,7 @@ mod tests {
         let expected = VerbatimUrl::parse_url(
             "https://github.com/flask.git@b90a4f1f4a370e92054b9cc9db0efcb864f87ebe",
         )?;
-        assert_eq!(apply_redirect(&verbatim, &redirect), expected);
+        assert_eq!(apply_redirect(&verbatim, redirect), expected);
 
         Ok(())
     }

--- a/crates/uv-resolver/src/resolver/index.rs
+++ b/crates/uv-resolver/src/resolver/index.rs
@@ -1,14 +1,11 @@
-use cache_key::CanonicalUrl;
-use dashmap::DashMap;
 use std::sync::Arc;
-use url::Url;
 
 use distribution_types::PackageId;
 use once_map::OnceMap;
 use pypi_types::Metadata23;
 use uv_normalize::PackageName;
 
-use super::provider::VersionsResponse;
+use crate::resolver::provider::VersionsResponse;
 
 /// In-memory index of package metadata.
 #[derive(Default)]
@@ -19,11 +16,6 @@ pub struct InMemoryIndex {
 
     /// A map from package ID to metadata for that distribution.
     pub(crate) distributions: OnceMap<PackageId, Metadata23>,
-
-    /// A map from source URL to precise URL. For example, the source URL
-    /// `git+https://github.com/pallets/flask.git` could be redirected to
-    /// `git+https://github.com/pallets/flask.git@c2f65dd1cfff0672b902fd5b30815f0b4137214c`.
-    pub(crate) redirects: DashMap<CanonicalUrl, Url>,
 }
 
 impl InMemoryIndex {
@@ -35,11 +27,6 @@ impl InMemoryIndex {
     /// Insert a [`Metadata23`] into the index.
     pub fn insert_metadata(&self, package_id: PackageId, metadata: Metadata23) {
         self.distributions.done(package_id, metadata);
-    }
-
-    /// Insert a redirect from a source URL to a target URL.
-    pub fn insert_redirect(&self, source: CanonicalUrl, target: Url) {
-        self.redirects.insert(source, target);
     }
 
     /// Get the [`VersionsResponse`] for a given package name, without waiting.

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -2,7 +2,6 @@ use std::future::Future;
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use url::Url;
 
 use distribution_types::{Dist, IndexLocations};
 use platform_tags::Tags;
@@ -17,7 +16,7 @@ use crate::version_map::VersionMap;
 use crate::yanks::AllowedYanks;
 
 pub type PackageVersionsResult = Result<VersionsResponse, uv_client::Error>;
-pub type WheelMetadataResult = Result<(Metadata23, Option<Url>), uv_distribution::Error>;
+pub type WheelMetadataResult = Result<Metadata23, uv_distribution::Error>;
 
 /// The response when requesting versions for a package
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

Rather than storing the `redirects` on the resolver, this PR just re-uses the "convert this URL to precise" logic when we convert to a `Resolution` after-the-fact. I think this is a lot simpler: it removes state from the resolver, and simplifies a lot of the hooks around distribution fetching (e.g., `get_or_build_wheel_metadata` no longer returns `(Metadata23, Option<Url>)`).
