### PR TITLE
Revert "Use manylinux: auto for aarch64 builds (#3444)"

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -297,12 +297,10 @@ jobs:
         run: python scripts/transform_readme.py --target pypi
       - name: "Build wheels"
         uses: PyO3/maturin-action@v1
-        env:
-          # Workaround ring 0.17 build issue
-          CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
         with:
           target: ${{ matrix.platform.target }}
-          manylinux: auto
+          # On `aarch64`, use `manylinux: 2_28`; otherwise, use `manylinux: auto`.
+          manylinux: ${{ matrix.platform.arch == 'aarch64' && '2_28' || 'auto' }}
           docker-options: ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist --features self-update
       - uses: uraimo/run-on-arch-action@v2


### PR DESCRIPTION
This reverts commit 8bcb2365bfef10d791b8cc801b0a473bbd0a75f5.
