### PR TITLE
Revert Docker image publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,24 +92,11 @@ jobs:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
 
-  custom-build-docker:
-    needs:
-      - plan
-    if: ${{ needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' || inputs.tag == 'dry-run' }}
-    uses: ./.github/workflows/build-docker.yml
-    with:
-      plan: ${{ needs.plan.outputs.val }}
-    secrets: inherit
-    permissions:
-      packages: write
-      contents: read
-
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:
     needs:
       - plan
       - custom-build-binaries
-      - custom-build-docker
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,5 +244,3 @@ build-local-artifacts = false
 local-artifacts-jobs = ["./build-binaries"]
 # Publish jobs to run in CI
 publish-jobs = ["./publish-pypi"]
-# We allow modifications for Docker package publish permissions
-allow-dirty = ["ci"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,7 +241,7 @@ dispatch-releases = true
 # Whether CI should include auto-generated code to build local artifacts
 build-local-artifacts = false
 # Local artifacts jobs to run in CI
-local-artifacts-jobs = ["./build-binaries", "./build-docker"]
+local-artifacts-jobs = ["./build-binaries"]
 # Publish jobs to run in CI
 publish-jobs = ["./publish-pypi"]
 # We allow modifications for Docker package publish permissions


### PR DESCRIPTION
This reverts commit 1bf9d879ab2a3302b1b30d8387633157f884d27d from #3155 and ccf4a85f89b9eacbc2a5261bb32059a377349703 from #3195.

This failed again https://github.com/astral-sh/uv/actions/runs/8802514365/job/24158431085 despite #3195 

We need to verify this works again before we add it to the release pipeline — I need to make a release so reverting instead of fixing.
