### PR TITLE
ci: build musllinux_1_1 wheels

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -520,6 +520,7 @@ jobs:
           run: |
             apk add python3
             python3 -m venv .venv
+            .venv/bin/pip install --upgrade pip
             .venv/bin/pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             .venv/bin/${{ env.MODULE_NAME }} --help
       - name: "Upload wheels"

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -509,18 +509,18 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          manylinux: musllinux_1_2
+          manylinux: musllinux_1_1
           args: --release --locked --out dist --features self-update
       - name: "Test wheel"
         if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: addnab/docker-run-action@v3
         with:
-          image: alpine:latest
+          image: alpine:3.12
           options: -v ${{ github.workspace }}:/io -w /io
           run: |
             apk add python3
-            python -m venv .venv
-            .venv/bin/pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+            python3 -m venv .venv
+            .venv/bin/pip install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
             .venv/bin/${{ env.MODULE_NAME }} --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4
@@ -573,7 +573,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          manylinux: musllinux_1_2
+          manylinux: musllinux_1_1
           args: --release --locked --out dist --features self-update
           docker-options: ${{ matrix.platform.maturin_docker_options }}
       - uses: uraimo/run-on-arch-action@v2


### PR DESCRIPTION
This is needed to include uv in manylinux, which has both the musllinux_1_1 and musllinux_1_2 images.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

We are looking into including uv in the `pypa/manylinux` docker images, so that cibuildwheel will be able to use it. But to do so, we need all actively supported images to be able to take it, including musllinux_1_1.

## Test Plan

The test was updated to make sure Alpine 3.12, which musllinux was based on, can run uv.

The binary build does need to be triggered on this PR to make sure it works. Ah, https://github.com/astral-sh/uv/blob/5b6040184de9be1813cde1ff6c55762ee304ad99/.github/workflows/build-binaries.yml#L15-L20 is a good idea, nice.

Will need a followup to fill out the other platforms `pypa/manylinux` supports for musllinux.
