### PR TITLE
30s default http read timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ replacement for common `pip` and `pip-tools` workflows.
 - 🧪 Tested at-scale against the top 10,000 PyPI packages.
 - 🖥️ Support for macOS, Linux, and Windows.
 - 🧰 Advanced features such as [dependency version overrides](#dependency-overrides) and
-   [alternative resolution strategies](#resolution-strategy).
+  [alternative resolution strategies](#resolution-strategy).
 - ⁉️ Best-in-class error messages with a conflict-tracking resolver.
 - 🤝 Support for a wide range of advanced `pip` features, including editable installs, Git
   dependencies, direct URL dependencies, local dependencies, constraints, source distributions,
@@ -516,7 +516,7 @@ In addition, uv respects the following environment variables:
   enable trace-level logging. See the [tracing documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax)
   for more.
 - `HTTP_TIMEOUT` (or `UV_HTTP_TIMEOUT`): If set, uv will use this value (in seconds) as the timeout
-  for HTTP requests.
+  for HTTP reads (default: 30s).
 - `PYC_INVALIDATION_MODE`: The validation modes to use when run with `--compile`.
   See: [`PycInvalidationMode`](https://docs.python.org/3/library/py_compile.html#py_compile.PycInvalidationMode).
 - `VIRTUAL_ENV`: Used to detect an activated virtual environment.

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -112,7 +112,7 @@ impl<'a> BaseClientBuilder<'a> {
 
         // Timeout options, matching https://doc.rust-lang.org/nightly/cargo/reference/config.html#httptimeout
         // `UV_REQUEST_TIMEOUT` is provided for backwards compatibility with v0.1.6
-        let default_timeout = 10;
+        let default_timeout = 30;
         let timeout = env::var("UV_HTTP_TIMEOUT")
             .or_else(|_| env::var("UV_REQUEST_TIMEOUT"))
             .or_else(|_| env::var("HTTP_TIMEOUT"))

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -112,7 +112,7 @@ impl<'a> BaseClientBuilder<'a> {
 
         // Timeout options, matching https://doc.rust-lang.org/nightly/cargo/reference/config.html#httptimeout
         // `UV_REQUEST_TIMEOUT` is provided for backwards compatibility with v0.1.6
-        let default_timeout = 5 * 60;
+        let default_timeout = 10;
         let timeout = env::var("UV_HTTP_TIMEOUT")
             .or_else(|_| env::var("UV_REQUEST_TIMEOUT"))
             .or_else(|_| env::var("HTTP_TIMEOUT"))


### PR DESCRIPTION
Since we're now using read timeouts and not total timeouts, we can use a lower threshold, a single read shouldn't take 5 min (and not even 10s).

The 10s value is somewhat arbitrary.

Like #3144, this is a breaking change in some sense.