### PR TITLE
Restore seeding of authentication cache from index URLs

### DIFF
--- a/crates/uv-auth/src/lib.rs
+++ b/crates/uv-auth/src/lib.rs
@@ -4,12 +4,16 @@ mod keyring;
 mod middleware;
 mod netloc;
 
+use std::sync::Arc;
+
 use cache::CredentialsCache;
+use credentials::Credentials;
 
 pub use keyring::KeyringProvider;
 pub use middleware::AuthMiddleware;
 use netloc::NetLoc;
 use once_cell::sync::Lazy;
+use url::Url;
 
 // TODO(zanieb): Consider passing a cache explicitly throughout
 
@@ -17,3 +21,15 @@ use once_cell::sync::Lazy;
 ///
 /// This is used to share credentials across uv clients.
 pub(crate) static CREDENTIALS_CACHE: Lazy<CredentialsCache> = Lazy::new(CredentialsCache::default);
+
+/// Populate the global authentication store with credentials on a URL, if there are any.
+///
+/// Returns `true` if the store was updated.
+pub fn store_credentials_from_url(url: &Url) -> bool {
+    if let Some(credentials) = Credentials::from_url(url) {
+        CREDENTIALS_CACHE.insert(url, Arc::new(credentials));
+        true
+    } else {
+        false
+    }
+}

--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -17,6 +17,7 @@ use distribution_types::{IndexLocations, LocalEditable, LocalEditables, Verbatim
 use install_wheel_rs::linker::LinkMode;
 use platform_tags::Tags;
 use requirements_txt::EditableRequirement;
+use uv_auth::store_credentials_from_url;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::KeyringProviderType;
@@ -218,6 +219,11 @@ pub(crate) async fn pip_compile(
     // Incorporate any index locations from the provided sources.
     let index_locations =
         index_locations.combine(index_url, extra_index_urls, find_links, no_index);
+
+    // Add all authenticated sources to the cache.
+    for url in index_locations.urls() {
+        store_credentials_from_url(url);
+    }
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -19,6 +19,7 @@ use pep508_rs::{MarkerEnvironment, Requirement};
 use platform_tags::Tags;
 use pypi_types::{Metadata23, Yanked};
 use requirements_txt::EditableRequirement;
+use uv_auth::store_credentials_from_url;
 use uv_cache::Cache;
 use uv_client::{
     BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClient, RegistryClientBuilder,
@@ -202,6 +203,11 @@ pub(crate) async fn pip_install(
     // Incorporate any index locations from the provided sources.
     let index_locations =
         index_locations.combine(index_url, extra_index_urls, find_links, no_index);
+
+    // Add all authenticated sources to the cache.
+    for url in index_locations.urls() {
+        store_credentials_from_url(url);
+    }
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -14,6 +14,7 @@ use install_wheel_rs::linker::LinkMode;
 use platform_tags::Tags;
 use pypi_types::Yanked;
 use requirements_txt::EditableRequirement;
+use uv_auth::store_credentials_from_url;
 use uv_cache::{ArchiveTarget, ArchiveTimestamp, Cache};
 use uv_client::{
     BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClient, RegistryClientBuilder,
@@ -149,6 +150,11 @@ pub(crate) async fn pip_sync(
     // Incorporate any index locations from the provided sources.
     let index_locations =
         index_locations.combine(index_url, extra_index_urls, find_links, no_index);
+
+    // Add all authenticated sources to the cache.
+    for url in index_locations.urls() {
+        store_credentials_from_url(url);
+    }
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 use distribution_types::{DistributionMetadata, IndexLocations, Name, ResolvedDist};
 use install_wheel_rs::linker::LinkMode;
 use pep508_rs::Requirement;
+use uv_auth::store_credentials_from_url;
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::KeyringProviderType;
@@ -118,6 +119,11 @@ async fn venv_impl(
     } else {
         find_default_python(cache).into_diagnostic()?
     };
+
+    // Add all authenticated sources to the cache.
+    for url in index_locations.urls() {
+        store_credentials_from_url(url);
+    }
 
     writeln!(
         printer.stderr(),


### PR DESCRIPTION
Roughly reverts https://github.com/astral-sh/uv/pull/2976/commits/f7820ceaa7a24613ce89da77c48a0454c1e94616 to reduce possible race conditions for pre-authenticated index URLs

Part of:

- https://github.com/astral-sh/uv/issues/3123
- https://github.com/astral-sh/uv/issues/3122