### PR TITLE
Dedicated error type for direct url parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,7 @@ dependencies = [
  "cache-key",
  "distribution-filename",
  "fs-err",
+ "git2",
  "itertools 0.12.1",
  "once_cell",
  "pep440_rs",

--- a/crates/distribution-types/Cargo.toml
+++ b/crates/distribution-types/Cargo.toml
@@ -25,6 +25,7 @@ uv-normalize = { workspace = true }
 
 anyhow = { workspace = true }
 fs-err = { workspace = true }
+git2 = { workspace = true }
 itertools = { workspace = true }
 once_cell = { workspace = true }
 rkyv = { workspace = true }

--- a/crates/distribution-types/src/cached.rs
+++ b/crates/distribution-types/src/cached.rs
@@ -116,7 +116,7 @@ impl CachedDist {
                         editable: dist.editable,
                     })))
                 } else {
-                    DirectUrl::try_from(dist.url.raw()).map(Some)
+                    Ok(Some(DirectUrl::try_from(dist.url.raw())?))
                 }
             }
         }

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -3,6 +3,7 @@ use tokio::task::JoinError;
 use zip::result::ZipError;
 
 use distribution_filename::WheelFilenameError;
+use distribution_types::DirectUrlError;
 use pep440_rs::Version;
 use pypi_types::HashDigest;
 use uv_client::BetterReqwestError;
@@ -22,6 +23,8 @@ pub enum Error {
     JoinRelativeUrl(#[from] pypi_types::JoinRelativeError),
     #[error("Git operation failed")]
     Git(#[source] anyhow::Error),
+    #[error(transparent)]
+    DirectUrl(#[from] Box<DirectUrlError>),
     #[error(transparent)]
     Reqwest(#[from] BetterReqwestError),
     #[error(transparent)]

--- a/crates/uv-distribution/src/git.rs
+++ b/crates/uv-distribution/src/git.rs
@@ -67,7 +67,7 @@ pub(crate) async fn fetch_git_archive(
     )
     .map_err(Error::CacheWrite)?;
 
-    let DirectGitUrl { url, subdirectory } = DirectGitUrl::try_from(url).map_err(Error::Git)?;
+    let DirectGitUrl { url, subdirectory } = DirectGitUrl::try_from(url).map_err(Box::new)?;
 
     // Fetch the Git repository.
     let source = if let Some(reporter) = reporter {
@@ -95,7 +95,7 @@ pub(crate) async fn resolve_precise(
     cache: &Cache,
     reporter: Option<&Arc<dyn Reporter>>,
 ) -> Result<Option<Url>, Error> {
-    let DirectGitUrl { url, subdirectory } = DirectGitUrl::try_from(url).map_err(Error::Git)?;
+    let DirectGitUrl { url, subdirectory } = DirectGitUrl::try_from(url).map_err(Box::new)?;
 
     // If the Git reference already contains a complete SHA, short-circuit.
     if url.precise().is_some() {

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -51,7 +51,7 @@ impl GitUrl {
 }
 
 impl TryFrom<Url> for GitUrl {
-    type Error = anyhow::Error;
+    type Error = git2::Error;
 
     /// Initialize a [`GitUrl`] source from a URL.
     fn try_from(mut url: Url) -> Result<Self, Self::Error> {


### PR DESCRIPTION
Add a dedicated error type for direct url parsing. This change is broken out from the new uv requirement type, which uses direct url parsing internally.