### PR TITLE
Add apache airflow test case

### DIFF
--- a/scripts/requirements/airflow.in
+++ b/scripts/requirements/airflow.in
@@ -1,0 +1,2 @@
+apache-airflow[all]
+apache-airflow-providers-apache-beam>3.0.0


### PR DESCRIPTION
I like using airflow as a complex resolution test case. The second requirement is the missing bound to enforce a successful resolution.