### PR TITLE
Avoid treating localhost URLs as local file paths

### DIFF
--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -442,7 +442,10 @@ fn installed_satisfies_requirement(
             if let InstalledDist::Url(installed) = &distribution {
                 if &installed.url == url.raw() {
                     // If the requirement came from a local path, check freshness.
-                    if let Ok(archive) = url.to_file_path() {
+                    if let Some(archive) = (url.scheme() == "file")
+                        .then(|| url.to_file_path().ok())
+                        .flatten()
+                    {
                         if ArchiveTimestamp::up_to_date_with(
                             &archive,
                             ArchiveTarget::Install(distribution),

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -398,12 +398,14 @@ impl<'a> SitePackages<'a> {
                             }
 
                             // If the requirement came from a local path, check freshness.
-                            if let Ok(archive) = url.to_file_path() {
-                                if !ArchiveTimestamp::up_to_date_with(
-                                    &archive,
-                                    ArchiveTarget::Install(distribution),
-                                )? {
-                                    return Ok(false);
+                            if url.scheme() == "file" {
+                                if let Ok(archive) = url.to_file_path() {
+                                    if !ArchiveTimestamp::up_to_date_with(
+                                        &archive,
+                                        ArchiveTarget::Install(distribution),
+                                    )? {
+                                        return Ok(false);
+                                    }
                                 }
                             }
                         }
@@ -441,12 +443,14 @@ impl<'a> SitePackages<'a> {
                                 }
 
                                 // If the requirement came from a local path, check freshness.
-                                if let Ok(archive) = url.to_file_path() {
-                                    if !ArchiveTimestamp::up_to_date_with(
-                                        &archive,
-                                        ArchiveTarget::Install(distribution),
-                                    )? {
-                                        return Ok(false);
+                                if url.scheme() == "file" {
+                                    if let Ok(archive) = url.to_file_path() {
+                                        if !ArchiveTimestamp::up_to_date_with(
+                                            &archive,
+                                            ArchiveTarget::Install(distribution),
+                                        )? {
+                                            return Ok(false);
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/3128.

## Test Plan

- `python -m http.server`
- `cargo run pip install "http://localhost:8000/werkzeug-3.0.2-py3-none-any.whl"`
- `cargo run pip install "http://localhost:8000/werkzeug-3.0.2-py3-none-any.whl"`
