### PR TITLE
Only perform fetches of credentials for a realm once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,6 +4492,7 @@ dependencies = [
  "futures",
  "http",
  "insta",
+ "once-map",
  "once_cell",
  "reqwest",
  "reqwest-middleware",

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -10,11 +10,12 @@ base64 = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 once_cell = { workspace = true }
+once-map = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 rust-netrc = { workspace = true }
-tracing = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
 

--- a/crates/uv-auth/src/cache.rs
+++ b/crates/uv-auth/src/cache.rs
@@ -4,12 +4,15 @@ use std::{collections::HashMap, sync::Mutex};
 use crate::credentials::{Credentials, Username};
 use crate::Realm;
 
+use once_map::OnceMap;
 use tracing::trace;
 use url::Url;
 
 pub struct CredentialsCache {
     /// A cache per realm and username
     realms: Mutex<HashMap<(Realm, Username), Arc<Credentials>>>,
+    /// A cache tracking the result of fetches from external services
+    pub(crate) fetches: OnceMap<(Realm, Username), Option<Arc<Credentials>>>,
     /// A cache per URL, uses a trie for efficient prefix queries.
     urls: Mutex<UrlTrie>,
 }
@@ -25,6 +28,7 @@ impl CredentialsCache {
     pub fn new() -> Self {
         Self {
             realms: Mutex::new(HashMap::new()),
+            fetches: OnceMap::default(),
             urls: Mutex::new(UrlTrie::new()),
         }
     }


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/3205

Tested with

`RUST_LOG=uv=trace cargo run -- pip install -r scripts/requirements/trio.in --index-url https://oauth2accesstoken@us-central1-python.pkg.dev/zb-test-project-421213/pypyi/simple/ --no-cache --keyring-provider subprocess -vv --reinstall 2>&1 | grep keyring`

On `main` you can see a dozen keyring attempts at once. Here, the other requests wait for the first attempt and only a single keyring call is performed.