### PR TITLE
add `sys_path` to `Interpreter` struct

### DIFF
--- a/crates/uv-interpreter/python/get_interpreter_info.py
+++ b/crates/uv-interpreter/python/get_interpreter_info.py
@@ -550,6 +550,7 @@ def main() -> None:
         "prefix": sys.prefix,
         "base_executable": getattr(sys, "_base_executable", None),
         "sys_executable": sys.executable,
+        "sys_path": sys.path,
         "stdlib": sysconfig.get_path("stdlib"),
         "scheme": get_scheme(),
         "virtualenv": get_virtualenv(),

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -643,6 +643,10 @@ mod tests {
                 "base_prefix": "/home/ferris/.pyenv/versions/3.12.0",
                 "prefix": "/home/ferris/projects/uv/.venv",
                 "sys_executable": "/home/ferris/projects/uv/.venv/bin/python",
+                "sys_path": [
+                    "/home/ferris/.pyenv/versions/3.12.0/lib/python3.12/lib/python3.12",
+                    "/home/ferris/.pyenv/versions/3.12.0/lib/python3.12/site-packages"
+                ],
                 "stdlib": "/home/ferris/.pyenv/versions/3.12.0/lib/python3.12",
                 "scheme": {
                     "data": "/home/ferris/.pyenv/versions/3.12.0",

--- a/crates/uv-interpreter/src/interpreter.rs
+++ b/crates/uv-interpreter/src/interpreter.rs
@@ -31,6 +31,7 @@ pub struct Interpreter {
     base_prefix: PathBuf,
     base_executable: Option<PathBuf>,
     sys_executable: PathBuf,
+    sys_path: Vec<PathBuf>,
     stdlib: PathBuf,
     tags: OnceCell<Tags>,
     target: Option<Target>,
@@ -59,6 +60,7 @@ impl Interpreter {
             base_prefix: info.base_prefix,
             base_executable: info.base_executable,
             sys_executable: info.sys_executable,
+            sys_path: info.sys_path,
             stdlib: info.stdlib,
             tags: OnceCell::new(),
             target: None,
@@ -89,6 +91,7 @@ impl Interpreter {
             base_prefix: PathBuf::from("/dev/null"),
             base_executable: None,
             sys_executable: PathBuf::from("/dev/null"),
+            sys_path: vec![],
             stdlib: PathBuf::from("/dev/null"),
             tags: OnceCell::new(),
             target: None,
@@ -283,6 +286,11 @@ impl Interpreter {
         &self.sys_executable
     }
 
+    /// Return the `sys.path` for this Python interpreter.
+    pub fn sys_path(&self) -> &Vec<PathBuf> {
+        &self.sys_path
+    }
+
     /// Return the `stdlib` path for this Python interpreter, as returned by `sysconfig.get_paths()`.
     pub fn stdlib(&self) -> &Path {
         &self.stdlib
@@ -419,6 +427,7 @@ struct InterpreterInfo {
     base_prefix: PathBuf,
     base_executable: Option<PathBuf>,
     sys_executable: PathBuf,
+    sys_path: Vec<PathBuf>,
     stdlib: PathBuf,
     gil_disabled: bool,
 }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
likely necessary to resolve https://github.com/astral-sh/uv/issues/2500

made this a separate PR in an attempt to make the changes as small as possible; let me know if it's preferred to keep them as a single PR.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
- edited the test in `interpreter.rs`
- tested manually via `println!` 

```
$ cargo run --quiet pip show test
["/Users/chankang/Library/Caches/uv/.tmpKzNEPN", "/Users/chankang/.pyenv/versions/3.12.2/lib/python312.zip", "/Users/chankang/.pyenv/versions/3.12.2/lib/python3.12", "/Users/chankang/.pyenv/versions/3.12.2/lib/python3.12/lib-dynload", "/Users/chankang/repos/uv/.venv/lib/python3.12/site-packages"]
warning: Package(s) not found for: test
chankang@chans-Air ~/repos/uv -  (syspath)
$ git diff
diff --git a/crates/uv-interpreter/src/environment.rs b/crates/uv-interpreter/src/environment.rs
index 33b785ce..8ebf0864 100644
--- a/crates/uv-interpreter/src/environment.rs
+++ b/crates/uv-interpreter/src/environment.rs
@@ -106,6 +106,7 @@ impl PythonEnvironment {
     /// Some distributions also create symbolic links from `purelib` to `platlib`; in such cases, we
     /// still deduplicate the entries, returning a single path.
     pub fn site_packages(&self) -> impl Iterator<Item = &Path> {
+        println!("{:?}", self.interpreter.sys_path());
         if let Some(target) = self.interpreter.target() {
             Either::Left(std::iter::once(target.root()))
         } else {
chankang@chans-Air ~/repos/uv -  (syspath)
$ python -c "import sys; print(sys.path)"
['', '/Users/chankang/.pyenv/versions/3.12.2/lib/python312.zip', '/Users/chankang/.pyenv/versions/3.12.2/lib/python3.12', '/Users/chankang/.pyenv/versions/3.12.2/lib/python3.12/lib-dynload', '/Users/chankang/.pyenv/versions/3.12.2/lib/python3.12/site-packages']
chankang@chans-Air ~/repos/uv -  (syspath)
```

<!-- How was it tested? -->
