### PR TITLE
Enforce and backtrack on invalid versions in source metadata

### DIFF
--- a/crates/distribution-types/src/buildable.rs
+++ b/crates/distribution-types/src/buildable.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::path::Path;
 
+use pep440_rs::Version;
 use url::Url;
 
 use uv_normalize::PackageName;
@@ -24,6 +25,15 @@ impl BuildableSource<'_> {
     pub fn name(&self) -> Option<&PackageName> {
         match self {
             Self::Dist(dist) => Some(dist.name()),
+            Self::Url(_) => None,
+        }
+    }
+
+    /// Return the [`Version`] of the source, if available.
+    pub fn version(&self) -> Option<&Version> {
+        match self {
+            Self::Dist(SourceDist::Registry(dist)) => Some(&dist.filename.version),
+            Self::Dist(_) => None,
             Self::Url(_) => None,
         }
     }

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -3,6 +3,7 @@ use tokio::task::JoinError;
 use zip::result::ZipError;
 
 use distribution_filename::WheelFilenameError;
+use pep440_rs::Version;
 use uv_client::BetterReqwestError;
 use uv_normalize::PackageName;
 
@@ -47,6 +48,8 @@ pub enum Error {
         given: PackageName,
         metadata: PackageName,
     },
+    #[error("Package metadata version `{metadata}` does not match given version `{given}`")]
+    VersionMismatch { given: Version, metadata: Version },
     #[error("Failed to parse metadata from built wheel")]
     Metadata(#[from] pypi_types::MetadataError),
     #[error("Failed to read `dist-info` metadata from built wheel")]

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -446,6 +446,15 @@ impl PubGrubReportFormatter<'_> {
                                                     reason: reason.clone(),
                                                 });
                                             }
+                                            IncompletePackage::InconsistentMetadata(reason) => {
+                                                hints.insert(
+                                                    PubGrubHint::InconsistentVersionMetadata {
+                                                        package: package.clone(),
+                                                        version: version.clone(),
+                                                        reason: reason.clone(),
+                                                    },
+                                                );
+                                            }
                                             IncompletePackage::InvalidStructure(reason) => {
                                                 hints.insert(
                                                     PubGrubHint::InvalidVersionStructure {
@@ -524,6 +533,15 @@ pub(crate) enum PubGrubHint {
     },
     /// Metadata for a package version could not be parsed.
     InvalidVersionMetadata {
+        package: PubGrubPackage,
+        #[derivative(PartialEq = "ignore", Hash = "ignore")]
+        version: Version,
+        #[derivative(PartialEq = "ignore", Hash = "ignore")]
+        reason: String,
+    },
+    /// Metadata for a package version was inconsistent (e.g., the package name did not match that
+    /// of the file).
+    InconsistentVersionMetadata {
         package: PubGrubPackage,
         #[derivative(PartialEq = "ignore", Hash = "ignore")]
         version: Version,
@@ -622,6 +640,21 @@ impl std::fmt::Display for PubGrubHint {
                 write!(
                     f,
                     "{}{} The structure of {}=={} was invalid:\n{}",
+                    "hint".bold().cyan(),
+                    ":".bold(),
+                    package.bold(),
+                    version.bold(),
+                    textwrap::indent(reason, "  ")
+                )
+            }
+            PubGrubHint::InconsistentVersionMetadata {
+                package,
+                version,
+                reason,
+            } => {
+                write!(
+                    f,
+                    "{}{} Metadata for {}=={} was inconsistent:\n{}",
                     "hint".bold().cyan(),
                     ":".bold(),
                     package.bold(),


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

If we build a source distribution from the registry, and the version doesn't match that of the filename, we should error, just as we do for mismatched package names. However, we should also backtrack here, which we didn't previously.

Closes https://github.com/astral-sh/uv/issues/2953.

## Test Plan

Verified that `cargo run pip install docutils --verbose --no-cache --reinstall` installs `docutils==0.21` instead of the invalid `docutils==0.21.post1`.

In the logs, I see:

```
WARN Unable to extract metadata for docutils: Package metadata version `0.21` does not match given version `0.21.post1`
```
