### PR TITLE
Respect cached local `--find-links` in install plan

### DIFF
--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -150,10 +150,9 @@ impl<'a, Context: BuildContext + Send + Sync> DistributionDatabase<'a, Context> 
                         Url::parse(url).map_err(|err| Error::Url(url.clone(), err))?
                     }
                     FileLocation::Path(path) => {
-                        let url = Url::from_file_path(path).expect("path is absolute");
                         let cache_entry = self.build_context.cache().entry(
                             CacheBucket::Wheels,
-                            WheelCache::Url(&url).wheel_dir(wheel.name().as_ref()),
+                            WheelCache::Index(&wheel.index).wheel_dir(wheel.name().as_ref()),
                             wheel.filename.stem(),
                         );
                         return self

--- a/crates/uv-distribution/src/index/registry_wheel_index.rs
+++ b/crates/uv-distribution/src/index/registry_wheel_index.rs
@@ -83,7 +83,10 @@ impl<'a> RegistryWheelIndex<'a> {
         let flat_index_urls: Vec<IndexUrl> = index_locations
             .flat_index()
             .filter_map(|flat_index| match flat_index {
-                FlatIndexLocation::Path(_) => None,
+                FlatIndexLocation::Path(path) => {
+                    let path = fs_err::canonicalize(path).ok()?;
+                    Some(IndexUrl::Url(VerbatimUrl::from_path(path)))
+                }
                 FlatIndexLocation::Url(url) => {
                     Some(IndexUrl::Url(VerbatimUrl::unknown(url.clone())))
                 }


### PR DESCRIPTION
## Summary

I think this is kind of just an oversight. If a wheel is available via `--find-links`, and the index is "local", we never find it in the cache.

## Test Plan

`cargo test`