### PR TITLE
Show resolution diagnostics after `pip install`

### DIFF
--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -595,6 +595,17 @@ async fn resolve(
         .dimmed()
     )?;
 
+    // Notify the user of any diagnostics.
+    for diagnostic in resolution.diagnostics() {
+        writeln!(
+            printer.stderr(),
+            "{}{} {}",
+            "warning".yellow().bold(),
+            ":".bold(),
+            diagnostic.message().bold()
+        )?;
+    }
+
     Ok(resolution)
 }
 

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -708,6 +708,7 @@ fn missing_extra() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    warning: The package `package-a==1.0.0` does not have an extra named `extra`.
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0
@@ -1080,6 +1081,7 @@ fn extra_does_not_exist_backtrack() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    warning: The package `package-a==3.0.0` does not have an extra named `extra`.
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==3.0.0


### PR DESCRIPTION
## Summary

These are shown in `pip compile`, but absent from `pip install`.

See: #2828.
