### PR TITLE
Read and write `uv.lock` based on project root

### DIFF
--- a/crates/uv/src/commands/project/discovery.rs
+++ b/crates/uv/src/commands/project/discovery.rs
@@ -28,6 +28,8 @@ pub(crate) struct Project {
     name: PackageName,
     /// The path to the `pyproject.toml` file.
     path: PathBuf,
+    /// The path to the project root.
+    root: PathBuf,
 }
 
 impl Project {
@@ -56,6 +58,7 @@ impl Project {
                 return Ok(Some(Self {
                     name,
                     path: pyproject_path,
+                    root: ancestor.to_path_buf(),
                 }));
             }
         }
@@ -63,17 +66,22 @@ impl Project {
         Ok(None)
     }
 
+    /// Return the [`PackageName`] for the project.
+    pub(crate) fn name(&self) -> &PackageName {
+        &self.name
+    }
+
+    /// Return the root path for the project.
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+
     /// Return the requirements for the project.
     pub(crate) fn requirements(&self) -> Vec<RequirementsSource> {
         vec![
             RequirementsSource::from_requirements_file(self.path.clone()),
-            RequirementsSource::from_source_tree(self.path.parent().unwrap().to_path_buf()),
+            RequirementsSource::from_source_tree(self.root.clone()),
         ]
-    }
-
-    /// Return the [`PackageName`] for the project.
-    pub(crate) fn name(&self) -> &PackageName {
-        &self.name
     }
 }
 

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -134,7 +134,7 @@ pub(crate) async fn lock(
     // Write the lockfile to disk.
     let lock = resolution.lock()?;
     let encoded = toml::to_string_pretty(&lock)?;
-    fs_err::tokio::write("uv.lock", encoded.as_bytes()).await?;
+    fs_err::tokio::write(project.root().join("uv.lock"), encoded.as_bytes()).await?;
 
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -41,7 +41,7 @@ pub(crate) async fn sync(
 
     // Read the lockfile.
     let resolution = {
-        let encoded = fs_err::tokio::read_to_string("uv.lock").await?;
+        let encoded = fs_err::tokio::read_to_string(project.root().join("uv.lock")).await?;
         let lock: Lock = toml::from_str(&encoded)?;
         lock.to_resolution(markers, tags, project.name())
     };


### PR DESCRIPTION
## Summary

The `uv.lock` location is no longer based on the current working directory, but rather, on the discovered project name.
