### PR TITLE
Use `dashmap::DashSet` in `uv_extract::unzip`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4857,6 +4857,7 @@ version = "0.0.1"
 dependencies = [
  "async-compression",
  "async_zip",
+ "dashmap",
  "fs-err",
  "futures",
  "md-5",

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -17,6 +17,7 @@ pypi-types = { workspace = true }
 
 async-compression = { workspace = true, features = ["bzip2", "gzip", "zstd"] }
 async_zip = { workspace = true, features = ["tokio"] }
+dashmap = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 md-5.workspace = true

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -13,11 +13,7 @@ use crate::Error;
 /// This is useful for unzipping files as they're being downloaded. If the archive
 /// is already fully on disk, consider using `unzip_archive`, which can use multiple
 /// threads to work faster in that case.
-pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
-    reader: R,
-    target: impl AsRef<Path>,
-) -> Result<(), Error> {
-    let target = target.as_ref();
+pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(reader: R, target: &Path) -> Result<(), Error> {
     let mut reader = futures::io::BufReader::with_capacity(128 * 1024, reader.compat());
     let mut zip = async_zip::base::read::stream::ZipFileReader::new(&mut reader);
 
@@ -210,7 +206,7 @@ pub async fn archive<R: tokio::io::AsyncRead + Unpin>(
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("zip"))
     {
-        unzip(reader, target).await?;
+        unzip(reader, target.as_ref()).await?;
         return Ok(());
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Use `dashmap::HashSet` over `Mutex<HashSet>`.
Suggested in https://github.com/astral-sh/uv/pull/3435#discussion_r1592917098.

This is a bit more complex that I thought: the original hashmap lock was held through the `create_dir_all` call, and if we naively swap it for dashmap this is not the case anymore which creates a race condition. See f9a5feaa5b39892364c3f8b63f9ba22aa7917a75.

I don't know if this is worth it, feel free to close if not.