### PR TITLE
Apply normcase to line from easy-install.pth

### DIFF
--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -142,9 +142,14 @@ impl InstalledDist {
             // https://setuptools.pypa.io/en/latest/deprecated/python_eggs.html#egg-links
             // https://github.com/pypa/pip/blob/946f95d17431f645da8e2e0bf4054a72db5be766/src/pip/_internal/metadata/importlib/_envs.py#L86-L108
             let contents = fs::read_to_string(path)?;
-            let target = if let Some(line) = contents.lines().find(|line| !line.is_empty()) {
-                PathBuf::from(line.trim())
-            } else {
+            let Some(target) = contents.lines().find_map(|line| {
+                let line = line.trim();
+                if line.is_empty() {
+                    None
+                } else {
+                    Some(PathBuf::from(line))
+                }
+            }) else {
                 warn!("Invalid `.egg-link` file: {path:?}");
                 return Ok(None);
             };

--- a/crates/install-wheel-rs/src/uninstall.rs
+++ b/crates/install-wheel-rs/src/uninstall.rs
@@ -233,6 +233,14 @@ pub fn uninstall_legacy_editable(egg_link: &Path) -> Result<Uninstall, Error> {
         })
         .ok_or_else(|| Error::InvalidEggLink(egg_link.to_path_buf()))?;
 
+    let target_line = if cfg!(windows) {
+        // Do the equivalent of os.path.normcase
+        // This comes from `pkg_resources.normalize_path`
+        target_line.replace('\\', "/").to_lowercase()
+    } else {
+        target_line.to_owned()
+    };
+
     match fs::remove_file(egg_link) {
         Ok(()) => {
             debug!("Removed file: {}", egg_link.display());

--- a/crates/install-wheel-rs/src/uninstall.rs
+++ b/crates/install-wheel-rs/src/uninstall.rs
@@ -211,6 +211,14 @@ pub fn uninstall_egg(egg_info: &Path) -> Result<Uninstall, Error> {
     })
 }
 
+fn normcase(s: &str) -> String {
+    if cfg!(windows) {
+        s.replace('/', "\\").to_lowercase()
+    } else {
+        s.to_owned()
+    }
+}
+
 static EASY_INSTALL_PTH: Lazy<Mutex<i32>> = Lazy::new(Mutex::default);
 
 /// Uninstall the legacy editable represented by the `.egg-link` file.
@@ -232,14 +240,6 @@ pub fn uninstall_legacy_editable(egg_link: &Path) -> Result<Uninstall, Error> {
             }
         })
         .ok_or_else(|| Error::InvalidEggLink(egg_link.to_path_buf()))?;
-
-    fn normcase(s: &str) -> String {
-        if cfg!(windows) {
-            s.replace('/', "\\").to_lowercase()
-        } else {
-            s.to_owned()
-        }
-    }
 
     // This comes from `pkg_resources.normalize_path`
     let target_line = normcase(target_line);

--- a/crates/install-wheel-rs/src/uninstall.rs
+++ b/crates/install-wheel-rs/src/uninstall.rs
@@ -233,13 +233,16 @@ pub fn uninstall_legacy_editable(egg_link: &Path) -> Result<Uninstall, Error> {
         })
         .ok_or_else(|| Error::InvalidEggLink(egg_link.to_path_buf()))?;
 
-    let target_line = if cfg!(windows) {
-        // Do the equivalent of os.path.normcase
-        // This comes from `pkg_resources.normalize_path`
-        target_line.replace('\\', "/").to_lowercase()
-    } else {
-        target_line.to_owned()
-    };
+    fn normcase(s: &str) -> String {
+        if cfg!(windows) {
+            s.replace('/', "\\").to_lowercase()
+        } else {
+            s.to_owned()
+        }
+    }
+
+    // This comes from `pkg_resources.normalize_path`
+    let target_line = normcase(target_line);
 
     match fs::remove_file(egg_link) {
         Ok(()) => {

--- a/crates/uv/tests/pip_uninstall.rs
+++ b/crates/uv/tests/pip_uninstall.rs
@@ -474,6 +474,14 @@ fn uninstall_egg_info() -> Result<()> {
     Ok(())
 }
 
+fn normcase(s: &str) -> String {
+    if cfg!(windows) {
+        s.replace('/', "\\").to_lowercase()
+    } else {
+        s.to_owned()
+    }
+}
+
 /// Uninstall a legacy editable package in a virtual environment.
 #[test]
 fn uninstall_legacy_editable() -> Result<()> {
@@ -499,14 +507,6 @@ Version: 0.22.0
     site_packages
         .child("zstandard.egg-link")
         .write_str(target.path().to_str().unwrap())?;
-
-    fn normcase(s: &str) -> String {
-        if cfg!(windows) {
-            s.replace('/', "\\").to_lowercase()
-        } else {
-            s.to_owned()
-        }
-    }
 
     site_packages.child("easy-install.pth").write_str(&format!(
         "something\n{}\nanother thing\n",

--- a/crates/uv/tests/pip_uninstall.rs
+++ b/crates/uv/tests/pip_uninstall.rs
@@ -500,9 +500,17 @@ Version: 0.22.0
         .child("zstandard.egg-link")
         .write_str(target.path().to_str().unwrap())?;
 
+    fn normcase(s: &str) -> String {
+        if cfg!(windows) {
+            s.replace('/', "\\").to_lowercase()
+        } else {
+            s.to_owned()
+        }
+    }
+
     site_packages.child("easy-install.pth").write_str(&format!(
         "something\n{}\nanother thing\n",
-        target.path().to_str().unwrap()
+        normcase(target.path().to_str().unwrap())
     ))?;
 
     // Run `pip uninstall`.


### PR DESCRIPTION
Thanks for the suggestion from https://github.com/astral-sh/uv/pull/3415#discussion_r1591772942

Also it looks like you improved `egg-link` parsing in https://github.com/astral-sh/uv/pull/3415/commits/e23c91f52e7df1a5230fc3cb7ca6d3d4ca0b24a2 so copying the changes over to the other parse site (happy to move this to a helper too, if so lmk where to put it)