### PR TITLE
Log which requirements were or weren't satisfied

### DIFF
--- a/crates/uv-installer/src/lib.rs
+++ b/crates/uv-installer/src/lib.rs
@@ -3,7 +3,7 @@ pub use downloader::{Downloader, Reporter as DownloadReporter};
 pub use editable::{is_dynamic, BuiltEditable, ResolvedEditable};
 pub use installer::{Installer, Reporter as InstallReporter};
 pub use plan::{Plan, Planner};
-pub use site_packages::{Diagnostic, SitePackages};
+pub use site_packages::{Diagnostic, SatisfiesResult, SitePackages};
 pub use uninstall::{uninstall, UninstallError};
 
 mod compile;

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -293,8 +293,7 @@ impl<'a> SitePackages<'a> {
         Ok(diagnostics)
     }
 
-    /// Returns `Ok(None)` if the installed packages satisfy the given requirements or the
-    /// requirement that is not satisfied as `Ok(SatisfiesResult::Unsatisfied(_))`.
+    /// Returns if the installed packages satisfy the given requirements.
     pub fn satisfies(
         &self,
         requirements: &[RequirementEntry],
@@ -509,10 +508,16 @@ impl<'a> SitePackages<'a> {
     }
 }
 
+/// We check if all requirements are already satisfied, recursing through the requirements tree.
+#[derive(Debug)]
 pub enum SatisfiesResult {
+    /// All requirements are recursively satisfied.
     Fresh {
+        /// The flattened set (transitive closure) of all requirements checked.
         recursive_requirements: FxHashSet<RequirementEntry>,
     },
+    /// We found an unsatisfied requirement. Since we exit early, we only know about the first
+    /// unsatisfied requirement.
     Unsatisfied(String),
 }
 

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Context, Result};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 use tempfile::tempdir_in;
-use tracing::debug;
+use tracing::{debug, enabled, Level};
 
 use distribution_types::{
     DistributionMetadata, IndexLocations, InstalledMetadata, LocalDist, LocalEditable,
@@ -180,14 +180,16 @@ pub(crate) async fn pip_install(
             SatisfiesResult::Fresh {
                 recursive_requirements,
             } => {
-                debug!(
-                    "All requirements satisfied: {}",
-                    recursive_requirements
+                if enabled!(Level::DEBUG) {
+                    for requirement in recursive_requirements
                         .iter()
                         .map(ToString::to_string)
                         .sorted()
-                        .join(" | ")
-                );
+                    {
+                        debug!("Requirement satisfied: {requirement}");
+                    }
+                }
+
                 debug!(
                     "All editables satisfied: {}",
                     editables.iter().map(ToString::to_string).join(" | ")

--- a/crates/uv/src/commands/pip_install.rs
+++ b/crates/uv/src/commands/pip_install.rs
@@ -30,7 +30,9 @@ use uv_configuration::{
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::BuildDispatch;
 use uv_fs::Simplified;
-use uv_installer::{BuiltEditable, Downloader, Plan, Planner, ResolvedEditable, SitePackages};
+use uv_installer::{
+    BuiltEditable, Downloader, Plan, Planner, ResolvedEditable, SatisfiesResult, SitePackages,
+};
 use uv_interpreter::{Interpreter, PythonEnvironment, Target};
 use uv_normalize::PackageName;
 use uv_requirements::{
@@ -173,28 +175,44 @@ pub(crate) async fn pip_install(
     // If the requirements are already satisfied, we're done. Ideally, the resolver would be fast
     // enough to let us remove this check. But right now, for large environments, it's an order of
     // magnitude faster to validate the environment than to resolve the requirements.
-    if reinstall.is_none()
-        && upgrade.is_none()
-        && source_trees.is_empty()
-        && overrides.is_empty()
-        && site_packages.satisfies(&requirements, &editables, &constraints)?
-    {
-        let num_requirements = requirements.len() + editables.len();
-        let s = if num_requirements == 1 { "" } else { "s" };
-        writeln!(
-            printer.stderr(),
-            "{}",
-            format!(
-                "Audited {} in {}",
-                format!("{num_requirements} package{s}").bold(),
-                elapsed(start.elapsed())
-            )
-            .dimmed()
-        )?;
-        if dry_run {
-            writeln!(printer.stderr(), "Would make no changes")?;
+    if reinstall.is_none() && upgrade.is_none() && source_trees.is_empty() && overrides.is_empty() {
+        match site_packages.satisfies(&requirements, &editables, &constraints)? {
+            SatisfiesResult::Fresh {
+                recursive_requirements,
+            } => {
+                debug!(
+                    "All requirements satisfied: {}",
+                    recursive_requirements
+                        .iter()
+                        .map(ToString::to_string)
+                        .sorted()
+                        .join(" | ")
+                );
+                debug!(
+                    "All editables satisfied: {}",
+                    editables.iter().map(ToString::to_string).join(" | ")
+                );
+                let num_requirements = requirements.len() + editables.len();
+                let s = if num_requirements == 1 { "" } else { "s" };
+                writeln!(
+                    printer.stderr(),
+                    "{}",
+                    format!(
+                        "Audited {} in {}",
+                        format!("{num_requirements} package{s}").bold(),
+                        elapsed(start.elapsed())
+                    )
+                    .dimmed()
+                )?;
+                if dry_run {
+                    writeln!(printer.stderr(), "Would make no changes")?;
+                }
+                return Ok(ExitStatus::Success);
+            }
+            SatisfiesResult::Unsatisfied(requirement) => {
+                debug!("At least one requirement is not satisfied: {requirement}");
+            }
         }
-        return Ok(ExitStatus::Success);
     }
 
     let interpreter = venv.interpreter().clone();


### PR DESCRIPTION
Previously, a noop `uv pip install` would only show "Audited {} package(s)" but no details, not even with `-vv`. Now it debug logs which requirements were met and it also debug logs which requirement was missing to trigger the full routine, allowing it investigate caching behaviour.

First `uv pip install -v jupyter`:

```
DEBUG At least one requirement is not satisfied: jupyter
```

Second `uv pip install -v jupyter`:

```
DEBUG Found a virtualenv named .venv at: /home/konsti/projects/uv-main/.venv
DEBUG Cached interpreter info for Python 3.12.1, skipping probing: .venv/bin/python
DEBUG Using Python 3.12.1 environment at .venv/bin/python
DEBUG Trying to lock if free: .venv/.lock
DEBUG Requirement satisfied: anyio
DEBUG Requirement satisfied: anyio>=3.1.0
DEBUG Requirement satisfied: argon2-cffi-bindings
DEBUG Requirement satisfied: argon2-cffi>=21.1
DEBUG Requirement satisfied: arrow>=0.15.0
DEBUG Requirement satisfied: asttokens>=2.1.0
DEBUG Requirement satisfied: async-lru>=1.0.0
DEBUG Requirement satisfied: attrs>=22.2.0
DEBUG Requirement satisfied: babel>=2.10
...
DEBUG Requirement satisfied: webencodings
DEBUG Requirement satisfied: webencodings>=0.4
DEBUG Requirement satisfied: websocket-client>=1.7
DEBUG Requirement satisfied: widgetsnbextension~=4.0.10
DEBUG All editables satisfied: 
Audited 1 package in 12ms
```

This will clash with the `tool.uv.sources` PR, i'll rebase it on top.
