### PR TITLE
Enforce HTTP timeouts on a per-read (rather than per-request) basis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,7 +2732,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset 0.9.1",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -3025,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
  "async-compression",
  "base64 0.22.0",

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -125,7 +125,7 @@ impl<'a> BaseClientBuilder<'a> {
                     })
             })
             .unwrap_or(default_timeout);
-        debug!("Using registry request timeout of {}s", timeout);
+        debug!("Using registry request timeout of {timeout}s");
 
         // Initialize the base client.
         let client = self.client.clone().unwrap_or_else(|| {
@@ -145,7 +145,7 @@ impl<'a> BaseClientBuilder<'a> {
             let client_core = ClientBuilder::new()
                 .user_agent(user_agent_string)
                 .pool_max_idle_per_host(20)
-                .timeout(std::time::Duration::from_secs(timeout))
+                .read_timeout(std::time::Duration::from_secs(timeout))
                 .tls_built_in_root_certs(false);
 
             // Configure TLS.


### PR DESCRIPTION
## Summary

This leverages the new `read_timeout` property, which ensures that (like pip) our timeout is not applied to the _entire_ request, but rather, to each individual read operation.

Closes: #1921.

See: #1912.
