### PR TITLE
Ignore `compile_invalid_pyc_invalidation_mode` on macOS

### DIFF
--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -3036,6 +3036,7 @@ fn compile() -> Result<()> {
 
 /// Test that the `PYC_INVALIDATION_MODE` option is recognized and that the error handling works.
 #[test]
+#[cfg_attr(macos, ignore = "The bytecode trace is spuriously different on macOS")]
 fn compile_invalid_pyc_invalidation_mode() -> Result<()> {
     let context = TestContext::new("3.12");
 


### PR DESCRIPTION
## Summary

This is annoying both locally in CI. If anyone wants to fuss with the filters to fix it, that's fine too, but IMO it's better to disable than leave it enabled on macOS for now.
