### PR TITLE
Avoid adding extras when expanding constraints

### DIFF
--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -323,13 +323,11 @@ fn compile_constraint_extra() -> Result<()> {
         # via
         #   jinja2
         #   werkzeug
-    python-dotenv==1.0.1
-        # via flask
     werkzeug==3.0.1
         # via flask
 
     ----- stderr -----
-    Resolved 8 packages in [TIME]
+    Resolved 7 packages in [TIME]
     "###
     );
 


### PR DESCRIPTION
## Summary

See the diff in the tests. If you have a constraint with an extra, we should respect it, but we shouldn't _add_ the extra to the requirements.