### PR TITLE
Apply advisory locks when building source distributions

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -11,6 +11,7 @@ use rustc_hash::FxHashSet;
 use tempfile::{tempdir, TempDir};
 use tracing::debug;
 
+pub use archive::ArchiveId;
 use distribution_types::InstalledDist;
 use pypi_types::Metadata23;
 use uv_fs::{cachedir, directories};
@@ -23,7 +24,6 @@ use crate::removal::{rm_rf, Removal};
 pub use crate::timestamp::Timestamp;
 pub use crate::wheel::WheelCache;
 use crate::wheel::WheelCacheKind;
-pub use archive::ArchiveId;
 
 mod archive;
 mod by_timestamp;
@@ -93,12 +93,6 @@ impl CacheShard {
     #[must_use]
     pub fn shard(&self, dir: impl AsRef<Path>) -> Self {
         Self(self.0.join(dir.as_ref()))
-    }
-
-    /// Acquire a lock on the shard.
-    pub fn lock(&self) -> io::Result<uv_fs::LockedFile> {
-        fs_err::create_dir_all(&self.0)?;
-        uv_fs::LockedFile::acquire(self.0.join(".lock"), self.0.display())
     }
 }
 

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -94,6 +94,12 @@ impl CacheShard {
     pub fn shard(&self, dir: impl AsRef<Path>) -> Self {
         Self(self.0.join(dir.as_ref()))
     }
+
+    /// Acquire a lock on the shard.
+    pub fn lock(&self) -> io::Result<uv_fs::LockedFile> {
+        fs_err::create_dir_all(&self.0)?;
+        uv_fs::LockedFile::acquire(self.0.join(".lock"), self.0.display())
+    }
 }
 
 impl AsRef<Path> for CacheShard {

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -1273,7 +1273,7 @@ fn install_url_source_dist_cached() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Removed 126 files for tqdm ([SIZE])
+    Removed 127 files for tqdm ([SIZE])
     "###
     );
 
@@ -1370,7 +1370,7 @@ fn install_git_source_dist_cached() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Removed 3 files for werkzeug ([SIZE])
+    Removed 4 files for werkzeug ([SIZE])
     "###
     );
 
@@ -1471,7 +1471,7 @@ fn install_registry_source_dist_cached() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Removed 616 files for future ([SIZE])
+    Removed 617 files for future ([SIZE])
     "###
     );
 
@@ -1576,7 +1576,7 @@ fn install_path_source_dist_cached() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Removed 102 files for wheel ([SIZE])
+    Removed 103 files for wheel ([SIZE])
     "###
     );
 


### PR DESCRIPTION
## Summary

I don't love this, but it turns out that setuptools is not robust to parallel builds: https://github.com/pypa/setuptools/issues/3119. As a result, if you run uv from multiple processes, and they each attempt to build the same source distribution, you can hit failures.

This PR applies an advisory lock to the source distribution directory. We apply it unconditionally, even if we ultimately find something in the cache and _don't_ do a build, which helps ensure that we only build the distribution once (and wait for that build to complete) rather than kicking off builds from each thread.

Closes https://github.com/astral-sh/uv/issues/3512.

## Test Plan

Ran:

```sh
#!/bin/bash
make_venv(){
    target/debug/uv venv $1
    source $1/bin/activate
    target/debug/uv pip install opentracing --no-deps --verbose
}

for i in {1..8}
do
   make_venv ./$1/$i &
done
```