### PR TITLE
uv-distribution: include all wheels in distribution types

### DIFF
--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -39,7 +39,7 @@ use std::str::FromStr;
 use anyhow::Result;
 use url::Url;
 
-use distribution_filename::{DistFilename, SourceDistFilename, WheelFilename};
+use distribution_filename::{SourceDistFilename, WheelFilename};
 use pep440_rs::Version;
 use pep508_rs::{Pep508Url, VerbatimUrl};
 use uv_git::GitUrl;
@@ -158,10 +158,40 @@ pub enum SourceDist {
 
 /// A built distribution (wheel) that exists in a registry, like `PyPI`.
 #[derive(Debug, Clone)]
-pub struct RegistryBuiltDist {
+pub struct RegistryBuiltWheel {
     pub filename: WheelFilename,
     pub file: Box<File>,
     pub index: IndexUrl,
+}
+
+/// A built distribution (wheel) that exists in a registry, like `PyPI`.
+#[derive(Debug, Clone)]
+pub struct RegistryBuiltDist {
+    /// All wheels associated with this distribution. It is guaranteed
+    /// that there is at least one wheel.
+    pub wheels: Vec<RegistryBuiltWheel>,
+    /// The "best" wheel selected based on the current wheel tag
+    /// environment.
+    ///
+    /// This is guaranteed to point into a valid entry in `wheels`.
+    pub best_wheel_index: usize,
+    /// A source distribution if one exists for this distribution.
+    ///
+    /// It is possible for this to be `None`. For example, when a distribution
+    /// has no source distribution, or if it does have one but isn't compatible
+    /// with the user configuration. (e.g., If `Requires-Python` isn't
+    /// compatible with the installed/target Python versions, or if something
+    /// like `--exclude-newer` was used.)
+    pub source_dist: Option<RegistrySourceDist>,
+    // Ideally, this type would have an index URL on it, and the
+    // `RegistryBuiltDist` and `RegistrySourceDist` types would *not* have an
+    // index URL on them. Alas, the --find-links feature makes it technically
+    // possible for the indexes to diverge across wheels/sdists in the same
+    // distribution.
+    //
+    // Note though that at time of writing, when generating a universal lock
+    // file, we require that all index URLs across wheels/sdists for a single
+    // distribution are equivalent.
 }
 
 /// A built distribution (wheel) that exists at an arbitrary URL.
@@ -235,26 +265,6 @@ pub struct DirectorySourceDist {
 }
 
 impl Dist {
-    /// Create a [`Dist`] for a registry-based distribution.
-    pub fn from_registry(filename: DistFilename, file: File, index: IndexUrl) -> Self {
-        match filename {
-            DistFilename::WheelFilename(filename) => {
-                Self::Built(BuiltDist::Registry(RegistryBuiltDist {
-                    filename,
-                    file: Box::new(file),
-                    index,
-                }))
-            }
-            DistFilename::SourceDistFilename(filename) => {
-                Self::Source(SourceDist::Registry(RegistrySourceDist {
-                    filename,
-                    file: Box::new(file),
-                    index,
-                }))
-            }
-        }
-    }
-
     /// A remote built distribution (`.whl`) or source distribution from a `http://` or `https://`
     /// URL.
     pub fn from_http_url(
@@ -424,11 +434,28 @@ impl Dist {
     }
 }
 
+impl From<RegistryBuiltWheel> for Dist {
+    fn from(wheel: RegistryBuiltWheel) -> Dist {
+        let regdist = RegistryBuiltDist {
+            wheels: vec![wheel],
+            best_wheel_index: 0,
+            source_dist: None,
+        };
+        Dist::Built(BuiltDist::Registry(regdist))
+    }
+}
+
+impl From<RegistrySourceDist> for Dist {
+    fn from(sdist: RegistrySourceDist) -> Dist {
+        Dist::Source(SourceDist::Registry(sdist))
+    }
+}
+
 impl BuiltDist {
     /// Returns the [`IndexUrl`], if the distribution is from a registry.
     pub fn index(&self) -> Option<&IndexUrl> {
         match self {
-            Self::Registry(registry) => Some(&registry.index),
+            Self::Registry(registry) => Some(&registry.best_wheel().index),
             Self::DirectUrl(_) => None,
             Self::Path(_) => None,
         }
@@ -437,14 +464,14 @@ impl BuiltDist {
     /// Returns the [`File`] instance, if this distribution is from a registry.
     pub fn file(&self) -> Option<&File> {
         match self {
-            Self::Registry(registry) => Some(&registry.file),
+            Self::Registry(registry) => Some(&registry.best_wheel().file),
             Self::DirectUrl(_) | Self::Path(_) => None,
         }
     }
 
     pub fn version(&self) -> &Version {
         match self {
-            Self::Registry(wheel) => &wheel.filename.version,
+            Self::Registry(wheels) => &wheels.best_wheel().filename.version,
             Self::DirectUrl(wheel) => &wheel.filename.version,
             Self::Path(wheel) => &wheel.filename.version,
         }
@@ -493,9 +520,22 @@ impl SourceDist {
     }
 }
 
-impl Name for RegistryBuiltDist {
+impl RegistryBuiltDist {
+    /// Returns the best or "most compatible" wheel in this distribution.
+    pub fn best_wheel(&self) -> &RegistryBuiltWheel {
+        &self.wheels[self.best_wheel_index]
+    }
+}
+
+impl Name for RegistryBuiltWheel {
     fn name(&self) -> &PackageName {
         &self.filename.name
+    }
+}
+
+impl Name for RegistryBuiltDist {
+    fn name(&self) -> &PackageName {
+        self.best_wheel().name()
     }
 }
 
@@ -572,9 +612,15 @@ impl Name for Dist {
     }
 }
 
-impl DistributionMetadata for RegistryBuiltDist {
+impl DistributionMetadata for RegistryBuiltWheel {
     fn version_or_url(&self) -> VersionOrUrlRef {
         VersionOrUrlRef::Version(&self.filename.version)
+    }
+}
+
+impl DistributionMetadata for RegistryBuiltDist {
+    fn version_or_url(&self) -> VersionOrUrlRef {
+        self.best_wheel().version_or_url()
     }
 }
 
@@ -680,13 +726,23 @@ impl RemoteSource for Url {
     }
 }
 
-impl RemoteSource for RegistryBuiltDist {
+impl RemoteSource for RegistryBuiltWheel {
     fn filename(&self) -> Result<Cow<'_, str>, Error> {
         self.file.filename()
     }
 
     fn size(&self) -> Option<u64> {
         self.file.size()
+    }
+}
+
+impl RemoteSource for RegistryBuiltDist {
+    fn filename(&self) -> Result<Cow<'_, str>, Error> {
+        self.best_wheel().filename()
+    }
+
+    fn size(&self) -> Option<u64> {
+        self.best_wheel().size()
     }
 }
 
@@ -892,13 +948,23 @@ impl Identifier for FileLocation {
     }
 }
 
-impl Identifier for RegistryBuiltDist {
+impl Identifier for RegistryBuiltWheel {
     fn distribution_id(&self) -> DistributionId {
         self.file.distribution_id()
     }
 
     fn resource_id(&self) -> ResourceId {
         self.file.resource_id()
+    }
+}
+
+impl Identifier for RegistryBuiltDist {
+    fn distribution_id(&self) -> DistributionId {
+        self.best_wheel().distribution_id()
+    }
+
+    fn resource_id(&self) -> ResourceId {
+        self.best_wheel().resource_id()
     }
 }
 

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -182,7 +182,7 @@ pub struct RegistryBuiltDist {
     /// with the user configuration. (e.g., If `Requires-Python` isn't
     /// compatible with the installed/target Python versions, or if something
     /// like `--exclude-newer` was used.)
-    pub source_dist: Option<RegistrySourceDist>,
+    pub sdist: Option<RegistrySourceDist>,
     // Ideally, this type would have an index URL on it, and the
     // `RegistryBuiltDist` and `RegistrySourceDist` types would *not* have an
     // index URL on them. Alas, the --find-links feature makes it technically
@@ -431,23 +431,6 @@ impl Dist {
             Self::Built(wheel) => Some(wheel.version()),
             Self::Source(source_dist) => source_dist.version(),
         }
-    }
-}
-
-impl From<RegistryBuiltWheel> for Dist {
-    fn from(wheel: RegistryBuiltWheel) -> Dist {
-        let regdist = RegistryBuiltDist {
-            wheels: vec![wheel],
-            best_wheel_index: 0,
-            source_dist: None,
-        };
-        Dist::Built(BuiltDist::Registry(regdist))
-    }
-}
-
-impl From<RegistrySourceDist> for Dist {
-    fn from(sdist: RegistrySourceDist) -> Dist {
-        Dist::Source(SourceDist::Registry(sdist))
     }
 }
 

--- a/crates/distribution-types/src/prioritized_distribution.rs
+++ b/crates/distribution-types/src/prioritized_distribution.rs
@@ -4,7 +4,7 @@ use pep440_rs::VersionSpecifiers;
 use platform_tags::{IncompatibleTag, TagPriority};
 use pypi_types::{HashDigest, Yanked};
 
-use crate::{Dist, InstalledDist, ResolvedDistRef};
+use crate::{InstalledDist, RegistryBuiltWheel, RegistrySourceDist, ResolvedDistRef};
 
 /// A collection of distributions that have been filtered by relevance.
 #[derive(Debug, Default, Clone)]
@@ -14,9 +14,12 @@ pub struct PrioritizedDist(Box<PrioritizedDistInner>);
 #[derive(Debug, Default, Clone)]
 struct PrioritizedDistInner {
     /// The highest-priority source distribution. Between compatible source distributions this priority is arbitrary.
-    source: Option<(Dist, SourceDistCompatibility)>,
-    /// The highest-priority wheel.
-    wheel: Option<(Dist, WheelCompatibility)>,
+    source: Option<(RegistrySourceDist, SourceDistCompatibility)>,
+    /// The highest-priority wheel index. When present, it is
+    /// guaranteed to be a valid index into `wheels`.
+    best_wheel_index: Option<usize>,
+    /// The set of all wheels associated with this distribution.
+    wheels: Vec<(RegistryBuiltWheel, WheelCompatibility)>,
     /// The hashes for each distribution.
     hashes: Vec<HashDigest>,
 }
@@ -27,14 +30,14 @@ pub enum CompatibleDist<'a> {
     /// The distribution is already installed and can be used.
     InstalledDist(&'a InstalledDist),
     /// The distribution should be resolved and installed using a source distribution.
-    SourceDist(&'a Dist),
+    SourceDist(&'a RegistrySourceDist),
     /// The distribution should be resolved and installed using a wheel distribution.
-    CompatibleWheel(&'a Dist, TagPriority),
+    CompatibleWheel(&'a RegistryBuiltWheel, TagPriority),
     /// The distribution should be resolved using an incompatible wheel distribution, but
     /// installed using a source distribution.
     IncompatibleWheel {
-        source_dist: &'a Dist,
-        wheel: &'a Dist,
+        source_dist: &'a RegistrySourceDist,
+        wheel: &'a RegistryBuiltWheel,
     },
 }
 
@@ -152,12 +155,13 @@ pub enum HashComparison {
 impl PrioritizedDist {
     /// Create a new [`PrioritizedDist`] from the given wheel distribution.
     pub fn from_built(
-        dist: Dist,
+        dist: RegistryBuiltWheel,
         hashes: Vec<HashDigest>,
         compatibility: WheelCompatibility,
     ) -> Self {
         Self(Box::new(PrioritizedDistInner {
-            wheel: Some((dist, compatibility)),
+            best_wheel_index: Some(0),
+            wheels: vec![(dist, compatibility)],
             source: None,
             hashes,
         }))
@@ -165,12 +169,13 @@ impl PrioritizedDist {
 
     /// Create a new [`PrioritizedDist`] from the given source distribution.
     pub fn from_source(
-        dist: Dist,
+        dist: RegistrySourceDist,
         hashes: Vec<HashDigest>,
         compatibility: SourceDistCompatibility,
     ) -> Self {
         Self(Box::new(PrioritizedDistInner {
-            wheel: None,
+            best_wheel_index: None,
+            wheels: vec![],
             source: Some((dist, compatibility)),
             hashes,
         }))
@@ -179,26 +184,26 @@ impl PrioritizedDist {
     /// Insert the given built distribution into the [`PrioritizedDist`].
     pub fn insert_built(
         &mut self,
-        dist: Dist,
+        dist: RegistryBuiltWheel,
         hashes: Vec<HashDigest>,
         compatibility: WheelCompatibility,
     ) {
         // Track the highest-priority wheel.
-        if let Some((.., existing_compatibility)) = &self.0.wheel {
+        if let Some((.., existing_compatibility)) = self.best_wheel() {
             if compatibility.is_more_compatible(existing_compatibility) {
-                self.0.wheel = Some((dist, compatibility));
+                self.0.best_wheel_index = Some(self.0.wheels.len());
             }
         } else {
-            self.0.wheel = Some((dist, compatibility));
+            self.0.best_wheel_index = Some(self.0.wheels.len());
         }
-
+        self.0.wheels.push((dist, compatibility));
         self.0.hashes.extend(hashes);
     }
 
     /// Insert the given source distribution into the [`PrioritizedDist`].
     pub fn insert_source(
         &mut self,
-        dist: Dist,
+        dist: RegistrySourceDist,
         hashes: Vec<HashDigest>,
         compatibility: SourceDistCompatibility,
     ) {
@@ -216,7 +221,8 @@ impl PrioritizedDist {
 
     /// Return the highest-priority distribution for the package version, if any.
     pub fn get(&self) -> Option<CompatibleDist> {
-        match (&self.0.wheel, &self.0.source) {
+        let best_wheel = self.0.best_wheel_index.map(|i| &self.0.wheels[i]);
+        match (&best_wheel, &self.0.source) {
             // If both are compatible, break ties based on the hash outcome. For example, prefer a
             // source distribution with a matching hash over a wheel with a mismatched hash. When
             // the outcomes are equivalent (e.g., both have a matching hash), prefer the wheel.
@@ -250,27 +256,25 @@ impl PrioritizedDist {
         }
     }
 
-    /// Return the incompatible source distribution, if any.
-    pub fn incompatible_source(&self) -> Option<(&Dist, &IncompatibleSource)> {
+    /// Return the incompatibility for the best source distribution, if any.
+    pub fn incompatible_source(&self) -> Option<&IncompatibleSource> {
         self.0
             .source
             .as_ref()
-            .and_then(|(dist, compatibility)| match compatibility {
+            .and_then(|(_, compatibility)| match compatibility {
                 SourceDistCompatibility::Compatible(_) => None,
-                SourceDistCompatibility::Incompatible(incompatibility) => {
-                    Some((dist, incompatibility))
-                }
+                SourceDistCompatibility::Incompatible(incompatibility) => Some(incompatibility),
             })
     }
 
-    /// Return the incompatible built distribution, if any.
-    pub fn incompatible_wheel(&self) -> Option<(&Dist, &IncompatibleWheel)> {
+    /// Return the incompatibility for the best wheel, if any.
+    pub fn incompatible_wheel(&self) -> Option<&IncompatibleWheel> {
         self.0
-            .wheel
-            .as_ref()
-            .and_then(|(dist, compatibility)| match compatibility {
+            .best_wheel_index
+            .map(|i| &self.0.wheels[i])
+            .and_then(|(_, compatibility)| match compatibility {
                 WheelCompatibility::Compatible(_, _) => None,
-                WheelCompatibility::Incompatible(incompatibility) => Some((dist, incompatibility)),
+                WheelCompatibility::Incompatible(incompatibility) => Some(incompatibility),
             })
     }
 
@@ -282,7 +286,13 @@ impl PrioritizedDist {
     /// Returns true if and only if this distribution does not contain any
     /// source distributions or wheels.
     pub fn is_empty(&self) -> bool {
-        self.0.source.is_none() && self.0.wheel.is_none()
+        self.0.source.is_none() && self.0.wheels.is_empty()
+    }
+
+    /// Returns the "best" wheel in this prioritized distribution, if one
+    /// exists.
+    fn best_wheel(&self) -> Option<&(RegistryBuiltWheel, WheelCompatibility)> {
+        self.0.best_wheel_index.map(|i| &self.0.wheels[i])
     }
 }
 
@@ -291,12 +301,15 @@ impl<'a> CompatibleDist<'a> {
     pub fn for_resolution(&self) -> ResolvedDistRef<'a> {
         match *self {
             CompatibleDist::InstalledDist(dist) => ResolvedDistRef::Installed(dist),
-            CompatibleDist::SourceDist(sdist) => ResolvedDistRef::Installable(sdist),
-            CompatibleDist::CompatibleWheel(wheel, _) => ResolvedDistRef::Installable(wheel),
-            CompatibleDist::IncompatibleWheel {
-                source_dist: _,
-                wheel,
-            } => ResolvedDistRef::Installable(wheel),
+            CompatibleDist::SourceDist(sdist) => {
+                ResolvedDistRef::InstallableRegistrySourceDist(sdist)
+            }
+            CompatibleDist::CompatibleWheel(wheel, _) => {
+                ResolvedDistRef::InstallableRegistryBuiltDist(wheel)
+            }
+            CompatibleDist::IncompatibleWheel { wheel, .. } => {
+                ResolvedDistRef::InstallableRegistryBuiltDist(wheel)
+            }
         }
     }
 
@@ -304,12 +317,15 @@ impl<'a> CompatibleDist<'a> {
     pub fn for_installation(&self) -> ResolvedDistRef<'a> {
         match *self {
             CompatibleDist::InstalledDist(dist) => ResolvedDistRef::Installed(dist),
-            CompatibleDist::SourceDist(sdist) => ResolvedDistRef::Installable(sdist),
-            CompatibleDist::CompatibleWheel(wheel, _) => ResolvedDistRef::Installable(wheel),
-            CompatibleDist::IncompatibleWheel {
-                source_dist,
-                wheel: _,
-            } => ResolvedDistRef::Installable(source_dist),
+            CompatibleDist::SourceDist(sdist) => {
+                ResolvedDistRef::InstallableRegistrySourceDist(sdist)
+            }
+            CompatibleDist::CompatibleWheel(wheel, _) => {
+                ResolvedDistRef::InstallableRegistryBuiltDist(wheel)
+            }
+            CompatibleDist::IncompatibleWheel { source_dist, .. } => {
+                ResolvedDistRef::InstallableRegistrySourceDist(source_dist)
+            }
         }
     }
 

--- a/crates/distribution-types/src/resolution.rs
+++ b/crates/distribution-types/src/resolution.rs
@@ -74,9 +74,11 @@ impl From<&ResolvedDist> for Requirement {
     fn from(resolved_dist: &ResolvedDist) -> Self {
         let source = match resolved_dist {
             ResolvedDist::Installable(dist) => match dist {
-                Dist::Built(BuiltDist::Registry(wheel)) => RequirementSource::Registry {
+                Dist::Built(BuiltDist::Registry(wheels)) => RequirementSource::Registry {
                     specifier: pep440_rs::VersionSpecifiers::from(
-                        pep440_rs::VersionSpecifier::equals_version(wheel.filename.version.clone()),
+                        pep440_rs::VersionSpecifier::equals_version(
+                            wheels.best_wheel().filename.version.clone(),
+                        ),
                     ),
                     index: None,
                 },

--- a/crates/distribution-types/src/resolved.rs
+++ b/crates/distribution-types/src/resolved.rs
@@ -4,7 +4,7 @@ use pep508_rs::PackageName;
 
 use crate::{
     Dist, DistributionId, DistributionMetadata, Identifier, IndexUrl, InstalledDist, Name,
-    ResourceId, VersionOrUrlRef,
+    RegistryBuiltWheel, RegistrySourceDist, ResourceId, VersionOrUrlRef,
 };
 
 /// A distribution that can be used for resolution and installation.
@@ -20,7 +20,8 @@ pub enum ResolvedDist {
 #[derive(Debug, Clone)]
 pub enum ResolvedDistRef<'a> {
     Installed(&'a InstalledDist),
-    Installable(&'a Dist),
+    InstallableRegistrySourceDist(&'a RegistrySourceDist),
+    InstallableRegistryBuiltDist(&'a RegistryBuiltWheel),
 }
 
 impl ResolvedDist {
@@ -44,7 +45,12 @@ impl ResolvedDist {
 impl ResolvedDistRef<'_> {
     pub fn to_owned(&self) -> ResolvedDist {
         match self {
-            Self::Installable(dist) => ResolvedDist::Installable((*dist).clone()),
+            Self::InstallableRegistrySourceDist(dist) => {
+                ResolvedDist::Installable(Dist::from((*dist).clone()))
+            }
+            Self::InstallableRegistryBuiltDist(dist) => {
+                ResolvedDist::Installable(Dist::from((*dist).clone()))
+            }
             Self::Installed(dist) => ResolvedDist::Installed((*dist).clone()),
         }
     }
@@ -53,7 +59,8 @@ impl ResolvedDistRef<'_> {
 impl Display for ResolvedDistRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Installable(dist) => Display::fmt(dist, f),
+            Self::InstallableRegistrySourceDist(dist) => Display::fmt(dist, f),
+            Self::InstallableRegistryBuiltDist(dist) => Display::fmt(dist, f),
             Self::Installed(dist) => Display::fmt(dist, f),
         }
     }
@@ -62,7 +69,8 @@ impl Display for ResolvedDistRef<'_> {
 impl Name for ResolvedDistRef<'_> {
     fn name(&self) -> &PackageName {
         match self {
-            Self::Installable(dist) => dist.name(),
+            Self::InstallableRegistrySourceDist(dist) => dist.name(),
+            Self::InstallableRegistryBuiltDist(dist) => dist.name(),
             Self::Installed(dist) => dist.name(),
         }
     }
@@ -72,7 +80,8 @@ impl DistributionMetadata for ResolvedDistRef<'_> {
     fn version_or_url(&self) -> VersionOrUrlRef {
         match self {
             Self::Installed(installed) => VersionOrUrlRef::Version(installed.version()),
-            Self::Installable(dist) => dist.version_or_url(),
+            Self::InstallableRegistrySourceDist(dist) => dist.version_or_url(),
+            Self::InstallableRegistryBuiltDist(dist) => dist.version_or_url(),
         }
     }
 }
@@ -81,14 +90,16 @@ impl Identifier for ResolvedDistRef<'_> {
     fn distribution_id(&self) -> DistributionId {
         match self {
             Self::Installed(dist) => dist.distribution_id(),
-            Self::Installable(dist) => dist.distribution_id(),
+            Self::InstallableRegistrySourceDist(dist) => dist.distribution_id(),
+            Self::InstallableRegistryBuiltDist(dist) => dist.distribution_id(),
         }
     }
 
     fn resource_id(&self) -> ResourceId {
         match self {
             Self::Installed(dist) => dist.resource_id(),
-            Self::Installable(dist) => dist.resource_id(),
+            Self::InstallableRegistrySourceDist(dist) => dist.resource_id(),
+            Self::InstallableRegistryBuiltDist(dist) => dist.resource_id(),
         }
     }
 }

--- a/crates/distribution-types/src/traits.rs
+++ b/crates/distribution-types/src/traits.rs
@@ -10,7 +10,7 @@ use crate::{
     BuiltDist, CachedDirectUrlDist, CachedDist, CachedRegistryDist, DirectUrlBuiltDist,
     DirectUrlSourceDist, Dist, DistributionId, GitSourceDist, InstalledDirectUrlDist,
     InstalledDist, InstalledRegistryDist, InstalledVersion, LocalDist, PackageId, PathBuiltDist,
-    PathSourceDist, RegistryBuiltDist, RegistrySourceDist, ResourceId, SourceDist, VersionId,
+    PathSourceDist, RegistryBuiltWheel, RegistrySourceDist, ResourceId, SourceDist, VersionId,
     VersionOrUrlRef,
 };
 
@@ -203,7 +203,7 @@ impl std::fmt::Display for PathSourceDist {
     }
 }
 
-impl std::fmt::Display for RegistryBuiltDist {
+impl std::fmt::Display for RegistryBuiltWheel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}{}", self.name(), self.version_or_url())
     }

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -173,7 +173,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         }
 
         match dist {
-            BuiltDist::Registry(wheel) => {
+            BuiltDist::Registry(wheels) => {
+                let wheel = wheels.best_wheel();
                 let url = match &wheel.file.url {
                     FileLocation::RelativeUrl(base, url) => {
                         pypi_types::base_url_join_relative(base, url)?

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -406,9 +406,9 @@ impl<'a> From<&'a PrioritizedDist> for CandidateDist<'a> {
             // We always return the source distribution (if one exists) instead of the wheel
             // but in the future we may want to return both so the resolver can explain
             // why neither distribution kind can be used.
-            let dist = if let Some((_, incompatibility)) = value.incompatible_source() {
+            let dist = if let Some(incompatibility) = value.incompatible_source() {
                 IncompatibleDist::Source(incompatibility.clone())
-            } else if let Some((_, incompatibility)) = value.incompatible_wheel() {
+            } else if let Some(incompatibility) = value.incompatible_wheel() {
                 IncompatibleDist::Wheel(incompatibility.clone())
             } else {
                 IncompatibleDist::Unavailable

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -6,9 +6,9 @@ use tracing::instrument;
 
 use distribution_filename::{DistFilename, SourceDistFilename, WheelFilename};
 use distribution_types::{
-    BuiltDist, Dist, File, HashComparison, HashPolicy, IncompatibleSource, IncompatibleWheel,
-    IndexUrl, PrioritizedDist, RegistryBuiltDist, RegistrySourceDist, SourceDist,
-    SourceDistCompatibility, WheelCompatibility,
+    File, HashComparison, HashPolicy, IncompatibleSource, IncompatibleWheel, IndexUrl,
+    PrioritizedDist, RegistryBuiltWheel, RegistrySourceDist, SourceDistCompatibility,
+    WheelCompatibility,
 };
 use pep440_rs::Version;
 use platform_tags::{TagCompatibility, Tags};
@@ -80,11 +80,11 @@ impl FlatIndex {
 
                 let compatibility =
                     Self::wheel_compatibility(&filename, &file.hashes, tags, hasher, no_binary);
-                let dist = Dist::Built(BuiltDist::Registry(RegistryBuiltDist {
+                let dist = RegistryBuiltWheel {
                     filename,
                     file: Box::new(file),
                     index,
-                }));
+                };
                 match distributions.0.entry(version) {
                     Entry::Occupied(mut entry) => {
                         entry.get_mut().insert_built(dist, vec![], compatibility);
@@ -97,11 +97,11 @@ impl FlatIndex {
             DistFilename::SourceDistFilename(filename) => {
                 let compatibility =
                     Self::source_dist_compatibility(&filename, &file.hashes, hasher, no_build);
-                let dist = Dist::Source(SourceDist::Registry(RegistrySourceDist {
+                let dist = RegistrySourceDist {
                     filename: filename.clone(),
                     file: Box::new(file),
                     index,
-                }));
+                };
                 match distributions.0.entry(filename.version) {
                     Entry::Occupied(mut entry) => {
                         entry.get_mut().insert_source(dist, vec![], compatibility);

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -208,13 +208,8 @@ impl Distribution {
         annotated_dist: &AnnotatedDist,
     ) -> Result<Distribution, LockError> {
         let id = DistributionId::from_annotated_dist(annotated_dist);
-        let mut sdist = None;
-        let mut wheels = vec![];
-        if let Some(dist) = Wheel::from_annotated_dist(annotated_dist)? {
-            wheels.push(dist);
-        } else if let Some(dist) = SourceDist::from_annotated_dist(annotated_dist)? {
-            sdist = Some(dist);
-        }
+        let wheels = Wheel::from_annotated_dist(annotated_dist)?;
+        let sdist = SourceDist::from_annotated_dist(annotated_dist)?;
         Ok(Distribution {
             id,
             // TODO: Refactoring is needed to get the marker expressions for a
@@ -233,30 +228,23 @@ impl Distribution {
 
     /// Convert the [`Distribution`] to a [`Dist`] that can be used in installation.
     fn to_dist(&self, _marker_env: &MarkerEnvironment, tags: &Tags) -> Dist {
-        if let Some(wheel) = self.find_best_wheel(tags) {
+        if let Some(best_wheel_index) = self.find_best_wheel(tags) {
             return match self.id.source.kind {
                 SourceKind::Registry => {
-                    let filename: WheelFilename = wheel.filename.clone();
-                    let file = Box::new(distribution_types::File {
-                        dist_info_metadata: false,
-                        filename: filename.to_string(),
-                        hashes: vec![],
-                        requires_python: None,
-                        size: None,
-                        upload_time_utc_ms: None,
-                        url: FileLocation::AbsoluteUrl(wheel.url.to_string()),
-                        yanked: None,
-                    });
-                    let index = IndexUrl::Pypi(VerbatimUrl::from_url(self.id.source.url.clone()));
-                    let reg_dist = RegistryBuiltWheel {
-                        filename,
-                        file,
-                        index,
+                    let wheels = self
+                        .wheels
+                        .iter()
+                        .map(|wheel| wheel.to_registry_dist(&self.id.source))
+                        .collect();
+                    let reg_built_dist = RegistryBuiltDist {
+                        wheels,
+                        best_wheel_index,
+                        sdist: None,
                     };
-                    Dist::from(reg_dist)
+                    Dist::Built(BuiltDist::Registry(reg_built_dist))
                 }
                 SourceKind::Path => {
-                    let filename: WheelFilename = wheel.filename.clone();
+                    let filename: WheelFilename = self.wheels[best_wheel_index].filename.clone();
                     let path_dist = PathBuiltDist {
                         filename,
                         url: VerbatimUrl::from_url(self.id.source.url.clone()),
@@ -300,24 +288,24 @@ impl Distribution {
         panic!("invalid lock distribution")
     }
 
-    fn find_best_wheel(&self, tags: &Tags) -> Option<&Wheel> {
-        let mut best: Option<(TagPriority, &Wheel)> = None;
-        for wheel in &self.wheels {
+    fn find_best_wheel(&self, tags: &Tags) -> Option<usize> {
+        let mut best: Option<(TagPriority, usize)> = None;
+        for (i, wheel) in self.wheels.iter().enumerate() {
             let TagCompatibility::Compatible(priority) = wheel.filename.compatibility(tags) else {
                 continue;
             };
             match best {
                 None => {
-                    best = Some((priority, wheel));
+                    best = Some((priority, i));
                 }
                 Some((best_priority, _)) => {
                     if priority > best_priority {
-                        best = Some((priority, wheel));
+                        best = Some((priority, i));
                     }
                 }
             }
         }
-        best.map(|(_, wheel)| wheel)
+        best.map(|(_, i)| i)
     }
 }
 
@@ -650,6 +638,12 @@ impl SourceDist {
 
     fn from_dist(dist: &Dist, hashes: &[HashDigest]) -> Result<Option<SourceDist>, LockError> {
         match *dist {
+            Dist::Built(BuiltDist::Registry(ref built_dist)) => {
+                let Some(sdist) = built_dist.sdist.as_ref() else {
+                    return Ok(None);
+                };
+                SourceDist::from_registry_dist(sdist).map(Some)
+            }
             Dist::Built(_) => Ok(None),
             Dist::Source(ref source_dist) => {
                 SourceDist::from_source_dist(source_dist, hashes).map(Some)
@@ -747,7 +741,7 @@ pub(crate) struct Wheel {
 }
 
 impl Wheel {
-    fn from_annotated_dist(annotated_dist: &AnnotatedDist) -> Result<Option<Wheel>, LockError> {
+    fn from_annotated_dist(annotated_dist: &AnnotatedDist) -> Result<Vec<Wheel>, LockError> {
         match annotated_dist.dist {
             // TODO: Do we want to try to lock already-installed distributions?
             // Or should we return an error?
@@ -756,39 +750,45 @@ impl Wheel {
         }
     }
 
-    fn from_dist(dist: &Dist, hashes: &[HashDigest]) -> Result<Option<Wheel>, LockError> {
+    fn from_dist(dist: &Dist, hashes: &[HashDigest]) -> Result<Vec<Wheel>, LockError> {
         match *dist {
-            Dist::Built(ref built_dist) => Wheel::from_built_dist(built_dist, hashes).map(Some),
-            Dist::Source(_) => Ok(None),
+            Dist::Built(ref built_dist) => Wheel::from_built_dist(built_dist, hashes),
+            Dist::Source(_) => Ok(vec![]),
         }
     }
 
-    fn from_built_dist(built_dist: &BuiltDist, hashes: &[HashDigest]) -> Result<Wheel, LockError> {
+    fn from_built_dist(
+        built_dist: &BuiltDist,
+        hashes: &[HashDigest],
+    ) -> Result<Vec<Wheel>, LockError> {
         match *built_dist {
             BuiltDist::Registry(ref reg_dist) => Wheel::from_registry_dist(reg_dist),
             BuiltDist::DirectUrl(ref direct_dist) => {
-                Ok(Wheel::from_direct_dist(direct_dist, hashes))
+                Ok(vec![Wheel::from_direct_dist(direct_dist, hashes)])
             }
-            BuiltDist::Path(ref path_dist) => Ok(Wheel::from_path_dist(path_dist, hashes)),
+            BuiltDist::Path(ref path_dist) => Ok(vec![Wheel::from_path_dist(path_dist, hashes)]),
         }
     }
 
-    fn from_registry_dist(reg_dist: &RegistryBuiltDist) -> Result<Wheel, LockError> {
-        // FIXME: Is it guaranteed that there is at least one hash?
-        // If not, we probably need to make this fallible.
-        let wheel = reg_dist.best_wheel();
-        let filename = wheel.filename.clone();
-        let url = wheel
-            .file
-            .url
-            .to_url()
-            .map_err(LockError::invalid_file_url)?;
-        let hash = Hash::from(wheel.file.hashes[0].clone());
-        Ok(Wheel {
-            url,
-            hash: Some(hash),
-            filename,
-        })
+    fn from_registry_dist(reg_dist: &RegistryBuiltDist) -> Result<Vec<Wheel>, LockError> {
+        let mut wheels = vec![];
+        for wheel in &reg_dist.wheels {
+            let filename = wheel.filename.clone();
+            let url = wheel
+                .file
+                .url
+                .to_url()
+                .map_err(LockError::invalid_file_url)?;
+            // FIXME: Is it guaranteed that there is at least one hash?
+            // If not, we probably need to make this fallible.
+            let hash = Some(Hash::from(wheel.file.hashes[0].clone()));
+            wheels.push(Wheel {
+                url,
+                hash,
+                filename,
+            });
+        }
+        Ok(wheels)
     }
 
     fn from_direct_dist(direct_dist: &DirectUrlBuiltDist, hashes: &[HashDigest]) -> Wheel {
@@ -804,6 +804,26 @@ impl Wheel {
             url: path_dist.url.to_url(),
             hash: hashes.first().cloned().map(Hash::from),
             filename: path_dist.filename.clone(),
+        }
+    }
+
+    fn to_registry_dist(&self, source: &Source) -> RegistryBuiltWheel {
+        let filename: WheelFilename = self.filename.clone();
+        let file = Box::new(distribution_types::File {
+            dist_info_metadata: false,
+            filename: filename.to_string(),
+            hashes: vec![],
+            requires_python: None,
+            size: None,
+            upload_time_utc_ms: None,
+            url: FileLocation::AbsoluteUrl(self.url.to_string()),
+            yanked: None,
+        });
+        let index = IndexUrl::Url(VerbatimUrl::from_url(source.url.clone()));
+        RegistryBuiltWheel {
+            filename,
+            file,
+            index,
         }
     }
 }

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -143,15 +143,7 @@ impl BatchPrefetcher {
             );
             prefetch_count += 1;
             if index.distributions.register(candidate.version_id()) {
-                let request = match dist {
-                    ResolvedDistRef::InstallableRegistrySourceDist(dist) => {
-                        Request::Dist(Dist::from((*dist).clone()))
-                    }
-                    ResolvedDistRef::InstallableRegistryBuiltDist(dist) => {
-                        Request::Dist(Dist::from((*dist).clone()))
-                    }
-                    ResolvedDistRef::Installed(dist) => Request::Installed(dist.clone()),
-                };
+                let request = Request::from(dist);
                 request_sink.send(request).await?;
             }
         }

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashMap;
 use tokio::sync::mpsc::Sender;
 use tracing::{debug, trace};
 
-use distribution_types::{DistributionMetadata, ResolvedDistRef};
+use distribution_types::DistributionMetadata;
 use pep440_rs::Version;
 
 use crate::candidate_selector::{CandidateDist, CandidateSelector};
@@ -144,7 +144,12 @@ impl BatchPrefetcher {
             prefetch_count += 1;
             if index.distributions.register(candidate.version_id()) {
                 let request = match dist {
-                    ResolvedDistRef::Installable(dist) => Request::Dist(dist.clone()),
+                    ResolvedDistRef::InstallableRegistrySourceDist(dist) => {
+                        Request::Dist(Dist::from((*dist).clone()))
+                    }
+                    ResolvedDistRef::InstallableRegistryBuiltDist(dist) => {
+                        Request::Dist(Dist::from((*dist).clone()))
+                    }
                     ResolvedDistRef::Installed(dist) => Request::Installed(dist.clone()),
                 };
                 request_sink.send(request).await?;

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -839,7 +839,10 @@ impl<'a, Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvide
                 };
 
                 let filename = match dist.for_installation() {
-                    ResolvedDistRef::Installable(dist) => {
+                    ResolvedDistRef::InstallableRegistrySourceDist(dist) => {
+                        dist.filename().unwrap_or(Cow::Borrowed("unknown filename"))
+                    }
+                    ResolvedDistRef::InstallableRegistryBuiltDist(dist) => {
                         dist.filename().unwrap_or(Cow::Borrowed("unknown filename"))
                     }
                     ResolvedDistRef::Installed(_) => Cow::Borrowed("installed"),
@@ -862,7 +865,12 @@ impl<'a, Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvide
                 if matches!(package, PubGrubPackage::Package(_, _, _)) {
                     if self.index.distributions.register(candidate.version_id()) {
                         let request = match dist.for_resolution() {
-                            ResolvedDistRef::Installable(dist) => Request::Dist(dist.clone()),
+                            ResolvedDistRef::InstallableRegistrySourceDist(dist) => {
+                                Request::Dist(Dist::from((*dist).clone()))
+                            }
+                            ResolvedDistRef::InstallableRegistryBuiltDist(dist) => {
+                                Request::Dist(Dist::from((*dist).clone()))
+                            }
                             ResolvedDistRef::Installed(dist) => Request::Installed(dist.clone()),
                         };
                         request_sink.send(request).await?;

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -7,8 +7,8 @@ use tracing::instrument;
 
 use distribution_filename::{DistFilename, WheelFilename};
 use distribution_types::{
-    Dist, HashComparison, IncompatibleSource, IncompatibleWheel, IndexUrl, PrioritizedDist,
-    SourceDistCompatibility, WheelCompatibility,
+    HashComparison, IncompatibleSource, IncompatibleWheel, IndexUrl, PrioritizedDist,
+    RegistryBuiltWheel, RegistrySourceDist, SourceDistCompatibility, WheelCompatibility,
 };
 use pep440_rs::{Version, VersionSpecifiers};
 use platform_tags::{TagCompatibility, Tags};
@@ -396,11 +396,11 @@ impl VersionMapLazy {
                             excluded,
                             upload_time,
                         );
-                        let dist = Dist::from_registry(
-                            DistFilename::WheelFilename(filename),
-                            file,
-                            self.index.clone(),
-                        );
+                        let dist = RegistryBuiltWheel {
+                            filename,
+                            file: Box::new(file),
+                            index: self.index.clone(),
+                        };
                         priority_dist.insert_built(dist, hashes, compatibility);
                     }
                     DistFilename::SourceDistFilename(filename) => {
@@ -412,11 +412,11 @@ impl VersionMapLazy {
                             excluded,
                             upload_time,
                         );
-                        let dist = Dist::from_registry(
-                            DistFilename::SourceDistFilename(filename),
-                            file,
-                            self.index.clone(),
-                        );
+                        let dist = RegistrySourceDist {
+                            filename,
+                            file: Box::new(file),
+                            index: self.index.clone(),
+                        };
                         priority_dist.insert_source(dist, hashes, compatibility);
                     }
                 }


### PR DESCRIPTION
Our current flow of data from "simple registry package" to "final
resolved distribution" goes through a number of types:

* `SimpleMetadata` is the API response from a registry that includes all
published versions for a package. Each version has an assortment of metadata
associated with it.
* `VersionFiles` is the aforementioned metadata. It is split in two: a
group of files for source distributions and a group of files for wheels.
* `PrioritizedDist` collects a subset of the files from `VersionFiles`
to form a selection of the "best" sdist and the "best" wheel for the
current environment.
* `CompatibleDist` is created from a borrowed `PrioritizedDist` that,
perhaps among other things, encapsulates the decision of whether to pick
an sdist or a wheel. (This decision depends both on compatibility and
the action being performed. e.g., When doing installation, a
`CompatibleDist` will sometimes select an sdist over a wheel.)
* `ResolvedDistRef` is like a `ResolvedDist`, but borrows a `Dist`.
* `ResolvedDist` is the almost-final-form of a distribution in a
resolution and is created from a `ResolvedDistRef`.
* `AnnotatedResolvedDist` is a new data type that is the actual final
form of a distribution that a universal lock file cares about. It
bundles a `ResolvedDist` with some metadata needed to generate a lock
file.

One of the requirements of a universal lock file is that we include all
wheels (and maybe all source distributions? but at least one if it's
present) associated with a distribution. But the above flow of data (in
the step from `VersionFiles` to `PrioritizedDist`) drops all wheels
except for the best one.

To remedy this, in this PR, we rejigger `PrioritizedDist`,
`CompatibleDist` and `ResolvedDistRef` so that all wheel data is
preserved. And when a `ResolvedDistRef` is finally turned into a
`ResolvedDist`, we copy all of the wheel data. And finally, we adjust
the `Lock` constructor to read this new data and include it in the lock
file. To make this work, we also modify `RegistryBuiltDist` so that it
can contain one or more wheels instead of just one.

One shortcoming here (called out in the code as a FIXME) is that if a
source distribution is selected as the "best" thing to use (perhaps
there are no compatible wheels), then the wheels won't end up in the
lock file. I plan to fix this in a follow-up PR.

We also aren't totally consistent on source distribution naming.
Sometimes we use `sdist`. Sometimes `source`. Sometimes `source_dist`.
I think it'd be nice to just use `sdist` everywhere, but I do prefer
the type names to be `SourceDist`. And sometimes you want function
names to match the type names (i.e., `from_source_dist`), which in turn
leads to an appearance of inconsistency. I'm open to ideas.

Closes #3351