### PR TITLE
add compat arg --user error message to pip install

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1332,6 +1332,9 @@ pub(crate) struct PipInstallArgs {
 
     #[arg(long, hide = true)]
     pub(crate) unstable_uv_lock_file: Option<String>,
+
+    #[command(flatten)]
+    pub(crate) compat_args: compat::PipInstallCompatArgs,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/compat/mod.rs
+++ b/crates/uv/src/compat/mod.rs
@@ -352,3 +352,29 @@ impl CompatArgs for VenvCompatArgs {
         Ok(())
     }
 }
+
+/// Arguments for `pip install` compatibility.
+///
+/// These represent a subset of the `pip install` interface that uv supports by default.
+#[derive(Args)]
+#[allow(clippy::struct_excessive_bools)]
+pub(crate) struct PipInstallCompatArgs {
+    #[clap(long, hide = false)]
+    user: bool,
+}
+
+impl CompatArgs for PipInstallCompatArgs {
+    /// Validate the arguments passed for `pip install` compatibility.
+    ///
+    /// This method will warn when an argument is passed that has no effect but matches uv's
+    /// behavior. If an argument is passed that does _not_ match uv's behavior, this method will
+    /// return an error.
+    fn validate(&self) -> Result<()> {
+        if self.user {
+            return Err(anyhow!(
+                "pip install's `--user` is unsupported (use a virtual environment instead)."
+            ));
+        }
+        Ok(())
+    }
+}

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -285,6 +285,7 @@ async fn run() -> Result<ExitStatus> {
         Commands::Pip(PipNamespace {
             command: PipCommand::Install(args),
         }) => {
+            args.compat_args.validate()?;
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = PipInstallSettings::resolve(args, workspace);
 

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -456,6 +456,7 @@ impl PipInstallSettings {
             exclude_newer,
             dry_run,
             unstable_uv_lock_file,
+            compat_args: _,
         } = args;
 
         Self {


### PR DESCRIPTION
Resolves [#3419](https://github.com/astral-sh/uv/issues/3419)

## Summary

Add compatargs to pip install command and hint the user to create a venv for --user arg.

## Test Plan

Tested it locally.

```bash
cargo run pip install --user flask
   Compiling uv v0.1.39 (/home/ahmedilyas/uv/crates/uv)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.96s
     Running `target/debug/uv pip install --user flask`
error: pip install's `--user` is unsupported (use a virtual environment instead).
```
