### PR TITLE
Skip Python 2 versions when locating Python

### DIFF
--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -74,6 +74,8 @@ pub enum Error {
         stdout: String,
         stderr: String,
     },
+    #[error("Requested Python version ({0}) is unsupported")]
+    UnsupportedPython(String),
     #[error("Failed to write to cache")]
     Encode(#[from] rmp_serde::encode::Error),
     #[error("Broken virtualenv: Failed to parse pyvenv.cfg")]


### PR DESCRIPTION
## Summary

Unfortunately, the `-I` flag was added in Python 3.4. So if we query a Python version prior to 3.4 (e.g., Python 2.7), we can't run our script at all, and lose the ability to match against our structured error.

This PR adds an additional check against the stderr output for these cases.

Closes https://github.com/astral-sh/uv/issues/3474.

## Test Plan

Installed Python 2.7, and verified that it was skipped (and that we instead found my `python3`).