### PR TITLE
Allow all arguments to be repeated in the CLI

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -20,7 +20,7 @@ use crate::compat;
 
 #[derive(Parser)]
 #[command(author, version, long_version = crate::version::version(), about)]
-#[command(propagate_version = true)]
+#[command(propagate_version = true, args_override_self = true)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary

We need to decide if we actually want to change this, but I wanted to test it out anyway.

Closes https://github.com/astral-sh/uv/issues/3248.

## Test Plan

Ran `echo "flask" | cargo run pip compile - --output-file req.txt --output-file foo.txt`, and verified that `foo.txt` was populated.
