### PR TITLE
Ignore direct URL distributions in prefetcher

### DIFF
--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -52,7 +52,7 @@ impl BatchPrefetcher {
         index: &InMemoryIndex,
         selector: &CandidateSelector,
     ) -> anyhow::Result<(), ResolveError> {
-        let PubGrubPackage::Package(package_name, _, _) = &next else {
+        let PubGrubPackage::Package(package_name, None, None) = &next else {
             return Ok(());
         };
 


### PR DESCRIPTION
## Summary

The prefetcher tallies the number of times we tried a given package, and then once we hit a threshold, grabs the version map, assuming it's already been fetched. For direct URL distributions, though, we don't have a version map! And there's no need to prefetch.

Closes https://github.com/astral-sh/uv/issues/2941.