### PR TITLE
Unset target when creating virtual environments

### DIFF
--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -103,6 +103,7 @@ impl Interpreter {
             scheme: virtualenv.scheme,
             sys_executable: virtualenv.executable,
             prefix: virtualenv.root,
+            target: None,
             ..self
         }
     }


### PR DESCRIPTION
## Summary

We were writing the build dependencies into the `--target` directory, which both made builds fail and led to them leaking into the user's directory.

Closes https://github.com/astral-sh/uv/issues/3349.

