### PR TITLE
Change exclude-newer behavior to include indexes missing upload-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ date, allowing reproduction of installations regardless of new package releases.
 as a RFC 3339 timestamp (e.g., `2006-12-02T02:07:43Z`) or UTC date in the same format (e.g., `2006-12-02`).
 
 Note the package index must support the `upload-time` field as specified in [`PEP 700`](https://peps.python.org/pep-0700/).
-If the field is not present for a given distribution, the distribution will be treated as unavailable.
+If the field is not present for a given distribution, the distribution will be treated as older than the given date.
 
 To ensure reproducibility, messages for unsatisfiable resolutions will not mention that distributions were excluded
 due to the `--exclude-newer` flag — newer distributions will be treated as if they do not exist.

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -372,7 +372,7 @@ impl VersionMapLazy {
                                 "{} is missing an upload date, but user provided: {exclude_newer}",
                                 file.filename,
                             );
-                            (true, None)
+                            (false, None)
                         }
                         _ => (false, None),
                     }


### PR DESCRIPTION
## Summary

Currently, when --exclude-newer is given, all indexes that are missing it are treated entirely as unavailable. This makes it impossible to use this flag in combination with many indexes.

The new behavior warns about the missing field, but treats the distribution as available when the upload date it unknown.

This makes it possible to use this flag while still using packages from indexes that don't support `upload-time`.

### Rationale
If any extra-indexes are incompatible with exclude-newer, it would be more useful to have a best-effort attempt instead of ignoring the extra indexes and likely failing the solve.

## Test Plan
I'm going to see what CI says about this.
<!-- How was it tested? -->
