### PR TITLE
Fix a few typos found by codespell

### DIFF
--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -2098,7 +2098,7 @@ impl std::fmt::Display for VersionParseError {
                 write!(
                     f,
                     "found a `{precursor}` indicating the start of a local \
-                     component in a version, but did not find any alpha-numeric \
+                     component in a version, but did not find any alphanumeric \
                      ASCII segment following the `{precursor}`",
                 )
             }
@@ -2138,7 +2138,7 @@ pub(crate) enum ErrorKind {
     /// Occurs when an epoch version does not have a number after the `!`.
     NoLeadingReleaseNumber,
     /// Occurs when a `+` (or a `.` after the first local segment) is seen
-    /// (indicating a local component of a version), but no alpha-numeric ASCII
+    /// (indicating a local component of a version), but no alphanumeric ASCII
     /// string is found following it.
     LocalEmpty {
         /// Either a `+` or a `[-_.]` indicating what was found that demands a

--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -117,7 +117,7 @@ This is a little extra cost, but the idea is that a `CachePolicy` (not an
 `ArchivedCachePolicy`) should only be used in the slower path (i.e., when you
 actually need to make an HTTP request).
 
-[`rkyv::vec::ArchivedVec`]: hhttps://docs.rs/rkyv/0.7.43/rkyv/vec/struct.ArchivedVec.html
+[`rkyv::vec::ArchivedVec`]: https://docs.rs/rkyv/0.7.43/rkyv/vec/struct.ArchivedVec.html
 [`rkyv::string::ArchivedString`]: https://docs.rs/rkyv/0.7.43/rkyv/string/struct.ArchivedString.html
 
 # Additional reading

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -947,7 +947,7 @@ pub(crate) fn with_fetch_options(
 
 /// Attempts to fetch the given git `reference` for a Git repository.
 ///
-/// This is the main entry for git clone/fetch. It does the followings:
+/// This is the main entry for git clone/fetch. It does the following:
 ///
 /// * Turns [`GitReference`] into refspecs accordingly.
 /// * Dispatches `git fetch` using libgit2 or git CLI.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -221,7 +221,7 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
     /// reader of the resolution that knows to exclude distributions that can't
     /// be used in the current environment.
     ///
-    /// When a marker environment is provided, the reslver is in
+    /// When a marker environment is provided, the resolver is in
     /// "non-universal" mode, which corresponds to standard `pip` behavior that
     /// works only for a specific marker environment.
     #[allow(clippy::too_many_arguments)]
@@ -1376,7 +1376,7 @@ struct ResolverState {
     /// in this state. We also ultimately retrieve the final set of version
     /// assignments (to packages) from this state's "partial solution."
     pubgrub: State<UvDependencyProvider>,
-    /// The next package on which to run unit propgation.
+    /// The next package on which to run unit propagation.
     next: PubGrubPackage,
     /// The set of pinned versions we accrue throughout resolution.
     ///

--- a/crates/uv/src/commands/pip_check.rs
+++ b/crates/uv/src/commands/pip_check.rs
@@ -14,7 +14,7 @@ use uv_interpreter::PythonEnvironment;
 use crate::commands::{elapsed, ExitStatus};
 use crate::printer::Printer;
 
-/// Check for incompatibilties in installed packages.
+/// Check for incompatibilities in installed packages.
 pub(crate) fn pip_check(
     python: Option<&str>,
     system: bool,


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Just fix typos.

While `alpha-numeric` is not really a misspelling:
- it is missing from mainstream curated dictionaries, all of them suggest `alphanumeric`;
- it is less used than `alphanumeric` (more than ⨉10 less) according to the Google [Ngram Viewer](https://books.google.com/ngrams/graph?content=alpha-numeric%2Calphanumeric&year_start=1900&year_end=2019&corpus=en-2019);
- it is [missing from SCOWL](http://app.aspell.net/lookup?dict=en_US-large;words=alpha-numeric).

## Test Plan

CI jobs.