### PR TITLE
Separate interpreter selectors into `implementation` and `platform` modules

### DIFF
--- a/crates/uv-interpreter/src/implementation.rs
+++ b/crates/uv-interpreter/src/implementation.rs
@@ -1,0 +1,47 @@
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Unknown Python implementation `{0}`")]
+    UnknownImplementation(String),
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum ImplementationName {
+    Cpython,
+}
+
+impl ImplementationName {
+    #[allow(dead_code)]
+    pub(crate) fn iter() -> impl Iterator<Item = &'static ImplementationName> {
+        static NAMES: &[ImplementationName] = &[ImplementationName::Cpython];
+        NAMES.iter()
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Cpython => "cpython",
+        }
+    }
+}
+
+impl FromStr for ImplementationName {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "cpython" => Ok(Self::Cpython),
+            _ => Err(Error::UnknownImplementation(s.to_string())),
+        }
+    }
+}
+
+impl Display for ImplementationName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -25,11 +25,12 @@ pub use crate::target::Target;
 
 mod environment;
 mod find_python;
+mod implementation;
 mod interpreter;
 pub mod managed;
+pub mod platform;
 mod py_launcher;
 mod python_version;
-pub mod selectors;
 mod target;
 
 #[derive(Debug, Error)]

--- a/crates/uv-interpreter/src/managed/downloads.rs
+++ b/crates/uv-interpreter/src/managed/downloads.rs
@@ -3,7 +3,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use crate::selectors::{Arch, ImplementationName, Libc, Os, PythonSelectorError};
+use crate::implementation::{Error as ImplementationError, ImplementationName};
+use crate::platform::{Arch, Error as PlatformError, Libc, Os};
 use crate::PythonVersion;
 use thiserror::Error;
 use uv_client::BetterReqwestError;
@@ -18,7 +19,9 @@ use uv_fs::Simplified;
 #[derive(Error, Debug)]
 pub enum Error {
     #[error(transparent)]
-    SelectorError(#[from] PythonSelectorError),
+    PlatformError(#[from] PlatformError),
+    #[error(transparent)]
+    ImplementationError(#[from] ImplementationError),
     #[error("invalid python version: {0}")]
     InvalidPythonVersion(String),
     #[error("download failed")]

--- a/crates/uv-interpreter/src/managed/find.rs
+++ b/crates/uv-interpreter/src/managed/find.rs
@@ -3,8 +3,10 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use crate::managed::downloads::Error;
-use crate::python_version::PythonVersion;
-use crate::selectors::{Arch, Libc, Os};
+use crate::{
+    platform::{Arch, Libc, Os},
+    python_version::PythonVersion,
+};
 
 use once_cell::sync::Lazy;
 


### PR DESCRIPTION
Split out of #3266

The "selector" concept doesn't seem well enough defined as-is. For example, `PythonVersion` belongs there but isn't present. Going for smaller modules instead.