### PR TITLE
Fix install_registry_source_dist_cached on Gentoo

### DIFF
--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -1449,13 +1449,13 @@ fn install_registry_source_dist_cached() -> Result<()> {
 
     let filters: Vec<(&str, &str)> = if cfg!(windows) {
         // On Windows, the number of files removed is different.
-        [("Removed 615 files", "Removed 616 files")]
+        [("Removed 616 files", "Removed 617 files")]
             .into_iter()
             .chain(context.filters())
             .collect()
     } else {
         // For some Linux distributions, like Gentoo, the number of files removed is different.
-        [("Removed 614 files", "Removed 616 files")]
+        [("Removed 615 files", "Removed 617 files")]
             .into_iter()
             .chain(context.filters())
             .collect()


### PR DESCRIPTION
## Summary

Increment the removed file counts in filters
in install_registry_source_dist_cached test, to make it work again on Gentoo.  The tested counts were updated
in 9a92a3ad3771a78d36214aa958f51bf7bb992f80, but the filters were not. That said, the respective count increased in Gentoo as well, so adjust both input and output strings.  I'm updating Windows as a guesswork, though I suspect that filter may not be necessary anymore, given that CI was passing.

## Test Plan

`cargo test` on Gentoo :-).