### PR TITLE
Reduce `GitSourceDist` URL usage

### DIFF
--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -475,17 +475,6 @@ impl SourceDist {
         }
     }
 
-    #[must_use]
-    pub fn with_url(self, url: Url) -> Self {
-        match self {
-            Self::Git(dist) => Self::Git(GitSourceDist {
-                url: VerbatimUrl::unknown(url),
-                ..dist
-            }),
-            dist => dist,
-        }
-    }
-
     /// Return true if the distribution is editable.
     pub fn is_editable(&self) -> bool {
         match self {

--- a/crates/uv-distribution/src/index/built_wheel_index.rs
+++ b/crates/uv-distribution/src/index/built_wheel_index.rs
@@ -1,4 +1,6 @@
-use distribution_types::{DirectUrlSourceDist, GitSourceDist, Hashed, PathSourceDist};
+use distribution_types::{
+    DirectUrlSourceDist, DirectorySourceDist, GitSourceDist, Hashed, PathSourceDist,
+};
 use platform_tags::Tags;
 use uv_cache::{ArchiveTimestamp, Cache, CacheBucket, CacheShard, WheelCache};
 use uv_fs::symlinks;

--- a/crates/uv-distribution/src/index/built_wheel_index.rs
+++ b/crates/uv-distribution/src/index/built_wheel_index.rs
@@ -1,6 +1,4 @@
-use distribution_types::{
-    git_reference, DirectUrlSourceDist, DirectorySourceDist, GitSourceDist, Hashed, PathSourceDist,
-};
+use distribution_types::{DirectUrlSourceDist, GitSourceDist, Hashed, PathSourceDist};
 use platform_tags::Tags;
 use uv_cache::{ArchiveTimestamp, Cache, CacheBucket, CacheShard, WheelCache};
 use uv_fs::symlinks;
@@ -129,9 +127,7 @@ impl<'a> BuiltWheelIndex<'a> {
             return None;
         }
 
-        let Ok(Some(git_sha)) = git_reference(source_dist.url.to_url()) else {
-            return None;
-        };
+        let git_sha = source_dist.git.precise()?;
 
         let cache_shard = self.cache.shard(
             CacheBucket::BuiltWheels,

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -428,14 +428,14 @@ impl Source {
     }
 
     fn from_git_dist(git_dist: &GitSourceDist) -> Source {
-        // FIXME: Fill in the git revision details here. They aren't in
-        // `GitSourceDist`, so this will likely need some refactoring.
+        // FIXME: Fill in the git revision details here. GitSource and GitSourceDist are slightly
+        // mismatched atm
         Source {
             kind: SourceKind::Git(GitSource {
-                precise: None,
+                precise: git_dist.git.precise().map(|git_sha| git_sha.to_string()),
                 kind: GitSourceKind::DefaultBranch,
             }),
-            url: git_dist.url.to_url(),
+            url: git_dist.git.repository().clone(),
         }
     }
 }

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -428,8 +428,8 @@ impl Source {
     }
 
     fn from_git_dist(git_dist: &GitSourceDist) -> Source {
-        // FIXME: Fill in the git revision details here. GitSource and GitSourceDist are slightly
-        // mismatched atm
+        // TODO(konsti): Fill in the Git revision details. GitSource and GitSourceDist are
+        // slightly mismatched.
         Source {
             kind: SourceKind::Git(GitSource {
                 precise: git_dist.git.precise().map(|git_sha| git_sha.to_string()),

--- a/crates/uv-resolver/src/redirect.rs
+++ b/crates/uv-resolver/src/redirect.rs
@@ -48,7 +48,7 @@ pub(crate) fn url_to_precise(url: VerbatimParsedUrl) -> VerbatimParsedUrl {
         return url;
     };
 
-    // TODO(konsti): Remove once we carry more context on the `Dist`s.
+    // TODO(konsti): Remove once we carry more context on the `Dist` (e.g., `BranchOrTag` vs. `Tag`).
     let lowered_git_ref = git_url
         .reference()
         .as_str()


### PR DESCRIPTION
Refactor the easy-to-remove usage of the `VerbatimUrl` on `GitSourceDist`