### PR TITLE
Remove `Into::into`

### DIFF
--- a/crates/pypi-types/src/simple_json.rs
+++ b/crates/pypi-types/src/simple_json.rs
@@ -64,7 +64,7 @@ where
         return Ok(None);
     };
     Ok(Some(
-        LenientVersionSpecifiers::from_str(&string).map(Into::into),
+        LenientVersionSpecifiers::from_str(&string).map(VersionSpecifiers::from),
     ))
 }
 


### PR DESCRIPTION
Motivated by https://github.com/astral-sh/uv/pull/3263#discussion_r1585896159

I don't think we can lint againt this since we do want to allow `.into()`, just not the bare `Into::into` call.