### PR TITLE
Read base requirements from `pyproject.toml` in `uv run`

### DIFF
--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -8,7 +8,7 @@ use uv_warnings::warn_user;
 
 use crate::confirm;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RequirementsSource {
     /// A package was provided on the command line (e.g., `pip install flask`).
     Package(String),

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1634,7 +1634,7 @@ pub(crate) struct RunArgs {
     #[arg(allow_hyphen_values = true)]
     pub(crate) args: Vec<String>,
 
-    /// Always use a new virtual environment.
+    /// Always use a new virtual environment for execution.
     #[arg(long)]
     pub(crate) isolated: bool,
 

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -597,7 +597,7 @@ async fn run() -> Result<ExitStatus> {
             commands::run(
                 args.command,
                 args.args,
-                &requirements,
+                requirements,
                 args.isolated,
                 &cache,
                 printer,


### PR DESCRIPTION
In addition to the requested requirements, we include requirements from a `pyproject.toml` file if it exists and install the current directory.

Closes https://github.com/astral-sh/uv/issues/3104