### PR TITLE
Centralize installed dist satisfies requirement check

### DIFF
--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -463,12 +463,23 @@ pub enum VersionOrUrl {
 }
 
 /// Unowned version specifier or URL to install.
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
 pub enum VersionOrUrlRef<'a> {
     /// A PEP 440 version specifier set
     VersionSpecifier(&'a VersionSpecifiers),
     /// A installable URL
     Url(&'a VerbatimUrl),
+}
+
+impl<'a> From<&'a VersionOrUrl> for VersionOrUrlRef<'a> {
+    fn from(value: &'a VersionOrUrl) -> Self {
+        match value {
+            VersionOrUrl::VersionSpecifier(version_specifier) => {
+                VersionOrUrlRef::VersionSpecifier(version_specifier)
+            }
+            VersionOrUrl::Url(url) => VersionOrUrlRef::Url(url),
+        }
+    }
 }
 
 /// A [`Cursor`] over a string.

--- a/crates/uv-installer/src/lib.rs
+++ b/crates/uv-installer/src/lib.rs
@@ -11,5 +11,6 @@ mod downloader;
 mod editable;
 mod installer;
 mod plan;
+mod satisfies;
 mod site_packages;
 mod uninstall;

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -12,7 +12,7 @@ use distribution_types::{
 };
 use pep508_rs::{Requirement, VersionOrUrl};
 use platform_tags::Tags;
