### PR TITLE
Upgrade macOS target to 12.0

### DIFF
--- a/crates/uv-configuration/src/target_triple.rs
+++ b/crates/uv-configuration/src/target_triple.rs
@@ -66,7 +66,7 @@ impl TargetTriple {
             ),
             Self::Macos | Self::Aarch64AppleDarwin => Platform::new(
                 Os::Macos {
-                    major: 11,
+                    major: 12,
                     minor: 0,
                 },
                 Arch::Aarch64,


### PR DESCRIPTION
## Summary

macOS 11 has been EOL for 7 months, and it seems like it's common to publish ARM-only wheels at 12.0+. I think this is a better default for ARM macs.

Closes https://github.com/astral-sh/uv/issues/3227.

## Test Plan

`cargo run pip install scikit-learn==1.3.2 --python-platform macos --no-build`
