### PR TITLE
Support unnamed requirements in `--require-hashes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4842,6 +4842,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "url",
  "uv-cache",
  "uv-configuration",
  "uv-interpreter",

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -1083,30 +1083,6 @@ impl Identifier for BuildableSource<'_> {
     }
 }
 
-impl Name for SourceDistFilename {
-    fn name(&self) -> &PackageName {
-        &self.name
-    }
-}
-
-impl DistributionMetadata for SourceDistFilename {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Version(&self.version)
-    }
-}
-
-impl Name for WheelFilename {
-    fn name(&self) -> &PackageName {
-        &self.name
-    }
-}
-
-impl DistributionMetadata for WheelFilename {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Version(&self.version)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use crate::{BuiltDist, Dist, SourceDist};

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -1083,6 +1083,30 @@ impl Identifier for BuildableSource<'_> {
     }
 }
 
+impl Name for SourceDistFilename {
+    fn name(&self) -> &PackageName {
+        &self.name
+    }
+}
+
+impl DistributionMetadata for SourceDistFilename {
+    fn version_or_url(&self) -> VersionOrUrl {
+        VersionOrUrl::Version(&self.version)
+    }
+}
+
+impl Name for WheelFilename {
+    fn name(&self) -> &PackageName {
+        &self.name
+    }
+}
+
+impl DistributionMetadata for WheelFilename {
+    fn version_or_url(&self) -> VersionOrUrl {
+        VersionOrUrl::Version(&self.version)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::{BuiltDist, Dist, SourceDist};

--- a/crates/distribution-types/src/traits.rs
+++ b/crates/distribution-types/src/traits.rs
@@ -10,16 +10,14 @@ use crate::{
     BuiltDist, CachedDirectUrlDist, CachedDist, CachedRegistryDist, DirectUrlBuiltDist,
     DirectUrlSourceDist, Dist, DistributionId, GitSourceDist, InstalledDirectUrlDist,
     InstalledDist, InstalledRegistryDist, InstalledVersion, LocalDist, PackageId, PathBuiltDist,
-    PathSourceDist, RegistryBuiltDist, RegistrySourceDist, ResourceId, SourceDist, VersionOrUrl,
+    PathSourceDist, RegistryBuiltDist, RegistrySourceDist, ResourceId, SourceDist, VersionId,
+    VersionOrUrl,
 };
 
 pub trait Name {
     /// Return the normalized [`PackageName`] of the distribution.
     fn name(&self) -> &PackageName;
 }
-
-// Okay, lets make this `VersionId`, then add `PackageId` which identifies a package, which can
-// either be a package _name_ or a URL. Then everything should "just work".
 
 /// Metadata that can be resolved from a requirements specification alone (i.e., prior to building
 /// or installing the distribution).
@@ -28,16 +26,29 @@ pub trait DistributionMetadata: Name {
     /// for URL-based distributions.
     fn version_or_url(&self) -> VersionOrUrl;
 
-    /// Returns a unique identifier for the package (e.g., `black==23.10.0`).
+    /// Returns a unique identifier for the package at the given version (e.g., `black==23.10.0`).
     ///
     /// Note that this is not equivalent to a unique identifier for the _distribution_, as multiple
     /// registry-based distributions (e.g., different wheels for the same package and version)
-    /// will return the same package ID, but different distribution IDs.
-    fn package_id(&self) -> PackageId {
+    /// will return the same version ID, but different distribution IDs.
+    fn version_id(&self) -> VersionId {
         match self.version_or_url() {
             VersionOrUrl::Version(version) => {
-                PackageId::from_registry(self.name().clone(), version.clone())
+                VersionId::from_registry(self.name().clone(), version.clone())
             }
+            VersionOrUrl::Url(url) => VersionId::from_url(url),
+        }
+    }
+
+    /// Returns a unique identifier for a package. A package can either be identified by a name
+    /// (e.g., `black`) or a URL (e.g., `git+https://github.com/psf/black`).
+    ///
+    /// Note that this is not equivalent to a unique identifier for the _distribution_, as multiple
+    /// registry-based distributions (e.g., different wheels for the same package and version)
+    /// will return the same version ID, but different distribution IDs.
+    fn package_id(&self) -> PackageId {
+        match self.version_or_url() {
+            VersionOrUrl::Version(_) => PackageId::from_registry(self.name().clone()),
             VersionOrUrl::Url(url) => PackageId::from_url(url),
         }
     }

--- a/crates/distribution-types/src/traits.rs
+++ b/crates/distribution-types/src/traits.rs
@@ -18,6 +18,9 @@ pub trait Name {
     fn name(&self) -> &PackageName;
 }
 
