### PR TITLE
Use `into_par_iter` instead of `par_bridge`

### DIFF
--- a/crates/uv-extract/src/sync.rs
+++ b/crates/uv-extract/src/sync.rs
@@ -17,7 +17,7 @@ pub fn unzip<R: Send + std::io::Read + std::io::Seek + HasLength>(
     let archive = ZipArchive::new(CloneableSeekableReader::new(reader))?;
     let directories = Mutex::new(FxHashSet::default());
     (0..archive.len())
-        .par_bridge()
+        .into_par_iter()
         .map(|file_number| {
             let mut archive = archive.clone();
             let mut file = archive.by_index(file_number)?;


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Use the native rayon range iterator instead of bridging the standard library's.