### PR TITLE
Use kebab-case for serde enums

### DIFF
--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -203,6 +203,7 @@ fn parse_scripts(
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum LinkMode {
     /// Clone (i.e., copy-on-write) packages from the wheel into the site packages.

--- a/crates/uv-configuration/src/authentication.rs
+++ b/crates/uv-configuration/src/authentication.rs
@@ -4,6 +4,10 @@ use uv_auth::{self, KeyringProvider};
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(deny_unknown_fields, rename_all = "kebab-case")
+)]
 pub enum KeyringProviderType {
     /// Do not use keyring for credential lookup.
     #[default]

--- a/crates/uv-configuration/src/build_options.rs
+++ b/crates/uv-configuration/src/build_options.rs
@@ -199,6 +199,10 @@ impl NoBuild {
 #[derive(Debug, Default, Clone, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(deny_unknown_fields, rename_all = "kebab-case")
+)]
 pub enum IndexStrategy {
     /// Only use results from the first index that returns a match for a given package name.
     ///

--- a/crates/uv-resolver/src/prerelease_mode.rs
+++ b/crates/uv-resolver/src/prerelease_mode.rs
@@ -8,6 +8,10 @@ use crate::Manifest;
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(deny_unknown_fields, rename_all = "kebab-case")
+)]
 pub enum PreReleaseMode {
     /// Disallow all pre-release versions.
     Disallow,

--- a/crates/uv-resolver/src/resolution.rs
+++ b/crates/uv-resolver/src/resolution.rs
@@ -36,6 +36,10 @@ use crate::{Manifest, ResolveError};
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(deny_unknown_fields, rename_all = "kebab-case")
+)]
 pub enum AnnotationStyle {
     /// Render the annotations on a single, comma-separated line.
     Line,

--- a/crates/uv-resolver/src/resolution_mode.rs
+++ b/crates/uv-resolver/src/resolution_mode.rs
@@ -8,6 +8,10 @@ use crate::Manifest;
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    serde(deny_unknown_fields, rename_all = "kebab-case")
+)]
 pub enum ResolutionMode {
     /// Resolve the highest compatible version of each package.
     #[default]


### PR DESCRIPTION
By default, these serialize as (e.g.) `LowestDirect`. This now matches the format we use in Ruff.