### PR TITLE
chore: update axoupdater to 0.4.0 and add a test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,13 +295,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "axoupdater"
-version = "0.3.6"
+name = "axotag"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f40156112045abb1409e115d684306b9ff005399fd10ce2caf33bd800742b4"
+checksum = "d888fac0b73e64cbdf36a743fc5a25af5ae955c357535cb420b389bf1e1a6c54"
+dependencies = [
+ "miette",
+ "semver",
+ "thiserror",
+]
+
+[[package]]
+name = "axoupdater"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7306cf5b4c3e7037d27ed5e9f7dc1b24d9941c77601e1e24c7d87839df6d8a2"
 dependencies = [
  "axoasset",
  "axoprocess",
+ "axotag",
  "camino",
  "homedir",
  "miette",
@@ -2667,7 +2679,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset 0.9.0",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -3336,6 +3348,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ async-compression = { version = "0.4.6" }
 async-trait = { version = "0.1.78" }
 async_http_range_reader = { version = "0.7.0" }
 async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "1dcb40cfe1bf5325a6fd4bfcf9894db40241f585", features = ["deflate"] }
-axoupdater = { version = "0.3.1", default-features = false }
+axoupdater = { version = "0.4.0", default-features = false }
 backoff = { version = "0.4.0" }
 base64 = { version = "0.22.0" }
 cachedir = { version = "0.3.1" }

--- a/crates/uv/tests/self_update.rs
+++ b/crates/uv/tests/self_update.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "self-update")]
+
+use crate::common::get_bin;
+use axoupdater::{
+    test::helpers::{perform_runtest, RuntestArgs},
+    ReleaseSourceType,
+};
+use std::process::Command;
+
+mod common;
+
+#[test]
+fn check_self_update() {
+    // To maximally emulate behaviour in practice, this test actually modifies CARGO_HOME
+    // and therefore should only be run in CI by default, where it can't hurt developers.
+    // We use the "CI" env-var that CI machines tend to run
+    if std::env::var("CI").map(|s| s.is_empty()).unwrap_or(true) {
+        return;
+    }
+
+    // Configure the runtest
+    let args = RuntestArgs {
+        app_name: "uv".to_owned(),
+        package: "uv".to_owned(),
+        owner: "astral-sh".to_owned(),
+        bin: get_bin(),
+        binaries: vec!["uv".to_owned()],
+        args: vec!["self".to_owned(), "update".to_owned()],
+        release_type: ReleaseSourceType::GitHub,
+    };
+
+    // install and update the application
+    let installed_bin = perform_runtest(&args);
+
+    // check that the binary works like normal
+    let status = Command::new(installed_bin)
+        .arg("--version")
+        .status()
+        .expect("failed to run 'uv --version'");
+    assert!(status.success(), "'uv --version' returned non-zero");
+}


### PR DESCRIPTION
## Summary

This updates to the version of axoupdater used in cargo-dist 0.13.0's own selfupdate command, with all relevant fixes for platforms. It also tentatively introduces a mildly dangerous self-runtest that runs `uv self update` and checks that the binary is installed and executable.

I *believe* some adjustments need to be made to your CI to have this new test run, because it requires the `self-update` feature to be enabled, and I didn't want to just start messing with how you do feature coverage in your CI. **As a result I haven't yet had a chance to actually fully run this in CI**, though I've locally tested it on windows (with the guard disabled).


## Test Plan

Most of the machinery here is provided by axoupdater itself (cargo-dist also includes a variant of these tests in its codebase). This initial implementation has a couple major limitations: 

* This is For Reals modifying the system that runs the test (so it's off unless it detects it's running in CI, and if you want variations on this test they'll need to be [run in serial](https://github.com/axodotdev/cargo-dist/blob/5e7826f7b09a64e5ba9edc16dab8cee7b13daa27/cargo-dist/tests/cli-tests.rs#L235)). Since many of the testing issues were surrounding precise details of Actual Deployed Executions, this seemed worth the tradeoff.
* The actual installer *script* it's ultimately invoking is the one you last published, and *not* the one that cargo-dist will make when you next publish.

We're already working on implementing some logic for "get cargo-dist to generate a fresh installer script too", which is in fact the basis of a huge amount of cargo-dist's own testsuite. Now that we're dogfooding this stuff, it should be quite hard for this stuff to break without cargo-dist's own codebase noticing it first.


<!-- How was it tested? -->
