### PR TITLE
fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -621,7 +621,7 @@ pass the `--native-tls` command-line flag to enable this behavior.
 - Avoid attempting rename in copy fallback path ([#1546](https://github.com/astral-sh/uv/pull/1546))
 - Fix list rendering in `venv --help` output ([#1459](https://github.com/astral-sh/uv/pull/1459))
 - Fix trailing commas on `Requires-Python` in HTML indexes  ([#1507](https://github.com/astral-sh/uv/pull/1507))
-- Read from `/bin/sh` if `/bin/ls` cannot be found when determing libc path ([#1433](https://github.com/astral-sh/uv/pull/1433))
+- Read from `/bin/sh` if `/bin/ls` cannot be found when determining libc path ([#1433](https://github.com/astral-sh/uv/pull/1433))
 - Remove URL encoding when determining file name ([#1555](https://github.com/astral-sh/uv/pull/1555))
 - Support recursive extras ([#1435](https://github.com/astral-sh/uv/pull/1435))
 - Use comparable representation for `PackageId` ([#1543](https://github.com/astral-sh/uv/pull/1543))
@@ -677,4 +677,4 @@ pass the `--native-tls` command-line flag to enable this behavior.
 ### Documentation
 
 - Fix diagram alignment ([#1354](https://github.com/astral-sh/uv/pull/1354))
-- Grammer nit ([#1345](https://github.com/astral-sh/uv/pull/1345))
+- Grammar nit ([#1345](https://github.com/astral-sh/uv/pull/1345))

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -301,7 +301,7 @@ pub(crate) async fn pip_sync(
             &flat_index,
             &index,
             &build_dispatch,
-            // TODO(zanieb): We should consier support for installed packages in pip sync
+            // TODO(zanieb): We should consider support for installed packages in pip sync
             &EmptyInstalledPackages,
         )?
         .with_reporter(reporter);

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -304,19 +304,19 @@ pub fn bootstrapped_pythons() -> Option<Vec<PathBuf>> {
         .parent()
         .unwrap()
         .to_path_buf();
-    let boostrap_dir = if let Some(boostrap_dir) = env::var_os("UV_BOOTSTRAP_DIR") {
-        let boostrap_dir = PathBuf::from(boostrap_dir);
-        if boostrap_dir.is_absolute() {
-            boostrap_dir
+    let bootstrap_dir = if let Some(bootstrap_dir) = env::var_os("UV_BOOTSTRAP_DIR") {
+        let bootstrap_dir = PathBuf::from(bootstrap_dir);
+        if bootstrap_dir.is_absolute() {
+            bootstrap_dir
         } else {
             // cargo test changes directory to the test crate, but doesn't tell us from where the user is running the
             // tests. We'll assume that it's the project root.
-            project_root.join(boostrap_dir)
+            project_root.join(bootstrap_dir)
         }
     } else {
         project_root.join("bin")
     };
-    let bootstrapped_pythons = boostrap_dir.join("versions");
+    let bootstrapped_pythons = bootstrap_dir.join("versions");
     let Ok(bootstrapped_pythons) = fs_err::read_dir(bootstrapped_pythons) else {
         return None;
     };

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -501,7 +501,7 @@ fn dependency_excludes_range_of_compatible_versions() {
 /// There is a non-contiguous range of compatible versions for the requested package
 /// `a`, but another dependency `c` excludes the range. This is the same as
 /// `dependency-excludes-range-of-compatible-versions` but some of the versions of
-/// `a` are incompatible for another reason e.g. dependency on non-existant package
+/// `a` are incompatible for another reason e.g. dependency on non-existent package
 /// `d`.
 ///
 /// ```text
@@ -3483,7 +3483,7 @@ fn package_only_prereleases_boundary() {
     "###);
 
     // Since there are only prerelease versions of `a` available, a prerelease is
-    // allowed. Since the user did not explictly request a pre-release, pre-releases at
+    // allowed. Since the user did not explicitly request a pre-release, pre-releases at
     // the boundary should not be selected.
     assert_installed(
         &context.venv,

--- a/scripts/check_cache_compat.py
+++ b/scripts/check_cache_compat.py
@@ -59,9 +59,9 @@ def check_cache_with_package(
     uv_previous: str,
     package: str,
 ):
-    # The coverage here is rough and not particularly targetted — we're just performing various
+    # The coverage here is rough and not particularly targeted — we're just performing various
     # operations in the hope of catching cache load issues. As cache problems are discovered in
-    # the future, we should expand coverage with targetted cases.
+    # the future, we should expand coverage with targeted cases.
 
     # First, install with the previous uv to populate the cache
     install_package(uv=uv_previous, package=package, flags=[])


### PR DESCRIPTION
## Summary

I ran `pre-commit run -a` on the repo as part of testing #2802, and it autofixed a lot of typos.
