### PR TITLE
Better error for unsupported Python version

### DIFF
--- a/crates/uv-interpreter/python/get_interpreter_info.py
+++ b/crates/uv-interpreter/python/get_interpreter_info.py
@@ -22,11 +22,15 @@ def format_full_version(info):
 
 
 if sys.version_info[0] < 3:
-    print(json.dumps({
-        "result": "error",
-        "kind": "unsupported_python_version",
-        "python_version": format_full_version(sys.version_info),
-    }))
+    print(
+        json.dumps(
+            {
+                "result": "error",
+                "kind": "unsupported_python_version",
+                "python_version": format_full_version(sys.version_info),
+            }
+        )
+    )
     sys.exit(0)
 
 if hasattr(sys, "implementation"):
@@ -440,11 +444,15 @@ def get_operating_system_and_architecture():
 
     if operating_system == "linux":
         if sys.version_info < (3, 7):
-            print(json.dumps({
-                "result": "error",
-                "kind": "unsupported_python_version",
-                "python_version": format_full_version(sys.version_info),
-            }))
+            print(
+                json.dumps(
+                    {
+                        "result": "error",
+                        "kind": "unsupported_python_version",
+                        "python_version": format_full_version(sys.version_info),
+                    }
+                )
+            )
             sys.exit(0)
 
         # noinspection PyProtectedMember

--- a/crates/uv-interpreter/python/get_interpreter_info.py
+++ b/crates/uv-interpreter/python/get_interpreter_info.py
@@ -22,7 +22,11 @@ def format_full_version(info):
 
 
 if sys.version_info[0] < 3:
-    print(json.dumps({"result": "error", "kind": "unsupported_python_version"}))
+    print(json.dumps({
+        "result": "error",
+        "kind": "unsupported_python_version",
+        "python_version": format_full_version(sys.version_info),
+    }))
     sys.exit(0)
 
 if hasattr(sys, "implementation"):
@@ -435,6 +439,14 @@ def get_operating_system_and_architecture():
         architecture = version_arch
 
     if operating_system == "linux":
+        if sys.version_info < (3, 7):
+            print(json.dumps({
+                "result": "error",
+                "kind": "unsupported_python_version",
+                "python_version": format_full_version(sys.version_info),
+            }))
+            sys.exit(0)
+
         # noinspection PyProtectedMember
         from .packaging._manylinux import _get_glibc_version
 

--- a/crates/uv-interpreter/src/find_python.rs
+++ b/crates/uv-interpreter/src/find_python.rs
@@ -152,7 +152,7 @@ fn find_python(
                         Ok(interpreter) => interpreter,
                         Err(
                             err @ Error::QueryScript {
-                                err: InterpreterInfoError::UnsupportedPythonVersion,
+                                err: InterpreterInfoError::UnsupportedPythonVersion { .. },
                                 ..
                             },
                         ) => {

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -404,8 +404,8 @@ pub enum InterpreterInfoError {
     LibcNotFound,
     #[error("Unknown operation system: `{operating_system}`")]
     UnknownOperatingSystem { operating_system: String },
-    #[error("Python 2 is not supported. Please use Python 3.8 or newer.")]
-    UnsupportedPythonVersion,
+    #[error("Python {python_version} is not supported. Please use Python 3.8 or newer.")]
+    UnsupportedPythonVersion { python_version: String },
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
Fixes #3371

It seems like uv doesn't proactively enforce 3.8+ and in most cases just issues a warning. This PR keeps that property, only adding the new check when it is known to fail. I checked the imports in this file and the other ones seem fine.