### PR TITLE
Use the larger runner for Windows clippy runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,16 @@ jobs:
         run: pipx run ruff check .
 
   cargo-clippy:
-    name: "cargo clippy"
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: "ubuntu"
+            runner: "ubuntu-latest"
+          - os: "windows"
+            runner: "windows-latest-large"
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ["${{ matrix.runner }}"]
+    name: "cargo clippy | ${{ matrix.os }}"
     steps:
       - uses: actions/checkout@v4
       - name: "Install Rust toolchain"


### PR DESCRIPTION
Running clippy can apparently be longer than the tests in https://github.com/astral-sh/uv/pull/3040