### PR TITLE
Allow `--python` and `--system` on `pip compile`

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -383,6 +383,15 @@ pub(crate) struct PipCompileArgs {
     #[arg(long, env = "UV_EXTRA_INDEX_URL", value_delimiter = ' ', value_parser = parse_index_url)]
     pub(crate) extra_index_url: Option<Vec<Maybe<IndexUrl>>>,
 
+    /// Locations to search for candidate distributions, beyond those found in the indexes.
+    ///
+    /// If a path, the target must be a directory that contains package as wheel files (`.whl`) or
+    /// source distributions (`.tar.gz` or `.zip`) at the top level.
+    ///
+    /// If a URL, the page must contain a flat list of links to package files.
+    #[arg(long, short)]
+    pub(crate) find_links: Option<Vec<FlatIndexLocation>>,
+
     /// Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those
     /// discovered via `--find-links`.
     #[arg(long)]
@@ -406,14 +415,36 @@ pub(crate) struct PipCompileArgs {
     #[arg(long, value_enum, env = "UV_KEYRING_PROVIDER")]
     pub(crate) keyring_provider: Option<KeyringProviderType>,
 
-    /// Locations to search for candidate distributions, beyond those found in the indexes.
+    /// The Python interpreter against which to compile the requirements.
     ///
-    /// If a path, the target must be a directory that contains package as wheel files (`.whl`) or
-    /// source distributions (`.tar.gz` or `.zip`) at the top level.
+    /// By default, `uv` uses the virtual environment in the current working directory or any parent
+    /// directory, falling back to searching for a Python executable in `PATH`. The `--python`
+    /// option allows you to specify a different interpreter.
     ///
-    /// If a URL, the page must contain a flat list of links to package files.
-    #[arg(long, short)]
-    pub(crate) find_links: Option<Vec<FlatIndexLocation>>,
+    /// Supported formats:
+    /// - `3.10` looks for an installed Python 3.10 using `py --list-paths` on Windows, or
+    ///   `python3.10` on Linux and macOS.
+    /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
+    /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
+    #[arg(long, verbatim_doc_comment, group = "discovery")]
+    pub(crate) python: Option<String>,
+
+    /// Install packages into the system Python.
+    ///
+    /// By default, `uv` uses the virtual environment in the current working directory or any parent
+    /// directory, falling back to searching for a Python executable in `PATH`. The `--system`
+    /// option instructs `uv` to avoid using a virtual environment Python and restrict its search to
+    /// the system path.
+    #[arg(
+        long,
+        env = "UV_SYSTEM_PYTHON",
+        group = "discovery",
+        overrides_with("no_system")
+    )]
+    pub(crate) system: bool,
+
+    #[arg(long, overrides_with("system"))]
+    pub(crate) no_system: bool,
 
     /// Allow package upgrades, ignoring pinned versions in the existing output file.
     #[arg(long, short = 'U')]

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -257,6 +257,8 @@ async fn run() -> Result<ExitStatus> {
                 args.shared.exclude_newer,
                 args.shared.annotation_style,
                 args.shared.link_mode,
+                args.shared.python,
+                args.shared.system,
                 globals.native_tls,
                 globals.quiet,
                 cache,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -117,6 +117,9 @@ impl PipCompileSettings {
             index_strategy,
             keyring_provider,
             find_links,
+            python,
+            system,
+            no_system,
             upgrade,
             upgrade_package,
             generate_hashes,
@@ -156,6 +159,8 @@ impl PipCompileSettings {
             // Shared settings.
             shared: PipSharedSettings::combine(
                 PipOptions {
+                    python,
+                    system: flag(system, no_system),
                     offline: flag(offline, no_offline),
                     index_url: index_url.and_then(Maybe::into_option),
                     extra_index_url: extra_index_url.map(|extra_index_urls| {


### PR DESCRIPTION
## Summary

I think these are useful to have for consistency, though the `--system` variant requires some new threading.

Closes: https://github.com/astral-sh/uv/issues/2242.
