### PR TITLE
Replace PyPI-internal Hashes representation with flat vector

### DIFF
--- a/crates/distribution-types/src/file.rs
+++ b/crates/distribution-types/src/file.rs
@@ -25,7 +25,7 @@ pub enum FileConversionError {
 #[archive(check_bytes)]
 #[archive_attr(derive(Debug))]
 pub struct File {
-    pub dist_info_metadata: Option<DistInfoMetadata>,
+    pub dist_info_metadata: bool,
     pub filename: String,
     pub hashes: Vec<HashDigest>,
     pub requires_python: Option<VersionSpecifiers>,
@@ -43,7 +43,10 @@ impl File {
     /// `TryFrom` instead of `From` to filter out files with invalid requires python version specifiers
     pub fn try_from(file: pypi_types::File, base: &Url) -> Result<Self, FileConversionError> {
         Ok(Self {
-            dist_info_metadata: file.dist_info_metadata,
+            dist_info_metadata: file
+                .dist_info_metadata
+                .as_ref()
+                .is_some_and(DistInfoMetadata::is_available),
             filename: file.filename,
             hashes: file.hashes.into_digests(),
             requires_python: file

--- a/crates/distribution-types/src/file.rs
+++ b/crates/distribution-types/src/file.rs
@@ -7,7 +7,7 @@ use url::Url;
 
 use pep440_rs::{VersionSpecifiers, VersionSpecifiersParseError};
 use pep508_rs::split_scheme;
-use pypi_types::{DistInfoMetadata, Hashes, Yanked};
+use pypi_types::{DistInfoMetadata, HashDigest, Yanked};
 
 /// Error converting [`pypi_types::File`] to [`distribution_type::File`].
 #[derive(Debug, Error)]
@@ -27,7 +27,7 @@ pub enum FileConversionError {
 pub struct File {
     pub dist_info_metadata: Option<DistInfoMetadata>,
     pub filename: String,
-    pub hashes: Hashes,
+    pub hashes: Vec<HashDigest>,
     pub requires_python: Option<VersionSpecifiers>,
     pub size: Option<u64>,
     // N.B. We don't use a chrono DateTime<Utc> here because it's a little
@@ -45,7 +45,7 @@ impl File {
         Ok(Self {
             dist_info_metadata: file.dist_info_metadata,
             filename: file.filename,
-            hashes: file.hashes,
+            hashes: file.hashes.into_digests(),
             requires_python: file
                 .requires_python
                 .transpose()

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -774,16 +774,16 @@ impl Identifier for Url {
 
 impl Identifier for File {
     fn distribution_id(&self) -> DistributionId {
-        if let Some(hash) = self.hashes.as_str() {
-            DistributionId::new(hash)
+        if let Some(hash) = self.hashes.first() {
+            DistributionId::new(&*hash.digest)
         } else {
             self.url.distribution_id()
         }
     }
 
     fn resource_id(&self) -> ResourceId {
-        if let Some(hash) = self.hashes.as_str() {
-            ResourceId::new(hash)
+        if let Some(hash) = self.hashes.first() {
+            ResourceId::new(&*hash.digest)
         } else {
             self.url.resource_id()
         }

--- a/crates/pypi-types/src/simple_json.rs
+++ b/crates/pypi-types/src/simple_json.rs
@@ -68,11 +68,7 @@ where
     ))
 }
 
-#[derive(
-    Debug, Clone, Serialize, Deserialize, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
-)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum DistInfoMetadata {
     Bool(bool),
@@ -125,23 +121,7 @@ impl Default for Yanked {
 /// A dictionary mapping a hash name to a hex encoded digest of the file.
 ///
 /// PEP 691 says multiple hashes can be included and the interpretation is left to the client.
-#[derive(
-    Debug,
-    Clone,
-    Ord,
-    PartialOrd,
-    Eq,
-    PartialEq,
-    Hash,
-    Default,
-    Serialize,
-    Deserialize,
-    rkyv::Archive,
-    rkyv::Deserialize,
-    rkyv::Serialize,
-)]
-#[archive(check_bytes)]
-#[archive_attr(derive(Debug))]
+#[derive(Debug, Clone, Eq, PartialEq, Default, Deserialize)]
 pub struct Hashes {
     pub md5: Option<Box<str>>,
     pub sha256: Option<Box<str>>,
@@ -153,16 +133,10 @@ impl Hashes {
     /// Convert a set of [`Hashes`] into a list of [`HashDigest`]s.
     pub fn into_digests(self) -> Vec<HashDigest> {
         let mut digests = Vec::new();
-        if let Some(md5) = self.md5 {
+        if let Some(sha512) = self.sha512 {
             digests.push(HashDigest {
-                algorithm: HashAlgorithm::Md5,
-                digest: md5,
-            });
-        }
-        if let Some(sha256) = self.sha256 {
-            digests.push(HashDigest {
-                algorithm: HashAlgorithm::Sha256,
-                digest: sha256,
+                algorithm: HashAlgorithm::Sha512,
+                digest: sha512,
             });
         }
         if let Some(sha384) = self.sha384 {
@@ -171,10 +145,16 @@ impl Hashes {
                 digest: sha384,
             });
         }
-        if let Some(sha512) = self.sha512 {
+        if let Some(sha256) = self.sha256 {
             digests.push(HashDigest {
-                algorithm: HashAlgorithm::Sha512,
-                digest: sha512,
+                algorithm: HashAlgorithm::Sha256,
+                digest: sha256,
+            });
+        }
+        if let Some(md5) = self.md5 {
+            digests.push(HashDigest {
+                algorithm: HashAlgorithm::Md5,
+                digest: md5,
             });
         }
         digests
@@ -310,7 +290,6 @@ impl std::fmt::Display for HashAlgorithm {
 #[archive_attr(derive(Debug))]
 pub struct HashDigest {
     pub algorithm: HashAlgorithm,
-    // TODO(charlie): This should be a Vec<u8>.
     pub digest: Box<str>,
 }
 

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -598,7 +598,7 @@ impl CacheBucket {
             Self::FlatIndex => "flat-index-v0",
             Self::Git => "git-v0",
             Self::Interpreter => "interpreter-v0",
-            Self::Simple => "simple-v6",
+            Self::Simple => "simple-v7",
             Self::Wheels => "wheels-v0",
             Self::Archive => "archive-v0",
         }

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -236,7 +236,7 @@ impl<'a> FlatIndexClient<'a> {
             };
 
             let file = File {
-                dist_info_metadata: None,
+                dist_info_metadata: false,
                 filename: filename.to_string(),
                 hashes: Vec::new(),
                 requires_python: None,

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -17,7 +17,7 @@ use distribution_types::{
 use pep440_rs::Version;
 use pep508_rs::VerbatimUrl;
 use platform_tags::Tags;
-use pypi_types::Hashes;
+
 use uv_cache::{Cache, CacheBucket};
 use uv_configuration::{NoBinary, NoBuild};
 use uv_normalize::PackageName;
@@ -238,7 +238,7 @@ impl<'a> FlatIndexClient<'a> {
             let file = File {
                 dist_info_metadata: None,
                 filename: filename.to_string(),
-                hashes: Hashes::default(),
+                hashes: Vec::new(),
                 requires_python: None,
                 size: None,
                 upload_time_utc_ms: None,
@@ -323,10 +323,10 @@ impl FlatIndex {
                 }));
                 match distributions.0.entry(version) {
                     Entry::Occupied(mut entry) => {
-                        entry.get_mut().insert_built(dist, None, compatibility);
+                        entry.get_mut().insert_built(dist, vec![], compatibility);
                     }
                     Entry::Vacant(entry) => {
-                        entry.insert(PrioritizedDist::from_built(dist, None, compatibility));
+                        entry.insert(PrioritizedDist::from_built(dist, vec![], compatibility));
                     }
                 }
             }
@@ -339,10 +339,10 @@ impl FlatIndex {
                 }));
                 match distributions.0.entry(filename.version) {
                     Entry::Occupied(mut entry) => {
-                        entry.get_mut().insert_source(dist, None, compatibility);
+                        entry.get_mut().insert_source(dist, vec![], compatibility);
                     }
                     Entry::Vacant(entry) => {
-                        entry.insert(PrioritizedDist::from_source(dist, None, compatibility));
+                        entry.insert(PrioritizedDist::from_source(dist, vec![], compatibility));
                     }
                 }
             }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -424,11 +424,7 @@ impl RegistryClient {
     ) -> Result<Metadata23, Error> {
         // If the metadata file is available at its own url (PEP 658), download it from there.
         let filename = WheelFilename::from_str(&file.filename).map_err(ErrorKind::WheelFilename)?;
-        if file
-            .dist_info_metadata
-            .as_ref()
-            .is_some_and(pypi_types::DistInfoMetadata::is_available)
-        {
+        if file.dist_info_metadata {
             let mut url = url.clone();
             url.set_path(&format!("{}.metadata", url.path()));
 

--- a/crates/uv-resolver/src/preferences.rs
+++ b/crates/uv-resolver/src/preferences.rs
@@ -6,7 +6,7 @@ use pep440_rs::{Operator, Version};
 use pep508_rs::{
     MarkerEnvironment, Requirement, RequirementsTxtRequirement, UnnamedRequirement, VersionOrUrl,
 };
-use pypi_types::{HashError, Hashes};
+use pypi_types::{HashDigest, HashError};
 use requirements_txt::RequirementEntry;
 use tracing::trace;
 use uv_normalize::PackageName;
@@ -23,7 +23,7 @@ pub enum PreferenceError {
 #[derive(Clone, Debug)]
 pub struct Preference {
     requirement: Requirement,
-    hashes: Vec<Hashes>,
+    hashes: Vec<HashDigest>,
 }
 
 impl Preference {
@@ -40,7 +40,7 @@ impl Preference {
                 .hashes
                 .iter()
                 .map(String::as_str)
-                .map(Hashes::from_str)
+                .map(HashDigest::from_str)
                 .collect::<Result<_, _>>()?,
         })
     }
@@ -146,7 +146,7 @@ impl Preferences {
         &self,
         package_name: &PackageName,
         version: &Version,
-    ) -> Option<&[Hashes]> {
+    ) -> Option<&[HashDigest]> {
         self.0
             .get(package_name)
             .filter(|pin| pin.version() == version)
@@ -158,7 +158,7 @@ impl Preferences {
 #[derive(Debug, Clone)]
 struct Pin {
     version: Version,
-    hashes: Vec<Hashes>,
+    hashes: Vec<HashDigest>,
 }
 
 impl Pin {
@@ -168,7 +168,7 @@ impl Pin {
     }
 
     /// Return the hashes of the pinned package.
-    fn hashes(&self) -> &[Hashes] {
+    fn hashes(&self) -> &[HashDigest] {
         &self.hashes
     }
 }

--- a/crates/uv-resolver/src/resolution.rs
+++ b/crates/uv-resolver/src/resolution.rs
@@ -18,7 +18,7 @@ use distribution_types::{
 use once_map::OnceMap;
 use pep440_rs::Version;
 use pep508_rs::MarkerEnvironment;
-use pypi_types::Hashes;
+use pypi_types::HashDigest;
 use uv_distribution::to_precise;
 use uv_normalize::{ExtraName, PackageName};
 
@@ -50,7 +50,7 @@ pub struct ResolutionGraph {
     /// The underlying graph.
     petgraph: petgraph::graph::Graph<ResolvedDist, Range<Version>, petgraph::Directed>,
     /// The metadata for every distribution in this resolution.
-    hashes: FxHashMap<PackageName, Vec<Hashes>>,
+    hashes: FxHashMap<PackageName, Vec<HashDigest>>,
     /// The enabled extras for every distribution in this resolution.
     extras: FxHashMap<PackageName, Vec<ExtraName>>,
     /// The set of editable requirements in this resolution.
@@ -649,12 +649,10 @@ impl std::fmt::Display for DisplayResolutionGraph<'_> {
                     .filter(|hashes| !hashes.is_empty())
                 {
                     for hash in hashes {
-                        if let Some(hash) = hash.to_string() {
-                            has_hashes = true;
-                            line.push_str(" \\\n");
-                            line.push_str("    --hash=");
-                            line.push_str(&hash);
-                        }
+                        has_hashes = true;
+                        line.push_str(" \\\n");
+                        line.push_str("    --hash=");
+                        line.push_str(&hash.to_string());
                     }
                 }
             }

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -12,7 +12,7 @@ use distribution_types::{
 };
 use pep440_rs::{Version, VersionSpecifiers};
 use platform_tags::Tags;
-use pypi_types::{Hashes, Yanked};
+use pypi_types::{HashDigest, Yanked};
 use rkyv::{de::deserializers::SharedDeserializeMap, Deserialize};
 use uv_client::{FlatDistributions, OwnedArchive, SimpleMetadata, VersionFiles};
 use uv_configuration::{NoBinary, NoBuild};
@@ -176,7 +176,7 @@ impl VersionMap {
     }
 
     /// Return the [`Hashes`] for the given version, if any.
-    pub(crate) fn hashes(&self, version: &Version) -> Option<Vec<Hashes>> {
+    pub(crate) fn hashes(&self, version: &Version) -> Option<Vec<HashDigest>> {
         match self.inner {
             VersionMapInner::Eager(ref map) => map.get(version).map(|file| file.hashes().to_vec()),
             VersionMapInner::Lazy(ref lazy) => lazy.get(version).map(|file| file.hashes().to_vec()),
@@ -378,7 +378,7 @@ impl VersionMapLazy {
                 let version = filename.version().clone();
                 let requires_python = file.requires_python.clone();
                 let yanked = file.yanked.clone();
-                let hash = file.hashes.clone();
+                let hashes = file.hashes.clone();
                 match filename {
                     DistFilename::WheelFilename(filename) => {
                         let compatibility = self.wheel_compatibility(
@@ -394,7 +394,7 @@ impl VersionMapLazy {
                             file,
                             self.index.clone(),
                         );
-                        priority_dist.insert_built(dist, Some(hash), compatibility);
+                        priority_dist.insert_built(dist, hashes, compatibility);
                     }
                     DistFilename::SourceDistFilename(filename) => {
                         let compatibility = self.source_dist_compatibility(
@@ -409,7 +409,7 @@ impl VersionMapLazy {
                             file,
                             self.index.clone(),
                         );
-                        priority_dist.insert_source(dist, Some(hash), compatibility);
+                        priority_dist.insert_source(dist, hashes, compatibility);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Right now, we have a `Hashes` representation that looks like:

```rust
/// A dictionary mapping a hash name to a hex encoded digest of the file.
///
/// PEP 691 says multiple hashes can be included and the interpretation is left to the client.
#[derive(Debug, Clone, Eq, PartialEq, Default, Deserialize)]
pub struct Hashes {
    pub md5: Option<Box<str>>,
    pub sha256: Option<Box<str>>,
    pub sha384: Option<Box<str>>,
    pub sha512: Option<Box<str>>,
}
```

It stems from the PyPI API, which returns a dictionary of hashes.

We tend to pass these around as a vector of `Vec<Hashes>`. But it's a bit strange because each entry in that vector could contain multiple hashes. And it makes it difficult to ask questions like "Is `sha256:ab21378ca980a8` in the set of hashes"?

This PR instead treats `Hashes` as the PyPI-internal type, and uses a new `Vec<HashDigest>` everywhere in our own APIs.