### PR TITLE
Parse marker tree before evaluation

### DIFF
--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -17,7 +17,7 @@
 #![warn(missing_docs)]
 
 use cursor::Cursor;
-use marker::{ExtraOperator, Reporter};
+use marker::ExtraOperator;
 #[cfg(feature = "pyo3")]
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
@@ -469,6 +469,21 @@ impl Pep508Url for Url {
 
     fn parse_url(url: &str, _working_dir: Option<&Path>) -> Result<Self, Self::Err> {
         Url::parse(url)
+    }
+}
+
+/// A reporter for warnings that occur during marker parsing or evaluation.
+pub trait Reporter {
+    /// Report a warning.
+    fn report(&mut self, kind: MarkerWarningKind, warning: String);
+}
+
+impl<F> Reporter for F
+where
+    F: FnMut(MarkerWarningKind, String),
+{
+    fn report(&mut self, kind: MarkerWarningKind, warning: String) {
+        (self)(kind, warning)
     }
 }
 

--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -17,7 +17,6 @@
 #![warn(missing_docs)]
 
 use cursor::Cursor;
-use marker::ExtraOperator;
 #[cfg(feature = "pyo3")]
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
@@ -41,8 +40,9 @@ use unicode_width::UnicodeWidthChar;
 use url::Url;
 
 pub use marker::{
-    MarkerEnvironment, MarkerEnvironmentBuilder, MarkerExpression, MarkerOperator, MarkerTree,
-    MarkerValue, MarkerValueString, MarkerValueVersion, MarkerWarningKind, StringVersion,
+    ExtraOperator, MarkerEnvironment, MarkerEnvironmentBuilder, MarkerExpression, MarkerOperator,
+    MarkerTree, MarkerValue, MarkerValueString, MarkerValueVersion, MarkerWarningKind,
+    StringVersion,
 };
 #[cfg(feature = "pyo3")]
 use pep440_rs::PyVersion;

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -1488,17 +1488,17 @@ impl Display for MarkerExpression {
                 operator,
                 value,
             } => {
-                write!(f, "{key} {operator} {value}")
+                write!(f, "{key} {operator} '{value}'")
             }
             MarkerExpression::StringInverted {
                 value,
                 operator,
                 key,
             } => {
-                write!(f, "{value} {operator} {key}")
+                write!(f, "'{value}' {operator} {key}")
             }
             MarkerExpression::Extra { operator, name } => {
-                write!(f, "extra {operator} {name}")
+                write!(f, "extra {operator} '{name}'")
             }
             MarkerExpression::Arbitrary {
                 l_value,

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -903,12 +903,12 @@ impl<'a> TryFrom<MarkerEnvironmentBuilder<'a>> for MarkerEnvironment {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[allow(missing_docs)]
 pub enum MarkerExpression {
-    /// <version key> <version op> <quoted PEP 440 version>
+    /// A version expression, e.g. `<version key> <version op> <quoted PEP 440 version>`.
     Version {
         key: MarkerValueVersion,
         specifier: VersionSpecifier,
     },
-    /// <quoted PEP 440 version> <version op> <version key>
+    /// An inverted version expression, e.g `<quoted PEP 440 version> <version op> <version key>`.
     VersionInverted {
         /// No star allowed here, `'3.*' == python_version` is not a valid PEP 440 comparison.
         version: Version,
@@ -921,7 +921,7 @@ pub enum MarkerExpression {
         operator: MarkerOperator,
         value: String,
     },
-    /// An string marker comparison, e.g. `'...' == sys_platform`.
+    /// An inverted string marker comparison, e.g. `'...' == sys_platform`.
     StringInverted {
         value: String,
         operator: MarkerOperator,
@@ -1004,7 +1004,8 @@ impl MarkerExpression {
                     reporter.report(
                         MarkerWarningKind::Pep440Error,
                         format!(
-                            "Expected double quoted PEP 440 version to compare with {}, found {}, will evaluate to false",
+                            "Expected double quoted PEP 440 version to compare with {}, found {},
+                            will evaluate to false",
                             key, r_value
                         ),
                     );
@@ -1031,7 +1032,12 @@ impl MarkerExpression {
                     MarkerValue::Extra
                     | MarkerValue::MarkerEnvVersion(_)
                     | MarkerValue::MarkerEnvString(_) => {
-                        reporter.report(MarkerWarningKind::MarkerMarkerComparison, "Comparing two markers with each other doesn't make any sense, will evaluate to false".to_string());
+                        reporter.report(
+                            MarkerWarningKind::MarkerMarkerComparison,
+                            "Comparing two markers with each other doesn't make any sense,
+                            will evaluate to false"
+                                .to_string(),
+                        );
 
                         return MarkerExpression::arbitrary(
                             MarkerValue::MarkerEnvString(key),
@@ -1054,7 +1060,12 @@ impl MarkerExpression {
                     MarkerValue::MarkerEnvVersion(_)
                     | MarkerValue::MarkerEnvString(_)
                     | MarkerValue::Extra => {
-                        reporter.report(MarkerWarningKind::ExtraInvalidComparison, "Comparing extra with something other than a quoted string is wrong, will evaluate to false".to_string());
+                        reporter.report(
+                            MarkerWarningKind::ExtraInvalidComparison,
+                            "Comparing extra with something other than a quoted string is wrong,
+                            will evaluate to false"
+                                .to_string(),
+                        );
                         return MarkerExpression::arbitrary(l_value, operator, r_value);
                     }
                     MarkerValue::QuotedString(value) => value,
@@ -1116,7 +1127,8 @@ impl MarkerExpression {
                         );
 
                         reporter.report(MarkerWarningKind::StringStringComparison, format!(
-                            "Comparing two quoted strings with each other doesn't make sense: {expr}, will evaluate to false"
+                            "Comparing two quoted strings with each other doesn't make sense: {expr},
+                            will evaluate to false"
                         ));
 
                         expr
@@ -1165,14 +1177,15 @@ impl MarkerExpression {
 
         let Some(operator) = marker_operator.to_pep440_operator() else {
             reporter.report(
-                    MarkerWarningKind::Pep440Error,
-                    format!(
-                        "Expected PEP 440 version operator to compare {} with '{}', found '{}', will evaluate to false",
-                        key,
-                        pattern.version(),
-                        marker_operator
-                    ),
-                );
+                MarkerWarningKind::Pep440Error,
+                format!(
+                    "Expected PEP 440 version operator to compare {} with '{}',
+                    found '{}', will evaluate to false",
+                    key,
+                    pattern.version(),
+                    marker_operator
+                ),
+            );
 
             return None;
         };
@@ -1217,14 +1230,13 @@ impl MarkerExpression {
 
         let Some(operator) = marker_operator.to_pep440_operator() else {
             reporter.report(
-                    MarkerWarningKind::Pep440Error,
-                    format!(
-                        "Expected PEP 440 version operator to compare {} with '{}', found '{}', will evaluate to false",
-                        key,
-                        version,
-                        marker_operator
-                    ),
-                );
+                MarkerWarningKind::Pep440Error,
+                format!(
+                    "Expected PEP 440 version operator to compare {} with '{}',
+                    found '{}', will evaluate to false",
+                    key, version, marker_operator
+                ),
+            );
 
             return None;
         };
@@ -1258,7 +1270,12 @@ impl MarkerExpression {
         match ExtraOperator::from_marker_operator(operator.clone()) {
             Some(operator) => Some(MarkerExpression::Extra { operator, name }),
             None => {
-                reporter.report(MarkerWarningKind::ExtraInvalidComparison, "Comparing extra with something other than a quoted string is wrong, will evaluate to false".to_string());
+                reporter.report(
+                    MarkerWarningKind::ExtraInvalidComparison,
+                    "Comparing extra with something other than a quoted string is wrong,
+                    will evaluate to false"
+                        .to_string(),
+                );
                 None
             }
         }

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -945,7 +945,9 @@ pub enum MarkerExpression {
 /// The operator for an extra expression, either '==' or '!='.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ExtraOperator {
+    /// `==`
     Equal,
+    /// `!=`
     NotEqual,
 }
 

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -26,7 +26,7 @@ use pep440_rs::{Version, VersionParseError, VersionPattern, VersionSpecifier};
 use uv_normalize::ExtraName;
 
 use crate::cursor::Cursor;
-use crate::{Pep508Error, Pep508ErrorSource, Pep508Url, TracingReporter};
+use crate::{Pep508Error, Pep508ErrorSource, Pep508Url, Reporter, TracingReporter};
 
 /// Ways in which marker evaluation can fail
 #[derive(Debug, Eq, Hash, Ord, PartialOrd, PartialEq, Clone, Copy)]
@@ -968,21 +968,6 @@ impl Display for ExtraOperator {
     }
 }
 
-/// A reporter for warnings that occur during marker parsing or evaluation.
-pub trait Reporter {
-    /// Report a warning.
-    fn report(&mut self, kind: MarkerWarningKind, warning: String);
-}
-
-impl<F> Reporter for F
-where
-    F: FnMut(MarkerWarningKind, String),
-{
-    fn report(&mut self, kind: MarkerWarningKind, warning: String) {
-        (self)(kind, warning)
-    }
-}
-
 impl MarkerExpression {
     /// Parse a [`MarkerExpression`] from a string with the given reporter.
     pub fn parse_reporter(s: &str, reporter: &mut impl Reporter) -> Result<Self, Pep508Error> {
@@ -1155,7 +1140,7 @@ impl MarkerExpression {
     /// Creates an instance of `MarkerExpression::Version` with the given values.
     ///
     /// Reports a warning on failure, and returns `None`.
-    fn version(
+    pub fn version(
         key: MarkerValueVersion,
         marker_operator: MarkerOperator,
         value: &str,

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -1031,13 +1031,11 @@ impl MarkerExpression {
 
                 match MarkerExpression::version(key.clone(), operator.clone(), &value, reporter) {
                     Some(expr) => expr,
-                    None => {
-                        return MarkerExpression::arbitrary(
-                            MarkerValue::MarkerEnvVersion(key),
-                            operator,
-                            MarkerValue::QuotedString(value),
-                        )
-                    }
+                    None => MarkerExpression::arbitrary(
+                        MarkerValue::MarkerEnvVersion(key),
+                        operator,
+                        MarkerValue::QuotedString(value),
+                    ),
                 }
             }
             // The only sound choice for this is `<env key> <op> <string>`
@@ -1077,13 +1075,11 @@ impl MarkerExpression {
 
                 match MarkerExpression::extra(operator.clone(), &value, reporter) {
                     Some(expr) => expr,
-                    None => {
-                        return MarkerExpression::arbitrary(
-                            MarkerValue::Extra,
-                            operator,
-                            MarkerValue::QuotedString(value),
-                        )
-                    }
+                    None => MarkerExpression::arbitrary(
+                        MarkerValue::Extra,
+                        operator,
+                        MarkerValue::QuotedString(value),
+                    ),
                 }
             }
             // This is either MarkerEnvVersion, MarkerEnvString or Extra inverted
@@ -1098,13 +1094,11 @@ impl MarkerExpression {
                             reporter,
                         ) {
                             Some(expr) => expr,
-                            None => {
-                                return MarkerExpression::arbitrary(
-                                    MarkerValue::QuotedString(l_string),
-                                    operator,
-                                    MarkerValue::MarkerEnvVersion(key),
-                                )
-                            }
+                            None => MarkerExpression::arbitrary(
+                                MarkerValue::QuotedString(l_string),
+                                operator,
+                                MarkerValue::MarkerEnvVersion(key),
+                            ),
                         }
                     }
                     // '...' == <env key>
@@ -1117,13 +1111,11 @@ impl MarkerExpression {
                     MarkerValue::Extra => {
                         match MarkerExpression::extra(operator.clone(), &l_string, reporter) {
                             Some(expr) => expr,
-                            None => {
-                                return MarkerExpression::arbitrary(
-                                    MarkerValue::QuotedString(l_string),
-                                    operator,
-                                    MarkerValue::Extra,
-                                )
-                            }
+                            None => MarkerExpression::arbitrary(
+                                MarkerValue::QuotedString(l_string),
+                                operator,
+                                MarkerValue::Extra,
+                            ),
                         }
                     }
                     // `'...' == '...'`, doesn't make much sense
@@ -1264,7 +1256,7 @@ impl MarkerExpression {
         value: &str,
         reporter: &mut impl Reporter,
     ) -> Option<MarkerExpression> {
-        let name = match ExtraName::from_str(&value) {
+        let name = match ExtraName::from_str(value) {
             Ok(name) => name,
             Err(err) => {
                 reporter.report(
@@ -1344,11 +1336,11 @@ impl MarkerExpression {
             MarkerExpression::Extra {
                 operator: ExtraOperator::Equal,
                 name,
-            } => extras.contains(&name),
+            } => extras.contains(name),
             MarkerExpression::Extra {
                 operator: ExtraOperator::NotEqual,
                 name,
-            } => !extras.contains(&name),
+            } => !extras.contains(name),
             MarkerExpression::Arbitrary { .. } => true,
         }
     }
@@ -1417,11 +1409,11 @@ impl MarkerExpression {
             MarkerExpression::Extra {
                 operator: ExtraOperator::Equal,
                 name,
-            } => extras.contains(&name),
+            } => extras.contains(name),
             MarkerExpression::Extra {
                 operator: ExtraOperator::NotEqual,
                 name,
-            } => !extras.contains(&name),
+            } => !extras.contains(name),
             _ => true,
         }
     }
@@ -1606,11 +1598,11 @@ impl MarkerTree {
                 MarkerExpression::Extra {
                     operator: ExtraOperator::Equal,
                     name,
-                } => extras.contains(&name),
+                } => extras.contains(name),
                 MarkerExpression::Extra {
                     operator: ExtraOperator::NotEqual,
                     name,
-                } => !extras.contains(&name),
+                } => !extras.contains(name),
                 _ => false,
             }
         }

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -934,7 +934,7 @@ pub enum MarkerExpression {
     },
     /// An invalid or meaningless expression, such as '...' == '...'.
     ///
-    /// Invalid expressions always evaluate to true, and are warned for during parsing.
+    /// Invalid expressions always evaluate to `false`, and are warned for during parsing.
     Arbitrary {
         l_value: MarkerValue,
         operator: MarkerOperator,

--- a/crates/pep508-rs/src/unnamed.rs
+++ b/crates/pep508-rs/src/unnamed.rs
@@ -7,11 +7,11 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use uv_fs::normalize_url_path;
 use uv_normalize::ExtraName;
 
-use crate::marker::{parse_markers_cursor, Reporter};
+use crate::marker::parse_markers_cursor;
 use crate::{
-    default_reporter, expand_env_vars, parse_extras_cursor, split_extras, split_scheme, strip_host,
-    Cursor, MarkerEnvironment, MarkerTree, Pep508Error, Pep508ErrorSource, RequirementOrigin,
-    Scheme, VerbatimUrl, VerbatimUrlError,
+    expand_env_vars, parse_extras_cursor, split_extras, split_scheme, strip_host, Cursor,
+    MarkerEnvironment, MarkerTree, Pep508Error, Pep508ErrorSource, Reporter, RequirementOrigin,
+    Scheme, TracingReporter, VerbatimUrl, VerbatimUrlError,
 };
 
 /// A PEP 508-like, direct URL dependency specifier without a package name.
@@ -110,7 +110,7 @@ impl FromStr for UnnamedRequirement {
 
     /// Parse a PEP 508-like direct URL requirement without a package name.
     fn from_str(input: &str) -> Result<Self, Self::Err> {
-        parse_unnamed_requirement(&mut Cursor::new(input), None, &mut default_reporter)
+        parse_unnamed_requirement(&mut Cursor::new(input), None, &mut TracingReporter)
     }
 }
 

--- a/crates/requirements-txt/src/requirement.rs
+++ b/crates/requirements-txt/src/requirement.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use distribution_types::ParsedUrlError;
 use pep508_rs::{
-    default_reporter, Pep508Error, Pep508ErrorSource, RequirementOrigin, UnnamedRequirement,
+    Pep508Error, Pep508ErrorSource, RequirementOrigin, TracingReporter, UnnamedRequirement,
 };
 
 /// A requirement specifier in a `requirements.txt` file.
@@ -54,7 +54,7 @@ impl RequirementsTxtRequirement {
                     Ok(Self::Unnamed(UnnamedRequirement::parse(
                         input,
                         &working_dir,
-                        &mut default_reporter,
+                        &mut TracingReporter,
                     )?))
                 }
                 _ => Err(RequirementsTxtRequirementError::Pep508(err)),

--- a/crates/requirements-txt/src/requirement.rs
+++ b/crates/requirements-txt/src/requirement.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 use thiserror::Error;
 
 use distribution_types::ParsedUrlError;
-use pep508_rs::{Pep508Error, Pep508ErrorSource, RequirementOrigin, UnnamedRequirement};
+use pep508_rs::{
+    default_reporter, Pep508Error, Pep508ErrorSource, RequirementOrigin, UnnamedRequirement,
+};
 
 /// A requirement specifier in a `requirements.txt` file.
 ///
@@ -52,6 +54,7 @@ impl RequirementsTxtRequirement {
                     Ok(Self::Unnamed(UnnamedRequirement::parse(
                         input,
                         &working_dir,
+                        &mut default_reporter,
                     )?))
                 }
                 _ => Err(RequirementsTxtRequirementError::Pep508(err)),

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
@@ -27,25 +27,21 @@ RequirementsTxt {
                         And(
                             [
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: GreaterEqual,
-                                        r_value: QuotedString(
-                                            "3.8",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.8",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: LessThan,
-                                        r_value: QuotedString(
-                                            "4.0",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: LessThan,
+                                            version: "4.0",
+                                        },
                                     },
                                 ),
                             ],
@@ -85,25 +81,21 @@ RequirementsTxt {
                         And(
                             [
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: GreaterEqual,
-                                        r_value: QuotedString(
-                                            "3.8",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.8",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: LessThan,
-                                        r_value: QuotedString(
-                                            "4",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: LessThan,
+                                            version: "4",
+                                        },
                                     },
                                 ),
                             ],
@@ -143,36 +135,28 @@ RequirementsTxt {
                         And(
                             [
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: GreaterEqual,
-                                        r_value: QuotedString(
-                                            "3.8",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.8",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: LessThan,
-                                        r_value: QuotedString(
-                                            "4",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: LessThan,
+                                            version: "4",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvString(
-                                            PlatformSystem,
-                                        ),
+                                    String {
+                                        key: PlatformSystem,
                                         operator: Equal,
-                                        r_value: QuotedString(
-                                            "Windows",
-                                        ),
+                                        value: "Windows",
                                     },
                                 ),
                             ],
@@ -212,25 +196,21 @@ RequirementsTxt {
                         And(
                             [
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: GreaterEqual,
-                                        r_value: QuotedString(
-                                            "3.8",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.8",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: LessThan,
-                                        r_value: QuotedString(
-                                            "4.0",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: LessThan,
+                                            version: "4.0",
+                                        },
                                     },
                                 ),
                             ],
@@ -271,25 +251,21 @@ RequirementsTxt {
                         And(
                             [
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: GreaterEqual,
-                                        r_value: QuotedString(
-                                            "3.8",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.8",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: LessThan,
-                                        r_value: QuotedString(
-                                            "4.0",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: LessThan,
+                                            version: "4.0",
+                                        },
                                     },
                                 ),
                             ],

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-poetry-with-hashes.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-poetry-with-hashes.txt.snap
@@ -27,25 +27,21 @@ RequirementsTxt {
                         And(
                             [
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: GreaterEqual,
-                                        r_value: QuotedString(
-                                            "3.8",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.8",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: LessThan,
-                                        r_value: QuotedString(
-                                            "4.0",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: LessThan,
+                                            version: "4.0",
+                                        },
                                     },
                                 ),
                             ],
@@ -85,25 +81,21 @@ RequirementsTxt {
                         And(
                             [
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: GreaterEqual,
-                                        r_value: QuotedString(
-                                            "3.8",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.8",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: LessThan,
-                                        r_value: QuotedString(
-                                            "4",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: LessThan,
+                                            version: "4",
+                                        },
                                     },
                                 ),
                             ],
@@ -143,36 +135,28 @@ RequirementsTxt {
                         And(
                             [
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: GreaterEqual,
-                                        r_value: QuotedString(
-                                            "3.8",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.8",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: LessThan,
-                                        r_value: QuotedString(
-                                            "4",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: LessThan,
+                                            version: "4",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvString(
-                                            PlatformSystem,
-                                        ),
+                                    String {
+                                        key: PlatformSystem,
                                         operator: Equal,
-                                        r_value: QuotedString(
-                                            "Windows",
-                                        ),
+                                        value: "Windows",
                                     },
                                 ),
                             ],
@@ -212,25 +196,21 @@ RequirementsTxt {
                         And(
                             [
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: GreaterEqual,
-                                        r_value: QuotedString(
-                                            "3.8",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.8",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: LessThan,
-                                        r_value: QuotedString(
-                                            "4.0",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: LessThan,
+                                            version: "4.0",
+                                        },
                                     },
                                 ),
                             ],
@@ -271,25 +251,21 @@ RequirementsTxt {
                         And(
                             [
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: GreaterEqual,
-                                        r_value: QuotedString(
-                                            "3.8",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.8",
+                                        },
                                     },
                                 ),
                                 Expression(
-                                    MarkerExpression {
-                                        l_value: MarkerEnvVersion(
-                                            PythonVersion,
-                                        ),
-                                        operator: LessThan,
-                                        r_value: QuotedString(
-                                            "4.0",
-                                        ),
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: LessThan,
+                                            version: "4.0",
+                                        },
                                     },
                                 ),
                             ],


### PR DESCRIPTION
## Summary

Parse `MarkerTree` expressions upfront, instead of lazily during evaluation.

This makes implementing https://github.com/astral-sh/uv/issues/3355 a lot easier.