### PR TITLE
Add negation flags to the CLI

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -258,10 +258,16 @@ pub(crate) struct PipCompileArgs {
     #[arg(long, conflicts_with = "extra")]
     pub(crate) all_extras: bool,
 
+    #[arg(long, overrides_with("all_extras"), hide = true)]
+    pub(crate) no_all_extras: bool,
+
     /// Ignore package dependencies, instead only add those packages explicitly listed
     /// on the command line to the resulting the requirements file.
     #[arg(long)]
     pub(crate) no_deps: bool,
+
+    #[arg(long, overrides_with("no_deps"), hide = true)]
+    pub(crate) deps: bool,
 
     /// The strategy to use when selecting between the different compatible versions for a given
     /// package requirement.
@@ -290,16 +296,25 @@ pub(crate) struct PipCompileArgs {
     /// By default, `uv` strips extras, as any packages pulled in by the extras are already included
     /// as dependencies in the output file directly. Further, output files generated with
     /// `--no-strip-extras` cannot be used as constraints files in `install` and `sync` invocations.
-    #[arg(long)]
+    #[arg(long, overrides_with("strip_extras"))]
     pub(crate) no_strip_extras: bool,
 
+    #[arg(long, overrides_with("no_strip_extras"), hide = true)]
+    pub(crate) strip_extras: bool,
+
     /// Exclude comment annotations indicating the source of each package.
-    #[arg(long)]
+    #[arg(long, overrides_with("annotate"))]
     pub(crate) no_annotate: bool,
 
+    #[arg(long, overrides_with("no_annotate"), hide = true)]
+    pub(crate) annotate: bool,
+
     /// Exclude the comment header at the top of the generated output file.
-    #[arg(long)]
+    #[arg(long, overrides_with("header"))]
     pub(crate) no_header: bool,
+
+    #[arg(long, overrides_with("no_header"), hide = true)]
+    pub(crate) header: bool,
 
     /// Choose the style of the annotation comments, which indicate the source of each package.
     ///
@@ -316,9 +331,13 @@ pub(crate) struct PipCompileArgs {
         global = true,
         long,
         conflicts_with = "refresh",
-        conflicts_with = "refresh_package"
+        conflicts_with = "refresh_package",
+        overrides_with("no_offline")
     )]
     pub(crate) offline: bool,
+
+    #[arg(long, overrides_with("offline"), hide = true)]
+    pub(crate) no_offline: bool,
 
     /// Refresh all cached data.
     #[arg(long)]
@@ -402,19 +421,28 @@ pub(crate) struct PipCompileArgs {
     pub(crate) upgrade_package: Option<Vec<PackageName>>,
 
     /// Include distribution hashes in the output file.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_generate_hashes"))]
     pub(crate) generate_hashes: bool,
+
+    #[arg(long, overrides_with("generate_hashes"), hide = true)]
+    pub(crate) no_generate_hashes: bool,
 
     /// Use legacy `setuptools` behavior when building source distributions without a
     /// `pyproject.toml`.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_legacy_setup_py"))]
     pub(crate) legacy_setup_py: bool,
+
+    #[arg(long, overrides_with("legacy_setup_py"), hide = true)]
+    pub(crate) no_legacy_setup_py: bool,
 
     /// Disable isolation when building source distributions.
     ///
     /// Assumes that build dependencies specified by PEP 518 are already installed.
-    #[arg(long)]
+    #[arg(long, overrides_with("build_isolation"))]
     pub(crate) no_build_isolation: bool,
+
+    #[arg(long, overrides_with("no_build_isolation"), hide = true)]
+    pub(crate) build_isolation: bool,
 
     /// Don't build source distributions.
     ///
@@ -423,8 +451,16 @@ pub(crate) struct PipCompileArgs {
     /// exit with an error.
     ///
     /// Alias for `--only-binary :all:`.
-    #[arg(long, conflicts_with = "only_binary")]
+    #[arg(long, conflicts_with = "only_binary", overrides_with = "build")]
     pub(crate) no_build: bool,
+
+    #[arg(
+        long,
+        conflicts_with = "only_binary",
+        overrides_with("no_build"),
+        hide = true
+    )]
+    pub(crate) build: bool,
 
     /// Only use pre-built wheels; don't build source distributions.
     ///
@@ -462,12 +498,18 @@ pub(crate) struct PipCompileArgs {
     pub(crate) no_emit_package: Option<Vec<PackageName>>,
 
     /// Include `--index-url` and `--extra-index-url` entries in the generated output file.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_emit_index_url"))]
     pub(crate) emit_index_url: bool,
 
+    #[arg(long, overrides_with("emit_index_url"), hide = true)]
+    pub(crate) no_emit_index_url: bool,
+
     /// Include `--find-links` entries in the generated output file.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_emit_find_links"))]
     pub(crate) emit_find_links: bool,
+
+    #[arg(long, overrides_with("emit_find_links"), hide = true)]
+    pub(crate) no_emit_find_links: bool,
 
     /// Whether to emit a marker string indicating when it is known that the
     /// resulting set of pinned dependencies is valid.
@@ -475,13 +517,19 @@ pub(crate) struct PipCompileArgs {
     /// The pinned dependencies may be valid even when the marker expression is
     /// false, but when the expression is true, the requirements are known to
     /// be correct.
-    #[arg(long, hide = true)]
+    #[arg(long, overrides_with("no_emit_marker_expression"), hide = true)]
     pub(crate) emit_marker_expression: bool,
+
+    #[arg(long, overrides_with("emit_marker_expression"), hide = true)]
+    pub(crate) no_emit_marker_expression: bool,
 
     /// Include comment annotations indicating the index used to resolve each package (e.g.,
     /// `# from https://pypi.org/simple`).
-    #[arg(long)]
+    #[arg(long, overrides_with("no_emit_index_annotation"))]
     pub(crate) emit_index_annotation: bool,
+
+    #[arg(long, overrides_with("emit_index_annotation"), hide = true)]
+    pub(crate) no_emit_index_annotation: bool,
 
     #[command(flatten)]
     pub(crate) compat_args: compat::PipCompileCompatArgs,
@@ -502,14 +550,17 @@ pub(crate) struct PipSyncArgs {
     #[arg(long)]
     pub(crate) reinstall_package: Vec<PackageName>,
 
-    /// Run offline, i.e., without accessing the network.
     #[arg(
         global = true,
         long,
         conflicts_with = "refresh",
-        conflicts_with = "refresh_package"
+        conflicts_with = "refresh_package",
+        overrides_with("no_offline")
     )]
     pub(crate) offline: bool,
+
+    #[arg(long, overrides_with("offline"), hide = true)]
+    pub(crate) no_offline: bool,
 
     /// Refresh all cached data.
     #[arg(long)]
@@ -583,8 +634,11 @@ pub(crate) struct PipSyncArgs {
     /// - Editable installs are not supported.
     /// - Local dependencies are not supported, unless they point to a specific wheel (`.whl`) or
     ///   source archive (`.zip`, `.tar.gz`), as opposed to a directory.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_require_hashes"))]
     pub(crate) require_hashes: bool,
+
+    #[arg(long, overrides_with("require_hashes"), hide = true)]
+    pub(crate) no_require_hashes: bool,
 
     /// Attempt to use `keyring` for authentication for index URLs.
     ///
@@ -618,8 +672,16 @@ pub(crate) struct PipSyncArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[arg(long, env = "UV_SYSTEM_PYTHON", group = "discovery")]
+    #[arg(
+        long,
+        env = "UV_SYSTEM_PYTHON",
+        group = "discovery",
+        overrides_with("no_system")
+    )]
     pub(crate) system: bool,
+
+    #[arg(long, overrides_with("system"))]
+    pub(crate) no_system: bool,
 
     /// Allow `uv` to modify an `EXTERNALLY-MANAGED` Python installation.
     ///
@@ -627,19 +689,33 @@ pub(crate) struct PipSyncArgs {
     /// environments, when installing into Python installations that are managed by an external
     /// package manager, like `apt`. It should be used with caution, as such Python installations
     /// explicitly recommend against modifications by other package managers (like `uv` or `pip`).
-    #[arg(long, env = "UV_BREAK_SYSTEM_PACKAGES", requires = "discovery")]
+    #[arg(
+        long,
+        env = "UV_BREAK_SYSTEM_PACKAGES",
+        requires = "discovery",
+        overrides_with("no_break_system_packages")
+    )]
     pub(crate) break_system_packages: bool,
