### PR TITLE
Respect `MACOSX_DEPLOYMENT_TARGET` in `--python-platform`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4736,6 +4736,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tracing",
  "uv-auth",
  "uv-cache",
  "uv-normalize",

--- a/README.md
+++ b/README.md
@@ -584,6 +584,9 @@ In addition, uv respects the following environment variables:
 - `ZSH_VERSION`: Used to detect the use of the Zsh shell.
 - `RAYON_NUM_THREADS`: Used to control the number of threads used when unzipping and installing
   packages. See the [rayon documentation](https://docs.rs/rayon/latest/rayon/) for more.
+- `MACOSX_DEPLOYMENT_TARGET`: Used with `--python-platform macos` and related variants to set the
+  deployment target (i.e., the minimum supported macOS version). Defaults to `12.0`, the
+  least-recent non-EOL macOS version at time of writing.
 
 ## Versioning
 

--- a/crates/uv-configuration/Cargo.toml
+++ b/crates/uv-configuration/Cargo.toml
@@ -27,6 +27,7 @@ rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 
 [features]
 default = []

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -815,14 +815,14 @@
           ]
         },
         {
-          "description": "An ARM-based macOS target, as seen on Apple Silicon devices, with support for the least-recent, non-EOL macOS version (12.0).",
+          "description": "An ARM-based macOS target, as seen on Apple Silicon devices\n\nBy default, assumes the least-recent, non-EOL macOS version (12.0), but respects the `MACOSX_DEPLOYMENT_TARGET` environment variable if set.",
           "type": "string",
           "enum": [
             "aarch64-apple-darwin"
           ]
         },
         {
-          "description": "An x86 macOS target, with support for the least-recent, non-EOL macOS version (12.0).",
+          "description": "An x86 macOS target.\n\nBy default, assumes the least-recent, non-EOL macOS version (12.0), but respects the `MACOSX_DEPLOYMENT_TARGET` environment variable if set.",
           "type": "string",
           "enum": [
             "x86_64-apple-darwin"


### PR DESCRIPTION
## Summary

This is universal environment variable used to determine the mac OS deployment target. We now respect it in `--python-platform` -- so we default to 12.0, but users can override it as needed.
