### PR TITLE
Enable global configuration files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5026,6 +5026,7 @@ dependencies = [
 name = "uv-workspace"
 version = "0.0.1"
 dependencies = [
+ "dirs-sys",
  "distribution-types",
  "fs-err",
  "install-wheel-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ dashmap = { version = "5.5.3" }
 data-encoding = { version = "2.5.0" }
 derivative = { version = "2.2.0" }
 directories = { version = "5.0.1" }
+dirs-sys = { version = "0.4.1" }
 dunce = { version = "1.0.4" }
 either = { version = "1.9.0" }
 encoding_rs_io = { version = "0.1.7" }

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -24,6 +24,7 @@ uv-resolver = { workspace = true, features = ["schemars", "serde"] }
 uv-toolchain = { workspace = true, features = ["schemars", "serde"] }
 uv-warnings = { workspace = true }
 
+dirs-sys = { workspace = true }
 fs-err = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -109,11 +109,16 @@ async fn run() -> Result<ExitStatus> {
         }
     };
 
-    // Load the workspace settings.
+    // Load the workspace settings, prioritizing (in order):
+    // 1. The configuration file specified on the command-line.
+    // 2. The configuration file in the current directory.
+    // 3. The user configuration file.
     let workspace = if let Some(config_file) = cli.config_file.as_ref() {
         Some(uv_workspace::Workspace::from_file(config_file)?)
+    } else if let Some(workspace) = uv_workspace::Workspace::find(env::current_dir()?)? {
+        Some(workspace)
     } else {
-        uv_workspace::Workspace::find(env::current_dir()?)?
+        uv_workspace::Workspace::user()?
     };
 
     // Resolve the global settings.


### PR DESCRIPTION
## Summary

Enables `uv` to read configuration from (e.g.) `/Users/crmarsh/.config/uv/uv.toml` on macOS and Linux, and `C:\Users\Charlie\AppData\Roaming\uv\uv.toml` on Windows.

This differs slightly from Ruff, which uses the `Application Support` directory on macOS. But I've deviated here. based on the preferences expressed in https://github.com/astral-sh/ruff/issues/10739.