+
+    #[arg(long, overrides_with("break_system_packages"))]
+    pub(crate) no_break_system_packages: bool,
 
     /// Use legacy `setuptools` behavior when building source distributions without a
     /// `pyproject.toml`.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_legacy_setup_py"))]
     pub(crate) legacy_setup_py: bool,
+
+    #[arg(long, overrides_with("legacy_setup_py"), hide = true)]
+    pub(crate) no_legacy_setup_py: bool,
 
     /// Disable isolation when building source distributions.
     ///
     /// Assumes that build dependencies specified by PEP 518 are already installed.
-    #[arg(long)]
+    #[arg(long, overrides_with("build_isolation"))]
     pub(crate) no_build_isolation: bool,
+
+    #[arg(long, overrides_with("no_build_isolation"), hide = true)]
+    pub(crate) build_isolation: bool,
 
     /// Don't build source distributions.
     ///
@@ -648,8 +724,22 @@ pub(crate) struct PipSyncArgs {
     /// exit with an error.
     ///
     /// Alias for `--only-binary :all:`.
-    #[arg(long, conflicts_with = "no_binary", conflicts_with = "only_binary")]
+    #[arg(
+        long,
+        conflicts_with = "no_binary",
+        conflicts_with = "only_binary",
+        overrides_with("build")
+    )]
     pub(crate) no_build: bool,
+
+    #[arg(
+        long,
+        conflicts_with = "no_binary",
+        conflicts_with = "only_binary",
+        overrides_with("no_build"),
+        hide = true
+    )]
+    pub(crate) build: bool,
 
     /// Don't install pre-built wheels.
     ///
