### PR TITLE
Remove unused `download_and_extract_archive` method

### DIFF
--- a/crates/uv-distribution/src/lib.rs
+++ b/crates/uv-distribution/src/lib.rs
@@ -4,7 +4,7 @@ pub use error::Error;
 pub use git::is_same_reference;
 pub use index::{BuiltWheelIndex, RegistryWheelIndex};
 pub use reporter::Reporter;
-pub use source::{download_and_extract_archive, SourceDistributionBuilder};
+pub use source::SourceDistributionBuilder;
 pub use unzip::Unzip;
 
 mod distribution_database;


### PR DESCRIPTION
## Summary

This was introduced at some point but then removed in favor of accessing the database directly.
