### PR TITLE
Add `--config-file` support

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -30,6 +30,10 @@ pub(crate) struct Cli {
 
     #[command(flatten)]
     pub(crate) cache_args: CacheArgs,
+
+    /// The path to a `pyproject.toml` or `uv.toml` file to use for configuration.
+    #[arg(long, short, env = "UV_CONFIG_FILE", hide = true)]
+    pub(crate) config_file: Option<PathBuf>,
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -110,7 +110,11 @@ async fn run() -> Result<ExitStatus> {
     };
 
     // Load the workspace settings.
-    let workspace = uv_workspace::Workspace::find(env::current_dir()?)?;
+    let workspace = if let Some(config_file) = cli.config_file.as_ref() {
+        Some(uv_workspace::Workspace::from_file(config_file)?)
+    } else {
+        uv_workspace::Workspace::find(env::current_dir()?)?
+    };
 
     // Resolve the global settings.
     let globals = GlobalSettings::resolve(cli.global_args, workspace.as_ref());


### PR DESCRIPTION
## Summary

Users can now pass a config file on the command line, e.g., with `--config-file /path/to/file.py`.
