### PR TITLE
Use Metadata10 to parse PKG-INFO of legacy editable

### DIFF
--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -168,7 +168,7 @@ impl InstalledDist {
                     return Ok(None);
                 }
             };
-            let metadata = match pypi_types::Metadata23::parse_pkg_info(&content) {
+            let metadata = match pypi_types::Metadata10::parse_pkg_info(&content) {
                 Ok(metadata) => metadata,
                 Err(err) => {
                     warn!("Failed to parse metadata for {path:?}: {err}");
@@ -178,7 +178,7 @@ impl InstalledDist {
 
             return Ok(Some(Self::LegacyEditable(InstalledLegacyEditable {
                 name: metadata.name,
-                version: metadata.version,
+                version: Version::from_str(&metadata.version)?,
                 egg_link: path.to_path_buf(),
                 target,
                 target_url: url,

--- a/crates/pypi-types/src/metadata.rs
+++ b/crates/pypi-types/src/metadata.rs
@@ -285,6 +285,7 @@ pub(crate) struct Project {
 #[serde(rename_all = "kebab-case")]
 pub struct Metadata10 {
     pub name: PackageName,
+    pub version: String,
 }
 
 impl Metadata10 {
@@ -296,7 +297,10 @@ impl Metadata10 {
                 .get_first_value("Name")
                 .ok_or(MetadataError::FieldNotFound("Name"))?,
         )?;
-        Ok(Self { name })
+        let version = headers
+            .get_first_value("Version")
+            .ok_or(MetadataError::FieldNotFound("Version"))?;
+        Ok(Self { name, version })
     }
 }
 

--- a/crates/uv/tests/pip_freeze.rs
+++ b/crates/uv/tests/pip_freeze.rs
@@ -279,7 +279,7 @@ fn freeze_with_legacy_editable() -> Result<()> {
         .child("zstandard.egg-info")
         .child("PKG-INFO")
         .write_str(
-            "Metadata-Version: 2.2
+            "Metadata-Version: 2.1
 Name: zstandard
 Version: 0.22.0
 ",

--- a/crates/uv/tests/pip_uninstall.rs
+++ b/crates/uv/tests/pip_uninstall.rs
@@ -490,7 +490,7 @@ fn uninstall_legacy_editable() -> Result<()> {
         .child("zstandard.egg-info")
         .child("PKG-INFO")
         .write_str(
-            "Metadata-Version: 2.2
+            "Metadata-Version: 2.1
 Name: zstandard
 Version: 0.22.0
 ",


### PR DESCRIPTION
It turns out setuptools often uses Metadata-Version 2.1 in their PKG-INFO: https://github.com/hauntsaninja/setuptools/blob/4e766834d72623f3b938f1d4148547ea73af1bf5/setuptools/dist.py#L64
`Metadata23` requires Metadata-Version of at least 2.2.

This means that uv doesn't actually recognise legacy editable installations from the most common way you'd actually get legacy editable installations (works great for most legacy editables I make at work though!)

Anyway, over here we only need the version and don't care about anything else. Rather than make a `Metadata21`, I just add a version field to `Metadata10`. The one slightly tricky thing is that only Metadata-Version 1.2 and greater guarantee that the [version number is PEP 440 compatible](https://peps.python.org/pep-0345/#version), so I store the version in `Metadata10` as a `String` and only parse to `Version` at time of use.

Also did you know that back in 2004, paramiko had a pokemon based versioning system?