### PR TITLE
Always activate non-pep508-extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ distribution-types = { path = "crates/distribution-types" }
 install-wheel-rs = { path = "crates/install-wheel-rs", default-features = false }
 once-map = { path = "crates/once-map" }
 pep440_rs = { path = "crates/pep440-rs" }
-pep508_rs = { path = "crates/pep508-rs" }
+pep508_rs = { path = "crates/pep508-rs", features = ["non-pep508-extensions"] }
 platform-tags = { path = "crates/platform-tags" }
 pypi-types = { path = "crates/pypi-types" }
 requirements-txt = { path = "crates/requirements-txt" }

--- a/crates/requirements-txt/Cargo.toml
+++ b/crates/requirements-txt/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 distribution-types = { workspace = true }
 pep440_rs = { workspace = true }
-pep508_rs = { workspace = true, features = ["non-pep508-extensions"] }
+pep508_rs = { workspace = true }
 uv-client = { workspace = true }
 uv-fs = { workspace = true }
 uv-normalize = { workspace = true }

--- a/crates/uv-interpreter/Cargo.toml
+++ b/crates/uv-interpreter/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 cache-key = { workspace = true }
 install-wheel-rs = { workspace = true }
 pep440_rs = { workspace = true }
-pep508_rs = { workspace = true, features = ["non-pep508-extensions"] }
+pep508_rs = { workspace = true }
 platform-tags = { workspace = true }
 pypi-types = { workspace = true }
 uv-cache = { workspace = true }


### PR DESCRIPTION
Avoid compilation errors when running partial tests due to that feature being missing.