### PR TITLE
Improve renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,42 +1,37 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "suppressNotifications": ["prEditedNotification"],
-  "extends": ["config:recommended"],
-  "labels": ["internal"],
-  "schedule": ["before 4am on Monday"],
-  "separateMajorMinor": false,
-  "enabledManagers": [
-    "github-actions",
-    "pre-commit",
-    "cargo",
-  ],
-  "cargo": {
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  dependencyDashboard: true,
+  suppressNotifications: ["prEditedNotification"],
+  extends: ["config:recommended"],
+  labels: ["internal"],
+  schedule: ["on Monday"],
+  separateMajorMinor: false,
+  prHourlyLimit: 10,
+  enabledManagers: ["github-actions", "pre-commit", "cargo"],
+  cargo: {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy
-    "rangeStrategy": "update-lockfile",
-    "fileMatch": [
-      "^crates/.*Cargo\\.toml$",
-    ],
+    rangeStrategy: "update-lockfile",
+    fileMatch: ["^crates/.*Cargo\\.toml$"],
   },
   "pre-commit": {
-    "enabled": true,
+    enabled: true,
   },
-  "packageRules": [
+  packageRules: [
     {
       // Group upload/download artifact updates, the versions are dependent
-      "groupName": "Artifact GitHub Actions dependencies",
-      "matchManagers": ["github-actions"],
-      "matchPackagePatterns": ["actions/.*-artifact"],
-      "description": "Weekly update of artifact-related GitHub Actions dependencies",
+      groupName: "Artifact GitHub Actions dependencies",
+      matchManagers: ["github-actions"],
+      matchPackagePatterns: ["actions/.*-artifact"],
+      description: "Weekly update of artifact-related GitHub Actions dependencies",
     },
     {
-      "groupName": "pre-commit dependencies",
-      "matchManagers": ["pre-commit"],
-      "description": "Weekly update of pre-commit dependencies",
+      groupName: "pre-commit dependencies",
+      matchManagers: ["pre-commit"],
+      description: "Weekly update of pre-commit dependencies",
     },
   ],
-  "vulnerabilityAlerts": {
-    "commitMessageSuffix": "",
-    "labels": ["internal", "security"],
+  vulnerabilityAlerts: {
+    commitMessageSuffix: "",
+    labels: ["internal", "security"],
   },
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: cargo fmt --all --check
 
       - name: "Prettier"
-        run: npx prettier --check "**/*.{yaml,yml}"
+        run: npx prettier --check "**/*.{json5,yaml,yml}"
 
       - name: "Ruff format"
         run: pipx run ruff format --diff .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     rev: v3.1.0
     hooks:
       - id: prettier
-        types: [yaml]
+        types: [yaml, json5]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     rev: v3.1.0
     hooks:
       - id: prettier
-        types: [yaml, json5]
+        types_or: [yaml, json5]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.1


### PR DESCRIPTION
## Summary

A bunch of changes were made to Ruff's renovate config on Monday; this PR syncs uv's config to apply the same updates. Changes made:

- Give renovate more time in which to create PRs on Mondays (same as https://github.com/astral-sh/ruff/commit/2ea0c3dce6412990d522e262828a247c746d9e07)
- Allow renovate to create more than 2 PRs an hour (same as https://github.com/astral-sh/ruff/commit/8d547ef83a85a5cabe749a4cf09a41f931dc8116)
- Run prettier on the config file (done at Ruff in https://github.com/astral-sh/ruff/commit/877a9145ae7cd92a52a54f10b58d95366369b084)

## Test Plan

I validated the config using renovate's CLI tool:

```
(renovate-sync) % npx --yes --package renovate -- renovate-config-validator                                                               ~/dev/uv
(node:78418) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 INFO: Validating .github/renovate.json5
 INFO: Config validated successfully
```
