### PR TITLE
Improve operating system and architecture types in `uv-toolchain`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4815,6 +4815,7 @@ dependencies = [
  "anyhow",
  "fs-err",
  "futures",
+ "once_cell",
  "reqwest",
  "reqwest-middleware",
  "tempfile",

--- a/crates/uv-dev/src/fetch_python.rs
+++ b/crates/uv-dev/src/fetch_python.rs
@@ -1,25 +1,15 @@
-use fs_err as fs;
-use std::collections::HashMap;
-
-use std::str::FromStr;
-
 use anyhow::Result;
 use clap::Parser;
-
-use futures::StreamExt;
-
-use itertools::Itertools;
-
-use tokio::time::Instant;
-
-use uv_fs::replace_symlink;
-
-#[cfg(windows)]
-use fs_err::tokio::hard_link;
+use fs_err as fs;
 #[cfg(unix)]
 use fs_err::tokio::symlink;
-
+use futures::StreamExt;
+use itertools::Itertools;
+use std::collections::HashMap;
+use std::str::FromStr;
+use tokio::time::Instant;
 use tracing::{info, info_span, Instrument};
+use uv_fs::replace_symlink;
 
 use uv_fs::Simplified;
 use uv_toolchain::{

--- a/crates/uv-dev/src/fetch_python.rs
+++ b/crates/uv-dev/src/fetch_python.rs
@@ -97,13 +97,8 @@ pub(crate) async fn fetch_python(args: FetchPythonArgs) -> Result<()> {
     let mut links = HashMap::new();
     for (version, path) in results {
         // TODO(zanieb): This path should be a part of the download metadata
-        let executable = if cfg!(windows) {
-            path.join("install").join("python.exe")
-        } else if cfg!(unix) {
-            path.join("install").join("bin").join("python3")
-        } else {
-            unimplemented!("Only Windows and Unix systems are supported.")
-        };
+        #[cfg(unix)]
+        let executable = path.join("install").join("bin").join("python3");
 
         // On Windows, linking the executable generally results in broken installations
         // and each toolchain path will need to be added to the PATH separately in the

--- a/crates/uv-toolchain/Cargo.toml
+++ b/crates/uv-toolchain/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }
 url = { workspace = true }
 tracing = { workspace = true }
+once_cell = {workspace = true}
 
 [lints]
 workspace = true

--- a/crates/uv-toolchain/Cargo.toml
+++ b/crates/uv-toolchain/Cargo.toml
@@ -16,17 +16,17 @@ uv-interpreter = { workspace = true }
 uv-fs = { workspace = true }
 
 anyhow = { workspace = true }
+fs-err = { workspace = true }
+futures = { workspace = true }
+once_cell = {workspace = true}
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tempfile = { workspace = true }
-fs-err = { workspace = true }
-futures = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }
-url = { workspace = true }
 tracing = { workspace = true }
-once_cell = {workspace = true}
+url = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/uv-toolchain/python-version-metadata.json
+++ b/crates/uv-toolchain/python-version-metadata.json
@@ -1,18 +1,7 @@
 {
-  "cpython-3.12.2-darwin-arm64-none": {
+  "cpython-3.12.2-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "2afcc8b25c55793f6ceb0bef2e547e101f53c9e25a0fe0332320e5381a1f0fdb"
-  },
-  "cpython-3.12.2-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -21,20 +10,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "469a7fd0d0a09936c5db41b5ac83bb29d5bfeb721aa483ac92f3f7ac4d311097"
   },
-  "cpython-3.12.2-windows-i686-none": {
+  "cpython-3.12.2-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "ee985ae6a6a98f4d5bd19fd8c59f45235911d19b64e1dbd026261b8103f15db5"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "2afcc8b25c55793f6ceb0bef2e547e101f53c9e25a0fe0332320e5381a1f0fdb"
   },
-  "cpython-3.12.2-linux-ppc64le-gnu": {
+  "cpython-3.12.2-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -54,16 +43,16 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "f40b88607928b5ee34ff87c1d574c8493a1604d7a40474e1b03731184186f419"
   },
-  "cpython-3.12.2-darwin-x86_64-none": {
+  "cpython-3.12.2-windows-x86-none": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "b4b4d19c36e86803aa0b4410395f5568bef28d82666efba926e44dbe06345a12"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "ee985ae6a6a98f4d5bd19fd8c59f45235911d19b64e1dbd026261b8103f15db5"
   },
   "cpython-3.12.2-linux-x86_64-gnu": {
     "name": "cpython",
@@ -87,6 +76,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "7ec1dc7ad8223ec5839a57d232fd3cf730987f7b0f88b2c4f15ee935bcabbaa9"
   },
+  "cpython-3.12.2-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "b4b4d19c36e86803aa0b4410395f5568bef28d82666efba926e44dbe06345a12"
+  },
   "cpython-3.12.2-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -98,20 +98,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "a1daf5e8ceb23d34ea29b16b5123b06694810fe7acc5c8384426435c63bf731e"
   },
-  "cpython-3.12.1-darwin-arm64-none": {
+  "cpython-3.12.1-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "61e51e3490537b800fcefad718157cf775de41044e95aa538b63ab599f66f3a9"
-  },
-  "cpython-3.12.1-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -120,20 +109,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "9009da24f436611d0bf086b8ea62aaed1c27104af5b770ddcfc92b60db06da8c"
   },
-  "cpython-3.12.1-windows-i686-none": {
+  "cpython-3.12.1-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "22866d35fdf58e90e75d6ba9aa78c288b452ea7041fa9bc5549eca9daa431883"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "61e51e3490537b800fcefad718157cf775de41044e95aa538b63ab599f66f3a9"
   },
-  "cpython-3.12.1-linux-ppc64le-gnu": {
+  "cpython-3.12.1-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -153,16 +142,16 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "505a4fbace661a43b354a059022eb31efb406859a5f7227109ebf0f278f20503"
   },
-  "cpython-3.12.1-darwin-x86_64-none": {
+  "cpython-3.12.1-windows-x86-none": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "bf2b176b0426d7b4d4909c1b19bbb25b4893f9ebdc61e32df144df2b10dcc800"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "22866d35fdf58e90e75d6ba9aa78c288b452ea7041fa9bc5549eca9daa431883"
   },
   "cpython-3.12.1-linux-x86_64-gnu": {
     "name": "cpython",
@@ -186,6 +175,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "c4b07a02d8f0986b56e010a67132e5eeba1def4991c6c06ed184f831a484a06f"
   },
+  "cpython-3.12.1-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "bf2b176b0426d7b4d4909c1b19bbb25b4893f9ebdc61e32df144df2b10dcc800"
+  },
   "cpython-3.12.1-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -197,20 +197,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "d9bc1b566250bf51818976bf98bf50e1f4c59b2503b50d29250cac5ab5ef6b38"
   },
-  "cpython-3.12.0-darwin-arm64-none": {
+  "cpython-3.12.0-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "25fc8cd41e975d18d13bcc8f8beffa096ff8a0b86c4a737e1c6617900092c966"
-  },
-  "cpython-3.12.0-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -219,20 +208,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "eb05c976374a9a44596ce340ab35e5461014f30202c3cbe10edcbfbe5ac4a6a1"
   },
-  "cpython-3.12.0-windows-i686-none": {
+  "cpython-3.12.0-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "465e91b6e6d0d1c40c8a4bce3642c4adcb9b75cf03fbd5fd5a33a36358249289"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "25fc8cd41e975d18d13bcc8f8beffa096ff8a0b86c4a737e1c6617900092c966"
   },
-  "cpython-3.12.0-linux-ppc64le-gnu": {
+  "cpython-3.12.0-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -252,16 +241,16 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "5b1a1effbb43df57ad014fcebf4b20089e504d89613e7b8db22d9ccb9fb00a6c"
   },
-  "cpython-3.12.0-darwin-x86_64-none": {
+  "cpython-3.12.0-windows-x86-none": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 12,
     "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "3b4781e7fd4efabe574ba0954e54c35c7d5ac4dc5b2990b40796c1c6aec67d79"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "465e91b6e6d0d1c40c8a4bce3642c4adcb9b75cf03fbd5fd5a33a36358249289"
   },
   "cpython-3.12.0-linux-x86_64-gnu": {
     "name": "cpython",
@@ -285,6 +274,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "91b42595cb4b69ff396e746dc492caf67b952a3ed1a367a4ace1acc965ed9cdb"
   },
+  "cpython-3.12.0-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "3b4781e7fd4efabe574ba0954e54c35c7d5ac4dc5b2990b40796c1c6aec67d79"
+  },
   "cpython-3.12.0-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -296,20 +296,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "5bdff7ed56550d96f9b26a27a8c25f0cc58a03bff19e5f52bba84366183cab8b"
   },
-  "cpython-3.11.8-darwin-arm64-none": {
+  "cpython-3.11.8-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "c0650884b929253b8688797d1955850f6e339bf0428b3d935f62ab3159f66362"
-  },
-  "cpython-3.11.8-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -318,20 +307,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "45bf082aca6b7d5e7261852720a72b92f5305e9fdb07b10f6588cb51d8f83ff2"
   },
-  "cpython-3.11.8-windows-i686-none": {
+  "cpython-3.11.8-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "c3e90962996177a027bd73dd9fd8c42a2d6ef832cda26db4ab4efc6105160537"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "c0650884b929253b8688797d1955850f6e339bf0428b3d935f62ab3159f66362"
   },
-  "cpython-3.11.8-linux-ppc64le-gnu": {
+  "cpython-3.11.8-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -351,16 +340,16 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "d495830b5980ed689bd7588aa556bac9c43ff766d8a8b32e7791b8ed664b04f3"
   },
-  "cpython-3.11.8-darwin-x86_64-none": {
+  "cpython-3.11.8-windows-x86-none": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "54f8c8ad7313b3505e495bb093825d85eab244306ca4278836a2c7b5b74fb053"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "c3e90962996177a027bd73dd9fd8c42a2d6ef832cda26db4ab4efc6105160537"
   },
   "cpython-3.11.8-linux-x86_64-gnu": {
     "name": "cpython",
@@ -384,6 +373,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "a03a9d8c1f770ce418716a2e8185df7b3a9e0012cdc220f9f2d24480a432650b"
   },
+  "cpython-3.11.8-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "54f8c8ad7313b3505e495bb093825d85eab244306ca4278836a2c7b5b74fb053"
+  },
   "cpython-3.11.8-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -395,20 +395,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "6da82390f7ac49f6c4b19a5b8019c4ddc1eef2c5ad6a2f2d32773a27663a4e14"
   },
-  "cpython-3.11.7-darwin-arm64-none": {
+  "cpython-3.11.7-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "c1f3dd13825906a5eae23ed8de9b653edb620568b2e0226eef3784eb1cce7eed"
-  },
-  "cpython-3.11.7-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -417,20 +406,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "e3a375f8f16198ccf8dbede231536544265e5b4b6b0f0df97c5b29503c5864e2"
   },
-  "cpython-3.11.7-windows-i686-none": {
+  "cpython-3.11.7-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "6613f1f9238d19969d8a2827deec84611cb772503207056cc9f0deb89bea48cd"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "c1f3dd13825906a5eae23ed8de9b653edb620568b2e0226eef3784eb1cce7eed"
   },
-  "cpython-3.11.7-linux-ppc64le-gnu": {
+  "cpython-3.11.7-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -450,16 +439,16 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "91b33369025b7e0079f603cd2a99f9a5932daa8ded113d5090f29c075c993df7"
   },
-  "cpython-3.11.7-darwin-x86_64-none": {
+  "cpython-3.11.7-windows-x86-none": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "3f8caf73f2bfe22efa9666974c119727e163716e88af8ed3caa1e0ae5493de61"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "6613f1f9238d19969d8a2827deec84611cb772503207056cc9f0deb89bea48cd"
   },
   "cpython-3.11.7-linux-x86_64-gnu": {
     "name": "cpython",
@@ -483,6 +472,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "f387d373d64447bbba8a5657712f93b1dbdfd7246cdfe5a0493f39b83d46ec7c"
   },
+  "cpython-3.11.7-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "3f8caf73f2bfe22efa9666974c119727e163716e88af8ed3caa1e0ae5493de61"
+  },
   "cpython-3.11.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -494,20 +494,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "89d1d8f080e5494ea57918fc5ecf3d483ffef943cd5a336e64da150cd44b4aa0"
   },
-  "cpython-3.11.6-darwin-arm64-none": {
+  "cpython-3.11.6-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "6e9007bcbbf51203e89c34a87ed42561630a35bc4eb04a565c92ba7159fe5826"
-  },
-  "cpython-3.11.6-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -516,20 +505,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "d63d6eb065e60899b25853fe6bbd9f60ea6c3b12f4854adc75cb818bad55f4e9"
   },
-  "cpython-3.11.6-windows-i686-none": {
+  "cpython-3.11.6-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "2670731428191d4476bf260c8144ccf06f9e5f8ac6f2de1dc444ca96ab627082"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "6e9007bcbbf51203e89c34a87ed42561630a35bc4eb04a565c92ba7159fe5826"
   },
-  "cpython-3.11.6-linux-ppc64le-gnu": {
+  "cpython-3.11.6-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -549,16 +538,16 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "78252aa883fed18de7bb9b146450e42dd75d78c345f56c1301bb042317a1d4f7"
   },
-  "cpython-3.11.6-darwin-x86_64-none": {
+  "cpython-3.11.6-windows-x86-none": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "3685156e4139e89484c071ba1a1b85be0b4e302a786de5a170d3b0713863c2e8"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "2670731428191d4476bf260c8144ccf06f9e5f8ac6f2de1dc444ca96ab627082"
   },
   "cpython-3.11.6-linux-x86_64-gnu": {
     "name": "cpython",
@@ -582,6 +571,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "1b6e32ec93c5a18a03a9da9e2a3a3738d67b733df0795edcff9fd749c33ab931"
   },
+  "cpython-3.11.6-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "3685156e4139e89484c071ba1a1b85be0b4e302a786de5a170d3b0713863c2e8"
+  },
   "cpython-3.11.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -593,20 +593,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "38d2c2fa2f9effbf486207bef7141d1b5c385ad30729ab0c976e6a852a2a9401"
   },
-  "cpython-3.11.5-darwin-arm64-none": {
+  "cpython-3.11.5-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "7bee180b764722a73c2599fbe2c3a6121cf6bbcb08cb3082851e93c43fe130e7"
-  },
-  "cpython-3.11.5-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -615,31 +604,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "ac4b1e91d1cb7027595bfa4667090406331b291b2e346fb74e42b7031b216787"
   },
-  "cpython-3.11.5-linux-i686-gnu": {
+  "cpython-3.11.5-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "75d27b399b323c25d8250fda9857e388bf1b03ba1eb7925ec23cf12042a63a88"
-  },
-  "cpython-3.11.5-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "c9ffe9c2c88685ce3064f734cbdfede0a07de7d826fada58f8045f3bd8f81a9d"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "7bee180b764722a73c2599fbe2c3a6121cf6bbcb08cb3082851e93c43fe130e7"
   },
-  "cpython-3.11.5-linux-ppc64le-gnu": {
+  "cpython-3.11.5-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -659,16 +637,27 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "b0819032ec336d6e1d9e9bfdba546bf854a7b7248f8720a6d07da72c4ac927e5"
   },
-  "cpython-3.11.5-darwin-x86_64-none": {
+  "cpython-3.11.5-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "75d27b399b323c25d8250fda9857e388bf1b03ba1eb7925ec23cf12042a63a88"
+  },
+  "cpython-3.11.5-windows-x86-none": {
+    "name": "cpython",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "e43d70a49919641ca2939a5a9107b13d5fef8c13af0f511a33a94bb6af2044f0"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "c9ffe9c2c88685ce3064f734cbdfede0a07de7d826fada58f8045f3bd8f81a9d"
   },
   "cpython-3.11.5-linux-x86_64-gnu": {
     "name": "cpython",
@@ -692,6 +681,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "9dcf19ee54fb936cb9fd0f02fd655e790663534bc12e142e460c1b30a0b54dbd"
   },
+  "cpython-3.11.5-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "e43d70a49919641ca2939a5a9107b13d5fef8c13af0f511a33a94bb6af2044f0"
+  },
   "cpython-3.11.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -703,20 +703,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "6e4d20e6d498f9edeb3c28cb9541ad20f675f16da350b078e40a9dcfd93cdc3d"
   },
-  "cpython-3.11.4-darwin-arm64-none": {
+  "cpython-3.11.4-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "988d476c806f71a3233ff4266eda166a5d28cf83ba306ac88b4220554fc83e8c"
-  },
-  "cpython-3.11.4-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -725,31 +714,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "37cf00439b57adf7ffef4a349d62dcf09739ba67b670e903b00b25f81fbb8a68"
   },
-  "cpython-3.11.4-linux-i686-gnu": {
+  "cpython-3.11.4-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "a9051364b5c2e28205f8484cae03d16c86b45df5d117324e846d0f5e870fe9fb"
-  },
-  "cpython-3.11.4-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "0d22f43c5bb3f27ff2f9e8c60b0d7abd391bb2cac1790b0960970ff5580f6e9a"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "988d476c806f71a3233ff4266eda166a5d28cf83ba306ac88b4220554fc83e8c"
   },
-  "cpython-3.11.4-linux-ppc64le-gnu": {
+  "cpython-3.11.4-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -769,16 +747,27 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "8ef6b5fa86b4abf51865b346b7cf8df36e474ed308869fc0ac3fe82de39194a4"
   },
-  "cpython-3.11.4-darwin-x86_64-none": {
+  "cpython-3.11.4-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a9051364b5c2e28205f8484cae03d16c86b45df5d117324e846d0f5e870fe9fb"
+  },
+  "cpython-3.11.4-windows-x86-none": {
+    "name": "cpython",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "6d9765785316c7f1c07def71b413c92c84302f798b30ee09e2e0b5da28353a51"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "0d22f43c5bb3f27ff2f9e8c60b0d7abd391bb2cac1790b0960970ff5580f6e9a"
   },
   "cpython-3.11.4-linux-x86_64-gnu": {
     "name": "cpython",
@@ -802,6 +791,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "fc2ea02ced875c90b8d025b409d58c4f045df8ba951bfa2b8b0a3cfe11c3b41c"
   },
+  "cpython-3.11.4-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "6d9765785316c7f1c07def71b413c92c84302f798b30ee09e2e0b5da28353a51"
+  },
   "cpython-3.11.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -813,20 +813,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "1692d795d6199b2261161ae54250009ffad0317929302903f6f2c773befd4d76"
   },
-  "cpython-3.11.3-darwin-arm64-none": {
+  "cpython-3.11.3-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "cd296d628ceebf55a78c7f6a7aed379eba9dbd72045d002e1c2c85af0d6f5049"
-  },
-  "cpython-3.11.3-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -835,31 +824,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "991521082b0347878ba855c4986d77cc805c22ef75159bc95dd24bfd80275e27"
   },
-  "cpython-3.11.3-linux-i686-gnu": {
+  "cpython-3.11.3-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7bd694eb848328e96f524ded0f9b9eca6230d71fce3cd49b335a5c33450f3e04"
-  },
-  "cpython-3.11.3-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "877c90ef778a526aa25ab417034f5e70728ac14e5eb1fa5cfd741f531203a3fc"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "cd296d628ceebf55a78c7f6a7aed379eba9dbd72045d002e1c2c85af0d6f5049"
   },
-  "cpython-3.11.3-linux-ppc64le-gnu": {
+  "cpython-3.11.3-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -868,16 +846,27 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "241d583be3ecc34d76fafa0d186cb504ce5625eb2c0e895dc4f4073a649e5c73"
   },
-  "cpython-3.11.3-darwin-x86_64-none": {
+  "cpython-3.11.3-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7bd694eb848328e96f524ded0f9b9eca6230d71fce3cd49b335a5c33450f3e04"
+  },
+  "cpython-3.11.3-windows-x86-none": {
+    "name": "cpython",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 11,
     "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "2fbb31a8bc6663e2d31d3054319b51a29b1915c03222a94b9d563233e11d1bef"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "877c90ef778a526aa25ab417034f5e70728ac14e5eb1fa5cfd741f531203a3fc"
   },
   "cpython-3.11.3-linux-x86_64-gnu": {
     "name": "cpython",
@@ -901,6 +890,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "8c5adef5bc627f39e93b920af86ef740e917aa698530ff727978d446a07bbd8b"
   },
+  "cpython-3.11.3-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "2fbb31a8bc6663e2d31d3054319b51a29b1915c03222a94b9d563233e11d1bef"
+  },
   "cpython-3.11.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -912,20 +912,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "9d27e607fb1cb2d766e17f27853013d8c0f0b09ac53127aaff03ec89ab13370d"
   },
-  "cpython-3.11.1-darwin-arm64-none": {
+  "cpython-3.11.1-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "da187194cc351d827232b1d2d85b2855d7e25a4ada3e47bc34b4f87b1d989be5"
-  },
-  "cpython-3.11.1-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -934,9 +923,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "8fe27d850c02aa7bb34088fad5b48df90b4b841f40e1472243b8ab9da8776e40"
   },
-  "cpython-3.11.1-linux-i686-gnu": {
+  "cpython-3.11.1-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "da187194cc351d827232b1d2d85b2855d7e25a4ada3e47bc34b4f87b1d989be5"
+  },
+  "cpython-3.11.1-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -945,9 +945,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "7986ebe82c07ecd2eb94fd1b3c9ebbb2366db2360e38f29ae0543e857551d0bf"
   },
-  "cpython-3.11.1-windows-i686-none": {
+  "cpython-3.11.1-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -955,17 +955,6 @@
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "b062ac2c72a85510fb9300675bd5c716baede21e9482ef6335247b4aa006584c"
-  },
-  "cpython-3.11.1-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "0eb61be53ee13cf75a30b8a164ef513a2c7995b25b118a3a503245d46231b13a"
   },
   "cpython-3.11.1-linux-x86_64-gnu": {
     "name": "cpython",
@@ -989,6 +978,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "ec5da5b428f6d91d96cde2621c0380f67bb96e4257d2628bc70b50e75ec5f629"
   },
+  "cpython-3.11.1-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "0eb61be53ee13cf75a30b8a164ef513a2c7995b25b118a3a503245d46231b13a"
+  },
   "cpython-3.11.1-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1000,20 +1000,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "f5c46fffda7d7894b975af728f739b02d1cec50fd4a3ea49f69de9ceaae74b17"
   },
-  "cpython-3.10.13-darwin-arm64-none": {
+  "cpython-3.10.13-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "57b83a4aa32bdbe7611f1290313ef24f2574dff5fa59181c0ccb26c14c688b73"
-  },
-  "cpython-3.10.13-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1022,31 +1011,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "06a53040504e1e2fdcb32dc0d61b123bea76725b5c14031c8f64e28f52ae5a5f"
   },
-  "cpython-3.10.13-linux-i686-gnu": {
+  "cpython-3.10.13-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "08a3a1ff61b7ed2c87db7a9f88630781d98fabc2efb499f38ae0ead05973eb56"
-  },
-  "cpython-3.10.13-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "c8b99dcf267c574fdfbdf4e9d63ec7a4aa4608565fee3fba0b2f73843b9713b2"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "57b83a4aa32bdbe7611f1290313ef24f2574dff5fa59181c0ccb26c14c688b73"
   },
-  "cpython-3.10.13-linux-ppc64le-gnu": {
+  "cpython-3.10.13-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1066,16 +1044,27 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "fe46914541126297c7a8636845c2e7188868eaa617bb6e293871fca4a5cb63f7"
   },
