### PR TITLE
Default to `python` when `uv run` does not recieve a command

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1628,7 +1628,7 @@ pub(crate) struct VenvArgs {
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct RunArgs {
     /// The command to run.
-    pub(crate) command: String,
+    pub(crate) target: Option<String>,
 
     /// The arguments to the command.
     #[arg(allow_hyphen_values = true)]

--- a/crates/uv/src/commands/run.rs
+++ b/crates/uv/src/commands/run.rs
@@ -39,7 +39,7 @@ use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
 /// Run a command.
 #[allow(clippy::unnecessary_wraps, clippy::too_many_arguments)]
 pub(crate) async fn run(
-    command: String,
+    target: Option<String>,
     args: Vec<String>,
     mut requirements: Vec<RequirementsSource>,
     isolated: bool,
@@ -47,6 +47,8 @@ pub(crate) async fn run(
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
+    let command = target.unwrap_or("python".to_string());
+
     // Copy the requirements into a set of overrides; we'll use this to prioritize
     // requested requirements over those discovered in the project.
     // We must retain these requirements as direct dependencies too, as overrides
@@ -88,7 +90,8 @@ pub(crate) async fn run(
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
     // TODO(zanieb): Throw a nicer error message if the command is not found
-    debug!("Running `{command} {}`", args.join(" "));
+    let space = if args.is_empty() { "" } else { " " };
+    debug!("Running `{command}{space}{}`", args.join(" "));
     let mut handle = process.spawn()?;
     let status = handle.wait().await?;
 

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -595,7 +595,7 @@ async fn run() -> Result<ExitStatus> {
                 .collect::<Vec<_>>();
 
             commands::run(
-                args.command,
+                args.target,
                 args.args,
                 requirements,
                 args.isolated,


### PR DESCRIPTION
This means that a bare `uv run` invocation drops you into a REPL.

This behavior is internally controversial, and may best be served by a dedicated `uv repl` command. I would imagine it's important to fail if no command is given in _some_ circumstances, but those may be resolved by _not_ doing this if we do not detect a TTY.

Regardless, I'm interested in giving this a try for a bit during this experimental phase.