### PR TITLE
Force color for build error messages

### DIFF
--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -999,6 +999,7 @@ async fn run_python_script(
         .env("PATH", modified_path)
         // Activate the venv
         .env("VIRTUAL_ENV", venv.root())
+        .env("CLICOLOR_FORCE", "1")
         .output()
         .await
         .map_err(|err| Error::CommandFailed(venv.python_executable().to_path_buf(), err))


### PR DESCRIPTION
Since we're using anstream's strip stream, we can force color output from child processes and strip them when we redirect to a file

Before:

![image](https://github.com/astral-sh/uv/assets/6826232/ce8aafe9-687c-4c4a-970a-22abd660bc71)

After:

![image](https://github.com/astral-sh/uv/assets/6826232/bacedf1c-2462-4947-bd2f-393476a8031b)

Redirecting to a file correctly strips color codes.