### PR TITLE
use reference counting for MarkerEnvironment

### DIFF
--- a/crates/bench/benches/uv.rs
+++ b/crates/bench/benches/uv.rs
@@ -38,13 +38,12 @@ criterion_main!(uv);
 
 mod resolver {
     use std::path::{Path, PathBuf};
-    use std::str::FromStr;
 
     use anyhow::Result;
     use once_cell::sync::Lazy;
 
     use distribution_types::{IndexLocations, Requirement, Resolution, SourceDist};
-    use pep508_rs::{MarkerEnvironment, StringVersion};
+    use pep508_rs::{MarkerEnvironment, MarkerEnvironmentBuilder};
     use platform_tags::{Arch, Os, Platform, Tags};
     use uv_cache::Cache;
     use uv_client::RegistryClient;
@@ -58,19 +57,19 @@ mod resolver {
     };
 
     static MARKERS: Lazy<MarkerEnvironment> = Lazy::new(|| {
-        MarkerEnvironment {
-            implementation_name: "cpython".to_string(),
-            implementation_version: StringVersion::from_str("3.11.5").unwrap(),
-            os_name: "posix".to_string(),
-            platform_machine: "arm64".to_string(),
-            platform_python_implementation: "CPython".to_string(),
-            platform_release: "21.6.0".to_string(),
-            platform_system: "Darwin".to_string(),
-            platform_version: "Darwin Kernel Version 21.6.0: Mon Aug 22 20:19:52 PDT 2022; root:xnu-8020.140.49~2/RELEASE_ARM64_T6000".to_string(),
-            python_full_version: StringVersion::from_str("3.11.5").unwrap(),
-            python_version: StringVersion::from_str("3.11").unwrap(),
-            sys_platform: "darwin".to_string(),
-        }
+        MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
+            implementation_name: "cpython",
+            implementation_version: "3.11.5",
+            os_name: "posix",
+            platform_machine: "arm64",
+            platform_python_implementation: "CPython",
+            platform_release: "21.6.0",
+            platform_system: "Darwin",
+            platform_version: "Darwin Kernel Version 21.6.0: Mon Aug 22 20:19:52 PDT 2022; root:xnu-8020.140.49~2/RELEASE_ARM64_T6000",
+            python_full_version: "3.11.5",
+            python_version: "3.11",
+            sys_platform: "darwin",
+        }).unwrap()
     });
 
     static PLATFORM: Platform = Platform::new(

--- a/crates/pep508-rs/Cargo.toml
+++ b/crates/pep508-rs/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = { workspace = true }
 pyo3 = { workspace = true, optional = true, features = ["abi3", "extension-module"] }
 pyo3-log = { workspace = true, optional = true }
 regex = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -40,8 +40,8 @@ use unicode_width::UnicodeWidthChar;
 use url::Url;
 
 pub use marker::{
-    MarkerEnvironment, MarkerExpression, MarkerOperator, MarkerTree, MarkerValue,
-    MarkerValueString, MarkerValueVersion, MarkerWarningKind, StringVersion,
+    MarkerEnvironment, MarkerEnvironmentBuilder, MarkerExpression, MarkerOperator, MarkerTree,
+    MarkerValue, MarkerValueString, MarkerValueVersion, MarkerWarningKind, StringVersion,
 };
 #[cfg(feature = "pyo3")]
 use pep440_rs::PyVersion;

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -13,6 +13,7 @@ use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use std::str::FromStr;
+use std::sync::Arc;
 
 #[cfg(feature = "pyo3")]
 use pyo3::{
@@ -361,8 +362,14 @@ impl Deref for StringVersion {
 /// Some are `(String, Version)` because we have to support version comparison
 #[allow(missing_docs, clippy::unsafe_derive_deserialize)]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
-#[cfg_attr(feature = "pyo3", pyclass(get_all, module = "pep508"))]
+#[cfg_attr(feature = "pyo3", pyclass(module = "pep508"))]
 pub struct MarkerEnvironment {
+    #[serde(flatten)]
+    inner: Arc<MarkerEnvironmentInner>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
+struct MarkerEnvironmentInner {
     implementation_name: String,
     implementation_version: StringVersion,
     os_name: String,
@@ -420,7 +427,7 @@ impl MarkerEnvironment {
     /// Some example values are: `cpython`.
     #[inline]
     pub fn implementation_name(&self) -> &str {
-        &self.implementation_name
+        &self.inner.implementation_name
     }
 
     /// Returns the Python implementation version for this environment.
@@ -435,7 +442,7 @@ impl MarkerEnvironment {
     /// [PEP 508 environment markers]: https://peps.python.org/pep-0508/#environment-markers
     #[inline]
     pub fn implementation_version(&self) -> &StringVersion {
-        &self.implementation_version
+        &self.inner.implementation_version
     }
 
     /// Returns the name of the operating system for this environment.
@@ -445,7 +452,7 @@ impl MarkerEnvironment {
     /// Some example values are: `posix`, `java`.
     #[inline]
     pub fn os_name(&self) -> &str {
-        &self.os_name
+        &self.inner.os_name
     }
 
     /// Returns the name of the machine for this environment's platform.
@@ -455,7 +462,7 @@ impl MarkerEnvironment {
     /// Some example values are: `x86_64`.
     #[inline]
     pub fn platform_machine(&self) -> &str {
-        &self.platform_machine
+        &self.inner.platform_machine
     }
 
     /// Returns the name of the Python implementation for this environment's
@@ -466,7 +473,7 @@ impl MarkerEnvironment {
     /// Some example values are: `CPython`, `Jython`.
     #[inline]
     pub fn platform_python_implementation(&self) -> &str {
-        &self.platform_python_implementation
+        &self.inner.platform_python_implementation
     }
 
     /// Returns the release for this environment's platform.
@@ -476,7 +483,7 @@ impl MarkerEnvironment {
     /// Some example values are: `3.14.1-x86_64-linode39`, `14.5.0`, `1.8.0_51`.
     #[inline]
     pub fn platform_release(&self) -> &str {
-        &self.platform_release
+        &self.inner.platform_release
     }
 
     /// Returns the system for this environment's platform.
@@ -486,7 +493,7 @@ impl MarkerEnvironment {
     /// Some example values are: `Linux`, `Windows`, `Java`.
     #[inline]
     pub fn platform_system(&self) -> &str {
-        &self.platform_system
+        &self.inner.platform_system
     }
 
     /// Returns the version for this environment's platform.
@@ -499,7 +506,7 @@ impl MarkerEnvironment {
     /// root:xnu-2782.40.9~2/RELEASE_X86_64`.
     #[inline]
     pub fn platform_version(&self) -> &str {
-        &self.platform_version
+        &self.inner.platform_version
     }
 
     /// Returns the full version of Python for this environment.
@@ -509,7 +516,7 @@ impl MarkerEnvironment {
     /// Some example values are: `3.4.0`, `3.5.0b1`.
     #[inline]
     pub fn python_full_version(&self) -> &StringVersion {
-        &self.python_full_version
+        &self.inner.python_full_version
     }
 
     /// Returns the version of Python for this environment.
@@ -519,7 +526,7 @@ impl MarkerEnvironment {
     /// Some example values are: `3.4`, `2.7`.
     #[inline]
     pub fn python_version(&self) -> &StringVersion {
-        &self.python_version
+        &self.inner.python_version
     }
 
     /// Returns the name of the system platform for this environment.
@@ -530,7 +537,7 @@ impl MarkerEnvironment {
     /// (note that `linux` is from Python3 and `linux2` from Python2).
     #[inline]
     pub fn sys_platform(&self) -> &str {
-        &self.sys_platform
+        &self.inner.sys_platform
     }
 }
 
@@ -540,44 +547,39 @@ impl MarkerEnvironment {
     ///
     /// See also [`MarkerEnvironment::implementation_name`].
     #[inline]
-    pub fn with_implementation_name(self, value: impl Into<String>) -> MarkerEnvironment {
-        MarkerEnvironment {
-            implementation_name: value.into(),
-            ..self
-        }
+    pub fn with_implementation_name(mut self, value: impl Into<String>) -> MarkerEnvironment {
+        Arc::make_mut(&mut self.inner).implementation_name = value.into();
+        self
     }
 
     /// Set the Python implementation version for this environment.
     ///
     /// See also [`MarkerEnvironment::implementation_version`].
     #[inline]
-    pub fn with_implementation_version(self, value: impl Into<StringVersion>) -> MarkerEnvironment {
-        MarkerEnvironment {
-            implementation_version: value.into(),
-            ..self
-        }
+    pub fn with_implementation_version(
+        mut self,
+        value: impl Into<StringVersion>,
+    ) -> MarkerEnvironment {
+        Arc::make_mut(&mut self.inner).implementation_version = value.into();
+        self
     }
 
     /// Set the name of the operating system for this environment.
     ///
     /// See also [`MarkerEnvironment::os_name`].
     #[inline]
-    pub fn with_os_name(self, value: impl Into<String>) -> MarkerEnvironment {
-        MarkerEnvironment {
-            os_name: value.into(),
-            ..self
-        }
+    pub fn with_os_name(mut self, value: impl Into<String>) -> MarkerEnvironment {
+        Arc::make_mut(&mut self.inner).os_name = value.into();
+        self
     }
 
     /// Set the name of the machine for this environment's platform.
     ///
     /// See also [`MarkerEnvironment::platform_machine`].
     #[inline]
-    pub fn with_platform_machine(self, value: impl Into<String>) -> MarkerEnvironment {
-        MarkerEnvironment {
-            platform_machine: value.into(),
-            ..self
-        }
+    pub fn with_platform_machine(mut self, value: impl Into<String>) -> MarkerEnvironment {
+        Arc::make_mut(&mut self.inner).platform_machine = value.into();
+        self
     }
 
     /// Set the name of the Python implementation for this environment's
@@ -586,79 +588,68 @@ impl MarkerEnvironment {
     /// See also [`MarkerEnvironment::platform_python_implementation`].
     #[inline]
     pub fn with_platform_python_implementation(
-        self,
+        mut self,
         value: impl Into<String>,
     ) -> MarkerEnvironment {
-        MarkerEnvironment {
-            platform_python_implementation: value.into(),
-            ..self
-        }
+        Arc::make_mut(&mut self.inner).platform_python_implementation = value.into();
+        self
     }
 
     /// Set the release for this environment's platform.
     ///
     /// See also [`MarkerEnvironment::platform_release`].
     #[inline]
-    pub fn with_platform_release(self, value: impl Into<String>) -> MarkerEnvironment {
-        MarkerEnvironment {
-            platform_release: value.into(),
-            ..self
-        }
+    pub fn with_platform_release(mut self, value: impl Into<String>) -> MarkerEnvironment {
+        Arc::make_mut(&mut self.inner).platform_release = value.into();
+        self
     }
 
     /// Set the system for this environment's platform.
     ///
     /// See also [`MarkerEnvironment::platform_system`].
     #[inline]
-    pub fn with_platform_system(self, value: impl Into<String>) -> MarkerEnvironment {
-        MarkerEnvironment {
-            platform_system: value.into(),
-            ..self
-        }
+    pub fn with_platform_system(mut self, value: impl Into<String>) -> MarkerEnvironment {
+        Arc::make_mut(&mut self.inner).platform_system = value.into();
+        self
     }
 
     /// Set the version for this environment's platform.
     ///
     /// See also [`MarkerEnvironment::platform_version`].
     #[inline]
-    pub fn with_platform_version(self, value: impl Into<String>) -> MarkerEnvironment {
-        MarkerEnvironment {
-            platform_version: value.into(),
-            ..self
-        }
+    pub fn with_platform_version(mut self, value: impl Into<String>) -> MarkerEnvironment {
+        Arc::make_mut(&mut self.inner).platform_version = value.into();
+        self
     }
 
     /// Set the full version of Python for this environment.
     ///
     /// See also [`MarkerEnvironment::python_full_version`].
     #[inline]
-    pub fn with_python_full_version(self, value: impl Into<StringVersion>) -> MarkerEnvironment {
-        MarkerEnvironment {
-            python_full_version: value.into(),
-            ..self
-        }
+    pub fn with_python_full_version(
+        mut self,
+        value: impl Into<StringVersion>,
+    ) -> MarkerEnvironment {
+        Arc::make_mut(&mut self.inner).python_full_version = value.into();
+        self
     }
 
     /// Set the version of Python for this environment.
     ///
     /// See also [`MarkerEnvironment::python_full_version`].
     #[inline]
-    pub fn with_python_version(self, value: impl Into<StringVersion>) -> MarkerEnvironment {
-        MarkerEnvironment {
-            python_version: value.into(),
-            ..self
-        }
+    pub fn with_python_version(mut self, value: impl Into<StringVersion>) -> MarkerEnvironment {
+        Arc::make_mut(&mut self.inner).python_version = value.into();
+        self
     }
 
     /// Set the name of the system platform for this environment.
     ///
     /// See also [`MarkerEnvironment::sys_platform`].
     #[inline]
-    pub fn with_sys_platform(self, value: impl Into<String>) -> MarkerEnvironment {
-        MarkerEnvironment {
-            sys_platform: value.into(),
-            ..self
-        }
+    pub fn with_sys_platform(mut self, value: impl Into<String>) -> MarkerEnvironment {
+        Arc::make_mut(&mut self.inner).sys_platform = value.into();
+        self
     }
 }
 
@@ -711,17 +702,19 @@ impl MarkerEnvironment {
             ))
         })?;
         Ok(Self {
-            implementation_name: implementation_name.to_string(),
-            implementation_version,
-            os_name: os_name.to_string(),
-            platform_machine: platform_machine.to_string(),
-            platform_python_implementation: platform_python_implementation.to_string(),
-            platform_release: platform_release.to_string(),
-            platform_system: platform_system.to_string(),
-            platform_version: platform_version.to_string(),
-            python_full_version,
-            python_version,
-            sys_platform: sys_platform.to_string(),
+            inner: Arc::new(MarkerEnvironmentInner {
+                implementation_name: implementation_name.to_string(),
+                implementation_version,
+                os_name: os_name.to_string(),
+                platform_machine: platform_machine.to_string(),
+                platform_python_implementation: platform_python_implementation.to_string(),
+                platform_release: platform_release.to_string(),
+                platform_system: platform_system.to_string(),
+                platform_version: platform_version.to_string(),
+                python_full_version,
+                python_version,
+                sys_platform: sys_platform.to_string(),
+            }),
         })
     }
 
@@ -773,21 +766,90 @@ impl MarkerEnvironment {
             ))
         })?;
         Ok(Self {
-            implementation_name: name,
-            implementation_version,
-            os_name: os.getattr("name")?.extract()?,
-            platform_machine: platform.getattr("machine")?.call0()?.extract()?,
-            platform_python_implementation: platform
-                .getattr("python_implementation")?
-                .call0()?
-                .extract()?,
-            platform_release: platform.getattr("release")?.call0()?.extract()?,
-            platform_system: platform.getattr("system")?.call0()?.extract()?,
-            platform_version: platform.getattr("version")?.call0()?.extract()?,
-            python_full_version,
-            python_version,
-            sys_platform: sys.getattr("platform")?.extract()?,
+            inner: Arc::new(MarkerEnvironmentInner {
+                implementation_name: name,
+                implementation_version,
+                os_name: os.getattr("name")?.extract()?,
+                platform_machine: platform.getattr("machine")?.call0()?.extract()?,
+                platform_python_implementation: platform
+                    .getattr("python_implementation")?
+                    .call0()?
+                    .extract()?,
+                platform_release: platform.getattr("release")?.call0()?.extract()?,
+                platform_system: platform.getattr("system")?.call0()?.extract()?,
+                platform_version: platform.getattr("version")?.call0()?.extract()?,
+                python_full_version,
+                python_version,
+                sys_platform: sys.getattr("platform")?.extract()?,
+            }),
         })
+    }
+
+    /// Returns the name of the Python implementation for this environment.
+    #[getter]
+    pub fn py_implementation_name(&self) -> String {
+        self.implementation_name().to_string()
+    }
+
+    /// Returns the Python implementation version for this environment.
+    #[getter]
+    pub fn py_implementation_version(&self) -> StringVersion {
+        self.implementation_version().clone()
+    }
+
+    /// Returns the name of the operating system for this environment.
+    #[getter]
+    pub fn py_os_name(&self) -> String {
+        self.os_name().to_string()
+    }
+
+    /// Returns the name of the machine for this environment's platform.
+    #[getter]
+    pub fn py_platform_machine(&self) -> String {
+        self.platform_machine().to_string()
+    }
+
+    /// Returns the name of the Python implementation for this environment's
+    /// platform.
+    #[getter]
+    pub fn py_platform_python_implementation(&self) -> String {
+        self.platform_python_implementation().to_string()
+    }
+
+    /// Returns the release for this environment's platform.
+    #[getter]
+    pub fn py_platform_release(&self) -> String {
+        self.platform_release().to_string()
+    }
+
+    /// Returns the system for this environment's platform.
+    #[getter]
+    pub fn py_platform_system(&self) -> String {
+        self.platform_system().to_string()
+    }
+
+    /// Returns the version for this environment's platform.
+    #[getter]
+    pub fn py_platform_version(&self) -> String {
+        self.platform_version().to_string()
+    }
+
+    /// Returns the full version of Python for this environment.
+    #[getter]
+    pub fn py_python_full_version(&self) -> StringVersion {
+        self.python_full_version().clone()
+    }
+
+    /// Returns the version of Python for this environment.
+    #[getter]
+    pub fn py_python_version(&self) -> StringVersion {
+        self.python_version().clone()
+    }
+
+    /// Returns the name of the system platform for this environment.
+    #[getter]
+    pub fn py_sys_platform(&self) -> String {
+        self.sys_platform().to_string()
     }
 }
 
@@ -820,17 +882,19 @@ impl<'a> TryFrom<MarkerEnvironmentBuilder<'a>> for MarkerEnvironment {
 
     fn try_from(builder: MarkerEnvironmentBuilder<'a>) -> Result<Self, Self::Error> {
         Ok(MarkerEnvironment {
-            implementation_name: builder.implementation_name.to_string(),
-            implementation_version: builder.implementation_version.parse()?,
-            os_name: builder.os_name.to_string(),
-            platform_machine: builder.platform_machine.to_string(),
-            platform_python_implementation: builder.platform_python_implementation.to_string(),
-            platform_release: builder.platform_release.to_string(),
-            platform_system: builder.platform_system.to_string(),
-            platform_version: builder.platform_version.to_string(),
-            python_full_version: builder.python_full_version.parse()?,
-            python_version: builder.python_version.parse()?,
-            sys_platform: builder.sys_platform.to_string(),
+            inner: Arc::new(MarkerEnvironmentInner {
+                implementation_name: builder.implementation_name.to_string(),
+                implementation_version: builder.implementation_version.parse()?,
+                os_name: builder.os_name.to_string(),
+                platform_machine: builder.platform_machine.to_string(),
+                platform_python_implementation: builder.platform_python_implementation.to_string(),
+                platform_release: builder.platform_release.to_string(),
+                platform_system: builder.platform_system.to_string(),
+                platform_version: builder.platform_version.to_string(),
+                python_full_version: builder.python_full_version.parse()?,
+                python_version: builder.python_version.parse()?,
+                sys_platform: builder.sys_platform.to_string(),
+            }),
         })
     }
 }

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -411,6 +411,257 @@ impl MarkerEnvironment {
     }
 }
 
+/// APIs for retrieving specific parts of a marker environment.
+impl MarkerEnvironment {
+    /// Returns the name of the Python implementation for this environment.
+    ///
+    /// This is equivalent to `sys.implementation.name`.
+    ///
+    /// Some example values are: `cpython`.
+    #[inline]
+    pub fn implementation_name(&self) -> &str {
+        &self.implementation_name
+    }
+
+    /// Returns the Python implementation version for this environment.
+    ///
+    /// This value is derived from `sys.implementation.version`. See [PEP 508
+    /// environment markers] for full details.
+    ///
+    /// This is equivalent to `sys.implementation.name`.
+    ///
+    /// Some example values are: `3.4.0`, `3.5.0b1`.
+    ///
+    /// [PEP 508 environment markers]: https://peps.python.org/pep-0508/#environment-markers
+    #[inline]
+    pub fn implementation_version(&self) -> &StringVersion {
+        &self.implementation_version
+    }
+
+    /// Returns the name of the operating system for this environment.
+    ///
+    /// This is equivalent to `os.name`.
+    ///
+    /// Some example values are: `posix`, `java`.
+    #[inline]
+    pub fn os_name(&self) -> &str {
+        &self.os_name
+    }
+
+    /// Returns the name of the machine for this environment's platform.
+    ///
+    /// This is equivalent to `platform.machine()`.
+    ///
+    /// Some example values are: `x86_64`.
+    #[inline]
+    pub fn platform_machine(&self) -> &str {
+        &self.platform_machine
+    }
+
+    /// Returns the name of the Python implementation for this environment's
+    /// platform.
+    ///
+    /// This is equivalent to `platform.python_implementation()`.
+    ///
+    /// Some example values are: `CPython`, `Jython`.
+    #[inline]
+    pub fn platform_python_implementation(&self) -> &str {
+        &self.platform_python_implementation
+    }
+
+    /// Returns the release for this environment's platform.
+    ///
+    /// This is equivalent to `platform.release()`.
+    ///
+    /// Some example values are: `3.14.1-x86_64-linode39`, `14.5.0`, `1.8.0_51`.
+    #[inline]
+    pub fn platform_release(&self) -> &str {
+        &self.platform_release
+    }
+
+    /// Returns the system for this environment's platform.
+    ///
+    /// This is equivalent to `platform.system()`.
+    ///
+    /// Some example values are: `Linux`, `Windows`, `Java`.
+    #[inline]
+    pub fn platform_system(&self) -> &str {
+        &self.platform_system
+    }
+
+    /// Returns the version for this environment's platform.
+    ///
+    /// This is equivalent to `platform.version()`.
+    ///
+    /// Some example values are: `#1 SMP Fri Apr 25 13:07:35 EDT 2014`,
+    /// `Java HotSpot(TM) 64-Bit Server VM, 25.51-b03, Oracle Corporation`,
+    /// `Darwin Kernel Version 14.5.0: Wed Jul 29 02:18:53 PDT 2015;
+    /// root:xnu-2782.40.9~2/RELEASE_X86_64`.
+    #[inline]
+    pub fn platform_version(&self) -> &str {
+        &self.platform_version
+    }
+
+    /// Returns the full version of Python for this environment.
+    ///
+    /// This is equivalent to `platform.python_version()`.
+    ///
+    /// Some example values are: `3.4.0`, `3.5.0b1`.
+    #[inline]
+    pub fn python_full_version(&self) -> &StringVersion {
+        &self.python_full_version
+    }
+
+    /// Returns the version of Python for this environment.
+    ///
+    /// This is equivalent to `'.'.join(platform.python_version_tuple()[:2])`.
+    ///
+    /// Some example values are: `3.4`, `2.7`.
+    #[inline]
+    pub fn python_version(&self) -> &StringVersion {
+        &self.python_version
+    }
+
+    /// Returns the name of the system platform for this environment.
+    ///
+    /// This is equivalent to `sys.platform`.
+    ///
+    /// Some example values are: `linux`, `linux2`, `darwin`, `java1.8.0_51`
+    /// (note that `linux` is from Python3 and `linux2` from Python2).
+    #[inline]
+    pub fn sys_platform(&self) -> &str {
+        &self.sys_platform
+    }
+}
+
+/// APIs for setting specific parts of a marker environment.
+impl MarkerEnvironment {
+    /// Set the name of the Python implementation for this environment.
+    ///
+    /// See also [`MarkerEnvironment::implementation_name`].
+    #[inline]
+    pub fn with_implementation_name(self, value: impl Into<String>) -> MarkerEnvironment {
+        MarkerEnvironment {
+            implementation_name: value.into(),
+            ..self
+        }
+    }
+
+    /// Set the Python implementation version for this environment.
+    ///
+    /// See also [`MarkerEnvironment::implementation_version`].
+    #[inline]
+    pub fn with_implementation_version(self, value: impl Into<StringVersion>) -> MarkerEnvironment {
+        MarkerEnvironment {
+            implementation_version: value.into(),
+            ..self
+        }
+    }
+
+    /// Set the name of the operating system for this environment.
+    ///
+    /// See also [`MarkerEnvironment::os_name`].
+    #[inline]
+    pub fn with_os_name(self, value: impl Into<String>) -> MarkerEnvironment {
+        MarkerEnvironment {
+            os_name: value.into(),
+            ..self
+        }
+    }
+
+    /// Set the name of the machine for this environment's platform.
+    ///
+    /// See also [`MarkerEnvironment::platform_machine`].
+    #[inline]
+    pub fn with_platform_machine(self, value: impl Into<String>) -> MarkerEnvironment {
+        MarkerEnvironment {
+            platform_machine: value.into(),
+            ..self
+        }
+    }
+
+    /// Set the name of the Python implementation for this environment's
+    /// platform.
+    ///
+    /// See also [`MarkerEnvironment::platform_python_implementation`].
+    #[inline]
+    pub fn with_platform_python_implementation(
+        self,
+        value: impl Into<String>,
+    ) -> MarkerEnvironment {
+        MarkerEnvironment {
+            platform_python_implementation: value.into(),
+            ..self
+        }
+    }
+
+    /// Set the release for this environment's platform.
+    ///
+    /// See also [`MarkerEnvironment::platform_release`].
+    #[inline]
+    pub fn with_platform_release(self, value: impl Into<String>) -> MarkerEnvironment {
+        MarkerEnvironment {
+            platform_release: value.into(),
+            ..self
+        }
+    }
+
+    /// Set the system for this environment's platform.
+    ///
+    /// See also [`MarkerEnvironment::platform_system`].
+    #[inline]
+    pub fn with_platform_system(self, value: impl Into<String>) -> MarkerEnvironment {
+        MarkerEnvironment {
+            platform_system: value.into(),
+            ..self
+        }
+    }
+
+    /// Set the version for this environment's platform.
+    ///
+    /// See also [`MarkerEnvironment::platform_version`].
+    #[inline]
+    pub fn with_platform_version(self, value: impl Into<String>) -> MarkerEnvironment {
+        MarkerEnvironment {
+            platform_version: value.into(),
+            ..self
+        }
+    }
+
+    /// Set the full version of Python for this environment.
+    ///
+    /// See also [`MarkerEnvironment::python_full_version`].
+    #[inline]
+    pub fn with_python_full_version(self, value: impl Into<StringVersion>) -> MarkerEnvironment {
+        MarkerEnvironment {
+            python_full_version: value.into(),
+            ..self
+        }
+    }
+
+    /// Set the version of Python for this environment.
+    ///
+    /// See also [`MarkerEnvironment::python_full_version`].
+    #[inline]
+    pub fn with_python(self, value: impl Into<StringVersion>) -> MarkerEnvironment {
+        MarkerEnvironment {
+            python_version: value.into(),
+            ..self
+        }
+    }
+
+    /// Set the name of the system platform for this environment.
+    ///
+    /// See also [`MarkerEnvironment::sys_platform`].
+    #[inline]
+    pub fn with_sys_platform(self, value: impl Into<String>) -> MarkerEnvironment {
+        MarkerEnvironment {
+            sys_platform: value.into(),
+            ..self
+        }
+    }
+}
+
 #[cfg(feature = "pyo3")]
 #[pymethods]
 impl MarkerEnvironment {

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -1604,8 +1604,8 @@ mod test {
             assert_eq!(
                 captured_logs[0].body,
                 "Expected PEP 440 version to compare with python_version, found '3.9.', \
-                 evaluating to false: after parsing 3.9, found \".\" after it, \
-                 which is not part of a valid version"
+                 evaluating to false: after parsing '3.9', found '.', which is \
+                 not part of a valid version"
             );
             assert_eq!(captured_logs[0].level, log::Level::Warn);
             assert_eq!(captured_logs.len(), 1);

--- a/crates/uv-client/src/linehaul.rs
+++ b/crates/uv-client/src/linehaul.rs
@@ -118,17 +118,17 @@ impl LineHaul {
                 name: Some("uv".to_string()),
                 version: Some(version().to_string()),
             }),
-            python: Some(markers.python_full_version.version.to_string()),
+            python: Some(markers.python_full_version().version.to_string()),
             implementation: Option::from(Implementation {
-                name: Some(markers.platform_python_implementation.to_string()),
-                version: Some(markers.python_full_version.version.to_string()),
+                name: Some(markers.platform_python_implementation().to_string()),
+                version: Some(markers.python_full_version().version.to_string()),
             }),
             distro,
             system: Option::from(System {
-                name: Some(markers.platform_system.to_string()),
-                release: Some(markers.platform_release.to_string()),
+                name: Some(markers.platform_system().to_string()),
+                release: Some(markers.platform_release().to_string()),
             }),
-            cpu: Some(markers.platform_machine.to_string()),
+            cpu: Some(markers.platform_machine().to_string()),
             // Should probably always be None in uv.
             openssl_version: None,
             // Should probably always be None in uv.

--- a/crates/uv-client/tests/user_agent_version.rs
+++ b/crates/uv-client/tests/user_agent_version.rs
@@ -8,7 +8,7 @@ use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use insta::{assert_json_snapshot, assert_snapshot, with_settings};
-use pep508_rs::{MarkerEnvironment, StringVersion};
+use pep508_rs::{MarkerEnvironment, MarkerEnvironmentBuilder};
 use platform_tags::{Arch, Os, Platform};
 use tokio::net::TcpListener;
 use uv_cache::Cache;
@@ -106,28 +106,20 @@ async fn test_user_agent_has_linehaul() -> Result<()> {
     });
 
     // Add some representative markers for an Ubuntu CI runner
-    let markers = MarkerEnvironment {
-        implementation_name: "cpython".to_string(),
-        implementation_version: StringVersion {
-            string: "3.12.2".to_string(),
-            version: "3.12.2".parse()?,
-        },
-        os_name: "posix".to_string(),
-        platform_machine: "x86_64".to_string(),
-        platform_python_implementation: "CPython".to_string(),
-        platform_release: "6.5.0-1016-azure".to_string(),
-        platform_system: "Linux".to_string(),
-        platform_version: "#16~22.04.1-Ubuntu SMP Fri Feb 16 15:42:02 UTC 2024".to_string(),
-        python_full_version: StringVersion {
-            string: "3.12.2".to_string(),
-            version: "3.12.2".parse()?,
-        },
-        python_version: StringVersion {
-            string: "3.12".to_string(),
-            version: "3.12".parse()?,
-        },
-        sys_platform: "linux".to_string(),
-    };
+    let markers = MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
+        implementation_name: "cpython",
+        implementation_version: "3.12.2",
+        os_name: "posix",
+        platform_machine: "x86_64",
+        platform_python_implementation: "CPython",
+        platform_release: "6.5.0-1016-azure",
+        platform_system: "Linux",
+        platform_version: "#16~22.04.1-Ubuntu SMP Fri Feb 16 15:42:02 UTC 2024",
+        python_full_version: "3.12.2",
+        python_version: "3.12",
+        sys_platform: "linux",
+    })
+    .unwrap();
 
     // Initialize uv-client
     let cache = Cache::temp()?;

--- a/crates/uv-configuration/src/target_triple.rs
+++ b/crates/uv-configuration/src/target_triple.rs
@@ -261,21 +261,13 @@ impl TargetTriple {
     /// The returned [`MarkerEnvironment`] will preserve the base environment's Python version
     /// markers, but override its platform markers.
     pub fn markers(self, base: &MarkerEnvironment) -> MarkerEnvironment {
-        MarkerEnvironment {
-            // Platform markers
-            os_name: self.os_name().to_string(),
-            platform_machine: self.platform_machine().to_string(),
-            platform_system: self.platform_system().to_string(),
-            sys_platform: self.sys_platform().to_string(),
-            platform_release: self.platform_release().to_string(),
-            platform_version: self.platform_version().to_string(),
-            // Python version markers
-            implementation_name: base.implementation_name.clone(),
-            implementation_version: base.implementation_version.clone(),
-            platform_python_implementation: base.platform_python_implementation.clone(),
-            python_full_version: base.python_full_version.clone(),
-            python_version: base.python_version.clone(),
-        }
+        base.clone()
+            .with_os_name(self.os_name())
+            .with_platform_machine(self.platform_machine())
+            .with_platform_system(self.platform_system())
+            .with_sys_platform(self.sys_platform())
+            .with_platform_release(self.platform_release())
+            .with_platform_version(self.platform_version())
     }
 }
 

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -202,31 +202,31 @@ impl Interpreter {
 
     /// Returns the Python version.
     #[inline]
-    pub const fn python_version(&self) -> &Version {
-        &self.markers.python_full_version.version
+    pub fn python_version(&self) -> &Version {
+        &self.markers.python_full_version().version
     }
 
     /// Returns the `python_full_version` marker corresponding to this Python version.
     #[inline]
-    pub const fn python_full_version(&self) -> &StringVersion {
-        &self.markers.python_full_version
+    pub fn python_full_version(&self) -> &StringVersion {
+        self.markers.python_full_version()
     }
 
     /// Return the major version of this Python version.
     pub fn python_major(&self) -> u8 {
-        let major = self.markers.python_full_version.version.release()[0];
+        let major = self.markers.python_full_version().version.release()[0];
         u8::try_from(major).expect("invalid major version")
     }
 
     /// Return the minor version of this Python version.
     pub fn python_minor(&self) -> u8 {
-        let minor = self.markers.python_full_version.version.release()[1];
+        let minor = self.markers.python_full_version().version.release()[1];
         u8::try_from(minor).expect("invalid minor version")
     }
 
     /// Return the patch version of this Python version.
     pub fn python_patch(&self) -> u8 {
-        let minor = self.markers.python_full_version.version.release()[2];
+        let minor = self.markers.python_full_version().version.release()[2];
         u8::try_from(minor).expect("invalid patch version")
     }
 
@@ -237,13 +237,13 @@ impl Interpreter {
 
     /// Return the major version of the implementation (e.g., `CPython` or `PyPy`).
     pub fn implementation_major(&self) -> u8 {
-        let major = self.markers.implementation_version.version.release()[0];
+        let major = self.markers.implementation_version().version.release()[0];
         u8::try_from(major).expect("invalid major version")
     }
 
     /// Return the minor version of the implementation (e.g., `CPython` or `PyPy`).
     pub fn implementation_minor(&self) -> u8 {
-        let minor = self.markers.implementation_version.version.release()[1];
+        let minor = self.markers.implementation_version().version.release()[1];
         u8::try_from(minor).expect("invalid minor version")
     }
 
@@ -254,7 +254,7 @@ impl Interpreter {
 
     /// Returns the implementation name (e.g., `CPython` or `PyPy`).
     pub fn implementation_name(&self) -> &str {
-        &self.markers.implementation_name
+        self.markers.implementation_name()
     }
 
     /// Return the `sys.base_exec_prefix` path for this Python interpreter.
@@ -337,7 +337,7 @@ impl Interpreter {
         Layout {
             python_version: self.python_tuple(),
             sys_executable: self.sys_executable().to_path_buf(),
-            os_name: self.markers.os_name.clone(),
+            os_name: self.markers.os_name().to_string(),
             scheme: if let Some(target) = self.target.as_ref() {
                 target.scheme()
             } else {
@@ -540,7 +540,7 @@ impl InterpreterInfo {
                         if cached.timestamp == modified {
                             debug!(
                                 "Cached interpreter info for Python {}, skipping probing: {}",
-                                cached.data.markers.python_full_version,
+                                cached.data.markers.python_full_version(),
                                 executable.user_display()
                             );
                             return Ok(cached.data);
@@ -567,7 +567,7 @@ impl InterpreterInfo {
         let info = Self::query(executable, cache)?;
         debug!(
             "Found Python {} for: {}",
-            info.markers.python_full_version,
+            info.markers.python_full_version(),
             executable.display()
         );
 
@@ -670,7 +670,7 @@ mod tests {
         .unwrap();
         let interpreter = Interpreter::query(&mocked_interpreter, &cache).unwrap();
         assert_eq!(
-            interpreter.markers.python_version.version,
+            interpreter.markers.python_version().version,
             Version::from_str("3.12").unwrap()
         );
         fs::write(
@@ -683,7 +683,7 @@ mod tests {
         .unwrap();
         let interpreter = Interpreter::query(&mocked_interpreter, &cache).unwrap();
         assert_eq!(
-            interpreter.markers.python_version.version,
+            interpreter.markers.python_version().version,
             Version::from_str("3.13").unwrap()
         );
     }

--- a/crates/uv-interpreter/src/python_version.rs
+++ b/crates/uv-interpreter/src/python_version.rs
@@ -88,29 +88,29 @@ impl PythonVersion {
         let mut markers = base.clone();
 
         // Ex) `implementation_version == "3.12.0"`
-        if markers.implementation_name == "cpython" {
+        if markers.implementation_name() == "cpython" {
             let python_full_version = self.python_full_version();
-            markers.implementation_version = StringVersion {
+            markers = markers.with_implementation_version(StringVersion {
                 // Retain the verbatim representation, provided by the user.
                 string: self.0.to_string(),
                 version: python_full_version,
-            };
+            });
         }
 
         // Ex) `python_full_version == "3.12.0"`
         let python_full_version = self.python_full_version();
-        markers.python_full_version = StringVersion {
+        markers = markers.with_python_full_version(StringVersion {
             // Retain the verbatim representation, provided by the user.
             string: self.0.to_string(),
             version: python_full_version,
-        };
+        });
 
         // Ex) `python_version == "3.12"`
         let python_version = self.python_version();
-        markers.python_version = StringVersion {
+        markers = markers.with_python_version(StringVersion {
             string: python_version.to_string(),
             version: python_version,
-        };
+        });
 
         markers
     }

--- a/crates/uv-resolver/src/python_requirement.rs
+++ b/crates/uv-resolver/src/python_requirement.rs
@@ -20,7 +20,7 @@ impl PythonRequirement {
     }
 
     pub fn from_marker_environment(interpreter: &Interpreter, env: &MarkerEnvironment) -> Self {
-        Self::new(interpreter, &env.python_full_version)
+        Self::new(interpreter, env.python_full_version())
     }
 
     /// Return the installed version of Python.

--- a/crates/uv-resolver/tests/resolver.rs
+++ b/crates/uv-resolver/tests/resolver.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, Utc};
 use once_cell::sync::Lazy;
 
 use distribution_types::{IndexLocations, Requirement, Resolution, SourceDist};
-use pep508_rs::{MarkerEnvironment, StringVersion};
+use pep508_rs::{MarkerEnvironment, MarkerEnvironmentBuilder};
 use platform_tags::{Arch, Os, Platform, Tags};
 use uv_cache::Cache;
 use uv_client::RegistryClientBuilder;
@@ -724,19 +724,19 @@ async fn msgraph_sdk() -> Result<()> {
 }
 
 static MARKERS_311: Lazy<MarkerEnvironment> = Lazy::new(|| {
-    MarkerEnvironment {
-        implementation_name: "cpython".to_string(),
-        implementation_version: StringVersion::from_str("3.11.5").unwrap(),
-        os_name: "posix".to_string(),
-        platform_machine: "arm64".to_string(),
-        platform_python_implementation: "CPython".to_string(),
-        platform_release: "21.6.0".to_string(),
-        platform_system: "Darwin".to_string(),
-        platform_version: "Darwin Kernel Version 21.6.0: Mon Aug 22 20:19:52 PDT 2022; root:xnu-8020.140.49~2/RELEASE_ARM64_T6000".to_string(),
-        python_full_version: StringVersion::from_str("3.11.5").unwrap(),
-        python_version: StringVersion::from_str("3.11").unwrap(),
-        sys_platform: "darwin".to_string(),
-    }
+    MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
+        implementation_name: "cpython",
+        implementation_version: "3.11.5",
+        os_name: "posix",
+        platform_machine: "arm64",
+        platform_python_implementation: "CPython",
+        platform_release: "21.6.0",
+        platform_system: "Darwin",
+        platform_version: "Darwin Kernel Version 21.6.0: Mon Aug 22 20:19:52 PDT 2022; root:xnu-8020.140.49~2/RELEASE_ARM64_T6000",
+        python_full_version: "3.11.5",
+        python_version: "3.11",
+        sys_platform: "darwin",
+    }).unwrap()
 });
 
 static TAGS_311: Lazy<Tags> = Lazy::new(|| {
@@ -757,19 +757,19 @@ static TAGS_311: Lazy<Tags> = Lazy::new(|| {
 });
 
 static MARKERS_310: Lazy<MarkerEnvironment> = Lazy::new(|| {
-    MarkerEnvironment {
-        implementation_name: "cpython".to_string(),
-        implementation_version: StringVersion::from_str("3.10.5").unwrap(),
-        os_name: "posix".to_string(),
-        platform_machine: "arm64".to_string(),
-        platform_python_implementation: "CPython".to_string(),
-        platform_release: "21.6.0".to_string(),
-        platform_system: "Darwin".to_string(),
-        platform_version: "Darwin Kernel Version 21.6.0: Mon Aug 22 20:19:52 PDT 2022; root:xnu-8020.140.49~2/RELEASE_ARM64_T6000".to_string(),
-        python_full_version: StringVersion::from_str("3.10.5").unwrap(),
-        python_version: StringVersion::from_str("3.10").unwrap(),
-        sys_platform: "darwin".to_string(),
-    }
+    MarkerEnvironment::try_from(MarkerEnvironmentBuilder {
+        implementation_name: "cpython",
+        implementation_version: "3.10.5",
+        os_name: "posix",
+        platform_machine: "arm64",
+        platform_python_implementation: "CPython",
+        platform_release: "21.6.0",
+        platform_system: "Darwin",
+        platform_version: "Darwin Kernel Version 21.6.0: Mon Aug 22 20:19:52 PDT 2022; root:xnu-8020.140.49~2/RELEASE_ARM64_T6000",
+        python_full_version: "3.10.5",
+        python_version: "3.10",
+        sys_platform: "darwin",
+    }).unwrap()
 });
 
 static TAGS_310: Lazy<Tags> = Lazy::new(|| {

--- a/crates/uv-virtualenv/src/bare.rs
+++ b/crates/uv-virtualenv/src/bare.rs
@@ -235,12 +235,15 @@ pub fn create_bare_venv(
         ),
         (
             "implementation".to_string(),
-            interpreter.markers().platform_python_implementation.clone(),
+            interpreter
+                .markers()
+                .platform_python_implementation()
+                .to_string(),
         ),
         ("uv".to_string(), version().to_string()),
         (
             "version_info".to_string(),
-            interpreter.markers().python_full_version.string.clone(),
+            interpreter.markers().python_full_version().string.clone(),
         ),
         (
             "include-system-site-packages".to_string(),


### PR DESCRIPTION
This PR makes the `MarkerEnvironment` type in the `pep508_rs` crate
fully encapsulated. It then changes its internal representation to use
an `Arc` so that clones are cheap.

This representation more closely matches how this type is commonly
used: it is constructed approximately once at startup from
interpreter state and then passed down into various routines for
requirement filtering. There are some parts of `uv` that mutate a
`MarkerEnvironment` (like setting the `python_full_version` based on
the `-p/--python` CLI flag) or create a new one (like from a target
triple), but these are generally "one time" things whose cost is
immaterial to the overall runtime of `uv`.

The impetus for this change was a loose desire to remove lifetimes from
some parts of the code. Namely, because `MarkerEnvironment` clones were
not cheap before this change, we typically used `&MarkerEnvironment`
everywhere. While not done in this PR, the idea is that in the future,
we can just use `MarkerEnvironment` instead.

I'm considering pursuing similar changes for other types. The change
for this type was somewhat gnarly due to how widely used it was.

The main downside of this change, and encapsulation in general, is that
it typically make the definition/implementation of the type itself
more verbose. For example, we have a new inner type, a new builder
type, getters, setters and the pyo3 `get_all` convenience function
no longer works, so we have to write that out ourselves too. But,
importantly, calling code can now clone without worry, and the calling
code generally doesn't get more much more complicated.
