### PR TITLE
Skip scenario tests on Windows

### DIFF
--- a/crates/uv/tests/pip_compile_scenarios.rs
+++ b/crates/uv/tests/pip_compile_scenarios.rs
@@ -3,7 +3,7 @@
 //! Generated with `./scripts/sync_scenarios.sh`
 //! Scenarios from <https://github.com/zanieb/packse/tree/0.3.12/scenarios>
 //!
-#![cfg(all(feature = "python", feature = "pypi"))]
+#![cfg(all(feature = "python", feature = "pypi", unix))]
 
 use std::env;
 use std::process::Command;

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -3,7 +3,7 @@
 //! Generated with `./scripts/sync_scenarios.sh`
 //! Scenarios from <https://github.com/zanieb/packse/tree/0.3.12/scenarios>
 //!
-#![cfg(all(feature = "python", feature = "pypi"))]
+#![cfg(all(feature = "python", feature = "pypi", unix))]
 
 use std::path::Path;
 use std::process::Command;

--- a/scripts/scenarios/templates/compile.mustache
+++ b/scripts/scenarios/templates/compile.mustache
@@ -3,7 +3,7 @@
 //! Generated with `{{generated_with}}`
 //! Scenarios from <{{generated_from}}>
 //!
-#![cfg(all(feature = "python", feature = "pypi"))]
+#![cfg(all(feature = "python", feature = "pypi", unix))]
 
 use std::env;
 use std::process::Command;

--- a/scripts/scenarios/templates/install.mustache
+++ b/scripts/scenarios/templates/install.mustache
@@ -3,7 +3,7 @@
 //! Generated with `{{generated_with}}`
 //! Scenarios from <{{generated_from}}>
 //!
-#![cfg(all(feature = "python", feature = "pypi"))]
+#![cfg(all(feature = "python", feature = "pypi", unix))]
 
 use std::path::Path;
 use std::process::Command;


### PR DESCRIPTION
These tests are about resolver correctness, which should not be platform dependent and Windows CI is horribly slow.
