### PR TITLE
Discover `uv run` projects hierarchically

### DIFF
--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -22,6 +22,8 @@ pub enum RequirementsSource {
     SetupPy(PathBuf),
     /// Dependencies were provided via a `setup.cfg` file (e.g., `pip-compile setup.cfg`).
     SetupCfg(PathBuf),
+    /// Dependencies were provided via a path to a source tree (e.g., `pip install .`).
+    SourceTree(PathBuf),
 }
 
 impl RequirementsSource {
@@ -122,6 +124,12 @@ impl RequirementsSource {
         Self::Package(name)
     }
 
+    /// Parse a [`RequirementsSource`] from a user-provided string, assumed to be a path to a source
+    /// tree.
+    pub fn from_source_tree(path: PathBuf) -> Self {
+        Self::SourceTree(path)
+    }
+
     /// Returns `true` if the source allows extras to be specified.
     pub fn allows_extras(&self) -> bool {
         matches!(
@@ -139,7 +147,8 @@ impl std::fmt::Display for RequirementsSource {
             Self::RequirementsTxt(path)
             | Self::PyprojectToml(path)
             | Self::SetupPy(path)
-            | Self::SetupCfg(path) => {
+            | Self::SetupCfg(path)
+            | Self::SourceTree(path) => {
                 write!(f, "{}", path.simplified_display())
             }
         }

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -11,6 +11,7 @@ use distribution_types::{
     FlatIndexLocation, IndexUrl, Requirement, RequirementSource, UnresolvedRequirement,
     UnresolvedRequirementSpecification,
 };
+use pep508_rs::{UnnamedRequirement, VerbatimUrl};
 use requirements_txt::{
     EditableRequirement, FindLink, RequirementEntry, RequirementsTxt, RequirementsTxtRequirement,
 };
@@ -155,6 +156,29 @@ impl RequirementsSpecification {
                 overrides: vec![],
                 editables: vec![],
                 source_trees: vec![path.clone()],
+                extras: FxHashSet::default(),
+                index_url: None,
+                extra_index_urls: vec![],
+                no_index: false,
+                find_links: vec![],
+                no_binary: NoBinary::default(),
+                no_build: NoBuild::default(),
+            },
+            RequirementsSource::SourceTree(path) => Self {
+                project: None,
+                requirements: vec![UnresolvedRequirementSpecification {
+                    requirement: UnresolvedRequirement::Unnamed(UnnamedRequirement {
+                        url: VerbatimUrl::from_path(path),
+                        extras: vec![],
+                        marker: None,
+                        origin: None,
+                    }),
+                    hashes: vec![],
+                }],
+                constraints: vec![],
+                overrides: vec![],
+                editables: vec![],
+                source_trees: vec![],
                 extras: FxHashSet::default(),
                 index_url: None,
                 extra_index_urls: vec![],

--- a/crates/uv/src/commands/project/discovery.rs
+++ b/crates/uv/src/commands/project/discovery.rs
@@ -1,0 +1,40 @@
+use std::path::{Path, PathBuf};
+
+use tracing::debug;
+use uv_fs::Simplified;
+
+use uv_requirements::RequirementsSource;
+
+#[derive(Debug, Clone)]
+pub(crate) struct Project {
+    /// The path to the `pyproject.toml` file.
+    path: PathBuf,
+}
+
+impl Project {
+    /// Find the current project.
+    pub(crate) fn find(path: impl AsRef<Path>) -> Option<Self> {
+        for ancestor in path.as_ref().ancestors() {
+            let pyproject_path = ancestor.join("pyproject.toml");
+            if pyproject_path.exists() {
+                debug!(
+                    "Loading requirements from: {}",
+                    pyproject_path.user_display()
+                );
+                return Some(Self {
+                    path: pyproject_path,
+                });
+            }
+        }
+
+        None
+    }
+
+    /// Return the requirements for the project.
+    pub(crate) fn requirements(&self) -> Vec<RequirementsSource> {
+        vec![
+            RequirementsSource::from_requirements_file(self.path.clone()),
+            RequirementsSource::from_source_tree(self.path.parent().unwrap().to_path_buf()),
+        ]
+    }
+}

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -13,6 +13,7 @@ use uv_resolver::{FlatIndex, InMemoryIndex, OptionsBuilder};
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 use uv_warnings::warn_user;
 
+use crate::commands::project::discovery::Project;
 use crate::commands::project::Error;
 use crate::commands::{project, ExitStatus};
 use crate::printer::Printer;
@@ -32,9 +33,9 @@ pub(crate) async fn lock(
     let venv = PythonEnvironment::from_virtualenv(cache)?;
 
     // Find the project requirements.
-    let Some(requirements) = project::find_project()? else {
+    let Some(project) = Project::find(std::env::current_dir()?) else {
         return Err(anyhow::anyhow!(
-            "Unable to find `pyproject.toml` for project project."
+            "Unable to find `pyproject.toml` for project."
         ));
     };
 
@@ -45,7 +46,7 @@ pub(crate) async fn lock(
     // TODO(zanieb): Consider allowing constraints and extras
     // TODO(zanieb): Allow specifying extras somehow
     let spec = RequirementsSpecification::from_sources(
-        &requirements,
+        &project.requirements(),
         &[],
         &[],
         &ExtrasSpecification::None,


### PR DESCRIPTION
## Summary

Ensures that running `uv run` in a subdirectory of a project behaves just as-if in the project root.

Closes https://github.com/astral-sh/uv/issues/3490.

