### PR TITLE
Allow unknown pyproject.toml fields

### DIFF
--- a/crates/uv-requirements/src/pyproject.rs
+++ b/crates/uv-requirements/src/pyproject.rs
@@ -109,7 +109,6 @@ pub struct Tool {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[serde(deny_unknown_fields)]
 pub struct ToolUv {
     pub sources: Option<HashMap<PackageName, Source>>,
     pub workspace: Option<ToolUvWorkspace>,
@@ -117,7 +116,6 @@ pub struct ToolUv {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[serde(deny_unknown_fields)]
 pub struct ToolUvWorkspace {
     pub members: Option<Vec<SerdePattern>>,
     pub exclude: Option<Vec<SerdePattern>>,

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -58,7 +58,6 @@
       ]
     }
   },
-  "additionalProperties": false,
   "definitions": {
     "AnnotationStyle": {
       "description": "Indicate the style of annotation comments, used to indicate the dependencies that requested each package.",
@@ -916,8 +915,7 @@
             "$ref": "#/definitions/String"
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #3510, we use typo error messages though.

Tested manually by adding `[tool.uv.pip]`, we should add proper tests for this feature.