### PR TITLE
fix platform_machine for macos arm

### DIFF
--- a/crates/uv-configuration/src/target_triple.rs
+++ b/crates/uv-configuration/src/target_triple.rs
@@ -143,7 +143,7 @@ impl TargetTriple {
         match self {
             Self::Windows | Self::X8664PcWindowsMsvc => "x86_64",
             Self::Linux | Self::X8664UnknownLinuxGnu => "x86_64",
-            Self::Macos | Self::Aarch64AppleDarwin => "aarch64",
+            Self::Macos | Self::Aarch64AppleDarwin => "arm64",
             Self::X8664AppleDarwin => "x86_64",
             Self::Aarch64UnknownLinuxGnu => "aarch64",
             Self::Aarch64UnknownLinuxMusl => "aarch64",


### PR DESCRIPTION
## Summary

based on PEP 508 the `platform_machine` should be same as `platform.machine()` output: https://peps.python.org/pep-0508/#environment-markers

From my macOS M2 

```python
In [1]: import platform

In [2]: platform.machine()
Out[2]: 'arm64'
```

I napari we also use `arm64` in requirements and it works as expected: 
https://github.com/napari/napari/blob/9fcf63e69ac61b5dff0259c8618f828cc5169a9c/pyproject.toml#L120 

## Test Plan

<!-- How was it tested? -->
