### PR TITLE
Avoid attempting to build editables when fetching metadata

### DIFF
--- a/crates/uv-resolver/src/editables.rs
+++ b/crates/uv-resolver/src/editables.rs
@@ -34,6 +34,11 @@ impl Editables {
         self.0.get(name)
     }
 
+    /// Returns `true` if the given package is editable.
+    pub(crate) fn contains(&self, name: &PackageName) -> bool {
+        self.0.contains_key(name)
+    }
+
     /// Iterate over all editables.
     pub(crate) fn iter(&self) -> impl Iterator<Item = &(LocalEditable, Metadata23, Requirements)> {
         self.0.values()

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -616,6 +616,11 @@ impl<'a, Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvide
                     return Err(ResolveError::UnhashedPackage(name.clone()));
                 }
 
+                // If the package is an editable, we don't need to fetch metadata.
+                if self.editables.contains(name) {
+                    return Ok(());
+                }
+
                 // Emit a request to fetch the metadata for this distribution.
                 let dist = Dist::from_url(name.clone(), url.clone())?;
                 if self.index.distributions.register(dist.version_id()) {
@@ -956,7 +961,7 @@ impl<'a, Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvide
                 if self.dependency_mode.is_direct() {
                     // If an extra is provided, wait for the metadata to be available, since it's
                     // still required for reporting diagnostics.
-                    if extra.is_some() && self.editables.get(package_name).is_none() {
+                    if extra.is_some() && !self.editables.contains(package_name) {
                         // Determine the distribution to lookup.
                         let dist = match url {
                             Some(url) => PubGrubDistribution::from_url(package_name, url),

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1704,14 +1704,16 @@ fn only_binary_dependent_editables() {
         .arg(root_path.join("first_editable"))
         .arg("-e")
         .arg(root_path.join("second_editable")), @r###"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     Built 2 editables in [TIME]
-    error: Failed to build `first-editable @ file://[WORKSPACE]/scripts/packages/dependent_editables/first_editable`
-      Caused by: Building source distributions is disabled
+    Resolved 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     + first-editable==0.0.1 (from file://[WORKSPACE]/scripts/packages/dependent_editables/first_editable)
+     + second-editable==0.0.1 (from file://[WORKSPACE]/scripts/packages/dependent_editables/second_editable)
     "###
     );
 }


### PR DESCRIPTION
## Summary

If we see an editable as a dependency, we currently attempt to fetch its metadata, when we shouldn't.

Closes https://github.com/astral-sh/uv/issues/3562.