### PR TITLE
Add a `--isolated` mode to ignore on-disk configuration

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -33,8 +33,13 @@ pub(crate) struct Cli {
     pub(crate) cache_args: CacheArgs,
 
     /// The path to a `pyproject.toml` or `uv.toml` file to use for configuration.
-    #[arg(long, short, env = "UV_CONFIG_FILE", hide = true)]
+    #[arg(long, env = "UV_CONFIG_FILE", hide = true)]
     pub(crate) config_file: Option<PathBuf>,
+
+    /// Avoid discovering a `pyproject.toml` or `uv.toml` file in the current directory or any
+    /// parent directories.
+    #[arg(long, hide = true)]
+    pub(crate) isolated: bool,
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -112,6 +112,8 @@ async fn run() -> Result<ExitStatus> {
     // 3. The user configuration file.
     let workspace = if let Some(config_file) = cli.config_file.as_ref() {
         Some(uv_workspace::Workspace::from_file(config_file)?)
+    } else if cli.isolated {
+        None
     } else if let Some(workspace) = uv_workspace::Workspace::find(env::current_dir()?)? {
         Some(workspace)
     } else {


### PR DESCRIPTION
## Summary

We have the same thing in Ruff. Really useful.