-use uv_cache::{ArchiveTarget, ArchiveTimestamp, Cache, CacheBucket, WheelCache};
+use uv_cache::{ArchiveTimestamp, Cache, CacheBucket, WheelCache};
 use uv_configuration::{NoBinary, Reinstall};
 use uv_distribution::{
     BuiltWheelIndex, HttpArchivePointer, LocalArchivePointer, RegistryWheelIndex,
@@ -21,6 +21,7 @@ use uv_fs::Simplified;
 use uv_interpreter::PythonEnvironment;
 use uv_types::HashStrategy;
 
+use crate::satisfies::RequirementSatisfaction;
 use crate::{ResolvedEditable, SitePackages};
 
 /// A planner to generate an [`Plan`] based on a set of requirements.
@@ -182,10 +183,20 @@ impl<'a> Planner<'a> {
                 match installed_dists.as_slice() {
                     [] => {}
                     [distribution] => {
-                        if installed_satisfies_requirement(distribution, requirement)? {
-                            debug!("Requirement already installed: {distribution}");
-                            installed.push(distribution.clone());
-                            continue;
+                        match RequirementSatisfaction::check(
+                            distribution,
+                            requirement.version_or_url.as_ref().map(Into::into),
+                            requirement,
+                        )? {
+                            RequirementSatisfaction::Mismatch => {}
+                            RequirementSatisfaction::Satisfied => {
+                                debug!("Requirement already installed: {distribution}");
+                                installed.push(distribution.clone());
+                                continue;
+                            }
+                            RequirementSatisfaction::OutOfDate => {
+                                debug!("Requirement installed, but not fresh: {distribution}");
+                            }
                         }
                         reinstalls.push(distribution.clone());
                     }
@@ -415,54 +426,4 @@ pub struct Plan {
     /// Any distributions that are already installed in the current environment, and are
     /// _not_ necessary to satisfy the requirements.
     pub extraneous: Vec<InstalledDist>,
-}
-
-/// Returns true if a requirement is satisfied by an installed distribution.
-///
-/// Returns an error if IO fails during a freshness check for a local path.
-fn installed_satisfies_requirement(
-    distribution: &InstalledDist,
-    requirement: &Requirement,
-) -> Result<bool> {
-    // Filter out already-installed packages.
-    match requirement.version_or_url.as_ref() {
-        // Accept any version of the package.
-        None => return Ok(true),
-
-        // If the requirement comes from a registry, check by name.
-        Some(VersionOrUrl::VersionSpecifier(version_specifier)) => {
-            if version_specifier.contains(distribution.version()) {
-                debug!("Requirement already satisfied: {distribution}");
-                return Ok(true);
-            }
-        }
-
-        // If the requirement comes from a direct URL, check by URL.
-        Some(VersionOrUrl::Url(url)) => {
-            if let InstalledDist::Url(installed) = &distribution {
-                if !installed.editable && &installed.url == url.raw() {
-                    // If the requirement came from a local path, check freshness.
-                    if let Some(archive) = (url.scheme() == "file")
-                        .then(|| url.to_file_path().ok())
-                        .flatten()
-                    {
-                        if ArchiveTimestamp::up_to_date_with(
-                            &archive,
-                            ArchiveTarget::Install(distribution),
-                        )? {
-                            debug!("Requirement already satisfied (and up-to-date): {installed}");
-                            return Ok(true);
-                        }
-                        debug!("Requirement already satisfied (but not up-to-date): {installed}");
-                    } else {
-                        // Otherwise, assume the requirement is up-to-date.
-                        debug!("Requirement already satisfied (assumed up-to-date): {installed}");
-                        return Ok(true);
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(false)
 }

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -10,7 +10,7 @@ use distribution_types::{
     BuiltDist, CachedDirectUrlDist, CachedDist, Dist, IndexLocations, InstalledDist,
     InstalledMetadata, InstalledVersion, Name, SourceDist,
 };
-use pep508_rs::{Requirement, VersionOrUrl};
+use pep508_rs::{Requirement, VersionOrUrl, VersionOrUrlRef};
 use platform_tags::Tags;
 use uv_cache::{ArchiveTimestamp, Cache, CacheBucket, WheelCache};
 use uv_configuration::{NoBinary, Reinstall};
@@ -185,7 +185,10 @@ impl<'a> Planner<'a> {
                     [distribution] => {
                         match RequirementSatisfaction::check(
                             distribution,
-                            requirement.version_or_url.as_ref().map(Into::into),
+                            requirement
+                                .version_or_url
+                                .as_ref()
+                                .map(VersionOrUrlRef::from),
                             requirement,
                         )? {
                             RequirementSatisfaction::Mismatch => {}

--- a/crates/uv-installer/src/satisfies.rs
+++ b/crates/uv-installer/src/satisfies.rs
@@ -1,0 +1,70 @@
+use anyhow::Result;
+use std::fmt::Debug;
+use tracing::trace;
+
+use distribution_types::InstalledDist;
+use pep508_rs::VersionOrUrlRef;
+
+use uv_cache::{ArchiveTarget, ArchiveTimestamp};
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum RequirementSatisfaction {
+    Mismatch,
+    Satisfied,
+    OutOfDate,
+}
+
+impl RequirementSatisfaction {
+    /// Returns true if a requirement is satisfied by an installed distribution.
+    ///
+    /// Returns an error if IO fails during a freshness check for a local path.
+    pub(crate) fn check(
+        distribution: &InstalledDist,
+        version_or_url: Option<VersionOrUrlRef>,
+        requirement: impl Debug,
+    ) -> Result<Self> {
+        trace!(
+            "Comparing installed with requirement: {:?} {:?}",
+            distribution,
+            requirement
+        );
+        // Filter out already-installed packages.
+        match version_or_url {
+            // Accept any version of the package.
+            None => return Ok(Self::Satisfied),
+
+            // If the requirement comes from a registry, check by name.
+            Some(VersionOrUrlRef::VersionSpecifier(version_specifier)) => {
+                if version_specifier.contains(distribution.version()) {
+                    return Ok(Self::Satisfied);
+                }
+            }
+
+            // If the requirement comes from a direct URL, check by URL.
+            Some(VersionOrUrlRef::Url(url)) => {
+                if let InstalledDist::Url(installed) = &distribution {
+                    if !installed.editable && &installed.url == url.raw() {
+                        // If the requirement came from a local path, check freshness.
+                        return if let Some(archive) = (url.scheme() == "file")
+                            .then(|| url.to_file_path().ok())
+                            .flatten()
+                        {
+                            if ArchiveTimestamp::up_to_date_with(
+                                &archive,
+                                ArchiveTarget::Install(distribution),
+                            )? {
+                                return Ok(Self::Satisfied);
+                            }
+                            Ok(Self::OutOfDate)
+                        } else {
+                            // Otherwise, assume the requirement is up-to-date.
+                            Ok(Self::Satisfied)
+                        };
+                    }
+                }
+            }
+        }
+
+        Ok(Self::Mismatch)
+    }
+}

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use distribution_types::{InstalledDist, InstalledMetadata, InstalledVersion, Name};
 use pep440_rs::{Version, VersionSpecifiers};
-use pep508_rs::{Requirement, VerbatimUrl};
+use pep508_rs::{Requirement, VerbatimUrl, VersionOrUrlRef};
 use requirements_txt::{EditableRequirement, RequirementEntry, RequirementsTxtRequirement};
 use uv_cache::{ArchiveTarget, ArchiveTimestamp};
 use uv_interpreter::PythonEnvironment;
@@ -397,7 +397,10 @@ impl<'a> SitePackages<'a> {
                     for constraint in constraints {
                         match RequirementSatisfaction::check(
                             distribution,
-                            constraint.version_or_url.as_ref().map(Into::into),
+                            constraint
+                                .version_or_url
+                                .as_ref()
+                                .map(VersionOrUrlRef::from),
                             constraint,
                         )? {
                             RequirementSatisfaction::Mismatch


### PR DESCRIPTION
Another split out from https://github.com/astral-sh/uv/pull/3263. This abstracts the copy&pasted check whether an installed distribution satisfies a requirement used by both plan.rs and site_packages.rs into a shared module. It's less useful here than with the new requirement but helps with reducing https://github.com/astral-sh/uv/pull/3263 diff size.