### PR TITLE
Add a layer of indirection to the local path-based wheel cache

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -795,6 +795,12 @@ impl ArchiveTimestamp {
         }
     }
 
+    /// Return the modification timestamp for a file.
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, io::Error> {
+        let metadata = fs_err::metadata(path.as_ref())?;
+        Ok(Self::Exact(Timestamp::from_metadata(&metadata)))
+    }
+
     /// Return the modification timestamp for an archive.
     pub fn timestamp(&self) -> Timestamp {
         match self {

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -1708,7 +1708,7 @@ fn install_path_built_dist_cached() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Removed 1 file for tomli ([SIZE])
+    Removed 2 files for tomli ([SIZE])
     "###
     );
 


### PR DESCRIPTION
## Summary

Right now, the path-based wheel cache just looks at the symlink to the archives directory, checks the timestamp on it, and continues with that symlink as long as the timestamp is up-to-date.

The HTTP-based wheel meanwhile, uses an intermediary `.http` file, which includes the HTTP caching information. The `.http` file's payload is just a path pointing to an entry in the archives directory.

This PR modifies the path-based codepaths to use a similar cache file, which stores a timestamp along with a path to the archives directory. The main advantage here is that we can add other data to this cache file (namely, hashes in the future).

## Test Plan

Beyond existing tests, I also verified that this doesn't require a version bump:

```
git checkout main 
cargo run pip install ~/Downloads/zeal-0.0.1-py3-none-any.whl --cache-dir baz --reinstall
git checkout charlie/manifest
cargo run pip install ~/Downloads/zeal-0.0.1-py3-none-any.whl --cache-dir baz --reinstall
cargo run pip install ~/Downloads/zeal-0.0.1-py3-none-any.whl --cache-dir baz --reinstall --refresh
```
