### PR TITLE
Move argument normalization into settings construction

### DIFF
--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -23,7 +23,7 @@ pub struct SourceTreeResolver<'a, Context: BuildContext + Send + Sync> {
     /// The requirements for the project.
     source_trees: Vec<PathBuf>,
     /// The extras to include when resolving requirements.
-    extras: &'a ExtrasSpecification<'a>,
+    extras: &'a ExtrasSpecification,
     /// The hash policy to enforce.
     hasher: &'a HashStrategy,
     /// The in-memory index for resolving dependencies.
@@ -36,7 +36,7 @@ impl<'a, Context: BuildContext + Send + Sync> SourceTreeResolver<'a, Context> {
     /// Instantiate a new [`SourceTreeResolver`] for a given set of `source_trees`.
     pub fn new(
         source_trees: Vec<PathBuf>,
-        extras: &'a ExtrasSpecification<'a>,
+        extras: &'a ExtrasSpecification,
         hasher: &'a HashStrategy,
         context: &'a Context,
         client: &'a RegistryClient,

--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -147,14 +147,25 @@ impl std::fmt::Display for RequirementsSource {
 }
 
 #[derive(Debug, Default, Clone)]
-pub enum ExtrasSpecification<'a> {
+pub enum ExtrasSpecification {
     #[default]
     None,
     All,
-    Some(&'a [ExtraName]),
+    Some(Vec<ExtraName>),
 }
 
-impl ExtrasSpecification<'_> {
+impl ExtrasSpecification {
+    /// Determine the extras specification to use based on the command-line arguments.
+    pub fn from_args(all_extras: bool, extra: Vec<ExtraName>) -> Self {
+        if all_extras {
+            ExtrasSpecification::All
+        } else if extra.is_empty() {
+            ExtrasSpecification::None
+        } else {
+            ExtrasSpecification::Some(extra)
+        }
+    }
+
     /// Returns true if a name is included in the extra specification.
     pub fn contains(&self, name: &ExtraName) -> bool {
         match self {

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -51,7 +51,7 @@ impl RequirementsSpecification {
     #[instrument(skip_all, level = Level::DEBUG, fields(source = % source))]
     pub async fn from_source(
         source: &RequirementsSource,
-        extras: &ExtrasSpecification<'_>,
+        extras: &ExtrasSpecification,
         client_builder: &BaseClientBuilder<'_>,
     ) -> Result<Self> {
         Ok(match source {
@@ -224,7 +224,7 @@ impl RequirementsSpecification {
         requirements: &[RequirementsSource],
         constraints: &[RequirementsSource],
         overrides: &[RequirementsSource],
-        extras: &ExtrasSpecification<'_>,
+        extras: &ExtrasSpecification,
         client_builder: &BaseClientBuilder<'_>,
     ) -> Result<Self> {
         let mut spec = Self::default();

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -350,7 +350,7 @@ pub(crate) struct PipCompileArgs {
 
     /// Refresh cached data for a specific package.
     #[arg(long)]
-    pub(crate) refresh_package: Option<Vec<PackageName>>,
+    pub(crate) refresh_package: Vec<PackageName>,
 
     /// The method to use when installing packages from the global cache.
     ///
@@ -455,7 +455,7 @@ pub(crate) struct PipCompileArgs {
     /// Allow upgrades for a specific package, ignoring pinned versions in the existing output
     /// file.
     #[arg(long, short = 'P')]
-    pub(crate) upgrade_package: Option<Vec<PackageName>>,
+    pub(crate) upgrade_package: Vec<PackageName>,
 
     /// Include distribution hashes in the output file.
     #[arg(long, overrides_with("no_generate_hashes"))]
@@ -901,7 +901,7 @@ pub(crate) struct PipInstallArgs {
 
     /// Allow upgrade of a specific package.
     #[arg(long, short = 'P')]
-    pub(crate) upgrade_package: Option<Vec<PackageName>>,
+    pub(crate) upgrade_package: Vec<PackageName>,
 
     /// Reinstall all packages, regardless of whether they're already installed.
     #[arg(long, alias = "force-reinstall")]
@@ -909,7 +909,7 @@ pub(crate) struct PipInstallArgs {
 
     /// Reinstall a specific package, regardless of whether it's already installed.
     #[arg(long)]
-    pub(crate) reinstall_package: Option<Vec<PackageName>>,
+    pub(crate) reinstall_package: Vec<PackageName>,
 
     #[arg(
         global = true,
@@ -929,7 +929,7 @@ pub(crate) struct PipInstallArgs {
 
     /// Refresh cached data for a specific package.
     #[arg(long)]
-    pub(crate) refresh_package: Option<Vec<PackageName>>,
+    pub(crate) refresh_package: Vec<PackageName>,
 
     /// Ignore package dependencies, instead only installing those packages explicitly listed
     /// on the command line or in the requirements files.

--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -53,7 +53,7 @@ pub(crate) async fn pip_compile(
     requirements: &[RequirementsSource],
     constraints: &[RequirementsSource],
     overrides: &[RequirementsSource],
-    extras: ExtrasSpecification<'_>,
+    extras: ExtrasSpecification,
     output_file: Option<&Path>,
     resolution_mode: ResolutionMode,
     prerelease_mode: PreReleaseMode,
@@ -131,7 +131,7 @@ pub(crate) async fn pip_compile(
     // If all the metadata could be statically resolved, validate that every extra was used. If we
     // need to resolve metadata via PEP 517, we don't know which extras are used until much later.
     if source_trees.is_empty() {
-        if let ExtrasSpecification::Some(extras) = extras {
+        if let ExtrasSpecification::Some(extras) = &extras {
             let mut unused_extras = extras
                 .iter()
                 .filter(|extra| !used_extras.contains(extra))

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -57,7 +57,7 @@ pub(crate) async fn pip_install(
     requirements: &[RequirementsSource],
     constraints: &[RequirementsSource],
     overrides: &[RequirementsSource],
-    extras: &ExtrasSpecification<'_>,
+    extras: &ExtrasSpecification,
     resolution_mode: ResolutionMode,
     prerelease_mode: PreReleaseMode,
     dependency_mode: DependencyMode,
@@ -426,7 +426,7 @@ async fn read_requirements(
     requirements: &[RequirementsSource],
     constraints: &[RequirementsSource],
     overrides: &[RequirementsSource],
-    extras: &ExtrasSpecification<'_>,
+    extras: &ExtrasSpecification,
     client_builder: &BaseClientBuilder<'_>,
 ) -> Result<RequirementsSpecification, Error> {
     // If the user requests `extras` but does not provide a valid source (e.g., a `pyproject.toml`),


### PR DESCRIPTION
## Summary

No behavior changes, but the idea here is that we move the argument normalization code (e.g., create an `Upgrade` struct from `--upgrade` and `--upgrade-package`) into the `settings.rs` file, where we build the common settings structs.

This reduces a lot of the logic and duplication across commands in `main.rs`.