### PR TITLE
Add discovery of Python versions installed with `uv-toolchain`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4337,6 +4337,7 @@ dependencies = [
  "uv-normalize",
  "uv-requirements",
  "uv-resolver",
+ "uv-toolchain",
  "uv-types",
  "uv-virtualenv",
  "uv-warnings",
@@ -4717,6 +4718,7 @@ dependencies = [
  "tracing",
  "uv-cache",
  "uv-fs",
+ "uv-toolchain",
  "which",
  "winapi",
 ]
@@ -4816,6 +4818,8 @@ dependencies = [
  "fs-err",
  "futures",
  "once_cell",
+ "pep440_rs",
+ "pep508_rs",
  "reqwest",
  "reqwest-middleware",
  "tempfile",
@@ -4827,7 +4831,6 @@ dependencies = [
  "uv-client",
  "uv-extract",
  "uv-fs",
- "uv-interpreter",
 ]
 
 [[package]]

--- a/crates/uv-interpreter/Cargo.toml
+++ b/crates/uv-interpreter/Cargo.toml
@@ -21,6 +21,7 @@ platform-tags = { workspace = true }
 pypi-types = { workspace = true }
 uv-cache = { workspace = true }
 uv-fs = { workspace = true }
+uv-toolchain = { workspace = true }
 
 configparser = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }

--- a/crates/uv-interpreter/src/find_python.rs
+++ b/crates/uv-interpreter/src/find_python.rs
@@ -7,10 +7,11 @@ use tracing::{debug, instrument};
 
 use uv_cache::Cache;
 use uv_fs::normalize_path;
+use uv_toolchain::PythonVersion;
 
 use crate::interpreter::InterpreterInfoError;
 use crate::python_environment::{detect_python_executable, detect_virtual_env};
-use crate::{Error, Interpreter, PythonVersion};
+use crate::{Error, Interpreter};
 
 /// Find a Python of a specific version, a binary with a name or a path to a binary.
 ///
@@ -464,7 +465,7 @@ fn find_version(
     let version_matches = |interpreter: &Interpreter| -> bool {
         if let Some(python_version) = python_version {
             // If a patch version was provided, check for an exact match
-            python_version.is_satisfied_by(interpreter)
+            interpreter.satisfies(python_version)
         } else {
             // The version always matches if one was not provided
             true

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -316,7 +316,7 @@ impl Interpreter {
         }
     }
 
-    /// Check if the given Python version is satisfied by this interpreter.
+    /// Check if the interpreter matches the given Python version.
     ///
     /// If a patch version is present, we will require an exact match.
     /// Otherwise, just the major and minor version numbers need to match.

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -16,6 +16,7 @@ use platform_tags::{Tags, TagsError};
 use pypi_types::Scheme;
 use uv_cache::{Cache, CacheBucket, CachedByTimestamp, Freshness, Timestamp};
 use uv_fs::{write_atomic_sync, PythonExt, Simplified};
+use uv_toolchain::PythonVersion;
 
 use crate::Error;
 use crate::Virtualenv;
@@ -312,6 +313,18 @@ impl Interpreter {
                     self.include().to_path_buf()
                 },
             },
+        }
+    }
+
+    /// Check if the given Python version is satisfied by this interpreter.
+    ///
+    /// If a patch version is present, we will require an exact match.
+    /// Otherwise, just the major and minor version numbers need to match.
+    pub fn satisfies(&self, version: &PythonVersion) -> bool {
+        if version.patch().is_some() {
+            version.version() == self.python_version()
+        } else {
+            (version.major(), version.minor()) == self.python_tuple()
         }
     }
 }

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -19,14 +19,12 @@ pub use crate::find_python::{find_best_python, find_default_python, find_request
 pub use crate::interpreter::Interpreter;
 use crate::interpreter::InterpreterInfoError;
 pub use crate::python_environment::PythonEnvironment;
-pub use crate::python_version::PythonVersion;
 pub use crate::virtualenv::Virtualenv;
 
 mod cfg;
 mod find_python;
 mod interpreter;
 mod python_environment;
-mod python_version;
 mod virtualenv;
 
 #[derive(Debug, Error)]

--- a/crates/uv-toolchain/Cargo.toml
+++ b/crates/uv-toolchain/Cargo.toml
@@ -12,8 +12,9 @@ license.workspace = true
 [dependencies]
 uv-client = { workspace = true }
 uv-extract = { workspace = true }
-uv-interpreter = { workspace = true }
 uv-fs = { workspace = true }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
 
 anyhow = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/uv-toolchain/src/downloads.rs
+++ b/crates/uv-toolchain/src/downloads.rs
@@ -40,6 +40,12 @@ pub enum Error {
         #[source]
         err: io::Error,
     },
+    #[error("failed to read toolchain directory: {0}", dir.user_display())]
+    ReadError {
+        dir: PathBuf,
+        #[source]
+        err: io::Error,
+    },
 }
 
 #[derive(Debug, PartialEq)]
