### PR TITLE
Add `python-patch` feature to isolate tests that require Python patch versions to match our suite

### DIFF
--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -82,9 +82,11 @@ regex = { version = "1.10.3" }
 reqwest = { version = "0.11.23", features = ["blocking"], default-features = false }
 
 [features]
-default = ["flate2/zlib-ng", "python", "pypi", "git", "maturin"]
+default = ["flate2/zlib-ng", "python", "pypi", "git", "maturin", "python-patch"]
 # Introduces a dependency on a local Python installation.
 python = []
+# Introduces a dependency on a local Python installation with specific patch versions.
+python-patch = []
 # Introduces a dependency on PyPI.
 pypi = []
 # Introduces a dependency on Git.

--- a/crates/uv/tests/pip_compile_scenarios.rs
+++ b/crates/uv/tests/pip_compile_scenarios.rs
@@ -386,6 +386,7 @@ fn incompatible_python_compatible_override_other_wheel() -> Result<()> {
 ///     └── a-1.0.0
 ///         └── requires python>=3.8.4
 /// ```
+#[cfg(feature = "python-patch")]
 #[test]
 fn python_patch_override_no_patch() -> Result<()> {
     let context = TestContext::new("3.8.18");
@@ -433,6 +434,7 @@ fn python_patch_override_no_patch() -> Result<()> {
 ///     └── a-1.0.0
 ///         └── requires python>=3.8.0
 /// ```
+#[cfg(feature = "python-patch")]
 #[test]
 fn python_patch_override_patch_compatible() -> Result<()> {
     let context = TestContext::new("3.8.18");

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -501,7 +501,7 @@ fn dependency_excludes_range_of_compatible_versions() {
 /// There is a non-contiguous range of compatible versions for the requested package
 /// `a`, but another dependency `c` excludes the range. This is the same as
 /// `dependency-excludes-range-of-compatible-versions` but some of the versions of
-/// `a` are incompatible for another reason e.g. dependency on non-existent package
+/// `a` are incompatible for another reason e.g. dependency on non-existant package
 /// `d`.
 ///
 /// ```text
@@ -3485,7 +3485,7 @@ fn package_only_prereleases_boundary() {
     "###);
 
     // Since there are only prerelease versions of `a` available, a prerelease is
-    // allowed. Since the user did not explicitly request a pre-release, pre-releases at
+    // allowed. Since the user did not explictly request a pre-release, pre-releases at
     // the boundary should not be selected.
     assert_installed(
         &context.venv,
@@ -3780,6 +3780,7 @@ fn python_greater_than_current() {
 ///     └── a-1.0.0
 ///         └── requires python>=3.8.14 (incompatible with environment)
 /// ```
+#[cfg(feature = "python-patch")]
 #[test]
 fn python_greater_than_current_patch() {
     let context = TestContext::new("3.8.12");

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -281,6 +281,7 @@ fn create_venv_unknown_python_patch() {
     context.venv.assert(predicates::path::missing());
 }
 
+#[cfg(feature = "python-patch")]
 #[test]
 fn create_venv_python_patch() {
     let context = VenvTestContext::new(&["3.12.1"]);

--- a/scripts/scenarios/generate.py
+++ b/scripts/scenarios/generate.py
@@ -133,6 +133,13 @@ def main(scenarios: list[Path], snapshot_update: bool = True):
             else []
         )
 
+    # Hack to track which scenarios require a specific Python patch version
+    for scenario in data["scenarios"]:
+        if "patch" in scenario["name"]:
+            scenario["python_patch"] = True
+        else:
+            scenario["python_patch"] = False
+
     # We don't yet support local versions that aren't expressed as direct dependencies.
     for scenario in data["scenarios"]:
         expected = scenario["expected"]

--- a/scripts/scenarios/templates/compile.mustache
+++ b/scripts/scenarios/templates/compile.mustache
@@ -58,6 +58,9 @@ fn command(context: &TestContext, python_versions: &[&str]) -> Command {
 /// {{.}}
 {{/tree}}
 /// ```
+{{#python_patch}}
+#[cfg(feature = "python-patch")]
+{{/python_patch}}
 #[test]
 fn {{module_name}}() -> Result<()> {
     let context = TestContext::new("{{environment.python}}");

--- a/scripts/scenarios/templates/install.mustache
+++ b/scripts/scenarios/templates/install.mustache
@@ -77,6 +77,9 @@ fn command(context: &TestContext) -> Command {
 /// {{.}}
 {{/tree}}
 /// ```
+{{#python_patch}}
+#[cfg(feature = "python-patch")]
+{{/python_patch}}
 #[test]
 fn {{module_name}}() {
     let context = TestContext::new("{{environment.python}}");


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/2165
Follows https://github.com/astral-sh/uv/pull/2930