### PR TITLE
feat: Refactor `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=${BUILDPLATFORM} ubuntu AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:24.04 AS builder
 # Configure the shell to exit early if any command fails, or when referencing unset variables.
 # Additionally `-x` outputs each command run, this is helpful for troubleshooting failures.
 SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
 
-RUN <<HEREDOC
-  apt update && apt install -y --no-install-recommends \
-    build-essential \
-    curl \
-    python3-venv \
-    cmake
+RUN \
+  --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+  --mount=target=/var/cache/apt,type=cache,sharing=locked \
+  <<HEREDOC
+    # https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#example-cache-apt-packages
+    rm -f /etc/apt/apt.conf.d/docker-clean
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
-  apt clean
-  rm -rf /var/lib/apt/lists/*
+    apt update && apt install -y --no-install-recommends \
+      build-essential \
+      curl \
+      python3-venv \
+      cmake
 HEREDOC
 
 ENV HOME="/root"
@@ -23,7 +27,7 @@ WORKDIR $HOME
 # Setup zig as cross compiling linker
 RUN <<HEREDOC
   python3 -m venv $HOME/.venv
-  .venv/bin/pip install cargo-zigbuild
+  .venv/bin/pip install --no-cache-dir cargo-zigbuild
 HEREDOC
 
 # Install rust
@@ -43,6 +47,9 @@ RUN <<HEREDOC
 
   # Install `rustup` to match the toolchain version in `rust-toolchain.toml`:
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none
+  # Ensure toolchain to be installed upon rustup command uses the minimal profile to avoid excess layer weight:
+  # https://github.com/rust-lang/rustup/issues/3805#issuecomment-2094066914
+  echo 'profile = "minimal"' >> rust-toolchain.toml
   # Add the relevant musl target triple (to build uv as static binary):
   rustup target add "${CARGO_BUILD_TARGET}"
 
@@ -50,15 +57,29 @@ RUN <<HEREDOC
   echo "${CARGO_BUILD_TARGET}" > rust_target.txt
 HEREDOC
 
-# Build uv
+# Build app
+ARG APP_NAME=uv
+ARG CARGO_HOME=/usr/local/cargo
 COPY crates/ crates/
 COPY Cargo.toml Cargo.lock .
-RUN <<HEREDOC
-  cargo zigbuild --target "$(cat rust_target.txt)" --bin uv --release
-  cp "target/$(cat rust_target.txt)/release/uv" /uv
+RUN \
+  --mount=type=cache,target="/root/.cache/zig",id="zig-cache" \
+  # Cache mounts (dirs for crates cache + build target):
+  # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+  # CAUTION: As cargo uses multiple lock files (eg: `${CARGO_HOME}/{.global-cache,.package-cache,.package-cache-mutate}`), do not mount subdirs individually.
+  --mount=type=cache,target="${CARGO_HOME}",id="cargo-cache" \
+  # This cache mount is specific enough that you may not have any concurrent builds needing to share it, communicate that expectation explicitly:
+  --mount=type=cache,target="target/",id="cargo-target-${APP_NAME}",sharing=locked \
+  # These are redundant as they're easily reconstructed from cache above. Use TMPFS mounts to exclude from cache mounts:
+  # TMPFS mount is a better choice than `rm -rf` command (which is risky on a cache mount that is shared across concurrent builds).
+  --mount=type=tmpfs,target="${CARGO_HOME}/registry/src" \
+  --mount=type=tmpfs,target="${CARGO_HOME}/git/checkouts" \
+  <<HEREDOC
+    cargo zigbuild --release --target "$(cat rust_target.txt)" --bin "${APP_NAME}"
+    cp "target/$(cat rust_target.txt)/release/${APP_NAME}" "/${APP_NAME}"
 
-  # TODO(konsti): Optimize binary size, with a version that also works when cross compiling
-  # strip --strip-all /uv
+    # TODO(konsti): Optimize binary size, with a version that also works when cross compiling
+    # strip --strip-all /uv
 HEREDOC
 
 FROM scratch AS output

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM --platform=${BUILDPLATFORM} ubuntu:24.04 AS builder
+FROM --platform=${BUILDPLATFORM} ubuntu:24.04 AS builder-base
 # Configure the shell to exit early if any command fails, or when referencing unset variables.
 # Additionally `-x` outputs each command run, this is helpful for troubleshooting failures.
 SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
@@ -10,6 +10,7 @@ RUN \
   --mount=target=/var/cache/apt,type=cache,sharing=locked \
   <<HEREDOC
     # https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#example-cache-apt-packages
+    # https://stackoverflow.com/questions/66808788/docker-can-you-cache-apt-get-package-installs#comment135104889_72851168
     rm -f /etc/apt/apt.conf.d/docker-clean
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
@@ -24,33 +25,42 @@ ENV HOME="/root"
 ENV PATH="$HOME/.venv/bin:$PATH"
 WORKDIR $HOME
 
-# Setup zig as cross compiling linker
+# Setup zig as cross compiling linker:
 RUN <<HEREDOC
   python3 -m venv $HOME/.venv
   .venv/bin/pip install --no-cache-dir cargo-zigbuild
 HEREDOC
 
-# Install rust
+# Install rust:
 ENV PATH="$HOME/.cargo/bin:$PATH"
 COPY rust-toolchain.toml .
 RUN <<HEREDOC
-  # Install `rustup` to match the toolchain version in `rust-toolchain.toml`:
+  # Install rustup, but skip installing a default toolchain as we only want the version from `rust-toolchain.toml`:
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none
 
-  # Ensure toolchain to be installed upon rustup command uses the minimal profile to avoid excess layer weight:
+  # When rustup installs the toolchain ensure it actually uses the minimal profile, avoiding excess layer weight:
   # https://github.com/rust-lang/rustup/issues/3805#issuecomment-2094066914
   echo 'profile = "minimal"' >> rust-toolchain.toml
   echo 'targets = [ "aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl" ]' >> rust-toolchain.toml
-  # Add the relevant musl target triple (to build uv as static binary):
+  # Add the relevant musl target triples (for a building binary with static linking):
   # Workaround until `ensure` arrives: https://github.com/rust-lang/rustup/issues/2686#issuecomment-788825744
   rustup show
 HEREDOC
 
-# Build app for both AMD64 + ARM64
-ARG APP_NAME=uv
-ARG CARGO_HOME=/usr/local/cargo
+# Handle individual images differences for ARM64 / AMD64:
+FROM builder-base AS builder-arm64
+ENV CARGO_BUILD_TARGET=aarch64-unknown-linux-musl
+
+FROM builder-base AS builder-amd64
+ENV CARGO_BUILD_TARGET=x86_64-unknown-linux-musl
+
+# Build app:
+FROM builder-${TARGETARCH} AS builder-app
 COPY crates/ crates/
 COPY Cargo.toml Cargo.lock .
+ARG APP_NAME=uv
+ARG CARGO_HOME=/usr/local/cargo
+ARG TARGETPLATFORM
 RUN \
   --mount=type=cache,target="/root/.cache/zig",id="zig-cache" \
   # Cache mounts (dirs for crates cache + build target):
@@ -58,28 +68,18 @@ RUN \
   # CAUTION: As cargo uses multiple lock files (eg: `${CARGO_HOME}/{.global-cache,.package-cache,.package-cache-mutate}`), do not mount subdirs individually.
   --mount=type=cache,target="${CARGO_HOME}",id="cargo-cache" \
   # This cache mount is specific enough that you may not have any concurrent builds needing to share it, communicate that expectation explicitly:
-  --mount=type=cache,target="target/",id="cargo-target-${APP_NAME}",sharing=locked \
+  --mount=type=cache,target="target/",id="cargo-target-${APP_NAME}-${TARGETPLATFORM}",sharing=locked \
   # These are redundant as they're easily reconstructed from cache above. Use TMPFS mounts to exclude from cache mounts:
   # TMPFS mount is a better choice than `rm -rf` command (which is risky on a cache mount that is shared across concurrent builds).
   --mount=type=tmpfs,target="${CARGO_HOME}/registry/src" \
   --mount=type=tmpfs,target="${CARGO_HOME}/git/checkouts" \
   <<HEREDOC
-    BUILD_TARGETS=('aarch64-unknown-linux-musl' 'x86_64-unknown-linux-musl')
-    for BUILD_TARGET in "${BUILD_TARGETS[@]}"; do
-      cargo zigbuild --release --bin "${APP_NAME}" --target "${BUILD_TARGET}"
-
-      mkdir -p /dist/${BUILD_TARGET}/
-      cp "target/${BUILD_TARGET}/release/${APP_NAME}" "/dist/${BUILD_TARGET}/${APP_NAME}"
-    done
+    cargo zigbuild --release --bin "${APP_NAME}" --target "${CARGO_BUILD_TARGET}"
+    cp "target/${CARGO_BUILD_TARGET}/release/${APP_NAME}" "/${APP_NAME}"
 HEREDOC
 
-# Handle individual ARM64 + AMD64 images:
-FROM scratch AS output-arm64
-COPY --from=builder /dist/aarch64-unknown-linux-musl/uv /uv
-
-FROM scratch AS output-amd64
-COPY --from=builder /dist/x86_64-unknown-linux-musl/uv /uv
-
-FROM output-${TARGETARCH}
+# Final stage - Image containing only uv + empty /io dir:
+FROM scratch
+COPY --from=builder-app /uv /uv
 WORKDIR /io
 ENTRYPOINT ["/uv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,67 @@
-FROM --platform=$BUILDPLATFORM ubuntu as build
+# syntax=docker/dockerfile:1
+
+FROM --platform=${BUILDPLATFORM} ubuntu AS builder
+# Configure the shell to exit early if any command fails, or when referencing unset variables.
+# Additionally `-x` outputs each command run, this is helpful for troubleshooting failures.
+SHELL ["/bin/bash", "-eux", "-o", "pipefail", "-c"]
+
+RUN <<HEREDOC
+  apt update && apt install -y --no-install-recommends \
+    build-essential \
+    curl \
+    python3-venv \
+    cmake
+
+  apt clean
+  rm -rf /var/lib/apt/lists/*
+HEREDOC
+
 ENV HOME="/root"
+ENV PATH="$HOME/.venv/bin:$PATH"
 WORKDIR $HOME
 
-RUN apt update \
-  && apt install -y --no-install-recommends \
-  build-essential \
-  curl \
-  python3-venv \
-  cmake \
-  && apt clean \
-  && rm -rf /var/lib/apt/lists/*
-
 # Setup zig as cross compiling linker
-RUN python3 -m venv $HOME/.venv
-RUN .venv/bin/pip install cargo-zigbuild
-ENV PATH="$HOME/.venv/bin:$PATH"
+RUN <<HEREDOC
+  python3 -m venv $HOME/.venv
+  .venv/bin/pip install cargo-zigbuild
+HEREDOC
 
 # Install rust
-ARG TARGETPLATFORM
-RUN case "$TARGETPLATFORM" in \
-  "linux/arm64") echo "aarch64-unknown-linux-musl" > rust_target.txt ;; \
-  "linux/amd64") echo "x86_64-unknown-linux-musl" > rust_target.txt ;; \
-  *) exit 1 ;; \
-  esac
-# Update rustup whenever we bump the rust version
-COPY rust-toolchain.toml rust-toolchain.toml
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --target $(cat rust_target.txt) --profile minimal --default-toolchain none
 ENV PATH="$HOME/.cargo/bin:$PATH"
-# Installs the correct toolchain version from rust-toolchain.toml and then the musl target
-RUN rustup target add $(cat rust_target.txt)
+COPY rust-toolchain.toml .
+ARG TARGETPLATFORM
+RUN <<HEREDOC
+  case "${TARGETPLATFORM}" in
+    ( 'linux/arm64' )
+      CARGO_BUILD_TARGET='aarch64-unknown-linux-musl'
+      ;;
+    ( 'linux/amd64' )
+      CARGO_BUILD_TARGET='x86_64-unknown-linux-musl'
+      ;;
+    *) exit 1 ;;
+  esac
 
-# Build
-COPY crates crates
-COPY ./Cargo.toml Cargo.toml
-COPY ./Cargo.lock Cargo.lock
-RUN cargo zigbuild --bin uv --target $(cat rust_target.txt) --release
-RUN cp target/$(cat rust_target.txt)/release/uv /uv
-# TODO(konsti): Optimize binary size, with a version that also works when cross compiling
-# RUN strip --strip-all /uv
+  # Install `rustup` to match the toolchain version in `rust-toolchain.toml`:
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain none
+  # Add the relevant musl target triple (to build uv as static binary):
+  rustup target add "${CARGO_BUILD_TARGET}"
 
-FROM scratch
-COPY --from=build /uv /uv
+  # For the next RUN layer to reference:
+  echo "${CARGO_BUILD_TARGET}" > rust_target.txt
+HEREDOC
+
+# Build uv
+COPY crates/ crates/
+COPY Cargo.toml Cargo.lock .
+RUN <<HEREDOC
+  cargo zigbuild --target "$(cat rust_target.txt)" --bin uv --release
+  cp "target/$(cat rust_target.txt)/release/uv" /uv
+
+  # TODO(konsti): Optimize binary size, with a version that also works when cross compiling
+  # strip --strip-all /uv
+HEREDOC
+
+FROM scratch AS output
+COPY --from=builder /uv /uv
 WORKDIR /io
 ENTRYPOINT ["/uv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ COPY crates/ crates/
 COPY Cargo.toml Cargo.lock .
 ARG APP_NAME=uv
 ARG CARGO_HOME=/usr/local/cargo
+ARG RUSTFLAGS="-C strip=symbols -C relocation-model=static -C target-feature=+crt-static -C opt-level=z"
 ARG TARGETPLATFORM
 RUN \
   --mount=type=cache,target="/root/.cache/zig",id="zig-cache" \


### PR DESCRIPTION
## Summary

**TL;DR:**
- 4GB disk usage down to 1.7GB (_some extra weight externalized via cache mounts_).
- 68MB binary now builds to smaller 24MB size.
- Layer invalidation concerns reduced, especially with use of cache mounts (_less meaningful to CI, but good for local use_).
- Additional changes detailed below.

---

- The first commit introduces the larger diff as adopting HereDoc feature introduces indents and merging of some `RUN` layers.
  - I've also relocated and grouped some directives where appropriate, minimizing layer invalidation.
  - HereDoc usage brings the added benefit of better formatting for multi-line `RUN` content.
  - There doesn't seem to be a need for the early `--target` until explicitly adding the target triple.
- 2nd commit (will follow shortly) addresses excess disk weight for the builder image layers that's less obvious from the multi-stage build.
  - When ignoring the final stage, the total disk usage for the builder image is about 4GB.
    <details>
    <summary>Expand to see breakdown (4.11GB image)</summary>

    - **80MB** => Ubuntu base image (~116MB after apt update)
    - **+450MB** => apt update + system deps
    - **+13MB** => pip `/root/.venv` creation
    - **+390MB** => pip install cargo-zigbuild
      - 306MB `/root/.venv/lib/python3.12/site-packages/ziglang`
      - 79MB `/root/.cache/pip/http-v2` (_can be skipped with `pip install --no-cache-dir`_)
      - 2.7MB `/root/.venv/bin/cargo-zigbuild`
    - **+1.3GB** => rustup + toolchain + target setup
      - 15MB rustup install
      - 1.3GB `rust toolchain target add`, (_Over 600MB is from toolchain installing docs at `~/.rustup/toolchains/1.78-x86_64-unknown-linux-gnu/share/doc/rust/html`, the `minimal` rustup profile doesn't apply due to `rust-toolchain.toml`_)
    - **+1.8GB** => Build cache for `uv`:
      - 270MB `/root/.cache/zig from cargo-zigbuild`
      - 300MB `/root/.cargo/registry/` (_51MB `cache/`, 21MB `index/`, 225MB `src`_)
      - 1.2GB `target/` dir
        - 360MB `target/release/{build,deps}` (_180MB each_)
        - 835MB `target/<triple>/release/` (_168MB `build/`, 667MB `deps/`_)
      - 68MB `uv` (_copied from target build dir_)

    ---
    </details>

  - The `RUN --mount` usage allows for caching useful data locally that would otherwise be invalidated across builds when you'd rather have it available. It also minimizes the impact of unused layers from past builds piling up until a prune is run. This is mostly a benefit for local usage rather than CI runners.
  - With the fix for the rustup profile and proper handling of cacheable content, the image size falls below 1.6GB and iterative builds of the image are much faster.
- The 3rd / 4th commits simplify the cross-platform build. There isn't a need for the conditional block to install a target.
  - Since the image is to be built from the same build host (`FROM --platform=${BUILDPLATFORM}`), you can just install both targets in advance? Then use `TARGETPLATFORM` ARG to implicitly get the preferred platform  binary build.
  - Now the `builder` stage shares all the same common layers, instead of diverging at the `TARGETPLATFORM` ARG. This is viable due to `cargo-zigbuild` supporting cross-platform builds easily.
- The 5th commit tackles the inline comment about optimizing the build size of the binary, reducing it from the current 68MB to 24MB, better than the current `uv` binary distributed via other install methods. You can use UPX to reduce this furth from 23.6MB to 6.7MB (_<10% current published size for the image_), at the expense of 300ms startup latency and potentially false positive to AV scanners.



## Test Plan

I've built the image locally, you still get the binary output successfully. Let me know if you'd like me to test something specific?

```console
# Using Docker v25 on Windows 11 via WSL2, with docker-container driver builder:
$ docker buildx create --name=container --driver=docker-container --use --bootstrap

