### PR TITLE
Zb/editable only binary

### DIFF
--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1515,6 +1515,33 @@ fn only_binary_requirements_txt() {
     );
 }
 
+
+/// `--only-binary` does not apply to editable requirements
+#[test]
+fn only_binary_editable() {
+    let context = TestContext::new("3.12");
+
+    // Install the editable package.
+    uv_snapshot!(context.filters(), context.install()
+        .arg("--only-binary")
+        .arg(":all:")
+        .arg("-e")
+        .arg(context.workspace_root.join("scripts/packages/setuptools_editable")), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Built 1 editable in [TIME]
+    Resolved 2 packages in [TIME]
+    Downloaded 1 package in [TIME]
+    Installed 2 packages in [TIME]
+     + iniconfig==2.0.0
+     + setuptools-editable==0.1.0 (from file://[WORKSPACE]/scripts/packages/setuptools_editable)
+    "###
+    );
+}
+
 /// Install a package into a virtual environment, and ensuring that the executable permissions
 /// are retained.
 ///

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1520,13 +1520,20 @@ fn only_binary_requirements_txt() {
 #[test]
 fn only_binary_editable() {
     let context = TestContext::new("3.12");
-
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt
+        .write_str(format! (r"
+        --editable {}
+        --editable {}
+        ", context.workspace_root.join("scripts/packages/black_editable").display(),
+        context.workspace_root.join("scripts/packages/root_editable").display(),
+        ).as_str())
+        .unwrap();
     // Install the editable package.
     uv_snapshot!(context.filters(), context.install()
-        .arg("--only-binary")
-        .arg(":all:")
-        .arg("-e")
-        .arg(context.workspace_root.join("scripts/packages/setuptools_editable")), @r###"
+        .arg("--no-build")
+        .arg("-r")
+        .arg("requirements.txt"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
! DO NOT MERGE!
## Summary
This change demonstrates the error with --editable packages which depend on eachother and the --no-build flag, reported in https://github.com/astral-sh/uv/issues/3513

## Test Plan
This *is* a test, effectively
