### PR TITLE
Rename `distribution_types::VersionOrUrl` to `VersionOrUrlRef`

### DIFF
--- a/crates/distribution-types/src/cached.rs
+++ b/crates/distribution-types/src/cached.rs
@@ -9,7 +9,7 @@ use uv_normalize::PackageName;
 
 use crate::{
     BuiltDist, Dist, DistributionMetadata, Hashed, InstalledMetadata, InstalledVersion, Name,
-    ParsedLocalFileUrl, ParsedUrl, SourceDist, VersionOrUrl,
+    ParsedLocalFileUrl, ParsedUrl, SourceDist, VersionOrUrlRef,
 };
 
 /// A built distribution (wheel) that exists in the local cache.
@@ -187,19 +187,19 @@ impl Name for CachedDist {
 }
 
 impl DistributionMetadata for CachedRegistryDist {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Version(&self.filename.version)
+    fn version_or_url(&self) -> VersionOrUrlRef {
+        VersionOrUrlRef::Version(&self.filename.version)
     }
 }
 
 impl DistributionMetadata for CachedDirectUrlDist {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Url(&self.url)
+    fn version_or_url(&self) -> VersionOrUrlRef {
+        VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for CachedDist {
-    fn version_or_url(&self) -> VersionOrUrl {
+    fn version_or_url(&self) -> VersionOrUrlRef {
         match self {
             Self::Registry(dist) => dist.version_or_url(),
             Self::Url(dist) => dist.version_or_url(),

--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -11,7 +11,7 @@ use pypi_types::DirectUrl;
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
 
-use crate::{DistributionMetadata, InstalledMetadata, InstalledVersion, Name, VersionOrUrl};
+use crate::{DistributionMetadata, InstalledMetadata, InstalledVersion, Name, VersionOrUrlRef};
 
 /// A built distribution (wheel) that is installed in a virtual environment.
 #[derive(Debug, Clone)]
@@ -150,8 +150,8 @@ impl InstalledDist {
 }
 
 impl DistributionMetadata for InstalledDist {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Version(self.version())
+    fn version_or_url(&self) -> VersionOrUrlRef {
+        VersionOrUrlRef::Version(self.version())
     }
 }
 

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -81,27 +81,27 @@ mod specified_requirement;
 mod traits;
 
 #[derive(Debug, Clone)]
-pub enum VersionOrUrl<'a> {
+pub enum VersionOrUrlRef<'a> {
     /// A PEP 440 version specifier, used to identify a distribution in a registry.
     Version(&'a Version),
     /// A URL, used to identify a distribution at an arbitrary location.
     Url(&'a VerbatimUrl),
 }
 
-impl Verbatim for VersionOrUrl<'_> {
+impl Verbatim for VersionOrUrlRef<'_> {
     fn verbatim(&self) -> Cow<'_, str> {
         match self {
-            VersionOrUrl::Version(version) => Cow::Owned(format!("=={version}")),
-            VersionOrUrl::Url(url) => Cow::Owned(format!(" @ {}", url.verbatim())),
+            VersionOrUrlRef::Version(version) => Cow::Owned(format!("=={version}")),
+            VersionOrUrlRef::Url(url) => Cow::Owned(format!(" @ {}", url.verbatim())),
         }
     }
 }
 
-impl std::fmt::Display for VersionOrUrl<'_> {
+impl std::fmt::Display for VersionOrUrlRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            VersionOrUrl::Version(version) => write!(f, "=={version}"),
-            VersionOrUrl::Url(url) => write!(f, " @ {url}"),
+            VersionOrUrlRef::Version(version) => write!(f, "=={version}"),
+            VersionOrUrlRef::Url(url) => write!(f, " @ {url}"),
         }
     }
 }
@@ -572,49 +572,49 @@ impl Name for Dist {
 }
 
 impl DistributionMetadata for RegistryBuiltDist {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Version(&self.filename.version)
+    fn version_or_url(&self) -> VersionOrUrlRef {
+        VersionOrUrlRef::Version(&self.filename.version)
     }
 }
 
 impl DistributionMetadata for DirectUrlBuiltDist {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Url(&self.url)
+    fn version_or_url(&self) -> VersionOrUrlRef {
+        VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for PathBuiltDist {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Url(&self.url)
+    fn version_or_url(&self) -> VersionOrUrlRef {
+        VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for RegistrySourceDist {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Version(&self.filename.version)
+    fn version_or_url(&self) -> VersionOrUrlRef {
+        VersionOrUrlRef::Version(&self.filename.version)
     }
 }
 
 impl DistributionMetadata for DirectUrlSourceDist {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Url(&self.url)
+    fn version_or_url(&self) -> VersionOrUrlRef {
+        VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for GitSourceDist {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Url(&self.url)
+    fn version_or_url(&self) -> VersionOrUrlRef {
+        VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for PathSourceDist {
-    fn version_or_url(&self) -> VersionOrUrl {
-        VersionOrUrl::Url(&self.url)
+    fn version_or_url(&self) -> VersionOrUrlRef {
+        VersionOrUrlRef::Url(&self.url)
     }
 }
 
 impl DistributionMetadata for SourceDist {
-    fn version_or_url(&self) -> VersionOrUrl {
+    fn version_or_url(&self) -> VersionOrUrlRef {
         match self {
             Self::Registry(dist) => dist.version_or_url(),
             Self::DirectUrl(dist) => dist.version_or_url(),
@@ -625,7 +625,7 @@ impl DistributionMetadata for SourceDist {
 }
 
 impl DistributionMetadata for BuiltDist {
-    fn version_or_url(&self) -> VersionOrUrl {
+    fn version_or_url(&self) -> VersionOrUrlRef {
         match self {
             Self::Registry(dist) => dist.version_or_url(),
             Self::DirectUrl(dist) => dist.version_or_url(),
@@ -635,7 +635,7 @@ impl DistributionMetadata for BuiltDist {
 }
 
 impl DistributionMetadata for Dist {
-    fn version_or_url(&self) -> VersionOrUrl {
+    fn version_or_url(&self) -> VersionOrUrlRef {
         match self {
             Self::Built(dist) => dist.version_or_url(),
             Self::Source(dist) => dist.version_or_url(),

--- a/crates/distribution-types/src/resolved.rs
+++ b/crates/distribution-types/src/resolved.rs
@@ -4,7 +4,7 @@ use pep508_rs::PackageName;
 
 use crate::{
     Dist, DistributionId, DistributionMetadata, Identifier, IndexUrl, InstalledDist, Name,
-    ResourceId, VersionOrUrl,
+    ResourceId, VersionOrUrlRef,
 };
 
 /// A distribution that can be used for resolution and installation.
@@ -69,9 +69,9 @@ impl Name for ResolvedDistRef<'_> {
 }
 
 impl DistributionMetadata for ResolvedDistRef<'_> {
-    fn version_or_url(&self) -> VersionOrUrl {
+    fn version_or_url(&self) -> VersionOrUrlRef {
         match self {
-            Self::Installed(installed) => VersionOrUrl::Version(installed.version()),
+            Self::Installed(installed) => VersionOrUrlRef::Version(installed.version()),
             Self::Installable(dist) => dist.version_or_url(),
         }
     }
@@ -103,7 +103,7 @@ impl Name for ResolvedDist {
 }
 
 impl DistributionMetadata for ResolvedDist {
-    fn version_or_url(&self) -> VersionOrUrl {
+    fn version_or_url(&self) -> VersionOrUrlRef {
         match self {
             Self::Installed(installed) => installed.version_or_url(),
             Self::Installable(dist) => dist.version_or_url(),

--- a/crates/distribution-types/src/traits.rs
+++ b/crates/distribution-types/src/traits.rs
@@ -11,7 +11,7 @@ use crate::{
     DirectUrlSourceDist, Dist, DistributionId, GitSourceDist, InstalledDirectUrlDist,
     InstalledDist, InstalledRegistryDist, InstalledVersion, LocalDist, PackageId, PathBuiltDist,
     PathSourceDist, RegistryBuiltDist, RegistrySourceDist, ResourceId, SourceDist, VersionId,
-    VersionOrUrl,
+    VersionOrUrlRef,
 };
 
 pub trait Name {
@@ -24,7 +24,7 @@ pub trait Name {
 pub trait DistributionMetadata: Name {
     /// Return a [`pep440_rs::Version`], for registry-based distributions, or a [`url::Url`],
     /// for URL-based distributions.
-    fn version_or_url(&self) -> VersionOrUrl;
+    fn version_or_url(&self) -> VersionOrUrlRef;
 
     /// Returns a unique identifier for the package at the given version (e.g., `black==23.10.0`).
     ///
@@ -33,10 +33,10 @@ pub trait DistributionMetadata: Name {
     /// will return the same version ID, but different distribution IDs.
     fn version_id(&self) -> VersionId {
         match self.version_or_url() {
-            VersionOrUrl::Version(version) => {
+            VersionOrUrlRef::Version(version) => {
                 VersionId::from_registry(self.name().clone(), version.clone())
             }
-            VersionOrUrl::Url(url) => VersionId::from_url(url),
+            VersionOrUrlRef::Url(url) => VersionId::from_url(url),
         }
     }
 
@@ -48,8 +48,8 @@ pub trait DistributionMetadata: Name {
     /// will return the same version ID, but different distribution IDs.
     fn package_id(&self) -> PackageId {
         match self.version_or_url() {
-            VersionOrUrl::Version(_) => PackageId::from_registry(self.name().clone()),
-            VersionOrUrl::Url(url) => PackageId::from_url(url),
+            VersionOrUrlRef::Version(_) => PackageId::from_registry(self.name().clone()),
+            VersionOrUrlRef::Url(url) => PackageId::from_url(url),
         }
     }
 }

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -469,7 +469,7 @@ impl Name for Candidate<'_> {
 }
 
 impl DistributionMetadata for Candidate<'_> {
-    fn version_or_url(&self) -> distribution_types::VersionOrUrl {
-        distribution_types::VersionOrUrl::Version(self.version)
+    fn version_or_url(&self) -> distribution_types::VersionOrUrlRef {
+        distribution_types::VersionOrUrlRef::Version(self.version)
     }
 }

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -8,7 +8,7 @@ use distribution_filename::WheelFilename;
 use distribution_types::{
     BuiltDist, DirectUrlBuiltDist, DirectUrlSourceDist, Dist, DistributionMetadata, FileLocation,
     GitSourceDist, IndexUrl, Name, PathBuiltDist, PathSourceDist, RegistryBuiltDist,
-    RegistrySourceDist, Resolution, ResolvedDist, ToUrlError, VersionOrUrl,
+    RegistrySourceDist, Resolution, ResolvedDist, ToUrlError, VersionOrUrlRef,
 };
 use pep440_rs::Version;
 use pep508_rs::{MarkerEnvironment, VerbatimUrl};
@@ -279,11 +279,11 @@ impl DistributionId {
     fn from_resolved_dist(resolved_dist: &ResolvedDist) -> DistributionId {
         let name = resolved_dist.name().clone();
         let version = match resolved_dist.version_or_url() {
-            VersionOrUrl::Version(v) => v.clone(),
+            VersionOrUrlRef::Version(v) => v.clone(),
             // TODO: We need a way to thread the version number for these
             // cases down into this routine. The version number isn't yet in a
             // `ResolutionGraph`, so this will require a bit of refactoring.
-            VersionOrUrl::Url(_) => todo!(),
+            VersionOrUrlRef::Url(_) => todo!(),
         };
         let source = Source::from_resolved_dist(resolved_dist);
         DistributionId {

--- a/crates/uv-resolver/src/pubgrub/distribution.rs
+++ b/crates/uv-resolver/src/pubgrub/distribution.rs
@@ -1,4 +1,4 @@
-use distribution_types::{DistributionMetadata, Name, VersionOrUrl};
+use distribution_types::{DistributionMetadata, Name, VersionOrUrlRef};
 use pep440_rs::Version;
 use pep508_rs::VerbatimUrl;
 use uv_normalize::PackageName;
@@ -29,10 +29,10 @@ impl Name for PubGrubDistribution<'_> {
 }
 
 impl DistributionMetadata for PubGrubDistribution<'_> {
-    fn version_or_url(&self) -> VersionOrUrl {
+    fn version_or_url(&self) -> VersionOrUrlRef {
         match self {
-            Self::Registry(_, version) => VersionOrUrl::Version(version),
-            Self::Url(_, url) => VersionOrUrl::Url(url),
+            Self::Registry(_, version) => VersionOrUrlRef::Version(version),
+            Self::Url(_, url) => VersionOrUrlRef::Url(url),
         }
     }
 }

--- a/crates/uv-resolver/src/resolution.rs
+++ b/crates/uv-resolver/src/resolution.rs
@@ -14,7 +14,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use distribution_types::{
     Dist, DistributionMetadata, IndexUrl, LocalEditable, Name, ParsedUrlError, Requirement,
-    ResolvedDist, Verbatim, VersionId, VersionOrUrl,
+    ResolvedDist, Verbatim, VersionId, VersionOrUrlRef,
 };
 use once_map::OnceMap;
 use pep440_rs::Version;
@@ -436,10 +436,10 @@ impl ResolutionGraph {
         for i in self.petgraph.node_indices() {
             let dist = &self.petgraph[i];
             let version_id = match dist.version_or_url() {
-                VersionOrUrl::Version(version) => {
+                VersionOrUrlRef::Version(version) => {
                     VersionId::from_registry(dist.name().clone(), version.clone())
                 }
-                VersionOrUrl::Url(verbatim_url) => VersionId::from_url(verbatim_url.raw()),
+                VersionOrUrlRef::Url(verbatim_url) => VersionId::from_url(verbatim_url.raw()),
             };
             let res = index
                 .distributions

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -19,7 +19,7 @@ use tracing::{debug, enabled, info_span, instrument, trace, warn, Instrument, Le
 use distribution_types::{
     BuiltDist, Dist, DistributionMetadata, IncompatibleDist, IncompatibleSource, IncompatibleWheel,
     InstalledDist, RemoteSource, Requirement, ResolvedDist, ResolvedDistRef, SourceDist,
-    VersionOrUrl,
+    VersionOrUrlRef,
 };
 pub(crate) use locals::Locals;
 use pep440_rs::{Version, MIN_VERSION};
@@ -1260,10 +1260,10 @@ impl<
                 PubGrubPackage::Python(_) => {}
                 PubGrubPackage::Extra(_, _, _) => {}
                 PubGrubPackage::Package(package_name, _extra, Some(url)) => {
-                    reporter.on_progress(package_name, &VersionOrUrl::Url(url));
+                    reporter.on_progress(package_name, &VersionOrUrlRef::Url(url));
                 }
                 PubGrubPackage::Package(package_name, _extra, None) => {
-                    reporter.on_progress(package_name, &VersionOrUrl::Version(version));
+                    reporter.on_progress(package_name, &VersionOrUrlRef::Version(version));
                 }
             }
         }

--- a/crates/uv-resolver/src/resolver/reporter.rs
+++ b/crates/uv-resolver/src/resolver/reporter.rs
@@ -2,14 +2,14 @@ use std::sync::Arc;
 
 use url::Url;
 
-use distribution_types::{BuildableSource, VersionOrUrl};
+use distribution_types::{BuildableSource, VersionOrUrlRef};
 use uv_normalize::PackageName;
 
 pub type BuildId = usize;
 
 pub trait Reporter: Send + Sync {
     /// Callback to invoke when a dependency is resolved.
-    fn on_progress(&self, name: &PackageName, version: &VersionOrUrl);
+    fn on_progress(&self, name: &PackageName, version: &VersionOrUrlRef);
 
     /// Callback to invoke when the resolution is complete.
     fn on_complete(&self);

--- a/crates/uv/src/commands/reporters.rs
+++ b/crates/uv/src/commands/reporters.rs
@@ -7,7 +7,7 @@ use url::Url;
 
 use distribution_types::{
     BuildableSource, CachedDist, DistributionMetadata, LocalEditable, Name, SourceDist,
-    VersionOrUrl,
+    VersionOrUrlRef,
 };
 use uv_normalize::PackageName;
 
@@ -200,12 +200,12 @@ impl ResolverReporter {
         self
     }
 
-    fn on_progress(&self, name: &PackageName, version_or_url: &VersionOrUrl) {
+    fn on_progress(&self, name: &PackageName, version_or_url: &VersionOrUrlRef) {
         match version_or_url {
-            VersionOrUrl::Version(version) => {
+            VersionOrUrlRef::Version(version) => {
                 self.progress.set_message(format!("{name}=={version}"));
             }
-            VersionOrUrl::Url(url) => {
+            VersionOrUrlRef::Url(url) => {
                 self.progress.set_message(format!("{name} @ {url}"));
             }
         }
@@ -276,7 +276,7 @@ impl ResolverReporter {
 }
 
 impl uv_resolver::ResolverReporter for ResolverReporter {
-    fn on_progress(&self, name: &PackageName, version_or_url: &VersionOrUrl) {
+    fn on_progress(&self, name: &PackageName, version_or_url: &VersionOrUrlRef) {
         self.on_progress(name, version_or_url);
     }
 


### PR DESCRIPTION
This is more consistent with the other `*Ref` types and reduces confusion with the real `VersionOrUrl` type.