### PR TITLE
Enable auto-wrapping of `--help` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -39,7 +39,7 @@ uv-types = { workspace = true }
 anstream = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "wrap_help"] }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 indicatif = { workspace = true }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -41,7 +41,7 @@ anstream = { workspace = true }
 anyhow = { workspace = true }
 axoupdater = { workspace = true, features = ["github_releases", "tokio"], optional = true }
 chrono = { workspace = true }
-clap = { workspace = true, features = ["derive", "string"] }
+clap = { workspace = true, features = ["derive", "string", "wrap_help"] }
 clap_complete_command = { workspace = true }
 flate2 = { workspace = true, default-features = false }
 fs-err = { workspace = true, features = ["tokio"] }


### PR DESCRIPTION
## Summary

Fixes #3057

On `main`, with a narrow terminal:

- <details>

  ![image](https://github.com/astral-sh/uv/assets/66076021/2453dcbc-739c-4174-ba2e-029cff3227a2)

  </details>

- <details>

  ![image](https://github.com/astral-sh/uv/assets/66076021/02553e90-fe35-4828-b50f-71f926a1e347)

  </details>

- <details>

  ![image](https://github.com/astral-sh/uv/assets/66076021/b33eac26-f2fe-4328-8aa0-c51235b7c4c3)

  </details>

- <details>

  ![image](https://github.com/astral-sh/uv/assets/66076021/e731f647-3519-4c54-ab33-b42500faf544)

  </details>

With PR:

- <details>

  ![image](https://github.com/astral-sh/uv/assets/66076021/0f1aaec0-960a-4060-95ba-f49bec2f6995)

  </details>

- <details>

  ![image](https://github.com/astral-sh/uv/assets/66076021/b8078125-bd57-41a9-9c09-1966c8971c92)

  </details>

- <details>

  ![image](https://github.com/astral-sh/uv/assets/66076021/c2f38eb0-5f67-46ee-8a09-47da9e9ce0a5)

  </details>

- <details>

  ![image](https://github.com/astral-sh/uv/assets/66076021/31b9fdca-938a-47ca-96ba-751d987c269e)

  </details>

## Test Plan

See screenshots in the summary
