### PR TITLE
Unify packse find links urls

### DIFF
--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -49,7 +49,7 @@ impl GitSource {
     }
 
     /// Fetch the underlying Git repository at the given revision.
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(repository = %self.git.repository, rev = ?self.git.precise))]
     pub fn fetch(self) -> Result<Fetch> {
         // The path to the repo, within the Git database.
         let ident = digest(&RepositoryUrl::new(&self.git.repository));

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -24,7 +24,9 @@ use uv_interpreter::{find_requested_python, PythonVersion};
 // Exclude any packages uploaded after this date.
 pub static EXCLUDE_NEWER: &str = "2024-03-25T00:00:00Z";
 
-pub const PACKSE_FIND_LINKS_URL: &str =
+/// Using a find links url allows using `--index-url` instead of `--extra-index-url` in tests
+/// to prevent dependency confusion attacks against our test suite.
+pub const BUILD_VENDOR_LINKS_URL: &str =
     "https://raw.githubusercontent.com/astral-sh/packse/0.3.14/vendor/links.html";
 
 #[doc(hidden)] // Macro and test context only, don't use directly.

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -24,6 +24,9 @@ use uv_interpreter::{find_requested_python, PythonVersion};
 // Exclude any packages uploaded after this date.
 pub static EXCLUDE_NEWER: &str = "2024-03-25T00:00:00Z";
 
+pub const PACKSE_FIND_LINKS_URL: &str =
+    "https://raw.githubusercontent.com/astral-sh/packse/0.3.13/vendor/links.html";
+
 #[doc(hidden)] // Macro and test context only, don't use directly.
 pub const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"--cache-dir [^\s]+", "--cache-dir [CACHE_DIR]"),

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -25,7 +25,7 @@ use uv_interpreter::{find_requested_python, PythonVersion};
 pub static EXCLUDE_NEWER: &str = "2024-03-25T00:00:00Z";
 
 pub const PACKSE_FIND_LINKS_URL: &str =