@@ -681,11 +771,10 @@ pub(crate) struct PipSyncArgs {
     ///
     /// The compile option will process the entire site-packages directory for consistency and
     /// (like pip) ignore all errors.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_compile"))]
     pub(crate) compile: bool,
 
-    /// Don't compile Python files to bytecode.
-    #[arg(long, hide = true, conflicts_with = "compile")]
+    #[arg(long, overrides_with("compile"), hide = true)]
     pub(crate) no_compile: bool,
 
     /// Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
@@ -694,8 +783,11 @@ pub(crate) struct PipSyncArgs {
 
     /// Validate the virtual environment after completing the installation, to detect packages with
     /// missing dependencies or other issues.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_strict"))]
     pub(crate) strict: bool,
+
+    #[arg(long, overrides_with("strict"), hide = true)]
+    pub(crate) no_strict: bool,
 
     #[command(flatten)]
     pub(crate) compat_args: compat::PipSyncCompatArgs,
@@ -744,8 +836,11 @@ pub(crate) struct PipInstallArgs {
     pub(crate) extra: Option<Vec<ExtraName>>,
 
     /// Include all optional dependencies.
-    #[arg(long, conflicts_with = "extra")]
+    #[arg(long, conflicts_with = "extra", overrides_with = "no_all_extras")]
     pub(crate) all_extras: bool,
+
+    #[arg(long, overrides_with("all_extras"), hide = true)]
+    pub(crate) no_all_extras: bool,
 
     /// Allow package upgrades.
     #[arg(long, short = 'U')]
@@ -763,14 +858,17 @@ pub(crate) struct PipInstallArgs {
     #[arg(long)]
     pub(crate) reinstall_package: Option<Vec<PackageName>>,
 
-    /// Run offline, i.e., without accessing the network.
     #[arg(
         global = true,
         long,
         conflicts_with = "refresh",
-        conflicts_with = "refresh_package"
+        conflicts_with = "refresh_package",
+        overrides_with("no_offline")
     )]
     pub(crate) offline: bool,
+
+    #[arg(long, overrides_with("offline"), hide = true)]
+    pub(crate) no_offline: bool,
 
     /// Refresh all cached data.
     #[arg(long)]
@@ -782,8 +880,11 @@ pub(crate) struct PipInstallArgs {
 
     /// Ignore package dependencies, instead only installing those packages explicitly listed
     /// on the command line or in the requirements files.
-    #[arg(long)]
+    #[arg(long, overrides_with("deps"))]
     pub(crate) no_deps: bool,
+
+    #[arg(long, overrides_with("no_deps"), hide = true)]
+    pub(crate) deps: bool,
 
     /// The method to use when installing packages from the global cache.
     ///
@@ -867,8 +968,11 @@ pub(crate) struct PipInstallArgs {
     /// - Editable installs are not supported.
     /// - Local dependencies are not supported, unless they point to a specific wheel (`.whl`) or
     ///   source archive (`.zip`, `.tar.gz`), as opposed to a directory.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_require_hashes"))]
     pub(crate) require_hashes: bool,
+
+    #[arg(long, overrides_with("require_hashes"), hide = true)]
+    pub(crate) no_require_hashes: bool,
 
     /// Attempt to use `keyring` for authentication for index URLs.
     ///
@@ -902,8 +1006,16 @@ pub(crate) struct PipInstallArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[arg(long, env = "UV_SYSTEM_PYTHON", group = "discovery")]
+    #[arg(
+        long,
+        env = "UV_SYSTEM_PYTHON",
+        group = "discovery",
+        overrides_with("no_system")
+    )]
     pub(crate) system: bool,
+
+    #[arg(long, overrides_with("system"))]
+    pub(crate) no_system: bool,
 
     /// Allow `uv` to modify an `EXTERNALLY-MANAGED` Python installation.
     ///
@@ -911,19 +1023,33 @@ pub(crate) struct PipInstallArgs {
     /// environments, when installing into Python installations that are managed by an external
     /// package manager, like `apt`. It should be used with caution, as such Python installations
     /// explicitly recommend against modifications by other package managers (like `uv` or `pip`).
-    #[arg(long, env = "UV_BREAK_SYSTEM_PACKAGES", requires = "discovery")]
+    #[arg(
+        long,
+        env = "UV_BREAK_SYSTEM_PACKAGES",
+        requires = "discovery",
+        overrides_with("no_break_system_packages")
+    )]
     pub(crate) break_system_packages: bool,
+
+    #[arg(long, overrides_with("break_system_packages"))]
+    pub(crate) no_break_system_packages: bool,
 
     /// Use legacy `setuptools` behavior when building source distributions without a
     /// `pyproject.toml`.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_legacy_setup_py"))]
     pub(crate) legacy_setup_py: bool,
+
+    #[arg(long, overrides_with("legacy_setup_py"), hide = true)]
+    pub(crate) no_legacy_setup_py: bool,
 
     /// Disable isolation when building source distributions.
     ///
     /// Assumes that build dependencies specified by PEP 518 are already installed.
-    #[arg(long)]
+    #[arg(long, overrides_with("build_isolation"))]
     pub(crate) no_build_isolation: bool,
+
+    #[arg(long, overrides_with("no_build_isolation"), hide = true)]
+    pub(crate) build_isolation: bool,
 
     /// Don't build source distributions.
     ///
@@ -932,8 +1058,22 @@ pub(crate) struct PipInstallArgs {
     /// exit with an error.
     ///
     /// Alias for `--only-binary :all:`.
-    #[arg(long, conflicts_with = "no_binary", conflicts_with = "only_binary")]
+    #[arg(
+        long,
+        conflicts_with = "no_binary",
+        conflicts_with = "only_binary",
+        overrides_with("build")
+    )]
     pub(crate) no_build: bool,
+
+    #[arg(
+        long,
+        conflicts_with = "no_binary",
+        conflicts_with = "only_binary",
+        overrides_with("no_build"),
+        hide = true
+    )]
+    pub(crate) build: bool,
 
     /// Don't install pre-built wheels.
     ///
@@ -965,11 +1105,10 @@ pub(crate) struct PipInstallArgs {
     ///
     /// The compile option will process the entire site-packages directory for consistency and
     /// (like pip) ignore all errors.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_compile"))]
     pub(crate) compile: bool,
 
-    /// Don't compile Python files to bytecode.
-    #[arg(long, hide = true, conflicts_with = "compile")]
+    #[arg(long, overrides_with("compile"), hide = true)]
     pub(crate) no_compile: bool,
 
     /// Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
@@ -978,8 +1117,11 @@ pub(crate) struct PipInstallArgs {
 
     /// Validate the virtual environment after completing the installation, to detect packages with
     /// missing dependencies or other issues.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_strict"))]
     pub(crate) strict: bool,
+
+    #[arg(long, overrides_with("strict"), hide = true)]
+    pub(crate) no_strict: bool,
 
     /// Limit candidate packages to those that were uploaded prior to the given date.
     ///
@@ -1038,8 +1180,16 @@ pub(crate) struct PipUninstallArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[arg(long, env = "UV_SYSTEM_PYTHON", group = "discovery")]
+    #[arg(
+        long,
+        env = "UV_SYSTEM_PYTHON",
+        group = "discovery",
+        overrides_with("no_system")
+    )]
     pub(crate) system: bool,
