### PR TITLE
Use `macos-12` to build release wheels

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -63,7 +63,7 @@ jobs:
 
   macos-x86_64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
         with:
@@ -104,7 +104,7 @@ jobs:
 
   macos-universal:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

GitHub has started to change `macos-latest` to `macos-14`. But executables built on `macos-14` don't work on macOS 11 (see: https://github.com/astral-sh/uv/issues/3261). This PR explicitly uses `macos-12` instead (which is what we _intended_ to be using anyway).

Closes https://github.com/astral-sh/uv/issues/3261.