-    "https://raw.githubusercontent.com/astral-sh/packse/0.3.13/vendor/links.html";
+    "https://raw.githubusercontent.com/astral-sh/packse/0.3.14/vendor/links.html";
 
 #[doc(hidden)] // Macro and test context only, don't use directly.
 pub const INSTA_FILTERS: &[(&str, &str)] = &[

--- a/crates/uv/tests/pip_compile_scenarios.rs
+++ b/crates/uv/tests/pip_compile_scenarios.rs
@@ -1,7 +1,7 @@
 //! DO NOT EDIT
 //!
 //! Generated with `./scripts/sync_scenarios.sh`
-//! Scenarios from <https://github.com/zanieb/packse/tree/0.3.13/scenarios>
+//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.13/scenarios>
 //!
 #![cfg(all(feature = "python", feature = "pypi", unix))]
 
@@ -29,7 +29,7 @@ fn command(context: &TestContext, python_versions: &[&str]) -> Command {
         .arg("--index-url")
         .arg("https://astral-sh.github.io/packse/0.3.13/simple-html/")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/zanieb/packse/0.3.13/vendor/links.html")
+        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.13/vendor/links.html")
         .arg("--cache-dir")
         .arg(context.cache_dir.path())
         .env("VIRTUAL_ENV", context.venv.as_os_str())

--- a/crates/uv/tests/pip_compile_scenarios.rs
+++ b/crates/uv/tests/pip_compile_scenarios.rs
@@ -1,7 +1,7 @@
 //! DO NOT EDIT
 //!
 //! Generated with `./scripts/sync_scenarios.sh`
-//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.13/scenarios>
+//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.14/scenarios>
 //!
 #![cfg(all(feature = "python", feature = "pypi", unix))]
 
@@ -27,9 +27,9 @@ fn command(context: &TestContext, python_versions: &[&str]) -> Command {
         .arg("compile")
         .arg("requirements.in")
         .arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.13/simple-html/")
+        .arg("https://astral-sh.github.io/packse/0.3.14/simple-html/")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.13/vendor/links.html")
+        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.14/vendor/links.html")
         .arg("--cache-dir")
         .arg(context.cache_dir.path())
         .env("VIRTUAL_ENV", context.venv.as_os_str())

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use common::{uv_snapshot, TestContext};
 use uv_fs::Simplified;
 
-use crate::common::{get_bin, PACKSE_FIND_LINKS_URL};
+use crate::common::{get_bin, BUILD_VENDOR_LINKS_URL};
 
 mod common;
 
@@ -3168,7 +3168,7 @@ fn already_installed_dependent_editable() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg(PACKSE_FIND_LINKS_URL), @r###"
+        .arg(BUILD_VENDOR_LINKS_URL), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3203,7 +3203,7 @@ fn already_installed_dependent_editable() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg(PACKSE_FIND_LINKS_URL), @r###"
+        .arg(BUILD_VENDOR_LINKS_URL), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -3264,7 +3264,7 @@ fn already_installed_local_path_dependent() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg(PACKSE_FIND_LINKS_URL), @r###"
+        .arg(BUILD_VENDOR_LINKS_URL), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3299,7 +3299,7 @@ fn already_installed_local_path_dependent() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg(PACKSE_FIND_LINKS_URL), @r###"
+        .arg(BUILD_VENDOR_LINKS_URL), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -3339,7 +3339,7 @@ fn already_installed_local_path_dependent() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg(PACKSE_FIND_LINKS_URL), @r###"
+        .arg(BUILD_VENDOR_LINKS_URL), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -3361,7 +3361,7 @@ fn already_installed_local_path_dependent() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg(PACKSE_FIND_LINKS_URL), @r###"
+        .arg(BUILD_VENDOR_LINKS_URL), @r###"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1,5 +1,7 @@
 #![cfg(all(feature = "python", feature = "pypi"))]
 
+use std::process::Command;
+
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
@@ -7,12 +9,10 @@ use base64::{prelude::BASE64_STANDARD as base64, Engine};
 use indoc::indoc;
 use itertools::Itertools;
 
-use std::process::Command;
-
 use common::{uv_snapshot, TestContext};
 use uv_fs::Simplified;
 
-use crate::common::get_bin;
+use crate::common::{get_bin, PACKSE_FIND_LINKS_URL};
 
 mod common;
 
@@ -3168,7 +3168,7 @@ fn already_installed_dependent_editable() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.12/vendor/links.html"), @r###"
+        .arg(PACKSE_FIND_LINKS_URL), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3203,7 +3203,7 @@ fn already_installed_dependent_editable() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.12/vendor/links.html"), @r###"
+        .arg(PACKSE_FIND_LINKS_URL), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -3264,7 +3264,7 @@ fn already_installed_local_path_dependent() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.12/vendor/links.html"), @r###"
+        .arg(PACKSE_FIND_LINKS_URL), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -3299,7 +3299,7 @@ fn already_installed_local_path_dependent() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.12/vendor/links.html"), @r###"
+        .arg(PACKSE_FIND_LINKS_URL), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -3339,7 +3339,7 @@ fn already_installed_local_path_dependent() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.12/vendor/links.html"), @r###"
+        .arg(PACKSE_FIND_LINKS_URL), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
@@ -3361,7 +3361,7 @@ fn already_installed_local_path_dependent() {
         // Disable the index to guard this test against dependency confusion attacks
         .arg("--no-index")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.12/vendor/links.html"), @r###"
+        .arg(PACKSE_FIND_LINKS_URL), @r###"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -1,7 +1,7 @@
 //! DO NOT EDIT
 //!
 //! Generated with `./scripts/sync_scenarios.sh`
-//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.13/scenarios>
+//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.14/scenarios>
 //!
 #![cfg(all(feature = "python", feature = "pypi", unix))]
 
@@ -46,9 +46,9 @@ fn command(context: &TestContext) -> Command {
         .arg("pip")
         .arg("install")
         .arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.13/simple-html/")
+        .arg("https://astral-sh.github.io/packse/0.3.14/simple-html/")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.13/vendor/links.html")
+        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.14/vendor/links.html")
         .arg("--cache-dir")
         .arg(context.cache_dir.path())
         .env("VIRTUAL_ENV", context.venv.as_os_str())

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -1,7 +1,7 @@
 //! DO NOT EDIT
 //!
 //! Generated with `./scripts/sync_scenarios.sh`
-//! Scenarios from <https://github.com/zanieb/packse/tree/0.3.13/scenarios>
+//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.13/scenarios>
 //!
 #![cfg(all(feature = "python", feature = "pypi", unix))]
 
@@ -48,7 +48,7 @@ fn command(context: &TestContext) -> Command {
         .arg("--index-url")
         .arg("https://astral-sh.github.io/packse/0.3.13/simple-html/")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/zanieb/packse/0.3.13/vendor/links.html")
+        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.13/vendor/links.html")
         .arg("--cache-dir")
         .arg(context.cache_dir.path())
         .env("VIRTUAL_ENV", context.venv.as_os_str())

--- a/scripts/scenarios/generate.py
+++ b/scripts/scenarios/generate.py
@@ -65,7 +65,6 @@ except ImportError:
     )
     exit(1)
 
-
 try:
     import chevron_blue
 except ImportError:
@@ -175,11 +174,11 @@ def main(scenarios: list[Path], snapshot_update: bool = True):
 
         # Add generated metadata
         data["generated_from"] = (
-            f"https://github.com/zanieb/packse/tree/{ref}/scenarios"
+            f"https://github.com/astral-sh/packse/tree/{ref}/scenarios"
         )
         data["generated_with"] = "./scripts/sync_scenarios.sh"
         data["vendor_links"] = (
-            f"https://raw.githubusercontent.com/zanieb/packse/{ref}/vendor/links.html"
+            f"https://raw.githubusercontent.com/astral-sh/packse/{ref}/vendor/links.html"
         )
 
         data["index_url"] = f"https://astral-sh.github.io/packse/{ref}/simple-html/"

--- a/scripts/scenarios/requirements.txt
+++ b/scripts/scenarios/requirements.txt
@@ -36,7 +36,7 @@ nh3==0.2.17
     # via readme-renderer
 packaging==24.0
     # via hatchling
-packse==0.3.13
+packse==0.3.14
 pathspec==0.12.1
     # via hatchling
 pkginfo==1.10.0


### PR DESCRIPTION
The sync scenarios script is broken, so i did the updates manually

```
$ ./scripts/sync_scenarios.sh
Setting up a temporary environment...
Using Python 3.12.1 interpreter at: /home/konsti/projects/uv/.venv/bin/python3
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
  × No solution found when resolving dependencies:
  ╰─▶ Because docutils==0.21.post1 is unusable because the package metadata was inconsistent and you require docutils==0.21.post1, we can conclude that the requirements are unsatisfiable.

      hint: Metadata for docutils==0.21.post1 was inconsistent:
        Package metadata version `0.21` does not match given version `0.21.post1`
```