### PR TITLE
Add `--find-links` source distributions to the registry cache

### DIFF
--- a/crates/distribution-types/src/index_url.rs
+++ b/crates/distribution-types/src/index_url.rs
@@ -24,6 +24,7 @@ static DEFAULT_INDEX_URL: Lazy<IndexUrl> =
 pub enum IndexUrl {
     Pypi(VerbatimUrl),
     Url(VerbatimUrl),
+    Path(VerbatimUrl),
 }
 
 impl IndexUrl {
@@ -32,6 +33,7 @@ impl IndexUrl {
         match self {
             Self::Pypi(url) => url.raw(),
             Self::Url(url) => url.raw(),
+            Self::Path(url) => url.raw(),
         }
     }
 }
@@ -41,6 +43,7 @@ impl Display for IndexUrl {
         match self {
             Self::Pypi(url) => Display::fmt(url, f),
             Self::Url(url) => Display::fmt(url, f),
+            Self::Path(url) => Display::fmt(url, f),
         }
     }
 }
@@ -50,6 +53,7 @@ impl Verbatim for IndexUrl {
         match self {
             Self::Pypi(url) => url.verbatim(),
             Self::Url(url) => url.verbatim(),
+            Self::Path(url) => url.verbatim(),
         }
     }
 }
@@ -83,6 +87,7 @@ impl From<IndexUrl> for Url {
         match index {
             IndexUrl::Pypi(url) => url.to_url(),
             IndexUrl::Url(url) => url.to_url(),
+            IndexUrl::Path(url) => url.to_url(),
         }
     }
 }
@@ -94,6 +99,7 @@ impl Deref for IndexUrl {
         match &self {
             Self::Pypi(url) => url,
             Self::Url(url) => url,
+            Self::Path(url) => url,
         }
     }
 }

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -205,7 +205,7 @@ impl<'a> FlatIndexClient<'a> {
     fn read_from_directory(path: &PathBuf) -> Result<FlatIndexEntries, std::io::Error> {
         // Absolute paths are required for the URL conversion.
         let path = fs_err::canonicalize(path)?;
-        let index_url = IndexUrl::Url(VerbatimUrl::from_path(&path));
+        let index_url = IndexUrl::Path(VerbatimUrl::from_path(&path));
 
         let mut dists = Vec::new();
         for entry in fs_err::read_dir(path)? {

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -285,6 +285,7 @@ impl RegistryClient {
             Path::new(&match index {
                 IndexUrl::Pypi(_) => "pypi".to_string(),
                 IndexUrl::Url(url) => cache_key::digest(&cache_key::CanonicalUrl::new(url)),
+                IndexUrl::Path(url) => cache_key::digest(&cache_key::CanonicalUrl::new(url)),
             }),
             format!("{package_name}.rkyv"),
         );

--- a/crates/uv-distribution/src/index/cached_wheel.rs
+++ b/crates/uv-distribution/src/index/cached_wheel.rs
@@ -20,9 +20,14 @@ pub struct CachedWheel {
 
 impl CachedWheel {
     /// Try to parse a distribution from a cached directory name (like `typing-extensions-4.8.0-py3-none-any`).
-    pub fn from_built_source(path: &Path) -> Option<Self> {
+    pub fn from_built_source(path: impl AsRef<Path>) -> Option<Self> {
+        let path = path.as_ref();
+
+        // Determine the wheel filename.
         let filename = path.file_name()?.to_str()?;
         let filename = WheelFilename::from_stem(filename).ok()?;
+
+        // Convert to a cached wheel.
         let archive = path.canonicalize().ok()?;
         let entry = CacheEntry::from_path(archive);
         let hashes = Vec::new();
@@ -54,7 +59,9 @@ impl CachedWheel {
     }
 
     /// Read a cached wheel from a `.http` pointer (e.g., `anyio-4.0.0-py3-none-any.http`).
-    pub fn from_http_pointer(path: &Path, cache: &Cache) -> Option<Self> {
+    pub fn from_http_pointer(path: impl AsRef<Path>, cache: &Cache) -> Option<Self> {
+        let path = path.as_ref();
+
         // Determine the wheel filename.
         let filename = path.file_name()?.to_str()?;
         let filename = WheelFilename::from_stem(filename).ok()?;
@@ -73,7 +80,9 @@ impl CachedWheel {
     }
 
     /// Read a cached wheel from a `.rev` pointer (e.g., `anyio-4.0.0-py3-none-any.rev`).
-    pub fn from_local_pointer(path: &Path, cache: &Cache) -> Option<Self> {
+    pub fn from_local_pointer(path: impl AsRef<Path>, cache: &Cache) -> Option<Self> {
+        let path = path.as_ref();
+
         // Determine the wheel filename.
         let filename = path.file_name()?.to_str()?;
         let filename = WheelFilename::from_stem(filename).ok()?;


### PR DESCRIPTION
## Summary

Source distributions in `--find-links` are now properly picked up in the cache.

Closes https://github.com/astral-sh/uv/issues/2978.
