### PR TITLE
require serde and rkyv everywhere; remove optional serde and rkyv features

### DIFF
--- a/crates/distribution-filename/Cargo.toml
+++ b/crates/distribution-filename/Cargo.toml
@@ -12,16 +12,13 @@ license = { workspace = true }
 [lints]
 workspace = true
 
-[features]
-rkyv = ["dep:rkyv", "pep440_rs/rkyv", "uv-normalize/rkyv"]
-
 [dependencies]
 pep440_rs = { workspace = true }
 platform-tags = { workspace = true }
 uv-normalize = { workspace = true }
 
-rkyv = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+rkyv = { workspace = true }
+serde = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 

--- a/crates/distribution-filename/src/source_dist.rs
+++ b/crates/distribution-filename/src/source_dist.rs
@@ -1,21 +1,25 @@
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use pep440_rs::{Version, VersionParseError};
 use uv_normalize::{InvalidNameError, PackageName};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
 )]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(feature = "rkyv", archive_attr(derive(Debug)))]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug))]
 pub enum SourceDistExtension {
     Zip,
     TarGz,
@@ -62,14 +66,19 @@ impl SourceDistExtension {
 
 /// Note that this is a normalized and not an exact representation, keep the original string if you
 /// need the latter.
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
 )]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(feature = "rkyv", archive_attr(derive(Debug)))]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug))]
 pub struct SourceDistFilename {
     pub name: PackageName,
     pub version: Version,

--- a/crates/distribution-filename/src/wheel.rs
+++ b/crates/distribution-filename/src/wheel.rs
@@ -1,7 +1,6 @@
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-#[cfg(feature = "serde")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 use url::Url;
@@ -10,13 +9,9 @@ use pep440_rs::{Version, VersionParseError};
 use platform_tags::{TagCompatibility, Tags};
 use uv_normalize::{InvalidNameError, PackageName};
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
-)]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(feature = "rkyv", archive_attr(derive(Debug)))]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug))]
 pub struct WheelFilename {
     pub name: PackageName,
     pub version: Version,
@@ -196,7 +191,6 @@ impl TryFrom<&Url> for WheelFilename {
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for WheelFilename {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -207,7 +201,6 @@ impl<'de> Deserialize<'de> for WheelFilename {
     }
 }
 
-#[cfg(feature = "serde")]
 impl Serialize for WheelFilename {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/distribution-types/Cargo.toml
+++ b/crates/distribution-types/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 cache-key = { workspace = true }
-distribution-filename = { workspace = true, features = ["serde"] }
+distribution-filename = { workspace = true }
 pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
 platform-tags = { workspace = true }

--- a/crates/pep440-rs/Cargo.toml
+++ b/crates/pep440-rs/Cargo.toml
@@ -19,8 +19,8 @@ crate-type = ["rlib", "cdylib"]
 [dependencies]
 once_cell = { workspace = true }
 pyo3 = { workspace = true, optional = true, features = ["extension-module", "abi3-py37"] }
-serde = { workspace = true, features = ["derive"], optional = true }
-rkyv = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"] }
+rkyv = { workspace = true }
 tracing = { workspace = true, optional = true }
 unicode-width = { workspace = true }
 unscanny = { workspace = true }

--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -11,20 +11,14 @@ use pyo3::{
     basic::CompareOp, exceptions::PyValueError, pyclass, pymethods, FromPyObject, IntoPy, PyAny,
     PyObject, PyResult, Python,
 };
-#[cfg(feature = "serde")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 /// One of `~=` `==` `!=` `<=` `>=` `<` `>` `===`
-#[derive(Eq, PartialEq, Debug, Hash, Clone, Copy)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+#[derive(
+    Eq, PartialEq, Debug, Hash, Clone, Copy, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
 )]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(
-    feature = "rkyv",
-    archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))
-)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 #[cfg_attr(feature = "pyo3", pyclass)]
 pub enum Operator {
     /// `== 1.2.3`
@@ -248,30 +242,16 @@ impl std::fmt::Display for OperatorParseError {
 ///
 /// let version = Version::from_str("1.19").unwrap();
 /// ```
-#[derive(Clone)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
-)]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(
-    feature = "rkyv",
-    archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))
-)]
+#[derive(Clone, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 pub struct Version {
     inner: Arc<VersionInner>,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