+// Okay, lets make this `VersionId`, then add `PackageId` which identifies a package, which can
+// either be a package _name_ or a URL. Then everything should "just work".
+
 /// Metadata that can be resolved from a requirements specification alone (i.e., prior to building
 /// or installing the distribution).
 pub trait DistributionMetadata: Name {

--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -112,7 +112,7 @@ pub enum MissingLibrary {
 #[derive(Debug, Error)]
 pub struct MissingHeaderCause {
     missing_library: MissingLibrary,
-    package_id: String,
+    version_id: String,
 }
 
 impl Display for MissingHeaderCause {
@@ -122,22 +122,22 @@ impl Display for MissingHeaderCause {
                 write!(
                     f,
                     "This error likely indicates that you need to install a library that provides \"{}\" for {}",
-                    header, self.package_id
+                    header, self.version_id
                 )
             }
             MissingLibrary::Linker(library) => {
                 write!(
                     f,
                     "This error likely indicates that you need to install the library that provides a shared library \
-                    for {library} for {package_id} (e.g. lib{library}-dev)",
-                    library = library, package_id = self.package_id
+                    for {library} for {version_id} (e.g. lib{library}-dev)",
+                    library = library, version_id = self.version_id
                 )
             }
             MissingLibrary::PythonPackage(package) => {
                 write!(
                     f,
-                    "This error likely indicates that you need to `uv pip install {package}` into the build environment for {package_id}",
-                    package = package, package_id = self.package_id
+                    "This error likely indicates that you need to `uv pip install {package}` into the build environment for {version_id}",
+                    package = package, version_id = self.version_id
                 )
             }
         }
@@ -148,7 +148,7 @@ impl Error {
     fn from_command_output(
         message: String,
         output: &Output,
-        package_id: impl Into<String>,
+        version_id: impl Into<String>,
     ) -> Self {
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -178,7 +178,7 @@ impl Error {
                 stderr,
                 missing_header_cause: MissingHeaderCause {
                     missing_library,
-                    package_id: package_id.into(),
+                    version_id: version_id.into(),
                 },
             };
         }
@@ -364,7 +364,7 @@ pub struct SourceBuild {
     /// > it created.
     metadata_directory: Option<PathBuf>,
     /// Package id such as `foo-1.2.3`, for error reporting
-    package_id: String,
+    version_id: String,
     /// Whether we do a regular PEP 517 build or an PEP 660 editable build
     build_kind: BuildKind,
     /// Modified PATH that contains the `venv_bin`, `user_path` and `system_path` variables in that order
@@ -385,7 +385,7 @@ impl SourceBuild {
         interpreter: &Interpreter,
         build_context: &impl BuildContext,
         source_build_context: SourceBuildContext,
-        package_id: String,
+        version_id: String,
         setup_py: SetupPyStrategy,
         config_settings: ConfigSettings,
         build_isolation: BuildIsolation<'_>,
@@ -477,7 +477,7 @@ impl SourceBuild {
                     &venv,
                     pep517_backend,
                     build_context,
-                    &package_id,
+                    &version_id,
                     build_kind,
                     &config_settings,
                     &environment_variables,
@@ -497,7 +497,7 @@ impl SourceBuild {
             build_kind,
             config_settings,
             metadata_directory: None,
-            package_id,
+            version_id,
             environment_variables,
             modified_path,
         })
@@ -695,7 +695,7 @@ impl SourceBuild {
             return Err(Error::from_command_output(
                 "Build backend failed to determine metadata through `prepare_metadata_for_build_wheel`".to_string(),
                 &output,
-                &self.package_id,
+                &self.version_id,
             ));
         }
 
@@ -714,7 +714,7 @@ impl SourceBuild {
     /// dir.
     ///
     /// <https://packaging.python.org/en/latest/specifications/source-distribution-format/>
-    #[instrument(skip_all, fields(package_id = self.package_id))]
+    #[instrument(skip_all, fields(version_id = self.version_id))]
     pub async fn build_wheel(&self, wheel_dir: &Path) -> Result<String, Error> {
         // The build scripts run with the extracted root as cwd, so they need the absolute path.
         let wheel_dir = fs::canonicalize(wheel_dir)?;
@@ -750,7 +750,7 @@ impl SourceBuild {
                 return Err(Error::from_command_output(
                     "Failed building wheel through setup.py".to_string(),
                     &output,
-                    &self.package_id,
+                    &self.version_id,
                 ));
             }
             let dist = fs::read_dir(self.source_tree.join("dist"))?;
@@ -761,7 +761,7 @@ impl SourceBuild {
                         "Expected exactly wheel in `dist/` after invoking setup.py, found {dist_dir:?}"
                     ),
                     &output,
-                    &self.package_id)
+                    &self.version_id)
                 );
             };
 
@@ -831,7 +831,7 @@ impl SourceBuild {
                     self.build_kind
                 ),
                 &output,
-                &self.package_id,
+                &self.version_id,
             ));
         }
 
@@ -843,7 +843,7 @@ impl SourceBuild {
                     self.build_kind
                 ),
                 &output,
-                &self.package_id,
+                &self.version_id,
             ));
         }
         Ok(distribution_filename)
@@ -873,7 +873,7 @@ async fn create_pep517_build_environment(
     venv: &PythonEnvironment,
     pep517_backend: &Pep517Backend,
     build_context: &impl BuildContext,
-    package_id: &str,
+    version_id: &str,
     build_kind: BuildKind,
     config_settings: &ConfigSettings,
     environment_variables: &FxHashMap<OsString, OsString>,
@@ -927,7 +927,7 @@ async fn create_pep517_build_environment(
         return Err(Error::from_command_output(
             format!("Build backend failed to determine extra requires with `build_{build_kind}()`"),
             &output,
-            package_id,
+            version_id,
         ));
     }
 
@@ -938,7 +938,7 @@ async fn create_pep517_build_environment(
                 "Build backend failed to read extra requires from `get_requires_for_build_{build_kind}`: {err}"
             ),
             &output,
-            package_id,
+            version_id,
         )
     })?;
 
@@ -949,7 +949,7 @@ async fn create_pep517_build_environment(
                 "Build backend failed to return extra requires with `get_requires_for_build_{build_kind}`: {err}"
             ),
             &output,
-            package_id,
+            version_id,
         )
     })?;
 

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -269,12 +269,12 @@ impl<'a> BuildContext for BuildDispatch<'a> {
         Ok(())
     }
 
-    #[instrument(skip_all, fields(package_id = package_id, subdirectory = ?subdirectory))]
+    #[instrument(skip_all, fields(version_id = version_id, subdirectory = ?subdirectory))]
     async fn setup_build<'data>(
         &'data self,
         source: &'data Path,
         subdirectory: Option<&'data Path>,
