### PR TITLE
Make hash-checking failure mode stricter and safer

### DIFF
--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -25,10 +25,12 @@ impl HashStrategy {
         match self {
             Self::None => HashPolicy::None,
             Self::Generate => HashPolicy::Generate,
-            Self::Validate(hashes) => hashes
-                .get(&distribution.package_id())
-                .map(Vec::as_slice)
-                .map_or(HashPolicy::None, HashPolicy::Validate),
+            Self::Validate(hashes) => HashPolicy::Validate(
+                hashes
+                    .get(&distribution.package_id())
+                    .map(Vec::as_slice)
+                    .unwrap_or_default(),
+            ),
         }
     }
 
@@ -37,10 +39,12 @@ impl HashStrategy {
         match self {
             Self::None => HashPolicy::None,
             Self::Generate => HashPolicy::Generate,
-            Self::Validate(hashes) => hashes
-                .get(&PackageId::from_registry(name.clone()))
-                .map(Vec::as_slice)
-                .map_or(HashPolicy::None, HashPolicy::Validate),
+            Self::Validate(hashes) => HashPolicy::Validate(
+                hashes
+                    .get(&PackageId::from_registry(name.clone()))
+                    .map(Vec::as_slice)
+                    .unwrap_or_default(),
+            ),
         }
     }
 
@@ -49,10 +53,12 @@ impl HashStrategy {
         match self {
             Self::None => HashPolicy::None,
             Self::Generate => HashPolicy::Generate,
-            Self::Validate(hashes) => hashes
-                .get(&PackageId::from_url(url))
-                .map(Vec::as_slice)
-                .map_or(HashPolicy::None, HashPolicy::Validate),
+            Self::Validate(hashes) => HashPolicy::Validate(
+                hashes
+                    .get(&PackageId::from_url(url))
+                    .map(Vec::as_slice)
+                    .unwrap_or_default(),
+            ),
         }
     }
 


### PR DESCRIPTION
## Summary

If there are no hashes for a given package, we now return `Validate(&[])` so that the policy is impossible to satisfy. Previously, we returned `None`, which is always satisfied.

We don't really ever expect to hit this, because we detect this case in the resolver and raise a different error. But if we have a bug somewhere, it's better to fail with an error than silently let the package through.
