### PR TITLE
Rename the second direct url to parsed url

### DIFF
--- a/crates/distribution-types/src/cached.rs
+++ b/crates/distribution-types/src/cached.rs
@@ -7,7 +7,7 @@ use pep508_rs::VerbatimUrl;
 use pypi_types::HashDigest;
 use uv_normalize::PackageName;
 
-use crate::direct_url::{DirectUrl, LocalFileUrl};
+use crate::direct_url::{LocalFileUrl, ParsedUrl};
 use crate::hash::Hashed;
 use crate::{
     BuiltDist, Dist, DistributionMetadata, InstalledMetadata, InstalledVersion, Name, SourceDist,
@@ -104,19 +104,19 @@ impl CachedDist {
         }
     }
 
-    /// Return the [`DirectUrl`] of the distribution, if it exists.
-    pub fn direct_url(&self) -> Result<Option<DirectUrl>> {
+    /// Return the [`ParsedUrl`] of the distribution, if it exists.
+    pub fn parsed_url(&self) -> Result<Option<ParsedUrl>> {
         match self {
             Self::Registry(_) => Ok(None),
             Self::Url(dist) => {
                 if dist.editable {
                     assert_eq!(dist.url.scheme(), "file", "{}", dist.url);
-                    Ok(Some(DirectUrl::LocalFile(LocalFileUrl {
+                    Ok(Some(ParsedUrl::LocalFile(LocalFileUrl {
                         url: dist.url.raw().clone(),
                         editable: dist.editable,
                     })))
                 } else {
-                    Ok(Some(DirectUrl::try_from(dist.url.raw())?))
+                    Ok(Some(ParsedUrl::try_from(dist.url.raw())?))
                 }
             }
         }

--- a/crates/uv-installer/src/installer.rs
+++ b/crates/uv-installer/src/installer.rs
@@ -58,7 +58,7 @@ impl<'a> Installer<'a> {
                     wheel.path(),
                     wheel.filename(),
                     wheel
-                        .direct_url()?
+                        .parsed_url()?
                         .as_ref()
                         .map(pypi_types::DirectUrl::try_from)
                         .transpose()?


### PR DESCRIPTION
Previously, we got `pypi_types::DirectUrl` (the pypa spec direct_url.json format) and `distribution_types::DirectUrl` (an enum of all the url types we support). This lead me to confusion, so i'm renaming the latter one to the more appropriate `ParsedUrl`.