### PR TITLE
fix: remove cache generic from builder

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -102,7 +102,7 @@ impl<'a> RegistryClientBuilder<'a> {
     }
 
     #[must_use]
-    pub fn cache<T>(mut self, cache: Cache) -> Self {
+    pub fn cache(mut self, cache: Cache) -> Self {
         self.cache = cache;
         self
     }


### PR DESCRIPTION
Just a small fix, remove generic argument that I think was unused.