-  "cpython-3.10.13-darwin-x86_64-none": {
+  "cpython-3.10.13-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "08a3a1ff61b7ed2c87db7a9f88630781d98fabc2efb499f38ae0ead05973eb56"
+  },
+  "cpython-3.10.13-windows-x86-none": {
+    "name": "cpython",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "a41c1e28e2a646bac69e023873d40a43c5958d251c6adfa83d5811a7cb034c7a"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "c8b99dcf267c574fdfbdf4e9d63ec7a4aa4608565fee3fba0b2f73843b9713b2"
   },
   "cpython-3.10.13-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1099,6 +1088,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "fd18e6039be25bf23d13caf5140569df71d61312b823b715b3c788747fec48e9"
   },
+  "cpython-3.10.13-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "a41c1e28e2a646bac69e023873d40a43c5958d251c6adfa83d5811a7cb034c7a"
+  },
   "cpython-3.10.13-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1110,20 +1110,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "6a2c8f37509556e5d463b1f437cdf7772ebd84cdf183c258d783e64bb3109505"
   },
-  "cpython-3.10.12-darwin-arm64-none": {
+  "cpython-3.10.12-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "a7d0cadbe867cc53dd47d7327244154157a7cca02edb88cf3bb760a4f91d4e44"
-  },
-  "cpython-3.10.12-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1132,31 +1121,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "e30f2b4fd9bd79b9122e2975f3c17c9ddd727f8326b2e246378e81f7ecc7d74f"
   },
-  "cpython-3.10.12-linux-i686-gnu": {
+  "cpython-3.10.12-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "89c83fcdfd41c67e2dd2a037982556c657dc55fc1938c6f6cdcd5ffa614c1fb3"
-  },
-  "cpython-3.10.12-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "0743b9976f20b06d9cf12de9d1b2dfe06b13f76978275e9dac73a275624bde2c"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "a7d0cadbe867cc53dd47d7327244154157a7cca02edb88cf3bb760a4f91d4e44"
   },
-  "cpython-3.10.12-linux-ppc64le-gnu": {
+  "cpython-3.10.12-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1176,16 +1154,27 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "756579b52acb9b13b162ac901e56ff311def443e69d7f7259a91198b76a30ecb"
   },
-  "cpython-3.10.12-darwin-x86_64-none": {
+  "cpython-3.10.12-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "89c83fcdfd41c67e2dd2a037982556c657dc55fc1938c6f6cdcd5ffa614c1fb3"
+  },
+  "cpython-3.10.12-windows-x86-none": {
+    "name": "cpython",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "f1fa448384dd48033825e56ee6b5afc76c5dd67dcf2b73b61d2b252ae2e87bca"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "0743b9976f20b06d9cf12de9d1b2dfe06b13f76978275e9dac73a275624bde2c"
   },
   "cpython-3.10.12-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1209,6 +1198,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "b343cbe7c41b7698b568ea5252328cdccb213100efa71da8d3db6e21afd9f6cf"
   },
+  "cpython-3.10.12-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "f1fa448384dd48033825e56ee6b5afc76c5dd67dcf2b73b61d2b252ae2e87bca"
+  },
   "cpython-3.10.12-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1220,20 +1220,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "cb6e7c84d9e369a0ee76c9ea73d415a113ba9982db58f44e6bab5414838d35f3"
   },
-  "cpython-3.10.11-darwin-arm64-none": {
+  "cpython-3.10.11-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "da9c8a3cd04485fd397387ea2fa56f3cac71827aafb51d8438b2868f86eb345b"
-  },
-  "cpython-3.10.11-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1242,31 +1231,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "a5271cc014f2ce2ab54a0789556c15b84668e2afcc530512818c4b87c6a94483"
   },
-  "cpython-3.10.11-linux-i686-gnu": {
+  "cpython-3.10.11-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9304d6eeef48bd246a2959ebc76b20dbb2c6a81aa1d214f4471cb273c11717f2"
-  },
-  "cpython-3.10.11-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "60e76e136ab23b891ed1212e58bd11a73a19cd9fd884ec1c5653ca1c159d674e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "da9c8a3cd04485fd397387ea2fa56f3cac71827aafb51d8438b2868f86eb345b"
   },
-  "cpython-3.10.11-linux-ppc64le-gnu": {
+  "cpython-3.10.11-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1275,16 +1253,27 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "ac32e3788109ff0cc536a6108072d9203217df744cf56d3a4ab0b19857d8e244"
   },
-  "cpython-3.10.11-darwin-x86_64-none": {
+  "cpython-3.10.11-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9304d6eeef48bd246a2959ebc76b20dbb2c6a81aa1d214f4471cb273c11717f2"
+  },
+  "cpython-3.10.11-windows-x86-none": {
+    "name": "cpython",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "e84c12aa0285235eed365971ceedf040f4d8014f5342d371e138a4da9e4e9b7c"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "60e76e136ab23b891ed1212e58bd11a73a19cd9fd884ec1c5653ca1c159d674e"
   },
   "cpython-3.10.11-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1308,6 +1297,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "7918188e01a266915dd0945711e274d45c8d7fb540d48240e13c4fd96f43afbb"
   },
+  "cpython-3.10.11-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "e84c12aa0285235eed365971ceedf040f4d8014f5342d371e138a4da9e4e9b7c"
+  },
   "cpython-3.10.11-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1319,20 +1319,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "9b4dc4a335b6122ce783bc80f5015b683e3ab1a56054751c5df494db0521da67"
   },
-  "cpython-3.10.9-darwin-arm64-none": {
+  "cpython-3.10.9-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "2508b8d4b725bb45c3e03d2ddd2b8441f1a74677cb6bd6076e692c0923135ded"
-  },
-  "cpython-3.10.9-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1341,9 +1330,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "2c0996dd1fe35314e06e042081b24fb53f3b7b361c3e1b94a6ed659c275ca069"
   },
-  "cpython-3.10.9-linux-i686-gnu": {
+  "cpython-3.10.9-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "2508b8d4b725bb45c3e03d2ddd2b8441f1a74677cb6bd6076e692c0923135ded"
+  },
+  "cpython-3.10.9-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1352,9 +1352,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "f8c3a63620f412c4a9ccfb6e2435a96a55775550c81a452d164caa6d03a6a1da"
   },
-  "cpython-3.10.9-windows-i686-none": {
+  "cpython-3.10.9-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1362,17 +1362,6 @@
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "3d79cfd229ec12b678bbfd79c30fb4cbad9950d6bfb29741d2315b11839998b4"
-  },
-  "cpython-3.10.9-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "1153b4d3b03cf1e1d8ec93c098160586f665fcc2d162c0812140a716a688df58"
   },
   "cpython-3.10.9-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1396,6 +1385,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "1310f187a73b00164ec4ca34e643841c5c34cbb93fe0b3a3f9504e5ea5001ec7"
   },
+  "cpython-3.10.9-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "1153b4d3b03cf1e1d8ec93c098160586f665fcc2d162c0812140a716a688df58"
+  },
   "cpython-3.10.9-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1407,20 +1407,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "4cfa6299a78a3959102c461d126e4869616f0a49c60b44220c000fc9aecddd78"
   },
-  "cpython-3.10.8-darwin-arm64-none": {
+  "cpython-3.10.8-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "f8ba5f87153a17717e900ff7bba20e2eefe8a53a5bd3c78f9f6922d6d910912d"
-  },
-  "cpython-3.10.8-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1429,9 +1418,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "879e76260be226512693e37a28cc3a6670b5ee270a4440e4b04a7b415dba451c"
   },
-  "cpython-3.10.8-linux-i686-gnu": {
+  "cpython-3.10.8-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "f8ba5f87153a17717e900ff7bba20e2eefe8a53a5bd3c78f9f6922d6d910912d"
+  },
+  "cpython-3.10.8-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1440,9 +1440,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "ab434eccffeec4f6f51af017e4eed69d4f1ea55f48c5b89b8a8779df3fa799df"
   },
-  "cpython-3.10.8-windows-i686-none": {
+  "cpython-3.10.8-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1450,17 +1450,6 @@
     "patch": 8,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "7547ea172f7fa3d7619855f28780da9feb615b6cb52c5c64d34f65b542799fee"
-  },
-  "cpython-3.10.8-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "a18f81ecc7da0779be960ad35c561a834866c0e6d1310a4f742fddfd6163753f"
   },
   "cpython-3.10.8-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1484,6 +1473,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "bb87e933afcfd2e8de045e5a691feff1fb8fb06a09315b37d187762fddfc4546"
   },
+  "cpython-3.10.8-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "a18f81ecc7da0779be960ad35c561a834866c0e6d1310a4f742fddfd6163753f"
+  },
   "cpython-3.10.8-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1495,20 +1495,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "ab40f9584be896c697c5fca351ab82d7b55f01b8eb0494f0a15a67562e49161a"
   },
-  "cpython-3.10.7-darwin-arm64-none": {
+  "cpython-3.10.7-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "9f44cf63441a90f4ec99a032a2bda43971ae7964822daa0ee730a9cba15d50da"
-  },
-  "cpython-3.10.7-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1517,9 +1506,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "9f346729b523e860194635eb67c9f6bc8f12728ba7ddfe4fd80f2e6d685781e3"
   },
-  "cpython-3.10.7-linux-i686-gnu": {
+  "cpython-3.10.7-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "9f44cf63441a90f4ec99a032a2bda43971ae7964822daa0ee730a9cba15d50da"
+  },
+  "cpython-3.10.7-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1528,9 +1528,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "a79816c50abeb2752530f68b4d7d95b6f48392f44a9a7f135b91807d76872972"
   },
-  "cpython-3.10.7-windows-i686-none": {
+  "cpython-3.10.7-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1538,17 +1538,6 @@
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "323532701cb468199d6f14031b991f945d4bbf986ca818185e17e132d3763bdf"
-  },
-  "cpython-3.10.7-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "e03e28dc9fe55ea5ca06fece8f2f2a16646b217d28c0cd09ebcd512f444fdc90"
   },
   "cpython-3.10.7-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1572,6 +1561,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "7f2c933d23c0f38cf145c2d6c65b5cf53bb589690d394fd4c01b2230c23c2bff"
   },
+  "cpython-3.10.7-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "e03e28dc9fe55ea5ca06fece8f2f2a16646b217d28c0cd09ebcd512f444fdc90"
+  },
   "cpython-3.10.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1583,20 +1583,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "5363974e6ee6c91dbd6bc3533e38b02a26abc2ff1c9a095912f237b916be22d3"
   },
-  "cpython-3.10.6-darwin-arm64-none": {
+  "cpython-3.10.6-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "159230851a69cf5cab80318bce48674244d7c6304de81f44c22ff0abdf895cfa"
-  },
-  "cpython-3.10.6-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1605,9 +1594,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "edc1c9742b824caebbc5cb224c8990aa8658b81593fd9219accf3efa3e849501"
   },
-  "cpython-3.10.6-linux-i686-gnu": {
+  "cpython-3.10.6-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "159230851a69cf5cab80318bce48674244d7c6304de81f44c22ff0abdf895cfa"
+  },
+  "cpython-3.10.6-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1616,9 +1616,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "07fa4f5499b8885d1eea49caf5476d76305ab73494b7398dfd22c14093859e4f"
   },
-  "cpython-3.10.6-windows-i686-none": {
+  "cpython-3.10.6-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1626,17 +1626,6 @@
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "8d9a259e15d5a1be48ef13cd5627d7f6c15eadf41a3539e99ed1deee668c075e"
-  },
-  "cpython-3.10.6-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "9405499573a7aa8b67d070d096ded4f3e571f18c2b34762606ecc8025290b122"
   },
   "cpython-3.10.6-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1660,6 +1649,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "f859a72da0bb2f1261f8cebdac931b05b59474c7cb65cee8e85c34fc014dd452"
   },
+  "cpython-3.10.6-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "9405499573a7aa8b67d070d096ded4f3e571f18c2b34762606ecc8025290b122"
+  },
   "cpython-3.10.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1671,20 +1671,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "01dc349721594b1bb5b582651f81479a24352f718fdf6279101caa0f377b160a"
   },
-  "cpython-3.10.5-darwin-arm64-none": {
+  "cpython-3.10.5-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "f68d25dbe9daa96187fa9e05dd8969f46685547fecf1861a99af898f96a5379e"
-  },
-  "cpython-3.10.5-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1693,9 +1682,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "9fa6970a3d0a5dc26c4ed272bb1836d1f1f7a8f4b9d67f634d0262ff8c1fed0b"
   },
-  "cpython-3.10.5-linux-i686-gnu": {
+  "cpython-3.10.5-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "f68d25dbe9daa96187fa9e05dd8969f46685547fecf1861a99af898f96a5379e"
+  },
+  "cpython-3.10.5-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1704,9 +1704,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "63fcfc425adabc034c851dadfb499de3083fd7758582191c12162ad2471256b0"
   },
-  "cpython-3.10.5-windows-i686-none": {
+  "cpython-3.10.5-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1714,17 +1714,6 @@
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "e201192f0aa73904bc5a5f43d1ce4c9fb243dfe02138e690676713fe02c7d662"
-  },
-  "cpython-3.10.5-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "5e372e6738a733532aa985730d9a47ee4c77b7c706e91ef61d37aacbb2e54845"
   },
   "cpython-3.10.5-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1748,6 +1737,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "3682e0add14a3bac654afe467a84981628b0c7ebdccd4ebf26dfaa916238e2fe"
   },
+  "cpython-3.10.5-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "5e372e6738a733532aa985730d9a47ee4c77b7c706e91ef61d37aacbb2e54845"
+  },
   "cpython-3.10.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1759,20 +1759,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "cff35feefe423d4282e9a3e1bb756d0acbb2f776b1ada82c44c71ac3e1491448"
   },
-  "cpython-3.10.4-darwin-arm64-none": {
+  "cpython-3.10.4-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "c404f226195d79933b1e0a3ec88f0b79d35c873de592e223e11008f3a37f83d6"
-  },
-  "cpython-3.10.4-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1781,9 +1770,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "092369e9d170c4c1074e1b305accb74f9486e6185d2e3f3f971869ff89538d3e"
   },
-  "cpython-3.10.4-linux-i686-gnu": {
+  "cpython-3.10.4-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "c404f226195d79933b1e0a3ec88f0b79d35c873de592e223e11008f3a37f83d6"
+  },
+  "cpython-3.10.4-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1792,9 +1792,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "ba940a74a7434fe78d81aed9fb1e5ccdc3d97191a2db35716fc94e3b6604ace0"
   },
-  "cpython-3.10.4-windows-i686-none": {
+  "cpython-3.10.4-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1802,17 +1802,6 @@
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "c37a47e46de93473916f700a790cb43515f00745fba6790004e2731ec934f4d3"
-  },
-  "cpython-3.10.4-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "e447f00fe53168d18cbfe110645dbf33982a17580b9e4424a411f9245d99cd21"
   },
   "cpython-3.10.4-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1836,6 +1825,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "8b8b97f7746a3deca91ada408025457ced34f582dad2114b33ce6fec9cf35b28"
   },
+  "cpython-3.10.4-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "e447f00fe53168d18cbfe110645dbf33982a17580b9e4424a411f9245d99cd21"
+  },
   "cpython-3.10.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1847,20 +1847,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "d636dc1bcca74dd9c6e3b26f7c081b3e229336e8378fe554bf8ba65fe780a2ac"
   },
-  "cpython-3.10.3-darwin-arm64-none": {
+  "cpython-3.10.3-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "b1abefd0fc66922cf9749e4d5ceb97df4d3cfad0cd9cdc4bd04262a68d565698"
-  },
-  "cpython-3.10.3-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1869,9 +1858,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "101284d27578438da200be1f6b9a1ba621432c5549fa5517797ec320bf75e3d5"
   },
-  "cpython-3.10.3-linux-i686-gnu": {
+  "cpython-3.10.3-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "b1abefd0fc66922cf9749e4d5ceb97df4d3cfad0cd9cdc4bd04262a68d565698"
+  },
+  "cpython-3.10.3-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1880,9 +1880,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "43c1cd6e203bfba1a2eeb96cd2a15ce0ebde0e72ecc9555934116459347a9c28"
   },
-  "cpython-3.10.3-windows-i686-none": {
+  "cpython-3.10.3-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1890,17 +1890,6 @@
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "fbc0924a138937fe435fcdb20b0c6241290558e07f158e5578bd91cc8acef469"
-  },
-  "cpython-3.10.3-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "bc5d6f284b506104ff6b4e36cec84cbdb4602dfed4c6fe19971a808eb8c439ec"
   },
   "cpython-3.10.3-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1924,6 +1913,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "7c034d8a5787744939335ce43d64f2ddcc830a74e63773408d0c8f3c3a4e7916"
   },
+  "cpython-3.10.3-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "bc5d6f284b506104ff6b4e36cec84cbdb4602dfed4c6fe19971a808eb8c439ec"
+  },
   "cpython-3.10.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1935,20 +1935,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "72b91d26f54321ba90a86a3bbc711fa1ac31e0704fec352b36e70b0251ffb13c"
   },
-  "cpython-3.10.2-darwin-arm64-none": {
+  "cpython-3.10.2-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "1ef939fd471a9d346a7bc43d2c16fb483ddc4f98af6dad7f08a009e299977a1a"
-  },
-  "cpython-3.10.2-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1957,9 +1946,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "9936f1549f950311229465de509b35c062aa474e504c20a1d6f0f632da57e002"
   },
-  "cpython-3.10.2-linux-i686-gnu": {
+  "cpython-3.10.2-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "1ef939fd471a9d346a7bc43d2c16fb483ddc4f98af6dad7f08a009e299977a1a"
+  },
+  "cpython-3.10.2-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -1968,9 +1968,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "9be2a667f29ed048165cfb3f5dbe61703fd3e5956f8f517ae098740ac8411c0b"
   },
-  "cpython-3.10.2-windows-i686-none": {
+  "cpython-3.10.2-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -1978,17 +1978,6 @@
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "698b09b1b8321a4dc43d62f6230b62adcd0df018b2bcf5f1b4a7ce53dcf23bcc"
-  },
-  "cpython-3.10.2-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "bacf720c13ab67685a384f1417e9c2420972d88f29c8b7c26e72874177f2d120"
   },
   "cpython-3.10.2-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2012,6 +2001,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "df246cf27db346081935d33ce0344a185d1f08b04a4500eb1e21d4d922ee7eb4"
   },
+  "cpython-3.10.2-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "bacf720c13ab67685a384f1417e9c2420972d88f29c8b7c26e72874177f2d120"
+  },
   "cpython-3.10.2-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2023,20 +2023,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "7397e78a4fbe429144adc1f33af942bdd5175184e082ac88f3023b3a740dd1a0"
   },
-  "cpython-3.10.0-darwin-arm64-none": {
+  "cpython-3.10.0-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.10.0-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2045,9 +2034,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-unknown-linux-gnu-debug-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.10.0-linux-i686-gnu": {
+  "cpython-3.10.0-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 0,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.10.0-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2056,26 +2056,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-unknown-linux-gnu-debug-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.10.0-windows-i686-none": {
+  "cpython-3.10.0-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 10,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.10.0-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
     "sha256": null
   },
   "cpython-3.10.0-linux-x86_64-gnu": {
@@ -2100,6 +2089,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
     "sha256": null
   },
+  "cpython-3.10.0-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 0,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
+    "sha256": null
+  },
   "cpython-3.10.0-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2111,20 +2111,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.18-darwin-arm64-none": {
+  "cpython-3.9.18-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "579f9b68bbb3a915cbab9682e4d3c253bc96b0556b8a860982c49c25c61f974a"
-  },
-  "cpython-3.9.18-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2133,31 +2122,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "d27efd4609a3e15ff901040529d5689be99f2ebfe5132ab980d066d775068265"
   },
-  "cpython-3.9.18-linux-i686-gnu": {
+  "cpython-3.9.18-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7faf8fdfbad04e0356a9d52c9b8be4d40ffef85c9ab3e312c45bd64997ef8aa9"
-  },
-  "cpython-3.9.18-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "212d413ab6f854f588cf368fdd2aa140bb7c7ee930e3f7ac1002cba1e50e9685"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "579f9b68bbb3a915cbab9682e4d3c253bc96b0556b8a860982c49c25c61f974a"
   },
-  "cpython-3.9.18-linux-ppc64le-gnu": {
+  "cpython-3.9.18-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2177,16 +2155,27 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "dd05eff699ce5a7eee545bc05e4869c4e64ee02bf0c70691bcee215604c6b393"
   },
-  "cpython-3.9.18-darwin-x86_64-none": {
+  "cpython-3.9.18-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7faf8fdfbad04e0356a9d52c9b8be4d40ffef85c9ab3e312c45bd64997ef8aa9"
+  },
+  "cpython-3.9.18-windows-x86-none": {
+    "name": "cpython",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "146537b9b4a1baa672eed94373e149ca1ee339c4df121e8916d8436265e5245e"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "212d413ab6f854f588cf368fdd2aa140bb7c7ee930e3f7ac1002cba1e50e9685"
   },
   "cpython-3.9.18-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2210,6 +2199,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "8bf88ae2100e609902d98ec775468e3a41a834f6528e632d6d971f5f75340336"
   },
+  "cpython-3.9.18-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "146537b9b4a1baa672eed94373e149ca1ee339c4df121e8916d8436265e5245e"
+  },
   "cpython-3.9.18-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2221,20 +2221,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "924ed4f375ef73c73a725ef18ec6a72726456673d5a116f132f60860a25dd674"
   },
-  "cpython-3.9.17-darwin-arm64-none": {
+  "cpython-3.9.17-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "2902e2a0add6d584999fa27896b721a359f7308404e936e80b01b07aa06e8f5e"
-  },
-  "cpython-3.9.17-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2243,31 +2232,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "1f6c43d92ba9f4e15149cf5db6ecde11e05eee92c070a085e44f46c559520257"
   },
-  "cpython-3.9.17-linux-i686-gnu": {
+  "cpython-3.9.17-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "1a9b7edc16683410c27bc5b4b1761143bef7831a1ad172e7e3581c152c6837a2"
-  },
-  "cpython-3.9.17-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "ffac27bfb8bdf615d0fc6cbbe0becaa65b6ae73feec417919601497fce2be0ab"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "2902e2a0add6d584999fa27896b721a359f7308404e936e80b01b07aa06e8f5e"
   },
-  "cpython-3.9.17-linux-ppc64le-gnu": {
+  "cpython-3.9.17-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2287,16 +2265,27 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "bf8c846c1a4e52355d4ae294f4e1da9587d5415467eb6890bdf0f5a4c8cda396"
   },
-  "cpython-3.9.17-darwin-x86_64-none": {
+  "cpython-3.9.17-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1a9b7edc16683410c27bc5b4b1761143bef7831a1ad172e7e3581c152c6837a2"
+  },
+  "cpython-3.9.17-windows-x86-none": {
+    "name": "cpython",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "ba04f9813b78b61d60a27857949403a1b1dd8ac053e1f1aff72fe2689c238d3c"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "ffac27bfb8bdf615d0fc6cbbe0becaa65b6ae73feec417919601497fce2be0ab"
   },
   "cpython-3.9.17-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2320,6 +2309,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "8496473a97e1dd43bf96fc1cf19f02f305608ef6a783e0112274e0ae01df4f2a"
   },
+  "cpython-3.9.17-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "ba04f9813b78b61d60a27857949403a1b1dd8ac053e1f1aff72fe2689c238d3c"
+  },
   "cpython-3.9.17-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2331,20 +2331,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "209983b8227e4755197dfed4f6887e45b6a133f61e7eb913c0a934b0d0c3e00f"
   },