+
+    #[arg(long, overrides_with("system"))]
+    pub(crate) no_system: bool,
 
     /// Allow `uv` to modify an `EXTERNALLY-MANAGED` Python installation.
     ///
@@ -1047,12 +1197,23 @@ pub(crate) struct PipUninstallArgs {
     /// environments, when installing into Python installations that are managed by an external
     /// package manager, like `apt`. It should be used with caution, as such Python installations
     /// explicitly recommend against modifications by other package managers (like `uv` or `pip`).
-    #[arg(long, env = "UV_BREAK_SYSTEM_PACKAGES", requires = "discovery")]
+    #[arg(
+        long,
+        env = "UV_BREAK_SYSTEM_PACKAGES",
+        requires = "discovery",
+        overrides_with("no_break_system_packages")
+    )]
     pub(crate) break_system_packages: bool,
 
+    #[arg(long, overrides_with("break_system_packages"))]
+    pub(crate) no_break_system_packages: bool,
+
     /// Run offline, i.e., without accessing the network.
-    #[arg(global = true, long)]
+    #[arg(long, overrides_with("no_offline"))]
     pub(crate) offline: bool,
+
+    #[arg(long, overrides_with("offline"), hide = true)]
+    pub(crate) no_offline: bool,
 }
 
 #[derive(Args)]
@@ -1064,8 +1225,11 @@ pub(crate) struct PipFreezeArgs {
 
     /// Validate the virtual environment, to detect packages with missing dependencies or other
     /// issues.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_strict"))]
     pub(crate) strict: bool,
+
+    #[arg(long, overrides_with("strict"), hide = true)]
+    pub(crate) no_strict: bool,
 
     /// The Python interpreter for which packages should be listed.
     ///
@@ -1090,8 +1254,16 @@ pub(crate) struct PipFreezeArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution.
-    #[arg(long, env = "UV_SYSTEM_PYTHON", group = "discovery")]
+    #[arg(
+        long,
+        env = "UV_SYSTEM_PYTHON",
+        group = "discovery",
+        overrides_with("no_system")
+    )]
     pub(crate) system: bool,
+
+    #[arg(long, overrides_with("system"))]
+    pub(crate) no_system: bool,
 }
 
 #[derive(Args)]
@@ -1115,8 +1287,11 @@ pub(crate) struct PipListArgs {
 
     /// Validate the virtual environment, to detect packages with missing dependencies or other
     /// issues.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_strict"))]
     pub(crate) strict: bool,
+
+    #[arg(long, overrides_with("strict"), hide = true)]
+    pub(crate) no_strict: bool,
 
     /// The Python interpreter for which packages should be listed.
     ///
@@ -1141,8 +1316,16 @@ pub(crate) struct PipListArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution.
-    #[arg(long, env = "UV_SYSTEM_PYTHON", group = "discovery")]
+    #[arg(
+        long,
+        env = "UV_SYSTEM_PYTHON",
+        group = "discovery",
+        overrides_with("no_system")
+    )]
     pub(crate) system: bool,
+
+    #[arg(long, overrides_with("system"))]
+    pub(crate) no_system: bool,
 
     #[command(flatten)]
     pub(crate) compat_args: compat::PipListCompatArgs,
@@ -1174,8 +1357,16 @@ pub(crate) struct PipCheckArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution.
-    #[arg(long, env = "UV_SYSTEM_PYTHON", group = "discovery")]
+    #[arg(
+        long,
+        env = "UV_SYSTEM_PYTHON",
+        group = "discovery",
+        overrides_with("no_system")
+    )]
     pub(crate) system: bool,
+
+    #[arg(long, overrides_with("system"))]
+    pub(crate) no_system: bool,
 }
 
 #[derive(Args)]
@@ -1186,8 +1377,11 @@ pub(crate) struct PipShowArgs {
 
     /// Validate the virtual environment, to detect packages with missing dependencies or other
     /// issues.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_strict"))]
     pub(crate) strict: bool,
+
+    #[arg(long, overrides_with("strict"), hide = true)]
+    pub(crate) no_strict: bool,
 
     /// The Python interpreter for which packages should be listed.
     ///
@@ -1212,8 +1406,16 @@ pub(crate) struct PipShowArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution.
-    #[arg(long, env = "UV_SYSTEM_PYTHON", group = "discovery")]
+    #[arg(
+        long,
+        env = "UV_SYSTEM_PYTHON",
+        group = "discovery",
+        overrides_with("no_system")
+    )]
     pub(crate) system: bool,
+
+    #[arg(long, overrides_with("system"))]
+    pub(crate) no_system: bool,
 }
 
 #[derive(Args)]
@@ -1240,8 +1442,16 @@ pub(crate) struct VenvArgs {
     ///
     /// WARNING: `--system` is intended for use in continuous integration (CI) environments and
     /// should be used with caution, as it can modify the system Python installation.
-    #[arg(long, env = "UV_SYSTEM_PYTHON", group = "discovery")]
+    #[arg(
+        long,
+        env = "UV_SYSTEM_PYTHON",
+        group = "discovery",
+        overrides_with("no_system")
+    )]
     pub(crate) system: bool,