-)]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(
-    feature = "rkyv",
-    archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))
-)]
+#[derive(Clone, Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 enum VersionInner {
     Small { small: VersionSmall },
     Full { full: VersionFull },
@@ -636,7 +616,6 @@ impl Version {
 }
 
 /// <https://github.com/serde-rs/serde/issues/1316#issue-332908452>
-#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Version {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -648,7 +627,6 @@ impl<'de> Deserialize<'de> for Version {
 }
 
 /// <https://github.com/serde-rs/serde/issues/1316#issue-332908452>
-#[cfg(feature = "serde")]
 impl Serialize for Version {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -839,16 +817,9 @@ impl FromStr for Version {
 ///
 /// Thankfully, such versions are incredibly rare. Virtually all versions have
 /// zero or one pre, dev or post release components.
-#[derive(Clone, Debug)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
-)]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(
-    feature = "rkyv",
-    archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))
-)]
+#[derive(Clone, Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 struct VersionSmall {
     /// The representation discussed above.
     repr: u64,
@@ -1185,16 +1156,9 @@ impl VersionSmall {
 ///
 /// In general, the "full" representation is rarely used in practice since most
 /// versions will fit into the "small" representation.
-#[derive(Clone, Debug)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
-)]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(
-    feature = "rkyv",
-    archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))
-)]
+#[derive(Clone, Debug, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 struct VersionFull {
     /// The [versioning
     /// epoch](https://peps.python.org/pep-0440/#version-epochs). Normally
@@ -1314,17 +1278,22 @@ impl FromStr for VersionPattern {
 }
 
 /// An optional pre-release modifier and number applied to a version.
-#[derive(PartialEq, Eq, Debug, Hash, Clone, Copy, Ord, PartialOrd)]
+#[derive(
+    PartialEq,
+    Eq,
+    Debug,
+    Hash,
+    Clone,
+    Copy,
+    Ord,
+    PartialOrd,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 #[cfg_attr(feature = "pyo3", pyclass)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
-)]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(
-    feature = "rkyv",
-    archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))
-)]
 pub struct PreRelease {
     /// The kind of pre-release.
     pub kind: PreReleaseKind,
@@ -1335,17 +1304,22 @@ pub struct PreRelease {
 /// Optional prerelease modifier (alpha, beta or release candidate) appended to version
 ///
 /// <https://peps.python.org/pep-0440/#pre-releases>
-#[derive(PartialEq, Eq, Debug, Hash, Clone, Copy, Ord, PartialOrd)]
+#[derive(
+    PartialEq,
+    Eq,
+    Debug,
+    Hash,
+    Clone,
+    Copy,
+    Ord,
+    PartialOrd,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 #[cfg_attr(feature = "pyo3", pyclass)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
-)]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(
-    feature = "rkyv",
-    archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))
-)]
 pub enum PreReleaseKind {
     /// alpha prerelease
     Alpha,
@@ -1380,16 +1354,9 @@ impl std::fmt::Display for PreReleaseKind {
 /// > exactly.
 ///
 /// Luckily the default `Ord` implementation for `Vec<LocalSegment>` matches the PEP 440 rules.
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
-)]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(
-    feature = "rkyv",
-    archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))
-)]
+#[derive(Eq, PartialEq, Debug, Clone, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]
 pub enum LocalSegment {
     /// Not-parseable as integer segment of local version
     String(String),

--- a/crates/pep440-rs/src/version_specifier.rs
+++ b/crates/pep440-rs/src/version_specifier.rs
@@ -9,7 +9,6 @@ use pyo3::{
     pyclass::CompareOp,
     pymethods, Py, PyRef, PyRefMut, PyResult,
 };
-#[cfg(feature = "serde")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "pyo3")]
@@ -35,13 +34,9 @@ use crate::{
 /// // VersionSpecifiers derefs into a list of specifiers
 /// assert_eq!(version_specifiers.iter().position(|specifier| *specifier.operator() == Operator::LessThan), Some(1));
 /// ```
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
-)]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(feature = "rkyv", archive_attr(derive(Debug)))]
+#[derive(Eq, PartialEq, Debug, Clone, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug))]
 #[cfg_attr(feature = "pyo3", pyclass(sequence))]
 pub struct VersionSpecifiers(Vec<VersionSpecifier>);
 