-  "cpython-3.9.16-darwin-arm64-none": {
+  "cpython-3.9.16-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "c86ed2bf3ff290af10f96183c53e2b29e954abb520806fbe01d3ef2f9d809a75"
-  },
-  "cpython-3.9.16-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2353,31 +2342,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "57ac7ce9d3dd32c1277ee7295daf5ad7b5ecc929e65b31f11b1e7b94cd355ed1"
   },
-  "cpython-3.9.16-linux-i686-gnu": {
+  "cpython-3.9.16-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "e2a0226165550492e895369ee1b69a515f82e12cb969656012ee8e1543409661"
-  },
-  "cpython-3.9.16-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-    "sha256": "d7994b5febb375bb131d028f98f4902ba308913c77095457ccd159b521e20c52"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "c86ed2bf3ff290af10f96183c53e2b29e954abb520806fbe01d3ef2f9d809a75"
   },
-  "cpython-3.9.16-linux-ppc64le-gnu": {
+  "cpython-3.9.16-linux-powerpc64le-gnu": {
     "name": "cpython",
-    "arch": "ppc64le",
+    "arch": "powerpc64le",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2386,16 +2364,27 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "8b2e7ddc6feb116dfa6829cfc478be90a374dc5ce123a98bc77e86d0e93e917d"
   },
-  "cpython-3.9.16-darwin-x86_64-none": {
+  "cpython-3.9.16-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
+    "arch": "x86",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e2a0226165550492e895369ee1b69a515f82e12cb969656012ee8e1543409661"
+  },
+  "cpython-3.9.16-windows-x86-none": {
+    "name": "cpython",
+    "arch": "x86",
+    "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "5809626ca7907c8ea397341f3d5eafb280ed5b19cc5622e57b14d9b4362eba50"
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+    "sha256": "d7994b5febb375bb131d028f98f4902ba308913c77095457ccd159b521e20c52"
   },
   "cpython-3.9.16-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2419,6 +2408,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "c397f292021b33531248ad8fede24ef6249cc6172347b2017f92b4a71845b8ed"
   },
+  "cpython-3.9.16-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "5809626ca7907c8ea397341f3d5eafb280ed5b19cc5622e57b14d9b4362eba50"
+  },
   "cpython-3.9.16-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2430,20 +2430,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "199c821505e287c004c3796ba9ac4bd129d7793e1d833e9a7672ed03bdb397d4"
   },
-  "cpython-3.9.15-darwin-arm64-none": {
+  "cpython-3.9.15-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "1799b97619572ad595cd6d309bbcc57606138a57f4e90af04e04ee31d187e22f"
-  },
-  "cpython-3.9.15-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2452,9 +2441,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "0da1f081313b088c1381206e698e70fffdffc01e1b2ce284145c24ee5f5b4cbb"
   },
-  "cpython-3.9.15-linux-i686-gnu": {
+  "cpython-3.9.15-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "1799b97619572ad595cd6d309bbcc57606138a57f4e90af04e04ee31d187e22f"
+  },
+  "cpython-3.9.15-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2463,9 +2463,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "cbc6a14835022d89f4ca6042a06c4959d74d4bbb58e70bdbe0fe8d2928934922"
   },
-  "cpython-3.9.15-windows-i686-none": {
+  "cpython-3.9.15-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2473,17 +2473,6 @@
     "patch": 15,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "a5ad2a6ace97d458ad7b2857fba519c5c332362442d88e2b23ed818f243b8a78"
-  },
-  "cpython-3.9.15-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "50fd795eac55c4485e2fefbb8e7b365461817733c45becb50a7480a243e6000e"
   },
   "cpython-3.9.15-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2507,6 +2496,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "4597f0009cfb52e748a57badab28edf84a263390b777c182b18c36d666a01440"
   },
+  "cpython-3.9.15-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "50fd795eac55c4485e2fefbb8e7b365461817733c45becb50a7480a243e6000e"
+  },
   "cpython-3.9.15-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2518,20 +2518,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "d0f3ce1748a51779eedf155aea617c39426e3f7bfd93b4876cb172576b6e8bda"
   },
-  "cpython-3.9.14-darwin-arm64-none": {
+  "cpython-3.9.14-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "6b9d2ff724aff88a4d0790c86f2e5d17037736f35a796e71732624191ddd6e38"
-  },
-  "cpython-3.9.14-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2540,9 +2529,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "3020c743e4742d6e0e5d27fcb166c694bf1d9565369b2eaee9d68434304aebd2"
   },
-  "cpython-3.9.14-linux-i686-gnu": {
+  "cpython-3.9.14-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "6b9d2ff724aff88a4d0790c86f2e5d17037736f35a796e71732624191ddd6e38"
+  },
+  "cpython-3.9.14-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2551,9 +2551,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "83a11c4f3d1c0ec39119bd0513a8684b59b68c3989cf1e5042d7417d4770c904"
   },
-  "cpython-3.9.14-windows-i686-none": {
+  "cpython-3.9.14-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2561,17 +2561,6 @@
     "patch": 14,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "fae990eb312314102408cb0c0453dae670f0eb468f4cbf3e72327ceaa1276b46"
-  },
-  "cpython-3.9.14-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "186155e19b63da3248347415f888fbcf982c7587f6f927922ca243ae3f23ed2f"
   },
   "cpython-3.9.14-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2595,6 +2584,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "5638c12d47eb81adf96615cea8a5a61e8414c3ac03a8b570d30ae9998cb6d030"
   },
+  "cpython-3.9.14-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "186155e19b63da3248347415f888fbcf982c7587f6f927922ca243ae3f23ed2f"
+  },
   "cpython-3.9.14-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2606,20 +2606,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "49f27a3a18b4c2d765b0656c6529378a20b3e37fdb0aca9490576ff7a67243a9"
   },
-  "cpython-3.9.13-darwin-arm64-none": {
+  "cpython-3.9.13-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "8612e9328663c0747d1eae36b218d11c2fbc53c39ec7512c7ad6b1b57374a5dc"
-  },
-  "cpython-3.9.13-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2628,9 +2617,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "8c706ebb2c8970da4fbec95b0520b4632309bc6a3e115cf309e38f181b553d14"
   },
-  "cpython-3.9.13-linux-i686-gnu": {
+  "cpython-3.9.13-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "8612e9328663c0747d1eae36b218d11c2fbc53c39ec7512c7ad6b1b57374a5dc"
+  },
+  "cpython-3.9.13-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2639,9 +2639,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "7d33637b48c45acf8805d5460895dca29bf2740fd2cf502fde6c6a00637db6b5"
   },
-  "cpython-3.9.13-windows-i686-none": {
+  "cpython-3.9.13-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2649,17 +2649,6 @@
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "3860abee418825c6a33f76fe88773fb05eb4bc724d246f1af063106d9ea3f999"
-  },
-  "cpython-3.9.13-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "16d21a6e62c19c574a4a225961e80966449095a8eb2c4150905e30d4e807cf86"
   },
   "cpython-3.9.13-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2683,6 +2672,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "c7e48545a8291fe1be909c4454b5c48df0ee4e69e2b5e13b6144b4199c31f895"
   },
+  "cpython-3.9.13-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "16d21a6e62c19c574a4a225961e80966449095a8eb2c4150905e30d4e807cf86"
+  },
   "cpython-3.9.13-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2694,20 +2694,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "6ef2b164cae483c61da30fb6d245762b8d6d91346d66cb421989d6d1462e5a48"
   },
-  "cpython-3.9.12-darwin-arm64-none": {
+  "cpython-3.9.12-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "b3d09b3c12295e893ee8f2cb60e8af94d8a21fc5c65016282925220f5270b85b"
-  },
-  "cpython-3.9.12-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2716,9 +2705,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "202ef64e43570f0843ff5895fd9c1a2c36a96b48d52842fa95842d7d11025b20"
   },
-  "cpython-3.9.12-linux-i686-gnu": {
+  "cpython-3.9.12-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "b3d09b3c12295e893ee8f2cb60e8af94d8a21fc5c65016282925220f5270b85b"
+  },
+  "cpython-3.9.12-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2727,9 +2727,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "e52fdbe61dea847323cd6e81142d16a571dca9c0bcde3bfe5ae75a8d3d1a3bf4"
   },
-  "cpython-3.9.12-windows-i686-none": {
+  "cpython-3.9.12-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2737,17 +2737,6 @@
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "361b8fa66d6b5d5623fd5e64af29cf220a693ba86d031bf7ce2b61e1ea50f568"
-  },
-  "cpython-3.9.12-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "825970ae30ae7a30a5b039aa25f1b965e2d1fe046e196e61fa2a3af8fef8c5d9"
   },
   "cpython-3.9.12-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2771,6 +2760,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "eb122ab2bf0b2d71926984bc7cf5fef65b415abfe01a0974ed6c1a2502fac764"
   },
+  "cpython-3.9.12-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "825970ae30ae7a30a5b039aa25f1b965e2d1fe046e196e61fa2a3af8fef8c5d9"
+  },
   "cpython-3.9.12-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2782,20 +2782,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "c49f8b07e9c4dcfd7a5b55c131e882a4ebdf9f37fef1c7820c3ce9eb23bab8ab"
   },
-  "cpython-3.9.11-darwin-arm64-none": {
+  "cpython-3.9.11-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "6d9f20607a20e2cc5ad1428f7366832dc68403fc15f2e4f195817187e7b6dbbf"
-  },
-  "cpython-3.9.11-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2804,9 +2793,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "e1f3ae07a28a687f8602fb4d29a1b72cc5e113c61dc6769d0d85081ab3e09c71"
   },
-  "cpython-3.9.11-linux-i686-gnu": {
+  "cpython-3.9.11-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "6d9f20607a20e2cc5ad1428f7366832dc68403fc15f2e4f195817187e7b6dbbf"
+  },
+  "cpython-3.9.11-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2815,9 +2815,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "0be0a5f524c68d521be2417565ca43f3125b1845f996d6d62266aa431e673f93"
   },
-  "cpython-3.9.11-windows-i686-none": {
+  "cpython-3.9.11-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2825,17 +2825,6 @@
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "f06338422e7e3ad25d0cd61864bdb36d565d46440dd363cbb98821d388ed377a"
-  },
-  "cpython-3.9.11-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "35e649618e7e602778e72b91c9c50c97d01a0c3509d16225a1f41dd0fd6575f0"
   },
   "cpython-3.9.11-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2859,6 +2848,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "d83eb5c897120e32287cb6fe5c24dd2dcae00878b3f9d7002590d468bd5de0f1"
   },
+  "cpython-3.9.11-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "35e649618e7e602778e72b91c9c50c97d01a0c3509d16225a1f41dd0fd6575f0"
+  },
   "cpython-3.9.11-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2870,20 +2870,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "1fe3c519d43737dc7743aec43f72735e1429c79e06e3901b21bad67b642f1a10"
   },
-  "cpython-3.9.10-darwin-arm64-none": {
+  "cpython-3.9.10-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "ba1b63600ed8d9f3b8d739657bd8e7f5ca167de29a1a58d04b2cd9940b289464"
-  },
-  "cpython-3.9.10-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2892,9 +2881,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "8bf7ac2cd5825b8fde0a6e535266a57c97e82fd5a97877940920b403ca5e53d7"
   },
-  "cpython-3.9.10-linux-i686-gnu": {
+  "cpython-3.9.10-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "ba1b63600ed8d9f3b8d739657bd8e7f5ca167de29a1a58d04b2cd9940b289464"
+  },
+  "cpython-3.9.10-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2903,9 +2903,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "3e3bf4d3e71a2131e6c064d1e5019f58cb9c58fdceae4b76b26ac978a6d49aad"
   },
-  "cpython-3.9.10-windows-i686-none": {
+  "cpython-3.9.10-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -2913,17 +2913,6 @@
     "patch": 10,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "7f3ca15f89775f76a32e6ea9b2c9778ebf0cde753c5973d4493959e75dd92488"
-  },
-  "cpython-3.9.10-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "ef2f090ff920708b4b9aa5d6adf0dc930c09a4bf638d71e6883091f9e629193d"
   },
   "cpython-3.9.10-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2947,6 +2936,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "2744b817f249c0563b844cddd5aba4cc2fd449489b8bd59980d7a31de3a4ece1"
   },
+  "cpython-3.9.10-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "ef2f090ff920708b4b9aa5d6adf0dc930c09a4bf638d71e6883091f9e629193d"
+  },
   "cpython-3.9.10-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2958,20 +2958,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "56b2738599131d03b39b914ea0597862fd9096e5e64816bf19466bf026e74f0c"
   },
-  "cpython-3.9.7-darwin-arm64-none": {
+  "cpython-3.9.7-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.7-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2980,9 +2969,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-unknown-linux-gnu-debug-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.7-linux-i686-gnu": {
+  "cpython-3.9.7-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.7-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -2991,26 +2991,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-unknown-linux-gnu-debug-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.7-windows-i686-none": {
+  "cpython-3.9.7-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.7-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
     "sha256": null
   },
   "cpython-3.9.7-linux-x86_64-gnu": {
@@ -3035,6 +3024,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.7-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3046,20 +3046,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.6-darwin-arm64-none": {
+  "cpython-3.9.6-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.6-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3068,9 +3057,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-unknown-linux-gnu-debug-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.6-linux-i686-gnu": {
+  "cpython-3.9.6-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.6-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3079,26 +3079,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-unknown-linux-gnu-debug-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.6-windows-i686-none": {
+  "cpython-3.9.6-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.6-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
     "sha256": null
   },
   "cpython-3.9.6-linux-x86_64-gnu": {
@@ -3123,6 +3112,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.6-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3134,10 +3134,10 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.5-darwin-arm64-none": {
+  "cpython-3.9.5-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 9,
@@ -3145,9 +3145,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-aarch64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.5-linux-i686-gnu": {
+  "cpython-3.9.5-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3156,26 +3156,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-unknown-linux-gnu-debug-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.5-windows-i686-none": {
+  "cpython-3.9.5-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.5-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
     "sha256": null
   },
   "cpython-3.9.5-linux-x86_64-gnu": {
@@ -3200,6 +3189,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.5-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3211,10 +3211,10 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.4-darwin-arm64-none": {
+  "cpython-3.9.4-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 9,
@@ -3222,9 +3222,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-aarch64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.4-linux-i686-gnu": {
+  "cpython-3.9.4-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3233,26 +3233,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-unknown-linux-gnu-debug-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.4-windows-i686-none": {
+  "cpython-3.9.4-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.4-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
     "sha256": null
   },
   "cpython-3.9.4-linux-x86_64-gnu": {
@@ -3277,6 +3266,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.4-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3288,10 +3288,10 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.3-darwin-arm64-none": {
+  "cpython-3.9.3-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 9,
@@ -3299,26 +3299,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-aarch64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.3-windows-i686-none": {
+  "cpython-3.9.3-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-i686-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.3-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
     "sha256": null
   },
   "cpython-3.9.3-linux-x86_64-gnu": {
@@ -3343,6 +3332,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-musl-lto-20210413T2055.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.3-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3354,10 +3354,10 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.2-darwin-arm64-none": {
+  "cpython-3.9.2-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 9,
@@ -3365,9 +3365,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-aarch64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.2-linux-i686-gnu": {
+  "cpython-3.9.2-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3376,26 +3376,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-unknown-linux-gnu-debug-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.2-windows-i686-none": {
+  "cpython-3.9.2-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.2-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
     "sha256": null
   },
   "cpython-3.9.2-linux-x86_64-gnu": {
@@ -3420,6 +3409,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.2-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 2,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.2-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3431,26 +3431,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.1-windows-i686-none": {
+  "cpython-3.9.1-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 1,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.1-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 1,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
   "cpython-3.9.1-linux-x86_64-gnu": {
@@ -3475,6 +3464,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.1-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 1,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.1-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3486,26 +3486,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.0-windows-i686-none": {
+  "cpython-3.9.0-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 9,
     "patch": 0,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-i686-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.0-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 0,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
     "sha256": null
   },
   "cpython-3.9.0-linux-x86_64-gnu": {
@@ -3530,6 +3519,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.0-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 0,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.0-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3541,20 +3541,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.18-darwin-arm64-none": {
+  "cpython-3.8.18-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "c732c068cddcd6a008c1d6d8e35802f5bdc7323bd2eb64e77210d3d5fe4740c2"
-  },
-  "cpython-3.8.18-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3563,9 +3552,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "6d71175a090950c2063680f250b8799ab39eb139aa1721c853d8950aadd1d4e2"
   },
-  "cpython-3.8.18-windows-i686-none": {
+  "cpython-3.8.18-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 18,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "c732c068cddcd6a008c1d6d8e35802f5bdc7323bd2eb64e77210d3d5fe4740c2"
+  },
+  "cpython-3.8.18-windows-x86-none": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3573,17 +3573,6 @@
     "patch": 18,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "9f94c7b54b97116cd308e73cda0b7a7b7fff4515932c5cbba18eeae9ec798351"
-  },
-  "cpython-3.8.18-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 18,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "4d4b65dd821ce13dcf6dfea3ad5c2d4c3d3a8c2b7dd49fc35c1d79f66238e89b"
   },
   "cpython-3.8.18-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3607,6 +3596,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "fa1bf64cf52d830e7b4bba486c447ee955af644d167df7c42afd169c5dc71d6a"
   },
+  "cpython-3.8.18-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 18,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "4d4b65dd821ce13dcf6dfea3ad5c2d4c3d3a8c2b7dd49fc35c1d79f66238e89b"
+  },
   "cpython-3.8.18-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3618,20 +3618,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "c63abd9365a13196eb9f65db864f95b85c1f90b770d218c1acd104e6b48a99d3"
   },
-  "cpython-3.8.17-darwin-arm64-none": {
+  "cpython-3.8.17-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "d08a542bed35fc74ac6e8f6884c8aa29a77ff2f4ed04a06dcf91578dea622f9a"
-  },
-  "cpython-3.8.17-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3640,9 +3629,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "eaee5a0b79cc28943e19df54f314634795aee43a6670ce99c0306893a18fa784"
   },
-  "cpython-3.8.17-linux-i686-gnu": {
+  "cpython-3.8.17-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "d08a542bed35fc74ac6e8f6884c8aa29a77ff2f4ed04a06dcf91578dea622f9a"
+  },
+  "cpython-3.8.17-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3651,9 +3651,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "61ac08680c022f180a32dc82d84548aeb92c7194a489e3b3c532dc48f999d757"
   },
-  "cpython-3.8.17-windows-i686-none": {
+  "cpython-3.8.17-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3661,17 +3661,6 @@
     "patch": 17,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "0931d8ca0e060c6ac1dfcf6bb9b6dea0ac3a9d95daf7906a88128045f4464bf8"
-  },
-  "cpython-3.8.17-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 17,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "2c4925f5cf37d498e0d8cfe7b10591cc5f0cd80d2582f566b12006e6f96958b1"
   },
   "cpython-3.8.17-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3695,6 +3684,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "a316ba0b1f425b04c8dfd7a8a18a05d72ae5852732d401b16d7439bdf25caec3"
   },
+  "cpython-3.8.17-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "2c4925f5cf37d498e0d8cfe7b10591cc5f0cd80d2582f566b12006e6f96958b1"
+  },
   "cpython-3.8.17-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3706,20 +3706,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "68c7d03de5283c4812f2706c797b2139999a28cec647bc662d1459a922059318"
   },
-  "cpython-3.8.16-darwin-arm64-none": {
+  "cpython-3.8.16-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "bfc91d0a1d6d6dfaa5a31c925aa6adae82bd1ae5eb17813a9f0a50bf9d3e6305"
-  },
-  "cpython-3.8.16-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3728,9 +3717,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "423d43d93e2fe33b41ad66d35426f16541f09fee9d7272ae5decf5474ebbc225"
   },
-  "cpython-3.8.16-linux-i686-gnu": {
+  "cpython-3.8.16-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "bfc91d0a1d6d6dfaa5a31c925aa6adae82bd1ae5eb17813a9f0a50bf9d3e6305"
+  },
+  "cpython-3.8.16-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3739,9 +3739,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "9aa3e559130a47c33ee2b67f6ca69e2f10d8f70c1fd1e2871763b892372a6d9e"
   },
-  "cpython-3.8.16-windows-i686-none": {
+  "cpython-3.8.16-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3749,17 +3749,6 @@
     "patch": 16,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "5de953621402c11cc7db65ba15d45779e838d7ce78e7aa8d43c7d78fff177f13"
-  },
-  "cpython-3.8.16-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 16,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "21c0f4a0fa6ee518b9f2f1901c9667e3baf45d9f84235408b7ca50499d19f56d"
   },
   "cpython-3.8.16-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3783,6 +3772,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "f7d46196b44d12a26209ac74061200aac478b96c253eea93a0b9734efa642779"
   },
+  "cpython-3.8.16-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "21c0f4a0fa6ee518b9f2f1901c9667e3baf45d9f84235408b7ca50499d19f56d"
+  },
   "cpython-3.8.16-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3794,20 +3794,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "6316713c2dcb30127b38ced249fa9608830a33459580b71275a935aaa8cd5d5f"
   },
-  "cpython-3.8.15-darwin-arm64-none": {
+  "cpython-3.8.15-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "fc0f944e6f01ed649f79c873af1c317db61d2136b82081b4d7cbb7755f878035"
-  },
-  "cpython-3.8.15-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3816,9 +3805,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "2e80025eda686c14a9a0618ced40043c1d577a754b904fd7a382cd41abf9ca00"
   },
-  "cpython-3.8.15-linux-i686-gnu": {
+  "cpython-3.8.15-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "fc0f944e6f01ed649f79c873af1c317db61d2136b82081b4d7cbb7755f878035"
+  },
+  "cpython-3.8.15-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3827,9 +3827,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "b8436415ea9bd9970fb766f791a14b0e14ce6351fc4604eb158f1425e8bb4a33"
   },
-  "cpython-3.8.15-windows-i686-none": {
+  "cpython-3.8.15-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3837,17 +3837,6 @@
     "patch": 15,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "98bb2315c3567316c30b060d613c8d6067b368b64f08ef8fe6196341637c1d78"
-  },
-  "cpython-3.8.15-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 15,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "e4fd2fa2255295fbdcfadb8b48014fa80810305eccb246d355880aabb45cbe93"
   },
   "cpython-3.8.15-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3871,6 +3860,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "231b35d3c2cff0372d17cea7ff5168c0684a920b94a912ffc965c2518cacb694"
   },
+  "cpython-3.8.15-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "e4fd2fa2255295fbdcfadb8b48014fa80810305eccb246d355880aabb45cbe93"
+  },
   "cpython-3.8.15-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3882,20 +3882,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "59beac5610e6da0848ebaccd72f91f6aaaeed65ef59606d006af909e9e79beba"
   },
-  "cpython-3.8.14-darwin-arm64-none": {
+  "cpython-3.8.14-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "d17a3fcc161345efa2ec0b4ab9c9ed6c139d29128f2e34bb636338a484aa7b72"
-  },
-  "cpython-3.8.14-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3904,9 +3893,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "a14d8b5cbd8e1ca45cbcb49f4bf0b0440dc86eb95b7c3da3c463a704a3b4593c"
   },
-  "cpython-3.8.14-linux-i686-gnu": {
+  "cpython-3.8.14-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "d17a3fcc161345efa2ec0b4ab9c9ed6c139d29128f2e34bb636338a484aa7b72"
+  },
+  "cpython-3.8.14-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3915,9 +3915,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "631bb90fe8f2965d03400b268de90fe155ce51961296360d6578b7151aa9ef4c"
   },
-  "cpython-3.8.14-windows-i686-none": {
+  "cpython-3.8.14-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -3925,17 +3925,6 @@
     "patch": 14,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "e43f7a5044eac91e95df59fd08bf96f13245898876fc2afd90a081cfcd847e35"
-  },
-  "cpython-3.8.14-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 14,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "62edfea77b42e87ca2d85c482319211cd2dd68d55ba85c99f1834f7b64a60133"
   },
   "cpython-3.8.14-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3959,6 +3948,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "c6da442aaea160179a9379b297ccb3ba09b825fc27d84577fc28e62911451e7d"
   },
