### PR TITLE
Warn when an unsupported Python version is encountered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4862,6 +4862,7 @@ dependencies = [
  "uv-cache",
  "uv-fs",
  "uv-toolchain",
+ "uv-warnings",
  "which",
  "winapi",
 ]

--- a/crates/uv-interpreter/Cargo.toml
+++ b/crates/uv-interpreter/Cargo.toml
@@ -22,6 +22,7 @@ pypi-types = { workspace = true }
 uv-cache = { workspace = true }
 uv-fs = { workspace = true }
 uv-toolchain = { workspace = true }
+uv-warnings = { workspace = true }
 
 configparser = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -24,6 +24,7 @@ use uv_fs::Simplified;
 use uv_interpreter::{find_default_python, find_requested_python, Error};
 use uv_resolver::{ExcludeNewer, FlatIndex, InMemoryIndex, OptionsBuilder};
 use uv_types::{BuildContext, BuildIsolation, HashStrategy, InFlight};
+use uv_warnings::warn_user;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -119,6 +120,14 @@ async fn venv_impl(
     } else {
         find_default_python(cache).into_diagnostic()?
     };
+
+    // Warn on usage with an unsupported Python version
+    if interpreter.python_tuple() < (3, 8) {
+        warn_user!(
+            "uv is only compatible with Python 3.8+, found Python {}.",
+            interpreter.python_version()
+        );
+    }
 
     // Add all authenticated sources to the cache.
     for url in index_locations.urls() {

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -24,7 +24,6 @@ use uv_fs::Simplified;
 use uv_interpreter::{find_default_python, find_requested_python, Error};
 use uv_resolver::{ExcludeNewer, FlatIndex, InMemoryIndex, OptionsBuilder};
 use uv_types::{BuildContext, BuildIsolation, HashStrategy, InFlight};
-use uv_warnings::warn_user;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -120,14 +119,6 @@ async fn venv_impl(
     } else {
         find_default_python(cache).into_diagnostic()?
     };
-
-    // Warn on usage with an unsupported Python version
-    if interpreter.python_tuple() < (3, 8) {
-        warn_user!(
-            "uv is only compatible with Python 3.8+, found Python {}.",
-            interpreter.python_version()
-        );
-    }
 
     // Add all authenticated sources to the cache.
     for url in index_locations.urls() {

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -913,6 +913,7 @@ fn compile_python_37() -> Result<()> {
             "warning: The requested Python version 3.7 is not available; .* will be used to build dependencies instead.\n",
             "",
         ),
+        (r"warning: uv is only compatible with Python 3\.8\+, found Python 3\.7.*\n", "")
     ]
         .into_iter()
         .chain(context.filters())


### PR DESCRIPTION
I rebased https://github.com/astral-sh/uv/pull/2757 then realized that we want to implement this for more than `uv venv`.

Closes https://github.com/astral-sh/uv/issues/2587
Closes https://github.com/astral-sh/uv/issues/2757

```
❯ cargo run -q -- pip install -p /Users/mz/bin/python3.7 anyio
warning: uv is only compatible with Python 3.8+, found Python 3.7.17.
Audited 1 package in 84ms

❯ cargo run -q -- venv -p /Users/mz/bin/python3.7
warning: uv is only compatible with Python 3.8+, found Python 3.7.17.
Using Python 3.7.17 interpreter at: /Users/mz/bin/python3.7
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
```