### PR TITLE
Create dedicated abstractions for `.rev` and `.http` pointers

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -71,6 +71,12 @@ impl CacheEntry {
     }
 }
 
+impl AsRef<Path> for CacheEntry {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
 /// A subdirectory within the cache.
 #[derive(Debug, Clone)]
 pub struct CacheShard(PathBuf);

--- a/crates/uv-distribution/src/index/cached_wheel.rs
+++ b/crates/uv-distribution/src/index/cached_wheel.rs
@@ -4,10 +4,9 @@ use distribution_filename::WheelFilename;
 use distribution_types::{CachedDirectUrlDist, CachedRegistryDist, Hashed};
 use pep508_rs::VerbatimUrl;
 use pypi_types::HashDigest;
-use uv_cache::{CacheEntry, CachedByTimestamp};
-use uv_client::DataWithCachePolicy;
+use uv_cache::CacheEntry;
 
-use crate::archive::Archive;
+use crate::{HttpArchivePointer, LocalArchivePointer};
 
 #[derive(Debug, Clone)]
 pub struct CachedWheel {
@@ -61,9 +60,8 @@ impl CachedWheel {
         let filename = WheelFilename::from_stem(filename).ok()?;
 
         // Read the pointer.
-        let file = fs_err::File::open(path).ok()?;
-        let data = DataWithCachePolicy::from_reader(file).ok()?.data;
-        let archive = rmp_serde::from_slice::<Archive>(&data).ok()?;
+        let pointer = HttpArchivePointer::read_from(path).ok()??;
+        let archive = pointer.into_archive();
 
         // Convert to a cached wheel.
         let entry = CacheEntry::from_path(archive.path);
@@ -76,16 +74,14 @@ impl CachedWheel {
     }
 
     /// Read a cached wheel from a `.rev` pointer (e.g., `anyio-4.0.0-py3-none-any.rev`).
-    pub fn from_revision_pointer(path: &Path) -> Option<Self> {
+    pub fn from_local_pointer(path: &Path) -> Option<Self> {
         // Determine the wheel filename.
         let filename = path.file_name()?.to_str()?;
         let filename = WheelFilename::from_stem(filename).ok()?;
 
         // Read the pointer.
-        let cached = fs_err::read(path).ok()?;
-        let archive = rmp_serde::from_slice::<CachedByTimestamp<Archive>>(&cached)
-            .ok()?
-            .data;
+        let pointer = LocalArchivePointer::read_from(path).ok()??;
+        let archive = pointer.into_archive();
 
         // Convert to a cached wheel.
         let entry = CacheEntry::from_path(archive.path);

--- a/crates/uv-distribution/src/lib.rs
+++ b/crates/uv-distribution/src/lib.rs
@@ -1,5 +1,5 @@
 pub use archive::Archive;
-pub use distribution_database::{read_timestamped_archive, DistributionDatabase};
+pub use distribution_database::{DistributionDatabase, HttpArchivePointer, LocalArchivePointer};
 pub use download::LocalWheel;
 pub use error::Error;
 pub use git::{is_same_reference, to_precise};


### PR DESCRIPTION
## Summary

This PR formalizes some of the concepts we use in the cache for "pointers to things".

In the wheel cache, we have files like `annotated_types-0.6.0-py3-none-any.http`. This represents an unzipped wheel, cached alongside an HTTP caching policy. We now have a struct for this to encapsulate the logic: `HttpArchivePointer`.

Similarly, we have files like `annotated_types-0.6.0-py3-none-any.rev`. This represents an unzipped local wheel, alongside with a timestamp. We now have a struct for this to encapsulate the logic: `LocalArchivePointer`.

We have similar structs for source distributions too.
