### PR TITLE
Make the junction crate dependency Windows-only

### DIFF
--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -20,13 +20,15 @@ dunce = { workspace = true }
 encoding_rs_io = { workspace = true }
 fs-err = { workspace = true }
 fs2 = { workspace = true }
-junction = { workspace = true }
 once_cell = { workspace = true }
 path-absolutize = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true }
 urlencoding = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+junction = { workspace = true }
 
 [features]
 default = []


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Since the [`junction` crate](https://crates.io/crates/junction) implements Windows-only functionality, and since the only place it is used is guarded by `#[cfg(windows)]`,

https://github.com/astral-sh/uv/blob/1f626bfc7300a700257348e1890af90837c740e6/crates/uv-fs/src/lib.rs#L65-L86

it makes sense not to depend on this crate at all on non-Windows platforms.

If nothing else, this makes Linux distribution packagers’ lives just a *tiny* bit easier.

## Test Plan

<!-- How was it tested? -->

On Fedora Linux 39:

```
# To avoid an error when /tmp and the working directory are on different filesystems:
$ mkdir _tmp
$ TMPDIR="${PWD}/tmp" cargo run -p uv-dev -- fetch-python
$ cargo test
```

I don’t have access to a Windows system.