### PR TITLE
Unify editable handling between `sync` and `install`

### DIFF
--- a/crates/uv-installer/src/lib.rs
+++ b/crates/uv-installer/src/lib.rs
@@ -1,6 +1,6 @@
 pub use compile::{compile_tree, CompileError};
 pub use downloader::{Downloader, Reporter as DownloadReporter};
-pub use editable::{is_dynamic, BuiltEditable, ResolvedEditable};
+pub use editable::{is_dynamic, BuiltEditable, InstalledEditable, ResolvedEditable};
 pub use installer::{Installer, Reporter as InstallReporter};
 pub use plan::{Plan, Planner};
 pub use site_packages::{Diagnostic, SatisfiesResult, SitePackages};

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -114,7 +114,7 @@ impl<'a> Planner<'a> {
                     debug!("Treating editable requirement as immutable: {installed}");
 
                     // Remove from the site-packages index, to avoid marking as extraneous.
-                    let Some(editable) = installed.as_editable() else {
+                    let Some(editable) = installed.wheel.as_editable() else {
                         warn!("Editable requirement is not editable: {installed}");
                         continue;
                     };
@@ -127,7 +127,7 @@ impl<'a> Planner<'a> {
                 ResolvedEditable::Built(built) => {
                     debug!("Treating editable requirement as mutable: {built}");
 
-                    // Remove any editable installs.
+                    // Remove any editables.
                     let existing = site_packages.remove_editables(built.editable.raw());
                     reinstalls.extend(existing);
 

--- a/crates/uv/src/commands/pip/editables.rs
+++ b/crates/uv/src/commands/pip/editables.rs
@@ -1,0 +1,201 @@
+use std::fmt::Write;
+use std::ops::Deref;
+
+use anyhow::{anyhow, Context, Result};
+use owo_colors::OwoColorize;
+
+use distribution_types::{InstalledDist, LocalEditable, LocalEditables, Name};
+use platform_tags::Tags;
+use requirements_txt::EditableRequirement;
+use uv_cache::{ArchiveTarget, ArchiveTimestamp, Cache};
+use uv_client::RegistryClient;
+use uv_configuration::{Concurrency, Reinstall};
+use uv_dispatch::BuildDispatch;
+use uv_distribution::DistributionDatabase;
+use uv_installer::{is_dynamic, Downloader, InstalledEditable, ResolvedEditable, SitePackages};
+use uv_interpreter::Interpreter;
+use uv_types::HashStrategy;
+
+use crate::commands::elapsed;
+use crate::commands::reporters::DownloadReporter;
+use crate::printer::Printer;
+
+#[derive(Debug)]
+pub(crate) struct ResolvedEditables {
+    /// The set of resolved editables, including both those that were already installed and those
+    /// that were built.
+    pub(crate) editables: Vec<ResolvedEditable>,
+    /// The temporary directory in which the built editables were stored.
+    #[allow(dead_code)]
+    temp_dir: Option<tempfile::TempDir>,
+}
+
+impl Deref for ResolvedEditables {
+    type Target = [ResolvedEditable];
+
+    fn deref(&self) -> &Self::Target {
+        &self.editables
+    }
+}
+
+impl ResolvedEditables {
+    /// Resolve the set of editables that need to be installed.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn resolve(
+        editables: Vec<EditableRequirement>,
+        site_packages: &SitePackages<'_>,
+        reinstall: &Reinstall,
+        hasher: &HashStrategy,
+        interpreter: &Interpreter,
+        tags: &Tags,
+        cache: &Cache,
+        client: &RegistryClient,
+        build_dispatch: &BuildDispatch<'_>,
+        concurrency: Concurrency,
+        printer: Printer,
+    ) -> Result<Self> {
+        // Partition the editables into those that are already installed, and those that must be built.
+        let mut installed = Vec::with_capacity(editables.len());
+        let mut uninstalled = Vec::with_capacity(editables.len());
+        for editable in editables {
+            match reinstall {
+                Reinstall::None => {
+                    if let [dist] = site_packages.get_editables(editable.raw()).as_slice() {
+                        if let Some(editable) = up_to_date(&editable, dist)? {
+                            installed.push(editable);
+                        } else {
+                            uninstalled.push(editable);
+                        }
+                    } else {
+                        uninstalled.push(editable);
+                    }
+                }
+                Reinstall::All => {
+                    uninstalled.push(editable);
+                }
+                Reinstall::Packages(packages) => {
+                    if let [dist] = site_packages.get_editables(editable.raw()).as_slice() {
+                        if packages.contains(dist.name()) {
+                            uninstalled.push(editable);
+                        } else if let Some(editable) = up_to_date(&editable, dist)? {
+                            installed.push(editable);
+                        } else {
+                            uninstalled.push(editable);
+                        }
+                    } else {
+                        uninstalled.push(editable);
+                    }
+                }
+            }
+        }
+
+        // Build any editables.
+        let (built_editables, temp_dir) = if uninstalled.is_empty() {
+            (Vec::new(), None)
+        } else {
+            let start = std::time::Instant::now();
+
+            let downloader = Downloader::new(
+                cache,
+                tags,
+                hasher,
+                DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
+            )
+            .with_reporter(DownloadReporter::from(printer).with_length(uninstalled.len() as u64));
+
+            let editables = LocalEditables::from_editables(uninstalled.iter().map(|editable| {
+                let EditableRequirement {
+                    url,
+                    path,
+                    extras,
+                    origin: _,
+                } = editable;
+                LocalEditable {
+                    url: url.clone(),
+                    path: path.clone(),
+                    extras: extras.clone(),
+                }
+            }));
+
+            let temp_dir = tempfile::tempdir_in(cache.root())?;
+
+            let editables: Vec<_> = downloader
+                .build_editables(editables, temp_dir.path())
+                .await
+                .context("Failed to build editables")?
+                .into_iter()
+                .collect();
+
+            // Validate that the editables are compatible with the target Python version.
+            for editable in &editables {
+                if let Some(python_requires) = editable.metadata.requires_python.as_ref() {
+                    if !python_requires.contains(interpreter.python_version()) {
+                        return Err(anyhow!(
+                            "Editable `{}` requires Python {}, but {} is installed",
+                            editable.metadata.name,
+                            python_requires,
+                            interpreter.python_version()
+                        ));
+                    }
+                }
+            }
+
+            let s = if editables.len() == 1 { "" } else { "s" };
+            writeln!(
+                printer.stderr(),
+                "{}",
+                format!(
+                    "Built {} in {}",
+                    format!("{} editable{}", editables.len(), s).bold(),
+                    elapsed(start.elapsed())
+                )
+                .dimmed()
+            )?;
+
+            (editables, Some(temp_dir))
+        };
+
+        let editables = installed
+            .into_iter()
+            .map(ResolvedEditable::Installed)
+            .chain(built_editables.into_iter().map(ResolvedEditable::Built))
+            .collect::<Vec<_>>();
+
+        Ok(Self {
+            editables,
+            temp_dir,
+        })
+    }
+}
+
+/// Returns the [`InstalledEditable`] if the installed distribution is up-to-date for the given
+/// requirement.
+fn up_to_date(
+    editable: &EditableRequirement,
+    dist: &InstalledDist,
+) -> Result<Option<InstalledEditable>> {
+    // If the editable isn't up-to-date, don't reuse it.
+    if !ArchiveTimestamp::up_to_date_with(&editable.path, ArchiveTarget::Install(dist))? {
+        return Ok(None);
+    };
+
+    // If the editable is dynamic, don't reuse it.
+    if is_dynamic(editable) {
+        return Ok(None);
+    };
+
+    // If we can't read the metadata from the installed distribution, don't reuse it.
+    let Ok(metadata) = dist.metadata() else {
+        return Ok(None);
+    };
+
+    Ok(Some(InstalledEditable {
+        editable: LocalEditable {
+            url: editable.url.clone(),
+            path: editable.path.clone(),
+            extras: editable.extras.clone(),
+        },
+        wheel: (*dist).clone(),
+        metadata,
+    }))
+}

--- a/crates/uv/src/commands/pip/mod.rs
+++ b/crates/uv/src/commands/pip/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod check;
 pub(crate) mod compile;
+mod editables;
 pub(crate) mod freeze;
 pub(crate) mod install;
 pub(crate) mod list;

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -837,18 +837,15 @@ fn install_editable() {
     ----- stdout -----
 
     ----- stderr -----
-    Built 1 editable in [TIME]
     Resolved 10 packages in [TIME]
     Downloaded 6 packages in [TIME]
-    Installed 7 packages in [TIME]
+    Installed 6 packages in [TIME]
      + black==24.3.0
      + click==8.1.7
      + mypy-extensions==1.0.0
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
-     - poetry-editable==0.1.0 (from file://[WORKSPACE]/scripts/packages/poetry_editable)
-     + poetry-editable==0.1.0 (from file://[WORKSPACE]/scripts/packages/poetry_editable)
     "###
     );
 }


### PR DESCRIPTION
## Summary

Uses the editable handling from `pip sync`, and improves the abstractions such that we can pass those resolved editables into the resolver.
