### PR TITLE
Use fs_err for cachedir errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4540,7 +4540,6 @@ name = "uv-cache"
 version = "0.0.1"
 dependencies = [
  "cache-key",
- "cachedir",
  "clap",
  "directories",
  "distribution-types",
@@ -4761,6 +4760,7 @@ name = "uv-fs"
 version = "0.0.1"
 dependencies = [
  "backoff",
+ "cachedir",
  "dunce",
  "encoding_rs_io",
  "fs-err",
@@ -5011,7 +5011,6 @@ name = "uv-virtualenv"
 version = "0.0.4"
 dependencies = [
  "anstream",
- "cachedir",
  "clap",
  "directories",
  "fs-err",

--- a/crates/uv-cache/Cargo.toml
+++ b/crates/uv-cache/Cargo.toml
@@ -20,7 +20,6 @@ pypi-types = { workspace = true }
 uv-fs = { workspace = true, features = ["tokio"] }
 uv-normalize = { workspace = true }
 
-cachedir = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"], optional = true }
 directories = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 
 use distribution_types::InstalledDist;
 use pypi_types::Metadata23;
-use uv_fs::directories;
+use uv_fs::{cachedir, directories};
 use uv_normalize::PackageName;
 
 pub use crate::by_timestamp::CachedByTimestamp;

--- a/crates/uv-fs/Cargo.toml
+++ b/crates/uv-fs/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 uv-warnings = { workspace = true }
 
 backoff = { workspace = true }
+cachedir = { workspace = true }
 dunce = { workspace = true }
 encoding_rs_io = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/uv-fs/src/cachedir.rs
+++ b/crates/uv-fs/src/cachedir.rs
@@ -1,0 +1,42 @@
+//! Vendored from cachedir 0.3.1 to replace `std::fs` with `fs_err`.
+
+use std::io::Write;
+use std::{io, path};
+
+use cachedir::HEADER;
+
+/// Adds a tag to the specified `directory`.
+///
+/// Will return an error if:
+///
+/// * The `directory` exists and contains a `CACHEDIR.TAG` file, regardless of its content.
+/// * The file can't be created for any reason (the `directory` doesn't exist, permission error,
+///   can't write to the file etc.)
+pub fn add_tag<P: AsRef<path::Path>>(directory: P) -> io::Result<()> {
+    let directory = directory.as_ref();
+    match fs_err::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(directory.join("CACHEDIR.TAG"))
+    {
+        Ok(mut cachedir_tag) => cachedir_tag.write_all(HEADER),
+        Err(e) => Err(e),
+    }
+}
+
+/// Ensures the tag exists in `directory`.
+///
+/// This function considers the `CACHEDIR.TAG` file in `directory` existing, regardless of its
+/// content, as a success.
+///
+/// Will return an error if The tag file doesn't exist and can't be created for any reason
+/// (the `directory` doesn't exist, permission error, can't write to the file etc.).
+pub fn ensure_tag<P: AsRef<path::Path>>(directory: P) -> io::Result<()> {
+    match add_tag(directory) {
+        Err(e) => match e.kind() {
+            io::ErrorKind::AlreadyExists => Ok(()),
+            _ => Err(e),
+        },
+        other => other,
+    }
+}

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -10,6 +10,7 @@ use uv_warnings::warn_user;
 
 pub use crate::path::*;
 
+pub mod cachedir;
 mod path;
 
 /// Reads data from the path and requires that it be valid UTF-8.

--- a/crates/uv-virtualenv/Cargo.toml
+++ b/crates/uv-virtualenv/Cargo.toml
@@ -29,7 +29,6 @@ uv-interpreter = { workspace = true }
 uv-version = { workspace = true }
 
 anstream = { workspace = true }
-cachedir = { workspace = true }
 clap = { workspace = true, features = ["derive"], optional = true }
 directories = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/uv-virtualenv/src/bare.rs
+++ b/crates/uv-virtualenv/src/bare.rs
@@ -12,7 +12,7 @@ use pypi_types::Scheme;
 use tracing::info;
 
 use crate::{Error, Prompt};
-use uv_fs::Simplified;
+use uv_fs::{cachedir, Simplified};
 use uv_interpreter::{Interpreter, Virtualenv};
 use uv_version::version;
 

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -5,7 +5,6 @@ use std::vec;
 
 use anstream::eprint;
 use anyhow::Result;
-
 use itertools::Itertools;
 use miette::{Diagnostic, IntoDiagnostic};
 use owo_colors::OwoColorize;


### PR DESCRIPTION
When running

```
set UV_CACHE_DIR=%LOCALAPPDATA%\uv\cache-foo && uv venv venv
```

in windows CMD, the error would be just

```
error: The system cannot find the path specified. (os error 3)
```

The problem is that the first action in the cache dir is adding the tag, and the `cachedir` crate is using `std::fs` instead of `fs_err`. I've copied the two functions we use from the crate and changed the import from `std::fs` to `fs_err`.

The new error is

```
error: failed to open file `C:\Users\Konstantin\AppData\Local\uv\cache-foo \CACHEDIR.TAG`
  Caused by: The system cannot find the path specified. (os error 3)
```

which correctly explains the problem.

Closes #3280