### PR TITLE
Avoid panic for file url

### DIFF
--- a/crates/cache-key/src/canonical_url.rs
+++ b/crates/cache-key/src/canonical_url.rs
@@ -32,8 +32,8 @@ impl CanonicalUrl {
         }
 
         // Strip credentials.
-        url.set_password(None).unwrap();
-        url.set_username("").unwrap();
+        let _ = url.set_password(None);
+        let _ = url.set_username("");
 
         // Strip a trailing slash.
         if url.path().ends_with('/') {


### PR DESCRIPTION
When using find links with a file url, we shouldn't panic because we can't remove username/password for a host-less url.

See #3262
