### PR TITLE
add support for resolving without a marker environment

### DIFF
--- a/crates/bench/benches/uv.rs
+++ b/crates/bench/benches/uv.rs
@@ -50,7 +50,9 @@ mod resolver {
     use uv_client::RegistryClient;
     use uv_configuration::{BuildKind, NoBinary, NoBuild, SetupPyStrategy};
     use uv_interpreter::{Interpreter, PythonEnvironment};
-    use uv_resolver::{FlatIndex, InMemoryIndex, Manifest, Options, ResolutionGraph, Resolver};
+    use uv_resolver::{
+        FlatIndex, InMemoryIndex, Manifest, Options, PythonRequirement, ResolutionGraph, Resolver,
+    };
     use uv_types::{
         BuildContext, BuildIsolation, EmptyInstalledPackages, HashStrategy, SourceBuildTrait,
     };
@@ -93,12 +95,13 @@ mod resolver {
         let build_context = Context::new(cache, interpreter.clone());
         let hashes = HashStrategy::None;
         let installed_packages = EmptyInstalledPackages;
+        let python_requirement = PythonRequirement::from_marker_environment(&interpreter, &MARKERS);
 
         let resolver = Resolver::new(
             manifest,
             Options::default(),
-            &MARKERS,
-            &interpreter,
+            &python_requirement,
+            Some(&MARKERS),
             &TAGS,
             client,
             &flat_index,

--- a/crates/distribution-types/src/requirement.rs
+++ b/crates/distribution-types/src/requirement.rs
@@ -41,6 +41,23 @@ impl Requirement {
         }
     }
 
+    /// Returns whether the markers apply only for the given extras.
+    ///
+    /// When `env` is `None`, this specifically evaluates all marker
+    /// expressions based on the environment to `true`. That is, this provides
+    /// environment independent marker evaluation.
+    pub fn evaluate_optional_environment(
+        &self,
+        env: Option<&MarkerEnvironment>,
+        extras: &[ExtraName],
+    ) -> bool {
+        if let Some(marker) = &self.marker {
+            marker.evaluate_optional_environment(env, extras)
+        } else {
+            true
+        }
+    }
+
     /// Convert a [`pep508_rs::Requirement`] to a [`Requirement`].
     pub fn from_pep508(requirement: pep508_rs::Requirement) -> Result<Self, Box<ParsedUrlError>> {
         let source = match requirement.version_or_url {

--- a/crates/distribution-types/src/requirement.rs
+++ b/crates/distribution-types/src/requirement.rs
@@ -33,24 +33,11 @@ pub struct Requirement {
 
 impl Requirement {
     /// Returns whether the markers apply for the given environment.
-    pub fn evaluate_markers(&self, env: &MarkerEnvironment, extras: &[ExtraName]) -> bool {
-        if let Some(marker) = &self.marker {
-            marker.evaluate(env, extras)
-        } else {
-            true
-        }
-    }
-
-    /// Returns whether the markers apply only for the given extras.
     ///
     /// When `env` is `None`, this specifically evaluates all marker
     /// expressions based on the environment to `true`. That is, this provides
     /// environment independent marker evaluation.
-    pub fn evaluate_optional_environment(
-        &self,
-        env: Option<&MarkerEnvironment>,
-        extras: &[ExtraName],
-    ) -> bool {
+    pub fn evaluate_markers(&self, env: Option<&MarkerEnvironment>, extras: &[ExtraName]) -> bool {
         if let Some(marker) = &self.marker {
             marker.evaluate_optional_environment(env, extras)
         } else {

--- a/crates/distribution-types/src/specified_requirement.rs
+++ b/crates/distribution-types/src/specified_requirement.rs
@@ -45,10 +45,15 @@ impl Display for UnresolvedRequirement {
 
 impl UnresolvedRequirement {
     /// Returns whether the markers apply for the given environment.
-    pub fn evaluate_markers(&self, env: &MarkerEnvironment, extras: &[ExtraName]) -> bool {
+    ///
+    /// When the environment is not given, this treats all marker expressions
+    /// that reference the environment as true. In other words, it does
+    /// environment independent expression evaluation. (Which in turn devolves
+    /// to "only evaluate marker expressions that reference an extra name.")
+    pub fn evaluate_markers(&self, env: Option<&MarkerEnvironment>, extras: &[ExtraName]) -> bool {
         match self {
             Self::Named(requirement) => requirement.evaluate_markers(env, extras),
-            Self::Unnamed(requirement) => requirement.evaluate_markers(env, extras),
+            Self::Unnamed(requirement) => requirement.evaluate_optional_environment(env, extras),
         }
     }
 

--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -5,11 +5,11 @@
 //!
 //! ```
 //! use std::str::FromStr;
-//! use pep508_rs::Requirement;
+//! use pep508_rs::{Requirement, VerbatimUrl};
 //! use uv_normalize::ExtraName;
 //!
 //! let marker = r#"requests [security,tests] >= 2.8.1, == 2.8.* ; python_version > "3.8""#;
-//! let dependency_specification = Requirement::from_str(marker).unwrap();
+//! let dependency_specification = Requirement::<VerbatimUrl>::from_str(marker).unwrap();
 //! assert_eq!(dependency_specification.name.as_ref(), "requests");
 //! assert_eq!(dependency_specification.extras, vec![ExtraName::from_str("security").unwrap(), ExtraName::from_str("tests").unwrap()]);
 //! ```

--- a/crates/pep508-rs/src/unnamed.rs
+++ b/crates/pep508-rs/src/unnamed.rs
@@ -37,8 +37,17 @@ pub struct UnnamedRequirement {
 impl UnnamedRequirement {
     /// Returns whether the markers apply for the given environment
     pub fn evaluate_markers(&self, env: &MarkerEnvironment, extras: &[ExtraName]) -> bool {
+        self.evaluate_optional_environment(Some(env), extras)
+    }
+
+    /// Returns whether the markers apply for the given environment
+    pub fn evaluate_optional_environment(
+        &self,
+        env: Option<&MarkerEnvironment>,
+        extras: &[ExtraName],
+    ) -> bool {
         if let Some(marker) = &self.marker {
-            marker.evaluate(env, extras)
+            marker.evaluate_optional_environment(env, extras)
         } else {
             true
         }

--- a/crates/uv-dev/src/resolve_cli.rs
+++ b/crates/uv-dev/src/resolve_cli.rs
@@ -15,7 +15,9 @@ use uv_configuration::{ConfigSettings, NoBinary, NoBuild, SetupPyStrategy};
 use uv_dispatch::BuildDispatch;
 use uv_installer::SitePackages;
 use uv_interpreter::PythonEnvironment;
-use uv_resolver::{ExcludeNewer, FlatIndex, InMemoryIndex, Manifest, Options, Resolver};
+use uv_resolver::{
+    ExcludeNewer, FlatIndex, InMemoryIndex, Manifest, Options, PythonRequirement, Resolver,
+};
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 
 #[derive(ValueEnum, Default, Clone)]
@@ -98,6 +100,9 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
 
     // Copied from `BuildDispatch`
     let tags = venv.interpreter().tags()?;
+    let markers = venv.interpreter().markers();
+    let python_requirement =
+        PythonRequirement::from_marker_environment(venv.interpreter(), markers);
     let resolver = Resolver::new(
         Manifest::simple(
             args.requirements
@@ -107,8 +112,8 @@ pub(crate) async fn resolve_cli(args: ResolveCliArgs) -> Result<()> {
                 .collect::<Result<_, _>>()?,
         ),
         Options::default(),
-        venv.interpreter().markers(),
-        venv.interpreter(),
+        &python_requirement,
+        Some(venv.interpreter().markers()),
         tags,
         &client,
         &flat_index,

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -141,7 +141,7 @@ impl<'a> Planner<'a> {
 
         for requirement in self.requirements {
             // Filter out incompatible requirements.
-            if !requirement.evaluate_markers(venv.interpreter().markers(), &[]) {
+            if !requirement.evaluate_markers(Some(venv.interpreter().markers()), &[]) {
                 continue;
             }
 

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -296,7 +296,7 @@ impl<'a> SitePackages<'a> {
         for entry in requirements {
             if entry
                 .requirement
-                .evaluate_markers(self.venv.interpreter().markers(), &[])
+                .evaluate_markers(Some(self.venv.interpreter().markers()), &[])
             {
                 if seen.insert(entry.clone()) {
                     stack.push(entry.clone());

--- a/crates/uv-requirements/src/lookahead.rs
+++ b/crates/uv-requirements/src/lookahead.rs
@@ -96,9 +96,14 @@ impl<'a, Context: BuildContext> LookaheadResolver<'a, Context> {
     }
 
     /// Resolve the requirements from the provided source trees.
+    ///
+    /// When the environment is not given, this treats all marker expressions
+    /// that reference the environment as true. In other words, it does
+    /// environment independent expression evaluation. (Which in turn devolves
+    /// to "only evaluate marker expressions that reference an extra name.")
     pub async fn resolve(
         self,
-        markers: &MarkerEnvironment,
+        markers: Option<&MarkerEnvironment>,
     ) -> Result<Vec<RequestedRequirements>, LookaheadError> {
         let mut results = Vec::new();
         let mut futures = FuturesUnordered::new();

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -29,7 +29,7 @@ impl CandidateSelector {
     pub(crate) fn for_resolution(
         options: Options,
         manifest: &Manifest,
-        markers: &MarkerEnvironment,
+        markers: Option<&MarkerEnvironment>,
     ) -> Self {
         Self {
             resolution_strategy: ResolutionStrategy::from_mode(

--- a/crates/uv-resolver/src/preferences.rs
+++ b/crates/uv-resolver/src/preferences.rs
@@ -79,7 +79,7 @@ impl Preferences {
     /// to an applicable subset.
     pub(crate) fn from_iter<PreferenceIterator: IntoIterator<Item = Preference>>(
         preferences: PreferenceIterator,
-        markers: &MarkerEnvironment,
+        markers: Option<&MarkerEnvironment>,
     ) -> Self {
         Self(
             // TODO(zanieb): We should explicitly ensure that when a package name is seen multiple times

--- a/crates/uv-resolver/src/prerelease_mode.rs
+++ b/crates/uv-resolver/src/prerelease_mode.rs
@@ -56,7 +56,7 @@ impl PreReleaseStrategy {
     pub(crate) fn from_mode(
         mode: PreReleaseMode,
         manifest: &Manifest,
-        markers: &MarkerEnvironment,
+        markers: Option<&MarkerEnvironment>,
         dependencies: DependencyMode,
     ) -> Self {
         match mode {

--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -28,7 +28,7 @@ impl PubGrubDependencies {
         source_extra: Option<&ExtraName>,
         urls: &Urls,
         locals: &Locals,
-        env: &MarkerEnvironment,
+        env: Option<&MarkerEnvironment>,
     ) -> Result<Self, ResolveError> {
         let mut dependencies = Vec::default();
         let mut seen = FxHashSet::default();
@@ -70,7 +70,7 @@ fn add_requirements(
     source_extra: Option<&ExtraName>,
     urls: &Urls,
     locals: &Locals,
-    env: &MarkerEnvironment,
+    env: Option<&MarkerEnvironment>,
     dependencies: &mut Vec<(PubGrubPackage, Range<Version>)>,
     seen: &mut FxHashSet<ExtraName>,
 ) -> Result<(), ResolveError> {

--- a/crates/uv-resolver/src/python_requirement.rs
+++ b/crates/uv-resolver/src/python_requirement.rs
@@ -12,11 +12,15 @@ pub struct PythonRequirement {
 }
 
 impl PythonRequirement {
-    pub fn new(interpreter: &Interpreter, markers: &MarkerEnvironment) -> Self {
+    pub fn new(interpreter: &Interpreter, target: &StringVersion) -> Self {
         Self {
             installed: interpreter.python_full_version().clone(),
-            target: markers.python_full_version.clone(),
+            target: target.clone(),
         }
+    }
+
+    pub fn from_marker_environment(interpreter: &Interpreter, env: &MarkerEnvironment) -> Self {
+        Self::new(interpreter, &env.python_full_version)
     }
 
     /// Return the installed version of Python.

--- a/crates/uv-resolver/src/resolution_mode.rs
+++ b/crates/uv-resolver/src/resolution_mode.rs
@@ -37,7 +37,7 @@ impl ResolutionStrategy {
     pub(crate) fn from_mode(
         mode: ResolutionMode,
         manifest: &Manifest,
-        markers: &MarkerEnvironment,
+        markers: Option<&MarkerEnvironment>,
         dependencies: DependencyMode,
     ) -> Self {
         match mode {

--- a/crates/uv-resolver/src/resolver/locals.rs
+++ b/crates/uv-resolver/src/resolver/locals.rs
@@ -21,7 +21,7 @@ impl Locals {
     /// Determine the set of permitted local versions in the [`Manifest`].
     pub(crate) fn from_manifest(
         manifest: &Manifest,
-        markers: &MarkerEnvironment,
+        markers: Option<&MarkerEnvironment>,
         dependencies: DependencyMode,
     ) -> Self {
         let mut required: FxHashMap<PackageName, Version> = FxHashMap::default();

--- a/crates/uv-resolver/src/resolver/urls.rs
+++ b/crates/uv-resolver/src/resolver/urls.rs
@@ -15,7 +15,7 @@ pub(crate) struct Urls(FxHashMap<PackageName, VerbatimUrl>);
 impl Urls {
     pub(crate) fn from_manifest(
         manifest: &Manifest,
-        markers: &MarkerEnvironment,
+        markers: Option<&MarkerEnvironment>,
         dependencies: DependencyMode,
     ) -> Result<Self, ResolveError> {
         let mut urls: FxHashMap<PackageName, VerbatimUrl> = FxHashMap::default();

--- a/crates/uv-resolver/src/yanks.rs
+++ b/crates/uv-resolver/src/yanks.rs
@@ -15,7 +15,7 @@ pub struct AllowedYanks(FxHashMap<PackageName, FxHashSet<Version>>);
 impl AllowedYanks {
     pub fn from_manifest(
         manifest: &Manifest,
-        markers: &MarkerEnvironment,
+        markers: Option<&MarkerEnvironment>,
         dependencies: DependencyMode,
     ) -> Self {
         let mut allowed_yanks = FxHashMap::<PackageName, FxHashSet<Version>>::default();

--- a/crates/uv-resolver/tests/resolver.rs
+++ b/crates/uv-resolver/tests/resolver.rs
@@ -19,7 +19,8 @@ use uv_configuration::{BuildKind, Constraints, NoBinary, NoBuild, Overrides, Set
 use uv_interpreter::{find_default_python, Interpreter, PythonEnvironment};
 use uv_resolver::{
     DisplayResolutionGraph, ExcludeNewer, Exclusions, FlatIndex, InMemoryIndex, Manifest, Options,
-    OptionsBuilder, PreReleaseMode, Preference, ResolutionGraph, ResolutionMode, Resolver,
+    OptionsBuilder, PreReleaseMode, Preference, PythonRequirement, ResolutionGraph, ResolutionMode,
+    Resolver,
 };
 use uv_types::{
     BuildContext, BuildIsolation, EmptyInstalledPackages, HashStrategy, SourceBuildTrait,
@@ -126,14 +127,15 @@ async fn resolve(
     let real_interpreter =
         find_default_python(&Cache::temp().unwrap()).expect("Expected a python to be installed");
     let interpreter = Interpreter::artificial(real_interpreter.platform().clone(), markers.clone());
+    let python_requirement = PythonRequirement::from_marker_environment(&interpreter, markers);
     let build_context = DummyContext::new(Cache::temp()?, interpreter.clone());
     let hashes = HashStrategy::None;
     let installed_packages = EmptyInstalledPackages;
     let resolver = Resolver::new(
         manifest,
         options,
-        markers,
-        &interpreter,
+        &python_requirement,
+        Some(markers),
         tags,
         &client,
         &flat_index,

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -85,9 +85,14 @@ impl HashStrategy {
     }
 
     /// Generate the required hashes from a set of [`UnresolvedRequirement`] entries.
+    ///
+    /// When the environment is not given, this treats all marker expressions
+    /// that reference the environment as true. In other words, it does
+    /// environment independent expression evaluation. (Which in turn devolves
+    /// to "only evaluate marker expressions that reference an extra name.")
     pub fn from_requirements<'a>(
         requirements: impl Iterator<Item = (&'a UnresolvedRequirement, &'a [String])>,
-        markers: &MarkerEnvironment,
+        markers: Option<&MarkerEnvironment>,
     ) -> Result<Self, HashStrategyError> {
         let mut hashes = FxHashMap::<PackageId, Vec<HashDigest>>::default();
 

--- a/crates/uv/src/commands/workspace/mod.rs
+++ b/crates/uv/src/commands/workspace/mod.rs
@@ -22,7 +22,8 @@ use uv_requirements::{
     RequirementsSpecification, SourceTreeResolver,
 };
 use uv_resolver::{
-    Exclusions, FlatIndex, InMemoryIndex, Manifest, Options, ResolutionGraph, Resolver,
+    Exclusions, FlatIndex, InMemoryIndex, Manifest, Options, PythonRequirement, ResolutionGraph,
+    Resolver,
 };
 use uv_types::{EmptyInstalledPackages, HashStrategy, InFlight};
 
@@ -101,6 +102,7 @@ pub(crate) async fn resolve(
     let preferences = Vec::new();
     let constraints = Constraints::default();
     let overrides = Overrides::default();
+    let python_requirement = PythonRequirement::from_marker_environment(interpreter, markers);
     let editables = Vec::new();
     let installed_packages = EmptyInstalledPackages;
 
@@ -150,7 +152,7 @@ pub(crate) async fn resolve(
         index,
     )
     .with_reporter(ResolverReporter::from(printer))
-    .resolve(markers)
+    .resolve(Some(markers))
     .await?;
 
     // Create a manifest of the requirements.
@@ -169,8 +171,8 @@ pub(crate) async fn resolve(
     let resolver = Resolver::new(
         manifest,
         options,
-        markers,
-        interpreter,
+        &python_requirement,
+        Some(markers),
         tags,
         client,
         flat_index,


### PR DESCRIPTION
This PR touches a lot of code, but the conceptual change here is
pretty simple: make it so we can run the resolver without providing a
`MarkerEnvironment`. This also indicates that the resolver should run in
universal mode. That is, the effect of a missing marker environment is
that all marker expressions that reference the marker environment are
evaluated to `true`. That is, they are ignored. (The only markers we
evaluate in that context are extras, which are the only markers that
aren't dependent on the environment.)

One interesting change here is that a `Resolver` no longer needs an
`Interpreter`. Previously, it had only been using it to construct a
`PythonRequirement`, by filling in the installed version from the
`Interpreter` state. But we now construct a `PythonRequirement`
explicitly since its `target` Python version should no longer be tied to
the `MarkerEnvironment`. (Currently, the marker environment is mutated
such that its `python_full_version` is derived from multiple sources,
including the CLI, which I found a touch confusing.)

The change in behavior can now be observed through the
`--unstable-uv-lock-file` flag. First, without it:

```
$ cat requirements.in
anyio>=4.3.0 ; sys_platform == "linux"
anyio<4 ; sys_platform == "darwin"
$ cargo run -qp uv -- pip compile -p3.10 requirements.in
anyio==4.3.0
exceptiongroup==1.2.1
    # via anyio
idna==3.7
    # via anyio
sniffio==1.3.1
    # via anyio
typing-extensions==4.11.0
    # via anyio
```

And now with it:

```
$ cargo run -qp uv -- pip compile -p3.10 requirements.in --unstable-uv-lock-file
  x No solution found when resolving dependencies:
  `-> Because you require anyio>=4.3.0 and anyio<4, we can conclude that the requirements are unsatisfiable.
```

This is expected at this point because the marker expressions are being
explicitly ignored, *and* there is no forking done yet to account for
the conflict.

Closes #3352, Closes #3353
