### PR TITLE
Silence lint false positive

### DIFF
--- a/crates/uv-configuration/src/config_settings.rs
+++ b/crates/uv-configuration/src/config_settings.rs
@@ -40,6 +40,7 @@ enum ConfigSettingValue {
 ///
 /// See: <https://peps.python.org/pep-0517/#config-settings>
 #[derive(Debug, Default, Clone)]
+#[cfg_attr(not(feature = "serde"), allow(dead_code))]
 pub struct ConfigSettings(BTreeMap<String, ConfigSettingValue>);
 
 impl FromIterator<ConfigSettingEntry> for ConfigSettings {


### PR DESCRIPTION
When running the `uv-client` tests, i would previously get:

```
warning: field `0` is never read
  --> crates/uv-configuration/src/config_settings.rs:43:27
   |
43 | pub struct ConfigSettings(BTreeMap<String, ConfigSettingValue>);
   |            -------------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |            |
   |            field in this struct
   |
   = note: `ConfigSettings` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
43 | pub struct ConfigSettings(());
   |                           ~~

warning: `uv-configuration` (lib) generated 1 warning
```
