### PR TITLE
Store IDs rather than paths in the cache

### DIFF
--- a/crates/uv-cache/src/archive.rs
+++ b/crates/uv-cache/src/archive.rs
@@ -1,0 +1,24 @@
+use std::path::Path;
+
+/// A unique identifier for an archive (unzipped wheel) in the cache.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ArchiveId(String);
+
+impl Default for ArchiveId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArchiveId {
+    /// Generate a new unique identifier for an archive.
+    pub fn new() -> Self {
+        Self(nanoid::nanoid!())
+    }
+}
+
+impl AsRef<Path> for ArchiveId {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
+    }
+}

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -23,7 +23,9 @@ use crate::removal::{rm_rf, Removal};
 pub use crate::timestamp::Timestamp;
 pub use crate::wheel::WheelCache;
 use crate::wheel::WheelCacheKind;
+pub use archive::ArchiveId;
 
+mod archive;
 mod by_timestamp;
 #[cfg(feature = "clap")]
 mod cli;
@@ -173,6 +175,11 @@ impl Cache {
         CacheEntry::new(self.bucket(cache_bucket).join(dir), file)
     }
 
+    /// Return the path to an archive in the cache.
+    pub fn archive(&self, id: &ArchiveId) -> PathBuf {
+        self.bucket(CacheBucket::Archive).join(id)
+    }
+
     /// Returns `true` if a cache entry must be revalidated given the [`Refresh`] policy.
     pub fn must_revalidate(&self, package: &PackageName) -> bool {
         match &self.refresh {
@@ -214,18 +221,18 @@ impl Cache {
         }
     }
 
-    /// Persist a temporary directory to the artifact store.
+    /// Persist a temporary directory to the artifact store, returning its unique ID.
     pub async fn persist(
         &self,
         temp_dir: impl AsRef<Path>,
         path: impl AsRef<Path>,
-    ) -> io::Result<PathBuf> {
+    ) -> io::Result<ArchiveId> {
         // Create a unique ID for the artifact.
         // TODO(charlie): Support content-addressed persistence via SHAs.
-        let id = nanoid::nanoid!();
+        let id = ArchiveId::new();
 
         // Move the temporary directory into the directory store.
-        let archive_entry = self.entry(CacheBucket::Archive, "", id);
+        let archive_entry = self.entry(CacheBucket::Archive, "", &id);
         fs_err::create_dir_all(archive_entry.dir())?;
         uv_fs::rename_with_retry(temp_dir.as_ref(), archive_entry.path()).await?;
 
@@ -233,7 +240,7 @@ impl Cache {
         fs_err::create_dir_all(path.as_ref().parent().expect("Cache entry to have parent"))?;
         uv_fs::replace_symlink(archive_entry.path(), path.as_ref())?;
 
-        Ok(archive_entry.into_path_buf())
+        Ok(id)
     }
 
     /// Initialize a directory for use as a cache.

--- a/crates/uv-distribution/src/archive.rs
+++ b/crates/uv-distribution/src/archive.rs
@@ -1,31 +1,20 @@
-use std::path::PathBuf;
-
 use distribution_types::Hashed;
 use pypi_types::HashDigest;
+use uv_cache::ArchiveId;
 
 /// An archive (unzipped wheel) that exists in the local cache.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Archive {
-    /// The path to the archive entry in the wheel's archive bucket.
-    pub path: PathBuf,
+    /// The unique ID of the entry in the wheel's archive bucket.
+    pub id: ArchiveId,
     /// The computed hashes of the archive.
     pub hashes: Vec<HashDigest>,
 }
 
 impl Archive {
-    /// Create a new [`Archive`] with the given path and hashes.
-    pub(crate) fn new(path: PathBuf, hashes: Vec<HashDigest>) -> Self {
-        Self { path, hashes }
-    }
-
-    /// Return the path to the archive entry in the wheel's archive bucket.
-    pub fn path(&self) -> &PathBuf {
-        &self.path
-    }
-
-    /// Return the computed hashes of the archive.
-    pub fn hashes(&self) -> &[HashDigest] {
-        &self.hashes
+    /// Create a new [`Archive`] with the given ID and hashes.
+    pub(crate) fn new(id: ArchiveId, hashes: Vec<HashDigest>) -> Self {
+        Self { id, hashes }
     }
 }
 

--- a/crates/uv-distribution/src/index/registry_wheel_index.rs
+++ b/crates/uv-distribution/src/index/registry_wheel_index.rs
@@ -116,7 +116,9 @@ impl<'a> RegistryWheelIndex<'a> {
                     .extension()
                     .is_some_and(|ext| ext.eq_ignore_ascii_case("http"))
                 {
-                    if let Some(wheel) = CachedWheel::from_http_pointer(&wheel_dir.join(&file)) {
+                    if let Some(wheel) =
+                        CachedWheel::from_http_pointer(&wheel_dir.join(&file), cache)
+                    {
                         // Enforce hash-checking based on the built distribution.
                         if wheel.satisfies(hasher.get(package)) {
                             Self::add_wheel(wheel, tags, &mut versions);
@@ -128,7 +130,9 @@ impl<'a> RegistryWheelIndex<'a> {
                     .extension()
                     .is_some_and(|ext| ext.eq_ignore_ascii_case("rev"))
                 {
-                    if let Some(wheel) = CachedWheel::from_local_pointer(&wheel_dir.join(&file)) {
+                    if let Some(wheel) =
+                        CachedWheel::from_local_pointer(&wheel_dir.join(&file), cache)
+                    {
                         // Enforce hash-checking based on the built distribution.
                         if wheel.satisfies(hasher.get(package)) {
                             Self::add_wheel(wheel, tags, &mut versions);

--- a/crates/uv-distribution/src/source/revision.rs
+++ b/crates/uv-distribution/src/source/revision.rs
@@ -1,5 +1,6 @@
 use distribution_types::Hashed;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 use pypi_types::HashDigest;
 
@@ -11,7 +12,7 @@ use pypi_types::HashDigest;
 /// the distribution, despite the reported version number remaining the same.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct Revision {
-    id: String,
+    id: RevisionId,
     hashes: Vec<HashDigest>,
 }
 
@@ -19,13 +20,13 @@ impl Revision {
     /// Initialize a new [`Revision`] with a random UUID.
     pub(crate) fn new() -> Self {
         Self {
-            id: nanoid::nanoid!(),
+            id: RevisionId::new(),
             hashes: vec![],
         }
     }
 
     /// Return the unique ID of the manifest.
-    pub(crate) fn id(&self) -> &str {
+    pub(crate) fn id(&self) -> &RevisionId {
         &self.id
     }
 
@@ -50,5 +51,22 @@ impl Revision {
 impl Hashed for Revision {
     fn hashes(&self) -> &[HashDigest] {
         &self.hashes
+    }
+}
+
+/// A unique identifier for a revision of a source distribution.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RevisionId(String);
+
+impl RevisionId {
+    /// Generate a new unique identifier for an archive.
+    fn new() -> Self {
+        Self(nanoid::nanoid!())
+    }
+}
+
+impl AsRef<Path> for RevisionId {
+    fn as_ref(&self) -> &Path {
+        self.0.as_ref()
     }
 }

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -264,7 +264,7 @@ impl<'a> Planner<'a> {
                                         wheel.filename,
                                         wheel.url,
                                         archive.hashes,
-                                        archive.path,
+                                        cache.archive(&archive.id),
                                     );
 
                                     debug!("URL wheel requirement already cached: {cached_dist}");
@@ -306,7 +306,7 @@ impl<'a> Planner<'a> {
                                             wheel.filename,
                                             wheel.url,
                                             archive.hashes,
-                                            archive.path,
+                                            cache.archive(&archive.id),
                                         );
 
                                         debug!(


### PR DESCRIPTION
## Summary

Similar to `Revision`, we now store IDs in the `Archive` entires rather than absolute paths. This makes the cache robust to moves, etc.

Closes https://github.com/astral-sh/uv/issues/2908.
