### PR TITLE
Fix span recording with install_wheel_rs

### DIFF
--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -31,7 +31,7 @@ use crate::{Error, Layout};
 /// <https://packaging.python.org/en/latest/specifications/binary-distribution-format/#installing-a-wheel-distribution-1-0-py32-none-any-whl>
 ///
 /// Wheel 1.0: <https://www.python.org/dev/peps/pep-0427/>
-#[instrument(skip_all, fields(wheel = % wheel.as_ref().display()))]
+#[instrument(skip_all, fields(wheel = %filename))]
 pub fn install_wheel(
     layout: &Layout,
     wheel: impl AsRef<Path>,

--- a/crates/uv/src/logging.rs
+++ b/crates/uv/src/logging.rs
@@ -1,7 +1,7 @@
-use anstream::ColorChoice;
 use std::fmt;
 use std::str::FromStr;
 
+use anstream::ColorChoice;
 use anyhow::Context;
 use chrono::Utc;
 use owo_colors::OwoColorize;
@@ -128,11 +128,10 @@ pub(crate) fn setup_logging(
     };
 
     // Only record our own spans.
-    let durations_layer =
-        durations.with_filter(tracing_subscriber::filter::Targets::new().with_target(
-            env!("CARGO_PKG_NAME"),
-            tracing::level_filters::LevelFilter::INFO,
-        ));
+    let durations_layer = durations.with_filter(
+        tracing_subscriber::filter::Targets::new()
+            .with_target("", tracing::level_filters::LevelFilter::INFO),
+    );
 
     let filter = EnvFilter::builder()
         .with_default_directive(default_directive)


### PR DESCRIPTION
We would only record spans for `uv` prefixed crates, while the rayon operations are in `install_wheel_rs`, therefore "disappearing" spans from rayon.

With these changes, we can profile the parallel installation:

![jupyter](https://github.com/astral-sh/uv/assets/6826232/bb3c626a-ba9a-443d-9727-ac1e3bf14a71)
