### PR TITLE
uv-toolchain: use colocated temporary directory

### DIFF
--- a/crates/uv-toolchain/src/downloads.rs
+++ b/crates/uv-toolchain/src/downloads.rs
@@ -217,10 +217,10 @@ impl PythonDownload {
     pub async fn fetch(
         &self,
         client: &uv_client::BaseClient,
-        path: &Path,
+        parent_path: &Path,
     ) -> Result<DownloadResult, Error> {
         let url = Url::parse(self.url)?;
-        let path = path.join(self.key).clone();
+        let path = parent_path.join(self.key).clone();
 
         // If it already exists, return it
         if path.is_dir() {
@@ -234,7 +234,7 @@ impl PythonDownload {
         response.error_for_status_ref()?;
 
         // Download and extract into a temporary directory.
-        let temp_dir = tempfile::tempdir().map_err(Error::DownloadDirError)?;
+        let temp_dir = tempfile::tempdir_in(parent_path).map_err(Error::DownloadDirError)?;
 
         debug!(
             "Downloading {url} to temporary location {}",


### PR DESCRIPTION
Previously, this would use the "system" temporary directory.
Because we rename the resulting directory to its final destination,
and because renaming is implemented via hardlinking, and because
hardlinking doesn't work across mount points, and because /tmp is
commonly on a different mount point than where `uv` is checked out,
we "fix" this by putting the temporary directory somewhere close to
the final destination of the fetched artifact.

There are alternatives we might consider pursuing. For example,
if the `rename` fails, then we should probably do a recursive
directory copy. But this is a quick fix for now and it also
consistent with colocation of other temporary directories in `uv`.

The main downside of this change is that if a user does ^C while
`uv-dev fetch-python` is running, then there is no mechanism for
cleaning up temporary directories.
