### PR TITLE
Update BUILD_VENDOR_LINKS_URL from packse version

### DIFF
--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -25,7 +25,7 @@ pub static EXCLUDE_NEWER: &str = "2024-03-25T00:00:00Z";
 /// Using a find links url allows using `--index-url` instead of `--extra-index-url` in tests
 /// to prevent dependency confusion attacks against our test suite.
 pub const BUILD_VENDOR_LINKS_URL: &str =
-    "https://raw.githubusercontent.com/astral-sh/packse/0.3.14/vendor/links.html";
+    "https://raw.githubusercontent.com/astral-sh/packse/0.3.15/vendor/links.html";
 
 #[doc(hidden)] // Macro and test context only, don't use directly.
 pub const INSTA_FILTERS: &[(&str, &str)] = &[


### PR DESCRIPTION
Make `generate.py` update the packse version used in `BUILD_VENDOR_LINKS_URL`.

Closes #3245