### PR TITLE
Return computed hashes from metadata requests

### DIFF
--- a/crates/uv-distribution/src/lib.rs
+++ b/crates/uv-distribution/src/lib.rs
@@ -4,6 +4,7 @@ pub use download::LocalWheel;
 pub use error::Error;
 pub use git::{is_same_reference, to_precise};
 pub use index::{BuiltWheelIndex, RegistryWheelIndex};
+use pypi_types::{HashDigest, Metadata23};
 pub use reporter::Reporter;
 pub use source::SourceDistributionBuilder;
 
@@ -16,3 +17,21 @@ mod index;
 mod locks;
 mod reporter;
 mod source;
+
+/// The metadata associated with an archive.
+#[derive(Debug, Clone)]
+pub struct ArchiveMetadata {
+    /// The [`Metadata23`] for the underlying distribution.
+    pub metadata: Metadata23,
+    /// The hashes of the source or built archive.
+    pub hashes: Vec<HashDigest>,
+}
+
+impl From<Metadata23> for ArchiveMetadata {
+    fn from(metadata: Metadata23) -> Self {
+        Self {
+            metadata,
+            hashes: vec![],
+        }
+    }
+}

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -100,30 +100,30 @@ impl<'a, Context: BuildContext + Send + Sync> SourceTreeResolver<'a, Context> {
         // Fetch the metadata for the distribution.
         let metadata = {
             let id = PackageId::from_url(source.url());
-            if let Some(metadata) = self
+            if let Some(archive) = self
                 .index
                 .get_metadata(&id)
                 .as_deref()
                 .and_then(|response| {
-                    if let MetadataResponse::Found(metadata) = response {
-                        Some(metadata)
+                    if let MetadataResponse::Found(archive) = response {
+                        Some(archive)
                     } else {
                         None
                     }
                 })
             {
                 // If the metadata is already in the index, return it.
-                metadata.clone()
+                archive.metadata.clone()
             } else {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let source = BuildableSource::Url(source);
-                let metadata = self.database.build_wheel_metadata(&source, &[]).await?;
+                let archive = self.database.build_wheel_metadata(&source, &[]).await?;
 
                 // Insert the metadata into the index.
                 self.index
-                    .insert_metadata(id, MetadataResponse::Found(metadata.clone()));
+                    .insert_metadata(id, MetadataResponse::Found(archive.clone()));
 
-                metadata
+                archive.metadata
             }
         };
 

--- a/crates/uv-requirements/src/unnamed.rs
+++ b/crates/uv-requirements/src/unnamed.rs
@@ -250,24 +250,24 @@ impl<'a, Context: BuildContext + Send + Sync> NamedRequirementsResolver<'a, Cont
         // Fetch the metadata for the distribution.
         let name = {
             let id = PackageId::from_url(source.url());
-            if let Some(metadata) = index.get_metadata(&id).as_deref().and_then(|response| {
-                if let MetadataResponse::Found(metadata) = response {
-                    Some(metadata)
+            if let Some(archive) = index.get_metadata(&id).as_deref().and_then(|response| {
+                if let MetadataResponse::Found(archive) = response {
+                    Some(archive)
                 } else {
                     None
                 }
             }) {
                 // If the metadata is already in the index, return it.
-                metadata.name.clone()
+                archive.metadata.name.clone()
             } else {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let source = BuildableSource::Url(source);
-                let metadata = database.build_wheel_metadata(&source, &[]).await?;
+                let archive = database.build_wheel_metadata(&source, &[]).await?;
 
-                let name = metadata.name.clone();
+                let name = archive.metadata.name.clone();
 
                 // Insert the metadata into the index.
-                index.insert_metadata(id, MetadataResponse::Found(metadata));
+                index.insert_metadata(id, MetadataResponse::Found(archive));
 
                 name
             }

--- a/crates/uv-resolver/src/resolution.rs
+++ b/crates/uv-resolver/src/resolution.rs
@@ -177,14 +177,14 @@ impl ResolutionGraph {
                             )
                         });
 
-                        let MetadataResponse::Found(metadata) = &*response else {
+                        let MetadataResponse::Found(archive) = &*response else {
                             panic!(
                                 "Every package should have metadata: {:?}",
                                 dist.package_id()
                             )
                         };
 
-                        if metadata.provides_extras.contains(extra) {
+                        if archive.metadata.provides_extras.contains(extra) {
                             extras
                                 .entry(package_name.clone())
                                 .or_insert_with(Vec::new)
@@ -231,14 +231,14 @@ impl ResolutionGraph {
                             )
                         });
 
-                        let MetadataResponse::Found(metadata) = &*response else {
+                        let MetadataResponse::Found(archive) = &*response else {
                             panic!(
                                 "Every package should have metadata: {:?}",
                                 dist.package_id()
                             )
                         };
 
-                        if metadata.provides_extras.contains(extra) {
+                        if archive.metadata.provides_extras.contains(extra) {
                             extras
                                 .entry(package_name.clone())
                                 .or_insert_with(Vec::new)
@@ -441,13 +441,13 @@ impl ResolutionGraph {
                 .distributions
                 .get(&package_id)
                 .expect("every package in resolution graph has metadata");
-            let MetadataResponse::Found(md) = &*res else {
+            let MetadataResponse::Found(archive, ..) = &*res else {
                 panic!(
                     "Every package should have metadata: {:?}",
                     dist.package_id()
                 )
             };
-            for req in manifest.apply(&md.requires_dist) {
+            for req in manifest.apply(&archive.metadata.requires_dist) {
                 let Some(ref marker_tree) = req.marker else {
                     continue;
                 };

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -5,10 +5,10 @@ use chrono::{DateTime, Utc};
 
 use distribution_types::{Dist, IndexLocations, Name};
 use platform_tags::Tags;
-use pypi_types::Metadata23;
+
 use uv_client::RegistryClient;
 use uv_configuration::{NoBinary, NoBuild};
-use uv_distribution::DistributionDatabase;
+use uv_distribution::{ArchiveMetadata, DistributionDatabase};
 use uv_normalize::PackageName;
 use uv_types::{BuildContext, RequiredHashes};
 
@@ -36,7 +36,7 @@ pub enum VersionsResponse {
 #[derive(Debug)]
 pub enum MetadataResponse {
     /// The wheel metadata was found and parsed successfully.
-    Found(Metadata23),
+    Found(ArchiveMetadata),
     /// The wheel metadata was found, but could not be parsed.
     InvalidMetadata(Box<pypi_types::MetadataError>),
     /// The wheel metadata was found, but the metadata was inconsistent.


### PR DESCRIPTION
## Summary

This PR modifies the distribution database to return both the `Metadata23` and the computed hashes when clients request metadata.

No behavior changes, but this will be necessary to power `--generate-hashes`.
