### PR TITLE
Add preview mode and use for warning in `uv run`

### DIFF
--- a/crates/uv-configuration/src/lib.rs
+++ b/crates/uv-configuration/src/lib.rs
@@ -5,6 +5,7 @@ pub use constraints::*;
 pub use name_specifiers::*;
 pub use overrides::*;
 pub use package_options::*;
+pub use preview::*;
 pub use target_triple::*;
 
 mod authentication;
@@ -14,4 +15,5 @@ mod constraints;
 mod name_specifiers;
 mod overrides;
 mod package_options;
+mod preview;
 mod target_triple;

--- a/crates/uv-configuration/src/preview.rs
+++ b/crates/uv-configuration/src/preview.rs
@@ -1,0 +1,37 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PreviewMode {
+    #[default]
+    Disabled,
+    Enabled,
+}
+
+impl PreviewMode {
+    pub fn is_enabled(&self) -> bool {
+        matches!(self, Self::Enabled)
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        matches!(self, Self::Disabled)
+    }
+}
+
+impl From<bool> for PreviewMode {
+    fn from(version: bool) -> Self {
+        if version {
+            PreviewMode::Enabled
+        } else {
+            PreviewMode::Disabled
+        }
+    }
+}
+
+impl Display for PreviewMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disabled => write!(f, "disabled"),
+            Self::Enabled => write!(f, "enabled"),
+        }
+    }
+}

--- a/crates/uv-workspace/src/settings.rs
+++ b/crates/uv-workspace/src/settings.rs
@@ -33,6 +33,7 @@ pub(crate) struct Tools {
 pub struct Options {
     pub native_tls: Option<bool>,
     pub no_cache: Option<bool>,
+    pub preview: Option<bool>,
     pub cache_dir: Option<PathBuf>,
     pub pip: Option<PipOptions>,
 }

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -79,6 +79,13 @@ pub(crate) struct GlobalArgs {
 
     #[arg(global = true, long, overrides_with("native_tls"), hide = true)]
     pub(crate) no_native_tls: bool,
+
+    /// Whether to enable experimental, preview features.
+    #[arg(global = true, long, hide = true, env = "UV_PREVIEW", value_parser = clap::builder::BoolishValueParser::new(), overrides_with("no_preview"))]
+    pub(crate) preview: bool,
+
+    #[arg(global = true, long, overrides_with("preview"), hide = true)]
+    pub(crate) no_preview: bool,
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -476,6 +476,9 @@ async fn run() -> Result<ExitStatus> {
             .await
         }
         Commands::Run(args) => {
+            // Resolve the settings from the command-line arguments and workspace configuration.
+            let args = settings::RunSettings::resolve(args, workspace);
+
             let requirements = args
                 .with
                 .into_iter()
@@ -502,6 +505,7 @@ async fn run() -> Result<ExitStatus> {
                 requirements,
                 args.isolated,
                 args.no_workspace,
+                globals.preview,
                 &cache,
                 printer,
             )

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -31,6 +31,12 @@
           "type": "null"
         }
       ]
+    },
+    "preview": {
+      "type": [
+        "boolean",
+        "null"
+      ]
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Adds hidden `--preview` / `--no-preview` flags with `UV_PREVIEW` environment variable support. Copies the `PreviewMode` type from Ruff.

Does a little bit of extra work to port `uv run` to the new settings model.

Note we allow `uv run` invocations without preview and only use its presence to toggle an experimental warning.

## Test plan

```
❯ cargo run -q -- run --no-workspace -- python --version
warning: `uv run` is experimental and may change without warning.
Python 3.12.2
❯ cargo run -q -- run --no-workspace --preview -- python --version
Python 3.12.2
❯ UV_PREVIEW=1 cargo run -q -- run --no-workspace -- python --version
Python 3.12.2
```