### PR TITLE
chore: use uv-version in uv-virtualenv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5035,6 +5035,7 @@ dependencies = [
  "uv-cache",
  "uv-fs",
  "uv-interpreter",
+ "uv-version",
 ]
 
 [[package]]

--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -414,7 +414,6 @@ impl SourceBuild {
                 interpreter.clone(),
                 uv_virtualenv::Prompt::None,
                 false,
-                Vec::new(),
             )?,
             BuildIsolation::Shared(venv) => venv.clone(),
         };

--- a/crates/uv-virtualenv/Cargo.toml
+++ b/crates/uv-virtualenv/Cargo.toml
@@ -26,6 +26,7 @@ pypi-types = { workspace = true }
 uv-cache = { workspace = true }
 uv-fs = { workspace = true }
 uv-interpreter = { workspace = true }
+uv-version = { workspace = true }
 
 anstream = { workspace = true }
 cachedir = { workspace = true }

--- a/crates/uv-virtualenv/src/lib.rs
+++ b/crates/uv-virtualenv/src/lib.rs
@@ -18,8 +18,6 @@ pub enum Error {
     InterpreterError(#[from] uv_interpreter::Error),
     #[error(transparent)]
     Platform(#[from] PlatformError),
-    #[error("Reserved key used for pyvenv.cfg: {0}")]
-    ReservedConfigKey(String),
     #[error("Could not find a suitable Python executable for the virtual environment based on the interpreter: {0}")]
     NotFound(String),
 }
@@ -53,16 +51,9 @@ pub fn create_venv(
     interpreter: Interpreter,
     prompt: Prompt,
     system_site_packages: bool,
-    extra_cfg: Vec<(String, String)>,
 ) -> Result<PythonEnvironment, Error> {
     // Create the virtualenv at the given location.
-    let virtualenv = create_bare_venv(
-        location,
-        &interpreter,
-        prompt,
-        system_site_packages,
-        extra_cfg,
-    )?;
+    let virtualenv = create_bare_venv(location, &interpreter, prompt, system_site_packages)?;
 
     // Create the corresponding `PythonEnvironment`.
     let interpreter = interpreter.with_virtualenv(virtualenv);

--- a/crates/uv-virtualenv/src/main.rs
+++ b/crates/uv-virtualenv/src/main.rs
@@ -46,7 +46,6 @@ fn run() -> Result<(), uv_virtualenv::Error> {
         &interpreter,
         Prompt::from_args(cli.prompt),
         cli.system_site_packages,
-        Vec::new(),
     )?;
     Ok(())
 }

--- a/crates/uv/src/commands/run.rs
+++ b/crates/uv/src/commands/run.rs
@@ -233,7 +233,6 @@ async fn environment_for_run(
         python_env.into_interpreter(),
         uv_virtualenv::Prompt::None,
         false,
-        Vec::new(),
     )?;
 
     // Determine the tags, markers, and interpreter to use for resolution.

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -140,13 +140,9 @@ async fn venv_impl(
     )
     .into_diagnostic()?;
 
-    // Extra cfg for pyvenv.cfg to specify uv version
-    let extra_cfg = vec![("uv".to_string(), env!("CARGO_PKG_VERSION").to_string())];
-
     // Create the virtual environment.
-    let venv =
-        uv_virtualenv::create_venv(path, interpreter, prompt, system_site_packages, extra_cfg)
-            .map_err(VenvError::Creation)?;
+    let venv = uv_virtualenv::create_venv(path, interpreter, prompt, system_site_packages)
+        .map_err(VenvError::Creation)?;
 
     // Install seed packages.
     if seed {


### PR DESCRIPTION
## Summary

This is mainly a cleanup PR to leverage uv-version in uv-virtualenv instead of passing it via `uv`.
In #1852 I introduced the ability to pass extra cfg to `gourgeist` for the primary purpose of passing the uv version, but since the dawn of the uv-version crate dynamically passing more values to pyvenv.cfg is no longer needed.

## Test Plan

Existing `uv` tests should still verify `uv = <version>` exists in the venv and make sure no regressions were introduced.
