### PR TITLE
Fix `uv pip compile` with `UV_SYSTEM_PYTHON=1`

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -439,6 +439,7 @@ pub(crate) struct PipCompileArgs {
     #[arg(
         long,
         env = "UV_SYSTEM_PYTHON",
+        value_parser = clap::builder::BoolishValueParser::new(),
         group = "discovery",
         overrides_with("no_system")
     )]


### PR DESCRIPTION
## Summary

Following up 

- https://github.com/astral-sh/uv/pull/3113
- https://github.com/astral-sh/uv/pull/3115

It looks like `uv pip compile` command with `UV_SYSTEM_PYTHON` is missed because these two PRs are close in time. And thus resulting in


```bash
$ uv --version
uv 0.1.34 (9259eceeb 2024-04-19)
$ UV_SYSTEM_PYTHON=1 uv pip compile --upgrade requirements.in -o requirements.txt
error: invalid value '1' for '--system'
  [possible values: true, false]

For more information, try '--help'.
```