# Excess platforms omitted:
$ docker buildx ls
NAME/NODE     DRIVER/ENDPOINT             STATUS  BUILDKIT PLATFORMS
container *   docker-container
  container0  unix:///var/run/docker.sock running v0.13.2  linux/amd64, linux/arm64

# Building with both platforms and outputting the image contents from both platforms:
$ docker buildx build --builder=container --platform=linux/arm64,linux/amd64 --tag local/uv --output type=local,dest=/tmp/uv .
# ... Build output ...
 => exporting to client directory
 => => copying files linux/arm64 20.98MB
 => => copying files linux/amd64 23.67MB

# Exported contents:
$ ls /tmp/uv/*
/tmp/uv/linux_amd64:
io  uv
/tmp/uv/linux_arm64:
io  uv

# AMD64:
$ du -h /tmp/uv/linux_amd64/uv
23M     /tmp/uv/linux_amd64/uv
$ file /tmp/uv/linux_amd64/uv
/tmp/uv/linux_amd64/uv: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped

# ARM64:
$ du -h /tmp/uv/linux_arm64/uv
20M     /tmp/uv/linux_arm64/uv
$ file /tmp/uv/linux_arm64/uv
/tmp/uv/linux_arm64/uv: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
```

```console
# Equivalent output to running `docker run --rm -it local/uv`
$ /tmp/uv/linux_arm64/uv
Usage: uv [OPTIONS] <COMMAND>

Commands:
  pip      Resolve and install Python packages
  venv     Create a virtual environment
  cache    Manage the cache
  version  Display uv's version
  help     Print this message or the help of the given subcommand(s)

Options:
  -q, --quiet                  Do not print any output
  -v, --verbose...             Use verbose output
      --color <COLOR_CHOICE>   Control colors in output [default: auto] [possible values: auto, always, never]
      --native-tls             Whether to load TLS certificates from the platform's native certificate store [env: UV_NATIVE_TLS=]
  -n, --no-cache               Avoid reading from or writing to the cache [env: UV_NO_CACHE=]
      --cache-dir <CACHE_DIR>  Path to the cache directory [env: UV_CACHE_DIR=]
  -h, --help                   Print help (see more with '--help')
  -V, --version                Print version
```
