### PR TITLE
Add compatibility arguments for pip list

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1109,6 +1109,9 @@ pub(crate) struct PipListArgs {
     /// should be used with caution.
     #[clap(long, env = "UV_SYSTEM_PYTHON", group = "discovery")]
     pub(crate) system: bool,
+
+    #[command(flatten)]
+    pub(crate) compat_args: compat::PipListCompatArgs,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/compat/mod.rs
+++ b/crates/uv/src/compat/mod.rs
@@ -206,6 +206,31 @@ impl CompatArgs for PipCompileCompatArgs {
     }
 }
 
+/// Arguments for `pip list` compatibility.
+///
+/// These represent a subset of the `pip list` interface that uv supports by default.
+#[derive(Args)]
+#[allow(clippy::struct_excessive_bools)]
+pub(crate) struct PipListCompatArgs {
+    #[clap(long, hide = true)]
+    outdated: bool,
+}
+
+impl CompatArgs for crate::compat::PipListCompatArgs {
+    /// Validate the arguments passed for `pip list` compatibility.
+    ///
+    /// This method will warn when an argument is passed that has no effect but matches uv's
+    /// behavior. If an argument is passed that does _not_ match uv's behavior (e.g.,
+    /// `--outdated`), this method will return an error.
+    fn validate(&self) -> Result<()> {
+        if self.outdated {
+            return Err(anyhow!("pip list's `--outdated` is unsupported."));
+        }
+
+        Ok(())
+    }
+}
+
 /// Arguments for `pip-sync` compatibility.
 ///
 /// These represent a subset of the `pip-sync` interface that uv supports by default.

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -454,17 +454,21 @@ async fn run() -> Result<ExitStatus> {
         ),
         Commands::Pip(PipNamespace {
             command: PipCommand::List(args),
-        }) => commands::pip_list(
-            args.editable,
-            args.exclude_editable,
-            &args.exclude,
-            &args.format,
-            args.strict,
-            args.python.as_deref(),
-            args.system,
-            &cache,
-            printer,
-        ),
+        }) => {
+            args.compat_args.validate()?;
+
+            commands::pip_list(
+                args.editable,
+                args.exclude_editable,
+                &args.exclude,
+                &args.format,
+                args.strict,
+                args.python.as_deref(),
+                args.system,
+                &cache,
+                printer,
+            )
+        }
         Commands::Pip(PipNamespace {
             command: PipCommand::Show(args),
         }) => commands::pip_show(


### PR DESCRIPTION
Hello! This is my first PR so do not hesitate to let me know if anything should be done differently 🙌🏽  

## Summary

This PR starts adding useful error messages and warnings when people pass redundant or unsupported arguments to `pip list`. 

For now, I've just covered `pip list --outdated`, which is currently unsupported.

Closes https://github.com/astral-sh/uv/issues/2948
