### PR TITLE
uv-resolver: push resolver state to its own type

### DIFF
--- a/crates/uv-resolver/src/dependency_provider.rs
+++ b/crates/uv-resolver/src/dependency_provider.rs
@@ -10,6 +10,7 @@ use crate::resolver::UnavailableReason;
 
 /// We don't use a dependency provider, we interact with state directly, but we still need this one
 /// for type
+#[derive(Clone)]
 pub(crate) struct UvDependencyProvider;
 
 impl DependencyProvider for UvDependencyProvider {

--- a/crates/uv-resolver/src/pins.rs
+++ b/crates/uv-resolver/src/pins.rs
@@ -9,7 +9,7 @@ use crate::candidate_selector::Candidate;
 ///
 /// For example, given `Flask==3.0.0`, the [`FilePins`] would contain a mapping from `Flask` to
 /// `3.0.0` to the specific wheel or source distribution archive that was pinned for that version.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct FilePins(FxHashMap<PackageName, FxHashMap<pep440_rs::Version, ResolvedDist>>);
 
 impl FilePins {

--- a/crates/uv-resolver/src/pubgrub/priority.rs
+++ b/crates/uv-resolver/src/pubgrub/priority.rs
@@ -17,7 +17,7 @@ use crate::pubgrub::package::PubGrubPackage;
 /// version over packages that are constrained in some way over packages that are unconstrained.
 ///
 /// See: <https://github.com/pypa/pip/blob/ef78c129b1a966dbbbdb8ebfffc43723e89110d1/src/pip/_internal/resolution/resolvelib/provider.py#L120>
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct PubGrubPriorities(FxHashMap<PackageName, PubGrubPriority>);
 
 impl PubGrubPriorities {


### PR DESCRIPTION
This still keeps the resolver state on the stack, but it organizes it
into a more structured representation. This is a precursor to
implementing resolver forking, where we will ultimately put this state
on the heap. The idea is that this will let us maintain multiple
independent resolver states that will all produce their own resolution
(and potentially other forked states).

Closes #3354