+  "cpython-3.8.14-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "62edfea77b42e87ca2d85c482319211cd2dd68d55ba85c99f1834f7b64a60133"
+  },
   "cpython-3.8.14-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3970,20 +3970,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "6986b3e6edf7b37f96ea940b7ccba7b767ed3ea9b3faec2a2a60e5b2c4443314"
   },
-  "cpython-3.8.13-darwin-arm64-none": {
+  "cpython-3.8.13-linux-aarch64-gnu": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "a204e5f9e1566bdc170b163300a29fc9580d5c65cd6e896caf6500cd64471373"
-  },
-  "cpython-3.8.13-linux-arm64-gnu": {
-    "name": "cpython",
-    "arch": "arm64",
+    "arch": "aarch64",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -3992,9 +3981,20 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "3a927205db4686c182b5e8f3fc7fd7d82ec8f61c70d5b2bfddd9673c7ddc07ba"
   },
-  "cpython-3.8.13-linux-i686-gnu": {
+  "cpython-3.8.13-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "aarch64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "a204e5f9e1566bdc170b163300a29fc9580d5c65cd6e896caf6500cd64471373"
+  },
+  "cpython-3.8.13-linux-x86-gnu": {
+    "name": "cpython",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4003,9 +4003,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "6daf0405beae6d127a2dcae61d51a719236b861b4cabc220727e48547fd6f045"
   },
-  "cpython-3.8.13-windows-i686-none": {
+  "cpython-3.8.13-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4013,17 +4013,6 @@
     "patch": 13,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "5630739d1c6fcfbf90311d236c5e46314fc4b439364429bee12d0ffc95e134fb"
-  },
-  "cpython-3.8.13-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 13,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "f706a62de8582bf84b8b693c993314cd786f3e78639892cfd9a7283a526696f9"
   },
   "cpython-3.8.13-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4047,6 +4036,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "410f3223021d1b439cf8e4da699f868adada2066e354d88a00b5f365dc66c4bf"
   },
+  "cpython-3.8.13-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "f706a62de8582bf84b8b693c993314cd786f3e78639892cfd9a7283a526696f9"
+  },
   "cpython-3.8.13-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4058,10 +4058,10 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "c36b703b8b806a047ba71e5e85734ac78d204d3a2b7ebc2efcdc7d4af6f6c263"
   },
-  "cpython-3.8.12-darwin-arm64-none": {
+  "cpython-3.8.12-macos-aarch64-none": {
     "name": "cpython",
-    "arch": "arm64",
-    "os": "darwin",
+    "arch": "aarch64",
+    "os": "macos",
     "libc": "none",
     "major": 3,
     "minor": 8,
@@ -4069,9 +4069,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
     "sha256": "386f667f8d49b6c34aee1910cdc0b5b41883f9406f98e7d59a3753990b1cdbac"
   },
-  "cpython-3.8.12-linux-i686-gnu": {
+  "cpython-3.8.12-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4080,9 +4080,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "7cfac9a57e262be3e889036d7fc570293e6d3d74411ee23e1fa9aa470d387e6a"
   },
-  "cpython-3.8.12-windows-i686-none": {
+  "cpython-3.8.12-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
@@ -4090,17 +4090,6 @@
     "patch": 12,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "3e2e6c7de78b1924aad37904fed7bfbac6efa2bef05348e9be92180b2f2b1ae1"
-  },
-  "cpython-3.8.12-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 12,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-    "sha256": "cf614d96e2001d526061b3ce0569c79057fd0074ace472ff4f5f601262e08cdb"
   },
   "cpython-3.8.12-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4124,6 +4113,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-musl-lto-full.tar.zst",
     "sha256": "3d958e3f984637d8ca4a90a2e068737b268f87fc615121a6f1808cd46ccacc48"
   },
+  "cpython-3.8.12-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 12,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+    "sha256": "cf614d96e2001d526061b3ce0569c79057fd0074ace472ff4f5f601262e08cdb"
+  },
   "cpython-3.8.12-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4135,9 +4135,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-pc-windows-msvc-shared-pgo-full.tar.zst",
     "sha256": "33f278416ba8074f2ca6d7f8c17b311b60537c9e6431fd47948784c2a78ea227"
   },
-  "cpython-3.8.11-linux-i686-gnu": {
+  "cpython-3.8.11-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4146,26 +4146,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-unknown-linux-gnu-debug-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.11-windows-i686-none": {
+  "cpython-3.8.11-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 11,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.11-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 11,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
     "sha256": null
   },
   "cpython-3.8.11-linux-x86_64-gnu": {
@@ -4190,6 +4179,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.11-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 11,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.11-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4201,9 +4201,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.10-linux-i686-gnu": {
+  "cpython-3.8.10-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4212,26 +4212,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-unknown-linux-gnu-debug-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.10-windows-i686-none": {
+  "cpython-3.8.10-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 10,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.10-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 10,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
     "sha256": null
   },
   "cpython-3.8.10-linux-x86_64-gnu": {
@@ -4256,6 +4245,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.10-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 10,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.10-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4267,9 +4267,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.9-linux-i686-gnu": {
+  "cpython-3.8.9-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4278,26 +4278,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-unknown-linux-gnu-debug-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.9-windows-i686-none": {
+  "cpython-3.8.9-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.9-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
     "sha256": null
   },
   "cpython-3.8.9-linux-x86_64-gnu": {
@@ -4322,6 +4311,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.9-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 9,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.9-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4333,9 +4333,9 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.8-linux-i686-gnu": {
+  "cpython-3.8.8-linux-x86-gnu": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "linux",
     "libc": "gnu",
     "major": 3,
@@ -4344,26 +4344,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-unknown-linux-gnu-debug-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.8-windows-i686-none": {
+  "cpython-3.8.8-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 8,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.8-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 8,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
     "sha256": null
   },
   "cpython-3.8.8-linux-x86_64-gnu": {
@@ -4388,6 +4377,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.8-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 8,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.8-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4399,26 +4399,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.7-windows-i686-none": {
+  "cpython-3.8.7-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.7-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
   "cpython-3.8.7-linux-x86_64-gnu": {
@@ -4443,6 +4432,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.7-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4454,26 +4454,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.6-windows-i686-none": {
+  "cpython-3.8.6-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-i686-pc-windows-msvc-shared-pgo-20201021T0233.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.6-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
     "sha256": null
   },
   "cpython-3.8.6-linux-x86_64-gnu": {
@@ -4498,6 +4487,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.6-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4509,26 +4509,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-pc-windows-msvc-shared-pgo-20201021T0232.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.5-windows-i686-none": {
+  "cpython-3.8.5-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-i686-pc-windows-msvc-shared-pgo-20200830T2311.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.5-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.8.5-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
     "sha256": null
   },
   "cpython-3.8.5-linux-x86_64-gnu": {
@@ -4553,6 +4542,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.5-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.8.5-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4564,26 +4564,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-x86_64-pc-windows-msvc-shared-pgo-20200830T2254.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.3-windows-i686-none": {
+  "cpython-3.8.3-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-i686-pc-windows-msvc-shared-pgo-20200518T0154.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.3-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.8.3-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
     "sha256": null
   },
   "cpython-3.8.3-linux-x86_64-gnu": {
@@ -4608,6 +4597,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.3-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.8.3-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4619,26 +4619,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-pc-windows-msvc-shared-pgo-20200517T2207.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.2-windows-i686-none": {
+  "cpython-3.8.2-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 8,
     "patch": 2,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-i686-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.2-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 2,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-apple-darwin-pgo-20200418T2238.tar.zst",
     "sha256": null
   },
   "cpython-3.8.2-linux-x86_64-gnu": {
@@ -4652,6 +4641,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-unknown-linux-gnu-debug-20200418T2305.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.2-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 2,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-apple-darwin-pgo-20200418T2238.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.2-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4663,26 +4663,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.9-windows-i686-none": {
+  "cpython-3.7.9-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 9,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-i686-pc-windows-msvc-shared-pgo-20200823T0159.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.9-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 9,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.7.9-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
     "sha256": null
   },
   "cpython-3.7.9-linux-x86_64-gnu": {
@@ -4707,6 +4696,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
     "sha256": null
   },
+  "cpython-3.7.9-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 9,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.7.9-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
+    "sha256": null
+  },
   "cpython-3.7.9-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4718,26 +4718,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-pc-windows-msvc-shared-pgo-20200823T0118.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.7-windows-i686-none": {
+  "cpython-3.7.7-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 7,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-i686-pc-windows-msvc-shared-pgo-20200517T2153.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.7-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 7,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.7.7-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
     "sha256": null
   },
   "cpython-3.7.7-linux-x86_64-gnu": {
@@ -4762,6 +4751,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
     "sha256": null
   },
+  "cpython-3.7.7-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 7,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.7.7-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
+    "sha256": null
+  },
   "cpython-3.7.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4773,26 +4773,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-pc-windows-msvc-shared-pgo-20200517T2128.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.6-windows-i686-none": {
+  "cpython-3.7.6-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 6,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-x86-shared-pgo-20200217T0110.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.6-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 6,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-macos-20200216T2344.tar.zst",
     "sha256": null
   },
   "cpython-3.7.6-linux-x86_64-gnu": {
@@ -4817,6 +4806,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200217/cpython-3.7.6-linux64-musl-20200218T0557.tar.zst",
     "sha256": null
   },
+  "cpython-3.7.6-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 6,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-macos-20200216T2344.tar.zst",
+    "sha256": null
+  },
   "cpython-3.7.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4828,26 +4828,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-amd64-shared-pgo-20200217T0022.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.5-windows-i686-none": {
+  "cpython-3.7.5-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 5,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-x86-20191025T0549.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.5-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 5,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-macos-20191026T0535.tar.zst",
     "sha256": null
   },
   "cpython-3.7.5-linux-x86_64-gnu": {
@@ -4872,6 +4861,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-linux64-musl-20191026T0603.tar.zst",
     "sha256": null
   },
+  "cpython-3.7.5-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 5,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-macos-20191026T0535.tar.zst",
+    "sha256": null
+  },
   "cpython-3.7.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4883,26 +4883,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-amd64-20191025T0540.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.4-windows-i686-none": {
+  "cpython-3.7.4-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 4,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-x86-20190817T0235.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.4-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 4,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-macos-20190817T0220.tar.zst",
     "sha256": null
   },
   "cpython-3.7.4-linux-x86_64-gnu": {
@@ -4927,6 +4916,17 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-linux64-musl-20190817T0227.tar.zst",
     "sha256": null
   },
+  "cpython-3.7.4-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 4,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-macos-20190817T0220.tar.zst",
+    "sha256": null
+  },
   "cpython-3.7.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4938,26 +4938,15 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-amd64-20190817T0227.tar.zst",
     "sha256": null
   },
