### PR TITLE
Re-add dummy serde feature to pep440-rs and pep508-rs

### DIFF
--- a/crates/pep440-rs/Cargo.toml
+++ b/crates/pep440-rs/Cargo.toml
@@ -29,5 +29,5 @@ unscanny = { workspace = true }
 indoc = { version = "2.0.4" }
 
 [features]
-# Match the public version of the crate for prefix
+# Match the API of the published crate, for compatibility.
 serde = []

--- a/crates/pep440-rs/Cargo.toml
+++ b/crates/pep440-rs/Cargo.toml
@@ -27,3 +27,7 @@ unscanny = { workspace = true }
 
 [dev-dependencies]
 indoc = { version = "2.0.4" }
+
+[features]
+# Match the public version of the crate for prefix
+serde = []

--- a/crates/pep508-rs/Cargo.toml
+++ b/crates/pep508-rs/Cargo.toml
@@ -52,5 +52,5 @@ tracing = ["dep:tracing", "pep440_rs/tracing"]
 # be supported.
 non-pep508-extensions = []
 default = []
-# Match the public version of the crate for prefix
+# Match the API of the published crate, for compatibility.
 serde = []

--- a/crates/pep508-rs/Cargo.toml
+++ b/crates/pep508-rs/Cargo.toml
@@ -52,3 +52,5 @@ tracing = ["dep:tracing", "pep440_rs/tracing"]
 # be supported.
 non-pep508-extensions = []
 default = []
+# Match the public version of the crate for prefix
+serde = []


### PR DESCRIPTION
This keeps us in sync with the published pep440-rs and pep508-rs crates for prefix.