@@ -163,7 +158,6 @@ impl VersionSpecifiers {
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for VersionSpecifiers {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -174,7 +168,6 @@ impl<'de> Deserialize<'de> for VersionSpecifiers {
     }
 }
 
-#[cfg(feature = "serde")]
 impl Serialize for VersionSpecifiers {
     #[allow(unstable_name_collisions)]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -252,13 +245,9 @@ impl std::error::Error for VersionSpecifiersParseError {}
 /// let version_specifier = VersionSpecifier::from_str("== 1.*").unwrap();
 /// assert!(version_specifier.contains(&version));
 /// ```
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
-)]
-#[cfg_attr(feature = "rkyv", archive(check_bytes))]
-#[cfg_attr(feature = "rkyv", archive_attr(derive(Debug)))]
+#[derive(Eq, PartialEq, Debug, Clone, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug))]
 #[cfg_attr(feature = "pyo3", pyclass(get_all))]
 pub struct VersionSpecifier {
     /// ~=|==|!=|<=|>=|<|>|===, plus whether the version ended with a star
@@ -317,7 +306,6 @@ impl VersionSpecifier {
 }
 
 /// <https://github.com/serde-rs/serde/issues/1316#issue-332908452>
-#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for VersionSpecifier {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -329,7 +317,6 @@ impl<'de> Deserialize<'de> for VersionSpecifier {
 }
 
 /// <https://github.com/serde-rs/serde/issues/1316#issue-332908452>
-#[cfg(feature = "serde")]
 impl Serialize for VersionSpecifier {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/pep508-rs/Cargo.toml
+++ b/crates/pep508-rs/Cargo.toml
@@ -26,12 +26,12 @@ once_cell = { workspace = true }
 pyo3 = { workspace = true, optional = true, features = ["abi3", "extension-module"] }
 pyo3-log = { workspace = true, optional = true }
 regex = { workspace = true }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
 unicode-width = { workspace = true }
-url = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 insta = { version = "1.36.1" }
@@ -41,8 +41,6 @@ testing_logger = { version = "0.1.1" }
 
 [features]
 pyo3 = ["dep:pyo3", "pep440_rs/pyo3", "pyo3-log", "tracing", "tracing/log"]
-rkyv = ["pep440_rs/rkyv", "uv-normalize/rkyv"]
-serde = ["dep:serde", "pep440_rs/serde", "uv-normalize/serde", "url/serde"]
 tracing = ["dep:tracing", "pep440_rs/tracing"]
 # PEP 508 allows only URLs such as `foo @ https://example.org/foo` or `foo @ file:///home/ferris/foo`, and
 # arguably does not allow relative paths in file URLs (`foo @ file://./foo`,

--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -32,7 +32,6 @@ use pyo3::{
     create_exception, exceptions::PyNotImplementedError, pyclass, pyclass::CompareOp, pymethods,
     pymodule, types::PyModule, IntoPy, PyObject, PyResult, Python,
 };
-#[cfg(feature = "serde")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 use unicode_width::UnicodeWidthChar;
@@ -181,7 +180,6 @@ impl Display for Requirement {
 }
 
 /// <https://github.com/serde-rs/serde/issues/908#issuecomment-298027413>
-#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Requirement {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -193,7 +191,6 @@ impl<'de> Deserialize<'de> for Requirement {
 }
 
 /// <https://github.com/serde-rs/serde/issues/1316#issue-332908452>