-        package_id: &'data str,
+        version_id: &'data str,
         dist: Option<&'data SourceDist>,
         build_kind: BuildKind,
     ) -> Result<SourceBuild> {
@@ -304,7 +304,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
             self.interpreter,
             self,
             self.source_build_context.clone(),
-            package_id.to_string(),
+            version_id.to_string(),
             self.setup_py,
             self.config_settings.clone(),
             self.build_isolation,

--- a/crates/uv-distribution/src/index/built_wheel_index.rs
+++ b/crates/uv-distribution/src/index/built_wheel_index.rs
@@ -1,5 +1,5 @@
 use distribution_types::{
-    git_reference, DirectUrlSourceDist, GitSourceDist, Hashed, PathSourceDist,
+    git_reference, DirectUrlSourceDist, DistributionMetadata, GitSourceDist, Hashed, PathSourceDist,
 };
 use platform_tags::Tags;
 use uv_cache::{ArchiveTimestamp, Cache, CacheBucket, CacheShard, WheelCache};
@@ -47,7 +47,7 @@ impl<'a> BuiltWheelIndex<'a> {
 
         // Enforce hash-checking by omitting any wheels that don't satisfy the required hashes.
         let revision = pointer.into_revision();
-        if !revision.satisfies(self.hasher.get(&source_dist.name)) {
+        if !revision.satisfies(self.hasher.get(source_dist)) {
             return Ok(None);
         }
 
@@ -81,7 +81,7 @@ impl<'a> BuiltWheelIndex<'a> {
 
         // Enforce hash-checking by omitting any wheels that don't satisfy the required hashes.
         let revision = pointer.into_revision();
-        if !revision.satisfies(self.hasher.get(&source_dist.name)) {
+        if !revision.satisfies(self.hasher.get(source_dist)) {
             return Ok(None);
         }
 
@@ -91,7 +91,7 @@ impl<'a> BuiltWheelIndex<'a> {
     /// Return the most compatible [`CachedWheel`] for a given source distribution at a git URL.
     pub fn git(&self, source_dist: &GitSourceDist) -> Option<CachedWheel> {
         // Enforce hash-checking, which isn't supported for Git distributions.
-        if self.hasher.get(&source_dist.name).is_validate() {
+        if self.hasher.get(source_dist).is_validate() {
             return None;
         }
 

--- a/crates/uv-distribution/src/index/built_wheel_index.rs
+++ b/crates/uv-distribution/src/index/built_wheel_index.rs
@@ -1,5 +1,5 @@
 use distribution_types::{
-    git_reference, DirectUrlSourceDist, DistributionMetadata, GitSourceDist, Hashed, PathSourceDist,
+    git_reference, DirectUrlSourceDist, GitSourceDist, Hashed, PathSourceDist,
 };
 use platform_tags::Tags;
 use uv_cache::{ArchiveTimestamp, Cache, CacheBucket, CacheShard, WheelCache};

--- a/crates/uv-distribution/src/index/cached_wheel.rs
+++ b/crates/uv-distribution/src/index/cached_wheel.rs
@@ -1,10 +1,14 @@
 use std::path::Path;
 
 use distribution_filename::WheelFilename;
-use distribution_types::{CachedDirectUrlDist, CachedRegistryDist, Hashed};
+use distribution_types::{
+    CachedDirectUrlDist, CachedRegistryDist, DistributionMetadata, Hashed, Identifier, Name,
+    VersionOrUrl,
+};
 use pep508_rs::VerbatimUrl;
 use pypi_types::HashDigest;
 use uv_cache::{Cache, CacheBucket, CacheEntry};
+use uv_normalize::PackageName;
 
 use crate::{Archive, HttpArchivePointer, LocalArchivePointer};
 
@@ -98,6 +102,18 @@ impl CachedWheel {
             entry,
             hashes,
         })
+    }
+}
+
+impl Name for CachedWheel {
+    fn name(&self) -> &PackageName {
+        &self.filename.name
+    }
+}
+
+impl DistributionMetadata for CachedWheel {
+    fn version_or_url(&self) -> VersionOrUrl {
+        VersionOrUrl::Version(&self.filename.version)
     }
 }
 

--- a/crates/uv-distribution/src/index/cached_wheel.rs
+++ b/crates/uv-distribution/src/index/cached_wheel.rs
@@ -1,14 +1,10 @@
 use std::path::Path;
 
 use distribution_filename::WheelFilename;
-use distribution_types::{
-    CachedDirectUrlDist, CachedRegistryDist, DistributionMetadata, Hashed, Identifier, Name,
-    VersionOrUrl,
-};
+use distribution_types::{CachedDirectUrlDist, CachedRegistryDist, Hashed};
 use pep508_rs::VerbatimUrl;
 use pypi_types::HashDigest;
 use uv_cache::{Cache, CacheBucket, CacheEntry};
-use uv_normalize::PackageName;
 
 use crate::{Archive, HttpArchivePointer, LocalArchivePointer};
 
@@ -102,18 +98,6 @@ impl CachedWheel {
             entry,
             hashes,
         })
-    }
-}
-
-impl Name for CachedWheel {
-    fn name(&self) -> &PackageName {
-        &self.filename.name
-    }
-}
-
-impl DistributionMetadata for CachedWheel {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Version(&self.filename.version)
     }
 }
 

--- a/crates/uv-distribution/src/index/registry_wheel_index.rs
+++ b/crates/uv-distribution/src/index/registry_wheel_index.rs
@@ -3,7 +3,9 @@ use std::collections::BTreeMap;
 
 use rustc_hash::FxHashMap;
 
-use distribution_types::{CachedRegistryDist, FlatIndexLocation, Hashed, IndexLocations, IndexUrl};
+use distribution_types::{
+    CachedRegistryDist, DistributionMetadata, FlatIndexLocation, Hashed, IndexLocations, IndexUrl,
+};
 use pep440_rs::Version;
 use pep508_rs::VerbatimUrl;
 use platform_tags::Tags;
@@ -123,7 +125,7 @@ impl<'a> RegistryWheelIndex<'a> {
                                 CachedWheel::from_http_pointer(wheel_dir.join(file), cache)
                             {
                                 // Enforce hash-checking based on the built distribution.
-                                if wheel.satisfies(hasher.get(package)) {
+                                if wheel.satisfies(hasher.get(&wheel)) {
                                     Self::add_wheel(wheel, tags, &mut versions);
                                 }
                             }
@@ -139,7 +141,7 @@ impl<'a> RegistryWheelIndex<'a> {
                                 CachedWheel::from_local_pointer(wheel_dir.join(file), cache)
                             {
                                 // Enforce hash-checking based on the built distribution.
-                                if wheel.satisfies(hasher.get(package)) {
+                                if wheel.satisfies(hasher.get(&wheel)) {
                                     Self::add_wheel(wheel, tags, &mut versions);
                                 }
                             }
@@ -184,13 +186,14 @@ impl<'a> RegistryWheelIndex<'a> {
 
                 if let Some(revision) = revision {
                     // Enforce hash-checking based on the source distribution.
-                    if revision.satisfies(hasher.get(package)) {
-                        for wheel_dir in symlinks(cache_shard.join(revision.id())) {
-                            if let Some(wheel) = CachedWheel::from_built_source(wheel_dir) {
-                                Self::add_wheel(wheel, tags, &mut versions);
-                            }
-                        }
-                    }
+                    // We _could_ get it here because the version is in the path...
+                    // if revision.satisfies(hasher.get(package)) {
+                    //     for wheel_dir in symlinks(cache_shard.join(revision.id())) {
+                    //         if let Some(wheel) = CachedWheel::from_built_source(wheel_dir) {
+                    //             Self::add_wheel(wheel, tags, &mut versions);
+                    //         }
+                    //     }
+                    // }
                 }
             }
         }

--- a/crates/uv-distribution/src/index/registry_wheel_index.rs
+++ b/crates/uv-distribution/src/index/registry_wheel_index.rs
@@ -3,9 +3,7 @@ use std::collections::BTreeMap;
 
 use rustc_hash::FxHashMap;
 
-use distribution_types::{
-    CachedRegistryDist, DistributionMetadata, FlatIndexLocation, Hashed, IndexLocations, IndexUrl,
-};
+use distribution_types::{CachedRegistryDist, FlatIndexLocation, Hashed, IndexLocations, IndexUrl};
 use pep440_rs::Version;
 use pep508_rs::VerbatimUrl;
 use platform_tags::Tags;
@@ -125,7 +123,7 @@ impl<'a> RegistryWheelIndex<'a> {
                                 CachedWheel::from_http_pointer(wheel_dir.join(file), cache)
                             {
                                 // Enforce hash-checking based on the built distribution.
-                                if wheel.satisfies(hasher.get(&wheel)) {
+                                if wheel.satisfies(hasher.get_package(package)) {
                                     Self::add_wheel(wheel, tags, &mut versions);
                                 }
                             }
@@ -141,7 +139,7 @@ impl<'a> RegistryWheelIndex<'a> {
                                 CachedWheel::from_local_pointer(wheel_dir.join(file), cache)
                             {
                                 // Enforce hash-checking based on the built distribution.
-                                if wheel.satisfies(hasher.get(&wheel)) {
+                                if wheel.satisfies(hasher.get_package(package)) {
                                     Self::add_wheel(wheel, tags, &mut versions);
                                 }
                             }
@@ -186,14 +184,13 @@ impl<'a> RegistryWheelIndex<'a> {
 
                 if let Some(revision) = revision {
                     // Enforce hash-checking based on the source distribution.
-                    // We _could_ get it here because the version is in the path...
-                    // if revision.satisfies(hasher.get(package)) {
-                    //     for wheel_dir in symlinks(cache_shard.join(revision.id())) {
-                    //         if let Some(wheel) = CachedWheel::from_built_source(wheel_dir) {
-                    //             Self::add_wheel(wheel, tags, &mut versions);
-                    //         }
-                    //     }
-                    // }
+                    if revision.satisfies(hasher.get_package(package)) {
+                        for wheel_dir in symlinks(cache_shard.join(revision.id())) {
+                            if let Some(wheel) = CachedWheel::from_built_source(wheel_dir) {
+                                Self::add_wheel(wheel, tags, &mut versions);
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/crates/uv-installer/src/downloader.rs
+++ b/crates/uv-installer/src/downloader.rs
@@ -8,8 +8,8 @@ use tracing::instrument;
 use url::Url;
 
 use distribution_types::{
-    BuildableSource, CachedDist, Dist, Hashed, Identifier, LocalEditable, LocalEditables, Name,
-    RemoteSource,
+    BuildableSource, CachedDist, Dist, DistributionMetadata, Hashed, Identifier, LocalEditable,
+    LocalEditables, Name, RemoteSource,
 };
 use platform_tags::Tags;
 use uv_cache::Cache;
@@ -170,7 +170,7 @@ impl<'a, Context: BuildContext + Send + Sync> Downloader<'a, Context> {
     pub async fn get_wheel(&self, dist: Dist, in_flight: &InFlight) -> Result<CachedDist, Error> {
         let id = dist.distribution_id();
         if in_flight.downloads.register(id.clone()) {
-            let policy = self.hashes.get(dist.name());
+            let policy = self.hashes.get(&dist);
             let result = self
                 .database
                 .get_or_build_wheel(&dist, self.tags, policy)

--- a/crates/uv-installer/src/downloader.rs
+++ b/crates/uv-installer/src/downloader.rs
@@ -8,8 +8,8 @@ use tracing::instrument;
 use url::Url;
 
 use distribution_types::{
-    BuildableSource, CachedDist, Dist, DistributionMetadata, Hashed, Identifier, LocalEditable,
-    LocalEditables, Name, RemoteSource,
+    BuildableSource, CachedDist, Dist, Hashed, Identifier, LocalEditable, LocalEditables,
+    RemoteSource,
 };
 use platform_tags::Tags;
 use uv_cache::Cache;

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -5,11 +5,11 @@ use anyhow::{bail, Result};
 use rustc_hash::FxHashMap;
 use tracing::{debug, warn};
 
-use distribution_types::Hashed;
 use distribution_types::{
     BuiltDist, CachedDirectUrlDist, CachedDist, Dist, IndexLocations, InstalledDist,
     InstalledMetadata, InstalledVersion, Name, SourceDist,
 };
+use distribution_types::{DistributionMetadata, Hashed};
 use pep508_rs::{Requirement, VersionOrUrl};
 use platform_tags::Tags;
 use uv_cache::{ArchiveTarget, ArchiveTimestamp, Cache, CacheBucket, WheelCache};
@@ -259,7 +259,7 @@ impl<'a> Planner<'a> {
                             // Read the HTTP pointer.
                             if let Some(pointer) = HttpArchivePointer::read_from(&cache_entry)? {
                                 let archive = pointer.into_archive();
-                                if archive.satisfies(hasher.get(&requirement.name)) {
+                                if archive.satisfies(hasher.get(&wheel)) {
                                     let cached_dist = CachedDirectUrlDist::from_url(
                                         wheel.filename,
                                         wheel.url,
@@ -301,7 +301,7 @@ impl<'a> Planner<'a> {
                                 let timestamp = ArchiveTimestamp::from_file(&wheel.path)?;
                                 if pointer.is_up_to_date(timestamp) {
                                     let archive = pointer.into_archive();
-                                    if archive.satisfies(hasher.get(&requirement.name)) {
+                                    if archive.satisfies(hasher.get(&wheel)) {
                                         let cached_dist = CachedDirectUrlDist::from_url(
                                             wheel.filename,
                                             wheel.url,

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -5,15 +5,14 @@ use anyhow::{bail, Result};
 use rustc_hash::FxHashMap;
 use tracing::{debug, warn};
 
+use distribution_types::Hashed;
 use distribution_types::{
     BuiltDist, CachedDirectUrlDist, CachedDist, Dist, IndexLocations, InstalledDist,
     InstalledMetadata, InstalledVersion, Name, SourceDist,
 };
-use distribution_types::{DistributionMetadata, Hashed};
 use pep508_rs::{Requirement, VersionOrUrl};
 use platform_tags::Tags;
 use uv_cache::{ArchiveTarget, ArchiveTimestamp, Cache, CacheBucket, WheelCache};
-
 use uv_configuration::{NoBinary, Reinstall};
 use uv_distribution::{
     BuiltWheelIndex, HttpArchivePointer, LocalArchivePointer, RegistryWheelIndex,

--- a/crates/uv-requirements/src/lookahead.rs
+++ b/crates/uv-requirements/src/lookahead.rs
@@ -157,7 +157,7 @@ impl<'a, Context: BuildContext + Send + Sync> LookaheadResolver<'a, Context> {
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let archive = self
                     .database
-                    .get_or_build_wheel_metadata(&dist, self.hasher.get(dist.name()))
+                    .get_or_build_wheel_metadata(&dist, self.hasher.get(&dist))
                     .await
                     .with_context(|| match &dist {
                         Dist::Built(built) => format!("Failed to download: {built}"),

--- a/crates/uv-requirements/src/lookahead.rs
+++ b/crates/uv-requirements/src/lookahead.rs
@@ -5,7 +5,7 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use rustc_hash::FxHashSet;
 
-use distribution_types::{Dist, DistributionMetadata, LocalEditable, Name};
+use distribution_types::{Dist, DistributionMetadata, LocalEditable};
 use pep508_rs::{MarkerEnvironment, Requirement, VersionOrUrl};
 use pypi_types::Metadata23;
 use uv_client::RegistryClient;
@@ -138,7 +138,7 @@ impl<'a, Context: BuildContext + Send + Sync> LookaheadResolver<'a, Context> {
 
         // Fetch the metadata for the distribution.
         let requires_dist = {
-            let id = dist.package_id();
+            let id = dist.version_id();
             if let Some(archive) = self
                 .index
                 .get_metadata(&id)

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -92,8 +92,7 @@ impl<'a, Context: BuildContext + Send + Sync> SourceTreeResolver<'a, Context> {
         let hashes = match self.hasher {
             HashStrategy::None => HashPolicy::None,
             HashStrategy::Generate => HashPolicy::Generate,
-            HashStrategy::Validate(_) => {
-                // TODO(charlie): Support `--require-hashes` for unnamed requirements.
+            HashStrategy::Validate { .. } => {
                 return Err(anyhow::anyhow!(
                     "Hash-checking is not supported for local directories: {}",
                     source_tree.user_display()

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use futures::{StreamExt, TryStreamExt};
 use url::Url;
 
-use distribution_types::{BuildableSource, HashPolicy, PackageId, PathSourceUrl, SourceUrl};
+use distribution_types::{BuildableSource, HashPolicy, PathSourceUrl, SourceUrl, VersionId};
 use pep508_rs::Requirement;
 use uv_client::RegistryClient;
 use uv_distribution::{DistributionDatabase, Reporter};
@@ -102,7 +102,7 @@ impl<'a, Context: BuildContext + Send + Sync> SourceTreeResolver<'a, Context> {
 
         // Fetch the metadata for the distribution.
         let metadata = {
-            let id = PackageId::from_url(source.url());
+            let id = VersionId::from_url(source.url());
             if let Some(archive) = self
                 .index
                 .get_metadata(&id)

--- a/crates/uv-requirements/src/unnamed.rs
+++ b/crates/uv-requirements/src/unnamed.rs
@@ -252,22 +252,11 @@ impl<'a, Context: BuildContext + Send + Sync> NamedRequirementsResolver<'a, Cont
                 // If the metadata is already in the index, return it.
                 archive.metadata.name.clone()
             } else {
-                // Determine the hash policy. Since we don't have a package name, we perform a
-                // manual match.
-                let hashes = match hasher {
-                    HashStrategy::None => HashPolicy::None,
-                    HashStrategy::Generate => HashPolicy::Generate,
-                    HashStrategy::Validate(_) => {
-                        // TODO(charlie): Support `--require-hashes` for unnamed requirements.
-                        return Err(anyhow::anyhow!(
-                            "Unnamed requirements are not supported with `--require-hashes`"
-                        ));
-                    }
-                };
-
                 // Run the PEP 517 build process to extract metadata from the source distribution.
                 let source = BuildableSource::Url(source);
-                let archive = database.build_wheel_metadata(&source, hashes).await?;
+                let archive = database
+                    .build_wheel_metadata(&source, hasher.by_id(&id))
+                    .await?;
 
                 let name = archive.metadata.name.clone();
 

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -132,7 +132,7 @@ impl FlatIndex {
         }
 
         // Check if hashes line up
-        let hash = if let HashPolicy::Validate(required) = hasher.get(filename) {
+        let hash = if let HashPolicy::Validate(required) = hasher.get_package(&filename.name) {
             if hashes.is_empty() {
                 Hash::Missing
             } else if required.iter().any(|hash| hashes.contains(hash)) {
@@ -174,7 +174,7 @@ impl FlatIndex {
         };
 
         // Check if hashes line up
-        let hash = if let HashPolicy::Validate(required) = hasher.get(filename) {
+        let hash = if let HashPolicy::Validate(required) = hasher.get_package(&filename.name) {
             if hashes.is_empty() {
                 Hash::Missing
             } else if required.iter().any(|hash| hashes.contains(hash)) {

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -132,7 +132,7 @@ impl FlatIndex {
         }
 
         // Check if hashes line up
-        let hash = if let HashPolicy::Validate(required) = hasher.get(&filename.name) {
+        let hash = if let HashPolicy::Validate(required) = hasher.get(filename) {
             if hashes.is_empty() {
                 Hash::Missing
             } else if required.iter().any(|hash| hashes.contains(hash)) {
@@ -174,7 +174,7 @@ impl FlatIndex {
         };
 
         // Check if hashes line up
-        let hash = if let HashPolicy::Validate(required) = hasher.get(&filename.name) {
+        let hash = if let HashPolicy::Validate(required) = hasher.get(filename) {
             if hashes.is_empty() {
                 Hash::Missing
             } else if required.iter().any(|hash| hashes.contains(hash)) {

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -141,7 +141,7 @@ impl BatchPrefetcher {
                 dist
             );
             prefetch_count += 1;
-            if index.distributions.register(candidate.package_id()) {
+            if index.distributions.register(candidate.version_id()) {
                 let request = match dist {
                     ResolvedDistRef::Installable(dist) => Request::Dist(dist.clone()),
                     ResolvedDistRef::Installed(dist) => Request::Installed(dist.clone()),

--- a/crates/uv-resolver/src/resolver/index.rs
+++ b/crates/uv-resolver/src/resolver/index.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use distribution_types::PackageId;
+use distribution_types::VersionId;
 use once_map::OnceMap;
 use uv_normalize::PackageName;
 
@@ -14,7 +14,7 @@ pub struct InMemoryIndex {
     pub(crate) packages: OnceMap<PackageName, VersionsResponse>,
 
     /// A map from package ID to metadata for that distribution.
-    pub(crate) distributions: OnceMap<PackageId, MetadataResponse>,
+    pub(crate) distributions: OnceMap<VersionId, MetadataResponse>,
 }
 
 impl InMemoryIndex {
@@ -24,8 +24,8 @@ impl InMemoryIndex {
     }
 
     /// Insert a [`Metadata23`] into the index.
-    pub fn insert_metadata(&self, package_id: PackageId, response: MetadataResponse) {
-        self.distributions.done(package_id, response);
+    pub fn insert_metadata(&self, version_id: VersionId, response: MetadataResponse) {
+        self.distributions.done(version_id, response);
     }
 
     /// Get the [`VersionsResponse`] for a given package name, without waiting.
@@ -34,7 +34,7 @@ impl InMemoryIndex {
     }
 
     /// Get the [`MetadataResponse`] for a given package ID, without waiting.
-    pub fn get_metadata(&self, package_id: &PackageId) -> Option<Arc<MetadataResponse>> {
-        self.distributions.get(package_id)
+    pub fn get_metadata(&self, version_id: &VersionId) -> Option<Arc<MetadataResponse>> {
+        self.distributions.get(version_id)
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -537,14 +537,13 @@ impl<
             }
             PubGrubPackage::Package(name, _extra, Some(url)) => {
                 // Verify that the package is allowed under the hash-checking policy.
-                if !self.hasher.allows_package(name) {
+                if !self.hasher.allows_url(url) {
                     return Err(ResolveError::UnhashedPackage(name.clone()));
                 }
 
-                let dist = Dist::from_url(name.clone(), url.clone())?;
-
                 // Emit a request to fetch the metadata for this distribution.
-                if self.index.distributions.register(dist.package_id()) {
+                let dist = Dist::from_url(name.clone(), url.clone())?;
+                if self.index.distributions.register(dist.version_id()) {
                     priorities.add(dist.name().clone());
                     request_sink.send(Request::Dist(dist)).await?;
                 }
@@ -645,7 +644,7 @@ impl<
                 let response = self
                     .index
                     .distributions
-                    .wait(&dist.package_id())
+                    .wait(&dist.version_id())
                     .await
                     .ok_or(ResolveError::Unregistered)?;
 
@@ -795,7 +794,7 @@ impl<
                 let version = candidate.version().clone();
 
                 // Emit a request to fetch the metadata for this version.
-                if self.index.distributions.register(candidate.package_id()) {
+                if self.index.distributions.register(candidate.version_id()) {
                     let request = match dist.for_resolution() {
                         ResolvedDistRef::Installable(dist) => Request::Dist(dist.clone()),
                         ResolvedDistRef::Installed(dist) => Request::Installed(dist.clone()),
@@ -879,13 +878,13 @@ impl<
                             Some(url) => PubGrubDistribution::from_url(package_name, url),
                             None => PubGrubDistribution::from_registry(package_name, version),
                         };
-                        let package_id = dist.package_id();
+                        let version_id = dist.version_id();
 
                         // Wait for the metadata to be available.
                         self.index
                             .distributions
-                            .wait(&package_id)
-                            .instrument(info_span!("distributions_wait", %package_id))
+                            .wait(&version_id)
+                            .instrument(info_span!("distributions_wait", %version_id))
                             .await
                             .ok_or(ResolveError::Unregistered)?;
                     }
@@ -930,7 +929,7 @@ impl<
                     Some(url) => PubGrubDistribution::from_url(package_name, url),
                     None => PubGrubDistribution::from_registry(package_name, version),
                 };
-                let package_id = dist.package_id();
+                let version_id = dist.version_id();
 
                 // If the package does not exist in the registry or locally, we cannot fetch its dependencies
                 if self.unavailable_packages.get(package_name).is_some()
@@ -952,8 +951,8 @@ impl<
                 let response = self
                     .index
                     .distributions
-                    .wait(&package_id)
-                    .instrument(info_span!("distributions_wait", %package_id))
+                    .wait(&version_id)
+                    .instrument(info_span!("distributions_wait", %version_id))
                     .await
                     .ok_or(ResolveError::Unregistered)?;
 
@@ -1060,7 +1059,7 @@ impl<
                 Some(Response::Installed { dist, metadata }) => {
                     trace!("Received installed distribution metadata for: {dist}");
                     self.index.distributions.done(
-                        dist.package_id(),
+                        dist.version_id(),
                         MetadataResponse::Found(ArchiveMetadata::from(metadata)),
                     );
                 }
@@ -1078,7 +1077,7 @@ impl<
                         }
                         _ => {}
                     }
-                    self.index.distributions.done(dist.package_id(), metadata);
+                    self.index.distributions.done(dist.version_id(), metadata);
                 }
                 Some(Response::Dist {
                     dist: Dist::Source(dist),
@@ -1094,7 +1093,7 @@ impl<
                         }
                         _ => {}
                     }
-                    self.index.distributions.done(dist.package_id(), metadata);
+                    self.index.distributions.done(dist.version_id(), metadata);
                 }
                 None => {}
             }
@@ -1199,7 +1198,7 @@ impl<
                 };
 
                 // Emit a request to fetch the metadata for this version.
-                if self.index.distributions.register(candidate.package_id()) {
+                if self.index.distributions.register(candidate.version_id()) {
                     let dist = dist.for_resolution().to_owned();
 
                     let response = match dist {

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 
-use distribution_types::{Dist, IndexLocations, Name};
+use distribution_types::{Dist, DistributionMetadata, IndexLocations, Name};
 use platform_tags::Tags;
 
 use uv_client::RegistryClient;
@@ -181,7 +181,7 @@ impl<'a, Context: BuildContext + Send + Sync> ResolverProvider
     async fn get_or_build_wheel_metadata<'io>(&'io self, dist: &'io Dist) -> WheelMetadataResult {
         match self
             .fetcher
-            .get_or_build_wheel_metadata(dist, self.hasher.get(dist.name()))
+            .get_or_build_wheel_metadata(dist, self.hasher.get(dist))
             .await
         {
             Ok(metadata) => Ok(MetadataResponse::Found(metadata)),

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 
-use distribution_types::{Dist, DistributionMetadata, IndexLocations, Name};
+use distribution_types::{Dist, IndexLocations};
 use platform_tags::Tags;
 
 use uv_client::RegistryClient;

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -112,7 +112,8 @@ impl VersionMap {
             .allowed_versions(package_name)
             .cloned()
             .unwrap_or_default();
-        let required_hashes = hasher.get(package_name).digests().to_vec();
+        // let required_hashes = hasher.get(package_name).digests().to_vec();
+        let required_hashes = Vec::new();
         Self {
             inner: VersionMapInner::Lazy(VersionMapLazy {
                 map,
@@ -308,7 +309,8 @@ struct VersionMapLazy {
     /// Which yanked versions are allowed
     allowed_yanks: FxHashSet<Version>,
     /// The hashes of allowed distributions.
-    required_hashes: Vec<HashDigest>,
+    /// STOPSHIP(charlie): We'd need to clone the entire policy.
+    hasher: HashStrategy,
 }
 
 impl VersionMapLazy {

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -112,8 +112,7 @@ impl VersionMap {
             .allowed_versions(package_name)
             .cloned()
             .unwrap_or_default();
-        // let required_hashes = hasher.get(package_name).digests().to_vec();
-        let required_hashes = Vec::new();
+        let required_hashes = hasher.get_package(package_name).digests().to_vec();
         Self {
             inner: VersionMapInner::Lazy(VersionMapLazy {
                 map,
@@ -309,8 +308,7 @@ struct VersionMapLazy {
     /// Which yanked versions are allowed
     allowed_yanks: FxHashSet<Version>,
     /// The hashes of allowed distributions.
-    /// STOPSHIP(charlie): We'd need to clone the entire policy.
-    hasher: HashStrategy,
+    required_hashes: Vec<HashDigest>,
 }
 
 impl VersionMapLazy {

--- a/crates/uv-types/Cargo.toml
+++ b/crates/uv-types/Cargo.toml
@@ -30,6 +30,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
+url = { workspace = true }
 
 [features]
 default = []

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -1,8 +1,11 @@
-use distribution_types::HashPolicy;
-use rustc_hash::FxHashMap;
+use distribution_types::{DistributionMetadata, HashPolicy, PackageId};
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::str::FromStr;
+use url::Url;
 
-use pep508_rs::{MarkerEnvironment, Requirement, VersionOrUrl};
+use pep508_rs::{
+    MarkerEnvironment, Requirement, RequirementsTxtRequirement, VerbatimUrl, VersionOrUrl,
+};
 use pypi_types::{HashDigest, HashError};
 use uv_normalize::PackageName;
 
@@ -14,37 +17,82 @@ pub enum HashStrategy {
     Generate,
     /// Hashes should be validated against a pre-defined list of hashes. If necessary, hashes should
     /// be generated so as to ensure that the archive is valid.
-    Validate(FxHashMap<PackageName, Vec<HashDigest>>),
+    Validate {
+        hashes: FxHashMap<PackageId, Vec<HashDigest>>,
+        packages: FxHashMap<PackageName, Vec<HashDigest>>,
+        urls: FxHashSet<Url>,
+    },
 }
 
 impl HashStrategy {
-    /// Return the [`HashPolicy`] for the given package.
-    pub fn get(&self, package_name: &PackageName) -> HashPolicy {
+    /// Return the [`HashPolicy`] for the given distribution.
+    pub fn get<T: DistributionMetadata>(&self, distribution: &T) -> HashPolicy {
         match self {
             Self::None => HashPolicy::None,
             Self::Generate => HashPolicy::Generate,
-            Self::Validate(hashes) => hashes
-                .get(package_name)
+            Self::Validate { hashes, .. } => hashes
+                .get(&distribution.package_id())
                 .map(Vec::as_slice)
                 .map_or(HashPolicy::None, HashPolicy::Validate),
         }
     }
 
-    /// Returns `true` if the given package is allowed.
-    pub fn allows(&self, package_name: &PackageName) -> bool {
+    /// Return the [`HashPolicy`] for the given package ID.
+    pub fn by_id(&self, id: &PackageId) -> HashPolicy {
         match self {
-            Self::None => true,
-            Self::Generate => true,
-            Self::Validate(hashes) => hashes.contains_key(package_name),
+            Self::None => HashPolicy::None,
+            Self::Generate => HashPolicy::Generate,
+            Self::Validate { hashes, .. } => hashes
+                .get(id)
+                .map(Vec::as_slice)
+                .map_or(HashPolicy::None, HashPolicy::Validate),
         }
     }
 
-    /// Generate the required hashes from a set of [`Requirement`] entries.
+    /// Return the [`HashPolicy`] for the given package ID.
+    pub fn by_package(&self, name: &PackageName) -> HashPolicy {
+        match self {
+            Self::None => HashPolicy::None,
+            Self::Generate => HashPolicy::Generate,
+            Self::Validate { packages, .. } => packages
+                .get(name)
+                .map(Vec::as_slice)
+                .map_or(HashPolicy::None, HashPolicy::Validate),
+        }
+    }
+
+    /// Returns `true` if the given package is allowed. Used to prevent resolvers from inserting
+    /// packages that were not specified upfront.
+    ///
+    /// A package is allowed if it was specified with a pinned version and hash.
+    pub fn allows_package(&self, package: &PackageName) -> bool {
+        match self {
+            Self::None => true,
+            Self::Generate => true,
+            Self::Validate { packages, .. } => packages.contains_key(package),
+        }
+    }
+
+    /// Returns `true` if the given URL is allowed. Used to prevent resolvers from inserting URLs
+    /// that were not specified upfront.
+    ///
+    /// A URL is allowed if it was provided with a hash.
+    pub fn allows_url(&self, url: &Url) -> bool {
+        match self {
+            Self::None => true,
+            Self::Generate => true,
+            Self::Validate { urls, .. } => urls.contains(url),
+        }
+    }
+
+    /// Generate the required hashes from a set of [`RequirementsTxtRequirement`] entries.
     pub fn from_requirements(
-        requirements: impl Iterator<Item = (Requirement, Vec<String>)>,
+        requirements: impl Iterator<Item = (RequirementsTxtRequirement, Vec<String>)>,
         markers: &MarkerEnvironment,
     ) -> Result<Self, HashStrategyError> {
-        let mut hashes = FxHashMap::<PackageName, Vec<HashDigest>>::default();
+        let mut hashes = FxHashMap::<PackageId, Vec<HashDigest>>::default();
+        let mut packages = FxHashMap::<PackageName, Vec<HashDigest>>::default();
+        let mut urls = FxHashSet::<Url>::default();
 
         // For each requirement, map from name to allowed hashes. We use the last entry for each
         // package.
@@ -59,47 +107,68 @@ impl HashStrategy {
                 continue;
             }
 
-            // Every requirement must be either a pinned version or a direct URL.
-            match requirement.version_or_url.as_ref() {
-                Some(VersionOrUrl::Url(_)) => {
-                    // Direct URLs are always allowed.
-                }
-                Some(VersionOrUrl::VersionSpecifier(specifiers)) => {
-                    if specifiers
-                        .iter()
-                        .any(|specifier| matches!(specifier.operator(), pep440_rs::Operator::Equal))
-                    {
-                        // Pinned versions are allowed.
-                    } else {
-                        return Err(HashStrategyError::UnpinnedRequirement(
-                            requirement.to_string(),
-                        ));
-                    }
-                }
-                None => {
-                    return Err(HashStrategyError::UnpinnedRequirement(
-                        requirement.to_string(),
-                    ))
-                }
-            }
-
             // Every requirement must include a hash.
             if digests.is_empty() {
                 return Err(HashStrategyError::MissingHashes(requirement.to_string()));
             }
 
-            // Parse the hashes.
+           // Parse the hashes.
             let digests = digests
                 .iter()
                 .map(|digest| HashDigest::from_str(digest))
                 .collect::<Result<Vec<_>, _>>()
                 .unwrap();
 
-            // TODO(charlie): Extract hashes from URL fragments.
-            hashes.insert(requirement.name, digests);
+            // Every requirement must be either a pinned version or a direct URL.
+            match requirement {
+                RequirementsTxtRequirement::Pep508(requirement) => {
+                    match requirement.version_or_url.as_ref() {
+                        Some(VersionOrUrl::Url(url)) => {
+                            // Direct URLs are always allowed.
+                            urls.insert(url.to_url());
+                            hashes.insert(PackageId::from_url(url), digests);
+                        }
+                        Some(VersionOrUrl::VersionSpecifier(specifiers)) => {
+                            // Must be a single specifier.
+                            let [specifier] = specifiers.as_ref() else {
+                                return Err(HashStrategyError::UnpinnedRequirement(
+                                    requirement.to_string(),
+                                ));
+                            };
+
+                            // Must be pinned to a specific version.
+                            if *specifier.operator() != pep440_rs::Operator::Equal {
+                                return Err(HashStrategyError::UnpinnedRequirement(
+                                    requirement.to_string(),
+                                ));
+                            }
+
+                            packages.insert(requirement.name.clone(), digests);
+                            PackageId::from_registry(
+                                requirement.name.clone(),
+                                specifier.version().clone(),
+                            )
+                        }
+                        None => {
+                            return Err(HashStrategyError::UnpinnedRequirement(
+                                requirement.to_string(),
+                            ))
+                        }
+                    }
+                }
+                RequirementsTxtRequirement::Unnamed(requirement) => {
+                    // Direct URLs are always allowed.
+                    urls.insert(requirement.url.to_url());
+                    hashes.insert(PackageId::from_url(&requirement.url), digests);
+                }
+            };
         }
 
-        Ok(Self::Validate(hashes))
+        Ok(Self::Validate {
+            hashes,
+            packages,
+            urls,
+        })
     }
 }
 

--- a/crates/uv-types/src/traits.rs
+++ b/crates/uv-types/src/traits.rs
@@ -95,13 +95,13 @@ pub trait BuildContext: Sync {
     ///
     /// For PEP 517 builds, this calls `get_requires_for_build_wheel`.
     ///
-    /// `package_id` is for error reporting only.
+    /// `version_id` is for error reporting only.
     /// `dist` is for safety checks and may be null for editable builds.
     fn setup_build<'a>(
         &'a self,
         source: &'a Path,
         subdirectory: Option<&'a Path>,
-        package_id: &'a str,
+        version_id: &'a str,
         dist: Option<&'a SourceDist>,
         build_kind: BuildKind,
     ) -> impl Future<Output = Result<Self::SourceDistBuilder>> + Send + 'a;

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -191,10 +191,7 @@ pub(crate) async fn pip_install(
         HashStrategy::from_requirements(
             entries
                 .into_iter()
-                .filter_map(|requirement| match requirement.requirement {
-                    RequirementsTxtRequirement::Pep508(req) => Some((req, requirement.hashes)),
-                    RequirementsTxtRequirement::Unnamed(_) => None,
-                }),
+                .map(|entry| (entry.requirement, entry.hashes)),
             markers,
         )?
     } else {

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -15,7 +15,7 @@ use distribution_types::{
     LocalEditables, Name, Resolution,
 };
 use install_wheel_rs::linker::LinkMode;
-use pep508_rs::{MarkerEnvironment, Requirement, RequirementsTxtRequirement};
+use pep508_rs::{MarkerEnvironment, Requirement};
 use platform_tags::Tags;
 use pypi_types::{Metadata23, Yanked};
 use requirements_txt::EditableRequirement;

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -10,7 +10,7 @@ use distribution_types::{
     IndexLocations, InstalledMetadata, LocalDist, LocalEditable, LocalEditables, Name, ResolvedDist,
 };
 use install_wheel_rs::linker::LinkMode;
-use pep508_rs::RequirementsTxtRequirement;
+
 use platform_tags::Tags;
 use pypi_types::Yanked;
 use requirements_txt::EditableRequirement;

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -140,10 +140,7 @@ pub(crate) async fn pip_sync(
         HashStrategy::from_requirements(
             entries
                 .into_iter()
-                .filter_map(|requirement| match requirement.requirement {
-                    RequirementsTxtRequirement::Pep508(req) => Some((req, requirement.hashes)),
-                    RequirementsTxtRequirement::Unnamed(_) => None,
-                }),
+                .map(|entry| (entry.requirement, entry.hashes)),
             markers,
         )?
     } else {

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -3855,24 +3855,29 @@ fn require_hashes_source_path_mismatch() -> Result<()> {
     Ok(())
 }
 
-/// `--require-hashes` isn't supported for unnamed requirements (yet).
+/// We allow `--require-hashes` for direct URL dependencies.
 #[test]
 fn require_hashes_unnamed() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt
-        .write_str("https://foo.com --hash=sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f")?;
+        .write_str(indoc::indoc! {r"
+            https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl --hash=sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
+        "} )?;
 
     uv_snapshot!(command(&context)
         .arg("requirements.txt")
         .arg("--require-hashes"), @r###"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    error: Unnamed requirements are not supported with `--require-hashes`
+    Resolved 1 package in [TIME]
+    Downloaded 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + anyio==4.0.0 (from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl)
     "###
     );
 


### PR DESCRIPTION
## Summary

This PR enables `--require-hashes` with unnamed requirements. The key change is that `PackageId` becomes `VersionId` (since it refers to a package at a specific version), and the new `PackageId` consists of _either_ a package name _or_ a URL. The hashes are keyed by `PackageId`, so we can generate the `RequiredHashes` before we have names for all packages, and enforce them throughout.

Closes #2979.