### PR TITLE
Use preview mode for tool.uv.sources

### DIFF
--- a/crates/uv/src/commands/pip_compile.rs
+++ b/crates/uv/src/commands/pip_compile.rs
@@ -26,8 +26,8 @@ use uv_auth::store_credentials_from_url;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
-    ConfigSettings, Constraints, IndexStrategy, NoBinary, NoBuild, Overrides, SetupPyStrategy,
-    Upgrade,
+    ConfigSettings, Constraints, IndexStrategy, NoBinary, NoBuild, Overrides, PreviewMode,
+    SetupPyStrategy, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::BuildDispatch;
@@ -92,6 +92,7 @@ pub(crate) async fn pip_compile(
     uv_lock: bool,
     native_tls: bool,
     quiet: bool,
+    preview: PreviewMode,
     cache: Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -131,6 +132,7 @@ pub(crate) async fn pip_compile(
         overrides,
         &extras,
         &client_builder,
+        preview,
     )
     .await?;
 

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -28,8 +28,8 @@ use uv_client::{
     BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClient, RegistryClientBuilder,
 };
 use uv_configuration::{
-    ConfigSettings, Constraints, IndexStrategy, NoBinary, NoBuild, Overrides, Reinstall,
-    SetupPyStrategy, Upgrade,
+    ConfigSettings, Constraints, IndexStrategy, NoBinary, NoBuild, Overrides, PreviewMode,
+    Reinstall, SetupPyStrategy, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::BuildDispatch;
@@ -90,6 +90,7 @@ pub(crate) async fn pip_install(
     target: Option<Target>,
     uv_lock: Option<String>,
     native_tls: bool,
+    preview: PreviewMode,
     cache: Cache,
     dry_run: bool,
     printer: Printer,
@@ -122,6 +123,7 @@ pub(crate) async fn pip_install(
         overrides,
         extras,
         &client_builder,
+        preview,
     )
     .await?;
 
@@ -508,6 +510,7 @@ async fn read_requirements(
     overrides: &[RequirementsSource],
     extras: &ExtrasSpecification,
     client_builder: &BaseClientBuilder<'_>,
+    preview: PreviewMode,
 ) -> Result<RequirementsSpecification, Error> {
     // If the user requests `extras` but does not provide a valid source (e.g., a `pyproject.toml`),
     // return an error.
@@ -525,6 +528,7 @@ async fn read_requirements(
         overrides,
         extras,
         client_builder,
+        preview,
     )
     .await?;
 

--- a/crates/uv/src/commands/pip_sync.rs
+++ b/crates/uv/src/commands/pip_sync.rs
@@ -20,7 +20,7 @@ use uv_client::{
     BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClient, RegistryClientBuilder,
 };
 use uv_configuration::{
-    ConfigSettings, IndexStrategy, NoBinary, NoBuild, Reinstall, SetupPyStrategy,
+    ConfigSettings, IndexStrategy, NoBinary, NoBuild, PreviewMode, Reinstall, SetupPyStrategy,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::BuildDispatch;
@@ -64,6 +64,7 @@ pub(crate) async fn pip_sync(
     break_system_packages: bool,
     target: Option<Target>,
     native_tls: bool,
+    preview: PreviewMode,
     cache: Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -89,7 +90,7 @@ pub(crate) async fn pip_sync(
         find_links,
         no_binary: specified_no_binary,
         no_build: specified_no_build,
-    } = RequirementsSpecification::from_simple_sources(sources, &client_builder).await?;
+    } = RequirementsSpecification::from_simple_sources(sources, &client_builder, preview).await?;
 
     // Validate that the requirements are non-empty.
     let num_requirements = requirements.len() + source_trees.len() + editables.len();

--- a/crates/uv/src/commands/pip_uninstall.rs
+++ b/crates/uv/src/commands/pip_uninstall.rs
@@ -9,7 +9,7 @@ use distribution_types::{InstalledMetadata, Name, Requirement, UnresolvedRequire
 use pep508_rs::UnnamedRequirement;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity};
-use uv_configuration::KeyringProviderType;
+use uv_configuration::{KeyringProviderType, PreviewMode};
 use uv_fs::Simplified;
 use uv_interpreter::{PythonEnvironment, Target};
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
@@ -28,6 +28,7 @@ pub(crate) async fn pip_uninstall(
     cache: Cache,
     connectivity: Connectivity,
     native_tls: bool,
+    preview: PreviewMode,
     keyring_provider: KeyringProviderType,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -38,7 +39,8 @@ pub(crate) async fn pip_uninstall(
         .keyring(keyring_provider);
 
     // Read all requirements from the provided sources.
-    let spec = RequirementsSpecification::from_simple_sources(sources, &client_builder).await?;
+    let spec =
+        RequirementsSpecification::from_simple_sources(sources, &client_builder, preview).await?;
 
     // Detect the current Python interpreter.
     let venv = if let Some(python) = python.as_ref() {

--- a/crates/uv/src/commands/run.rs
+++ b/crates/uv/src/commands/run.rs
@@ -94,6 +94,7 @@ pub(crate) async fn run(
         &overrides,
         python.as_deref(),
         isolated,
+        preview,
         cache,
         printer,
     )
@@ -177,6 +178,7 @@ async fn environment_for_run(
     overrides: &[RequirementsSource],
     python: Option<&str>,
     isolated: bool,
+    preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<RunEnvironment> {
@@ -203,6 +205,7 @@ async fn environment_for_run(
         overrides,
         &ExtrasSpecification::None,
         &client_builder,
+        preview,
     )
     .await?;
 

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -232,6 +232,7 @@ async fn run() -> Result<ExitStatus> {
                 args.uv_lock,
                 globals.native_tls,
                 globals.quiet,
+                globals.preview,
                 cache,
                 printer,
             )
@@ -275,6 +276,7 @@ async fn run() -> Result<ExitStatus> {
                 args.shared.break_system_packages,
                 args.shared.target,
                 globals.native_tls,
+                globals.preview,
                 cache,
                 printer,
             )
@@ -341,6 +343,7 @@ async fn run() -> Result<ExitStatus> {
                 args.shared.target,
                 args.uv_lock,
                 globals.native_tls,
+                globals.preview,
                 cache,
                 args.dry_run,
                 printer,
@@ -372,6 +375,7 @@ async fn run() -> Result<ExitStatus> {
                 cache,
                 args.shared.connectivity,
                 globals.native_tls,
+                globals.preview,
                 args.shared.keyring_provider,
                 printer,
             )


### PR DESCRIPTION
Only allow using `tool.uv.sources` with preview mode, the design isn't finalized yet.

Not sure what to label this, do we want a preview section and label for the release notes?