### PR TITLE
Accept `--no-upgrade`, `--no-refresh`, etc. on the CLI

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -898,13 +898,17 @@ pub enum Refresh {
 
 impl Refresh {
     /// Determine the refresh strategy to use based on the command-line arguments.
-    pub fn from_args(refresh: bool, refresh_package: Vec<PackageName>) -> Self {
-        if refresh {
-            Self::All(Timestamp::now())
-        } else if !refresh_package.is_empty() {
-            Self::Packages(refresh_package, Timestamp::now())
-        } else {
-            Self::None
+    pub fn from_args(refresh: Option<bool>, refresh_package: Vec<PackageName>) -> Self {
+        match refresh {
+            Some(true) => Self::All(Timestamp::now()),
+            Some(false) => Self::None,
+            None => {
+                if refresh_package.is_empty() {
+                    Self::None
+                } else {
+                    Self::Packages(refresh_package, Timestamp::now())
+                }
+            }
         }
     }
 

--- a/crates/uv-configuration/src/package_options.rs
+++ b/crates/uv-configuration/src/package_options.rs
@@ -17,13 +17,17 @@ pub enum Reinstall {
 
 impl Reinstall {
     /// Determine the reinstall strategy to use.
-    pub fn from_args(reinstall: bool, reinstall_package: Vec<PackageName>) -> Self {
-        if reinstall {
-            Self::All
-        } else if !reinstall_package.is_empty() {
-            Self::Packages(reinstall_package)
-        } else {
-            Self::None
+    pub fn from_args(reinstall: Option<bool>, reinstall_package: Vec<PackageName>) -> Self {
+        match reinstall {
+            Some(true) => Self::All,
+            Some(false) => Self::None,
+            None => {
+                if reinstall_package.is_empty() {
+                    Self::None
+                } else {
+                    Self::Packages(reinstall_package)
+                }
+            }
         }
     }
 
@@ -53,13 +57,17 @@ pub enum Upgrade {
 
 impl Upgrade {
     /// Determine the upgrade strategy from the command-line arguments.
-    pub fn from_args(upgrade: bool, upgrade_package: Vec<PackageName>) -> Self {
-        if upgrade {
-            Self::All
-        } else if !upgrade_package.is_empty() {
-            Self::Packages(upgrade_package.into_iter().collect())
-        } else {
-            Self::None
+    pub fn from_args(upgrade: Option<bool>, upgrade_package: Vec<PackageName>) -> Self {
+        match upgrade {
+            Some(true) => Self::All,
+            Some(false) => Self::None,
+            None => {
+                if upgrade_package.is_empty() {
+                    Self::None
+                } else {
+                    Self::Packages(upgrade_package.into_iter().collect())
+                }
+            }
         }
     }
 

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -370,8 +370,11 @@ pub(crate) struct PipCompileArgs {
     pub(crate) no_offline: bool,
 
     /// Refresh all cached data.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_refresh"))]
     pub(crate) refresh: bool,
+
+    #[arg(long, overrides_with("refresh"), hide = true)]
+    pub(crate) no_refresh: bool,
 
     /// Refresh cached data for a specific package.
     #[arg(long)]
@@ -474,8 +477,11 @@ pub(crate) struct PipCompileArgs {
     pub(crate) no_system: bool,
 
     /// Allow package upgrades, ignoring pinned versions in the existing output file.
-    #[arg(long, short = 'U')]
+    #[arg(long, short = 'U', overrides_with("no_upgrade"))]
     pub(crate) upgrade: bool,
+
+    #[arg(long, overrides_with("upgrade"), hide = true)]
+    pub(crate) no_upgrade: bool,
 
     /// Allow upgrades for a specific package, ignoring pinned versions in the existing output
     /// file.
@@ -624,8 +630,11 @@ pub(crate) struct PipSyncArgs {
     pub(crate) src_file: Vec<PathBuf>,
 
     /// Reinstall all packages, regardless of whether they're already installed.
-    #[arg(long, alias = "force-reinstall")]
+    #[arg(long, alias = "force-reinstall", overrides_with("no_reinstall"))]
     pub(crate) reinstall: bool,
+
+    #[arg(long, overrides_with("reinstall"), hide = true)]
+    pub(crate) no_reinstall: bool,
 
     /// Reinstall a specific package, regardless of whether it's already installed.
     #[arg(long)]
@@ -644,8 +653,11 @@ pub(crate) struct PipSyncArgs {
     pub(crate) no_offline: bool,
 
     /// Refresh all cached data.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_refresh"))]
     pub(crate) refresh: bool,
+
+    #[arg(long, overrides_with("refresh"), hide = true)]
+    pub(crate) no_refresh: bool,
 
     /// Refresh cached data for a specific package.
     #[arg(long)]
@@ -971,16 +983,22 @@ pub(crate) struct PipInstallArgs {
     pub(crate) no_all_extras: bool,
 
     /// Allow package upgrades.
-    #[arg(long, short = 'U')]
+    #[arg(long, short = 'U', overrides_with("no_upgrade"))]
     pub(crate) upgrade: bool,
+
+    #[arg(long, overrides_with("upgrade"), hide = true)]
+    pub(crate) no_upgrade: bool,
 
     /// Allow upgrade of a specific package.
     #[arg(long, short = 'P')]
     pub(crate) upgrade_package: Vec<PackageName>,
 
     /// Reinstall all packages, regardless of whether they're already installed.
-    #[arg(long, alias = "force-reinstall")]
+    #[arg(long, alias = "force-reinstall", overrides_with("no_reinstall"))]
     pub(crate) reinstall: bool,
+
+    #[arg(long, overrides_with("reinstall"), hide = true)]
+    pub(crate) no_reinstall: bool,
 
     /// Reinstall a specific package, regardless of whether it's already installed.
     #[arg(long)]
@@ -999,8 +1017,11 @@ pub(crate) struct PipInstallArgs {
     pub(crate) no_offline: bool,
 
     /// Refresh all cached data.
-    #[arg(long)]
+    #[arg(long, overrides_with("no_refresh"))]
     pub(crate) refresh: bool,
+
+    #[arg(long, overrides_with("refresh"), hide = true)]
+    pub(crate) no_refresh: bool,
 
     /// Refresh cached data for a specific package.
     #[arg(long)]

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -159,6 +159,7 @@ impl PipCompileSettings {
             offline,
             no_offline,
             refresh,
+            no_refresh,
             refresh_package,
             link_mode,
             index_url,
@@ -171,6 +172,7 @@ impl PipCompileSettings {
             system,
             no_system,
             upgrade,
+            no_upgrade,
             upgrade_package,
             generate_hashes,
             no_generate_hashes,
@@ -207,8 +209,8 @@ impl PipCompileSettings {
                 .filter_map(Maybe::into_option)
                 .collect(),
             r#override,
-            refresh: Refresh::from_args(refresh, refresh_package),
-            upgrade: Upgrade::from_args(upgrade, upgrade_package),
+            refresh: Refresh::from_args(flag(refresh, no_refresh), refresh_package),
+            upgrade: Upgrade::from_args(flag(upgrade, no_upgrade), upgrade_package),
             uv_lock: flag(unstable_uv_lock_file, no_unstable_uv_lock_file).unwrap_or(false),
 
             // Shared settings.
@@ -287,10 +289,12 @@ impl PipSyncSettings {
         let PipSyncArgs {
             src_file,
             reinstall,
+            no_reinstall,
             reinstall_package,
             offline,
             refresh,
             no_offline,
+            no_refresh,
             refresh_package,
             link_mode,
             index_url,
@@ -328,8 +332,8 @@ impl PipSyncSettings {
         Self {
             // CLI-only settings.
             src_file,
-            reinstall: Reinstall::from_args(reinstall, reinstall_package),
-            refresh: Refresh::from_args(refresh, refresh_package),
+            reinstall: Reinstall::from_args(flag(reinstall, no_reinstall), reinstall_package),
+            refresh: Refresh::from_args(flag(refresh, no_refresh), refresh_package),
 
             // Shared settings.
             shared: PipSharedSettings::combine(
@@ -403,12 +407,15 @@ impl PipInstallSettings {
             all_extras,
             no_all_extras,
             upgrade,
+            no_upgrade,
             upgrade_package,
             reinstall,
+            no_reinstall,
             reinstall_package,
             offline,
             refresh,
             no_offline,
+            no_refresh,
             refresh_package,
             no_deps,
             deps,
@@ -459,9 +466,9 @@ impl PipInstallSettings {
                 .filter_map(Maybe::into_option)
                 .collect(),
             r#override,
-            upgrade: Upgrade::from_args(upgrade, upgrade_package),
-            reinstall: Reinstall::from_args(reinstall, reinstall_package),
-            refresh: Refresh::from_args(refresh, refresh_package),
+            upgrade: Upgrade::from_args(flag(upgrade, no_upgrade), upgrade_package),
+            reinstall: Reinstall::from_args(flag(reinstall, no_reinstall), reinstall_package),
+            refresh: Refresh::from_args(flag(refresh, no_refresh), refresh_package),
             dry_run,
 
             // Shared settings.


### PR DESCRIPTION
## Summary

We added `--no-X` variants for all other flags, but omitted these. Seems more consistent to support them.

Closes https://github.com/astral-sh/uv/issues/1900.
