### PR TITLE
Clone individual files on windows ReFS

### DIFF
--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -327,6 +327,15 @@ fn clone_recursive(
 
     debug!("Cloning {} to {}", from.display(), to.display());
 
+    if cfg!(windows) && from.is_dir() {
+        // On Windows, reflinking directories is not supported, so we copy each file instead.
+        fs::create_dir_all(&to)?;
+        for entry in fs::read_dir(from)? {
+            clone_recursive(site_packages, wheel, &entry?, attempt)?;
+        }
+        return Ok(());
+    }
+
     match attempt {
         Attempt::Initial => {
             if let Err(err) = reflink::reflink(&from, &to) {


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

Windows does not support cloning whole directories so clone each file instead.

closes #3547 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Ran ` uv pip install setuptools --link-mode=clone` manually 

<!-- How was it tested? -->
