### PR TITLE
Use directory instead of file when searching for uv.toml file

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -23,7 +23,7 @@ impl Workspace {
         let root = dir.join("uv");
         let file = root.join("uv.toml");
         Ok(Some(Self {
-            options: find_in_directory(&file)?.unwrap_or_default(),
+            options: read_file(&file).unwrap_or_default(),
             root,
         }))
     }

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -136,7 +136,7 @@ fn find_in_directory(dir: &Path) -> Result<Option<Options>, WorkspaceError> {
     Ok(None)
 }
 
-/// Load [`Options`] from a `pyproject.toml` or `ruff.toml` file.
+/// Load [`Options`] from a `pyproject.toml` or `uv.toml` file.
 fn read_file(path: &Path) -> Result<Options, WorkspaceError> {
     let content = fs_err::read_to_string(path)?;
     if path.ends_with("pyproject.toml") {


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The function `find_in_directory` joins `uv.toml`. The initial join in `user` is redundant.

Also a small comment fix.

## Test Plan

<!-- How was it tested? -->

Not really sure how to test this. Please suggest if any tests need to be added.