@@ -391,8 +397,8 @@ impl Libc {
     pub(crate) fn from_env() -> Result<Self, Error> {
         // TODO(zanieb): Perform this lookup
         match std::env::consts::OS {
-            "linux" | "macos" => Ok(Libc::Gnu),
-            "windows" => Ok(Libc::None),
+            "linux" => Ok(Libc::Gnu),
+            "windows" | "macos" => Ok(Libc::None),
             _ => Err(Error::LibcNotDetected()),
         }
     }

--- a/crates/uv-toolchain/src/downloads.rs
+++ b/crates/uv-toolchain/src/downloads.rs
@@ -3,9 +3,9 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use crate::PythonVersion;
 use thiserror::Error;
 use uv_client::BetterReqwestError;
-use uv_interpreter::PythonVersion;
 
 use futures::TryStreamExt;
 

--- a/crates/uv-toolchain/src/find.rs
+++ b/crates/uv-toolchain/src/find.rs
@@ -35,7 +35,6 @@ impl Toolchain {
     }
 }
 
-// TODO(zanieb): Implement version requests without patch versions
 pub fn toolchains_for_version(version: &PythonVersion) -> Result<Vec<Toolchain>, Error> {
     let platform_key = platform_key_from_env()?;
 

--- a/crates/uv-toolchain/src/find.rs
+++ b/crates/uv-toolchain/src/find.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use crate::downloads::{Arch, Error, Libc, Os};
@@ -22,6 +23,7 @@ pub static TOOLCHAIN_DIRECTORY: Lazy<PathBuf> = Lazy::new(|| {
 /// An installed Python toolchain.
 #[derive(Debug, Clone)]
 pub struct Toolchain {
+    /// The path to the top-level directory of the installed toolchain.
     path: PathBuf,
 }
 
@@ -83,12 +85,14 @@ pub fn toolchains_for_version(version: &PythonVersion) -> Result<Vec<Toolchain>,
         // Sort "newer" versions of Python first
         .rev()
         .filter_map(|path| {
-            if path.file_name().is_some_and(|filename| {
-                filename
-                    .to_string_lossy()
-                    .starts_with(&format!("cpython-{version}"))
-                    && filename.to_string_lossy().ends_with(&platform_key)
-            }) {
+            if path
+                .file_name()
+                .map(OsStr::to_string_lossy)
+                .is_some_and(|filename| {
+                    filename.starts_with(&format!("cpython-{version}"))
+                        && filename.ends_with(&platform_key)
+                })
+            {
                 Some(Toolchain { path })
             } else {
                 None

--- a/crates/uv-toolchain/src/find.rs
+++ b/crates/uv-toolchain/src/find.rs
@@ -1,4 +1,8 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+
+use crate::downloads::{Arch, Error, Libc, Os};
+use crate::python_version::PythonVersion;
 
 use once_cell::sync::Lazy;
 
@@ -13,3 +17,79 @@ pub static TOOLCHAIN_DIRECTORY: Lazy<PathBuf> = Lazy::new(|| {
         PathBuf::from,
     )
 });
+
+#[derive(Debug, Clone)]
+pub struct Toolchain {
+    path: PathBuf,
+}
+
+impl Toolchain {
+    pub fn executable(&self) -> PathBuf {
+        if cfg!(windows) {
+            self.path.join("install").join("python.exe")
+        } else if cfg!(unix) {
+            self.path.join("install").join("bin").join("python3")
+        } else {
+            unimplemented!("Only Windows and Unix systems are supported.")
+        }
+    }
+}
+
+// TODO(zanieb): Implement version requests without patch versions
+pub fn toolchains_for_version(version: &PythonVersion) -> Result<Vec<Toolchain>, Error> {
+    let platform_key = platform_key_from_env()?;
+
+    let toolchain_dirs = match fs_err::read_dir(TOOLCHAIN_DIRECTORY.to_path_buf()) {
+        Ok(toolchain_dirs) => {
+            // Collect sorted directory paths; `read_dir` is not stable across platforms
+            let directories: BTreeSet<_> = toolchain_dirs
+                .filter_map(|read_dir| match read_dir {
+                    Ok(entry) => match entry.file_type() {
+                        Ok(file_type) => file_type.is_dir().then_some(Ok(entry.path())),
+                        Err(err) => Some(Err(err)),
+                    },
+                    Err(err) => Some(Err(err)),
+                })
+                .collect::<Result<_, std::io::Error>>()
+                .map_err(|err| Error::ReadError {
+                    dir: TOOLCHAIN_DIRECTORY.to_path_buf(),
+                    err,
+                })?;
+            directories
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Vec::new());
+        }
+        Err(err) => {
+            return Err(Error::ReadError {
+                dir: TOOLCHAIN_DIRECTORY.to_path_buf(),
+                err,
+            })
+        }
+    };
+
+    Ok(toolchain_dirs
+        .into_iter()
+        // Sort "newer" versions of Python first
+        .rev()
+        .filter_map(|path| {
+            if path.file_name().is_some_and(|filename| {
+                filename
+                    .to_string_lossy()
+                    .starts_with(&format!("cpython-{version}"))
+                    && filename.to_string_lossy().ends_with(&platform_key)
+            }) {
+                Some(Toolchain { path })
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>())
+}
+
+fn platform_key_from_env() -> Result<String, Error> {
+    let os = Os::from_env()?;
+    let arch = Arch::from_env()?;
+    let libc = Libc::from_env()?;
+    Ok(format!("{os}-{arch}-{libc}").to_lowercase())
+}

--- a/crates/uv-toolchain/src/find.rs
+++ b/crates/uv-toolchain/src/find.rs
@@ -6,6 +6,7 @@ use crate::python_version::PythonVersion;
 
 use once_cell::sync::Lazy;
 
+/// The directory where Python toolchains are stored.
 pub static TOOLCHAIN_DIRECTORY: Lazy<PathBuf> = Lazy::new(|| {
     std::env::var_os("UV_BOOTSTRAP_DIR").map_or(
         Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
@@ -18,6 +19,7 @@ pub static TOOLCHAIN_DIRECTORY: Lazy<PathBuf> = Lazy::new(|| {
     )
 });
 
+/// An installed Python toolchain.
 #[derive(Debug, Clone)]
 pub struct Toolchain {
     path: PathBuf,
@@ -35,8 +37,17 @@ impl Toolchain {
     }
 }
 
+/// Return the toolchains that satisfy the given Python version on this platform.
+///
+/// ## Errors
+///
+/// - The platform metadata cannot be read
+/// - A directory in the toolchain directory cannot be read
 pub fn toolchains_for_version(version: &PythonVersion) -> Result<Vec<Toolchain>, Error> {
     let platform_key = platform_key_from_env()?;
+
+    // TODO(zanieb): Consider returning an iterator instead of a `Vec`
+    //               Note we need to collect paths regardless for sorting by version.
 
     let toolchain_dirs = match fs_err::read_dir(TOOLCHAIN_DIRECTORY.to_path_buf()) {
         Ok(toolchain_dirs) => {
@@ -86,6 +97,7 @@ pub fn toolchains_for_version(version: &PythonVersion) -> Result<Vec<Toolchain>,
         .collect::<Vec<_>>())
 }
 
+/// Generate a platform portion of a key from the environment.
 fn platform_key_from_env() -> Result<String, Error> {
     let os = Os::from_env()?;
     let arch = Arch::from_env()?;

--- a/crates/uv-toolchain/src/find.rs
+++ b/crates/uv-toolchain/src/find.rs
@@ -6,7 +6,7 @@ use crate::python_version::PythonVersion;
 
 use once_cell::sync::Lazy;
 
-/// The directory where Python toolchains are stored.
+/// The directory where Python toolchains we install are stored.
 pub static TOOLCHAIN_DIRECTORY: Lazy<PathBuf> = Lazy::new(|| {
     std::env::var_os("UV_BOOTSTRAP_DIR").map_or(
         Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())

--- a/crates/uv-toolchain/src/lib.rs
+++ b/crates/uv-toolchain/src/lib.rs
@@ -1,7 +1,7 @@
 pub use crate::downloads::{
     DownloadResult, Error, Platform, PythonDownload, PythonDownloadRequest,
 };
-pub use crate::find::TOOLCHAIN_DIRECTORY;
+pub use crate::find::{toolchains_for_version, Toolchain, TOOLCHAIN_DIRECTORY};
 pub use crate::python_version::PythonVersion;
 
 mod downloads;

--- a/crates/uv-toolchain/src/lib.rs
+++ b/crates/uv-toolchain/src/lib.rs
@@ -1,5 +1,9 @@
-pub use downloads::{DownloadResult, Error, Platform, PythonDownload, PythonDownloadRequest};
-pub use find::TOOLCHAIN_DIRECTORY;
+pub use crate::downloads::{
+    DownloadResult, Error, Platform, PythonDownload, PythonDownloadRequest,
+};
+pub use crate::find::TOOLCHAIN_DIRECTORY;
+pub use crate::python_version::PythonVersion;
 
 mod downloads;
 mod find;
+mod python_version;

--- a/crates/uv-toolchain/src/python_version.rs
+++ b/crates/uv-toolchain/src/python_version.rs
@@ -5,8 +5,6 @@ use std::str::FromStr;
 use pep440_rs::Version;
 use pep508_rs::{MarkerEnvironment, StringVersion};
 
-use crate::Interpreter;
-
 #[derive(Debug, Clone)]
 pub struct PythonVersion(StringVersion);
 
@@ -141,18 +139,6 @@ impl PythonVersion {
     pub fn without_patch(&self) -> Self {
         Self::from_str(format!("{}.{}", self.major(), self.minor()).as_str())
             .expect("dropping a patch should always be valid")
-    }
-
-    /// Check if this Python version is satisfied by the given interpreter.
-    ///
-    /// If a patch version is present, we will require an exact match.
-    /// Otherwise, just the major and minor version numbers need to match.
-    pub fn is_satisfied_by(&self, interpreter: &Interpreter) -> bool {
-        if self.patch().is_some() {
-            self.version() == interpreter.python_version()
-        } else {
-            (self.major(), self.minor()) == interpreter.python_tuple()
-        }
     }
 }
 

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -34,6 +34,7 @@ uv-resolver = { workspace = true, features = ["clap"] }
 uv-types = { workspace = true, features = ["clap"] }
 uv-configuration = { workspace = true, features = ["clap"] }
 uv-virtualenv = { workspace = true }
+uv-toolchain = { workspace = true }
 uv-warnings = { workspace = true }
 
 anstream = { workspace = true }

--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -29,7 +29,7 @@ use uv_configuration::{
 use uv_dispatch::BuildDispatch;
 use uv_fs::Simplified;
 use uv_installer::Downloader;
-use uv_interpreter::{find_best_python, PythonEnvironment, PythonVersion};
+use uv_interpreter::{find_best_python, PythonEnvironment};
 use uv_normalize::{ExtraName, PackageName};
 use uv_requirements::{
     upgrade::read_lockfile, ExtrasSpecification, LookaheadResolver, NamedRequirementsResolver,
@@ -39,6 +39,7 @@ use uv_resolver::{
     AnnotationStyle, DependencyMode, DisplayResolutionGraph, Exclusions, InMemoryIndex, Manifest,
     OptionsBuilder, PreReleaseMode, PythonRequirement, ResolutionMode, Resolver,
 };
+use uv_toolchain::PythonVersion;
 use uv_types::{BuildIsolation, EmptyInstalledPackages, InFlight};
 use uv_warnings::warn_user;
 

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -21,10 +21,10 @@ use uv_configuration::{
     Upgrade,
 };
 use uv_configuration::{IndexStrategy, NoBinary};
-use uv_interpreter::PythonVersion;
 use uv_normalize::{ExtraName, PackageName};
 use uv_requirements::{ExtrasSpecification, RequirementsSource};
 use uv_resolver::{AnnotationStyle, DependencyMode, PreReleaseMode, ResolutionMode};
+use uv_toolchain::PythonVersion;
 
 use crate::commands::{extra_name_with_clap_error, ExitStatus, ListFormat, VersionFormat};
 use crate::compat::CompatArgs;

--- a/crates/uv/tests/pip_compile_scenarios.rs
+++ b/crates/uv/tests/pip_compile_scenarios.rs
@@ -13,14 +13,14 @@ use assert_cmd::assert::OutputAssertExt;
 use assert_fs::fixture::{FileWriteStr, PathChild};
 use predicates::prelude::predicate;
 
-use common::{create_bin_with_executables, get_bin, uv_snapshot, TestContext};
+use common::{get_bin, python_path_with_versions, uv_snapshot, TestContext};
 
 mod common;
 
 /// Provision python binaries and return a `pip compile` command with options shared across all scenarios.
 fn command(context: &TestContext, python_versions: &[&str]) -> Command {
-    let bin = create_bin_with_executables(&context.temp_dir, python_versions)
-        .expect("Failed to create bin dir");
+    let python_path = python_path_with_versions(&context.temp_dir, python_versions)
+        .expect("Failed to create Python test path");
     let mut command = Command::new(get_bin());
     command
         .arg("pip")
@@ -34,7 +34,7 @@ fn command(context: &TestContext, python_versions: &[&str]) -> Command {
         .arg(context.cache_dir.path())
         .env("VIRTUAL_ENV", context.venv.as_os_str())
         .env("UV_NO_WRAP", "1")
-        .env("UV_TEST_PYTHON_PATH", bin)
+        .env("UV_TEST_PYTHON_PATH", python_path)
         .current_dir(&context.temp_dir);
 
     if cfg!(all(windows, debug_assertions)) {

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -13,7 +13,7 @@ use indoc::indoc;
 use predicates::Predicate;
 use url::Url;
 
-use common::{create_bin_with_executables, create_venv, uv_snapshot, venv_to_interpreter};
+use common::{create_venv, python_path_with_versions, uv_snapshot, venv_to_interpreter};
 use uv_fs::Simplified;
 
 use crate::common::{copy_dir_all, get_bin, TestContext};
@@ -338,8 +338,8 @@ fn link() -> Result<()> {
         .success();
 
     let venv2 = context.temp_dir.child(".venv2");
-    let bin = create_bin_with_executables(&context.temp_dir, &["3.12"])
-        .expect("Failed to create bin dir");
+    let python_path = python_path_with_versions(&context.temp_dir, &["3.12"])
+        .expect("Failed to create Python test path");
     Command::new(get_bin())
         .arg("venv")
         .arg(venv2.as_os_str())
@@ -347,7 +347,7 @@ fn link() -> Result<()> {
         .arg(context.cache_dir.path())
         .arg("--python")
         .arg("3.12")
-        .env("UV_TEST_PYTHON_PATH", bin)
+        .env("UV_TEST_PYTHON_PATH", python_path)
         .current_dir(&context.temp_dir)
         .assert()
         .success();

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -394,7 +394,7 @@ fn windows_shims() -> Result<()> {
     let context = VenvTestContext::new(&["3.9", "3.8"]);
     let shim_path = context.temp_dir.child("shim");
 
-    let py38 = std::env::split_paths(&context.bin)
+    let py38 = std::env::split_paths(&context.python_path)
         .last()
         .expect("python_path_with_versions to set up the python versions");
     // We want 3.8 and the first version should be 3.9.
@@ -414,7 +414,7 @@ fn windows_shims() -> Result<()> {
     uv_snapshot!(context.filters(), context.venv_command()
         .arg(context.venv.as_os_str())
         .arg("--clear")
-        .env("UV_TEST_PYTHON_PATH", format!("{};{}", shim_path.display(), context.bin.simplified_display())), @r###"
+        .env("UV_TEST_PYTHON_PATH", format!("{};{}", shim_path.display(), context.python_path.simplified_display())), @r###"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -9,11 +9,9 @@ use assert_fs::fixture::ChildPath;
 use assert_fs::prelude::*;
 use fs_err::PathExt;
 use uv_fs::Simplified;
-use uv_interpreter::PythonVersion;
+use uv_toolchain::PythonVersion;
 
-use crate::common::{
-    create_bin_with_executables, get_bin, uv_snapshot, TestContext, EXCLUDE_NEWER,
-};
+use crate::common::{get_bin, python_path_with_versions, uv_snapshot, TestContext, EXCLUDE_NEWER};
 
 mod common;
 
@@ -21,15 +19,15 @@ struct VenvTestContext {
     cache_dir: assert_fs::TempDir,
     temp_dir: assert_fs::TempDir,
     venv: ChildPath,
-    bin: OsString,
+    python_path: OsString,
     python_versions: Vec<PythonVersion>,
 }
 
 impl VenvTestContext {
     fn new(python_versions: &[&str]) -> Self {
         let temp_dir = assert_fs::TempDir::new().unwrap();
-        let bin = create_bin_with_executables(&temp_dir, python_versions)
-            .expect("Failed to create bin dir");
+        let python_path = python_path_with_versions(&temp_dir, python_versions)
+            .expect("Failed to create Python test path");
         let venv = temp_dir.child(".venv");
         let python_versions = python_versions
             .iter()
@@ -41,7 +39,7 @@ impl VenvTestContext {
             cache_dir: assert_fs::TempDir::new().unwrap(),
             temp_dir,
             venv,
-            bin,
+            python_path,
             python_versions,
         }
     }
@@ -54,7 +52,7 @@ impl VenvTestContext {
             .arg(self.cache_dir.path())
             .arg("--exclude-newer")
             .arg(EXCLUDE_NEWER)
-            .env("UV_TEST_PYTHON_PATH", self.bin.clone())
+            .env("UV_TEST_PYTHON_PATH", self.python_path.clone())
             .current_dir(self.temp_dir.path());
         command
     }
@@ -398,7 +396,7 @@ fn windows_shims() -> Result<()> {
 
     let py38 = std::env::split_paths(&context.bin)
         .last()
-        .expect("create_bin_with_executables to set up the python versions");
+        .expect("python_path_with_versions to set up the python versions");
     // We want 3.8 and the first version should be 3.9.
     // Picking the last is necessary to prove that shims work because the python version selects
     // the python version from the first path segment by default, so we take the last to prove it's not

--- a/scripts/scenarios/templates/compile.mustache
+++ b/scripts/scenarios/templates/compile.mustache
@@ -13,14 +13,14 @@ use assert_cmd::assert::OutputAssertExt;
 use assert_fs::fixture::{FileWriteStr, PathChild};
 use predicates::prelude::predicate;
 
-use common::{create_bin_with_executables, get_bin, uv_snapshot, TestContext};
+use common::{python_path_with_versions, get_bin, uv_snapshot, TestContext};
 
 mod common;
 
 /// Provision python binaries and return a `pip compile` command with options shared across all scenarios.
 fn command(context: &TestContext, python_versions: &[&str]) -> Command {
-    let bin = create_bin_with_executables(&context.temp_dir, python_versions)
-        .expect("Failed to create bin dir");
+    let python_path = python_path_with_versions(&context.temp_dir, python_versions)
+        .expect("Failed to create Python test path");
     let mut command = Command::new(get_bin());
     command
         .arg("pip")
@@ -34,7 +34,7 @@ fn command(context: &TestContext, python_versions: &[&str]) -> Command {
         .arg(context.cache_dir.path())
         .env("VIRTUAL_ENV", context.venv.as_os_str())
         .env("UV_NO_WRAP", "1")
-        .env("UV_TEST_PYTHON_PATH", bin)
+        .env("UV_TEST_PYTHON_PATH", python_path)
         .current_dir(&context.temp_dir);
 
     if cfg!(all(windows, debug_assertions)) {


### PR DESCRIPTION
Completes #2842 by fixing Windows tests.

Replaces our current bootstrapped Python version loading in tests with some naive toolchain Python version discovery.

There are no user facing changes here and there should be no change in test experience. I confirmed the test suite only fails on the following cases when the toolchain path is not populated:

```
uv::pip_compile_scenarios python_patch_override_no_patch
uv::pip_compile_scenarios python_patch_override_patch_compatible
uv::pip_install_scenarios python_greater_than_current_patch
uv::venv create_venv_python_patch
```
