### PR TITLE
Fix failing `system-test-macos-x86_64` test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
 
   build-binary-macos-x86_64:
     runs-on:
-      labels: macos-latest-large
+      labels: macos-14-large
     name: "build binary | macos x86_64"
     steps:
       - uses: actions/checkout@v4
@@ -589,7 +589,7 @@ jobs:
   system-test-macos-x86_64:
     needs: build-binary-macos-x86_64
     name: "check system | python on macos x86_64"
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

GitHub recently changed `macos-latest` to `macos-12`, so the x86 test started failing. I've migrated the tests to use dedicated labels, rather than the aliases.

See: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/