-  "cpython-3.7.3-windows-i686-none": {
+  "cpython-3.7.3-windows-x86-none": {
     "name": "cpython",
-    "arch": "i686",
+    "arch": "x86",
     "os": "windows",
     "libc": "none",
     "major": 3,
     "minor": 7,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-x86-20190709T0348.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.3-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 3,
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-macos-20190618T0523.tar.zst",
     "sha256": null
   },
   "cpython-3.7.3-linux-x86_64-gnu": {
@@ -4980,6 +4969,17 @@
     "minor": 7,
     "patch": 3,
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-linux64-musl-20190618T0400.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.7.3-macos-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "macos",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 3,
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-macos-20190618T0523.tar.zst",
     "sha256": null
   },
   "cpython-3.7.3-windows-x86_64-none": {

--- a/crates/uv-toolchain/src/find.rs
+++ b/crates/uv-toolchain/src/find.rs
@@ -1,0 +1,15 @@
+use std::path::{Path, PathBuf};
+
+use once_cell::sync::Lazy;
+
+pub static TOOLCHAIN_DIRECTORY: Lazy<PathBuf> = Lazy::new(|| {
+    std::env::var_os("UV_BOOTSTRAP_DIR").map_or(
+        Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+            .parent()
+            .expect("CARGO_MANIFEST_DIR should be nested in workspace")
+            .parent()
+            .expect("CARGO_MANIFEST_DIR should be doubly nested in workspace")
+            .join("bin"),
+        PathBuf::from,
+    )
+});

--- a/crates/uv-toolchain/src/lib.rs
+++ b/crates/uv-toolchain/src/lib.rs
@@ -1,3 +1,5 @@
 pub use downloads::{DownloadResult, Error, Platform, PythonDownload, PythonDownloadRequest};
+pub use find::TOOLCHAIN_DIRECTORY;
 
 mod downloads;
+mod find;

--- a/crates/uv-toolchain/src/python_versions.inc
+++ b/crates/uv-toolchain/src/python_versions.inc
@@ -5,48 +5,36 @@
 
 pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
     PythonDownload {
-        key: "cpython-3.12.2-darwin-arm64-none",
+        key: "cpython-3.12.2-linux-aarch64-gnu",
         major: 3,
         minor: 12,
         patch: 2,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("2afcc8b25c55793f6ceb0bef2e547e101f53c9e25a0fe0332320e5381a1f0fdb")
-    },
-    PythonDownload {
-        key: "cpython-3.12.2-linux-arm64-gnu",
-        major: 3,
-        minor: 12,
-        patch: 2,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("469a7fd0d0a09936c5db41b5ac83bb29d5bfeb721aa483ac92f3f7ac4d311097")
     },
     PythonDownload {
-        key: "cpython-3.12.2-windows-i686-none",
+        key: "cpython-3.12.2-macos-aarch64-none",
         major: 3,
         minor: 12,
         patch: 2,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("ee985ae6a6a98f4d5bd19fd8c59f45235911d19b64e1dbd026261b8103f15db5")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("2afcc8b25c55793f6ceb0bef2e547e101f53c9e25a0fe0332320e5381a1f0fdb")
     },
     PythonDownload {
-        key: "cpython-3.12.2-linux-ppc64le-gnu",
+        key: "cpython-3.12.2-linux-powerpc64le-gnu",
         major: 3,
         minor: 12,
         patch: 2,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -65,16 +53,16 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("f40b88607928b5ee34ff87c1d574c8493a1604d7a40474e1b03731184186f419")
     },
     PythonDownload {
-        key: "cpython-3.12.2-darwin-x86_64-none",
+        key: "cpython-3.12.2-windows-x86-none",
         major: 3,
         minor: 12,
         patch: 2,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("b4b4d19c36e86803aa0b4410395f5568bef28d82666efba926e44dbe06345a12")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("ee985ae6a6a98f4d5bd19fd8c59f45235911d19b64e1dbd026261b8103f15db5")
     },
     PythonDownload {
         key: "cpython-3.12.2-linux-x86_64-gnu",
@@ -101,6 +89,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("7ec1dc7ad8223ec5839a57d232fd3cf730987f7b0f88b2c4f15ee935bcabbaa9")
     },
     PythonDownload {
+        key: "cpython-3.12.2-macos-x86_64-none",
+        major: 3,
+        minor: 12,
+        patch: 2,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("b4b4d19c36e86803aa0b4410395f5568bef28d82666efba926e44dbe06345a12")
+    },
+    PythonDownload {
         key: "cpython-3.12.2-windows-x86_64-none",
         major: 3,
         minor: 12,
@@ -113,48 +113,36 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("a1daf5e8ceb23d34ea29b16b5123b06694810fe7acc5c8384426435c63bf731e")
     },
     PythonDownload {
-        key: "cpython-3.12.1-darwin-arm64-none",
+        key: "cpython-3.12.1-linux-aarch64-gnu",
         major: 3,
         minor: 12,
         patch: 1,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("61e51e3490537b800fcefad718157cf775de41044e95aa538b63ab599f66f3a9")
-    },
-    PythonDownload {
-        key: "cpython-3.12.1-linux-arm64-gnu",
-        major: 3,
-        minor: 12,
-        patch: 1,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("9009da24f436611d0bf086b8ea62aaed1c27104af5b770ddcfc92b60db06da8c")
     },
     PythonDownload {
-        key: "cpython-3.12.1-windows-i686-none",
+        key: "cpython-3.12.1-macos-aarch64-none",
         major: 3,
         minor: 12,
         patch: 1,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("22866d35fdf58e90e75d6ba9aa78c288b452ea7041fa9bc5549eca9daa431883")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("61e51e3490537b800fcefad718157cf775de41044e95aa538b63ab599f66f3a9")
     },
     PythonDownload {
-        key: "cpython-3.12.1-linux-ppc64le-gnu",
+        key: "cpython-3.12.1-linux-powerpc64le-gnu",
         major: 3,
         minor: 12,
         patch: 1,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -173,16 +161,16 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("505a4fbace661a43b354a059022eb31efb406859a5f7227109ebf0f278f20503")
     },
     PythonDownload {
-        key: "cpython-3.12.1-darwin-x86_64-none",
+        key: "cpython-3.12.1-windows-x86-none",
         major: 3,
         minor: 12,
         patch: 1,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("bf2b176b0426d7b4d4909c1b19bbb25b4893f9ebdc61e32df144df2b10dcc800")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("22866d35fdf58e90e75d6ba9aa78c288b452ea7041fa9bc5549eca9daa431883")
     },
     PythonDownload {
         key: "cpython-3.12.1-linux-x86_64-gnu",
@@ -209,6 +197,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("c4b07a02d8f0986b56e010a67132e5eeba1def4991c6c06ed184f831a484a06f")
     },
     PythonDownload {
+        key: "cpython-3.12.1-macos-x86_64-none",
+        major: 3,
+        minor: 12,
+        patch: 1,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("bf2b176b0426d7b4d4909c1b19bbb25b4893f9ebdc61e32df144df2b10dcc800")
+    },
+    PythonDownload {
         key: "cpython-3.12.1-windows-x86_64-none",
         major: 3,
         minor: 12,
@@ -221,48 +221,36 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("d9bc1b566250bf51818976bf98bf50e1f4c59b2503b50d29250cac5ab5ef6b38")
     },
     PythonDownload {
-        key: "cpython-3.12.0-darwin-arm64-none",
+        key: "cpython-3.12.0-linux-aarch64-gnu",
         major: 3,
         minor: 12,
         patch: 0,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("25fc8cd41e975d18d13bcc8f8beffa096ff8a0b86c4a737e1c6617900092c966")
-    },
-    PythonDownload {
-        key: "cpython-3.12.0-linux-arm64-gnu",
-        major: 3,
-        minor: 12,
-        patch: 0,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("eb05c976374a9a44596ce340ab35e5461014f30202c3cbe10edcbfbe5ac4a6a1")
     },
     PythonDownload {
-        key: "cpython-3.12.0-windows-i686-none",
+        key: "cpython-3.12.0-macos-aarch64-none",
         major: 3,
         minor: 12,
         patch: 0,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("465e91b6e6d0d1c40c8a4bce3642c4adcb9b75cf03fbd5fd5a33a36358249289")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("25fc8cd41e975d18d13bcc8f8beffa096ff8a0b86c4a737e1c6617900092c966")
     },
     PythonDownload {
-        key: "cpython-3.12.0-linux-ppc64le-gnu",
+        key: "cpython-3.12.0-linux-powerpc64le-gnu",
         major: 3,
         minor: 12,
         patch: 0,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -281,16 +269,16 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("5b1a1effbb43df57ad014fcebf4b20089e504d89613e7b8db22d9ccb9fb00a6c")
     },
     PythonDownload {
-        key: "cpython-3.12.0-darwin-x86_64-none",
+        key: "cpython-3.12.0-windows-x86-none",
         major: 3,
         minor: 12,
         patch: 0,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("3b4781e7fd4efabe574ba0954e54c35c7d5ac4dc5b2990b40796c1c6aec67d79")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("465e91b6e6d0d1c40c8a4bce3642c4adcb9b75cf03fbd5fd5a33a36358249289")
     },
     PythonDownload {
         key: "cpython-3.12.0-linux-x86_64-gnu",
@@ -317,6 +305,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("91b42595cb4b69ff396e746dc492caf67b952a3ed1a367a4ace1acc965ed9cdb")
     },
     PythonDownload {
+        key: "cpython-3.12.0-macos-x86_64-none",
+        major: 3,
+        minor: 12,
+        patch: 0,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("3b4781e7fd4efabe574ba0954e54c35c7d5ac4dc5b2990b40796c1c6aec67d79")
+    },
+    PythonDownload {
         key: "cpython-3.12.0-windows-x86_64-none",
         major: 3,
         minor: 12,
@@ -329,48 +329,36 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("5bdff7ed56550d96f9b26a27a8c25f0cc58a03bff19e5f52bba84366183cab8b")
     },
     PythonDownload {
-        key: "cpython-3.11.8-darwin-arm64-none",
+        key: "cpython-3.11.8-linux-aarch64-gnu",
         major: 3,
         minor: 11,
         patch: 8,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("c0650884b929253b8688797d1955850f6e339bf0428b3d935f62ab3159f66362")
-    },
-    PythonDownload {
-        key: "cpython-3.11.8-linux-arm64-gnu",
-        major: 3,
-        minor: 11,
-        patch: 8,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("45bf082aca6b7d5e7261852720a72b92f5305e9fdb07b10f6588cb51d8f83ff2")
     },
     PythonDownload {
-        key: "cpython-3.11.8-windows-i686-none",
+        key: "cpython-3.11.8-macos-aarch64-none",
         major: 3,
         minor: 11,
         patch: 8,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("c3e90962996177a027bd73dd9fd8c42a2d6ef832cda26db4ab4efc6105160537")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("c0650884b929253b8688797d1955850f6e339bf0428b3d935f62ab3159f66362")
     },
     PythonDownload {
-        key: "cpython-3.11.8-linux-ppc64le-gnu",
+        key: "cpython-3.11.8-linux-powerpc64le-gnu",
         major: 3,
         minor: 11,
         patch: 8,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -389,16 +377,16 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("d495830b5980ed689bd7588aa556bac9c43ff766d8a8b32e7791b8ed664b04f3")
     },
     PythonDownload {
-        key: "cpython-3.11.8-darwin-x86_64-none",
+        key: "cpython-3.11.8-windows-x86-none",
         major: 3,
         minor: 11,
         patch: 8,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("54f8c8ad7313b3505e495bb093825d85eab244306ca4278836a2c7b5b74fb053")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("c3e90962996177a027bd73dd9fd8c42a2d6ef832cda26db4ab4efc6105160537")
     },
     PythonDownload {
         key: "cpython-3.11.8-linux-x86_64-gnu",
@@ -425,6 +413,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("a03a9d8c1f770ce418716a2e8185df7b3a9e0012cdc220f9f2d24480a432650b")
     },
     PythonDownload {
+        key: "cpython-3.11.8-macos-x86_64-none",
+        major: 3,
+        minor: 11,
+        patch: 8,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("54f8c8ad7313b3505e495bb093825d85eab244306ca4278836a2c7b5b74fb053")
+    },
+    PythonDownload {
         key: "cpython-3.11.8-windows-x86_64-none",
         major: 3,
         minor: 11,
@@ -437,48 +437,36 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("6da82390f7ac49f6c4b19a5b8019c4ddc1eef2c5ad6a2f2d32773a27663a4e14")
     },
     PythonDownload {
-        key: "cpython-3.11.7-darwin-arm64-none",
+        key: "cpython-3.11.7-linux-aarch64-gnu",
         major: 3,
         minor: 11,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("c1f3dd13825906a5eae23ed8de9b653edb620568b2e0226eef3784eb1cce7eed")
-    },
-    PythonDownload {
-        key: "cpython-3.11.7-linux-arm64-gnu",
-        major: 3,
-        minor: 11,
-        patch: 7,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("e3a375f8f16198ccf8dbede231536544265e5b4b6b0f0df97c5b29503c5864e2")
     },
     PythonDownload {
-        key: "cpython-3.11.7-windows-i686-none",
+        key: "cpython-3.11.7-macos-aarch64-none",
         major: 3,
         minor: 11,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("6613f1f9238d19969d8a2827deec84611cb772503207056cc9f0deb89bea48cd")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("c1f3dd13825906a5eae23ed8de9b653edb620568b2e0226eef3784eb1cce7eed")
     },
     PythonDownload {
-        key: "cpython-3.11.7-linux-ppc64le-gnu",
+        key: "cpython-3.11.7-linux-powerpc64le-gnu",
         major: 3,
         minor: 11,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -497,16 +485,16 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("91b33369025b7e0079f603cd2a99f9a5932daa8ded113d5090f29c075c993df7")
     },
     PythonDownload {
-        key: "cpython-3.11.7-darwin-x86_64-none",
+        key: "cpython-3.11.7-windows-x86-none",
         major: 3,
         minor: 11,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("3f8caf73f2bfe22efa9666974c119727e163716e88af8ed3caa1e0ae5493de61")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("6613f1f9238d19969d8a2827deec84611cb772503207056cc9f0deb89bea48cd")
     },
     PythonDownload {
         key: "cpython-3.11.7-linux-x86_64-gnu",
@@ -533,6 +521,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("f387d373d64447bbba8a5657712f93b1dbdfd7246cdfe5a0493f39b83d46ec7c")
     },
     PythonDownload {
+        key: "cpython-3.11.7-macos-x86_64-none",
+        major: 3,
+        minor: 11,
+        patch: 7,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("3f8caf73f2bfe22efa9666974c119727e163716e88af8ed3caa1e0ae5493de61")
+    },
+    PythonDownload {
         key: "cpython-3.11.7-windows-x86_64-none",
         major: 3,
         minor: 11,
@@ -545,48 +545,36 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("89d1d8f080e5494ea57918fc5ecf3d483ffef943cd5a336e64da150cd44b4aa0")
     },
     PythonDownload {
-        key: "cpython-3.11.6-darwin-arm64-none",
+        key: "cpython-3.11.6-linux-aarch64-gnu",
         major: 3,
         minor: 11,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("6e9007bcbbf51203e89c34a87ed42561630a35bc4eb04a565c92ba7159fe5826")
-    },
-    PythonDownload {
-        key: "cpython-3.11.6-linux-arm64-gnu",
-        major: 3,
-        minor: 11,
-        patch: 6,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("d63d6eb065e60899b25853fe6bbd9f60ea6c3b12f4854adc75cb818bad55f4e9")
     },
     PythonDownload {
-        key: "cpython-3.11.6-windows-i686-none",
+        key: "cpython-3.11.6-macos-aarch64-none",
         major: 3,
         minor: 11,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("2670731428191d4476bf260c8144ccf06f9e5f8ac6f2de1dc444ca96ab627082")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("6e9007bcbbf51203e89c34a87ed42561630a35bc4eb04a565c92ba7159fe5826")
     },
     PythonDownload {
-        key: "cpython-3.11.6-linux-ppc64le-gnu",
+        key: "cpython-3.11.6-linux-powerpc64le-gnu",
         major: 3,
         minor: 11,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -605,16 +593,16 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("78252aa883fed18de7bb9b146450e42dd75d78c345f56c1301bb042317a1d4f7")
     },
     PythonDownload {
-        key: "cpython-3.11.6-darwin-x86_64-none",
+        key: "cpython-3.11.6-windows-x86-none",
         major: 3,
         minor: 11,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("3685156e4139e89484c071ba1a1b85be0b4e302a786de5a170d3b0713863c2e8")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("2670731428191d4476bf260c8144ccf06f9e5f8ac6f2de1dc444ca96ab627082")
     },
     PythonDownload {
         key: "cpython-3.11.6-linux-x86_64-gnu",
@@ -641,6 +629,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("1b6e32ec93c5a18a03a9da9e2a3a3738d67b733df0795edcff9fd749c33ab931")
     },
     PythonDownload {
+        key: "cpython-3.11.6-macos-x86_64-none",
+        major: 3,
+        minor: 11,
+        patch: 6,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("3685156e4139e89484c071ba1a1b85be0b4e302a786de5a170d3b0713863c2e8")
+    },
+    PythonDownload {
         key: "cpython-3.11.6-windows-x86_64-none",
         major: 3,
         minor: 11,
@@ -653,60 +653,36 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("38d2c2fa2f9effbf486207bef7141d1b5c385ad30729ab0c976e6a852a2a9401")
     },
     PythonDownload {
-        key: "cpython-3.11.5-darwin-arm64-none",
+        key: "cpython-3.11.5-linux-aarch64-gnu",
         major: 3,
         minor: 11,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("7bee180b764722a73c2599fbe2c3a6121cf6bbcb08cb3082851e93c43fe130e7")
-    },
-    PythonDownload {
-        key: "cpython-3.11.5-linux-arm64-gnu",
-        major: 3,
-        minor: 11,
-        patch: 5,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("ac4b1e91d1cb7027595bfa4667090406331b291b2e346fb74e42b7031b216787")
     },
     PythonDownload {
-        key: "cpython-3.11.5-linux-i686-gnu",
+        key: "cpython-3.11.5-macos-aarch64-none",
         major: 3,
         minor: 11,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Linux,
-        libc: Libc::Gnu,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
-        sha256: Some("75d27b399b323c25d8250fda9857e388bf1b03ba1eb7925ec23cf12042a63a88")
-    },
-    PythonDownload {
-        key: "cpython-3.11.5-windows-i686-none",
-        major: 3,
-        minor: 11,
-        patch: 5,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("c9ffe9c2c88685ce3064f734cbdfede0a07de7d826fada58f8045f3bd8f81a9d")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("7bee180b764722a73c2599fbe2c3a6121cf6bbcb08cb3082851e93c43fe130e7")
     },
     PythonDownload {
-        key: "cpython-3.11.5-linux-ppc64le-gnu",
+        key: "cpython-3.11.5-linux-powerpc64le-gnu",
         major: 3,
         minor: 11,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -725,16 +701,28 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("b0819032ec336d6e1d9e9bfdba546bf854a7b7248f8720a6d07da72c4ac927e5")
     },
     PythonDownload {
-        key: "cpython-3.11.5-darwin-x86_64-none",
+        key: "cpython-3.11.5-linux-x86-gnu",
         major: 3,
         minor: 11,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Linux,
+        libc: Libc::Gnu,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+        sha256: Some("75d27b399b323c25d8250fda9857e388bf1b03ba1eb7925ec23cf12042a63a88")
+    },
+    PythonDownload {
+        key: "cpython-3.11.5-windows-x86-none",
+        major: 3,
+        minor: 11,
+        patch: 5,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("e43d70a49919641ca2939a5a9107b13d5fef8c13af0f511a33a94bb6af2044f0")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("c9ffe9c2c88685ce3064f734cbdfede0a07de7d826fada58f8045f3bd8f81a9d")
     },
     PythonDownload {
         key: "cpython-3.11.5-linux-x86_64-gnu",
@@ -761,6 +749,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("9dcf19ee54fb936cb9fd0f02fd655e790663534bc12e142e460c1b30a0b54dbd")
     },
     PythonDownload {
+        key: "cpython-3.11.5-macos-x86_64-none",
+        major: 3,
+        minor: 11,
+        patch: 5,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("e43d70a49919641ca2939a5a9107b13d5fef8c13af0f511a33a94bb6af2044f0")
+    },
+    PythonDownload {
         key: "cpython-3.11.5-windows-x86_64-none",
         major: 3,
         minor: 11,
@@ -773,60 +773,36 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("6e4d20e6d498f9edeb3c28cb9541ad20f675f16da350b078e40a9dcfd93cdc3d")
     },
     PythonDownload {
-        key: "cpython-3.11.4-darwin-arm64-none",
+        key: "cpython-3.11.4-linux-aarch64-gnu",
         major: 3,
         minor: 11,
         patch: 4,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("988d476c806f71a3233ff4266eda166a5d28cf83ba306ac88b4220554fc83e8c")
-    },
-    PythonDownload {
-        key: "cpython-3.11.4-linux-arm64-gnu",
-        major: 3,
-        minor: 11,
-        patch: 4,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("37cf00439b57adf7ffef4a349d62dcf09739ba67b670e903b00b25f81fbb8a68")
     },
     PythonDownload {
-        key: "cpython-3.11.4-linux-i686-gnu",
+        key: "cpython-3.11.4-macos-aarch64-none",
         major: 3,
         minor: 11,
         patch: 4,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Linux,
-        libc: Libc::Gnu,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
-        sha256: Some("a9051364b5c2e28205f8484cae03d16c86b45df5d117324e846d0f5e870fe9fb")
-    },
-    PythonDownload {
-        key: "cpython-3.11.4-windows-i686-none",
-        major: 3,
-        minor: 11,
-        patch: 4,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("0d22f43c5bb3f27ff2f9e8c60b0d7abd391bb2cac1790b0960970ff5580f6e9a")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("988d476c806f71a3233ff4266eda166a5d28cf83ba306ac88b4220554fc83e8c")
     },
     PythonDownload {
-        key: "cpython-3.11.4-linux-ppc64le-gnu",
+        key: "cpython-3.11.4-linux-powerpc64le-gnu",
         major: 3,
         minor: 11,
         patch: 4,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -845,16 +821,28 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("8ef6b5fa86b4abf51865b346b7cf8df36e474ed308869fc0ac3fe82de39194a4")
     },
     PythonDownload {
-        key: "cpython-3.11.4-darwin-x86_64-none",
+        key: "cpython-3.11.4-linux-x86-gnu",
         major: 3,
         minor: 11,
         patch: 4,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Linux,
+        libc: Libc::Gnu,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+        sha256: Some("a9051364b5c2e28205f8484cae03d16c86b45df5d117324e846d0f5e870fe9fb")
+    },
+    PythonDownload {
+        key: "cpython-3.11.4-windows-x86-none",
+        major: 3,
+        minor: 11,
+        patch: 4,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("6d9765785316c7f1c07def71b413c92c84302f798b30ee09e2e0b5da28353a51")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("0d22f43c5bb3f27ff2f9e8c60b0d7abd391bb2cac1790b0960970ff5580f6e9a")
     },
     PythonDownload {
         key: "cpython-3.11.4-linux-x86_64-gnu",
@@ -881,6 +869,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("fc2ea02ced875c90b8d025b409d58c4f045df8ba951bfa2b8b0a3cfe11c3b41c")
     },
     PythonDownload {
+        key: "cpython-3.11.4-macos-x86_64-none",
+        major: 3,
+        minor: 11,
+        patch: 4,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("6d9765785316c7f1c07def71b413c92c84302f798b30ee09e2e0b5da28353a51")
+    },
+    PythonDownload {
         key: "cpython-3.11.4-windows-x86_64-none",
         major: 3,
         minor: 11,
@@ -893,76 +893,64 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("1692d795d6199b2261161ae54250009ffad0317929302903f6f2c773befd4d76")
     },
     PythonDownload {
-        key: "cpython-3.11.3-darwin-arm64-none",
+        key: "cpython-3.11.3-linux-aarch64-gnu",
         major: 3,
         minor: 11,
         patch: 3,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("cd296d628ceebf55a78c7f6a7aed379eba9dbd72045d002e1c2c85af0d6f5049")
-    },
-    PythonDownload {
-        key: "cpython-3.11.3-linux-arm64-gnu",
-        major: 3,
-        minor: 11,
-        patch: 3,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("991521082b0347878ba855c4986d77cc805c22ef75159bc95dd24bfd80275e27")
     },
     PythonDownload {
-        key: "cpython-3.11.3-linux-i686-gnu",
+        key: "cpython-3.11.3-macos-aarch64-none",
         major: 3,
         minor: 11,
         patch: 3,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Linux,
-        libc: Libc::Gnu,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
-        sha256: Some("7bd694eb848328e96f524ded0f9b9eca6230d71fce3cd49b335a5c33450f3e04")
-    },
-    PythonDownload {
-        key: "cpython-3.11.3-windows-i686-none",
-        major: 3,
-        minor: 11,
-        patch: 3,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("877c90ef778a526aa25ab417034f5e70728ac14e5eb1fa5cfd741f531203a3fc")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("cd296d628ceebf55a78c7f6a7aed379eba9dbd72045d002e1c2c85af0d6f5049")
     },
     PythonDownload {
-        key: "cpython-3.11.3-linux-ppc64le-gnu",
+        key: "cpython-3.11.3-linux-powerpc64le-gnu",
         major: 3,
         minor: 11,
         patch: 3,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("241d583be3ecc34d76fafa0d186cb504ce5625eb2c0e895dc4f4073a649e5c73")
     },
     PythonDownload {
-        key: "cpython-3.11.3-darwin-x86_64-none",
+        key: "cpython-3.11.3-linux-x86-gnu",
         major: 3,
         minor: 11,
         patch: 3,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Linux,
+        libc: Libc::Gnu,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+        sha256: Some("7bd694eb848328e96f524ded0f9b9eca6230d71fce3cd49b335a5c33450f3e04")
+    },
+    PythonDownload {
+        key: "cpython-3.11.3-windows-x86-none",
+        major: 3,
+        minor: 11,
+        patch: 3,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("2fbb31a8bc6663e2d31d3054319b51a29b1915c03222a94b9d563233e11d1bef")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("877c90ef778a526aa25ab417034f5e70728ac14e5eb1fa5cfd741f531203a3fc")
     },
     PythonDownload {
         key: "cpython-3.11.3-linux-x86_64-gnu",
@@ -989,6 +977,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("8c5adef5bc627f39e93b920af86ef740e917aa698530ff727978d446a07bbd8b")
     },
     PythonDownload {
+        key: "cpython-3.11.3-macos-x86_64-none",
+        major: 3,
+        minor: 11,
+        patch: 3,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("2fbb31a8bc6663e2d31d3054319b51a29b1915c03222a94b9d563233e11d1bef")
+    },
+    PythonDownload {
         key: "cpython-3.11.3-windows-x86_64-none",
         major: 3,
         minor: 11,
@@ -1001,64 +1001,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("9d27e607fb1cb2d766e17f27853013d8c0f0b09ac53127aaff03ec89ab13370d")
     },
     PythonDownload {
-        key: "cpython-3.11.1-darwin-arm64-none",
+        key: "cpython-3.11.1-linux-aarch64-gnu",
         major: 3,
         minor: 11,
         patch: 1,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("da187194cc351d827232b1d2d85b2855d7e25a4ada3e47bc34b4f87b1d989be5")
-    },
-    PythonDownload {
-        key: "cpython-3.11.1-linux-arm64-gnu",
-        major: 3,
-        minor: 11,
-        patch: 1,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("8fe27d850c02aa7bb34088fad5b48df90b4b841f40e1472243b8ab9da8776e40")
     },
     PythonDownload {
-        key: "cpython-3.11.1-linux-i686-gnu",
+        key: "cpython-3.11.1-macos-aarch64-none",
         major: 3,
         minor: 11,
         patch: 1,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("da187194cc351d827232b1d2d85b2855d7e25a4ada3e47bc34b4f87b1d989be5")
+    },
+    PythonDownload {
+        key: "cpython-3.11.1-linux-x86-gnu",
+        major: 3,
+        minor: 11,
+        patch: 1,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("7986ebe82c07ecd2eb94fd1b3c9ebbb2366db2360e38f29ae0543e857551d0bf")
     },
     PythonDownload {
-        key: "cpython-3.11.1-windows-i686-none",
+        key: "cpython-3.11.1-windows-x86-none",
         major: 3,
         minor: 11,
         patch: 1,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("b062ac2c72a85510fb9300675bd5c716baede21e9482ef6335247b4aa006584c")
-    },
-    PythonDownload {
-        key: "cpython-3.11.1-darwin-x86_64-none",
-        major: 3,
-        minor: 11,
-        patch: 1,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("0eb61be53ee13cf75a30b8a164ef513a2c7995b25b118a3a503245d46231b13a")
     },
     PythonDownload {
         key: "cpython-3.11.1-linux-x86_64-gnu",
@@ -1085,6 +1073,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("ec5da5b428f6d91d96cde2621c0380f67bb96e4257d2628bc70b50e75ec5f629")
     },
     PythonDownload {
+        key: "cpython-3.11.1-macos-x86_64-none",
+        major: 3,
+        minor: 11,
+        patch: 1,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("0eb61be53ee13cf75a30b8a164ef513a2c7995b25b118a3a503245d46231b13a")
+    },
+    PythonDownload {
         key: "cpython-3.11.1-windows-x86_64-none",
         major: 3,
         minor: 11,
@@ -1097,60 +1097,36 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("f5c46fffda7d7894b975af728f739b02d1cec50fd4a3ea49f69de9ceaae74b17")
     },
     PythonDownload {
-        key: "cpython-3.10.13-darwin-arm64-none",
+        key: "cpython-3.10.13-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 13,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("57b83a4aa32bdbe7611f1290313ef24f2574dff5fa59181c0ccb26c14c688b73")
-    },
-    PythonDownload {
-        key: "cpython-3.10.13-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 13,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("06a53040504e1e2fdcb32dc0d61b123bea76725b5c14031c8f64e28f52ae5a5f")
     },
     PythonDownload {
-        key: "cpython-3.10.13-linux-i686-gnu",
+        key: "cpython-3.10.13-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 13,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Linux,
-        libc: Libc::Gnu,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
-        sha256: Some("08a3a1ff61b7ed2c87db7a9f88630781d98fabc2efb499f38ae0ead05973eb56")
-    },
-    PythonDownload {
-        key: "cpython-3.10.13-windows-i686-none",
-        major: 3,
-        minor: 10,
-        patch: 13,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("c8b99dcf267c574fdfbdf4e9d63ec7a4aa4608565fee3fba0b2f73843b9713b2")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("57b83a4aa32bdbe7611f1290313ef24f2574dff5fa59181c0ccb26c14c688b73")
     },
     PythonDownload {
-        key: "cpython-3.10.13-linux-ppc64le-gnu",
+        key: "cpython-3.10.13-linux-powerpc64le-gnu",
         major: 3,
         minor: 10,
         patch: 13,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -1169,16 +1145,28 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("fe46914541126297c7a8636845c2e7188868eaa617bb6e293871fca4a5cb63f7")
     },
     PythonDownload {
-        key: "cpython-3.10.13-darwin-x86_64-none",
+        key: "cpython-3.10.13-linux-x86-gnu",
         major: 3,
         minor: 10,
         patch: 13,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Linux,
+        libc: Libc::Gnu,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+        sha256: Some("08a3a1ff61b7ed2c87db7a9f88630781d98fabc2efb499f38ae0ead05973eb56")
+    },
+    PythonDownload {
+        key: "cpython-3.10.13-windows-x86-none",
+        major: 3,
+        minor: 10,
+        patch: 13,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("a41c1e28e2a646bac69e023873d40a43c5958d251c6adfa83d5811a7cb034c7a")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("c8b99dcf267c574fdfbdf4e9d63ec7a4aa4608565fee3fba0b2f73843b9713b2")
     },
     PythonDownload {
         key: "cpython-3.10.13-linux-x86_64-gnu",
@@ -1205,6 +1193,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("fd18e6039be25bf23d13caf5140569df71d61312b823b715b3c788747fec48e9")
     },
     PythonDownload {
+        key: "cpython-3.10.13-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 13,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("a41c1e28e2a646bac69e023873d40a43c5958d251c6adfa83d5811a7cb034c7a")
+    },
+    PythonDownload {
         key: "cpython-3.10.13-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -1217,60 +1217,36 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("6a2c8f37509556e5d463b1f437cdf7772ebd84cdf183c258d783e64bb3109505")
     },
     PythonDownload {
-        key: "cpython-3.10.12-darwin-arm64-none",
+        key: "cpython-3.10.12-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 12,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("a7d0cadbe867cc53dd47d7327244154157a7cca02edb88cf3bb760a4f91d4e44")
-    },
-    PythonDownload {
-        key: "cpython-3.10.12-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 12,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("e30f2b4fd9bd79b9122e2975f3c17c9ddd727f8326b2e246378e81f7ecc7d74f")
     },
     PythonDownload {
-        key: "cpython-3.10.12-linux-i686-gnu",
+        key: "cpython-3.10.12-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 12,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Linux,
-        libc: Libc::Gnu,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
-        sha256: Some("89c83fcdfd41c67e2dd2a037982556c657dc55fc1938c6f6cdcd5ffa614c1fb3")
-    },
-    PythonDownload {
-        key: "cpython-3.10.12-windows-i686-none",
-        major: 3,
-        minor: 10,
-        patch: 12,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("0743b9976f20b06d9cf12de9d1b2dfe06b13f76978275e9dac73a275624bde2c")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("a7d0cadbe867cc53dd47d7327244154157a7cca02edb88cf3bb760a4f91d4e44")
     },
     PythonDownload {
-        key: "cpython-3.10.12-linux-ppc64le-gnu",
+        key: "cpython-3.10.12-linux-powerpc64le-gnu",
         major: 3,
         minor: 10,
         patch: 12,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -1289,16 +1265,28 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("756579b52acb9b13b162ac901e56ff311def443e69d7f7259a91198b76a30ecb")
     },
     PythonDownload {
-        key: "cpython-3.10.12-darwin-x86_64-none",
+        key: "cpython-3.10.12-linux-x86-gnu",
         major: 3,
         minor: 10,
         patch: 12,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Linux,
+        libc: Libc::Gnu,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+        sha256: Some("89c83fcdfd41c67e2dd2a037982556c657dc55fc1938c6f6cdcd5ffa614c1fb3")
+    },
+    PythonDownload {
+        key: "cpython-3.10.12-windows-x86-none",
+        major: 3,
+        minor: 10,
+        patch: 12,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("f1fa448384dd48033825e56ee6b5afc76c5dd67dcf2b73b61d2b252ae2e87bca")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("0743b9976f20b06d9cf12de9d1b2dfe06b13f76978275e9dac73a275624bde2c")
     },
     PythonDownload {
         key: "cpython-3.10.12-linux-x86_64-gnu",
@@ -1325,6 +1313,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("b343cbe7c41b7698b568ea5252328cdccb213100efa71da8d3db6e21afd9f6cf")
     },
     PythonDownload {
+        key: "cpython-3.10.12-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 12,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("f1fa448384dd48033825e56ee6b5afc76c5dd67dcf2b73b61d2b252ae2e87bca")
+    },
+    PythonDownload {
         key: "cpython-3.10.12-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -1337,76 +1337,64 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("cb6e7c84d9e369a0ee76c9ea73d415a113ba9982db58f44e6bab5414838d35f3")
     },
     PythonDownload {
-        key: "cpython-3.10.11-darwin-arm64-none",
+        key: "cpython-3.10.11-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 11,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("da9c8a3cd04485fd397387ea2fa56f3cac71827aafb51d8438b2868f86eb345b")
-    },
-    PythonDownload {
-        key: "cpython-3.10.11-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 11,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("a5271cc014f2ce2ab54a0789556c15b84668e2afcc530512818c4b87c6a94483")
     },
     PythonDownload {
-        key: "cpython-3.10.11-linux-i686-gnu",
+        key: "cpython-3.10.11-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 11,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Linux,
-        libc: Libc::Gnu,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
-        sha256: Some("9304d6eeef48bd246a2959ebc76b20dbb2c6a81aa1d214f4471cb273c11717f2")
-    },
-    PythonDownload {
-        key: "cpython-3.10.11-windows-i686-none",
-        major: 3,
-        minor: 10,
-        patch: 11,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("60e76e136ab23b891ed1212e58bd11a73a19cd9fd884ec1c5653ca1c159d674e")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("da9c8a3cd04485fd397387ea2fa56f3cac71827aafb51d8438b2868f86eb345b")
     },
     PythonDownload {
-        key: "cpython-3.10.11-linux-ppc64le-gnu",
+        key: "cpython-3.10.11-linux-powerpc64le-gnu",
         major: 3,
         minor: 10,
         patch: 11,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("ac32e3788109ff0cc536a6108072d9203217df744cf56d3a4ab0b19857d8e244")
     },
     PythonDownload {
-        key: "cpython-3.10.11-darwin-x86_64-none",
+        key: "cpython-3.10.11-linux-x86-gnu",
         major: 3,
         minor: 10,
         patch: 11,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Linux,
+        libc: Libc::Gnu,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+        sha256: Some("9304d6eeef48bd246a2959ebc76b20dbb2c6a81aa1d214f4471cb273c11717f2")
+    },
+    PythonDownload {
+        key: "cpython-3.10.11-windows-x86-none",
+        major: 3,
+        minor: 10,
+        patch: 11,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("e84c12aa0285235eed365971ceedf040f4d8014f5342d371e138a4da9e4e9b7c")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("60e76e136ab23b891ed1212e58bd11a73a19cd9fd884ec1c5653ca1c159d674e")
     },
     PythonDownload {
         key: "cpython-3.10.11-linux-x86_64-gnu",
@@ -1433,6 +1421,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("7918188e01a266915dd0945711e274d45c8d7fb540d48240e13c4fd96f43afbb")
     },
     PythonDownload {
+        key: "cpython-3.10.11-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 11,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("e84c12aa0285235eed365971ceedf040f4d8014f5342d371e138a4da9e4e9b7c")
+    },
+    PythonDownload {
         key: "cpython-3.10.11-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -1445,64 +1445,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("9b4dc4a335b6122ce783bc80f5015b683e3ab1a56054751c5df494db0521da67")
     },
     PythonDownload {
-        key: "cpython-3.10.9-darwin-arm64-none",
+        key: "cpython-3.10.9-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 9,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("2508b8d4b725bb45c3e03d2ddd2b8441f1a74677cb6bd6076e692c0923135ded")
-    },
-    PythonDownload {
-        key: "cpython-3.10.9-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 9,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("2c0996dd1fe35314e06e042081b24fb53f3b7b361c3e1b94a6ed659c275ca069")
     },
     PythonDownload {
-        key: "cpython-3.10.9-linux-i686-gnu",
+        key: "cpython-3.10.9-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 9,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("2508b8d4b725bb45c3e03d2ddd2b8441f1a74677cb6bd6076e692c0923135ded")
+    },
+    PythonDownload {
+        key: "cpython-3.10.9-linux-x86-gnu",
+        major: 3,
+        minor: 10,
+        patch: 9,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("f8c3a63620f412c4a9ccfb6e2435a96a55775550c81a452d164caa6d03a6a1da")
     },
     PythonDownload {
-        key: "cpython-3.10.9-windows-i686-none",
+        key: "cpython-3.10.9-windows-x86-none",
         major: 3,
         minor: 10,
         patch: 9,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("3d79cfd229ec12b678bbfd79c30fb4cbad9950d6bfb29741d2315b11839998b4")
-    },
-    PythonDownload {
-        key: "cpython-3.10.9-darwin-x86_64-none",
-        major: 3,
-        minor: 10,
-        patch: 9,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("1153b4d3b03cf1e1d8ec93c098160586f665fcc2d162c0812140a716a688df58")
     },
     PythonDownload {
         key: "cpython-3.10.9-linux-x86_64-gnu",
@@ -1529,6 +1517,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("1310f187a73b00164ec4ca34e643841c5c34cbb93fe0b3a3f9504e5ea5001ec7")
     },
     PythonDownload {
+        key: "cpython-3.10.9-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 9,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("1153b4d3b03cf1e1d8ec93c098160586f665fcc2d162c0812140a716a688df58")
+    },
+    PythonDownload {
         key: "cpython-3.10.9-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -1541,64 +1541,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("4cfa6299a78a3959102c461d126e4869616f0a49c60b44220c000fc9aecddd78")
     },
     PythonDownload {
-        key: "cpython-3.10.8-darwin-arm64-none",
+        key: "cpython-3.10.8-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 8,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("f8ba5f87153a17717e900ff7bba20e2eefe8a53a5bd3c78f9f6922d6d910912d")
-    },
-    PythonDownload {
-        key: "cpython-3.10.8-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 8,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("879e76260be226512693e37a28cc3a6670b5ee270a4440e4b04a7b415dba451c")
     },
     PythonDownload {
-        key: "cpython-3.10.8-linux-i686-gnu",
+        key: "cpython-3.10.8-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 8,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("f8ba5f87153a17717e900ff7bba20e2eefe8a53a5bd3c78f9f6922d6d910912d")
+    },
+    PythonDownload {
+        key: "cpython-3.10.8-linux-x86-gnu",
+        major: 3,
+        minor: 10,
+        patch: 8,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("ab434eccffeec4f6f51af017e4eed69d4f1ea55f48c5b89b8a8779df3fa799df")
     },
     PythonDownload {
-        key: "cpython-3.10.8-windows-i686-none",
+        key: "cpython-3.10.8-windows-x86-none",
         major: 3,
         minor: 10,
         patch: 8,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("7547ea172f7fa3d7619855f28780da9feb615b6cb52c5c64d34f65b542799fee")
-    },
-    PythonDownload {
-        key: "cpython-3.10.8-darwin-x86_64-none",
-        major: 3,
-        minor: 10,
-        patch: 8,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("a18f81ecc7da0779be960ad35c561a834866c0e6d1310a4f742fddfd6163753f")
     },
     PythonDownload {
         key: "cpython-3.10.8-linux-x86_64-gnu",
@@ -1625,6 +1613,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("bb87e933afcfd2e8de045e5a691feff1fb8fb06a09315b37d187762fddfc4546")
     },
     PythonDownload {
+        key: "cpython-3.10.8-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 8,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("a18f81ecc7da0779be960ad35c561a834866c0e6d1310a4f742fddfd6163753f")
+    },
+    PythonDownload {
         key: "cpython-3.10.8-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -1637,64 +1637,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("ab40f9584be896c697c5fca351ab82d7b55f01b8eb0494f0a15a67562e49161a")
     },
     PythonDownload {
-        key: "cpython-3.10.7-darwin-arm64-none",
+        key: "cpython-3.10.7-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("9f44cf63441a90f4ec99a032a2bda43971ae7964822daa0ee730a9cba15d50da")
-    },
-    PythonDownload {
-        key: "cpython-3.10.7-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 7,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("9f346729b523e860194635eb67c9f6bc8f12728ba7ddfe4fd80f2e6d685781e3")
     },
     PythonDownload {
-        key: "cpython-3.10.7-linux-i686-gnu",
+        key: "cpython-3.10.7-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("9f44cf63441a90f4ec99a032a2bda43971ae7964822daa0ee730a9cba15d50da")
+    },
+    PythonDownload {
+        key: "cpython-3.10.7-linux-x86-gnu",
+        major: 3,
+        minor: 10,
+        patch: 7,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("a79816c50abeb2752530f68b4d7d95b6f48392f44a9a7f135b91807d76872972")
     },
     PythonDownload {
-        key: "cpython-3.10.7-windows-i686-none",
+        key: "cpython-3.10.7-windows-x86-none",
         major: 3,
         minor: 10,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("323532701cb468199d6f14031b991f945d4bbf986ca818185e17e132d3763bdf")
-    },
-    PythonDownload {
-        key: "cpython-3.10.7-darwin-x86_64-none",
-        major: 3,
-        minor: 10,
-        patch: 7,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("e03e28dc9fe55ea5ca06fece8f2f2a16646b217d28c0cd09ebcd512f444fdc90")
     },
     PythonDownload {
         key: "cpython-3.10.7-linux-x86_64-gnu",
@@ -1721,6 +1709,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("7f2c933d23c0f38cf145c2d6c65b5cf53bb589690d394fd4c01b2230c23c2bff")
     },
     PythonDownload {
+        key: "cpython-3.10.7-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 7,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("e03e28dc9fe55ea5ca06fece8f2f2a16646b217d28c0cd09ebcd512f444fdc90")
+    },
+    PythonDownload {
         key: "cpython-3.10.7-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -1733,64 +1733,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("5363974e6ee6c91dbd6bc3533e38b02a26abc2ff1c9a095912f237b916be22d3")
     },
     PythonDownload {
-        key: "cpython-3.10.6-darwin-arm64-none",
+        key: "cpython-3.10.6-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("159230851a69cf5cab80318bce48674244d7c6304de81f44c22ff0abdf895cfa")
-    },
-    PythonDownload {
-        key: "cpython-3.10.6-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 6,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("edc1c9742b824caebbc5cb224c8990aa8658b81593fd9219accf3efa3e849501")
     },
     PythonDownload {
-        key: "cpython-3.10.6-linux-i686-gnu",
+        key: "cpython-3.10.6-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("159230851a69cf5cab80318bce48674244d7c6304de81f44c22ff0abdf895cfa")
+    },
+    PythonDownload {
+        key: "cpython-3.10.6-linux-x86-gnu",
+        major: 3,
+        minor: 10,
+        patch: 6,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("07fa4f5499b8885d1eea49caf5476d76305ab73494b7398dfd22c14093859e4f")
     },
     PythonDownload {
-        key: "cpython-3.10.6-windows-i686-none",
+        key: "cpython-3.10.6-windows-x86-none",
         major: 3,
         minor: 10,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("8d9a259e15d5a1be48ef13cd5627d7f6c15eadf41a3539e99ed1deee668c075e")
-    },
-    PythonDownload {
-        key: "cpython-3.10.6-darwin-x86_64-none",
-        major: 3,
-        minor: 10,
-        patch: 6,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("9405499573a7aa8b67d070d096ded4f3e571f18c2b34762606ecc8025290b122")
     },
     PythonDownload {
         key: "cpython-3.10.6-linux-x86_64-gnu",
@@ -1817,6 +1805,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("f859a72da0bb2f1261f8cebdac931b05b59474c7cb65cee8e85c34fc014dd452")
     },
     PythonDownload {
+        key: "cpython-3.10.6-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 6,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("9405499573a7aa8b67d070d096ded4f3e571f18c2b34762606ecc8025290b122")
+    },
+    PythonDownload {
         key: "cpython-3.10.6-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -1829,64 +1829,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("01dc349721594b1bb5b582651f81479a24352f718fdf6279101caa0f377b160a")
     },
     PythonDownload {
-        key: "cpython-3.10.5-darwin-arm64-none",
+        key: "cpython-3.10.5-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("f68d25dbe9daa96187fa9e05dd8969f46685547fecf1861a99af898f96a5379e")
-    },
-    PythonDownload {
-        key: "cpython-3.10.5-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 5,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("9fa6970a3d0a5dc26c4ed272bb1836d1f1f7a8f4b9d67f634d0262ff8c1fed0b")
     },
     PythonDownload {
-        key: "cpython-3.10.5-linux-i686-gnu",
+        key: "cpython-3.10.5-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("f68d25dbe9daa96187fa9e05dd8969f46685547fecf1861a99af898f96a5379e")
+    },
+    PythonDownload {
+        key: "cpython-3.10.5-linux-x86-gnu",
+        major: 3,
+        minor: 10,
+        patch: 5,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("63fcfc425adabc034c851dadfb499de3083fd7758582191c12162ad2471256b0")
     },
     PythonDownload {
-        key: "cpython-3.10.5-windows-i686-none",
+        key: "cpython-3.10.5-windows-x86-none",
         major: 3,
         minor: 10,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("e201192f0aa73904bc5a5f43d1ce4c9fb243dfe02138e690676713fe02c7d662")
-    },
-    PythonDownload {
-        key: "cpython-3.10.5-darwin-x86_64-none",
-        major: 3,
-        minor: 10,
-        patch: 5,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("5e372e6738a733532aa985730d9a47ee4c77b7c706e91ef61d37aacbb2e54845")
     },
     PythonDownload {
         key: "cpython-3.10.5-linux-x86_64-gnu",
@@ -1913,6 +1901,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("3682e0add14a3bac654afe467a84981628b0c7ebdccd4ebf26dfaa916238e2fe")
     },
     PythonDownload {
+        key: "cpython-3.10.5-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 5,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("5e372e6738a733532aa985730d9a47ee4c77b7c706e91ef61d37aacbb2e54845")
+    },
+    PythonDownload {
         key: "cpython-3.10.5-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -1925,64 +1925,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("cff35feefe423d4282e9a3e1bb756d0acbb2f776b1ada82c44c71ac3e1491448")
     },
     PythonDownload {
-        key: "cpython-3.10.4-darwin-arm64-none",
+        key: "cpython-3.10.4-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 4,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("c404f226195d79933b1e0a3ec88f0b79d35c873de592e223e11008f3a37f83d6")
-    },
-    PythonDownload {
-        key: "cpython-3.10.4-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 4,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("092369e9d170c4c1074e1b305accb74f9486e6185d2e3f3f971869ff89538d3e")
     },
     PythonDownload {
-        key: "cpython-3.10.4-linux-i686-gnu",
+        key: "cpython-3.10.4-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 4,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("c404f226195d79933b1e0a3ec88f0b79d35c873de592e223e11008f3a37f83d6")
+    },
+    PythonDownload {
+        key: "cpython-3.10.4-linux-x86-gnu",
+        major: 3,
+        minor: 10,
+        patch: 4,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("ba940a74a7434fe78d81aed9fb1e5ccdc3d97191a2db35716fc94e3b6604ace0")
     },
     PythonDownload {
-        key: "cpython-3.10.4-windows-i686-none",
+        key: "cpython-3.10.4-windows-x86-none",
         major: 3,
         minor: 10,
         patch: 4,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("c37a47e46de93473916f700a790cb43515f00745fba6790004e2731ec934f4d3")
-    },
-    PythonDownload {
-        key: "cpython-3.10.4-darwin-x86_64-none",
-        major: 3,
-        minor: 10,
-        patch: 4,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("e447f00fe53168d18cbfe110645dbf33982a17580b9e4424a411f9245d99cd21")
     },
     PythonDownload {
         key: "cpython-3.10.4-linux-x86_64-gnu",
@@ -2009,6 +1997,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("8b8b97f7746a3deca91ada408025457ced34f582dad2114b33ce6fec9cf35b28")
     },
     PythonDownload {
+        key: "cpython-3.10.4-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 4,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("e447f00fe53168d18cbfe110645dbf33982a17580b9e4424a411f9245d99cd21")
+    },
+    PythonDownload {
         key: "cpython-3.10.4-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -2021,64 +2021,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("d636dc1bcca74dd9c6e3b26f7c081b3e229336e8378fe554bf8ba65fe780a2ac")
     },
     PythonDownload {
-        key: "cpython-3.10.3-darwin-arm64-none",
+        key: "cpython-3.10.3-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 3,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("b1abefd0fc66922cf9749e4d5ceb97df4d3cfad0cd9cdc4bd04262a68d565698")
-    },
-    PythonDownload {
-        key: "cpython-3.10.3-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 3,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("101284d27578438da200be1f6b9a1ba621432c5549fa5517797ec320bf75e3d5")
     },
     PythonDownload {
-        key: "cpython-3.10.3-linux-i686-gnu",
+        key: "cpython-3.10.3-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 3,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("b1abefd0fc66922cf9749e4d5ceb97df4d3cfad0cd9cdc4bd04262a68d565698")
+    },
+    PythonDownload {
+        key: "cpython-3.10.3-linux-x86-gnu",
+        major: 3,
+        minor: 10,
+        patch: 3,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("43c1cd6e203bfba1a2eeb96cd2a15ce0ebde0e72ecc9555934116459347a9c28")
     },
     PythonDownload {
-        key: "cpython-3.10.3-windows-i686-none",
+        key: "cpython-3.10.3-windows-x86-none",
         major: 3,
         minor: 10,
         patch: 3,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("fbc0924a138937fe435fcdb20b0c6241290558e07f158e5578bd91cc8acef469")
-    },
-    PythonDownload {
-        key: "cpython-3.10.3-darwin-x86_64-none",
-        major: 3,
-        minor: 10,
-        patch: 3,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("bc5d6f284b506104ff6b4e36cec84cbdb4602dfed4c6fe19971a808eb8c439ec")
     },
     PythonDownload {
         key: "cpython-3.10.3-linux-x86_64-gnu",
@@ -2105,6 +2093,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("7c034d8a5787744939335ce43d64f2ddcc830a74e63773408d0c8f3c3a4e7916")
     },
     PythonDownload {
+        key: "cpython-3.10.3-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 3,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("bc5d6f284b506104ff6b4e36cec84cbdb4602dfed4c6fe19971a808eb8c439ec")
+    },
+    PythonDownload {
         key: "cpython-3.10.3-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -2117,64 +2117,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("72b91d26f54321ba90a86a3bbc711fa1ac31e0704fec352b36e70b0251ffb13c")
     },
     PythonDownload {
-        key: "cpython-3.10.2-darwin-arm64-none",
+        key: "cpython-3.10.2-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 2,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("1ef939fd471a9d346a7bc43d2c16fb483ddc4f98af6dad7f08a009e299977a1a")
-    },
-    PythonDownload {
-        key: "cpython-3.10.2-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 2,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("9936f1549f950311229465de509b35c062aa474e504c20a1d6f0f632da57e002")
     },
     PythonDownload {
-        key: "cpython-3.10.2-linux-i686-gnu",
+        key: "cpython-3.10.2-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 2,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("1ef939fd471a9d346a7bc43d2c16fb483ddc4f98af6dad7f08a009e299977a1a")
+    },
+    PythonDownload {
+        key: "cpython-3.10.2-linux-x86-gnu",
+        major: 3,
+        minor: 10,
+        patch: 2,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("9be2a667f29ed048165cfb3f5dbe61703fd3e5956f8f517ae098740ac8411c0b")
     },
     PythonDownload {
-        key: "cpython-3.10.2-windows-i686-none",
+        key: "cpython-3.10.2-windows-x86-none",
         major: 3,
         minor: 10,
         patch: 2,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("698b09b1b8321a4dc43d62f6230b62adcd0df018b2bcf5f1b4a7ce53dcf23bcc")
-    },
-    PythonDownload {
-        key: "cpython-3.10.2-darwin-x86_64-none",
-        major: 3,
-        minor: 10,
-        patch: 2,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("bacf720c13ab67685a384f1417e9c2420972d88f29c8b7c26e72874177f2d120")
     },
     PythonDownload {
         key: "cpython-3.10.2-linux-x86_64-gnu",
@@ -2201,6 +2189,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("df246cf27db346081935d33ce0344a185d1f08b04a4500eb1e21d4d922ee7eb4")
     },
     PythonDownload {
+        key: "cpython-3.10.2-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 2,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("bacf720c13ab67685a384f1417e9c2420972d88f29c8b7c26e72874177f2d120")
+    },
+    PythonDownload {
         key: "cpython-3.10.2-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -2213,63 +2213,51 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("7397e78a4fbe429144adc1f33af942bdd5175184e082ac88f3023b3a740dd1a0")
     },
     PythonDownload {
-        key: "cpython-3.10.0-darwin-arm64-none",
+        key: "cpython-3.10.0-linux-aarch64-gnu",
         major: 3,
         minor: 10,
         patch: 0,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.10.0-linux-arm64-gnu",
-        major: 3,
-        minor: 10,
-        patch: 0,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-unknown-linux-gnu-debug-20211017T1616.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.10.0-linux-i686-gnu",
+        key: "cpython-3.10.0-macos-aarch64-none",
         major: 3,
         minor: 10,
         patch: 0,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
+        key: "cpython-3.10.0-linux-x86-gnu",
+        major: 3,
+        minor: 10,
+        patch: 0,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-unknown-linux-gnu-debug-20211017T1616.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.10.0-windows-i686-none",
+        key: "cpython-3.10.0-windows-x86-none",
         major: 3,
         minor: 10,
         patch: 0,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.10.0-darwin-x86_64-none",
-        major: 3,
-        minor: 10,
-        patch: 0,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -2297,6 +2285,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.10.0-macos-x86_64-none",
+        major: 3,
+        minor: 10,
+        patch: 0,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.10.0-windows-x86_64-none",
         major: 3,
         minor: 10,
@@ -2309,60 +2309,36 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.18-darwin-arm64-none",
+        key: "cpython-3.9.18-linux-aarch64-gnu",
         major: 3,
         minor: 9,
         patch: 18,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("579f9b68bbb3a915cbab9682e4d3c253bc96b0556b8a860982c49c25c61f974a")
-    },
-    PythonDownload {
-        key: "cpython-3.9.18-linux-arm64-gnu",
-        major: 3,
-        minor: 9,
-        patch: 18,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("d27efd4609a3e15ff901040529d5689be99f2ebfe5132ab980d066d775068265")
     },
     PythonDownload {
-        key: "cpython-3.9.18-linux-i686-gnu",
+        key: "cpython-3.9.18-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 18,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Linux,
-        libc: Libc::Gnu,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
-        sha256: Some("7faf8fdfbad04e0356a9d52c9b8be4d40ffef85c9ab3e312c45bd64997ef8aa9")
-    },
-    PythonDownload {
-        key: "cpython-3.9.18-windows-i686-none",
-        major: 3,
-        minor: 9,
-        patch: 18,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("212d413ab6f854f588cf368fdd2aa140bb7c7ee930e3f7ac1002cba1e50e9685")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("579f9b68bbb3a915cbab9682e4d3c253bc96b0556b8a860982c49c25c61f974a")
     },
     PythonDownload {
-        key: "cpython-3.9.18-linux-ppc64le-gnu",
+        key: "cpython-3.9.18-linux-powerpc64le-gnu",
         major: 3,
         minor: 9,
         patch: 18,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -2381,16 +2357,28 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("dd05eff699ce5a7eee545bc05e4869c4e64ee02bf0c70691bcee215604c6b393")
     },
     PythonDownload {
-        key: "cpython-3.9.18-darwin-x86_64-none",
+        key: "cpython-3.9.18-linux-x86-gnu",
         major: 3,
         minor: 9,
         patch: 18,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Linux,
+        libc: Libc::Gnu,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+        sha256: Some("7faf8fdfbad04e0356a9d52c9b8be4d40ffef85c9ab3e312c45bd64997ef8aa9")
+    },
+    PythonDownload {
+        key: "cpython-3.9.18-windows-x86-none",
+        major: 3,
+        minor: 9,
+        patch: 18,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("146537b9b4a1baa672eed94373e149ca1ee339c4df121e8916d8436265e5245e")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("212d413ab6f854f588cf368fdd2aa140bb7c7ee930e3f7ac1002cba1e50e9685")
     },
     PythonDownload {
         key: "cpython-3.9.18-linux-x86_64-gnu",
@@ -2417,6 +2405,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("8bf88ae2100e609902d98ec775468e3a41a834f6528e632d6d971f5f75340336")
     },
     PythonDownload {
+        key: "cpython-3.9.18-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 18,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("146537b9b4a1baa672eed94373e149ca1ee339c4df121e8916d8436265e5245e")
+    },
+    PythonDownload {
         key: "cpython-3.9.18-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -2429,60 +2429,36 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("924ed4f375ef73c73a725ef18ec6a72726456673d5a116f132f60860a25dd674")
     },
     PythonDownload {
-        key: "cpython-3.9.17-darwin-arm64-none",
+        key: "cpython-3.9.17-linux-aarch64-gnu",
         major: 3,
         minor: 9,
         patch: 17,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("2902e2a0add6d584999fa27896b721a359f7308404e936e80b01b07aa06e8f5e")
-    },
-    PythonDownload {
-        key: "cpython-3.9.17-linux-arm64-gnu",
-        major: 3,
-        minor: 9,
-        patch: 17,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("1f6c43d92ba9f4e15149cf5db6ecde11e05eee92c070a085e44f46c559520257")
     },
     PythonDownload {
-        key: "cpython-3.9.17-linux-i686-gnu",
+        key: "cpython-3.9.17-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 17,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Linux,
-        libc: Libc::Gnu,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
-        sha256: Some("1a9b7edc16683410c27bc5b4b1761143bef7831a1ad172e7e3581c152c6837a2")
-    },
-    PythonDownload {
-        key: "cpython-3.9.17-windows-i686-none",
-        major: 3,
-        minor: 9,
-        patch: 17,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("ffac27bfb8bdf615d0fc6cbbe0becaa65b6ae73feec417919601497fce2be0ab")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("2902e2a0add6d584999fa27896b721a359f7308404e936e80b01b07aa06e8f5e")
     },
     PythonDownload {
-        key: "cpython-3.9.17-linux-ppc64le-gnu",
+        key: "cpython-3.9.17-linux-powerpc64le-gnu",
         major: 3,
         minor: 9,
         patch: 17,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
@@ -2501,16 +2477,28 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("bf8c846c1a4e52355d4ae294f4e1da9587d5415467eb6890bdf0f5a4c8cda396")
     },
     PythonDownload {
-        key: "cpython-3.9.17-darwin-x86_64-none",
+        key: "cpython-3.9.17-linux-x86-gnu",
         major: 3,
         minor: 9,
         patch: 17,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Linux,
+        libc: Libc::Gnu,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+        sha256: Some("1a9b7edc16683410c27bc5b4b1761143bef7831a1ad172e7e3581c152c6837a2")
+    },
+    PythonDownload {
+        key: "cpython-3.9.17-windows-x86-none",
+        major: 3,
+        minor: 9,
+        patch: 17,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("ba04f9813b78b61d60a27857949403a1b1dd8ac053e1f1aff72fe2689c238d3c")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("ffac27bfb8bdf615d0fc6cbbe0becaa65b6ae73feec417919601497fce2be0ab")
     },
     PythonDownload {
         key: "cpython-3.9.17-linux-x86_64-gnu",
@@ -2537,6 +2525,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("8496473a97e1dd43bf96fc1cf19f02f305608ef6a783e0112274e0ae01df4f2a")
     },
     PythonDownload {
+        key: "cpython-3.9.17-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 17,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("ba04f9813b78b61d60a27857949403a1b1dd8ac053e1f1aff72fe2689c238d3c")
+    },
+    PythonDownload {
         key: "cpython-3.9.17-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -2549,76 +2549,64 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("209983b8227e4755197dfed4f6887e45b6a133f61e7eb913c0a934b0d0c3e00f")
     },
     PythonDownload {
-        key: "cpython-3.9.16-darwin-arm64-none",
+        key: "cpython-3.9.16-linux-aarch64-gnu",
         major: 3,
         minor: 9,
         patch: 16,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("c86ed2bf3ff290af10f96183c53e2b29e954abb520806fbe01d3ef2f9d809a75")
-    },
-    PythonDownload {
-        key: "cpython-3.9.16-linux-arm64-gnu",
-        major: 3,
-        minor: 9,
-        patch: 16,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("57ac7ce9d3dd32c1277ee7295daf5ad7b5ecc929e65b31f11b1e7b94cd355ed1")
     },
     PythonDownload {
-        key: "cpython-3.9.16-linux-i686-gnu",
+        key: "cpython-3.9.16-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 16,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Linux,
-        libc: Libc::Gnu,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
-        sha256: Some("e2a0226165550492e895369ee1b69a515f82e12cb969656012ee8e1543409661")
-    },
-    PythonDownload {
-        key: "cpython-3.9.16-windows-i686-none",
-        major: 3,
-        minor: 9,
-        patch: 16,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
-        os: Os::Windows,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
-        sha256: Some("d7994b5febb375bb131d028f98f4902ba308913c77095457ccd159b521e20c52")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("c86ed2bf3ff290af10f96183c53e2b29e954abb520806fbe01d3ef2f9d809a75")
     },
     PythonDownload {
-        key: "cpython-3.9.16-linux-ppc64le-gnu",
+        key: "cpython-3.9.16-linux-powerpc64le-gnu",
         major: 3,
         minor: 9,
         patch: 16,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Ppc64Le,
+        arch: Arch::Powerpc64Le,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("8b2e7ddc6feb116dfa6829cfc478be90a374dc5ce123a98bc77e86d0e93e917d")
     },
     PythonDownload {
-        key: "cpython-3.9.16-darwin-x86_64-none",
+        key: "cpython-3.9.16-linux-x86-gnu",
         major: 3,
         minor: 9,
         patch: 16,
         implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
+        arch: Arch::X86,
+        os: Os::Linux,
+        libc: Libc::Gnu,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+        sha256: Some("e2a0226165550492e895369ee1b69a515f82e12cb969656012ee8e1543409661")
+    },
+    PythonDownload {
+        key: "cpython-3.9.16-windows-x86-none",
+        major: 3,
+        minor: 9,
+        patch: 16,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
+        os: Os::Windows,
         libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("5809626ca7907c8ea397341f3d5eafb280ed5b19cc5622e57b14d9b4362eba50")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
+        sha256: Some("d7994b5febb375bb131d028f98f4902ba308913c77095457ccd159b521e20c52")
     },
     PythonDownload {
         key: "cpython-3.9.16-linux-x86_64-gnu",
@@ -2645,6 +2633,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("c397f292021b33531248ad8fede24ef6249cc6172347b2017f92b4a71845b8ed")
     },
     PythonDownload {
+        key: "cpython-3.9.16-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 16,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("5809626ca7907c8ea397341f3d5eafb280ed5b19cc5622e57b14d9b4362eba50")
+    },
+    PythonDownload {
         key: "cpython-3.9.16-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -2657,64 +2657,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("199c821505e287c004c3796ba9ac4bd129d7793e1d833e9a7672ed03bdb397d4")
     },
     PythonDownload {
-        key: "cpython-3.9.15-darwin-arm64-none",
+        key: "cpython-3.9.15-linux-aarch64-gnu",
         major: 3,
         minor: 9,
         patch: 15,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("1799b97619572ad595cd6d309bbcc57606138a57f4e90af04e04ee31d187e22f")
-    },
-    PythonDownload {
-        key: "cpython-3.9.15-linux-arm64-gnu",
-        major: 3,
-        minor: 9,
-        patch: 15,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("0da1f081313b088c1381206e698e70fffdffc01e1b2ce284145c24ee5f5b4cbb")
     },
     PythonDownload {
-        key: "cpython-3.9.15-linux-i686-gnu",
+        key: "cpython-3.9.15-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 15,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("1799b97619572ad595cd6d309bbcc57606138a57f4e90af04e04ee31d187e22f")
+    },
+    PythonDownload {
+        key: "cpython-3.9.15-linux-x86-gnu",
+        major: 3,
+        minor: 9,
+        patch: 15,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("cbc6a14835022d89f4ca6042a06c4959d74d4bbb58e70bdbe0fe8d2928934922")
     },
     PythonDownload {
-        key: "cpython-3.9.15-windows-i686-none",
+        key: "cpython-3.9.15-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 15,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("a5ad2a6ace97d458ad7b2857fba519c5c332362442d88e2b23ed818f243b8a78")
-    },
-    PythonDownload {
-        key: "cpython-3.9.15-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 15,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("50fd795eac55c4485e2fefbb8e7b365461817733c45becb50a7480a243e6000e")
     },
     PythonDownload {
         key: "cpython-3.9.15-linux-x86_64-gnu",
@@ -2741,6 +2729,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("4597f0009cfb52e748a57badab28edf84a263390b777c182b18c36d666a01440")
     },
     PythonDownload {
+        key: "cpython-3.9.15-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 15,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("50fd795eac55c4485e2fefbb8e7b365461817733c45becb50a7480a243e6000e")
+    },
+    PythonDownload {
         key: "cpython-3.9.15-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -2753,64 +2753,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("d0f3ce1748a51779eedf155aea617c39426e3f7bfd93b4876cb172576b6e8bda")
     },
     PythonDownload {
-        key: "cpython-3.9.14-darwin-arm64-none",
+        key: "cpython-3.9.14-linux-aarch64-gnu",
         major: 3,
         minor: 9,
         patch: 14,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("6b9d2ff724aff88a4d0790c86f2e5d17037736f35a796e71732624191ddd6e38")
-    },
-    PythonDownload {
-        key: "cpython-3.9.14-linux-arm64-gnu",
-        major: 3,
-        minor: 9,
-        patch: 14,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("3020c743e4742d6e0e5d27fcb166c694bf1d9565369b2eaee9d68434304aebd2")
     },
     PythonDownload {
-        key: "cpython-3.9.14-linux-i686-gnu",
+        key: "cpython-3.9.14-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 14,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("6b9d2ff724aff88a4d0790c86f2e5d17037736f35a796e71732624191ddd6e38")
+    },
+    PythonDownload {
+        key: "cpython-3.9.14-linux-x86-gnu",
+        major: 3,
+        minor: 9,
+        patch: 14,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("83a11c4f3d1c0ec39119bd0513a8684b59b68c3989cf1e5042d7417d4770c904")
     },
     PythonDownload {
-        key: "cpython-3.9.14-windows-i686-none",
+        key: "cpython-3.9.14-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 14,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("fae990eb312314102408cb0c0453dae670f0eb468f4cbf3e72327ceaa1276b46")
-    },
-    PythonDownload {
-        key: "cpython-3.9.14-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 14,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("186155e19b63da3248347415f888fbcf982c7587f6f927922ca243ae3f23ed2f")
     },
     PythonDownload {
         key: "cpython-3.9.14-linux-x86_64-gnu",
@@ -2837,6 +2825,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("5638c12d47eb81adf96615cea8a5a61e8414c3ac03a8b570d30ae9998cb6d030")
     },
     PythonDownload {
+        key: "cpython-3.9.14-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 14,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("186155e19b63da3248347415f888fbcf982c7587f6f927922ca243ae3f23ed2f")
+    },
+    PythonDownload {
         key: "cpython-3.9.14-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -2849,64 +2849,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("49f27a3a18b4c2d765b0656c6529378a20b3e37fdb0aca9490576ff7a67243a9")
     },
     PythonDownload {
-        key: "cpython-3.9.13-darwin-arm64-none",
+        key: "cpython-3.9.13-linux-aarch64-gnu",
         major: 3,
         minor: 9,
         patch: 13,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("8612e9328663c0747d1eae36b218d11c2fbc53c39ec7512c7ad6b1b57374a5dc")
-    },
-    PythonDownload {
-        key: "cpython-3.9.13-linux-arm64-gnu",
-        major: 3,
-        minor: 9,
-        patch: 13,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("8c706ebb2c8970da4fbec95b0520b4632309bc6a3e115cf309e38f181b553d14")
     },
     PythonDownload {
-        key: "cpython-3.9.13-linux-i686-gnu",
+        key: "cpython-3.9.13-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 13,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("8612e9328663c0747d1eae36b218d11c2fbc53c39ec7512c7ad6b1b57374a5dc")
+    },
+    PythonDownload {
+        key: "cpython-3.9.13-linux-x86-gnu",
+        major: 3,
+        minor: 9,
+        patch: 13,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("7d33637b48c45acf8805d5460895dca29bf2740fd2cf502fde6c6a00637db6b5")
     },
     PythonDownload {
-        key: "cpython-3.9.13-windows-i686-none",
+        key: "cpython-3.9.13-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 13,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("3860abee418825c6a33f76fe88773fb05eb4bc724d246f1af063106d9ea3f999")
-    },
-    PythonDownload {
-        key: "cpython-3.9.13-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 13,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("16d21a6e62c19c574a4a225961e80966449095a8eb2c4150905e30d4e807cf86")
     },
     PythonDownload {
         key: "cpython-3.9.13-linux-x86_64-gnu",
@@ -2933,6 +2921,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("c7e48545a8291fe1be909c4454b5c48df0ee4e69e2b5e13b6144b4199c31f895")
     },
     PythonDownload {
+        key: "cpython-3.9.13-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 13,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("16d21a6e62c19c574a4a225961e80966449095a8eb2c4150905e30d4e807cf86")
+    },
+    PythonDownload {
         key: "cpython-3.9.13-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -2945,64 +2945,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("6ef2b164cae483c61da30fb6d245762b8d6d91346d66cb421989d6d1462e5a48")
     },
     PythonDownload {
-        key: "cpython-3.9.12-darwin-arm64-none",
+        key: "cpython-3.9.12-linux-aarch64-gnu",
         major: 3,
         minor: 9,
         patch: 12,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("b3d09b3c12295e893ee8f2cb60e8af94d8a21fc5c65016282925220f5270b85b")
-    },
-    PythonDownload {
-        key: "cpython-3.9.12-linux-arm64-gnu",
-        major: 3,
-        minor: 9,
-        patch: 12,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("202ef64e43570f0843ff5895fd9c1a2c36a96b48d52842fa95842d7d11025b20")
     },
     PythonDownload {
-        key: "cpython-3.9.12-linux-i686-gnu",
+        key: "cpython-3.9.12-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 12,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("b3d09b3c12295e893ee8f2cb60e8af94d8a21fc5c65016282925220f5270b85b")
+    },
+    PythonDownload {
+        key: "cpython-3.9.12-linux-x86-gnu",
+        major: 3,
+        minor: 9,
+        patch: 12,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("e52fdbe61dea847323cd6e81142d16a571dca9c0bcde3bfe5ae75a8d3d1a3bf4")
     },
     PythonDownload {
-        key: "cpython-3.9.12-windows-i686-none",
+        key: "cpython-3.9.12-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 12,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("361b8fa66d6b5d5623fd5e64af29cf220a693ba86d031bf7ce2b61e1ea50f568")
-    },
-    PythonDownload {
-        key: "cpython-3.9.12-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 12,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("825970ae30ae7a30a5b039aa25f1b965e2d1fe046e196e61fa2a3af8fef8c5d9")
     },
     PythonDownload {
         key: "cpython-3.9.12-linux-x86_64-gnu",
@@ -3029,6 +3017,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("eb122ab2bf0b2d71926984bc7cf5fef65b415abfe01a0974ed6c1a2502fac764")
     },
     PythonDownload {
+        key: "cpython-3.9.12-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 12,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("825970ae30ae7a30a5b039aa25f1b965e2d1fe046e196e61fa2a3af8fef8c5d9")
+    },
+    PythonDownload {
         key: "cpython-3.9.12-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -3041,64 +3041,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("c49f8b07e9c4dcfd7a5b55c131e882a4ebdf9f37fef1c7820c3ce9eb23bab8ab")
     },
     PythonDownload {
-        key: "cpython-3.9.11-darwin-arm64-none",
+        key: "cpython-3.9.11-linux-aarch64-gnu",
         major: 3,
         minor: 9,
         patch: 11,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("6d9f20607a20e2cc5ad1428f7366832dc68403fc15f2e4f195817187e7b6dbbf")
-    },
-    PythonDownload {
-        key: "cpython-3.9.11-linux-arm64-gnu",
-        major: 3,
-        minor: 9,
-        patch: 11,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("e1f3ae07a28a687f8602fb4d29a1b72cc5e113c61dc6769d0d85081ab3e09c71")
     },
     PythonDownload {
-        key: "cpython-3.9.11-linux-i686-gnu",
+        key: "cpython-3.9.11-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 11,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("6d9f20607a20e2cc5ad1428f7366832dc68403fc15f2e4f195817187e7b6dbbf")
+    },
+    PythonDownload {
+        key: "cpython-3.9.11-linux-x86-gnu",
+        major: 3,
+        minor: 9,
+        patch: 11,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("0be0a5f524c68d521be2417565ca43f3125b1845f996d6d62266aa431e673f93")
     },
     PythonDownload {
-        key: "cpython-3.9.11-windows-i686-none",
+        key: "cpython-3.9.11-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 11,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("f06338422e7e3ad25d0cd61864bdb36d565d46440dd363cbb98821d388ed377a")
-    },
-    PythonDownload {
-        key: "cpython-3.9.11-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 11,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("35e649618e7e602778e72b91c9c50c97d01a0c3509d16225a1f41dd0fd6575f0")
     },
     PythonDownload {
         key: "cpython-3.9.11-linux-x86_64-gnu",
@@ -3125,6 +3113,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("d83eb5c897120e32287cb6fe5c24dd2dcae00878b3f9d7002590d468bd5de0f1")
     },
     PythonDownload {
+        key: "cpython-3.9.11-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 11,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("35e649618e7e602778e72b91c9c50c97d01a0c3509d16225a1f41dd0fd6575f0")
+    },
+    PythonDownload {
         key: "cpython-3.9.11-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -3137,64 +3137,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("1fe3c519d43737dc7743aec43f72735e1429c79e06e3901b21bad67b642f1a10")
     },
     PythonDownload {
-        key: "cpython-3.9.10-darwin-arm64-none",
+        key: "cpython-3.9.10-linux-aarch64-gnu",
         major: 3,
         minor: 9,
         patch: 10,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("ba1b63600ed8d9f3b8d739657bd8e7f5ca167de29a1a58d04b2cd9940b289464")
-    },
-    PythonDownload {
-        key: "cpython-3.9.10-linux-arm64-gnu",
-        major: 3,
-        minor: 9,
-        patch: 10,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("8bf7ac2cd5825b8fde0a6e535266a57c97e82fd5a97877940920b403ca5e53d7")
     },
     PythonDownload {
-        key: "cpython-3.9.10-linux-i686-gnu",
+        key: "cpython-3.9.10-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 10,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("ba1b63600ed8d9f3b8d739657bd8e7f5ca167de29a1a58d04b2cd9940b289464")
+    },
+    PythonDownload {
+        key: "cpython-3.9.10-linux-x86-gnu",
+        major: 3,
+        minor: 9,
+        patch: 10,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("3e3bf4d3e71a2131e6c064d1e5019f58cb9c58fdceae4b76b26ac978a6d49aad")
     },
     PythonDownload {
-        key: "cpython-3.9.10-windows-i686-none",
+        key: "cpython-3.9.10-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 10,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("7f3ca15f89775f76a32e6ea9b2c9778ebf0cde753c5973d4493959e75dd92488")
-    },
-    PythonDownload {
-        key: "cpython-3.9.10-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 10,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("ef2f090ff920708b4b9aa5d6adf0dc930c09a4bf638d71e6883091f9e629193d")
     },
     PythonDownload {
         key: "cpython-3.9.10-linux-x86_64-gnu",
@@ -3221,6 +3209,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("2744b817f249c0563b844cddd5aba4cc2fd449489b8bd59980d7a31de3a4ece1")
     },
     PythonDownload {
+        key: "cpython-3.9.10-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 10,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("ef2f090ff920708b4b9aa5d6adf0dc930c09a4bf638d71e6883091f9e629193d")
+    },
+    PythonDownload {
         key: "cpython-3.9.10-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -3233,63 +3233,51 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("56b2738599131d03b39b914ea0597862fd9096e5e64816bf19466bf026e74f0c")
     },
     PythonDownload {
-        key: "cpython-3.9.7-darwin-arm64-none",
+        key: "cpython-3.9.7-linux-aarch64-gnu",
         major: 3,
         minor: 9,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.9.7-linux-arm64-gnu",
-        major: 3,
-        minor: 9,
-        patch: 7,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-unknown-linux-gnu-debug-20211017T1616.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.7-linux-i686-gnu",
+        key: "cpython-3.9.7-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
+        key: "cpython-3.9.7-linux-x86-gnu",
+        major: 3,
+        minor: 9,
+        patch: 7,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-unknown-linux-gnu-debug-20211017T1616.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.7-windows-i686-none",
+        key: "cpython-3.9.7-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.9.7-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 7,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -3317,6 +3305,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.9.7-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 7,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-pgo%2Blto-20211017T1616.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.9.7-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -3329,63 +3329,51 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.6-darwin-arm64-none",
+        key: "cpython-3.9.6-linux-aarch64-gnu",
         major: 3,
         minor: 9,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.9.6-linux-arm64-gnu",
-        major: 3,
-        minor: 9,
-        patch: 6,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-unknown-linux-gnu-debug-20210724T1424.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.6-linux-i686-gnu",
+        key: "cpython-3.9.6-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
+        key: "cpython-3.9.6-linux-x86-gnu",
+        major: 3,
+        minor: 9,
+        patch: 6,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-unknown-linux-gnu-debug-20210724T1424.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.6-windows-i686-none",
+        key: "cpython-3.9.6-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.9.6-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 6,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -3413,6 +3401,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.9.6-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 6,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.9.6-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -3425,51 +3425,39 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.5-darwin-arm64-none",
+        key: "cpython-3.9.5-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-aarch64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.5-linux-i686-gnu",
+        key: "cpython-3.9.5-linux-x86-gnu",
         major: 3,
         minor: 9,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-unknown-linux-gnu-debug-20210506T0943.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.5-windows-i686-none",
+        key: "cpython-3.9.5-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.9.5-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 5,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -3497,6 +3485,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.9.5-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 5,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.9.5-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -3509,51 +3509,39 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.4-darwin-arm64-none",
+        key: "cpython-3.9.4-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 4,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-aarch64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.4-linux-i686-gnu",
+        key: "cpython-3.9.4-linux-x86-gnu",
         major: 3,
         minor: 9,
         patch: 4,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-unknown-linux-gnu-debug-20210414T1515.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.4-windows-i686-none",
+        key: "cpython-3.9.4-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 4,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.9.4-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 4,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -3581,6 +3569,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.9.4-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 4,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.9.4-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -3593,39 +3593,27 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.3-darwin-arm64-none",
+        key: "cpython-3.9.3-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 3,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-aarch64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.3-windows-i686-none",
+        key: "cpython-3.9.3-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 3,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-i686-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.9.3-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 3,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -3653,6 +3641,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.9.3-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 3,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.9.3-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -3665,51 +3665,39 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.2-darwin-arm64-none",
+        key: "cpython-3.9.2-macos-aarch64-none",
         major: 3,
         minor: 9,
         patch: 2,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-aarch64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.2-linux-i686-gnu",
+        key: "cpython-3.9.2-linux-x86-gnu",
         major: 3,
         minor: 9,
         patch: 2,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-unknown-linux-gnu-debug-20210327T1202.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.2-windows-i686-none",
+        key: "cpython-3.9.2-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 2,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.9.2-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 2,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -3737,6 +3725,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.9.2-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 2,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.9.2-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -3749,27 +3749,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.1-windows-i686-none",
+        key: "cpython-3.9.1-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 1,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.9.1-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 1,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -3797,6 +3785,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.9.1-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 1,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.9.1-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -3809,27 +3809,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.9.0-windows-i686-none",
+        key: "cpython-3.9.0-windows-x86-none",
         major: 3,
         minor: 9,
         patch: 0,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-i686-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.9.0-darwin-x86_64-none",
-        major: 3,
-        minor: 9,
-        patch: 0,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -3857,6 +3845,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.9.0-macos-x86_64-none",
+        major: 3,
+        minor: 9,
+        patch: 0,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.9.0-windows-x86_64-none",
         major: 3,
         minor: 9,
@@ -3869,52 +3869,40 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.18-darwin-arm64-none",
+        key: "cpython-3.8.18-linux-aarch64-gnu",
         major: 3,
         minor: 8,
         patch: 18,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("c732c068cddcd6a008c1d6d8e35802f5bdc7323bd2eb64e77210d3d5fe4740c2")
-    },
-    PythonDownload {
-        key: "cpython-3.8.18-linux-arm64-gnu",
-        major: 3,
-        minor: 8,
-        patch: 18,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("6d71175a090950c2063680f250b8799ab39eb139aa1721c853d8950aadd1d4e2")
     },
     PythonDownload {
-        key: "cpython-3.8.18-windows-i686-none",
+        key: "cpython-3.8.18-macos-aarch64-none",
         major: 3,
         minor: 8,
         patch: 18,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("c732c068cddcd6a008c1d6d8e35802f5bdc7323bd2eb64e77210d3d5fe4740c2")
+    },
+    PythonDownload {
+        key: "cpython-3.8.18-windows-x86-none",
+        major: 3,
+        minor: 8,
+        patch: 18,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("9f94c7b54b97116cd308e73cda0b7a7b7fff4515932c5cbba18eeae9ec798351")
-    },
-    PythonDownload {
-        key: "cpython-3.8.18-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 18,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("4d4b65dd821ce13dcf6dfea3ad5c2d4c3d3a8c2b7dd49fc35c1d79f66238e89b")
     },
     PythonDownload {
         key: "cpython-3.8.18-linux-x86_64-gnu",
@@ -3941,6 +3929,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("fa1bf64cf52d830e7b4bba486c447ee955af644d167df7c42afd169c5dc71d6a")
     },
     PythonDownload {
+        key: "cpython-3.8.18-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 18,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("4d4b65dd821ce13dcf6dfea3ad5c2d4c3d3a8c2b7dd49fc35c1d79f66238e89b")
+    },
+    PythonDownload {
         key: "cpython-3.8.18-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -3953,64 +3953,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("c63abd9365a13196eb9f65db864f95b85c1f90b770d218c1acd104e6b48a99d3")
     },
     PythonDownload {
-        key: "cpython-3.8.17-darwin-arm64-none",
+        key: "cpython-3.8.17-linux-aarch64-gnu",
         major: 3,
         minor: 8,
         patch: 17,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("d08a542bed35fc74ac6e8f6884c8aa29a77ff2f4ed04a06dcf91578dea622f9a")
-    },
-    PythonDownload {
-        key: "cpython-3.8.17-linux-arm64-gnu",
-        major: 3,
-        minor: 8,
-        patch: 17,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("eaee5a0b79cc28943e19df54f314634795aee43a6670ce99c0306893a18fa784")
     },
     PythonDownload {
-        key: "cpython-3.8.17-linux-i686-gnu",
+        key: "cpython-3.8.17-macos-aarch64-none",
         major: 3,
         minor: 8,
         patch: 17,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("d08a542bed35fc74ac6e8f6884c8aa29a77ff2f4ed04a06dcf91578dea622f9a")
+    },
+    PythonDownload {
+        key: "cpython-3.8.17-linux-x86-gnu",
+        major: 3,
+        minor: 8,
+        patch: 17,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("61ac08680c022f180a32dc82d84548aeb92c7194a489e3b3c532dc48f999d757")
     },
     PythonDownload {
-        key: "cpython-3.8.17-windows-i686-none",
+        key: "cpython-3.8.17-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 17,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("0931d8ca0e060c6ac1dfcf6bb9b6dea0ac3a9d95daf7906a88128045f4464bf8")
-    },
-    PythonDownload {
-        key: "cpython-3.8.17-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 17,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("2c4925f5cf37d498e0d8cfe7b10591cc5f0cd80d2582f566b12006e6f96958b1")
     },
     PythonDownload {
         key: "cpython-3.8.17-linux-x86_64-gnu",
@@ -4037,6 +4025,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("a316ba0b1f425b04c8dfd7a8a18a05d72ae5852732d401b16d7439bdf25caec3")
     },
     PythonDownload {
+        key: "cpython-3.8.17-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 17,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("2c4925f5cf37d498e0d8cfe7b10591cc5f0cd80d2582f566b12006e6f96958b1")
+    },
+    PythonDownload {
         key: "cpython-3.8.17-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4049,64 +4049,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("68c7d03de5283c4812f2706c797b2139999a28cec647bc662d1459a922059318")
     },
     PythonDownload {
-        key: "cpython-3.8.16-darwin-arm64-none",
+        key: "cpython-3.8.16-linux-aarch64-gnu",
         major: 3,
         minor: 8,
         patch: 16,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("bfc91d0a1d6d6dfaa5a31c925aa6adae82bd1ae5eb17813a9f0a50bf9d3e6305")
-    },
-    PythonDownload {
-        key: "cpython-3.8.16-linux-arm64-gnu",
-        major: 3,
-        minor: 8,
-        patch: 16,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("423d43d93e2fe33b41ad66d35426f16541f09fee9d7272ae5decf5474ebbc225")
     },
     PythonDownload {
-        key: "cpython-3.8.16-linux-i686-gnu",
+        key: "cpython-3.8.16-macos-aarch64-none",
         major: 3,
         minor: 8,
         patch: 16,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("bfc91d0a1d6d6dfaa5a31c925aa6adae82bd1ae5eb17813a9f0a50bf9d3e6305")
+    },
+    PythonDownload {
+        key: "cpython-3.8.16-linux-x86-gnu",
+        major: 3,
+        minor: 8,
+        patch: 16,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("9aa3e559130a47c33ee2b67f6ca69e2f10d8f70c1fd1e2871763b892372a6d9e")
     },
     PythonDownload {
-        key: "cpython-3.8.16-windows-i686-none",
+        key: "cpython-3.8.16-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 16,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("5de953621402c11cc7db65ba15d45779e838d7ce78e7aa8d43c7d78fff177f13")
-    },
-    PythonDownload {
-        key: "cpython-3.8.16-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 16,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("21c0f4a0fa6ee518b9f2f1901c9667e3baf45d9f84235408b7ca50499d19f56d")
     },
     PythonDownload {
         key: "cpython-3.8.16-linux-x86_64-gnu",
@@ -4133,6 +4121,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("f7d46196b44d12a26209ac74061200aac478b96c253eea93a0b9734efa642779")
     },
     PythonDownload {
+        key: "cpython-3.8.16-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 16,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("21c0f4a0fa6ee518b9f2f1901c9667e3baf45d9f84235408b7ca50499d19f56d")
+    },
+    PythonDownload {
         key: "cpython-3.8.16-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4145,64 +4145,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("6316713c2dcb30127b38ced249fa9608830a33459580b71275a935aaa8cd5d5f")
     },
     PythonDownload {
-        key: "cpython-3.8.15-darwin-arm64-none",
+        key: "cpython-3.8.15-linux-aarch64-gnu",
         major: 3,
         minor: 8,
         patch: 15,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("fc0f944e6f01ed649f79c873af1c317db61d2136b82081b4d7cbb7755f878035")
-    },
-    PythonDownload {
-        key: "cpython-3.8.15-linux-arm64-gnu",
-        major: 3,
-        minor: 8,
-        patch: 15,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("2e80025eda686c14a9a0618ced40043c1d577a754b904fd7a382cd41abf9ca00")
     },
     PythonDownload {
-        key: "cpython-3.8.15-linux-i686-gnu",
+        key: "cpython-3.8.15-macos-aarch64-none",
         major: 3,
         minor: 8,
         patch: 15,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("fc0f944e6f01ed649f79c873af1c317db61d2136b82081b4d7cbb7755f878035")
+    },
+    PythonDownload {
+        key: "cpython-3.8.15-linux-x86-gnu",
+        major: 3,
+        minor: 8,
+        patch: 15,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("b8436415ea9bd9970fb766f791a14b0e14ce6351fc4604eb158f1425e8bb4a33")
     },
     PythonDownload {
-        key: "cpython-3.8.15-windows-i686-none",
+        key: "cpython-3.8.15-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 15,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("98bb2315c3567316c30b060d613c8d6067b368b64f08ef8fe6196341637c1d78")
-    },
-    PythonDownload {
-        key: "cpython-3.8.15-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 15,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("e4fd2fa2255295fbdcfadb8b48014fa80810305eccb246d355880aabb45cbe93")
     },
     PythonDownload {
         key: "cpython-3.8.15-linux-x86_64-gnu",
@@ -4229,6 +4217,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("231b35d3c2cff0372d17cea7ff5168c0684a920b94a912ffc965c2518cacb694")
     },
     PythonDownload {
+        key: "cpython-3.8.15-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 15,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("e4fd2fa2255295fbdcfadb8b48014fa80810305eccb246d355880aabb45cbe93")
+    },
+    PythonDownload {
         key: "cpython-3.8.15-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4241,64 +4241,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("59beac5610e6da0848ebaccd72f91f6aaaeed65ef59606d006af909e9e79beba")
     },
     PythonDownload {
-        key: "cpython-3.8.14-darwin-arm64-none",
+        key: "cpython-3.8.14-linux-aarch64-gnu",
         major: 3,
         minor: 8,
         patch: 14,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("d17a3fcc161345efa2ec0b4ab9c9ed6c139d29128f2e34bb636338a484aa7b72")
-    },
-    PythonDownload {
-        key: "cpython-3.8.14-linux-arm64-gnu",
-        major: 3,
-        minor: 8,
-        patch: 14,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("a14d8b5cbd8e1ca45cbcb49f4bf0b0440dc86eb95b7c3da3c463a704a3b4593c")
     },
     PythonDownload {
-        key: "cpython-3.8.14-linux-i686-gnu",
+        key: "cpython-3.8.14-macos-aarch64-none",
         major: 3,
         minor: 8,
         patch: 14,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("d17a3fcc161345efa2ec0b4ab9c9ed6c139d29128f2e34bb636338a484aa7b72")
+    },
+    PythonDownload {
+        key: "cpython-3.8.14-linux-x86-gnu",
+        major: 3,
+        minor: 8,
+        patch: 14,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("631bb90fe8f2965d03400b268de90fe155ce51961296360d6578b7151aa9ef4c")
     },
     PythonDownload {
-        key: "cpython-3.8.14-windows-i686-none",
+        key: "cpython-3.8.14-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 14,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("e43f7a5044eac91e95df59fd08bf96f13245898876fc2afd90a081cfcd847e35")
-    },
-    PythonDownload {
-        key: "cpython-3.8.14-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 14,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("62edfea77b42e87ca2d85c482319211cd2dd68d55ba85c99f1834f7b64a60133")
     },
     PythonDownload {
         key: "cpython-3.8.14-linux-x86_64-gnu",
@@ -4325,6 +4313,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("c6da442aaea160179a9379b297ccb3ba09b825fc27d84577fc28e62911451e7d")
     },
     PythonDownload {
+        key: "cpython-3.8.14-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 14,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("62edfea77b42e87ca2d85c482319211cd2dd68d55ba85c99f1834f7b64a60133")
+    },
+    PythonDownload {
         key: "cpython-3.8.14-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4337,64 +4337,52 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("6986b3e6edf7b37f96ea940b7ccba7b767ed3ea9b3faec2a2a60e5b2c4443314")
     },
     PythonDownload {
-        key: "cpython-3.8.13-darwin-arm64-none",
+        key: "cpython-3.8.13-linux-aarch64-gnu",
         major: 3,
         minor: 8,
         patch: 13,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("a204e5f9e1566bdc170b163300a29fc9580d5c65cd6e896caf6500cd64471373")
-    },
-    PythonDownload {
-        key: "cpython-3.8.13-linux-arm64-gnu",
-        major: 3,
-        minor: 8,
-        patch: 13,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
+        arch: Arch::Aarch64,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("3a927205db4686c182b5e8f3fc7fd7d82ec8f61c70d5b2bfddd9673c7ddc07ba")
     },
     PythonDownload {
-        key: "cpython-3.8.13-linux-i686-gnu",
+        key: "cpython-3.8.13-macos-aarch64-none",
         major: 3,
         minor: 8,
         patch: 13,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("a204e5f9e1566bdc170b163300a29fc9580d5c65cd6e896caf6500cd64471373")
+    },
+    PythonDownload {
+        key: "cpython-3.8.13-linux-x86-gnu",
+        major: 3,
+        minor: 8,
+        patch: 13,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("6daf0405beae6d127a2dcae61d51a719236b861b4cabc220727e48547fd6f045")
     },
     PythonDownload {
-        key: "cpython-3.8.13-windows-i686-none",
+        key: "cpython-3.8.13-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 13,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("5630739d1c6fcfbf90311d236c5e46314fc4b439364429bee12d0ffc95e134fb")
-    },
-    PythonDownload {
-        key: "cpython-3.8.13-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 13,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("f706a62de8582bf84b8b693c993314cd786f3e78639892cfd9a7283a526696f9")
     },
     PythonDownload {
         key: "cpython-3.8.13-linux-x86_64-gnu",
@@ -4421,6 +4409,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("410f3223021d1b439cf8e4da699f868adada2066e354d88a00b5f365dc66c4bf")
     },
     PythonDownload {
+        key: "cpython-3.8.13-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 13,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("f706a62de8582bf84b8b693c993314cd786f3e78639892cfd9a7283a526696f9")
+    },
+    PythonDownload {
         key: "cpython-3.8.13-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4433,52 +4433,40 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("c36b703b8b806a047ba71e5e85734ac78d204d3a2b7ebc2efcdc7d4af6f6c263")
     },
     PythonDownload {
-        key: "cpython-3.8.12-darwin-arm64-none",
+        key: "cpython-3.8.12-macos-aarch64-none",
         major: 3,
         minor: 8,
         patch: 12,
         implementation: ImplementationName::Cpython,
-        arch: Arch::Arm64,
-        os: Os::Darwin,
+        arch: Arch::Aarch64,
+        os: Os::Macos,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-aarch64-apple-darwin-pgo%2Blto-full.tar.zst",
         sha256: Some("386f667f8d49b6c34aee1910cdc0b5b41883f9406f98e7d59a3753990b1cdbac")
     },
     PythonDownload {
-        key: "cpython-3.8.12-linux-i686-gnu",
+        key: "cpython-3.8.12-linux-x86-gnu",
         major: 3,
         minor: 8,
         patch: 12,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
         sha256: Some("7cfac9a57e262be3e889036d7fc570293e6d3d74411ee23e1fa9aa470d387e6a")
     },
     PythonDownload {
-        key: "cpython-3.8.12-windows-i686-none",
+        key: "cpython-3.8.12-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 12,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-pc-windows-msvc-shared-pgo-full.tar.zst",
         sha256: Some("3e2e6c7de78b1924aad37904fed7bfbac6efa2bef05348e9be92180b2f2b1ae1")
-    },
-    PythonDownload {
-        key: "cpython-3.8.12-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 12,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
-        sha256: Some("cf614d96e2001d526061b3ce0569c79057fd0074ace472ff4f5f601262e08cdb")
     },
     PythonDownload {
         key: "cpython-3.8.12-linux-x86_64-gnu",
@@ -4505,6 +4493,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("3d958e3f984637d8ca4a90a2e068737b268f87fc615121a6f1808cd46ccacc48")
     },
     PythonDownload {
+        key: "cpython-3.8.12-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 12,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-pgo%2Blto-full.tar.zst",
+        sha256: Some("cf614d96e2001d526061b3ce0569c79057fd0074ace472ff4f5f601262e08cdb")
+    },
+    PythonDownload {
         key: "cpython-3.8.12-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4517,39 +4517,27 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: Some("33f278416ba8074f2ca6d7f8c17b311b60537c9e6431fd47948784c2a78ea227")
     },
     PythonDownload {
-        key: "cpython-3.8.11-linux-i686-gnu",
+        key: "cpython-3.8.11-linux-x86-gnu",
         major: 3,
         minor: 8,
         patch: 11,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-unknown-linux-gnu-debug-20210724T1424.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.11-windows-i686-none",
+        key: "cpython-3.8.11-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 11,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.8.11-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 11,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -4577,6 +4565,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.8.11-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 11,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.8.11-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4589,39 +4589,27 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.10-linux-i686-gnu",
+        key: "cpython-3.8.10-linux-x86-gnu",
         major: 3,
         minor: 8,
         patch: 10,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-unknown-linux-gnu-debug-20210506T0943.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.10-windows-i686-none",
+        key: "cpython-3.8.10-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 10,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.8.10-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 10,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -4649,6 +4637,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.8.10-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 10,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.8.10-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4661,39 +4661,27 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.9-linux-i686-gnu",
+        key: "cpython-3.8.9-linux-x86-gnu",
         major: 3,
         minor: 8,
         patch: 9,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-unknown-linux-gnu-debug-20210414T1515.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.9-windows-i686-none",
+        key: "cpython-3.8.9-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 9,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.8.9-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 9,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -4721,6 +4709,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.8.9-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 9,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.8.9-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4733,39 +4733,27 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.8-linux-i686-gnu",
+        key: "cpython-3.8.8-linux-x86-gnu",
         major: 3,
         minor: 8,
         patch: 8,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Linux,
         libc: Libc::Gnu,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-unknown-linux-gnu-debug-20210327T1202.tar.zst",
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.8-windows-i686-none",
+        key: "cpython-3.8.8-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 8,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.8.8-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 8,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -4793,6 +4781,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.8.8-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 8,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.8.8-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4805,27 +4805,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.7-windows-i686-none",
+        key: "cpython-3.8.7-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.8.7-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 7,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -4853,6 +4841,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.8.7-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 7,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.8.7-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4865,27 +4865,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.6-windows-i686-none",
+        key: "cpython-3.8.6-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-i686-pc-windows-msvc-shared-pgo-20201021T0233.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.8.6-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 6,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -4913,6 +4901,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.8.6-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 6,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.8.6-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4925,27 +4925,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.5-windows-i686-none",
+        key: "cpython-3.8.5-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-i686-pc-windows-msvc-shared-pgo-20200830T2311.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.8.5-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 5,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.8.5-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -4973,6 +4961,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.8.5-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 5,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.8.5-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.8.5-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -4985,27 +4985,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.3-windows-i686-none",
+        key: "cpython-3.8.3-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 3,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-i686-pc-windows-msvc-shared-pgo-20200518T0154.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.8.3-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 3,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.8.3-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -5033,6 +5021,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.8.3-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 3,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.8.3-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.8.3-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -5045,27 +5045,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.8.2-windows-i686-none",
+        key: "cpython-3.8.2-windows-x86-none",
         major: 3,
         minor: 8,
         patch: 2,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-i686-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.8.2-darwin-x86_64-none",
-        major: 3,
-        minor: 8,
-        patch: 2,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-apple-darwin-pgo-20200418T2238.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -5081,6 +5069,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.8.2-macos-x86_64-none",
+        major: 3,
+        minor: 8,
+        patch: 2,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-apple-darwin-pgo-20200418T2238.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.8.2-windows-x86_64-none",
         major: 3,
         minor: 8,
@@ -5093,27 +5093,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.7.9-windows-i686-none",
+        key: "cpython-3.7.9-windows-x86-none",
         major: 3,
         minor: 7,
         patch: 9,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-i686-pc-windows-msvc-shared-pgo-20200823T0159.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.7.9-darwin-x86_64-none",
-        major: 3,
-        minor: 7,
-        patch: 9,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.7.9-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -5141,6 +5129,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.7.9-macos-x86_64-none",
+        major: 3,
+        minor: 7,
+        patch: 9,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.7.9-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.7.9-windows-x86_64-none",
         major: 3,
         minor: 7,
@@ -5153,27 +5153,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.7.7-windows-i686-none",
+        key: "cpython-3.7.7-windows-x86-none",
         major: 3,
         minor: 7,
         patch: 7,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-i686-pc-windows-msvc-shared-pgo-20200517T2153.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.7.7-darwin-x86_64-none",
-        major: 3,
-        minor: 7,
-        patch: 7,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.7.7-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -5201,6 +5189,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.7.7-macos-x86_64-none",
+        major: 3,
+        minor: 7,
+        patch: 7,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.7.7-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.7.7-windows-x86_64-none",
         major: 3,
         minor: 7,
@@ -5213,27 +5213,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.7.6-windows-i686-none",
+        key: "cpython-3.7.6-windows-x86-none",
         major: 3,
         minor: 7,
         patch: 6,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-x86-shared-pgo-20200217T0110.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.7.6-darwin-x86_64-none",
-        major: 3,
-        minor: 7,
-        patch: 6,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-macos-20200216T2344.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -5261,6 +5249,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.7.6-macos-x86_64-none",
+        major: 3,
+        minor: 7,
+        patch: 6,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-macos-20200216T2344.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.7.6-windows-x86_64-none",
         major: 3,
         minor: 7,
@@ -5273,27 +5273,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.7.5-windows-i686-none",
+        key: "cpython-3.7.5-windows-x86-none",
         major: 3,
         minor: 7,
         patch: 5,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-x86-20191025T0549.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.7.5-darwin-x86_64-none",
-        major: 3,
-        minor: 7,
-        patch: 5,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-macos-20191026T0535.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -5321,6 +5309,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.7.5-macos-x86_64-none",
+        major: 3,
+        minor: 7,
+        patch: 5,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-macos-20191026T0535.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.7.5-windows-x86_64-none",
         major: 3,
         minor: 7,
@@ -5333,27 +5333,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.7.4-windows-i686-none",
+        key: "cpython-3.7.4-windows-x86-none",
         major: 3,
         minor: 7,
         patch: 4,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-x86-20190817T0235.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.7.4-darwin-x86_64-none",
-        major: 3,
-        minor: 7,
-        patch: 4,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-macos-20190817T0220.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -5381,6 +5369,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
+        key: "cpython-3.7.4-macos-x86_64-none",
+        major: 3,
+        minor: 7,
+        patch: 4,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-macos-20190817T0220.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
         key: "cpython-3.7.4-windows-x86_64-none",
         major: 3,
         minor: 7,
@@ -5393,27 +5393,15 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         sha256: None
     },
     PythonDownload {
-        key: "cpython-3.7.3-windows-i686-none",
+        key: "cpython-3.7.3-windows-x86-none",
         major: 3,
         minor: 7,
         patch: 3,
         implementation: ImplementationName::Cpython,
-        arch: Arch::I686,
+        arch: Arch::X86,
         os: Os::Windows,
         libc: Libc::None,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-x86-20190709T0348.tar.zst",
-        sha256: None
-    },
-    PythonDownload {
-        key: "cpython-3.7.3-darwin-x86_64-none",
-        major: 3,
-        minor: 7,
-        patch: 3,
-        implementation: ImplementationName::Cpython,
-        arch: Arch::X86_64,
-        os: Os::Darwin,
-        libc: Libc::None,
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-macos-20190618T0523.tar.zst",
         sha256: None
     },
     PythonDownload {
@@ -5438,6 +5426,18 @@ pub(crate) const PYTHON_DOWNLOADS: &[PythonDownload] = &[
         os: Os::Linux,
         libc: Libc::Musl,
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-linux64-musl-20190618T0400.tar.zst",
+        sha256: None
+    },
+    PythonDownload {
+        key: "cpython-3.7.3-macos-x86_64-none",
+        major: 3,
+        minor: 7,
+        patch: 3,
+        implementation: ImplementationName::Cpython,
+        arch: Arch::X86_64,
+        os: Os::Macos,
+        libc: Libc::None,
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-macos-20190618T0523.tar.zst",
         sha256: None
     },
     PythonDownload {


### PR DESCRIPTION
Prompted in https://github.com/astral-sh/uv/pull/2842#discussion_r1555640300

Updates the toolchain `Os` and `Arch` types to be a closer match to those in `platform-tags`.

They don't match exactly, e.g. we track `Libc` separately instead of using `Manylinux` and `Musllinux` and we don't need release versions. This makes me think we might not actually want to consolidate to central shared types.