### PR TITLE
Avoid waiting for metadata for `--no-deps` editables

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -864,7 +864,7 @@ impl<
                 if self.dependency_mode.is_direct() {
                     // If an extra is provided, wait for the metadata to be available, since it's
                     // still required for reporting diagnostics.
-                    if extra.is_some() {
+                    if extra.is_some() && self.editables.get(package_name).is_none() {
                         // Determine the distribution to lookup.
                         let dist = match url {
                             Some(url) => PubGrubDistribution::from_url(package_name, url),

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1495,6 +1495,33 @@ fn no_deps() {
     context.assert_command("import flask").failure();
 }
 
+/// Install an editable package from the command line into a virtual environment, ignoring its
+/// dependencies.
+#[test]
+fn no_deps_editable() {
+    let context = TestContext::new("3.12");
+
+    // Install the editable version of Black. This should remove the registry-based version.
+    uv_snapshot!(context.filters(), context.install()
+        .arg("--no-deps")
+        .arg("-e")
+        .arg(context.workspace_root.join("scripts/packages/black_editable[dev]")), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Built 1 editable in [TIME]
+    Resolved 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
+    "###
+    );
+
+    context.assert_command("import black").success();
+    context.assert_command("import aiohttp").failure();
+}
+
 /// Upgrade a package.
 #[test]
 fn install_upgrade() {


### PR DESCRIPTION
## Summary

We don't emit a request for this, so we shouldn't wait for it either -- we already have the metadata!

Closes https://github.com/astral-sh/uv/issues/3184.