-#[cfg(feature = "serde")]
 impl Serialize for Requirement {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -16,7 +16,6 @@ use pyo3::{
     basic::CompareOp, exceptions::PyValueError, pyclass, pymethods, types::PyAnyMethods, PyResult,
     Python,
 };
-#[cfg(feature = "serde")]
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
@@ -324,7 +323,6 @@ impl Display for StringVersion {
     }
 }
 
-#[cfg(feature = "serde")]
 impl Serialize for StringVersion {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -334,7 +332,6 @@ impl Serialize for StringVersion {
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for StringVersion {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -359,9 +356,8 @@ impl Deref for StringVersion {
 ///
 /// Some are `(String, Version)` because we have to support version comparison
 #[allow(missing_docs, clippy::unsafe_derive_deserialize)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "pyo3", pyclass(get_all, module = "pep508"))]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct MarkerEnvironment {
     pub implementation_name: String,
     pub implementation_version: StringVersion,
@@ -1683,7 +1679,6 @@ mod test {
         );
     }
 
-    #[cfg(feature = "serde")]
     #[test]
     fn test_marker_environment_from_json() {
         let _env: MarkerEnvironment = serde_json::from_str(

--- a/crates/pep508-rs/src/unnamed.rs
+++ b/crates/pep508-rs/src/unnamed.rs
@@ -62,7 +62,6 @@ impl Display for UnnamedRequirement {
 }
 
 /// <https://github.com/serde-rs/serde/issues/908#issuecomment-298027413>
-#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for UnnamedRequirement {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -74,7 +73,6 @@ impl<'de> Deserialize<'de> for UnnamedRequirement {
 }
 
 /// <https://github.com/serde-rs/serde/issues/1316#issue-332908452>
-#[cfg(feature = "serde")]
 impl Serialize for UnnamedRequirement {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/pep508-rs/src/verbatim_url.rs
+++ b/crates/pep508-rs/src/verbatim_url.rs
@@ -10,17 +10,13 @@ use url::{ParseError, Url};
 use uv_fs::normalize_path;
 
 /// A wrapper around [`Url`] that preserves the original string.
-#[derive(Debug, Clone, Eq, derivative::Derivative)]
+#[derive(Debug, Clone, Eq, derivative::Derivative, serde::Deserialize, serde::Serialize)]
 #[derivative(PartialEq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VerbatimUrl {
     /// The parsed URL.
-    #[cfg_attr(
-        feature = "serde",
-        serde(
-            serialize_with = "Url::serialize_internal",
-            deserialize_with = "Url::deserialize_internal"
-        )
+    #[serde(
+        serialize_with = "Url::serialize_internal",
+        deserialize_with = "Url::deserialize_internal"
     )]
     url: Url,
     /// The URL as it was provided by the user.

--- a/crates/platform-tags/Cargo.toml
+++ b/crates/platform-tags/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 rustc-hash = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/pypi-types/Cargo.toml
+++ b/crates/pypi-types/Cargo.toml
@@ -13,8 +13,8 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-pep440_rs = { workspace = true, features = ["rkyv", "serde"] }
-pep508_rs = { workspace = true, features = ["rkyv", "serde"] }
+pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
 uv-normalize = { workspace = true }
 
 chrono = { workspace = true, features = ["serde"] }

--- a/crates/requirements-txt/Cargo.toml
+++ b/crates/requirements-txt/Cargo.toml
@@ -13,7 +13,7 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-pep508_rs = { workspace = true, features = ["rkyv", "serde", "non-pep508-extensions"] }
+pep508_rs = { workspace = true, features = ["non-pep508-extensions"] }
 uv-client = { workspace = true }
 uv-fs = { workspace = true }
 uv-normalize = { workspace = true }

--- a/crates/uv-build/Cargo.toml
+++ b/crates/uv-build/Cargo.toml
@@ -20,7 +20,7 @@ pep508_rs = { workspace = true }
 uv-fs = { workspace = true }
 uv-interpreter = { workspace = true }
 uv-types = { workspace = true }
-uv-configuration = { workspace = true, features = ["serde"] }
+uv-configuration = { workspace = true }
 uv-virtualenv = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 cache-key = { workspace = true }
-distribution-filename = { workspace = true, features = ["rkyv", "serde"] }
+distribution-filename = { workspace = true }
 distribution-types = { workspace = true }
 install-wheel-rs = { workspace = true }
 pep440_rs = { workspace = true }

--- a/crates/uv-configuration/Cargo.toml
+++ b/crates/uv-configuration/Cargo.toml
@@ -23,9 +23,8 @@ clap = { workspace = true, features = ["derive"], optional = true }
 itertools = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = []
-serde = ["dep:serde", "dep:serde_json"]

--- a/crates/uv-configuration/src/authentication.rs
+++ b/crates/uv-configuration/src/authentication.rs
@@ -1,13 +1,9 @@
 use uv_auth::{self, KeyringProvider};
 
 /// Keyring provider type to use for credential lookup.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(deny_unknown_fields, rename_all = "kebab-case")
-)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum KeyringProviderType {
     /// Do not use keyring for credential lookup.

--- a/crates/uv-configuration/src/build_options.rs
+++ b/crates/uv-configuration/src/build_options.rs
@@ -196,13 +196,9 @@ impl NoBuild {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Hash, Eq, PartialEq, serde::Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(deny_unknown_fields, rename_all = "kebab-case")
-)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum IndexStrategy {
     /// Only use results from the first index that returns a match for a given package name.

--- a/crates/uv-configuration/src/config_settings.rs
+++ b/crates/uv-configuration/src/config_settings.rs
@@ -36,7 +36,6 @@ enum ConfigSettingValue {
     List(Vec<String>),
 }
 
-#[cfg(feature = "serde")]
 impl serde::Serialize for ConfigSettingValue {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
@@ -46,7 +45,6 @@ impl serde::Serialize for ConfigSettingValue {
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ConfigSettingValue {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct Visitor;
@@ -84,7 +82,6 @@ impl<'de> serde::Deserialize<'de> for ConfigSettingValue {
 /// See: <https://peps.python.org/pep-0517/#config-settings>
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(not(feature = "serde"), allow(dead_code))]
 pub struct ConfigSettings(BTreeMap<String, ConfigSettingValue>);
 
 impl FromIterator<ConfigSettingEntry> for ConfigSettings {
@@ -110,7 +107,6 @@ impl FromIterator<ConfigSettingEntry> for ConfigSettings {
     }
 }
 
-#[cfg(feature = "serde")]
 impl ConfigSettings {
     /// Convert the settings to a string that can be passed directly to a PEP 517 build backend.
     pub fn escape_for_python(&self) -> String {
@@ -118,7 +114,6 @@ impl ConfigSettings {
     }
 }
 
-#[cfg(feature = "serde")]
 impl serde::Serialize for ConfigSettings {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeMap;
@@ -131,7 +126,6 @@ impl serde::Serialize for ConfigSettings {
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for ConfigSettings {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct Visitor;
@@ -202,7 +196,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "serde")]
     fn escape_for_python() {
         let mut settings = ConfigSettings::default();
         settings.0.insert(

--- a/crates/uv-configuration/src/name_specifiers.rs
+++ b/crates/uv-configuration/src/name_specifiers.rs
@@ -21,7 +21,6 @@ impl FromStr for PackageNameSpecifier {
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for PackageNameSpecifier {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/uv-configuration/src/target_triple.rs
+++ b/crates/uv-configuration/src/target_triple.rs
@@ -5,13 +5,9 @@ use platform_tags::{Arch, Os, Platform};
 /// system.
 ///
 /// See: <https://doc.rust-lang.org/nightly/rustc/platform-support.html>
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(deny_unknown_fields, rename_all = "kebab-case")
-)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum TargetTriple {
     /// An alias for `x86_64-pc-windows-msvc`, the default target for Windows.

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 cache-key = { workspace = true }
-distribution-filename = { workspace = true, features = ["serde"] }
+distribution-filename = { workspace = true }
 distribution-types = { workspace = true }
 install-wheel-rs = { workspace = true }
 pep440_rs = { workspace = true }

--- a/crates/uv-interpreter/Cargo.toml
+++ b/crates/uv-interpreter/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 cache-key = { workspace = true }
 install-wheel-rs = { workspace = true }
 pep440_rs = { workspace = true }
-pep508_rs = { workspace = true, features = ["serde", "non-pep508-extensions"] }
+pep508_rs = { workspace = true, features = ["non-pep508-extensions"] }
 platform-tags = { workspace = true }
 pypi-types = { workspace = true }
 uv-cache = { workspace = true }

--- a/crates/uv-normalize/Cargo.toml
+++ b/crates/uv-normalize/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 description = "Normalization for distribution, package and extra anmes"
 
 [dependencies]
-rkyv = { workspace = true, optional = true }
+rkyv = { workspace = true }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive"] }

--- a/crates/uv-normalize/src/extra_name.rs
+++ b/crates/uv-normalize/src/extra_name.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{validate_and_normalize_owned, validate_and_normalize_ref, InvalidNameError};
 
@@ -14,8 +14,7 @@ use crate::{validate_and_normalize_owned, validate_and_normalize_ref, InvalidNam
 /// See:
 /// - <https://peps.python.org/pep-0685/#specification/>
 /// - <https://packaging.python.org/en/latest/specifications/name-normalization/>
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ExtraName(String);
 
@@ -34,7 +33,6 @@ impl FromStr for ExtraName {
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for ExtraName {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/uv-normalize/src/package_name.rs
+++ b/crates/uv-normalize/src/package_name.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::str::FromStr;
 
-#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{validate_and_normalize_owned, validate_and_normalize_ref, InvalidNameError};
@@ -12,15 +11,22 @@ use crate::{validate_and_normalize_owned, validate_and_normalize_ref, InvalidNam
 /// down to a single `-`, e.g., `---`, `.`, and `__` all get converted to just `-`.
 ///
 /// See: <https://packaging.python.org/en/latest/specifications/name-normalization/>
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize),
-    archive(check_bytes),
-    archive_attr(derive(Debug))
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
 )]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug))]
 pub struct PackageName(String);
 
 impl PackageName {
@@ -70,7 +76,6 @@ impl FromStr for PackageName {
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for PackageName {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 cache-key = { workspace = true }
-distribution-filename = { workspace = true, features = ["serde"] }
+distribution-filename = { workspace = true }
 distribution-types = { workspace = true }
 install-wheel-rs = { workspace = true }
 once-map = { workspace = true }
@@ -49,7 +49,7 @@ pubgrub = { workspace = true }
 rkyv = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 textwrap = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -3,8 +3,7 @@ use std::str::FromStr;
 use chrono::{DateTime, Days, NaiveDate, NaiveTime, Utc};
 
 /// A timestamp that excludes files newer than it.
-#[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Debug, Copy, Clone, serde::Deserialize, serde::Serialize)]
 pub struct ExcludeNewer(DateTime<Utc>);
 
 impl ExcludeNewer {

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -18,9 +18,8 @@ use rustc_hash::FxHashMap;
 use url::Url;
 use uv_normalize::PackageName;
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(into = "LockWire", try_from = "LockWire"))]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(into = "LockWire", try_from = "LockWire")]
 pub struct Lock {
     version: u32,
     distributions: Vec<Distribution>,
@@ -104,11 +103,10 @@ impl Lock {
     }
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 struct LockWire {
     version: u32,
-    #[cfg_attr(feature = "serde", serde(rename = "distribution"))]
+    #[serde(rename = "distribution")]
     distributions: Vec<Distribution>,
 }
 
@@ -171,24 +169,17 @@ impl TryFrom<LockWire> for Lock {
     }
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub(crate) struct Distribution {
-    #[cfg_attr(feature = "serde", serde(flatten))]
+    #[serde(flatten)]
     pub(crate) id: DistributionId,
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[serde(default)]
     pub(crate) marker: Option<String>,
-    #[cfg_attr(feature = "serde", serde(default))]
+    #[serde(default)]
     pub(crate) sourcedist: Option<SourceDist>,
-    #[cfg_attr(
-        feature = "serde",
-        serde(default, rename = "wheel", skip_serializing_if = "Vec::is_empty")
-    )]
+    #[serde(default, rename = "wheel", skip_serializing_if = "Vec::is_empty")]
     pub(crate) wheels: Vec<Wheel>,
-    #[cfg_attr(
-        feature = "serde",
-        serde(default, skip_serializing_if = "Vec::is_empty")
-    )]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) dependencies: Vec<Dependency>,
 }
 
@@ -275,8 +266,9 @@ impl Distribution {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(
+    Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, serde::Deserialize, serde::Serialize,
+)]
 pub(crate) struct DistributionId {
     pub(crate) name: PackageName,
     pub(crate) version: Version,
@@ -456,7 +448,6 @@ impl std::fmt::Display for Source {
     }
 }
 
-#[cfg(feature = "serde")]
 impl serde::Serialize for Source {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
@@ -466,7 +457,6 @@ impl serde::Serialize for Source {
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Source {
     fn deserialize<D>(d: D) -> Result<Source, D::Error>
     where
@@ -481,9 +471,10 @@ impl<'de> serde::Deserialize<'de> for Source {
 /// variants should be added without changing the relative ordering of other
 /// variants. Otherwise, this could cause the lock file to have a different
 /// canonical ordering of distributions.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
+#[derive(
+    Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, serde::Deserialize, serde::Serialize,
+)]
+#[serde(rename_all = "kebab-case")]
 pub(crate) enum SourceKind {
     Registry,
     Git(GitSource),
@@ -506,8 +497,9 @@ impl SourceKind {
 /// variants should be added without changing the relative ordering of other
 /// variants. Otherwise, this could cause the lock file to have a different
 /// canonical ordering of distributions.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(
+    Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, serde::Deserialize, serde::Serialize,
+)]
 pub(crate) struct GitSource {
     precise: Option<String>,
     kind: GitSourceKind,
@@ -536,8 +528,9 @@ impl GitSource {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(
+    Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, serde::Deserialize, serde::Serialize,
+)]
 enum GitSourceKind {
     Tag(String),
     Branch(String),
@@ -546,8 +539,7 @@ enum GitSourceKind {
 }
 
 /// Inspired by: <https://discuss.python.org/t/lock-files-again-but-this-time-w-sdists/46593>
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub(crate) struct SourceDist {
     /// A URL or file path (via `file://`) where the source dist that was
     /// locked against was found. The location does not need to exist in the
@@ -632,9 +624,8 @@ impl SourceDist {
 }
 
 /// Inspired by: <https://discuss.python.org/t/lock-files-again-but-this-time-w-sdists/46593>
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(into = "WheelWire", try_from = "WheelWire"))]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(into = "WheelWire", try_from = "WheelWire")]
 pub(crate) struct Wheel {
     /// A URL or file path (via `file://`) where the wheel that was locked
     /// against was found. The location does not need to exist in the future,
@@ -713,8 +704,7 @@ impl Wheel {
     }
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 struct WheelWire {
     /// A URL or file path (via `file://`) where the wheel that was locked
     /// against was found. The location does not need to exist in the future,
@@ -756,10 +746,9 @@ impl TryFrom<WheelWire> for Wheel {
 }
 
 /// A single dependency of a distribution in a lock file.
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, serde::Deserialize, serde::Serialize)]
 pub(crate) struct Dependency {
-    #[cfg_attr(feature = "serde", serde(flatten))]
+    #[serde(flatten)]
     id: DistributionId,
 }
 
@@ -806,7 +795,6 @@ impl std::fmt::Display for Hash {
     }
 }
 
-#[cfg(feature = "serde")]
 impl serde::Serialize for Hash {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
@@ -816,7 +804,6 @@ impl serde::Serialize for Hash {
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Hash {
     fn deserialize<D>(d: D) -> Result<Hash, D::Error>
     where

--- a/crates/uv-resolver/src/prerelease_mode.rs
+++ b/crates/uv-resolver/src/prerelease_mode.rs
@@ -5,13 +5,9 @@ use uv_normalize::PackageName;
 
 use crate::{DependencyMode, Manifest};
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(deny_unknown_fields, rename_all = "kebab-case")
-)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum PreReleaseMode {
     /// Disallow all pre-release versions.

--- a/crates/uv-resolver/src/resolution.rs
+++ b/crates/uv-resolver/src/resolution.rs
@@ -35,13 +35,9 @@ use crate::{Manifest, ResolveError};
 
 /// Indicate the style of annotation comments, used to indicate the dependencies that requested each
 /// package.
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, serde::Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(deny_unknown_fields, rename_all = "kebab-case")
-)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AnnotationStyle {
     /// Render the annotations on a single, comma-separated line.

--- a/crates/uv-resolver/src/resolution_mode.rs
+++ b/crates/uv-resolver/src/resolution_mode.rs
@@ -5,13 +5,9 @@ use uv_normalize::PackageName;
 
 use crate::{DependencyMode, Manifest};
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
-#[cfg_attr(
-    feature = "serde",
-    serde(deny_unknown_fields, rename_all = "kebab-case")
-)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ResolutionMode {
     /// Resolve the highest compatible version of each package.

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -15,10 +15,10 @@ workspace = true
 [dependencies]
 distribution-types = { workspace = true, features = ["schemars"] }
 install-wheel-rs = { workspace = true, features = ["schemars"] }
-uv-configuration = { workspace = true, features = ["schemars", "serde"] }
+uv-configuration = { workspace = true, features = ["schemars"] }
 uv-fs = { workspace = true }
 uv-normalize = { workspace = true, features = ["schemars"] }
-uv-resolver = { workspace = true, features = ["schemars", "serde"] }
+uv-resolver = { workspace = true, features = ["schemars"] }
 uv-interpreter = { workspace = true, features = ["schemars"] }
 uv-warnings = { workspace = true }
 


### PR DESCRIPTION
In *some* places in our crates, `serde` (and `rkyv`) are optional
dependencies. I believe this was done out of reasons of "good sense,"
that is, it follows a Rust ecosystem pattern where serde integration
tends to be an opt-in crate feature. (And similarly for `rkyv`.)

However, ultimately, `uv` itself requires `serde` and `rkyv` to
function. Since our crates are strictly internal, there are limited
consumers for our crates without `serde` (and `rkyv`) enabled. I think
one possibility is that optional `serde` (and `rkyv`) integration means
that someone can do this:

    cargo test -p pep440_rs

And this will run tests _without_ `serde` or `rkyv` enabled. That in
turn could lead to faster iteration time by reducing compile times. But,
I'm not sure this is worth supporting. The iterative compilation times of
individual crates are probably fast enough in debug mode, even with
`serde` and `rkyv` enabled. Namely, `serde` and `rkyv` themselves
shouldn't need to be re-compiled in most cases. On `main`:

```
from-scratch: `cargo test -p pep440_rs --lib` 0.685
incremental: `cargo test -p pep440_rs --lib` 0.278s
from-scratch: `cargo test -p pep440_rs --features serde,rkyv --lib` 3.948s
incremental: `cargo test -p pep440_rs --features serde,rkyv --lib` 0.321s
```

So while a from-scratch build does take significantly longer, an
incremental build is about the same.

The benefit of doing this change is two-fold:

1. It brings out crates into alignment with "reality." In particular,
   some crates were _implicitly_ relying on `serde` being enabled
   without explicitly declaring it. This technically means that our
   `Cargo.toml`s were wrong in some cases, but it is hard to observe it
   because of feature unification in a Cargo workspace.
2. We no longer need to deal with the cognitive burden of writing
   `#[cfg_attr(feature = "serde", ...)]` everywhere.
