### PR TITLE
Update Rust to v1.78

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.78"
 homepage = "https://pypi.org/project/uv/"
 documentation = "https://pypi.org/project/uv/"
 repository = "https://github.com/astral-sh/uv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.78"
+rust-version = "1.77"
 homepage = "https://pypi.org/project/uv/"
 documentation = "https://pypi.org/project/uv/"
 repository = "https://github.com/astral-sh/uv"

--- a/crates/platform-tags/src/tags.rs
+++ b/crates/platform-tags/src/tags.rs
@@ -64,7 +64,7 @@ impl TagCompatibility {
 /// wheel are compatible with the current environment.
 #[derive(Debug, Clone)]
 pub struct Tags {
-    /// python_tag |--> abi_tag |--> platform_tag |--> priority
+    /// `python_tag` |--> `abi_tag` |--> `platform_tag` |--> priority
     #[allow(clippy::type_complexity)]
     map: Arc<FxHashMap<String, FxHashMap<String, FxHashMap<String, TagPriority>>>>,
 }

--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -355,12 +355,12 @@ pub struct SourceBuild {
     venv: PythonEnvironment,
     /// Populated if `prepare_metadata_for_build_wheel` was called.
     ///
-    /// > If the build frontend has previously called prepare_metadata_for_build_wheel and depends
+    /// > If the build frontend has previously called `prepare_metadata_for_build_wheel` and depends
     /// > on the wheel resulting from this call to have metadata matching this earlier call, then
-    /// > it should provide the path to the created .dist-info directory as the metadata_directory
-    /// > argument. If this argument is provided, then build_wheel MUST produce a wheel with
+    /// > it should provide the path to the created .dist-info directory as the `metadata_directory`
+    /// > argument. If this argument is provided, then `build_wheel` MUST produce a wheel with
     /// > identical metadata. The directory passed in by the build frontend MUST be identical to the
-    /// > directory created by prepare_metadata_for_build_wheel, including any unrecognized files
+    /// > directory created by `prepare_metadata_for_build_wheel`, including any unrecognized files
     /// > it created.
     metadata_directory: Option<PathBuf>,
     /// Package id such as `foo-1.2.3`, for error reporting

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -376,7 +376,7 @@ impl Cache {
 pub enum CacheBucket {
     /// Wheels (excluding built wheels), alongside their metadata and cache policy.
     ///
-    /// There are three kinds from cache entries: Wheel metadata and policy as MsgPack files, the
+    /// There are three kinds from cache entries: Wheel metadata and policy as `MsgPack` files, the
     /// wheels themselves, and the unzipped wheel archives. If a wheel file is over an in-memory
     /// size threshold, we first download the zip file into the cache, then unzip it into a
     /// directory with the same name (exclusive of the `.whl` extension).
@@ -559,7 +559,7 @@ pub enum CacheBucket {
     ///
     /// # Example
     ///
-    /// The contents of each of the MsgPack files has a timestamp field in unix time, the [PEP 508]
+    /// The contents of each of the `MsgPack` files has a timestamp field in unix time, the [PEP 508]
     /// markers and some information from the `sys`/`sysconfig` modules.
     ///
     /// ```json

--- a/crates/uv-configuration/src/build_options.rs
+++ b/crates/uv-configuration/src/build_options.rs
@@ -218,7 +218,7 @@ pub enum IndexStrategy {
     /// even if the secondary index might contain compatible versions (e.g., variants of the same
     /// versions with different ABI tags or Python version constraints).
     ///
-    /// See: https://peps.python.org/pep-0708/
+    /// See: <https://peps.python.org/pep-0708/>
     #[cfg_attr(feature = "clap", clap(alias = "unsafe-any-match"))]
     UnsafeFirstMatch,
     /// Search for every package name across all indexes, preferring the "best" version found. If a
@@ -233,7 +233,7 @@ pub enum IndexStrategy {
     /// as internal packages, causing the resolver to install the malicious package in lieu of
     /// the intended internal package.
     ///
-    /// See: https://peps.python.org/pep-0708/
+    /// See: <https://peps.python.org/pep-0708/>
     UnsafeBestMatch,
 }
 

--- a/crates/uv-configuration/src/target_triple.rs
+++ b/crates/uv-configuration/src/target_triple.rs
@@ -43,15 +43,15 @@ pub enum TargetTriple {
     #[cfg_attr(feature = "clap", value(name = "aarch64-unknown-linux-musl"))]
     Aarch64UnknownLinuxMusl,
 
-    /// An x86_64 Linux target.
+    /// An `x86_64` Linux target.
     #[cfg_attr(feature = "clap", value(name = "x86_64-unknown-linux-musl"))]
     X8664UnknownLinuxMusl,
 
-    /// An x86_64 target for the `manylinux_2_17` platform.
+    /// An `x86_64` target for the `manylinux_2_17` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_17"))]
     X8664Manylinux217,
 
-    /// An x86_64 target for the `manylinux_2_28` platform.
+    /// An `x86_64` target for the `manylinux_2_28` platform.
     #[cfg_attr(feature = "clap", value(name = "x86_64-manylinux_2_28"))]
     X8664Manylinux228,
 

--- a/crates/uv-resolver/src/pubgrub/package.rs
+++ b/crates/uv-resolver/src/pubgrub/package.rs
@@ -26,7 +26,7 @@ pub enum PubGrubPackage {
         /// The URL of the package, if it was specified in the requirement.
         ///
         /// There are a few challenges that come with URL-based packages, and how they map to
-        /// PubGrub.
+        /// `PubGrub`.
         ///
         /// If the user declares a direct URL dependency, and then a transitive dependency
         /// appears for the same package, we need to ensure that the direct URL dependency can
@@ -70,9 +70,9 @@ pub enum PubGrubPackage {
     ///
     /// The benefit of the proxy package (versus `PubGrubPackage::Package("black", Some("colorama")`
     /// on its own) is that it enables us to avoid attempting to retrieve metadata for irrelevant
-    /// versions the extra variants by making it clear to PubGrub that the extra variant must match
+    /// versions the extra variants by making it clear to `PubGrub` that the extra variant must match
     /// the exact same version of the base variant. Without the proxy package, then when provided
-    /// requirements like `black==23.0.1` and `black[colorama]`, PubGrub may attempt to retrieve
+    /// requirements like `black==23.0.1` and `black[colorama]`, `PubGrub` may attempt to retrieve
     /// metadata for `black[colorama]` versions other than `23.0.1`.
     Extra(PackageName, ExtraName, Option<VerbatimUrl>),
 }

--- a/crates/uv/src/shell.rs
+++ b/crates/uv/src/shell.rs
@@ -3,19 +3,19 @@ use std::path::Path;
 /// Shells for which virtualenv activation scripts are available.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum Shell {
-    /// Bourne Again SHell (bash)
+    /// Bourne Again `SHell` (bash)
     Bash,
-    /// Friendly Interactive SHell (fish)
+    /// Friendly Interactive `SHell` (fish)
     Fish,
-    /// PowerShell
+    /// `PowerShell`
     Powershell,
     /// Cmd (Command Prompt)
     Cmd,
-    /// Z SHell (zsh)
+    /// Z `SHell` (zsh)
     Zsh,
     /// Nushell
     Nushell,
-    /// C SHell (csh)
+    /// C `SHell` (csh)
     Csh,
 }
 

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -1,5 +1,5 @@
 #![cfg(all(feature = "python", feature = "pypi"))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::disallowed_types))]
+#![allow(clippy::disallowed_types)]
 
 use std::env::current_dir;
 use std::fs;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.77"
+channel = "1.78"

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -121,14 +121,14 @@
           ]
         },
         {
-          "description": "Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next.\n\nIn this strategy, we look for every package across all indexes. When resolving, we attempt to use versions from the indexes in order, such that we exhaust all available versions from the first index before moving on to the next. Further, if a version is found to be incompatible in the first index, we do not reconsider that version in subsequent indexes, even if the secondary index might contain compatible versions (e.g., variants of the same versions with different ABI tags or Python version constraints).\n\nSee: https://peps.python.org/pep-0708/",
+          "description": "Search for every package name across all indexes, exhausting the versions from the first index before moving on to the next.\n\nIn this strategy, we look for every package across all indexes. When resolving, we attempt to use versions from the indexes in order, such that we exhaust all available versions from the first index before moving on to the next. Further, if a version is found to be incompatible in the first index, we do not reconsider that version in subsequent indexes, even if the secondary index might contain compatible versions (e.g., variants of the same versions with different ABI tags or Python version constraints).\n\nSee: <https://peps.python.org/pep-0708/>",
           "type": "string",
           "enum": [
             "unsafe-first-match"
           ]
         },
         {
-          "description": "Search for every package name across all indexes, preferring the \"best\" version found. If a package version is in multiple indexes, only look at the entry for the first index.\n\nIn this strategy, we look for every package across all indexes. When resolving, we consider all versions from all indexes, choosing the \"best\" version found (typically, the highest compatible version).\n\nThis most closely matches pip's behavior, but exposes the resolver to \"dependency confusion\" attacks whereby malicious actors can publish packages to public indexes with the same name as internal packages, causing the resolver to install the malicious package in lieu of the intended internal package.\n\nSee: https://peps.python.org/pep-0708/",
+          "description": "Search for every package name across all indexes, preferring the \"best\" version found. If a package version is in multiple indexes, only look at the entry for the first index.\n\nIn this strategy, we look for every package across all indexes. When resolving, we consider all versions from all indexes, choosing the \"best\" version found (typically, the highest compatible version).\n\nThis most closely matches pip's behavior, but exposes the resolver to \"dependency confusion\" attacks whereby malicious actors can publish packages to public indexes with the same name as internal packages, causing the resolver to install the malicious package in lieu of the intended internal package.\n\nSee: <https://peps.python.org/pep-0708/>",
           "type": "string",
           "enum": [
             "unsafe-best-match"
@@ -640,21 +640,21 @@
           ]
         },
         {
-          "description": "An x86_64 Linux target.",
+          "description": "An `x86_64` Linux target.",
           "type": "string",
           "enum": [
             "x8664-unknown-linux-musl"
           ]
         },
         {
-          "description": "An x86_64 target for the `manylinux_2_17` platform.",
+          "description": "An `x86_64` target for the `manylinux_2_17` platform.",
           "type": "string",
           "enum": [
             "x8664-manylinux217"
           ]
         },
         {
-          "description": "An x86_64 target for the `manylinux_2_28` platform.",
+          "description": "An `x86_64` target for the `manylinux_2_28` platform.",
           "type": "string",
           "enum": [
             "x8664-manylinux228"


### PR DESCRIPTION
## Summary

Updates rust to 1.78 in `rust-toolchain.toml`

See: https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html

### Potential blockers

* homebre still on 1.77 - https://github.com/Homebrew/homebrew-core/pull/170649
* conda-forge still on 1.77 - https://anaconda.org/conda-forge/rust
