### PR TITLE
Update the credentials cache to use an async mutex

### DIFF
--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -14,6 +14,7 @@ rust-netrc = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -101,7 +101,7 @@ impl Middleware for AuthMiddleware {
         trace!("Handling request for {url}");
 
         // Then check for credentials in (2) the cache
-        let credentials = self.cache().check(request.url(), credentials);
+        let credentials = self.cache().check(request.url(), credentials).await;
 
         // Track credentials that we might want to insert into the cache
         let mut new_credentials = None;
@@ -167,7 +167,7 @@ impl Middleware for AuthMiddleware {
 
             // Update the default credentials eagerly since requests are made concurrently
             // and we want to avoid expensive credential lookups
-            self.cache().set_default(&url, credentials.clone());
+            self.cache().set_default(&url, credentials.clone()).await;
 
             let result = next.run(request, extensions).await;
 
@@ -177,7 +177,7 @@ impl Middleware for AuthMiddleware {
                 .is_ok_and(|response| response.error_for_status_ref().is_ok())
             {
                 trace!("Updating cached credentials for {url}");
-                self.cache().insert(&url, credentials)
+                self.cache().insert(&url, credentials).await
             };
             result
         } else {


### PR DESCRIPTION
It seems wrong to use a sync mutex in an async context without strong justification. We're probably unnecessarily blocking the event loop.