### PR TITLE
Avoid calling `normalize_path` with relative paths that extend beyond the current directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,6 +2374,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4616,6 +4634,7 @@ dependencies = [
  "fs2",
  "junction",
  "once_cell",
+ "path-absolutize",
  "tempfile",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ miette = { version = "7.2.0" }
 nanoid = { version = "0.4.0" }
 once_cell = { version = "1.19.0" }
 owo-colors = { version = "4.0.0" }
+path-absolutize = { version = "3.1.1" }
 pathdiff = { version = "0.2.1" }
 petgraph = { version = "0.6.4" }
 platform-info = { version = "2.0.2" }

--- a/crates/pep508-rs/src/verbatim_url.rs
+++ b/crates/pep508-rs/src/verbatim_url.rs
@@ -42,7 +42,7 @@ impl VerbatimUrl {
         let path = path.as_ref();
 
         // Normalize the path.
-        let path = normalize_path(path);
+        let path = normalize_path(path).expect("path is absolute");
 
         // Extract the fragment, if it exists.
         let (path, fragment) = split_fragment(&path);
@@ -78,7 +78,7 @@ impl VerbatimUrl {
         };
 
         // Normalize the path.
-        let path = normalize_path(&path);
+        let path = normalize_path(&path).expect("path is absolute");
 
         // Extract the fragment, if it exists.
         let (path, fragment) = split_fragment(&path);
@@ -112,7 +112,9 @@ impl VerbatimUrl {
         };
 
         // Normalize the path.
-        let path = normalize_path(&path);
+        let Ok(path) = normalize_path(&path) else {
+            return Err(VerbatimUrlError::RelativePath(path));
+        };
 
         // Extract the fragment, if it exists.
         let (path, fragment) = split_fragment(&path);

--- a/crates/pep508-rs/src/verbatim_url.rs
+++ b/crates/pep508-rs/src/verbatim_url.rs
@@ -36,6 +36,8 @@ impl VerbatimUrl {
     }
 
     /// Create a [`VerbatimUrl`] from a file path.
+    ///
+    /// Assumes that the path is absolute.
     pub fn from_path(path: impl AsRef<Path>) -> Self {
         let path = path.as_ref();
 
@@ -76,7 +78,7 @@ impl VerbatimUrl {
         };
 
         // Normalize the path.
-        let path = normalize_path(path);
+        let path = normalize_path(&path);
 
         // Extract the fragment, if it exists.
         let (path, fragment) = split_fragment(&path);
@@ -110,7 +112,7 @@ impl VerbatimUrl {
         };
 
         // Normalize the path.
-        let path = normalize_path(path);
+        let path = normalize_path(&path);
 
         // Extract the fragment, if it exists.
         let (path, fragment) = split_fragment(&path);

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -22,6 +22,7 @@ fs-err = { workspace = true }
 fs2 = { workspace = true }
 junction = { workspace = true }
 once_cell = { workspace = true }
+path-absolutize = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true }

--- a/crates/uv-interpreter/src/find_python.rs
+++ b/crates/uv-interpreter/src/find_python.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 use tracing::{debug, instrument};
 
 use uv_cache::Cache;
-use uv_fs::normalize_path;
 use uv_toolchain::PythonVersion;
 
 use crate::interpreter::InterpreterInfoError;
@@ -52,9 +51,7 @@ pub fn find_requested_python(request: &str, cache: &Cache) -> Result<Option<Inte
         Interpreter::query(executable, cache).map(Some)
     } else {
         // `-p /home/ferris/.local/bin/python3.10`
-        let executable = normalize_path(request);
-
-        Interpreter::query(executable, cache).map(Some)
+        Interpreter::query(request, cache).map(Some)
     }
 }
 

--- a/crates/uv-interpreter/src/find_python.rs
+++ b/crates/uv-interpreter/src/find_python.rs
@@ -51,7 +51,8 @@ pub fn find_requested_python(request: &str, cache: &Cache) -> Result<Option<Inte
         Interpreter::query(executable, cache).map(Some)
     } else {
         // `-p /home/ferris/.local/bin/python3.10`
-        Interpreter::query(request, cache).map(Some)
+        let executable = uv_fs::absolutize_path(request.as_ref())?;
+        Interpreter::query(executable, cache).map(Some)
     }
 }
 

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -488,14 +488,13 @@ impl InterpreterInfo {
     /// unless the Python executable changes, so we use the executable's last modified
     /// time as a cache key.
     pub(crate) fn query_cached(executable: &Path, cache: &Cache) -> Result<Self, Error> {
-        let canonical = uv_fs::canonicalize_executable(executable)?;
-        let modified = Timestamp::from_path(&canonical)?;
-
         let cache_entry = cache.entry(
             CacheBucket::Interpreter,
             "",
-            format!("{}.msgpack", digest(&canonical)),
+            format!("{}.msgpack", digest(&executable)),
         );
+
+        let modified = Timestamp::from_path(uv_fs::canonicalize_executable(executable)?)?;
 
         // Read from the cache.
         if cache

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -488,15 +488,14 @@ impl InterpreterInfo {
     /// unless the Python executable changes, so we use the executable's last modified
     /// time as a cache key.
     pub(crate) fn query_cached(executable: &Path, cache: &Cache) -> Result<Self, Error> {
-        let executable_bytes = executable.as_os_str().as_encoded_bytes();
+        let canonical = uv_fs::canonicalize_executable(executable)?;
+        let modified = Timestamp::from_path(&canonical)?;
 
         let cache_entry = cache.entry(
             CacheBucket::Interpreter,
             "",
-            format!("{}.msgpack", digest(&executable_bytes)),
+            format!("{}.msgpack", digest(&canonical)),
         );
-
-        let modified = Timestamp::from_path(uv_fs::canonicalize_executable(executable)?)?;
 
         // Read from the cache.
         if cache

--- a/req.txt
+++ b/req.txt
@@ -1,0 +1,1 @@
+httpx @ git+https://github.com/encode/httpx@master


### PR DESCRIPTION
## Summary

It turns out that `normalize_path` (sourced from Cargo) has a subtle bug. If you pass it a relative path that traverses beyond the root, it silently drops components. So, e.g., passing `../foo/bar`, it will just drop the leading `..` and return `foo/bar`.

This PR encodes that behavior as a `Result` and avoids using it in such cases.

Closes https://github.com/astral-sh/uv/issues/3012.
