### PR TITLE
Update Rooster config to bump minor on breaking label

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ strip = true
 include = [{ path = "rust-toolchain.toml", format = ["sdist", "wheel"] }, { path = "LICENSE-APACHE", format = "sdist" }, { path = "LICENSE-MIT", format = "sdist" }]
 
 [tool.rooster]
-major_labels = []  # We do not use the major version number
-minor_labels = []  # Normally we'd bump the minor version on breaking changes, but we're waiting
+major_labels = []  # We do not use the major version number yet
+minor_labels = ["breaking"]
 changelog_ignore_labels = ["internal", "ci", "testing"]
 changelog_sections.breaking = "Breaking changes"
 changelog_sections.enhancement = "Enhancements"


### PR DESCRIPTION
Following https://github.com/astral-sh/uv/pull/3151