### PR TITLE
Fix Git URL construction in `tool.uv.sources`

### DIFF
--- a/crates/uv-requirements/src/pyproject.rs
+++ b/crates/uv-requirements/src/pyproject.rs
@@ -441,18 +441,18 @@ pub(crate) fn lower_requirement(
                 _ => return Err(LoweringError::MoreThanOneGitRef),
             };
 
+            // Create a PEP 508-compatible URL.
             let mut url = Url::parse(&format!("git+{git}"))?;
-            let mut given = git.to_string();
             if let Some(rev) = reference.as_str() {
                 url.set_path(&format!("{}@{}", url.path(), rev));
-                given = format!("{given}@{rev}");
             }
             if let Some(subdirectory) = &subdirectory {
                 url.set_fragment(Some(&format!("subdirectory={subdirectory}")));
-                given = format!("{given}#subdirectory={subdirectory}");
             }
-            let url = VerbatimUrl::from_url(url).with_given(given);
-            let repository = url.to_url().clone();
+            let url = VerbatimUrl::from_url(url);
+
+            let repository = git.clone();
+
             RequirementSource::Git {
                 url,
                 repository,

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -4667,13 +4667,15 @@ fn tool_uv_sources() -> Result<()> {
     uv_snapshot!(context.filters(), windows_filters=false, context.install()
         .arg("--preview")
         .arg("-r")
-        .arg(require_path), @r###"
+        .arg(require_path)
+        .arg("--extra")
+        .arg("utils"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    Audited 5 packages in [TIME]
+    Audited 6 packages in [TIME]
     "###
     );
     Ok(())


### PR DESCRIPTION
## Summary

We were including the `git+` prefix twice:

```
DEBUG At least one requirement is not satisfied: boltons @ git+git+https://github.com/mahmoud/boltons@57fbaa9b673ed85b32458b31baeeae230520e4a0@57fbaa9b673ed85b32458b31baeeae230520e4a0
```

## Test Plan

Extended the test to include a Git URL; verified that we don't trigger a reinstall.
