### PR TITLE
Add `Combine` implementations for non-`Vec` types

### DIFF
--- a/crates/uv-workspace/src/combine.rs
+++ b/crates/uv-workspace/src/combine.rs
@@ -1,4 +1,11 @@
-use uv_configuration::ConfigSettings;
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+
+use distribution_types::IndexUrl;
+use install_wheel_rs::linker::LinkMode;
+use uv_configuration::{ConfigSettings, IndexStrategy, KeyringProviderType, TargetTriple};
+use uv_interpreter::PythonVersion;
+use uv_resolver::{AnnotationStyle, ExcludeNewer, PreReleaseMode, ResolutionMode};
 
 use crate::{Options, PipOptions, Workspace};
 
@@ -32,14 +39,20 @@ impl Combine for Option<Workspace> {
 impl Combine for Options {
     fn combine(self, other: Options) -> Options {
         Options {
-            native_tls: self.native_tls.or(other.native_tls),
-            no_cache: self.no_cache.or(other.no_cache),
-            preview: self.preview.or(other.preview),
-            cache_dir: self.cache_dir.or(other.cache_dir),
-            pip: match (self.pip, other.pip) {
-                (Some(a), Some(b)) => Some(a.combine(b)),
-                (a, b) => a.or(b),
-            },
+            native_tls: self.native_tls.combine(other.native_tls),
+            no_cache: self.no_cache.combine(other.no_cache),
+            preview: self.preview.combine(other.preview),
+            cache_dir: self.cache_dir.combine(other.cache_dir),
+            pip: self.pip.combine(other.pip),
+        }
+    }
+}
+
+impl Combine for Option<PipOptions> {
+    fn combine(self, other: Option<PipOptions>) -> Option<PipOptions> {
+        match (self, other) {
+            (Some(a), Some(b)) => Some(a.combine(b)),
+            (a, b) => a.or(b),
         }
     }
 }
@@ -47,55 +60,88 @@ impl Combine for Options {
 impl Combine for PipOptions {
     fn combine(self, other: PipOptions) -> PipOptions {
         PipOptions {
-            // Collection types, which must be merged element-wise.
+            all_extras: self.all_extras.combine(other.all_extras),
+            annotation_style: self.annotation_style.combine(other.annotation_style),
+            break_system_packages: self
+                .break_system_packages
+                .combine(other.break_system_packages),
+            compile_bytecode: self.compile_bytecode.combine(other.compile_bytecode),
+            concurrent_builds: self.concurrent_builds.combine(other.concurrent_builds),
+            concurrent_downloads: self
+                .concurrent_downloads
+                .combine(other.concurrent_downloads),
+            config_settings: self.config_settings.combine(other.config_settings),
+            custom_compile_command: self
+                .custom_compile_command
+                .combine(other.custom_compile_command),
+            emit_find_links: self.emit_find_links.combine(other.emit_find_links),
+            emit_index_annotation: self
+                .emit_index_annotation
+                .combine(other.emit_index_annotation),
+            emit_index_url: self.emit_index_url.combine(other.emit_index_url),
+            emit_marker_expression: self
+                .emit_marker_expression
+                .combine(other.emit_marker_expression),
+            exclude_newer: self.exclude_newer.combine(other.exclude_newer),
+            extra: self.extra.combine(other.extra),
             extra_index_url: self.extra_index_url.combine(other.extra_index_url),
             find_links: self.find_links.combine(other.find_links),
+            generate_hashes: self.generate_hashes.combine(other.generate_hashes),
+            index_strategy: self.index_strategy.combine(other.index_strategy),
+            index_url: self.index_url.combine(other.index_url),
+            keyring_provider: self.keyring_provider.combine(other.keyring_provider),
+            legacy_setup_py: self.legacy_setup_py.combine(other.legacy_setup_py),
+            link_mode: self.link_mode.combine(other.link_mode),
+            no_annotate: self.no_annotate.combine(other.no_annotate),
             no_binary: self.no_binary.combine(other.no_binary),
-            only_binary: self.only_binary.combine(other.only_binary),
-            extra: self.extra.combine(other.extra),
-            config_settings: self.config_settings.combine(other.config_settings),
+            no_build: self.no_build.combine(other.no_build),
+            no_build_isolation: self.no_build_isolation.combine(other.no_build_isolation),
+            no_deps: self.no_deps.combine(other.no_deps),
             no_emit_package: self.no_emit_package.combine(other.no_emit_package),
-
-            // Non-collections, where the last value wins.
-            python: self.python.or(other.python),
-            system: self.system.or(other.system),
-            break_system_packages: self.break_system_packages.or(other.break_system_packages),
-            target: self.target.or(other.target),
-            offline: self.offline.or(other.offline),
-            index_url: self.index_url.or(other.index_url),
-            no_index: self.no_index.or(other.no_index),
-            index_strategy: self.index_strategy.or(other.index_strategy),
-            keyring_provider: self.keyring_provider.or(other.keyring_provider),
-            no_build: self.no_build.or(other.no_build),
-            no_build_isolation: self.no_build_isolation.or(other.no_build_isolation),
-            strict: self.strict.or(other.strict),
-            all_extras: self.all_extras.or(other.all_extras),
-            no_deps: self.no_deps.or(other.no_deps),
-            resolution: self.resolution.or(other.resolution),
-            prerelease: self.prerelease.or(other.prerelease),
-            output_file: self.output_file.or(other.output_file),
-            no_strip_extras: self.no_strip_extras.or(other.no_strip_extras),
-            no_annotate: self.no_annotate.or(other.no_annotate),
-            no_header: self.no_header.or(other.no_header),
-            custom_compile_command: self.custom_compile_command.or(other.custom_compile_command),
-            generate_hashes: self.generate_hashes.or(other.generate_hashes),
-            legacy_setup_py: self.legacy_setup_py.or(other.legacy_setup_py),
-            python_version: self.python_version.or(other.python_version),
-            python_platform: self.python_platform.or(other.python_platform),
-            exclude_newer: self.exclude_newer.or(other.exclude_newer),
-            emit_index_url: self.emit_index_url.or(other.emit_index_url),
-            emit_find_links: self.emit_find_links.or(other.emit_find_links),
-            emit_marker_expression: self.emit_marker_expression.or(other.emit_marker_expression),
-            emit_index_annotation: self.emit_index_annotation.or(other.emit_index_annotation),
-            annotation_style: self.annotation_style.or(other.annotation_style),
-            link_mode: self.link_mode.or(other.link_mode),
-            compile_bytecode: self.compile_bytecode.or(other.compile_bytecode),
-            require_hashes: self.require_hashes.or(other.require_hashes),
-            concurrent_downloads: self.concurrent_downloads.or(other.concurrent_downloads),
-            concurrent_builds: self.concurrent_builds.or(other.concurrent_builds),
+            no_header: self.no_header.combine(other.no_header),
+            no_index: self.no_index.combine(other.no_index),
+            no_strip_extras: self.no_strip_extras.combine(other.no_strip_extras),
+            offline: self.offline.combine(other.offline),
+            only_binary: self.only_binary.combine(other.only_binary),
+            output_file: self.output_file.combine(other.output_file),
+            prerelease: self.prerelease.combine(other.prerelease),
+            python: self.python.combine(other.python),
+            python_platform: self.python_platform.combine(other.python_platform),
+            python_version: self.python_version.combine(other.python_version),
+            require_hashes: self.require_hashes.combine(other.require_hashes),
+            resolution: self.resolution.combine(other.resolution),
+            strict: self.strict.combine(other.strict),
+            system: self.system.combine(other.system),
+            target: self.target.combine(other.target),
         }
     }
 }
+
+macro_rules! impl_combine_or {
+    ($name:ident) => {
+        impl Combine for Option<$name> {
+            /// Combine two values by taking the value in `other`, if it's `Some`.
+            fn combine(self, other: Option<$name>) -> Option<$name> {
+                other.or(self)
+            }
+        }
+    };
+}
+
+impl_combine_or!(AnnotationStyle);
+impl_combine_or!(ExcludeNewer);
+impl_combine_or!(IndexStrategy);
+impl_combine_or!(IndexUrl);
+impl_combine_or!(KeyringProviderType);
+impl_combine_or!(LinkMode);
+impl_combine_or!(NonZeroUsize);
+impl_combine_or!(PathBuf);
+impl_combine_or!(PreReleaseMode);
+impl_combine_or!(PythonVersion);
+impl_combine_or!(ResolutionMode);
+impl_combine_or!(String);
+impl_combine_or!(TargetTriple);
+impl_combine_or!(bool);
 
 impl<T> Combine for Option<Vec<T>> {
     /// Combine two vectors by extending the vector in `self` with the vector in `other`, if they're

--- a/crates/uv-workspace/src/combine.rs
+++ b/crates/uv-workspace/src/combine.rs
@@ -19,6 +19,8 @@ pub trait Combine {
     /// > precedence over ancestor directories, where the home directory is the lowest priority.
     /// > Arrays will be joined together with higher precedence items being placed later in the
     /// > merged array.
+    ///
+    /// ...with one exception: we place items with higher precedence earlier in the merged array.
     #[must_use]
     fn combine(self, other: Self) -> Self;
 }
@@ -60,59 +62,59 @@ impl Combine for Option<PipOptions> {
 impl Combine for PipOptions {
     fn combine(self, other: PipOptions) -> PipOptions {
         PipOptions {
-            all_extras: self.all_extras.combine(other.all_extras),
-            annotation_style: self.annotation_style.combine(other.annotation_style),
+            python: self.python.combine(other.python),
+            system: self.system.combine(other.system),
             break_system_packages: self
                 .break_system_packages
                 .combine(other.break_system_packages),
-            compile_bytecode: self.compile_bytecode.combine(other.compile_bytecode),
-            concurrent_builds: self.concurrent_builds.combine(other.concurrent_builds),
-            concurrent_downloads: self
-                .concurrent_downloads
-                .combine(other.concurrent_downloads),
-            config_settings: self.config_settings.combine(other.config_settings),
+            target: self.target.combine(other.target),
+            offline: self.offline.combine(other.offline),
+            index_url: self.index_url.combine(other.index_url),
+            extra_index_url: self.extra_index_url.combine(other.extra_index_url),
+            no_index: self.no_index.combine(other.no_index),
+            find_links: self.find_links.combine(other.find_links),
+            index_strategy: self.index_strategy.combine(other.index_strategy),
+            keyring_provider: self.keyring_provider.combine(other.keyring_provider),
+            no_build: self.no_build.combine(other.no_build),
+            no_binary: self.no_binary.combine(other.no_binary),
+            only_binary: self.only_binary.combine(other.only_binary),
+            no_build_isolation: self.no_build_isolation.combine(other.no_build_isolation),
+            strict: self.strict.combine(other.strict),
+            extra: self.extra.combine(other.extra),
+            all_extras: self.all_extras.combine(other.all_extras),
+            no_deps: self.no_deps.combine(other.no_deps),
+            resolution: self.resolution.combine(other.resolution),
+            prerelease: self.prerelease.combine(other.prerelease),
+            output_file: self.output_file.combine(other.output_file),
+            no_strip_extras: self.no_strip_extras.combine(other.no_strip_extras),
+            no_annotate: self.no_annotate.combine(other.no_annotate),
+            no_header: self.no_header.combine(other.no_header),
             custom_compile_command: self
                 .custom_compile_command
                 .combine(other.custom_compile_command),
-            emit_find_links: self.emit_find_links.combine(other.emit_find_links),
-            emit_index_annotation: self
-                .emit_index_annotation
-                .combine(other.emit_index_annotation),
+            generate_hashes: self.generate_hashes.combine(other.generate_hashes),
+            legacy_setup_py: self.legacy_setup_py.combine(other.legacy_setup_py),
+            config_settings: self.config_settings.combine(other.config_settings),
+            python_version: self.python_version.combine(other.python_version),
+            python_platform: self.python_platform.combine(other.python_platform),
+            exclude_newer: self.exclude_newer.combine(other.exclude_newer),
+            no_emit_package: self.no_emit_package.combine(other.no_emit_package),
             emit_index_url: self.emit_index_url.combine(other.emit_index_url),
+            emit_find_links: self.emit_find_links.combine(other.emit_find_links),
             emit_marker_expression: self
                 .emit_marker_expression
                 .combine(other.emit_marker_expression),
-            exclude_newer: self.exclude_newer.combine(other.exclude_newer),
-            extra: self.extra.combine(other.extra),
-            extra_index_url: self.extra_index_url.combine(other.extra_index_url),
-            find_links: self.find_links.combine(other.find_links),
-            generate_hashes: self.generate_hashes.combine(other.generate_hashes),
-            index_strategy: self.index_strategy.combine(other.index_strategy),
-            index_url: self.index_url.combine(other.index_url),
-            keyring_provider: self.keyring_provider.combine(other.keyring_provider),
-            legacy_setup_py: self.legacy_setup_py.combine(other.legacy_setup_py),
+            emit_index_annotation: self
+                .emit_index_annotation
+                .combine(other.emit_index_annotation),
+            annotation_style: self.annotation_style.combine(other.annotation_style),
             link_mode: self.link_mode.combine(other.link_mode),
-            no_annotate: self.no_annotate.combine(other.no_annotate),
-            no_binary: self.no_binary.combine(other.no_binary),
-            no_build: self.no_build.combine(other.no_build),
-            no_build_isolation: self.no_build_isolation.combine(other.no_build_isolation),
-            no_deps: self.no_deps.combine(other.no_deps),
-            no_emit_package: self.no_emit_package.combine(other.no_emit_package),
-            no_header: self.no_header.combine(other.no_header),
-            no_index: self.no_index.combine(other.no_index),
-            no_strip_extras: self.no_strip_extras.combine(other.no_strip_extras),
-            offline: self.offline.combine(other.offline),
-            only_binary: self.only_binary.combine(other.only_binary),
-            output_file: self.output_file.combine(other.output_file),
-            prerelease: self.prerelease.combine(other.prerelease),
-            python: self.python.combine(other.python),
-            python_platform: self.python_platform.combine(other.python_platform),
-            python_version: self.python_version.combine(other.python_version),
+            compile_bytecode: self.compile_bytecode.combine(other.compile_bytecode),
             require_hashes: self.require_hashes.combine(other.require_hashes),
-            resolution: self.resolution.combine(other.resolution),
-            strict: self.strict.combine(other.strict),
-            system: self.system.combine(other.system),
-            target: self.target.combine(other.target),
+            concurrent_downloads: self
+                .concurrent_downloads
+                .combine(other.concurrent_downloads),
+            concurrent_builds: self.concurrent_builds.combine(other.concurrent_builds),
         }
     }
 }
@@ -120,9 +122,8 @@ impl Combine for PipOptions {
 macro_rules! impl_combine_or {
     ($name:ident) => {
         impl Combine for Option<$name> {
-            /// Combine two values by taking the value in `other`, if it's `Some`.
             fn combine(self, other: Option<$name>) -> Option<$name> {
-                other.or(self)
+                self.or(other)
             }
         }
     };

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -17,7 +17,7 @@ use uv_interpreter::{PythonVersion, Target};
 use uv_normalize::PackageName;
 use uv_requirements::ExtrasSpecification;
 use uv_resolver::{AnnotationStyle, DependencyMode, ExcludeNewer, PreReleaseMode, ResolutionMode};
-use uv_workspace::{Combine, PipOptions, Workspace};
+use uv_workspace::{PipOptions, Workspace};
 
 use crate::cli::{
     ColorChoice, GlobalArgs, LockArgs, Maybe, PipCheckArgs, PipCompileArgs, PipFreezeArgs,
@@ -961,123 +961,93 @@ impl PipSharedSettings {
 
         Self {
             index_locations: IndexLocations::new(
-                args.index_url.combine(index_url),
-                args.extra_index_url
-                    .combine(extra_index_url)
-                    .unwrap_or_default(),
-                args.find_links.combine(find_links).unwrap_or_default(),
-                args.no_index.combine(no_index).unwrap_or_default(),
+                args.index_url.or(index_url),
+                args.extra_index_url.or(extra_index_url).unwrap_or_default(),
+                args.find_links.or(find_links).unwrap_or_default(),
+                args.no_index.or(no_index).unwrap_or_default(),
             ),
             extras: ExtrasSpecification::from_args(
-                args.all_extras.combine(all_extras).unwrap_or_default(),
-                args.extra.combine(extra).unwrap_or_default(),
+                args.all_extras.or(all_extras).unwrap_or_default(),
+                args.extra.or(extra).unwrap_or_default(),
             ),
-            dependency_mode: if args.no_deps.combine(no_deps).unwrap_or_default() {
+            dependency_mode: if args.no_deps.or(no_deps).unwrap_or_default() {
                 DependencyMode::Direct
             } else {
                 DependencyMode::Transitive
             },
-            resolution: args.resolution.combine(resolution).unwrap_or_default(),
-            prerelease: args.prerelease.combine(prerelease).unwrap_or_default(),
-            output_file: args.output_file.combine(output_file),
-            no_strip_extras: args
-                .no_strip_extras
-                .combine(no_strip_extras)
-                .unwrap_or_default(),
-            no_annotate: args.no_annotate.combine(no_annotate).unwrap_or_default(),
-            no_header: args.no_header.combine(no_header).unwrap_or_default(),
-            custom_compile_command: args.custom_compile_command.combine(custom_compile_command),
+            resolution: args.resolution.or(resolution).unwrap_or_default(),
+            prerelease: args.prerelease.or(prerelease).unwrap_or_default(),
+            output_file: args.output_file.or(output_file),
+            no_strip_extras: args.no_strip_extras.or(no_strip_extras).unwrap_or_default(),
+            no_annotate: args.no_annotate.or(no_annotate).unwrap_or_default(),
+            no_header: args.no_header.or(no_header).unwrap_or_default(),
+            custom_compile_command: args.custom_compile_command.or(custom_compile_command),
             annotation_style: args
                 .annotation_style
-                .combine(annotation_style)
+                .or(annotation_style)
                 .unwrap_or_default(),
-            connectivity: if args.offline.combine(offline).unwrap_or_default() {
+            connectivity: if args.offline.or(offline).unwrap_or_default() {
                 Connectivity::Offline
             } else {
                 Connectivity::Online
             },
-            index_strategy: args
-                .index_strategy
-                .combine(index_strategy)
-                .unwrap_or_default(),
+            index_strategy: args.index_strategy.or(index_strategy).unwrap_or_default(),
             keyring_provider: args
                 .keyring_provider
-                .combine(keyring_provider)
+                .or(keyring_provider)
                 .unwrap_or_default(),
-            generate_hashes: args
-                .generate_hashes
-                .combine(generate_hashes)
-                .unwrap_or_default(),
-            setup_py: if args
-                .legacy_setup_py
-                .combine(legacy_setup_py)
-                .unwrap_or_default()
-            {
+            generate_hashes: args.generate_hashes.or(generate_hashes).unwrap_or_default(),
+            setup_py: if args.legacy_setup_py.or(legacy_setup_py).unwrap_or_default() {
                 SetupPyStrategy::Setuptools
             } else {
                 SetupPyStrategy::Pep517
             },
             no_build_isolation: args
                 .no_build_isolation
-                .combine(no_build_isolation)
+                .or(no_build_isolation)
                 .unwrap_or_default(),
             no_build: NoBuild::from_args(
-                args.only_binary.combine(only_binary).unwrap_or_default(),
-                args.no_build.combine(no_build).unwrap_or_default(),
+                args.only_binary.or(only_binary).unwrap_or_default(),
+                args.no_build.or(no_build).unwrap_or_default(),
             ),
-            config_setting: args
-                .config_settings
-                .combine(config_settings)
-                .unwrap_or_default(),
-            python_version: args.python_version.combine(python_version),
-            python_platform: args.python_platform.combine(python_platform),
-            exclude_newer: args.exclude_newer.combine(exclude_newer),
-            no_emit_package: args
-                .no_emit_package
-                .combine(no_emit_package)
-                .unwrap_or_default(),
-            emit_index_url: args
-                .emit_index_url
-                .combine(emit_index_url)
-                .unwrap_or_default(),
-            emit_find_links: args
-                .emit_find_links
-                .combine(emit_find_links)
-                .unwrap_or_default(),
+            config_setting: args.config_settings.or(config_settings).unwrap_or_default(),
+            python_version: args.python_version.or(python_version),
+            python_platform: args.python_platform.or(python_platform),
+            exclude_newer: args.exclude_newer.or(exclude_newer),
+            no_emit_package: args.no_emit_package.or(no_emit_package).unwrap_or_default(),
+            emit_index_url: args.emit_index_url.or(emit_index_url).unwrap_or_default(),
+            emit_find_links: args.emit_find_links.or(emit_find_links).unwrap_or_default(),
             emit_marker_expression: args
                 .emit_marker_expression
-                .combine(emit_marker_expression)
+                .or(emit_marker_expression)
                 .unwrap_or_default(),
             emit_index_annotation: args
                 .emit_index_annotation
-                .combine(emit_index_annotation)
+                .or(emit_index_annotation)
                 .unwrap_or_default(),
-            link_mode: args.link_mode.combine(link_mode).unwrap_or_default(),
-            require_hashes: args
-                .require_hashes
-                .combine(require_hashes)
-                .unwrap_or_default(),
-            python: args.python.combine(python),
-            system: args.system.combine(system).unwrap_or_default(),
+            link_mode: args.link_mode.or(link_mode).unwrap_or_default(),
+            require_hashes: args.require_hashes.or(require_hashes).unwrap_or_default(),
+            python: args.python.or(python),
+            system: args.system.or(system).unwrap_or_default(),
             break_system_packages: args
                 .break_system_packages
-                .combine(break_system_packages)
+                .or(break_system_packages)
                 .unwrap_or_default(),
-            target: args.target.combine(target).map(Target::from),
-            no_binary: NoBinary::from_args(args.no_binary.combine(no_binary).unwrap_or_default()),
+            target: args.target.or(target).map(Target::from),
+            no_binary: NoBinary::from_args(args.no_binary.or(no_binary).unwrap_or_default()),
             compile_bytecode: args
                 .compile_bytecode
-                .combine(compile_bytecode)
+                .or(compile_bytecode)
                 .unwrap_or_default(),
-            strict: args.strict.combine(strict).unwrap_or_default(),
+            strict: args.strict.or(strict).unwrap_or_default(),
             concurrency: Concurrency {
                 downloads: args
                     .concurrent_downloads
-                    .combine(concurrent_downloads)
+                    .or(concurrent_downloads)
                     .map_or(Concurrency::DEFAULT_DOWNLOADS, NonZeroUsize::get),
                 builds: args
                     .concurrent_builds
-                    .combine(concurrent_builds)
+                    .or(concurrent_builds)
                     .map_or_else(Concurrency::default_builds, NonZeroUsize::get),
             },
         }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -17,7 +17,7 @@ use uv_interpreter::{PythonVersion, Target};
 use uv_normalize::PackageName;
 use uv_requirements::ExtrasSpecification;
 use uv_resolver::{AnnotationStyle, DependencyMode, ExcludeNewer, PreReleaseMode, ResolutionMode};
-use uv_workspace::{PipOptions, Workspace};
+use uv_workspace::{Combine, PipOptions, Workspace};
 
 use crate::cli::{
     ColorChoice, GlobalArgs, LockArgs, Maybe, PipCheckArgs, PipCompileArgs, PipFreezeArgs,
@@ -961,93 +961,123 @@ impl PipSharedSettings {
 
         Self {
             index_locations: IndexLocations::new(
-                args.index_url.or(index_url),
-                args.extra_index_url.or(extra_index_url).unwrap_or_default(),
-                args.find_links.or(find_links).unwrap_or_default(),
-                args.no_index.or(no_index).unwrap_or_default(),
+                args.index_url.combine(index_url),
+                args.extra_index_url
+                    .combine(extra_index_url)
+                    .unwrap_or_default(),
+                args.find_links.combine(find_links).unwrap_or_default(),
+                args.no_index.combine(no_index).unwrap_or_default(),
             ),
             extras: ExtrasSpecification::from_args(
-                args.all_extras.or(all_extras).unwrap_or_default(),
-                args.extra.or(extra).unwrap_or_default(),
+                args.all_extras.combine(all_extras).unwrap_or_default(),
+                args.extra.combine(extra).unwrap_or_default(),
             ),
-            dependency_mode: if args.no_deps.or(no_deps).unwrap_or_default() {
+            dependency_mode: if args.no_deps.combine(no_deps).unwrap_or_default() {
                 DependencyMode::Direct
             } else {
                 DependencyMode::Transitive
             },
-            resolution: args.resolution.or(resolution).unwrap_or_default(),
-            prerelease: args.prerelease.or(prerelease).unwrap_or_default(),
-            output_file: args.output_file.or(output_file),
-            no_strip_extras: args.no_strip_extras.or(no_strip_extras).unwrap_or_default(),
-            no_annotate: args.no_annotate.or(no_annotate).unwrap_or_default(),
-            no_header: args.no_header.or(no_header).unwrap_or_default(),
-            custom_compile_command: args.custom_compile_command.or(custom_compile_command),
+            resolution: args.resolution.combine(resolution).unwrap_or_default(),
+            prerelease: args.prerelease.combine(prerelease).unwrap_or_default(),
+            output_file: args.output_file.combine(output_file),
+            no_strip_extras: args
+                .no_strip_extras
+                .combine(no_strip_extras)
+                .unwrap_or_default(),
+            no_annotate: args.no_annotate.combine(no_annotate).unwrap_or_default(),
+            no_header: args.no_header.combine(no_header).unwrap_or_default(),
+            custom_compile_command: args.custom_compile_command.combine(custom_compile_command),
             annotation_style: args
                 .annotation_style
-                .or(annotation_style)
+                .combine(annotation_style)
                 .unwrap_or_default(),
-            connectivity: if args.offline.or(offline).unwrap_or_default() {
+            connectivity: if args.offline.combine(offline).unwrap_or_default() {
                 Connectivity::Offline
             } else {
                 Connectivity::Online
             },
-            index_strategy: args.index_strategy.or(index_strategy).unwrap_or_default(),
+            index_strategy: args
+                .index_strategy
+                .combine(index_strategy)
+                .unwrap_or_default(),
             keyring_provider: args
                 .keyring_provider
-                .or(keyring_provider)
+                .combine(keyring_provider)
                 .unwrap_or_default(),
-            generate_hashes: args.generate_hashes.or(generate_hashes).unwrap_or_default(),
-            setup_py: if args.legacy_setup_py.or(legacy_setup_py).unwrap_or_default() {
+            generate_hashes: args
+                .generate_hashes
+                .combine(generate_hashes)
+                .unwrap_or_default(),
+            setup_py: if args
+                .legacy_setup_py
+                .combine(legacy_setup_py)
+                .unwrap_or_default()
+            {
                 SetupPyStrategy::Setuptools
             } else {
                 SetupPyStrategy::Pep517
             },
             no_build_isolation: args
                 .no_build_isolation
-                .or(no_build_isolation)
+                .combine(no_build_isolation)
                 .unwrap_or_default(),
             no_build: NoBuild::from_args(
-                args.only_binary.or(only_binary).unwrap_or_default(),
-                args.no_build.or(no_build).unwrap_or_default(),
+                args.only_binary.combine(only_binary).unwrap_or_default(),
+                args.no_build.combine(no_build).unwrap_or_default(),
             ),
-            config_setting: args.config_settings.or(config_settings).unwrap_or_default(),
-            python_version: args.python_version.or(python_version),
-            python_platform: args.python_platform.or(python_platform),
-            exclude_newer: args.exclude_newer.or(exclude_newer),
-            no_emit_package: args.no_emit_package.or(no_emit_package).unwrap_or_default(),
-            emit_index_url: args.emit_index_url.or(emit_index_url).unwrap_or_default(),
-            emit_find_links: args.emit_find_links.or(emit_find_links).unwrap_or_default(),
+            config_setting: args
+                .config_settings
+                .combine(config_settings)
+                .unwrap_or_default(),
+            python_version: args.python_version.combine(python_version),
+            python_platform: args.python_platform.combine(python_platform),
+            exclude_newer: args.exclude_newer.combine(exclude_newer),
+            no_emit_package: args
+                .no_emit_package
+                .combine(no_emit_package)
+                .unwrap_or_default(),
+            emit_index_url: args
+                .emit_index_url
+                .combine(emit_index_url)
+                .unwrap_or_default(),
+            emit_find_links: args
+                .emit_find_links
+                .combine(emit_find_links)
+                .unwrap_or_default(),
             emit_marker_expression: args
                 .emit_marker_expression
-                .or(emit_marker_expression)
+                .combine(emit_marker_expression)
                 .unwrap_or_default(),
             emit_index_annotation: args
                 .emit_index_annotation
-                .or(emit_index_annotation)
+                .combine(emit_index_annotation)
                 .unwrap_or_default(),
-            link_mode: args.link_mode.or(link_mode).unwrap_or_default(),
-            require_hashes: args.require_hashes.or(require_hashes).unwrap_or_default(),
-            python: args.python.or(python),
-            system: args.system.or(system).unwrap_or_default(),
+            link_mode: args.link_mode.combine(link_mode).unwrap_or_default(),
+            require_hashes: args
+                .require_hashes
+                .combine(require_hashes)
+                .unwrap_or_default(),
+            python: args.python.combine(python),
+            system: args.system.combine(system).unwrap_or_default(),
             break_system_packages: args
                 .break_system_packages
-                .or(break_system_packages)
+                .combine(break_system_packages)
                 .unwrap_or_default(),
-            target: args.target.or(target).map(Target::from),
-            no_binary: NoBinary::from_args(args.no_binary.or(no_binary).unwrap_or_default()),
+            target: args.target.combine(target).map(Target::from),
+            no_binary: NoBinary::from_args(args.no_binary.combine(no_binary).unwrap_or_default()),
             compile_bytecode: args
                 .compile_bytecode
-                .or(compile_bytecode)
+                .combine(compile_bytecode)
                 .unwrap_or_default(),
-            strict: args.strict.or(strict).unwrap_or_default(),
+            strict: args.strict.combine(strict).unwrap_or_default(),
             concurrency: Concurrency {
                 downloads: args
                     .concurrent_downloads
-                    .or(concurrent_downloads)
+                    .combine(concurrent_downloads)
                     .map_or(Concurrency::DEFAULT_DOWNLOADS, NonZeroUsize::get),
                 builds: args
                     .concurrent_builds
-                    .or(concurrent_builds)
+                    .combine(concurrent_builds)
                     .map_or_else(Concurrency::default_builds, NonZeroUsize::get),
             },
         }


### PR DESCRIPTION
## Summary

Now, we just call `.combine` on all types, rather than needing to be aware of whether or not it's a vector. Previously, only `Option<Vec<T>>` had an implementation, so we had to specifically call `.combine` on vector types and `.or` on non-vector types. If you called `.or` on a non-vector type, the code would compile, but with the wrong behavior. This way, we get clear guidance from the compiler and a guarantee of correct behavior as we introduce new settings.
