### PR TITLE
Support freethreading python

### DIFF
--- a/crates/platform-tags/src/tags.rs
+++ b/crates/platform-tags/src/tags.rs
@@ -17,7 +17,7 @@ pub enum TagsError {
     UnknownImplementation(String),
     #[error("Invalid priority: {0}")]
     InvalidPriority(usize, #[source] std::num::TryFromIntError),
-    #[error("Only CPython can disable the GIL, not: {0}")]
+    #[error("Only CPython can be freethreading, not: {0}")]
     GilIsACpythonProblem(String),
 }
 
@@ -113,7 +113,7 @@ impl Tags {
         if let Implementation::CPython { gil_disabled } = implementation {
             // For some reason 3.2 is the minimum python for the cp abi
             for minor in (2..=python_version.1).rev() {
-                // No abi3 for freethreaded python
+                // No abi3 for freethreading python
                 if !gil_disabled {
                     for platform_tag in &platform_tags {
                         tags.push((

--- a/crates/platform-tags/src/tags.rs
+++ b/crates/platform-tags/src/tags.rs
@@ -113,7 +113,7 @@ impl Tags {
         if let Implementation::CPython { gil_disabled } = implementation {
             // For some reason 3.2 is the minimum python for the cp abi
             for minor in (2..=python_version.1).rev() {
-                // No abi3 for no-gil python
+                // No abi3 for freethreaded python
                 if !gil_disabled {
                     for platform_tag in &platform_tags {
                         tags.push((

--- a/crates/platform-tags/src/tags.rs
+++ b/crates/platform-tags/src/tags.rs
@@ -135,15 +135,6 @@ impl Tags {
                 }
             }
         }
-        if matches!(implementation, Implementation::CPython { .. }) {
-            for platform_tag in &platform_tags {
-                tags.push((
-                    implementation.language_tag((python_version.0, python_version.1)),
-                    "none".to_string(),
-                    platform_tag.clone(),
-                ));
-            }
-        }
         // 3. no abi (e.g. executable binary)
         for minor in (0..=python_version.1).rev() {
             for platform_tag in &platform_tags {

--- a/crates/platform-tags/src/tags.rs
+++ b/crates/platform-tags/src/tags.rs
@@ -110,21 +110,28 @@ impl Tags {
             ));
         }
         // 2. abi3 and no abi (e.g. executable binary)
-        // No abi3 for no-gil python
-        if matches!(
-            implementation,
-            Implementation::CPython {
-                gil_disabled: false
-            }
-        ) {
+        if let Implementation::CPython { gil_disabled } = implementation {
             // For some reason 3.2 is the minimum python for the cp abi
             for minor in (2..=python_version.1).rev() {
-                for platform_tag in &platform_tags {
-                    tags.push((
-                        implementation.language_tag((python_version.0, minor)),
-                        "abi3".to_string(),
-                        platform_tag.clone(),
-                    ));
+                // No abi3 for no-gil python
+                if !gil_disabled {
+                    for platform_tag in &platform_tags {
+                        tags.push((
+                            implementation.language_tag((python_version.0, minor)),
+                            "abi3".to_string(),
+                            platform_tag.clone(),
+                        ));
+                    }
+                }
+                // Only include `none` tags for the current CPython version
+                if minor == python_version.1 {
+                    for platform_tag in &platform_tags {
+                        tags.push((
+                            implementation.language_tag((python_version.0, minor)),
+                            "none".to_string(),
+                            platform_tag.clone(),
+                        ));
+                    }
                 }
             }
         }

--- a/crates/uv-cache/Cargo.toml
+++ b/crates/uv-cache/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 cache-key = { workspace = true }
 distribution-types = { workspace = true }
 pypi-types = { workspace = true }
-uv-fs = { workspace = true }
+uv-fs = { workspace = true, features = ["tokio"] }
 uv-normalize = { workspace = true }
 
 cachedir = { workspace = true }

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -610,7 +610,7 @@ impl CacheBucket {
             Self::BuiltWheels => "built-wheels-v3",
             Self::FlatIndex => "flat-index-v0",
             Self::Git => "git-v0",
-            Self::Interpreter => "interpreter-v0",
+            Self::Interpreter => "interpreter-v1",
             Self::Simple => "simple-v7",
             Self::Wheels => "wheels-v1",
             Self::Archive => "archive-v0",

--- a/crates/uv-interpreter/Cargo.toml
+++ b/crates/uv-interpreter/Cargo.toml
@@ -42,6 +42,6 @@ winapi = { workspace = true }
 [dev-dependencies]
 anyhow = { version = "1.0.80" }
 indoc = { version = "2.0.4" }
-insta = { version = "1.36.1" }
+insta = { version = "1.36.1", features = ["filters"] }
 itertools = { version = "0.12.1" }
 tempfile = { version = "3.9.0" }

--- a/crates/uv-interpreter/python/get_interpreter_info.py
+++ b/crates/uv-interpreter/python/get_interpreter_info.py
@@ -534,7 +534,7 @@ def main() -> None:
         "scheme": get_scheme(),
         "virtualenv": get_virtualenv(),
         "platform": get_operating_system_and_architecture(),
-        # The `t` abiflag for freethreaded python
+        # The `t` abiflag for freethreading python
         # https://peps.python.org/pep-0703/#build-configuration-changes
         "gil_disabled": bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
     }

--- a/crates/uv-interpreter/python/get_interpreter_info.py
+++ b/crates/uv-interpreter/python/get_interpreter_info.py
@@ -534,6 +534,8 @@ def main() -> None:
         "scheme": get_scheme(),
         "virtualenv": get_virtualenv(),
         "platform": get_operating_system_and_architecture(),
+        # The `t` abiflag: https://peps.python.org/pep-0703/#build-configuration-changes
+        "gil_disabled": bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
     }
     print(json.dumps(interpreter_info))
 

--- a/crates/uv-interpreter/python/get_interpreter_info.py
+++ b/crates/uv-interpreter/python/get_interpreter_info.py
@@ -534,7 +534,8 @@ def main() -> None:
         "scheme": get_scheme(),
         "virtualenv": get_virtualenv(),
         "platform": get_operating_system_and_architecture(),
-        # The `t` abiflag: https://peps.python.org/pep-0703/#build-configuration-changes
+        # The `t` abiflag for freethreaded python
+        # https://peps.python.org/pep-0703/#build-configuration-changes
         "gil_disabled": bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
     }
     print(json.dumps(interpreter_info))

--- a/crates/uv-interpreter/python/get_interpreter_info.py
+++ b/crates/uv-interpreter/python/get_interpreter_info.py
@@ -536,7 +536,7 @@ def main() -> None:
         "platform": get_operating_system_and_architecture(),
         # The `t` abiflag for freethreading python
         # https://peps.python.org/pep-0703/#build-configuration-changes
-        "gil_disabled": bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+        "gil_disabled": bool(sysconfig.get_config_var("Py_GIL_DISABLED")),
     }
     print(json.dumps(interpreter_info))
 

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -35,6 +35,7 @@ pub struct Interpreter {
     sys_executable: PathBuf,
     stdlib: PathBuf,
     tags: OnceCell<Tags>,
+    gil_disabled: bool,
 }
 
 impl Interpreter {
@@ -55,6 +56,7 @@ impl Interpreter {
             virtualenv: info.virtualenv,
             prefix: info.prefix,
             base_exec_prefix: info.base_exec_prefix,
+            gil_disabled: info.gil_disabled,
             base_prefix: info.base_prefix,
             base_executable: info.base_executable,
             sys_executable: info.sys_executable,
@@ -89,6 +91,7 @@ impl Interpreter {
             sys_executable: PathBuf::from("/dev/null"),
             stdlib: PathBuf::from("/dev/null"),
             tags: OnceCell::new(),
+            gil_disabled: false,
         }
     }
 
@@ -123,6 +126,7 @@ impl Interpreter {
                 self.python_tuple(),
                 self.implementation_name(),
                 self.implementation_tuple(),
+                self.gil_disabled,
             )
         })
     }
@@ -290,6 +294,15 @@ impl Interpreter {
         &self.virtualenv
     }
 
+    /// Return whether this is a Python 3.13+ no-GIL python, as specified by the sysconfig var
+    /// `Py_GIL_DISABLED`.
+    ///
+    /// No-GIL or free-threaded Python is incompatible with existing native modules, re-introducing
+    /// abiflags with a `t` flag. <https://peps.python.org/pep-0703/#build-configuration-changes>
+    pub fn gil_disabled(&self) -> bool {
+        self.gil_disabled
+    }
+
     /// Return the [`Layout`] environment used to install wheels into this interpreter.
     pub fn layout(&self) -> Layout {
         Layout {
@@ -374,6 +387,7 @@ struct InterpreterInfo {
     base_executable: Option<PathBuf>,
     sys_executable: PathBuf,
     stdlib: PathBuf,
+    gil_disabled: bool,
 }
 
 impl InterpreterInfo {

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -294,10 +294,10 @@ impl Interpreter {
         &self.virtualenv
     }
 
-    /// Return whether this is a Python 3.13+ no-GIL python, as specified by the sysconfig var
+    /// Return whether this is a Python 3.13+ freethreaded Python, as specified by the sysconfig var
     /// `Py_GIL_DISABLED`.
     ///
-    /// No-GIL or free-threaded Python is incompatible with existing native modules, re-introducing
+    /// Freethreaded Python is incompatible with earlier native modules, re-introducing
     /// abiflags with a `t` flag. <https://peps.python.org/pep-0703/#build-configuration-changes>
     pub fn gil_disabled(&self) -> bool {
         self.gil_disabled

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -294,10 +294,10 @@ impl Interpreter {
         &self.virtualenv
     }
 
-    /// Return whether this is a Python 3.13+ freethreaded Python, as specified by the sysconfig var
+    /// Return whether this is a Python 3.13+ freethreading Python, as specified by the sysconfig var
     /// `Py_GIL_DISABLED`.
     ///
-    /// Freethreaded Python is incompatible with earlier native modules, re-introducing
+    /// freethreading Python is incompatible with earlier native modules, re-introducing
     /// abiflags with a `t` flag. <https://peps.python.org/pep-0703/#build-configuration-changes>
     pub fn gil_disabled(&self) -> bool {
         self.gil_disabled
@@ -617,7 +617,8 @@ mod tests {
                     "platlib": "lib/python3.12/site-packages",
                     "purelib": "lib/python3.12/site-packages",
                     "scripts": "bin"
-                }
+                },
+                "gil_disabled": true
             }
         "##};
 

--- a/crates/uv-resolver/tests/resolver.rs
+++ b/crates/uv-resolver/tests/resolver.rs
@@ -700,6 +700,7 @@ static TAGS_311: Lazy<Tags> = Lazy::new(|| {
         (3, 11),
         "cpython",
         (3, 11),
+        false,
     )
     .unwrap()
 });
@@ -732,6 +733,7 @@ static TAGS_310: Lazy<Tags> = Lazy::new(|| {
         (3, 10),
         "cpython",
         (3, 10),
+        false,
     )
     .unwrap()
 });

--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -189,6 +189,7 @@ pub(crate) async fn pip_compile(
             (python_version.major(), python_version.minor()),
             interpreter.implementation_name(),
             interpreter.implementation_tuple(),
+            interpreter.gil_disabled(),
         )?)
     } else {
         Cow::Borrowed(interpreter.tags()?)


### PR DESCRIPTION
freethreaded python reintroduces abiflags since it is incompatible with regular native modules and abi3.

Tests: None yet! We're lacking cpython 3.13 no-gil builds we can use in ci.

My test setup:

```
PYTHON_CONFIGURE_OPTS="--enable-shared --disable-gil" pyenv install 3.13.0a5
cargo run -q -- venv -q -p python3.13 .venv3.13 --no-cache-dir && cargo run -q -- pip install -v psutil --no-cache-dir && .venv3.13/bin/python -c "import psutil"
```

Fixes #2429