### PR TITLE
Add hashes and versions to all distributions

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -963,8 +963,8 @@ impl<'a, Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvide
                 // If we're excluding transitive dependencies, short-circuit.
                 if self.dependency_mode.is_direct() {
                     // If an extra is provided, wait for the metadata to be available, since it's
-                    // still required for reporting diagnostics.
-                    if extra.is_some() && !self.editables.contains(package_name) {
+                    // still required for generating the lock file.
+                    if !self.editables.contains(package_name) {
                         // Determine the distribution to lookup.
                         let dist = match url {
                             Some(url) => PubGrubDistribution::from_url(package_name, url),


### PR DESCRIPTION
## Summary

In `ResolutionGraph::from_state`, we have mechanisms to grab the hashes and metadata for all distributions -- but we then throw that information away. This PR preserves it on a new `AnnotatedDist` (yikes, open to suggestions) that wraps `ResolvedDist` and includes (1) the hashes (computed or from the registry) and (2) the `Metadata23`, which lets us extract the version.

Closes https://github.com/astral-sh/uv/issues/3356.

Closes https://github.com/astral-sh/uv/issues/3357.
