### PR TITLE
Update toolchain discovery to avoid runtime panic

### DIFF
--- a/crates/uv-dev/src/fetch_python.rs
+++ b/crates/uv-dev/src/fetch_python.rs
@@ -25,7 +25,9 @@ pub(crate) struct FetchPythonArgs {
 pub(crate) async fn fetch_python(args: FetchPythonArgs) -> Result<()> {
     let start = Instant::now();
 
-    let bootstrap_dir = &*TOOLCHAIN_DIRECTORY;
+    let bootstrap_dir = TOOLCHAIN_DIRECTORY
+        .as_ref()
+        .expect("The toolchain directory must exist for bootstrapping");
 
     fs_err::create_dir_all(bootstrap_dir)?;
 

--- a/crates/uv-interpreter/src/managed/find.rs
+++ b/crates/uv-interpreter/src/managed/find.rs
@@ -9,15 +9,17 @@ use crate::selectors::{Arch, Libc, Os};
 use once_cell::sync::Lazy;
 
 /// The directory where Python toolchains we install are stored.
-pub static TOOLCHAIN_DIRECTORY: Lazy<PathBuf> = Lazy::new(|| {
+pub static TOOLCHAIN_DIRECTORY: Lazy<Option<PathBuf>> = Lazy::new(|| {
     std::env::var_os("UV_BOOTSTRAP_DIR").map_or(
-        Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
-            .parent()
-            .expect("CARGO_MANIFEST_DIR should be nested in workspace")
-            .parent()
-            .expect("CARGO_MANIFEST_DIR should be doubly nested in workspace")
-            .join("bin"),
-        PathBuf::from,
+        std::env::var_os("CARGO_MANIFEST_DIR").map(|manifest_dir| {
+            Path::new(&manifest_dir)
+                .parent()
+                .expect("CARGO_MANIFEST_DIR should be nested in workspace")
+                .parent()
+                .expect("CARGO_MANIFEST_DIR should be doubly nested in workspace")
+                .join("bin")
+        }),
+        |bootstrap_dir| Some(PathBuf::from(bootstrap_dir)),
     )
 });
 
@@ -40,19 +42,11 @@ impl Toolchain {
     }
 }
 
-/// Return the toolchains that satisfy the given Python version on this platform.
-///
-/// ## Errors
-///
-/// - The platform metadata cannot be read
-/// - A directory in the toolchain directory cannot be read
-pub fn toolchains_for_version(version: &PythonVersion) -> Result<Vec<Toolchain>, Error> {
-    let platform_key = platform_key_from_env()?;
-
-    // TODO(zanieb): Consider returning an iterator instead of a `Vec`
-    //               Note we need to collect paths regardless for sorting by version.
-
-    let toolchain_dirs = match fs_err::read_dir(TOOLCHAIN_DIRECTORY.to_path_buf()) {
+fn toolchain_directories() -> Result<BTreeSet<PathBuf>, Error> {
+    let Some(toolchain_dir) = TOOLCHAIN_DIRECTORY.as_ref() else {
+        return Ok(BTreeSet::default());
+    };
+    match fs_err::read_dir(toolchain_dir.clone()) {
         Ok(toolchain_dirs) => {
             // Collect sorted directory paths; `read_dir` is not stable across platforms
             let directories: BTreeSet<_> = toolchain_dirs
@@ -65,21 +59,32 @@ pub fn toolchains_for_version(version: &PythonVersion) -> Result<Vec<Toolchain>,
                 })
                 .collect::<Result<_, std::io::Error>>()
                 .map_err(|err| Error::ReadError {
-                    dir: TOOLCHAIN_DIRECTORY.to_path_buf(),
+                    dir: toolchain_dir.clone(),
                     err,
                 })?;
-            directories
+            Ok(directories)
         }
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(Vec::new());
-        }
-        Err(err) => {
-            return Err(Error::ReadError {
-                dir: TOOLCHAIN_DIRECTORY.to_path_buf(),
-                err,
-            })
-        }
-    };
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(BTreeSet::default()),
+        Err(err) => Err(Error::ReadError {
+            dir: toolchain_dir.clone(),
+            err,
+        }),
+    }
+}
+
+/// Return the toolchains that satisfy the given Python version on this platform.
+///
+/// ## Errors
+///
+/// - The platform metadata cannot be read
+/// - A directory in the toolchain directory cannot be read
+pub fn toolchains_for_version(version: &PythonVersion) -> Result<Vec<Toolchain>, Error> {
+    let platform_key = platform_key_from_env()?;
+
+    // TODO(zanieb): Consider returning an iterator instead of a `Vec`
+    //               Note we need to collect paths regardless for sorting by version.
+
+    let toolchain_dirs = toolchain_directories()?;
 
     Ok(toolchain_dirs
         .into_iter()


### PR DESCRIPTION
Split out of https://github.com/astral-sh/uv/pull/3266

If `UV_BOOTSTRAP_DIR` and `CARGO_MANIFEST_DIR` are both unset, we currently panic. This isn't good once we start to use managed toolchains in production. We'll need to change this more later once the toolchain directory is more user-facing.