### PR TITLE
Avoid stack overflows on more windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,9 @@ jobs:
           cargo nextest run --no-default-features --features python,pypi,git --workspace --status-level skip --failure-output immediate-final --no-fail-fast -j 12 --final-status-level slow
 
       - name: "Smoke test"
+        env:
+          # Avoid debug build stack overflows.
+          UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
         run: |
           Set-Alias -Name uv -Value ./target/debug/uv
           uv venv
@@ -815,6 +818,9 @@ jobs:
 
       - name: "Validate global Python install"
         shell: bash -el {0}
+        env:
+          # Avoid debug build stack overflows.
+          UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
         run: python ./scripts/check_system_python.py --uv ./uv
 
   system-test-amazonlinux:


### PR DESCRIPTION
Fix windows CI by increasing the debug stack size on windows:
* https://github.com/astral-sh/uv/actions/runs/8938560618/job/24553000399?pr=3340
* https://github.com/astral-sh/uv/actions/runs/8937835055/job/24550949991
* https://github.com/astral-sh/uv/actions/runs/8937835055/job/24550949261
* https://github.com/astral-sh/uv/actions/runs/8937835055/job/24550810405
