### PR TITLE
Rebrand workspace API as project API

### DIFF
--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -16,6 +16,9 @@ pub(crate) use pip_list::pip_list;
 pub(crate) use pip_show::pip_show;
 pub(crate) use pip_sync::pip_sync;
 pub(crate) use pip_uninstall::pip_uninstall;
+pub(crate) use project::lock::lock;
+pub(crate) use project::run::run;
+pub(crate) use project::sync::sync;
 #[cfg(feature = "self-update")]
 pub(crate) use self_update::self_update;
 use uv_cache::Cache;
@@ -25,9 +28,6 @@ use uv_interpreter::PythonEnvironment;
 use uv_normalize::PackageName;
 pub(crate) use venv::venv;
 pub(crate) use version::version;
-pub(crate) use workspace::lock::lock;
-pub(crate) use workspace::run::run;
-pub(crate) use workspace::sync::sync;
 
 use crate::printer::Printer;
 
@@ -42,12 +42,12 @@ mod pip_list;
 mod pip_show;
 mod pip_sync;
 mod pip_uninstall;
+mod project;
 mod reporters;
 #[cfg(feature = "self-update")]
 mod self_update;
 mod venv;
 mod version;
-mod workspace;
 
 #[derive(Copy, Clone)]
 pub(crate) enum ExitStatus {

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -13,8 +13,8 @@ use uv_resolver::{FlatIndex, InMemoryIndex, OptionsBuilder};
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 use uv_warnings::warn_user;
 
-use crate::commands::workspace::Error;
-use crate::commands::{workspace, ExitStatus};
+use crate::commands::project::Error;
+use crate::commands::{project, ExitStatus};
 use crate::printer::Printer;
 
 /// Resolve the project requirements into a lockfile.
@@ -31,10 +31,10 @@ pub(crate) async fn lock(
     // TODO(charlie): If the environment doesn't exist, create it.
     let venv = PythonEnvironment::from_virtualenv(cache)?;
 
-    // Find the workspace requirements.
-    let Some(requirements) = workspace::find_workspace()? else {
+    // Find the project requirements.
+    let Some(requirements) = project::find_project()? else {
         return Err(anyhow::anyhow!(
-            "Unable to find `pyproject.toml` for project workspace."
+            "Unable to find `pyproject.toml` for project project."
         ));
     };
 
@@ -105,7 +105,7 @@ pub(crate) async fn lock(
         .build();
 
     // Resolve the requirements.
-    let resolution = workspace::resolve(
+    let resolution = project::resolve(
         spec,
         &hasher,
         &interpreter,

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -63,7 +63,7 @@ pub(crate) enum Error {
 }
 
 /// Find the requirements for the current workspace.
-pub(crate) fn find_workspace() -> Result<Option<Vec<RequirementsSource>>> {
+pub(crate) fn find_project() -> Result<Option<Vec<RequirementsSource>>> {
     // TODO(zanieb): Add/use workspace logic to load requirements for a workspace
     // We cannot use `Workspace::find` yet because it depends on a `[tool.uv]` section
     let pyproject_path = std::env::current_dir()?.join("pyproject.toml");

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -13,7 +13,7 @@ use uv_resolver::{FlatIndex, InMemoryIndex, Lock};
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 use uv_warnings::warn_user;
 
-use crate::commands::{workspace, ExitStatus};
+use crate::commands::{project, ExitStatus};
 use crate::printer::Printer;
 
 /// Sync the project environment.
@@ -79,7 +79,7 @@ pub(crate) async fn sync(
     };
 
     // Sync the environment.
-    workspace::install(
+    project::install(
         &resolution,
         SitePackages::from_executable(&venv)?,
         &no_binary,


### PR DESCRIPTION
## Summary

I've started to refer to this as the "project" API in various places, it seems less duplicative than the "workspace" API which is a little different.
