### PR TITLE
Respect `editable = true` setting in sources map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4961,6 +4961,7 @@ dependencies = [
  "indexmap",
  "indoc",
  "insta",
+ "itertools 0.12.1",
  "path-absolutize",
  "pep440_rs",
  "pep508_rs",

--- a/crates/distribution-types/src/requirement.rs
+++ b/crates/distribution-types/src/requirement.rs
@@ -21,7 +21,7 @@ pub struct Requirements {
 /// A representation of dependency on a package, an extension over a PEP 508's requirement.
 ///
 /// The main change is using [`RequirementSource`] to represent all supported package sources over
-/// [`pep508_rs::VersionOrUrl`], which collapses all URL sources into a single stringly type.
+/// [`VersionOrUrl`], which collapses all URL sources into a single stringly type.
 #[derive(Hash, Debug, Clone, Eq, PartialEq)]
 pub struct Requirement {
     pub name: PackageName,
@@ -47,7 +47,7 @@ impl Requirement {
                 specifier: VersionSpecifiers::empty(),
                 index: None,
             },
-            // The most popular case: Just a name, a version range and maybe extras.
+            // The most popular case: just a name, a version range and maybe extras.
             Some(VersionOrUrl::VersionSpecifier(specifier)) => RequirementSource::Registry {
                 specifier,
                 index: None,

--- a/crates/uv-requirements/Cargo.toml
+++ b/crates/uv-requirements/Cargo.toml
@@ -18,6 +18,7 @@ pep508_rs = { workspace = true }
 pypi-types = { workspace = true }
 requirements-txt = { workspace = true, features = ["reqwest"] }
 uv-client = { workspace = true }
+uv-configuration = { workspace = true }
 uv-distribution = { workspace = true }
 uv-fs = { workspace = true }
 uv-git = { workspace = true }
@@ -25,7 +26,6 @@ uv-normalize = { workspace = true }
 uv-resolver = { workspace = true, features = ["clap"] }
 uv-types = { workspace = true }
 uv-warnings = { workspace = true }
-uv-configuration = { workspace = true }
 
 anyhow = { workspace = true }
 configparser = { workspace = true }
@@ -35,6 +35,7 @@ fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 glob = { workspace = true }
 indexmap = { workspace = true }
+itertools = { workspace = true }
 path-absolutize = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -4601,7 +4601,7 @@ fn tool_uv_sources() -> Result<()> {
         version = "0.0.0"
         dependencies = [
           "tqdm>4,<=5",
-          "packaging @ git+https://github.com/pypa/packaging",
+          "packaging @ git+https://github.com/pypa/packaging@32deafe8668a2130a3366b98154914d188f3718e",
           "poetry_editable",
           "urllib3 @ https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl",
           # Windows consistency
@@ -4619,7 +4619,7 @@ fn tool_uv_sources() -> Result<()> {
         [tool.uv.sources]
         tqdm = { url = "https://files.pythonhosted.org/packages/a5/d6/502a859bac4ad5e274255576cd3e15ca273cdb91731bc39fb840dd422ee9/tqdm-4.66.0-py3-none-any.whl" }
         boltons = { git = "https://github.com/mahmoud/boltons", rev = "57fbaa9b673ed85b32458b31baeeae230520e4a0" }
-        poetry_editable = { path = "../poetry_editable" }
+        poetry_editable = { path = "../poetry_editable", editable = true }
     "#})?;
 
     let project_root = fs_err::canonicalize(std::env::current_dir()?.join("../.."))?;
@@ -4646,8 +4646,9 @@ fn tool_uv_sources() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Built 1 editable in [TIME]
     Resolved 9 packages in [TIME]
-    Downloaded 9 packages in [TIME]
+    Downloaded 8 packages in [TIME]
     Installed 9 packages in [TIME]
      + anyio==4.3.0
      + boltons==24.0.1.dev0 (from git+https://github.com/mahmoud/boltons@57fbaa9b673ed85b32458b31baeeae230520e4a0)
@@ -4661,8 +4662,8 @@ fn tool_uv_sources() -> Result<()> {
     "###
     );
 
-    // Install the editable packages.
-    uv_snapshot!(context.install()
+    // Re-install the editable packages.
+    uv_snapshot!(context.filters(), windows_filters=false, context.install()
         .arg("-r")
         .arg(require_path), @r###"
     success: true
@@ -4670,8 +4671,7 @@ fn tool_uv_sources() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 8 packages in [TIME]
-    Audited 8 packages in [TIME]
+    Audited 5 packages in [TIME]
     "###
     );
     Ok(())


### PR DESCRIPTION
## Summary

We need to partition the editable and non-editable requirements. As-is, `editable = true` requirements were still being installed as non-editable.
