### PR TITLE
Allow local versions in wheel filenames

### DIFF
--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -52,7 +52,7 @@ pub fn install_wheel(
         }
 
         let version = Version::from_str(&version)?;
-        if version != filename.version {
+        if version != filename.version && version != filename.version.clone().without_local() {
             return Err(Error::MismatchedVersion(version, filename.version.clone()));
         }
     }


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/3594.

## Test Plan

`cargo run pip install --verbose https://github.com/Dao-AILab/flash-attention/releases/download/v2.5.8/flash_attn-2.5.8+cu122torch2.3cxx11abiFALSE-cp310-cp310-linux_x86_64.whl --no-deps`
