### PR TITLE
Remove `Option<bool>` for `--no-cache`

### DIFF
--- a/crates/uv-cache/src/cli.rs
+++ b/crates/uv-cache/src/cli.rs
@@ -14,9 +14,10 @@ pub struct CacheArgs {
         long,
         short,
         alias = "no-cache-dir",
-        env = "UV_NO_CACHE"
+        env = "UV_NO_CACHE",
+        value_parser = clap::builder::BoolishValueParser::new(),
     )]
-    pub no_cache: Option<bool>,
+    pub no_cache: bool,
 
     /// Path to the cache directory.
     ///
@@ -35,11 +36,8 @@ impl Cache {
     /// 4. A `.uv_cache` directory in the current working directory.
     ///
     /// Returns an absolute cache dir.
-    pub fn from_settings(
-        no_cache: Option<bool>,
-        cache_dir: Option<PathBuf>,
-    ) -> Result<Self, io::Error> {
-        if no_cache.unwrap_or(false) {
+    pub fn from_settings(no_cache: bool, cache_dir: Option<PathBuf>) -> Result<Self, io::Error> {
+        if no_cache {
             Cache::temp()
         } else if let Some(cache_dir) = cache_dir {
             Cache::from_path(cache_dir)

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -47,7 +47,7 @@ impl GlobalSettings {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct CacheSettings {
-    pub(crate) no_cache: Option<bool>,
+    pub(crate) no_cache: bool,
     pub(crate) cache_dir: Option<PathBuf>,
 }
 
@@ -55,9 +55,10 @@ impl CacheSettings {
     /// Resolve the [`CacheSettings`] from the CLI and workspace configuration.
     pub(crate) fn resolve(args: CacheArgs, workspace: Option<&Workspace>) -> Self {
         Self {
-            no_cache: args
-                .no_cache
-                .or(workspace.and_then(|workspace| workspace.options.no_cache)),
+            no_cache: args.no_cache
+                || workspace
+                    .and_then(|workspace| workspace.options.no_cache)
+                    .unwrap_or(false),
             cache_dir: args
                 .cache_dir
                 .or_else(|| workspace.and_then(|workspace| workspace.options.cache_dir.clone())),


### PR DESCRIPTION
## Summary

This was unintended. We ended up reverting `Option<bool>` everywhere, but I missed this once since it's in a separate file.

(If you use `Option<bool>`, Clap requires a value, like `--no-cache true`.)

## Test Plan

`cargo run pip install flask --no-cache`
