### PR TITLE
Improve trailing version string error message

### DIFF
--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -1487,8 +1487,8 @@ impl<'a> Parser<'a> {
         self.parse_local()?;
         self.bump_while(|byte| byte.is_ascii_whitespace());
         if !self.is_done() {
+            let version = String::from_utf8_lossy(&self.v[..self.i]).into_owned();
             let remaining = String::from_utf8_lossy(&self.v[self.i..]).into_owned();
-            let version = self.into_pattern().version;
             return Err(ErrorKind::UnexpectedEnd { version, remaining }.into());
         }
         Ok(self.into_pattern())
@@ -2149,7 +2149,7 @@ pub(crate) enum ErrorKind {
     /// trailing data in the string.
     UnexpectedEnd {
         /// The version that has been parsed so far.
-        version: Version,
+        version: String,
         /// The bytes that were remaining and not parsed.
         remaining: String,
     },
@@ -3141,7 +3141,7 @@ mod tests {
         assert_eq!(
             p("1.0-dev1.*").unwrap_err(),
             ErrorKind::UnexpectedEnd {
-                version: Version::new([1, 0]).with_dev(Some(1)),
+                version: "1.0-dev1".to_string(),
                 remaining: ".*".to_string()
             }
             .into(),
@@ -3149,10 +3149,7 @@ mod tests {
         assert_eq!(
             p("1.0a1.*").unwrap_err(),
             ErrorKind::UnexpectedEnd {
-                version: Version::new([1, 0]).with_pre(Some(PreRelease {
-                    kind: PreReleaseKind::Alpha,
-                    number: 1
-                })),
+                version: "1.0a1".to_string(),
                 remaining: ".*".to_string()
             }
             .into(),
@@ -3160,7 +3157,7 @@ mod tests {
         assert_eq!(
             p("1.0.post1.*").unwrap_err(),
             ErrorKind::UnexpectedEnd {
-                version: Version::new([1, 0]).with_post(Some(1)),
+                version: "1.0.post1".to_string(),
                 remaining: ".*".to_string()
             }
             .into(),
@@ -3525,7 +3522,7 @@ mod tests {
         assert_eq!(
             p("5.6./"),
             ErrorKind::UnexpectedEnd {
-                version: Version::new([5, 6]),
+                version: "5.6".to_string(),
                 remaining: "./".to_string()
             }
             .into()
@@ -3533,7 +3530,7 @@ mod tests {
         assert_eq!(
             p("5.6.-alpha2"),
             ErrorKind::UnexpectedEnd {
-                version: Version::new([5, 6]),
+                version: "5.6".to_string(),
                 remaining: ".-alpha2".to_string()
             }
             .into()
@@ -3557,7 +3554,7 @@ mod tests {
         assert_eq!(
             p("5.6-"),
             ErrorKind::UnexpectedEnd {
-                version: Version::new([5, 6]),
+                version: "5.6".to_string(),
                 remaining: "-".to_string()
             }
             .into()

--- a/crates/pep440-rs/src/version_specifier.rs
+++ b/crates/pep440-rs/src/version_specifier.rs
@@ -733,7 +733,7 @@ mod tests {
 
     use indoc::indoc;
 
-    use crate::{LocalSegment, PreRelease, PreReleaseKind};
+    use crate::LocalSegment;
 
     use super::*;
 
@@ -1437,10 +1437,7 @@ mod tests {
                 "==2.0a1.*",
                 ParseErrorKind::InvalidVersion(
                     version::ErrorKind::UnexpectedEnd {
-                        version: Version::new([2, 0]).with_pre(Some(PreRelease {
-                            kind: PreReleaseKind::Alpha,
-                            number: 1,
-                        })),
+                        version: "2.0a1".to_string(),
                         remaining: ".*".to_string(),
                     }
                     .into(),
@@ -1451,10 +1448,7 @@ mod tests {
                 "!=2.0a1.*",
                 ParseErrorKind::InvalidVersion(
                     version::ErrorKind::UnexpectedEnd {
-                        version: Version::new([2, 0]).with_pre(Some(PreRelease {
-                            kind: PreReleaseKind::Alpha,
-                            number: 1,
-                        })),
+                        version: "2.0a1".to_string(),
                         remaining: ".*".to_string(),
                     }
                     .into(),
@@ -1465,7 +1459,7 @@ mod tests {
                 "==2.0.post1.*",
                 ParseErrorKind::InvalidVersion(
                     version::ErrorKind::UnexpectedEnd {
-                        version: Version::new([2, 0]).with_post(Some(1)),
+                        version: "2.0.post1".to_string(),
                         remaining: ".*".to_string(),
                     }
                     .into(),
@@ -1476,7 +1470,7 @@ mod tests {
                 "!=2.0.post1.*",
                 ParseErrorKind::InvalidVersion(
                     version::ErrorKind::UnexpectedEnd {
-                        version: Version::new([2, 0]).with_post(Some(1)),
+                        version: "2.0.post1".to_string(),
                         remaining: ".*".to_string(),
                     }
                     .into(),
@@ -1487,7 +1481,7 @@ mod tests {
                 "==2.0.dev1.*",
                 ParseErrorKind::InvalidVersion(
                     version::ErrorKind::UnexpectedEnd {
-                        version: Version::new([2, 0]).with_dev(Some(1)),
+                        version: "2.0.dev1".to_string(),
                         remaining: ".*".to_string(),
                     }
                     .into(),
@@ -1498,7 +1492,7 @@ mod tests {
                 "!=2.0.dev1.*",
                 ParseErrorKind::InvalidVersion(
                     version::ErrorKind::UnexpectedEnd {
-                        version: Version::new([2, 0]).with_dev(Some(1)),
+                        version: "2.0.dev1".to_string(),
                         remaining: ".*".to_string(),
                     }
                     .into(),
@@ -1537,7 +1531,7 @@ mod tests {
                 "==1.0.dev1.*",
                 ParseErrorKind::InvalidVersion(
                     version::ErrorKind::UnexpectedEnd {
-                        version: Version::new([1, 0]).with_dev(Some(1)),
+                        version: "1.0.dev1".to_string(),
                         remaining: ".*".to_string(),
                     }
                     .into(),
@@ -1548,7 +1542,7 @@ mod tests {
                 "!=1.0.dev1.*",
                 ParseErrorKind::InvalidVersion(
                     version::ErrorKind::UnexpectedEnd {
-                        version: Version::new([1, 0]).with_dev(Some(1)),
+                        version: "1.0.dev1".to_string(),
                         remaining: ".*".to_string(),
                     }
                     .into(),

--- a/crates/uv/tests/pip_list.rs
+++ b/crates/uv/tests/pip_list.rs
@@ -663,13 +663,13 @@ Version: 0.1-bulbasaur
         .env("VIRTUAL_ENV", context.venv.as_os_str())
         .env("UV_NO_WRAP", "1")
         .current_dir(&context.temp_dir), @r###"
-success: false
-exit_code: 2
------ stdout -----
+    success: false
+    exit_code: 2
+    ----- stdout -----
 
------ stderr -----
-error: Failed to read metadata: from [SITE_PACKAGES]/paramiko.egg-link
- Caused by: after parsing '0.1b0', found 'ulbasaur', which is not part of a valid version
+    ----- stderr -----
+    error: Failed to read metadata: from [SITE_PACKAGES]/paramiko.egg-link
+     Caused by: after parsing '0.1-b', found 'ulbasaur', which is not part of a valid version
     "###
     );
 


### PR DESCRIPTION
We would previously show the parsed version when erroring due to trailing content after a valid version, which can look different than the input. E.g. when encountering `0.1-bulbasaur`, we would display:

```
after parsing '0.1b0', found 'ulbasaur', which is not part of a valid version
```

With storing the input string instead of the input version, we now show:

```
after parsing '0.1-b', found 'ulbasaur', which is not part of a valid version
```
