### PR TITLE
Update activate_this.py to use runpy instead of exec in the docstring

### DIFF
--- a/crates/uv-virtualenv/src/activator/activate_this.py
+++ b/crates/uv-virtualenv/src/activator/activate_this.py
@@ -22,7 +22,8 @@
 """
 Activate virtualenv for current interpreter:
 
-Use exec(open(this_file).read(), {'__file__': this_file}).
+import runpy
+runpy.run_path(this_file)
 
 This can be used when you must use an existing Python interpreter, not the virtualenv bin/python.
 """  # noqa: D415
@@ -36,7 +37,7 @@ import sys
 try:
     abs_file = os.path.abspath(__file__)
 except NameError as exc:
-    msg = "You must use exec(open(this_file).read(), {'__file__': this_file})"
+    msg = "You must use import runpy; runpy.run_path(this_file)"
     raise AssertionError(msg) from exc
 
 bin_dir = os.path.dirname(abs_file)


### PR DESCRIPTION
## Summary

runpy.run_path was added in python 2.7 and 3.2 - and every python that is not EOL supports it.

It is arguably nicer to read and the path is only given once in the command.

At least right now, runpy - unlike exec with S102 - is not flagged by any bandit-derived ruff check.
(I guess because it loads from a file instead of a simple string...)

Because of the import, it is also not a one-liner anymore. (But that could be fixed with an __import__('runpy').run_path...)

## Test Plan

import runpy
runpy.run_path('/path/to/venv/bin/activate_this.py')