### PR TITLE
Ignore 401 errors with multiple indexes

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -221,7 +221,7 @@ impl RegistryClient {
     ) -> Result<Vec<(IndexUrl, OwnedArchive<SimpleMetadata>)>, Error> {
         let mut it = self.index_urls.indexes().peekable();
         if it.peek().is_none() {
-            return Err(ErrorKind::NoIndex(package_name.as_ref().to_string()).into());
+            return Err(ErrorKind::NoIndex(package_name.to_string()).into());
         }
 
         let mut results = Vec::new();
@@ -239,6 +239,7 @@ impl RegistryClient {
                     ErrorKind::Offline(_) => continue,
                     ErrorKind::ReqwestError(err) => {
                         if err.status() == Some(StatusCode::NOT_FOUND)
+                            || err.status() == Some(StatusCode::UNAUTHORIZED)
                             || err.status() == Some(StatusCode::FORBIDDEN)
                         {
                             continue;


### PR DESCRIPTION
## Summary

It seems like Azure might return a 401 when you request a package that doesn't exist (even with valid credentials)? But I admittedly haven't tested this. (We already skip 403, and this seems similar?)

Closes https://github.com/astral-sh/uv/issues/3291.
