### PR TITLE
Use the term path instead of local file consistently

### DIFF
--- a/crates/distribution-types/src/cached.rs
+++ b/crates/distribution-types/src/cached.rs
@@ -9,7 +9,7 @@ use uv_normalize::PackageName;
 
 use crate::{
     BuiltDist, Dist, DistributionMetadata, Hashed, InstalledMetadata, InstalledVersion, Name,
-    ParsedLocalFileUrl, ParsedUrl, SourceDist, VersionOrUrlRef,
+    ParsedPathUrl, ParsedUrl, SourceDist, VersionOrUrlRef,
 };
 
 /// A built distribution (wheel) that exists in the local cache.
@@ -116,7 +116,7 @@ impl CachedDist {
             Self::Url(dist) => {
                 if dist.editable {
                     assert_eq!(dist.url.scheme(), "file", "{}", dist.url);
-                    Ok(Some(ParsedUrl::LocalFile(ParsedLocalFileUrl {
+                    Ok(Some(ParsedUrl::Path(ParsedPathUrl {
                         url: dist.url.raw().clone(),
                         path: dist
                             .url

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -374,9 +374,7 @@ impl Dist {
             ParsedUrl::Archive(archive) => {
                 Self::from_http_url(name, archive.url, archive.subdirectory, url.verbatim)
             }
-            ParsedUrl::LocalFile(file) => {
-                Self::from_file_url(name, &file.path, false, url.verbatim)
-            }
+            ParsedUrl::Path(file) => Self::from_file_url(name, &file.path, false, url.verbatim),
             ParsedUrl::Git(git) => {
                 Self::from_git_url(name, url.verbatim, git.url, git.subdirectory)
             }

--- a/crates/distribution-types/src/parsed_url.rs
+++ b/crates/distribution-types/src/parsed_url.rs
@@ -38,7 +38,7 @@ pub struct VerbatimParsedUrl {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum ParsedUrl {
     /// The direct URL is a path to a local directory or file.
-    LocalFile(ParsedLocalFileUrl),
+    Path(ParsedPathUrl),
     /// The direct URL is path to a Git repository.
     Git(ParsedGitUrl),
     /// The direct URL is a URL to an archive.
@@ -50,7 +50,7 @@ pub enum ParsedUrl {
 /// Examples:
 /// * `file:///home/ferris/my_project`
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct ParsedLocalFileUrl {
+pub struct ParsedPathUrl {
     pub url: Url,
     pub path: PathBuf,
     pub editable: bool,
@@ -159,7 +159,7 @@ impl TryFrom<Url> for ParsedUrl {
             let path = url
                 .to_file_path()
                 .map_err(|()| ParsedUrlError::InvalidFileUrl(url.clone()))?;
-            Ok(Self::LocalFile(ParsedLocalFileUrl {
+            Ok(Self::Path(ParsedPathUrl {
                 url,
                 path,
                 editable: false,
@@ -175,17 +175,17 @@ impl TryFrom<&ParsedUrl> for pypi_types::DirectUrl {
 
     fn try_from(value: &ParsedUrl) -> std::result::Result<Self, Self::Error> {
         match value {
-            ParsedUrl::LocalFile(value) => Self::try_from(value),
+            ParsedUrl::Path(value) => Self::try_from(value),
             ParsedUrl::Git(value) => Self::try_from(value),
             ParsedUrl::Archive(value) => Self::try_from(value),
         }
     }
 }
 
-impl TryFrom<&ParsedLocalFileUrl> for pypi_types::DirectUrl {
+impl TryFrom<&ParsedPathUrl> for pypi_types::DirectUrl {
     type Error = Error;
 
-    fn try_from(value: &ParsedLocalFileUrl) -> Result<Self, Self::Error> {
+    fn try_from(value: &ParsedPathUrl) -> Result<Self, Self::Error> {
         Ok(Self::LocalDirectory {
             url: value.url.to_string(),
             dir_info: pypi_types::DirInfo {
@@ -229,15 +229,15 @@ impl TryFrom<&ParsedGitUrl> for pypi_types::DirectUrl {
 impl From<ParsedUrl> for Url {
     fn from(value: ParsedUrl) -> Self {
         match value {
-            ParsedUrl::LocalFile(value) => value.into(),
+            ParsedUrl::Path(value) => value.into(),
             ParsedUrl::Git(value) => value.into(),
             ParsedUrl::Archive(value) => value.into(),
         }
     }
 }
 
-impl From<ParsedLocalFileUrl> for Url {
-    fn from(value: ParsedLocalFileUrl) -> Self {
+impl From<ParsedPathUrl> for Url {
+    fn from(value: ParsedPathUrl) -> Self {
         value.url
     }
 }

--- a/crates/distribution-types/src/requirement.rs
+++ b/crates/distribution-types/src/requirement.rs
@@ -183,7 +183,7 @@ impl RequirementSource {
     /// the PEP 508 string (after the `@`) as [`VerbatimUrl`].
     pub fn from_parsed_url(parsed_url: ParsedUrl, url: VerbatimUrl) -> Self {
         match parsed_url {
-            ParsedUrl::LocalFile(local_file) => RequirementSource::Path {
+            ParsedUrl::Path(local_file) => RequirementSource::Path {
                 path: local_file.path,
                 url,
                 editable: None,

--- a/crates/uv-resolver/src/resolver/urls.rs
+++ b/crates/uv-resolver/src/resolver/urls.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashMap;
 use tracing::debug;
 
 use distribution_types::{
-    ParsedArchiveUrl, ParsedGitUrl, ParsedLocalFileUrl, ParsedUrl, RequirementSource, Verbatim,
+    ParsedArchiveUrl, ParsedGitUrl, ParsedPathUrl, ParsedUrl, RequirementSource, Verbatim,
     VerbatimParsedUrl,
 };
 use pep508_rs::{MarkerEnvironment, VerbatimUrl};
@@ -27,7 +27,7 @@ impl Urls {
         // Add the editables themselves to the list of required URLs.
         for (editable, metadata, _) in &manifest.editables {
             let editable_url = VerbatimParsedUrl {
-                parsed_url: ParsedUrl::LocalFile(ParsedLocalFileUrl {
+                parsed_url: ParsedUrl::Path(ParsedPathUrl {
                     url: editable.url.to_url(),
                     path: editable.path.clone(),
                     editable: true,
@@ -84,7 +84,7 @@ impl Urls {
                     url,
                 } => {
                     let url = VerbatimParsedUrl {
-                        parsed_url: ParsedUrl::LocalFile(ParsedLocalFileUrl {
+                        parsed_url: ParsedUrl::Path(ParsedPathUrl {
                             url: url.to_url(),
                             path: path.clone(),
                             editable: (*editable).unwrap_or_default(),


### PR DESCRIPTION
Rename `ParsedLocalFileUrl` to `ParsedPathUrl`, eliminating the term `LocalFile` in favor of path.