### PR TITLE
Gave a better name to the `--color` placeholder

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -62,7 +62,7 @@ pub(crate) struct GlobalArgs {
         value_enum,
         default_value = "auto",
         conflicts_with = "no_color",
-	value_name = "COLOR_CHOICE"
+        value_name = "COLOR_CHOICE"
     )]
     pub(crate) color: ColorChoice,
 

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -61,7 +61,8 @@ pub(crate) struct GlobalArgs {
         long,
         value_enum,
         default_value = "auto",
-        conflicts_with = "no_color"
+        conflicts_with = "no_color",
+	value_name = "COLOR_CHOICE"
     )]
     pub(crate) color: ColorChoice,
 


### PR DESCRIPTION
## Summary

The cli gives <COLOR> as value placeholder which is misleading. I changed this to <COLOR_CHOICE> to make it obvious you don't supply a color but a ColorChoice value.

## Test Plan

Compiled and verified --help text was correct
