### PR TITLE
Fix single crate tokio features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ tempfile = { version = "3.9.0" }
 textwrap = { version = "0.16.1" }
 thiserror = { version = "1.0.56" }
 tl = { version = "0.7.7" }
-tokio = { version = "1.35.1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.35.1", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "sync"] }
 tokio-stream = { version = "0.1.14" }
 tokio-tar = { version = "0.3.1" }
 tokio-util = { version = "0.7.10", features = ["compat"] }

--- a/crates/requirements-txt/Cargo.toml
+++ b/crates/requirements-txt/Cargo.toml
@@ -40,4 +40,4 @@ insta = { version = "1.36.1", features = ["filters"] }
 itertools = { version = "0.12.1" }
 tempfile = { version = "3.9.0" }
 test-case = { version = "3.3.1" }
-tokio = { version = "1.35.1", features = ["macros"] }
+tokio = { version = "1.35.1" }

--- a/crates/uv-build/Cargo.toml
+++ b/crates/uv-build/Cargo.toml
@@ -33,7 +33,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync", "process"] }
+tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -40,7 +40,7 @@ sys-info = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tl = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
@@ -51,5 +51,5 @@ anyhow = { workspace = true }
 http-body-util = { version = "0.1.0" }
 hyper = { version = "1.2.0", features = ["server", "http1"] }
 hyper-util = { version = "0.1.3", features = ["tokio"] }
-insta = { version = "1.36.1" , features = ["filters", "json", "redactions"] }
-tokio = { workspace = true, features = ["fs", "macros"] }
+insta = { version = "1.36.1", features = ["filters", "json", "redactions"] }
+tokio = { workspace = true }

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -24,7 +24,7 @@ rayon = { workspace = true }
 rustc-hash = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["io-util"] }
+tokio = { workspace = true }
 tokio-tar = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }
 tracing = { workspace = true }

--- a/crates/uv-installer/Cargo.toml
+++ b/crates/uv-installer/Cargo.toml
@@ -41,7 +41,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["process"] }
+tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -52,7 +52,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 textwrap = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }


### PR DESCRIPTION
Previously, uv-auth would fail to compile due to a missing process feature. I chose to make all tokio features we use top level features, so we can share the tokio cache between all test invocations.