### PR TITLE
 Indent error messages 

### DIFF
--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -81,7 +81,7 @@ pub enum Error {
     Virtualenv(#[from] uv_virtualenv::Error),
     #[error("Failed to run {0}")]
     CommandFailed(PathBuf, #[source] io::Error),
-    #[error("{message} with {exit_code}\n--- stdout:\n{stdout}\n--- stderr:\n{stderr}\n---")]
+    #[error("{message} with {exit_code}\nstdout:\n{stdout}\nstderr:\n{stderr}\n")]
     BuildBackend {
         message: String,
         exit_code: ExitStatus,
@@ -89,7 +89,7 @@ pub enum Error {
         stderr: String,
     },
     /// Nudge the user towards installing the missing dev library
-    #[error("{message} with {exit_code}\n--- stdout:\n{stdout}\n--- stderr:\n{stderr}\n---")]
+    #[error("{message} with {exit_code}\nstdout:\n{stdout}\nstderr:\n{stderr}\n")]
     MissingHeader {
         message: String,
         exit_code: ExitStatus,
@@ -182,6 +182,9 @@ impl Error {
                 },
             };
         }
+
+        let stdout = stdout.lines().map(|line| format!(" | {line}")).join("\n");
+        let stderr = stderr.lines().map(|line| format!(" | {line}")).join("\n");
 
         Self::BuildBackend {
             message,

--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -999,6 +999,7 @@ async fn run_python_script(
         .env("PATH", modified_path)
         // Activate the venv
         .env("VIRTUAL_ENV", venv.root())
+        .env("CLICOLOR_FORCE", "1")
         .output()
         .await
         .map_err(|err| Error::CommandFailed(venv.python_executable().to_path_buf(), err))

--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -81,7 +81,7 @@ pub enum Error {
     Virtualenv(#[from] uv_virtualenv::Error),
     #[error("Failed to run {0}")]
     CommandFailed(PathBuf, #[source] io::Error),
-    #[error("{message} with {exit_code}\nstdout:\n{stdout}\nstderr:\n{stderr}\n")]
+    #[error("{message} with {exit_code}\n--- stdout:\n{stdout}\n--- stderr:\n{stderr}\n---")]
     BuildBackend {
         message: String,
         exit_code: ExitStatus,
@@ -89,7 +89,7 @@ pub enum Error {
         stderr: String,
     },
     /// Nudge the user towards installing the missing dev library
-    #[error("{message} with {exit_code}\nstdout:\n{stdout}\nstderr:\n{stderr}\n")]
+    #[error("{message} with {exit_code}\n--- stdout:\n{stdout}\n--- stderr:\n{stderr}\n---")]
     MissingHeader {
         message: String,
         exit_code: ExitStatus,
@@ -183,8 +183,8 @@ impl Error {
             };
         }
 
-        let stdout = stdout.lines().map(|line| format!(" | {line}")).join("\n");
-        let stderr = stderr.lines().map(|line| format!(" | {line}")).join("\n");
+        let stdout = stdout.lines().map(|line| format!("  {line}")).join("\n");
+        let stderr = stderr.lines().map(|line| format!("  {line}")).join("\n");
 
         Self::BuildBackend {
             message,


### PR DESCRIPTION
Before:

![image](https://github.com/astral-sh/uv/assets/6826232/9a07a525-2a33-446d-a671-422985d81ce1)

After:

![image](https://github.com/astral-sh/uv/assets/6826232/9bbca5e2-aef5-40bb-8961-e0bf9ccf64a2)

I'm not sure if we want that, but i wanted to try it out. If we like the style i'll improve the code.

pro:
* clear separation of command output
* supports nesting
con:
* breaks copy and paste of nested output
* output becomes longer