### PR TITLE
`serde` dependency of `uv-resolver` is not optional

### DIFF
--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -49,7 +49,7 @@ pubgrub = { workspace = true }
 rkyv = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 textwrap = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

https://github.com/astral-sh/uv/pull/3314 makes `uv-resolver` unconditionally depend on `serde`, so the dependency should not be optional. This was breaking https://github.com/astral-sh/uv/pull/3281.