### PR TITLE
add `UV_LINK_MODE` as env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,8 @@ uv accepts the following command-line arguments as environment variables:
   uv will require that all dependencies have a hash specified in the requirements file.
 - `UV_CONSTRAINT`: Equivalent to the `--constraint` command-line argument. If set, uv will use this
   file as the constraints file. Uses space-separated list of files.
+- `UV_LINK_MODE`: Equivalent to the `--link-mode` command-line argument. If set, uv will use this
+  as a link mode.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -383,7 +383,7 @@ pub(crate) struct PipCompileArgs {
     ///
     /// Defaults to `clone` (also known as Copy-on-Write) on macOS, and `hardlink` on Linux and
     /// Windows.
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, env = "UV_LINK_MODE")]
     pub(crate) link_mode: Option<install_wheel_rs::linker::LinkMode>,
 
     /// The URL of the Python package index (by default: <https://pypi.org/simple>).
@@ -644,7 +644,7 @@ pub(crate) struct PipSyncArgs {
     ///
     /// Defaults to `clone` (also known as Copy-on-Write) on macOS, and `hardlink` on Linux and
     /// Windows.
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, env = "UV_LINK_MODE")]
     pub(crate) link_mode: Option<install_wheel_rs::linker::LinkMode>,
 
     /// The URL of the Python package index (by default: <https://pypi.org/simple>).
@@ -995,7 +995,7 @@ pub(crate) struct PipInstallArgs {
     ///
     /// Defaults to `clone` (also known as Copy-on-Write) on macOS, and `hardlink` on Linux and
     /// Windows.
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, env = "UV_LINK_MODE")]
     pub(crate) link_mode: Option<install_wheel_rs::linker::LinkMode>,
 
     /// The strategy to use when selecting between the different compatible versions for a given
@@ -1641,7 +1641,7 @@ pub(crate) struct VenvArgs {
     ///
     /// Defaults to `clone` (also known as Copy-on-Write) on macOS, and `hardlink` on Linux and
     /// Windows.
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, env = "UV_LINK_MODE")]
     pub(crate) link_mode: Option<install_wheel_rs::linker::LinkMode>,
 
     /// The URL of the Python package index (by default: <https://pypi.org/simple>).


### PR DESCRIPTION
Resolves https://github.com/astral-sh/uv/issues/3313

## Summary

Add a new env variable `UV_LINK_MODE` as alias for the cli argument --link-mode. 
Updated the README env variables section.

## Test Plan

Tested manually using `UV_LINK_MODE=hardlink cargo run -p uv pip install flask`.