### PR TITLE
Upgrade `rs-async-zip` to support data descriptors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,8 @@ dependencies = [
 [[package]]
 name = "async_zip"
 version = "0.0.17"
-source = "git+https://github.com/charliermarsh/rs-async-zip?rev=cdd8320d6eec449b0cb1f27069d1a3116aff9364#cdd8320d6eec449b0cb1f27069d1a3116aff9364"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b9f7252833d5ed4b00aa9604b563529dd5e11de9c23615de2dcdf91eb87b52"
 dependencies = [
  "async-compression",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,8 +247,7 @@ dependencies = [
 [[package]]
 name = "async_zip"
 version = "0.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b9f7252833d5ed4b00aa9604b563529dd5e11de9c23615de2dcdf91eb87b52"
+source = "git+https://github.com/charliermarsh/rs-async-zip?rev=1dcb40cfe1bf5325a6fd4bfcf9894db40241f585#1dcb40cfe1bf5325a6fd4bfcf9894db40241f585"
 dependencies = [
  "async-compression",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 [[package]]
 name = "async_zip"
 version = "0.0.17"
-source = "git+https://github.com/charliermarsh/rs-async-zip?rev=70e8419cabee9ec5d3f25eff5821e1d539ac3873#70e8419cabee9ec5d3f25eff5821e1d539ac3873"
+source = "git+https://github.com/charliermarsh/rs-async-zip?rev=cdd8320d6eec449b0cb1f27069d1a3116aff9364#cdd8320d6eec449b0cb1f27069d1a3116aff9364"
 dependencies = [
  "async-compression",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,8 +246,8 @@ dependencies = [
 
 [[package]]
 name = "async_zip"
-version = "0.0.16"
-source = "git+https://github.com/charliermarsh/rs-async-zip?rev=d76801da0943de985254fc6255c0e476b57c5836#d76801da0943de985254fc6255c0e476b57c5836"
+version = "0.0.17"
+source = "git+https://github.com/charliermarsh/rs-async-zip?rev=70e8419cabee9ec5d3f25eff5821e1d539ac3873#70e8419cabee9ec5d3f25eff5821e1d539ac3873"
 dependencies = [
  "async-compression",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ async-channel = { version = "2.2.0" }
 async-compression = { version = "0.4.6" }
 async-trait = { version = "0.1.78" }
 async_http_range_reader = { version = "0.7.0" }
-async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "70e8419cabee9ec5d3f25eff5821e1d539ac3873", features = ["deflate"] }
+async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "cdd8320d6eec449b0cb1f27069d1a3116aff9364", features = ["deflate"] }
 axoupdater = { version = "0.3.1", default-features = false }
 backoff = { version = "0.4.0" }
 base64 = { version = "0.21.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ async-channel = { version = "2.2.0" }
 async-compression = { version = "0.4.6" }
 async-trait = { version = "0.1.78" }
 async_http_range_reader = { version = "0.7.0" }
-async_zip = { version = "0.0.17" , features = ["deflate"] }
+async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "1dcb40cfe1bf5325a6fd4bfcf9894db40241f585", features = ["deflate"] }
 axoupdater = { version = "0.3.1", default-features = false }
 backoff = { version = "0.4.0" }
 base64 = { version = "0.21.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ async-channel = { version = "2.2.0" }
 async-compression = { version = "0.4.6" }
 async-trait = { version = "0.1.78" }
 async_http_range_reader = { version = "0.7.0" }
-async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "d76801da0943de985254fc6255c0e476b57c5836", features = ["deflate"] }
+async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "70e8419cabee9ec5d3f25eff5821e1d539ac3873", features = ["deflate"] }
 axoupdater = { version = "0.3.1", default-features = false }
 backoff = { version = "0.4.0" }
 base64 = { version = "0.21.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ async-channel = { version = "2.2.0" }
 async-compression = { version = "0.4.6" }
 async-trait = { version = "0.1.78" }
 async_http_range_reader = { version = "0.7.0" }
-async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "cdd8320d6eec449b0cb1f27069d1a3116aff9364", features = ["deflate"] }
+async_zip = { version = "0.0.17" , features = ["deflate"] }
 axoupdater = { version = "0.3.1", default-features = false }
 backoff = { version = "0.4.0" }
 base64 = { version = "0.21.7" }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -424,7 +424,7 @@ impl RegistryClient {
     ) -> Result<Metadata23, Error> {
         // If the metadata file is available at its own url (PEP 658), download it from there.
         let filename = WheelFilename::from_str(&file.filename).map_err(ErrorKind::WheelFilename)?;
-        if file
+        if false && file
             .dist_info_metadata
             .as_ref()
             .is_some_and(pypi_types::DistInfoMetadata::is_available)

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -424,7 +424,7 @@ impl RegistryClient {
     ) -> Result<Metadata23, Error> {
         // If the metadata file is available at its own url (PEP 658), download it from there.
         let filename = WheelFilename::from_str(&file.filename).map_err(ErrorKind::WheelFilename)?;
-        if false && file
+        if file
             .dist_info_metadata
             .as_ref()
             .is_some_and(pypi_types::DistInfoMetadata::is_available)
@@ -618,7 +618,7 @@ async fn read_metadata_async_seek(
     debug_source: String,
     reader: impl tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin,
 ) -> Result<Metadata23, Error> {
-    let reader = futures::io::BufReader::with_capacity(128 * 1024, reader.compat());
+    let reader = futures::io::BufReader::new(reader.compat());
     let mut zip_reader = async_zip::base::read::seek::ZipFileReader::new(reader)
         .await
         .map_err(|err| ErrorKind::Zip(filename.clone(), err))?;

--- a/crates/uv-client/src/remote_metadata.rs
+++ b/crates/uv-client/src/remote_metadata.rs
@@ -1,5 +1,4 @@
 use async_http_range_reader::AsyncHttpRangeReader;
-use async_zip::tokio::read::seek::ZipFileReader;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
 use distribution_filename::WheelFilename;
@@ -61,7 +60,8 @@ pub(crate) async fn wheel_metadata_from_remote_zip(
         .await;
 
     // Construct a zip reader to uses the stream.
-    let mut reader = ZipFileReader::new(reader.compat())
+    let buffer = futures::io::BufReader::with_capacity(128 * 1024, reader.compat());
+    let mut reader = async_zip::base::read::seek::ZipFileReader::new(buffer)
         .await
         .map_err(|err| ErrorKind::Zip(filename.clone(), err))?;
 
@@ -89,6 +89,7 @@ pub(crate) async fn wheel_metadata_from_remote_zip(
     // Fetch the bytes from the zip archive that contain the requested file.
     reader
         .inner_mut()
+        .get_mut()
         .get_mut()
         .prefetch(offset..offset + size)
         .await;

--- a/crates/uv-client/src/remote_metadata.rs
+++ b/crates/uv-client/src/remote_metadata.rs
@@ -1,4 +1,5 @@
 use async_http_range_reader::AsyncHttpRangeReader;
+use futures::io::BufReader;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
 use distribution_filename::WheelFilename;
@@ -60,8 +61,8 @@ pub(crate) async fn wheel_metadata_from_remote_zip(
         .await;
 
     // Construct a zip reader to uses the stream.
-    let buffer = futures::io::BufReader::with_capacity(128 * 1024, reader.compat());
-    let mut reader = async_zip::base::read::seek::ZipFileReader::new(buffer)
+    let buf = BufReader::new(reader.compat());
+    let mut reader = async_zip::base::read::seek::ZipFileReader::new(buf)
         .await
         .map_err(|err| ErrorKind::Zip(filename.clone(), err))?;
 

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -481,8 +481,7 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                 file.seek(io::SeekFrom::Start(0))
                     .await
                     .map_err(Error::CacheWrite)?;
-                let reader = tokio::io::BufReader::new(file);
-                uv_extract::seek::unzip(reader, temp_dir.path()).await?;
+                uv_extract::seek::unzip(file, temp_dir.path()).await?;
 
                 // Persist the temporary directory to the directory store.
                 let archive = self

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1293,8 +1293,7 @@ async fn extract_archive(path: &Path, cache: &Cache) -> Result<ExtractedSource, 
         let reader = fs_err::tokio::File::open(&path)
             .await
             .map_err(Error::CacheRead)?;
-        uv_extract::seek::archive(reader, path, &temp_dir.path())
-            .await?;
+        uv_extract::seek::archive(reader, path, &temp_dir.path()).await?;
 
         // Extract the top-level directory from the archive.
         let extracted = match uv_extract::strip_component(temp_dir.path()) {

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1293,7 +1293,7 @@ async fn extract_archive(path: &Path, cache: &Cache) -> Result<ExtractedSource, 
         let reader = fs_err::tokio::File::open(&path)
             .await
             .map_err(Error::CacheRead)?;
-        uv_extract::seek::archive(tokio::io::BufReader::new(reader), path, &temp_dir.path())
+        uv_extract::seek::archive(reader, path, &temp_dir.path())
             .await?;
 
         // Extract the top-level directory from the archive.

--- a/crates/uv-extract/src/seek.rs
+++ b/crates/uv-extract/src/seek.rs
@@ -9,12 +9,12 @@ use crate::Error;
 /// Unzip a `.zip` archive into the target directory, requiring `Seek`.
 ///
 /// This is useful for unzipping files asynchronously that already exist on disk.
-pub async fn unzip<R: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin>(
+pub async fn unzip<R: tokio::io::AsyncBufRead + tokio::io::AsyncSeek + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
 ) -> Result<(), Error> {
     let target = target.as_ref();
-    let mut reader = reader.compat();
+    let mut reader = futures::io::BufReader::with_capacity(128 * 1024, reader.compat());
     let mut zip = async_zip::base::read::seek::ZipFileReader::new(&mut reader).await?;
 
     let mut directories = FxHashSet::default();

--- a/crates/uv-extract/src/seek.rs
+++ b/crates/uv-extract/src/seek.rs
@@ -14,7 +14,7 @@ pub async fn unzip<R: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin>(
     target: impl AsRef<Path>,
 ) -> Result<(), Error> {
     let target = target.as_ref();
-    let mut reader = futures::io::BufReader::with_capacity(128 * 1024, reader.compat());
+    let mut reader = futures::io::BufReader::new(reader.compat());
     let mut zip = async_zip::base::read::seek::ZipFileReader::new(&mut reader).await?;
 
     let mut directories = FxHashSet::default();

--- a/crates/uv-extract/src/seek.rs
+++ b/crates/uv-extract/src/seek.rs
@@ -9,7 +9,7 @@ use crate::Error;
 /// Unzip a `.zip` archive into the target directory, requiring `Seek`.
 ///
 /// This is useful for unzipping files asynchronously that already exist on disk.
-pub async fn unzip<R: tokio::io::AsyncBufRead + tokio::io::AsyncSeek + Unpin>(
+pub async fn unzip<R: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
 ) -> Result<(), Error> {
@@ -81,7 +81,7 @@ pub async fn unzip<R: tokio::io::AsyncBufRead + tokio::io::AsyncSeek + Unpin>(
 }
 
 /// Unzip a `.zip` or `.tar.gz` archive into the target directory, requiring `Seek`.
-pub async fn archive<R: tokio::io::AsyncBufRead + tokio::io::AsyncSeek + Unpin>(
+pub async fn archive<R: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin>(
     reader: R,
     source: impl AsRef<Path>,
     target: impl AsRef<Path>,

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -58,6 +58,42 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
         zip = entry.skip().await?;
     }
 
+    // On Unix, we need to set file permissions, which are stored in the central directory, at the
+    // end of the archive. The `ZipFileReader` reads until it sees a central directory signature,
+    // which indicates the first entry in the central directory. So we continue reading from there.
+    #[cfg(unix)]
+    {
+        use std::fs::Permissions;
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut directory = async_zip::base::read::cd::CentralDirectoryReader::new(&mut reader);
+        while let Some(entry) = directory.next().await? {
+            if entry.dir()? {
+                continue;
+            }
+
+            let Some(mode) = entry.unix_permissions() else {
+                continue;
+            };
+
+            // The executable bit is the only permission we preserve, otherwise we use the OS defaults.
+            // https://github.com/pypa/pip/blob/3898741e29b7279e7bffe044ecfbe20f6a438b1e/src/pip/_internal/utils/unpacking.py#L88-L100
+            let has_any_executable_bit = mode & 0o111;
+            if has_any_executable_bit != 0 {
+                // Construct the (expected) path to the file on-disk.
+                let path = entry.filename().as_str()?;
+                let path = target.join(path);
+
+                let permissions = fs_err::tokio::metadata(&path).await?.permissions();
+                fs_err::tokio::set_permissions(
+                    &path,
+                    Permissions::from_mode(permissions.mode() | 0o111),
+                )
+                .await?;
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -154,10 +154,11 @@ async fn untar_in<R: tokio::io::AsyncRead + Unpin, P: AsRef<Path>>(
 /// Unzip a `.tar.gz` archive into the target directory, without requiring `Seek`.
 ///
 /// This is useful for unpacking files as they're being downloaded.
-pub async fn untar<R: tokio::io::AsyncBufRead + Unpin>(
+pub async fn untar<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     target: impl AsRef<Path>,
 ) -> Result<(), Error> {
+    let reader = tokio::io::BufReader::new(reader);
     let decompressed_bytes = async_compression::tokio::bufread::GzipDecoder::new(reader);
     let mut archive = tokio_tar::ArchiveBuilder::new(decompressed_bytes)
         .set_preserve_mtime(false)
@@ -166,7 +167,7 @@ pub async fn untar<R: tokio::io::AsyncBufRead + Unpin>(
 }
 
 /// Unzip a `.zip` or `.tar.gz` archive into the target directory, without requiring `Seek`.
-pub async fn archive<R: tokio::io::AsyncBufRead + Unpin>(
+pub async fn archive<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     source: impl AsRef<Path>,
     target: impl AsRef<Path>,

--- a/req.in
+++ b/req.in
@@ -1,0 +1,3 @@
+--extra-index-url https://buf.build/gen/python
+
+hashb_foxglove_protocolbuffers_python==25.3.0.1.20240226043130+465630478360

--- a/req.in
+++ b/req.in
@@ -1,3 +1,0 @@
---extra-index-url https://buf.build/gen/python
-
-hashb_foxglove_protocolbuffers_python==25.3.0.1.20240226043130+465630478360


### PR DESCRIPTION
## Summary

Upgrading `rs-async-zip` enables us to support data descriptors in streaming. This both greatly improves performance for indexes that use data descriptors _and_ ensures that we support them in a few other places (e.g., zipped source distributions created in Finder).

Closes #2808.
