### PR TITLE
Add ticks around error messages more consistently

### DIFF
--- a/crates/distribution-types/src/file.rs
+++ b/crates/distribution-types/src/file.rs
@@ -12,7 +12,7 @@ use pypi_types::{DistInfoMetadata, HashDigest, Yanked};
 /// Error converting [`pypi_types::File`] to [`distribution_type::File`].
 #[derive(Debug, Error)]
 pub enum FileConversionError {
-    #[error("Failed to parse 'requires-python': {0}")]
+    #[error("Failed to parse 'requires-python': `{0}`")]
     RequiresPython(String, #[source] VersionSpecifiersParseError),
     #[error("Failed to parse URL: {0}")]
     Url(String, #[source] url::ParseError),

--- a/crates/platform-tags/src/tags.rs
+++ b/crates/platform-tags/src/tags.rs
@@ -11,11 +11,11 @@ use crate::{Arch, Os, Platform, PlatformError};
 pub enum TagsError {
     #[error(transparent)]
     PlatformError(#[from] PlatformError),
-    #[error("Unsupported implementation: {0}")]
+    #[error("Unsupported implementation: `{0}`")]
     UnsupportedImplementation(String),
-    #[error("Unknown implementation: {0}")]
+    #[error("Unknown implementation: `{0}`")]
     UnknownImplementation(String),
-    #[error("Invalid priority: {0}")]
+    #[error("Invalid priority: `{0}`")]
     InvalidPriority(usize, #[source] std::num::TryFromIntError),
     #[error("Only CPython can be freethreading, not: {0}")]
     GilIsACpythonProblem(String),
@@ -36,7 +36,7 @@ pub enum TagCompatibility {
 }
 
 impl Ord for TagCompatibility {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
         match (self, other) {
             (Self::Compatible(p_self), Self::Compatible(p_other)) => p_self.cmp(p_other),
             (Self::Incompatible(_), Self::Compatible(_)) => cmp::Ordering::Less,

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     NoBinary,
 
     // Network error
-    #[error("Failed to parse URL: `{0}`")]
+    #[error("Failed to parse URL: {0}")]
     Url(String, #[source] url::ParseError),
     #[error(transparent)]
     JoinRelativeUrl(#[from] pypi_types::JoinRelativeError),
@@ -41,9 +41,9 @@ pub enum Error {
     CacheEncode(#[from] rmp_serde::encode::Error),
 
     // Build error
-    #[error("Failed to build: {0}")]
+    #[error("Failed to build: `{0}`")]
     Build(String, #[source] anyhow::Error),
-    #[error("Failed to build editable: {0}")]
+    #[error("Failed to build editable: `{0}`")]
     BuildEditable(String, #[source] anyhow::Error),
     #[error("Built wheel has an invalid filename")]
     WheelFilename(#[from] WheelFilenameError),
@@ -90,7 +90,7 @@ pub enum Error {
     #[error("Failed to hash distribution")]
     HashExhaustion(#[source] std::io::Error),
 
-    #[error("Hash mismatch for {distribution}\n\nExpected:\n{expected}\n\nComputed:\n{actual}")]
+    #[error("Hash mismatch for `{distribution}`\n\nExpected:\n{expected}\n\nComputed:\n{actual}")]
     MismatchedHashes {
         distribution: String,
         expected: String,
@@ -98,26 +98,26 @@ pub enum Error {
     },
 
     #[error(
-        "Hash-checking is enabled, but no hashes were provided or computed for: {distribution}"
+        "Hash-checking is enabled, but no hashes were provided or computed for: `{distribution}`"
     )]
     MissingHashes { distribution: String },
 
-    #[error("Hash-checking is enabled, but no hashes were computed for: {distribution}\n\nExpected:\n{expected}")]
+    #[error("Hash-checking is enabled, but no hashes were computed for: `{distribution}`\n\nExpected:\n{expected}")]
     MissingActualHashes {
         distribution: String,
         expected: String,
     },
 
-    #[error("Hash-checking is enabled, but no hashes were provided for: {distribution}\n\nComputed:\n{actual}")]
+    #[error("Hash-checking is enabled, but no hashes were provided for: `{distribution}`\n\nComputed:\n{actual}")]
     MissingExpectedHashes {
         distribution: String,
         actual: String,
     },
 
-    #[error("Hash-checking is not supported for local directories: {0}")]
+    #[error("Hash-checking is not supported for local directories: `{0}`")]
     HashesNotSupportedSourceTree(String),
 
-    #[error("Hash-checking is not supported for Git repositories: {0}")]
+    #[error("Hash-checking is not supported for Git repositories: `{0}`")]
     HashesNotSupportedGit(String),
 }
 

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -25,7 +25,7 @@ use crate::resolver::{IncompletePackage, UnavailablePackage, VersionsResponse};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ResolveError {
-    #[error("Failed to find a version of {0} that satisfies the requirement")]
+    #[error("Failed to find a version of `{0}` that satisfies the requirement")]
     NotFound(Requirement),
 
     #[error(transparent)]
@@ -46,7 +46,7 @@ pub enum ResolveError {
         metadata: PackageName,
     },
 
-    #[error("~= operator requires at least two release segments: {0}")]
+    #[error("~= operator requires at least two release segments: `{0}`")]
     InvalidTildeEquals(pep440_rs::VersionSpecifier),
 
     #[error("Requirements contain conflicting URLs for package `{0}`:\n- {1}\n- {2}")]
@@ -64,20 +64,20 @@ pub enum ResolveError {
     #[error(transparent)]
     DistributionType(#[from] distribution_types::Error),
 
-    #[error("Failed to download: {0}")]
+    #[error("Failed to download `{0}`")]
     Fetch(Box<BuiltDist>, #[source] uv_distribution::Error),
 
-    #[error("Failed to download and build: {0}")]
+    #[error("Failed to download and build `{0}`")]
     FetchAndBuild(Box<SourceDist>, #[source] uv_distribution::Error),
 
-    #[error("Failed to read: {0}")]
+    #[error("Failed to read `{0}`")]
     Read(Box<PathBuiltDist>, #[source] uv_distribution::Error),
 
     // TODO(zanieb): Use `thiserror` in `InstalledDist` so we can avoid chaining `anyhow`
-    #[error("Failed to read metadata from installed package: {0}")]
+    #[error("Failed to read metadata from installed package `{0}`")]
     ReadInstalled(Box<InstalledDist>, #[source] anyhow::Error),
 
-    #[error("Failed to build: {0}")]
+    #[error("Failed to build `{0}`")]
     Build(Box<PathSourceDist>, #[source] uv_distribution::Error),
 
     #[error(transparent)]
@@ -94,7 +94,7 @@ pub enum ResolveError {
     #[error("Attempted to construct an invalid version specifier")]
     InvalidVersion(#[from] pep440_rs::VersionSpecifierBuildError),
 
-    #[error("In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: {0}")]
+    #[error("In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `{0}`")]
     UnhashedPackage(PackageName),
 
     /// Something unexpected happened.

--- a/crates/uv-resolver/src/preferences.rs
+++ b/crates/uv-resolver/src/preferences.rs
@@ -12,7 +12,7 @@ use uv_normalize::PackageName;
 
 #[derive(thiserror::Error, Debug)]
 pub enum PreferenceError {
-    #[error("direct URL requirements without package names are not supported: {0}")]
+    #[error("direct URL requirements without package names are not supported: `{0}`")]
     Bare(UnnamedRequirement),
     #[error(transparent)]
     Hash(#[from] HashError),

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -208,7 +208,7 @@ dependencies = ["flask==1.0.x"]
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to build: file://[TEMP_DIR]/
+    error: Failed to build: `file://[TEMP_DIR]/`
       Caused by: Build backend failed to determine extra requires with `build_wheel()` with exit code: 1
     --- stdout:
     configuration error: `project.dependencies[0]` must be pep508
@@ -2626,7 +2626,7 @@ fn no_build_isolation() -> Result<()> {
 
     ----- stderr -----
     error: Failed to download and build: anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz
-      Caused by: Failed to build: anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz
+      Caused by: Failed to build: `anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz`
       Caused by: Build backend failed to determine metadata through `prepare_metadata_for_build_wheel` with exit status: 1
     --- stdout:
 
@@ -3242,7 +3242,7 @@ fn install_package_basic_auth_from_keyring_wrong_password() {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download: anyio==4.3.0
+    error: Failed to download `anyio==4.3.0`
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl.metadata)
     "###
     );
@@ -3281,7 +3281,7 @@ fn install_package_basic_auth_from_keyring_wrong_username() {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download: anyio==4.3.0
+    error: Failed to download `anyio==4.3.0`
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl.metadata)
     "###
     );
@@ -4206,7 +4206,7 @@ fn require_hashes_mismatch() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: idna
+    error: In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `idna`
     "###
     );
 
@@ -4234,7 +4234,7 @@ fn require_hashes_missing_dependency() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: idna
+    error: In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `idna`
     "###
     );
 
@@ -4264,7 +4264,7 @@ fn require_hashes_editable() -> Result<()> {
 
     ----- stderr -----
     Built 1 editable in [TIME]
-    error: In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: aiohttp
+    error: In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `aiohttp`
     "###
     );
 

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -3297,7 +3297,7 @@ fn require_hashes_wheel_no_binary() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: anyio==4.0.0
-      Caused by: Hash mismatch for anyio==4.0.0
+      Caused by: Hash mismatch for `anyio==4.0.0`
 
     Expected:
       sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
@@ -3390,7 +3390,7 @@ fn require_hashes_source_only_binary() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: anyio==4.0.0
-      Caused by: Hash mismatch for anyio==4.0.0
+      Caused by: Hash mismatch for `anyio==4.0.0`
 
     Expected:
       sha256:f7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
@@ -3423,7 +3423,7 @@ fn require_hashes_wrong_digest() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: anyio==4.0.0
-      Caused by: Hash mismatch for anyio==4.0.0
+      Caused by: Hash mismatch for `anyio==4.0.0`
 
     Expected:
       sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
@@ -3456,7 +3456,7 @@ fn require_hashes_wrong_algorithm() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: anyio==4.0.0
-      Caused by: Hash mismatch for anyio==4.0.0
+      Caused by: Hash mismatch for `anyio==4.0.0`
 
     Expected:
       sha512:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
@@ -3524,8 +3524,8 @@ fn require_hashes_source_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download and build: anyio @ https://files.pythonhosted.org/packages/74/17/5075225ee1abbb93cd7fc30a2d343c6a3f5f71cf388f14768a7a38256581/anyio-4.0.0.tar.gz
-      Caused by: Hash mismatch for anyio @ https://files.pythonhosted.org/packages/74/17/5075225ee1abbb93cd7fc30a2d343c6a3f5f71cf388f14768a7a38256581/anyio-4.0.0.tar.gz
+    error: Failed to download and build `anyio @ https://files.pythonhosted.org/packages/74/17/5075225ee1abbb93cd7fc30a2d343c6a3f5f71cf388f14768a7a38256581/anyio-4.0.0.tar.gz`
+      Caused by: Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/74/17/5075225ee1abbb93cd7fc30a2d343c6a3f5f71cf388f14768a7a38256581/anyio-4.0.0.tar.gz`
 
     Expected:
       sha256:a7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
@@ -3555,8 +3555,8 @@ fn require_hashes_source_url_mismatch() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download and build: anyio @ https://files.pythonhosted.org/packages/74/17/5075225ee1abbb93cd7fc30a2d343c6a3f5f71cf388f14768a7a38256581/anyio-4.0.0.tar.gz
-      Caused by: Hash mismatch for anyio @ https://files.pythonhosted.org/packages/74/17/5075225ee1abbb93cd7fc30a2d343c6a3f5f71cf388f14768a7a38256581/anyio-4.0.0.tar.gz
+    error: Failed to download and build `anyio @ https://files.pythonhosted.org/packages/74/17/5075225ee1abbb93cd7fc30a2d343c6a3f5f71cf388f14768a7a38256581/anyio-4.0.0.tar.gz`
+      Caused by: Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/74/17/5075225ee1abbb93cd7fc30a2d343c6a3f5f71cf388f14768a7a38256581/anyio-4.0.0.tar.gz`
 
     Expected:
       sha256:a7ed51751b2c2add651e5747c891b47e26d2a21be5d32d9311dfe9692f3e5d7a
@@ -3627,7 +3627,7 @@ fn require_hashes_wheel_url() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
-      Caused by: Hash mismatch for anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
+      Caused by: Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
 
     Expected:
       sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
@@ -3682,7 +3682,7 @@ fn require_hashes_wheel_url_mismatch() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
-      Caused by: Hash mismatch for anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
+      Caused by: Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
 
     Expected:
       sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
@@ -3712,8 +3712,8 @@ fn require_hashes_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download and build: anyio @ git+https://github.com/agronholm/anyio@4a23745badf5bf5ef7928f1e346e9986bd696d82
-      Caused by: Hash-checking is not supported for Git repositories: anyio @ git+https://github.com/agronholm/anyio@4a23745badf5bf5ef7928f1e346e9986bd696d82
+    error: Failed to download and build `anyio @ git+https://github.com/agronholm/anyio@4a23745badf5bf5ef7928f1e346e9986bd696d82`
+      Caused by: Hash-checking is not supported for Git repositories: `anyio @ git+https://github.com/agronholm/anyio@4a23745badf5bf5ef7928f1e346e9986bd696d82`
     "###
     );
 
@@ -3742,8 +3742,8 @@ fn require_hashes_source_tree() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to build: black @ file://[WORKSPACE]/scripts/packages/black_editable
-      Caused by: Hash-checking is not supported for local directories: black @ file://[WORKSPACE]/scripts/packages/black_editable
+    error: Failed to build `black @ file://[WORKSPACE]/scripts/packages/black_editable`
+      Caused by: Hash-checking is not supported for local directories: `black @ file://[WORKSPACE]/scripts/packages/black_editable`
     "###
     );
 
@@ -3790,7 +3790,7 @@ fn require_hashes_re_download() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: anyio==4.0.0
-      Caused by: Hash mismatch for anyio==4.0.0
+      Caused by: Hash mismatch for `anyio==4.0.0`
 
     Expected:
       sha256:afdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
@@ -3881,7 +3881,7 @@ fn require_hashes_wheel_path_mismatch() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: tqdm @ file://[WORKSPACE]/scripts/links/tqdm-1000.0.0-py3-none-any.whl
-      Caused by: Hash mismatch for tqdm @ file://[WORKSPACE]/scripts/links/tqdm-1000.0.0-py3-none-any.whl
+      Caused by: Hash mismatch for `tqdm @ file://[WORKSPACE]/scripts/links/tqdm-1000.0.0-py3-none-any.whl`
 
     Expected:
       sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
@@ -3948,8 +3948,8 @@ fn require_hashes_source_path_mismatch() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to build: tqdm @ file://[WORKSPACE]/scripts/links/tqdm-999.0.0.tar.gz
-      Caused by: Hash mismatch for tqdm @ file://[WORKSPACE]/scripts/links/tqdm-999.0.0.tar.gz
+    error: Failed to build `tqdm @ file://[WORKSPACE]/scripts/links/tqdm-999.0.0.tar.gz`
+      Caused by: Hash mismatch for `tqdm @ file://[WORKSPACE]/scripts/links/tqdm-999.0.0.tar.gz`
 
     Expected:
       sha256:cfdb2b588b9fc25ede96d8db56ed50848b0b649dca3dd1df0b11f683bb9e0b5f
@@ -4162,7 +4162,7 @@ fn require_hashes_repeated_hash() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
-      Caused by: Hash mismatch for anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl
+      Caused by: Hash mismatch for `anyio @ https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl`
 
     Expected:
       md5:520d85e19168705cdf0223621b18831a
@@ -4292,7 +4292,7 @@ fn require_hashes_find_links_no_hash() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: example-a-961b4c22==1.0.0
-      Caused by: Hash mismatch for example-a-961b4c22==1.0.0
+      Caused by: Hash mismatch for `example-a-961b4c22==1.0.0`
 
     Expected:
       sha256:123
@@ -4322,7 +4322,7 @@ fn require_hashes_find_links_no_hash() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: example-a-961b4c22==1.0.0
-      Caused by: Hash mismatch for example-a-961b4c22==1.0.0
+      Caused by: Hash mismatch for `example-a-961b4c22==1.0.0`
 
     Expected:
       sha256:294e788dbe500fdc39e8b88e82652ab67409a1dc9dd06543d0fe0ae31b713eb3
@@ -4414,7 +4414,7 @@ fn require_hashes_find_links_invalid_hash() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: example-a-961b4c22==1.0.0
-      Caused by: Hash mismatch for example-a-961b4c22==1.0.0
+      Caused by: Hash mismatch for `example-a-961b4c22==1.0.0`
 
     Expected:
       sha256:123
@@ -4443,7 +4443,7 @@ fn require_hashes_find_links_invalid_hash() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: example-a-961b4c22==1.0.0
-      Caused by: Hash mismatch for example-a-961b4c22==1.0.0
+      Caused by: Hash mismatch for `example-a-961b4c22==1.0.0`
 
     Expected:
       sha256:8838f9d005ff0432b258ba648d9cabb1cbdf06ac29d14f788b02edae544032ea
@@ -4520,8 +4520,8 @@ fn require_hashes_find_links_invalid_hash() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download and build: example-a-961b4c22==1.0.0
-      Caused by: Hash mismatch for example-a-961b4c22==1.0.0
+    error: Failed to download and build `example-a-961b4c22==1.0.0`
+      Caused by: Hash mismatch for `example-a-961b4c22==1.0.0`
 
     Expected:
       sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e
@@ -4614,7 +4614,7 @@ fn require_hashes_registry_invalid_hash() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: example-a-961b4c22==1.0.0
-      Caused by: Hash mismatch for example-a-961b4c22==1.0.0
+      Caused by: Hash mismatch for `example-a-961b4c22==1.0.0`
 
     Expected:
       sha256:123
@@ -4643,7 +4643,7 @@ fn require_hashes_registry_invalid_hash() -> Result<()> {
     Resolved 1 package in [TIME]
     error: Failed to download distributions
       Caused by: Failed to fetch wheel: example-a-961b4c22==1.0.0
-      Caused by: Hash mismatch for example-a-961b4c22==1.0.0
+      Caused by: Hash mismatch for `example-a-961b4c22==1.0.0`
 
     Expected:
       sha256:8838f9d005ff0432b258ba648d9cabb1cbdf06ac29d14f788b02edae544032ea
@@ -4720,8 +4720,8 @@ fn require_hashes_registry_invalid_hash() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download and build: example-a-961b4c22==1.0.0
-      Caused by: Hash mismatch for example-a-961b4c22==1.0.0
+    error: Failed to download and build `example-a-961b4c22==1.0.0`
+      Caused by: Hash mismatch for `example-a-961b4c22==1.0.0`
 
     Expected:
       sha256:5d69f0b590514103234f0c3526563856f04d044d8d0ea1073a843ae429b3187e


### PR DESCRIPTION
## Summary

I found some of these too bare (e.g., when they _just_ show a package name with no other information). For me, this makes it easier to differentiate error message copy from data. But open to other opinions. Take a look at the fixture changes and LMK!