### PR TITLE
Remove `pacman` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,6 @@ pipx install uv
 
 # With Homebrew.
 brew install uv
-
-# With Pacman.
-pacman -S uv
 ```
 
 To create a virtual environment:


### PR DESCRIPTION
## Summary

If we want to enumerate more installers, I think they should go in a dedicated section.