### PR TITLE
Allow profiling tests with tracing instrumentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ toml = { version = "0.8.12" }
 tracing = { version = "0.1.40" }
 tracing-durations-export = { version = "0.2.0", features = ["plot"] }
 tracing-indicatif = { version = "0.3.6" }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "registry"] }
 tracing-tree = { version = "0.3.0" }
 unicode-width = { version = "0.1.11" }
 unscanny = { version = "0.1.0" }

--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -715,7 +715,7 @@ impl SourceBuild {
     ///
     /// <https://packaging.python.org/en/latest/specifications/source-distribution-format/>
     #[instrument(skip_all, fields(package_id = self.package_id))]
-    pub async fn build(&self, wheel_dir: &Path) -> Result<String, Error> {
+    pub async fn build_wheel(&self, wheel_dir: &Path) -> Result<String, Error> {
         // The build scripts run with the extracted root as cwd, so they need the absolute path.
         let wheel_dir = fs::canonicalize(wheel_dir)?;
 
@@ -856,7 +856,7 @@ impl SourceBuildTrait for SourceBuild {
     }
 
     async fn wheel<'a>(&'a self, wheel_dir: &'a Path) -> anyhow::Result<String> {
-        Ok(self.build(wheel_dir).await?)
+        Ok(self.build_wheel(wheel_dir).await?)
     }
 }
 

--- a/crates/uv-dev/src/build.rs
+++ b/crates/uv-dev/src/build.rs
@@ -91,5 +91,5 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
         FxHashMap::default(),
     )
     .await?;
-    Ok(wheel_dir.join(builder.build(&wheel_dir).await?))
+    Ok(wheel_dir.join(builder.build_wheel(&wheel_dir).await?))
 }

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1063,7 +1063,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     /// Build a source distribution, storing the built wheel in the cache.
     ///
     /// Returns the un-normalized disk filename, the parsed, normalized filename and the metadata
-    #[instrument(skip_all, fields(dist))]
+    #[instrument(skip_all, fields(dist = %source))]
     async fn build_distribution(
         &self,
         source: &BuildableSource<'_>,
@@ -1116,7 +1116,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     }
 
     /// Build the metadata for a source distribution.
-    #[instrument(skip_all, fields(dist))]
+    #[instrument(skip_all, fields(dist = %source))]
     async fn build_metadata(
         &self,
         source: &BuildableSource<'_>,

--- a/crates/uv/src/logging.rs
+++ b/crates/uv/src/logging.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 use anyhow::Context;
 use chrono::Utc;
 use owo_colors::OwoColorize;
-use tracing::level_filters::LevelFilter;
 use tracing::{Event, Subscriber};
 #[cfg(feature = "tracing-durations-export")]
 use tracing_durations_export::{
@@ -115,18 +114,25 @@ where
 /// includes targets and timestamps, along with all `uv=debug` messages by default.
 pub(crate) fn setup_logging(
     level: Level,
-    duration: impl Layer<Registry> + Send + Sync,
+    durations: impl Layer<Registry> + Send + Sync,
 ) -> anyhow::Result<()> {
     let default_directive = match level {
         Level::Default => {
             // Show nothing, but allow `RUST_LOG` to override.
-            LevelFilter::OFF.into()
+            tracing::level_filters::LevelFilter::OFF.into()
         }
         Level::Verbose | Level::ExtraVerbose => {
             // Show `DEBUG` messages from the CLI crate, but allow `RUST_LOG` to override.
             Directive::from_str("uv=trace").unwrap()
         }
     };
+
+    // Only record our own spans.
+    let durations_layer =
+        durations.with_filter(tracing_subscriber::filter::Targets::new().with_target(
+            env!("CARGO_PKG_NAME"),
+            tracing::level_filters::LevelFilter::INFO,
+        ));
 
     let filter = EnvFilter::builder()
         .with_default_directive(default_directive)
@@ -148,26 +154,26 @@ pub(crate) fn setup_logging(
                 ColorChoice::Auto => unreachable!(),
             };
             tracing_subscriber::registry()
-                .with(duration)
-                .with(filter)
+                .with(durations_layer)
                 .with(
                     tracing_subscriber::fmt::layer()
                         .event_format(format)
                         .with_writer(std::io::stderr)
-                        .with_ansi(ansi),
+                        .with_ansi(ansi)
+                        .with_filter(filter),
                 )
                 .init();
         }
         Level::ExtraVerbose => {
             // Regardless of the tracing level, include the uptime and target for each message.
             tracing_subscriber::registry()
-                .with(duration)
-                .with(filter)
+                .with(durations_layer)
                 .with(
                     HierarchicalLayer::default()
                         .with_targets(true)
                         .with_timer(Uptime::default())
-                        .with_writer(std::io::stderr),
+                        .with_writer(std::io::stderr)
+                        .with_filter(filter),
                 )
                 .init();
         }
@@ -178,15 +184,15 @@ pub(crate) fn setup_logging(
 
 /// Setup the `TRACING_DURATIONS_FILE` environment variable to enable tracing durations.
 #[cfg(feature = "tracing-durations-export")]
-pub(crate) fn setup_duration() -> (
+pub(crate) fn setup_duration() -> anyhow::Result<(
     Option<DurationsLayer<Registry>>,
     Option<DurationsLayerDropGuard>,
-) {
+)> {
     if let Ok(location) = std::env::var("TRACING_DURATIONS_FILE") {
         let location = std::path::PathBuf::from(location);
         if let Some(parent) = location.parent() {
             fs_err::create_dir_all(parent)
-                .expect("Failed to create parent of TRACING_DURATIONS_FILE");
+                .context("Failed to create parent of TRACING_DURATIONS_FILE")?;
         }
         let plot_config = PlotConfig {
             multi_lane: true,
@@ -203,9 +209,9 @@ pub(crate) fn setup_duration() -> (
             .plot_file(location.with_extension("svg"))
             .plot_config(plot_config)
             .build()
-            .expect("Couldn't create TRACING_DURATIONS_FILE files");
-        (Some(layer), Some(guard))
+            .context("Couldn't create TRACING_DURATIONS_FILE files")?;
+        Ok((Some(layer), Some(guard)))
     } else {
-        (None, None)
+        Ok((None, None))
     }
 }

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -1467,7 +1467,7 @@ async fn run() -> Result<ExitStatus> {
 
     // Configure the `tracing` crate, which controls internal logging.
     #[cfg(feature = "tracing-durations-export")]
-    let (duration_layer, _duration_guard) = logging::setup_duration();
+    let (duration_layer, _duration_guard) = logging::setup_duration()?;
     #[cfg(not(feature = "tracing-durations-export"))]
     let duration_layer = None::<tracing_subscriber::layer::Identity>;
     logging::setup_logging(


### PR DESCRIPTION
To get more insights into test performance, allow instrumenting tests with tracing-durations-export.

Usage:

```shell
# A single test
TRACING_DURATIONS_TEST_ROOT=$(pwd)/target/test-traces cargo test --features tracing-durations-export --test pip_install_scenarios no_binary -- --exact
# All tests
TRACING_DURATIONS_TEST_ROOT=$(pwd)/target/test-traces cargo nextest run --features tracing-durations-export
```

Then we can e.g. look at `target/test-traces/pip_install_scenarios::no_binary.svg` and see the builds it performs:

![image](https://github.com/astral-sh/uv/assets/6826232/40b4e094-debc-4b22-8aa3-9471998674af)