+
+    #[arg(long, overrides_with("system"))]
+    pub(crate) no_system: bool,
 
     /// Install seed packages (`pip`, `setuptools`, and `wheel`) into the virtual environment.
     #[arg(long)]
@@ -1329,8 +1539,11 @@ pub(crate) struct VenvArgs {
     pub(crate) keyring_provider: Option<KeyringProviderType>,
 
     /// Run offline, i.e., without accessing the network.
-    #[arg(global = true, long)]
+    #[arg(long, overrides_with("no_offline"))]
     pub(crate) offline: bool,
+
+    #[arg(long, overrides_with("offline"), hide = true)]
+    pub(crate) no_offline: bool,
 
     /// Limit candidate packages to those that were uploaded prior to the given date.
     ///

--- a/crates/uv/src/compat/mod.rs
+++ b/crates/uv/src/compat/mod.rs
@@ -28,9 +28,6 @@ pub(crate) struct PipCompileCompatArgs {
     no_reuse_hashes: bool,
 
     #[clap(long, hide = true)]
-    build_isolation: bool,
-
-    #[clap(long, hide = true)]
     resolver: Option<Resolver>,
 
     #[clap(long, hide = true)]
@@ -58,19 +55,10 @@ pub(crate) struct PipCompileCompatArgs {
     no_config: bool,
 
     #[clap(long, hide = true)]
-    no_emit_index_url: bool,
-
-    #[clap(long, hide = true)]
-    no_emit_find_links: bool,
-
-    #[clap(long, hide = true)]
     emit_options: bool,
 
     #[clap(long, hide = true)]
     no_emit_options: bool,
-
-    #[clap(long, hide = true)]
-    strip_extras: bool,
 
     #[clap(long, hide = true)]
     pip_args: Option<String>,
@@ -102,12 +90,6 @@ impl CompatArgs for PipCompileCompatArgs {
         if self.no_reuse_hashes {
             warn_user!(
                 "pip-compile's `--no-reuse-hashes` has no effect (uv doesn't reuse hashes)."
-            );
-        }
-
-        if self.build_isolation {
-            warn_user!(
-                "pip-compile's `--build-isolation` has no effect (uv always uses build isolation)."
             );
         }
 
@@ -168,18 +150,6 @@ impl CompatArgs for PipCompileCompatArgs {
             );
         }
 
-        if self.no_emit_index_url {
-            warn_user!(
-                "pip-compile's `--no-emit-index-url` has no effect (uv excludes index URLs by default)."
-            );
-        }
-
-        if self.no_emit_find_links {
-            warn_user!(
-                "pip-compile's `--no-emit-find-links` has no effect (uv excludes `--find-links` URLs by default)."
-            );
-        }
-
         if self.emit_options {
             return Err(anyhow!(
                 "pip-compile's `--emit-options` is unsupported (uv never emits options)."
@@ -188,12 +158,6 @@ impl CompatArgs for PipCompileCompatArgs {
 
         if self.no_emit_options {
             warn_user!("pip-compile's `--no-emit-options` has no effect (uv never emits options).");
-        }
-
-        if self.strip_extras {
-            warn_user!(
-                "pip-compile's `--strip-extras` has no effect (uv strips extras by default)."
-            );
         }
 
         if self.pip_args.is_some() {

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -92,17 +92,23 @@ impl PipCompileSettings {
             r#override,
             extra,
             all_extras,
+            no_all_extras,
             no_deps,
+            deps,
             resolution,
             prerelease,
             pre,
             output_file,
             no_strip_extras,
+            strip_extras,
             no_annotate,
+            annotate,
             no_header,
+            header,
             annotation_style,
             custom_compile_command,
             offline,
+            no_offline,
             refresh,
             refresh_package,
             link_mode,
@@ -115,18 +121,26 @@ impl PipCompileSettings {
             upgrade,
             upgrade_package,
             generate_hashes,
+            no_generate_hashes,
             legacy_setup_py,
+            no_legacy_setup_py,
             no_build_isolation,
+            build_isolation,
             no_build,
+            build,
             only_binary,
             config_setting,
             python_version,
             exclude_newer,
             no_emit_package,
             emit_index_url,
+            no_emit_index_url,
             emit_find_links,
+            no_emit_find_links,
             emit_marker_expression,
+            no_emit_marker_expression,
             emit_index_annotation,
+            no_emit_index_annotation,
             compat_args: _,
         } = args;
 
@@ -143,7 +157,7 @@ impl PipCompileSettings {
             // Shared settings.
             shared: PipSharedSettings::combine(
                 PipOptions {
-                    offline: Some(offline),
+                    offline: flag(offline, no_offline),
                     index_url: index_url.and_then(Maybe::into_option),
                     extra_index_url: extra_index_url.map(|extra_index_urls| {
                         extra_index_urls
@@ -155,12 +169,12 @@ impl PipCompileSettings {
                     find_links,
                     index_strategy,
                     keyring_provider,
-                    no_build: Some(no_build),
+                    no_build: flag(no_build, build),
                     only_binary,
-                    no_build_isolation: Some(no_build_isolation),
+                    no_build_isolation: flag(no_build_isolation, build_isolation),
                     extra,
-                    all_extras: Some(all_extras),
-                    no_deps: Some(no_deps),
+                    all_extras: flag(all_extras, no_all_extras),
+                    no_deps: flag(no_deps, deps),
                     resolution,
                     prerelease: if pre {
                         Some(PreReleaseMode::Allow)
@@ -168,22 +182,22 @@ impl PipCompileSettings {
                         prerelease
                     },
                     output_file,
-                    no_strip_extras: Some(no_strip_extras),
-                    no_annotate: Some(no_annotate),
-                    no_header: Some(no_header),
+                    no_strip_extras: flag(no_strip_extras, strip_extras),
+                    no_annotate: flag(no_annotate, annotate),
+                    no_header: flag(no_header, header),
                     custom_compile_command,
-                    generate_hashes: Some(generate_hashes),
-                    legacy_setup_py: Some(legacy_setup_py),
+                    generate_hashes: flag(generate_hashes, no_generate_hashes),
+                    legacy_setup_py: flag(legacy_setup_py, no_legacy_setup_py),
                     config_settings: config_setting.map(|config_settings| {
                         config_settings.into_iter().collect::<ConfigSettings>()
                     }),
                     python_version,
                     exclude_newer,
                     no_emit_package,
-                    emit_index_url: Some(emit_index_url),
-                    emit_find_links: Some(emit_find_links),
-                    emit_marker_expression: Some(emit_marker_expression),
-                    emit_index_annotation: Some(emit_index_annotation),
+                    emit_index_url: flag(emit_index_url, no_emit_index_url),
+                    emit_find_links: flag(emit_find_links, no_emit_find_links),
+                    emit_marker_expression: flag(emit_marker_expression, no_emit_marker_expression),
+                    emit_index_annotation: flag(emit_index_annotation, no_emit_index_annotation),
                     annotation_style,
                     link_mode,
                     ..PipOptions::default()
@@ -218,6 +232,7 @@ impl PipSyncSettings {
             reinstall_package,
             offline,
             refresh,
+            no_offline,
             refresh_package,
             link_mode,
             index_url,
@@ -226,19 +241,26 @@ impl PipSyncSettings {
             no_index,
             index_strategy,
             require_hashes,
+            no_require_hashes,
             keyring_provider,
             python,
             system,
+            no_system,
             break_system_packages,
+            no_break_system_packages,
             legacy_setup_py,
+            no_legacy_setup_py,
             no_build_isolation,
+            build_isolation,
             no_build,
+            build,
             no_binary,
             only_binary,
             compile,
-            no_compile: _,
+            no_compile,
             config_setting,
             strict,
+            no_strict,
             compat_args: _,
         } = args;
 
@@ -254,9 +276,9 @@ impl PipSyncSettings {
             shared: PipSharedSettings::combine(
                 PipOptions {
                     python,
-                    system: Some(system),
-                    break_system_packages: Some(break_system_packages),
-                    offline: Some(offline),
+                    system: flag(system, no_system),
+                    break_system_packages: flag(break_system_packages, no_break_system_packages),
+                    offline: flag(offline, no_offline),
                     index_url: index_url.and_then(Maybe::into_option),
                     extra_index_url: extra_index_url.map(|extra_index_urls| {
                         extra_index_urls
@@ -268,18 +290,18 @@ impl PipSyncSettings {
                     find_links,
                     index_strategy,
                     keyring_provider,
-                    no_build: Some(no_build),
+                    no_build: flag(no_build, build),
                     no_binary,
                     only_binary,
-                    no_build_isolation: Some(no_build_isolation),
-                    strict: Some(strict),
-                    legacy_setup_py: Some(legacy_setup_py),
+                    no_build_isolation: flag(no_build_isolation, build_isolation),
+                    strict: flag(strict, no_strict),
+                    legacy_setup_py: flag(legacy_setup_py, no_legacy_setup_py),
                     config_settings: config_setting.map(|config_settings| {
                         config_settings.into_iter().collect::<ConfigSettings>()
                     }),
                     link_mode,
-                    compile_bytecode: Some(compile),
-                    require_hashes: Some(require_hashes),
+                    compile_bytecode: flag(compile, no_compile),
+                    require_hashes: flag(require_hashes, no_require_hashes),
                     ..PipOptions::default()
                 },
                 workspace,
@@ -320,14 +342,17 @@ impl PipInstallSettings {
             r#override,
             extra,
             all_extras,
+            no_all_extras,
             upgrade,
             upgrade_package,
             reinstall,
             reinstall_package,
             offline,
             refresh,
+            no_offline,
             refresh_package,
             no_deps,
+            deps,
             link_mode,
             resolution,
             prerelease,
@@ -338,19 +363,26 @@ impl PipInstallSettings {
             no_index,
             index_strategy,
             require_hashes,
+            no_require_hashes,
             keyring_provider,
             python,
             system,
+            no_system,
             break_system_packages,
+            no_break_system_packages,
             legacy_setup_py,
+            no_legacy_setup_py,
             no_build_isolation,
+            build_isolation,
             no_build,
+            build,
             no_binary,
             only_binary,
             compile,
-            no_compile: _,
+            no_compile,
             config_setting,
             strict,
+            no_strict,
             exclude_newer,
             dry_run,
         } = args;
@@ -374,9 +406,9 @@ impl PipInstallSettings {
             shared: PipSharedSettings::combine(
                 PipOptions {
                     python,
-                    system: Some(system),
-                    break_system_packages: Some(break_system_packages),
-                    offline: Some(offline),
+                    system: flag(system, no_system),
+                    break_system_packages: flag(break_system_packages, no_break_system_packages),
+                    offline: flag(offline, no_offline),
                     index_url: index_url.and_then(Maybe::into_option),
                     extra_index_url: extra_index_url.map(|extra_index_urls| {
                         extra_index_urls
@@ -388,28 +420,28 @@ impl PipInstallSettings {
                     find_links,
                     index_strategy,
                     keyring_provider,
-                    no_build: Some(no_build),
+                    no_build: flag(no_build, build),
                     no_binary,
                     only_binary,
-                    no_build_isolation: Some(no_build_isolation),
-                    strict: Some(strict),
+                    no_build_isolation: flag(no_build_isolation, build_isolation),
+                    strict: flag(strict, no_strict),
                     extra,
-                    all_extras: Some(all_extras),
-                    no_deps: Some(no_deps),
+                    all_extras: flag(all_extras, no_all_extras),
+                    no_deps: flag(no_deps, deps),
                     resolution,
                     prerelease: if pre {
                         Some(PreReleaseMode::Allow)
                     } else {
                         prerelease
                     },
-                    legacy_setup_py: Some(legacy_setup_py),
+                    legacy_setup_py: flag(legacy_setup_py, no_legacy_setup_py),
                     config_settings: config_setting.map(|config_settings| {
                         config_settings.into_iter().collect::<ConfigSettings>()
                     }),
                     exclude_newer,
                     link_mode,
-                    compile_bytecode: Some(compile),
-                    require_hashes: Some(require_hashes),
+                    compile_bytecode: flag(compile, no_compile),
+                    require_hashes: flag(require_hashes, no_require_hashes),
                     ..PipOptions::default()
                 },
                 workspace,
@@ -438,8 +470,11 @@ impl PipUninstallSettings {
             python,
             keyring_provider,
             system,
+            no_system,
             break_system_packages,
+            no_break_system_packages,
             offline,
+            no_offline,
         } = args;
 
         Self {
@@ -451,9 +486,9 @@ impl PipUninstallSettings {
             shared: PipSharedSettings::combine(
                 PipOptions {
                     python,
-                    system: Some(system),
-                    break_system_packages: Some(break_system_packages),
-                    offline: Some(offline),
+                    system: flag(system, no_system),
+                    break_system_packages: flag(break_system_packages, no_break_system_packages),
+                    offline: flag(offline, no_offline),
                     keyring_provider,
                     ..PipOptions::default()
                 },
@@ -479,8 +514,10 @@ impl PipFreezeSettings {
         let PipFreezeArgs {
             exclude_editable,
             strict,
+            no_strict,
             python,
             system,
+            no_system,
         } = args;
 
         Self {
@@ -491,8 +528,8 @@ impl PipFreezeSettings {
             shared: PipSharedSettings::combine(
                 PipOptions {
                     python,
-                    system: Some(system),
-                    strict: Some(strict),
+                    system: flag(system, no_system),
+                    strict: flag(strict, no_strict),
                     ..PipOptions::default()
                 },
                 workspace,
@@ -524,8 +561,10 @@ impl PipListSettings {
             exclude,
             format,
             strict,
+            no_strict,
             python,
             system,
+            no_system,
             compat_args: _,
         } = args;
 
@@ -540,8 +579,8 @@ impl PipListSettings {
             shared: PipSharedSettings::combine(
                 PipOptions {
                     python,
-                    system: Some(system),
-                    strict: Some(strict),
+                    system: flag(system, no_system),
+                    strict: flag(strict, no_strict),
                     ..PipOptions::default()
                 },
                 workspace,
@@ -567,8 +606,10 @@ impl PipShowSettings {
         let PipShowArgs {
             package,
             strict,
+            no_strict,
             python,
             system,
+            no_system,
         } = args;
 
         Self {
@@ -579,8 +620,8 @@ impl PipShowSettings {
             shared: PipSharedSettings::combine(
                 PipOptions {
                     python,
-                    system: Some(system),
-                    strict: Some(strict),
+                    system: flag(system, no_system),
+                    strict: flag(strict, no_strict),
                     ..PipOptions::default()
                 },
                 workspace,
@@ -602,14 +643,18 @@ pub(crate) struct PipCheckSettings {
 impl PipCheckSettings {
     /// Resolve the [`PipCheckSettings`] from the CLI and workspace configuration.
     pub(crate) fn resolve(args: PipCheckArgs, workspace: Option<Workspace>) -> Self {
-        let PipCheckArgs { python, system } = args;
+        let PipCheckArgs {
+            python,
+            system,
+            no_system,
+        } = args;
 
         Self {
             // Shared settings.
             shared: PipSharedSettings::combine(
                 PipOptions {
                     python,
-                    system: Some(system),
+                    system: flag(system, no_system),
                     ..PipOptions::default()
                 },
                 workspace,
@@ -638,6 +683,7 @@ impl VenvSettings {
         let VenvArgs {
             python,
             system,
+            no_system,
             seed,
             name,
             prompt,
@@ -649,6 +695,7 @@ impl VenvSettings {
             index_strategy,
             keyring_provider,
             offline,
+            no_offline,
             exclude_newer,
             compat_args: _,
         } = args;
@@ -664,8 +711,8 @@ impl VenvSettings {
             shared: PipSharedSettings::combine(
                 PipOptions {
                     python,
-                    system: Some(system),
-                    offline: Some(offline),
+                    system: flag(system, no_system),
+                    offline: flag(offline, no_offline),
                     index_url: index_url.and_then(Maybe::into_option),
                     extra_index_url: extra_index_url.map(|extra_index_urls| {
                         extra_index_urls
@@ -782,59 +829,75 @@ impl PipSharedSettings {
 
         Self {
             extra: args.extra.or(extra).unwrap_or_default(),
-            all_extras: args.all_extras.unwrap_or(false) || all_extras.unwrap_or(false),
-            no_deps: args.no_deps.unwrap_or(false) || no_deps.unwrap_or(false),
+            all_extras: args.all_extras.or(all_extras).unwrap_or_default(),
+            no_deps: args.no_deps.or(no_deps).unwrap_or_default(),
             resolution: args.resolution.or(resolution).unwrap_or_default(),
             prerelease: args.prerelease.or(prerelease).unwrap_or_default(),
             output_file: args.output_file.or(output_file),
-            no_strip_extras: args.no_strip_extras.unwrap_or(false)
-                || no_strip_extras.unwrap_or(false),
-            no_annotate: args.no_annotate.unwrap_or(false) || no_annotate.unwrap_or(false),
-            no_header: args.no_header.unwrap_or(false) || no_header.unwrap_or(false),
+            no_strip_extras: args.no_strip_extras.or(no_strip_extras).unwrap_or_default(),
+            no_annotate: args.no_annotate.or(no_annotate).unwrap_or_default(),
+            no_header: args.no_header.or(no_header).unwrap_or_default(),
             custom_compile_command: args.custom_compile_command.or(custom_compile_command),
             annotation_style: args
                 .annotation_style
                 .or(annotation_style)
                 .unwrap_or_default(),
-            offline: args.offline.unwrap_or(false) || offline.unwrap_or(false),
+            offline: args.offline.or(offline).unwrap_or_default(),
             index_url: args.index_url.or(index_url),
             extra_index_url: args.extra_index_url.or(extra_index_url).unwrap_or_default(),
-            no_index: args.no_index.unwrap_or(false) || no_index.unwrap_or(false),
+            no_index: args.no_index.or(no_index).unwrap_or_default(),
             index_strategy: args.index_strategy.or(index_strategy).unwrap_or_default(),
             keyring_provider: args
                 .keyring_provider
                 .or(keyring_provider)
                 .unwrap_or_default(),
             find_links: args.find_links.or(find_links).unwrap_or_default(),
-            generate_hashes: args.generate_hashes.unwrap_or(false)
-                || generate_hashes.unwrap_or(false),
-            legacy_setup_py: args.legacy_setup_py.unwrap_or(false)
-                || legacy_setup_py.unwrap_or(false),
-            no_build_isolation: args.no_build_isolation.unwrap_or(false)
-                || no_build_isolation.unwrap_or(false),
-            no_build: args.no_build.unwrap_or(false) || no_build.unwrap_or(false),
+            generate_hashes: args.generate_hashes.or(generate_hashes).unwrap_or_default(),
+            legacy_setup_py: args.legacy_setup_py.or(legacy_setup_py).unwrap_or_default(),
+            no_build_isolation: args
+                .no_build_isolation
+                .or(no_build_isolation)
+                .unwrap_or_default(),
+            no_build: args.no_build.or(no_build).unwrap_or_default(),
             only_binary: args.only_binary.or(only_binary).unwrap_or_default(),
             config_setting: args.config_settings.or(config_settings).unwrap_or_default(),
             python_version: args.python_version.or(python_version),
             exclude_newer: args.exclude_newer.or(exclude_newer),
             no_emit_package: args.no_emit_package.or(no_emit_package).unwrap_or_default(),
-            emit_index_url: args.emit_index_url.unwrap_or(false) || emit_index_url.unwrap_or(false),
-            emit_find_links: args.emit_find_links.unwrap_or(false)
-                || emit_find_links.unwrap_or(false),
-            emit_marker_expression: args.emit_marker_expression.unwrap_or(false)
-                || emit_marker_expression.unwrap_or(false),
-            emit_index_annotation: args.emit_index_annotation.unwrap_or(false)
-                || emit_index_annotation.unwrap_or(false),
+            emit_index_url: args.emit_index_url.or(emit_index_url).unwrap_or_default(),
+            emit_find_links: args.emit_find_links.or(emit_find_links).unwrap_or_default(),
+            emit_marker_expression: args
+                .emit_marker_expression
+                .or(emit_marker_expression)
+                .unwrap_or_default(),
+            emit_index_annotation: args
+                .emit_index_annotation
+                .or(emit_index_annotation)
+                .unwrap_or_default(),
             link_mode: args.link_mode.or(link_mode).unwrap_or_default(),
-            require_hashes: args.require_hashes.unwrap_or(false) || require_hashes.unwrap_or(false),
+            require_hashes: args.require_hashes.or(require_hashes).unwrap_or_default(),
             python: args.python.or(python),
-            system: args.system.unwrap_or(false) || system.unwrap_or(false),
-            break_system_packages: args.break_system_packages.unwrap_or(false)
-                || break_system_packages.unwrap_or(false),
+            system: args.system.or(system).unwrap_or_default(),
+            break_system_packages: args
+                .break_system_packages
+                .or(break_system_packages)
+                .unwrap_or_default(),
             no_binary: args.no_binary.or(no_binary).unwrap_or_default(),
-            compile_bytecode: args.compile_bytecode.unwrap_or(false)
-                || compile_bytecode.unwrap_or(false),
-            strict: args.strict.unwrap_or(false) || strict.unwrap_or(false),
+            compile_bytecode: args
+                .compile_bytecode
+                .or(compile_bytecode)
+                .unwrap_or_default(),
+            strict: args.strict.or(strict).unwrap_or_default(),
         }
+    }
+}
+
+/// Given a boolean flag pair (like `--upgrade` and `--no-upgrade`), resolve the value of the flag.
+fn flag(yes: bool, no: bool) -> Option<bool> {
+    match (yes, no) {
+        (true, false) => Some(true),
+        (false, true) => Some(false),
+        (false, false) => None,
+        (..) => unreachable!("Clap should make this impossible"),
     }
 }


### PR DESCRIPTION
## Summary

Now that we can pick up configuration values from persistent files, we need to enable users to _disable_ those values from the CLI. For example, if a user has `emit_index_url = true` in the configuration file, they should be able to do `--no-emit-index-url` on the command-line. This PR adds support for such negations, following the same patterns we use in Ruff.
