### PR TITLE
Disable CentOS system check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,8 @@ jobs:
         run: python scripts/check_system_python.py --uv ./uv
 
   system-test-centos:
+    # https://github.com/astral-sh/uv/issues/2915
+    if: false
     needs: build-binary-linux
     name: "check system | python on centos"
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is broken (see https://github.com/astral-sh/uv/issues/2915) and not a priority since we have Amazon Linux coverage