### PR TITLE
Parse and store extras on editables

### DIFF
--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -137,7 +137,7 @@ create_exception!(
 /// A PEP 508 dependency specifier.
 #[derive(Hash, Debug, Clone, Eq, PartialEq)]
 pub struct Requirement<T: Pep508Url = VerbatimUrl> {
-    /// The distribution name such as `numpy` in
+    /// The distribution name such as `requests` in
     /// `requests [security,tests] >= 2.8.1, == 2.8.* ; python_version > "3.8"`.
     pub name: PackageName,
     /// The list of extras such as `security`, `tests` in
@@ -145,7 +145,7 @@ pub struct Requirement<T: Pep508Url = VerbatimUrl> {
     pub extras: Vec<ExtraName>,
     /// The version specifier such as `>= 2.8.1`, `== 2.8.*` in
     /// `requests [security,tests] >= 2.8.1, == 2.8.* ; python_version > "3.8"`.
-    /// or a url
+    /// or a URL.
     pub version_or_url: Option<VersionOrUrl<T>>,
     /// The markers such as `python_version > "3.8"` in
     /// `requests [security,tests] >= 2.8.1, == 2.8.* ; python_version > "3.8"`.
@@ -241,7 +241,7 @@ impl Deref for PyRequirement {
 #[cfg(feature = "pyo3")]
 #[pymethods]
 impl PyRequirement {
-    /// The distribution name such as `numpy` in
+    /// The distribution name such as `requests` in
     /// `requests [security,tests] >= 2.8.1, == 2.8.* ; python_version > "3.8"`
     #[getter]
     pub fn name(&self) -> String {

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-editable.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-editable.txt.snap
@@ -31,6 +31,7 @@ RequirementsTxt {
                     "dev",
                 ),
             ],
+            marker: None,
             path: "<REQUIREMENTS_DIR>/editable",
             origin: Some(
                 File(
@@ -63,6 +64,7 @@ RequirementsTxt {
                     "dev",
                 ),
             ],
+            marker: None,
             path: "<REQUIREMENTS_DIR>/editable",
             origin: Some(
                 File(
@@ -95,6 +97,28 @@ RequirementsTxt {
                     "dev",
                 ),
             ],
+            marker: Some(
+                And(
+                    [
+                        Expression(
+                            Version {
+                                key: PythonVersion,
+                                specifier: VersionSpecifier {
+                                    operator: GreaterThanEqual,
+                                    version: "3.9",
+                                },
+                            },
+                        ),
+                        Expression(
+                            String {
+                                key: OsName,
+                                operator: Equal,
+                                value: "posix",
+                            },
+                        ),
+                    ],
+                ),
+            ),
             path: "<REQUIREMENTS_DIR>/editable",
             origin: Some(
                 File(
@@ -127,6 +151,28 @@ RequirementsTxt {
                     "dev",
                 ),
             ],
+            marker: Some(
+                And(
+                    [
+                        Expression(
+                            Version {
+                                key: PythonVersion,
+                                specifier: VersionSpecifier {
+                                    operator: GreaterThanEqual,
+                                    version: "3.9",
+                                },
+                            },
+                        ),
+                        Expression(
+                            String {
+                                key: OsName,
+                                operator: Equal,
+                                value: "posix",
+                            },
+                        ),
+                    ],
+                ),
+            ),
             path: "<REQUIREMENTS_DIR>/editable",
             origin: Some(
                 File(
@@ -152,6 +198,28 @@ RequirementsTxt {
                 ),
             },
             extras: [],
+            marker: Some(
+                And(
+                    [
+                        Expression(
+                            Version {
+                                key: PythonVersion,
+                                specifier: VersionSpecifier {
+                                    operator: GreaterThanEqual,
+                                    version: "3.9",
+                                },
+                            },
+                        ),
+                        Expression(
+                            String {
+                                key: OsName,
+                                operator: Equal,
+                                value: "posix",
+                            },
+                        ),
+                    ],
+                ),
+            ),
             path: "<REQUIREMENTS_DIR>/editable",
             origin: Some(
                 File(
@@ -168,16 +236,17 @@ RequirementsTxt {
                     password: None,
                     host: None,
                     port: None,
-                    path: "<REQUIREMENTS_DIR>/editable;",
+                    path: "<REQUIREMENTS_DIR>/editable;%20python_version%20%3E=%20%223.9%22%20and%20os_name%20==%20%22posix%22",
                     query: None,
                     fragment: None,
                 },
                 given: Some(
-                    "./editable;",
+                    "./editable; python_version >= \"3.9\" and os_name == \"posix\"",
                 ),
             },
             extras: [],
-            path: "<REQUIREMENTS_DIR>/editable;",
+            marker: None,
+            path: "<REQUIREMENTS_DIR>/editable; python_version >= \"3.9\" and os_name == \"posix\"",
             origin: Some(
                 File(
                     "<REQUIREMENTS_DIR>/editable.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-editable.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-editable.txt.snap
@@ -31,6 +31,7 @@ RequirementsTxt {
                     "dev",
                 ),
             ],
+            marker: None,
             path: "<REQUIREMENTS_DIR>/editable",
             origin: Some(
                 File(
@@ -63,6 +64,7 @@ RequirementsTxt {
                     "dev",
                 ),
             ],
+            marker: None,
             path: "<REQUIREMENTS_DIR>/editable",
             origin: Some(
                 File(
@@ -95,6 +97,28 @@ RequirementsTxt {
                     "dev",
                 ),
             ],
+            marker: Some(
+                And(
+                    [
+                        Expression(
+                            Version {
+                                key: PythonVersion,
+                                specifier: VersionSpecifier {
+                                    operator: GreaterThanEqual,
+                                    version: "3.9",
+                                },
+                            },
+                        ),
+                        Expression(
+                            String {
+                                key: OsName,
+                                operator: Equal,
+                                value: "posix",
+                            },
+                        ),
+                    ],
+                ),
+            ),
             path: "<REQUIREMENTS_DIR>/editable",
             origin: Some(
                 File(
@@ -127,6 +151,28 @@ RequirementsTxt {
                     "dev",
                 ),
             ],
+            marker: Some(
+                And(
+                    [
+                        Expression(
+                            Version {
+                                key: PythonVersion,
+                                specifier: VersionSpecifier {
+                                    operator: GreaterThanEqual,
+                                    version: "3.9",
+                                },
+                            },
+                        ),
+                        Expression(
+                            String {
+                                key: OsName,
+                                operator: Equal,
+                                value: "posix",
+                            },
+                        ),
+                    ],
+                ),
+            ),
             path: "<REQUIREMENTS_DIR>/editable",
             origin: Some(
                 File(
@@ -152,6 +198,28 @@ RequirementsTxt {
                 ),
             },
             extras: [],
+            marker: Some(
+                And(
+                    [
+                        Expression(
+                            Version {
+                                key: PythonVersion,
+                                specifier: VersionSpecifier {
+                                    operator: GreaterThanEqual,
+                                    version: "3.9",
+                                },
+                            },
+                        ),
+                        Expression(
+                            String {
+                                key: OsName,
+                                operator: Equal,
+                                value: "posix",
+                            },
+                        ),
+                    ],
+                ),
+            ),
             path: "<REQUIREMENTS_DIR>/editable",
             origin: Some(
                 File(
@@ -168,16 +236,17 @@ RequirementsTxt {
                     password: None,
                     host: None,
                     port: None,
-                    path: "/<REQUIREMENTS_DIR>/editable;",
+                    path: "/<REQUIREMENTS_DIR>/editable;%20python_version%20%3E=%20%223.9%22%20and%20os_name%20==%20%22posix%22",
                     query: None,
                     fragment: None,
                 },
                 given: Some(
-                    "./editable;",
+                    "./editable; python_version >= \"3.9\" and os_name == \"posix\"",
                 ),
             },
             extras: [],
-            path: "<REQUIREMENTS_DIR>/editable;",
+            marker: None,
+            path: "<REQUIREMENTS_DIR>/editable; python_version >= \"3.9\" and os_name == \"posix\"",
             origin: Some(
                 File(
                     "<REQUIREMENTS_DIR>/editable.txt",

--- a/crates/requirements-txt/test-data/requirements-txt/editable.txt
+++ b/crates/requirements-txt/test-data/requirements-txt/editable.txt
@@ -5,13 +5,13 @@
 -e ./editable[d, dev]
 
 # OK
--e ./editable[d,dev] ; python_version >= "3.9" and python_ver
+-e ./editable[d,dev] ; python_version >= "3.9" and os_name == "posix"
 
 # OK (whitespace between extras; disallowed by pip)
--e ./editable[d, dev] ; python_version >= "3.9" and python_ver
+-e ./editable[d, dev] ; python_version >= "3.9" and os_name == "posix"
 
 # OK
--e ./editable ; python_version >= "3.9" and python_ver
+-e ./editable ; python_version >= "3.9" and os_name == "posix"
 
 # Disallowed (missing whitespace before colon)
--e ./editable; python_version >= "3.9" and python_ver
+-e ./editable; python_version >= "3.9" and os_name == "posix"

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -191,6 +191,7 @@ impl RequirementsSpecification {
                             Either::Left(EditableRequirement {
                                 url,
                                 path,
+                                marker: requirement.marker,
                                 extras: requirement.extras,
                                 origin: requirement.origin,
                             })

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -427,6 +427,7 @@ pub(crate) async fn pip_compile(
                 url,
                 extras,
                 path,
+                marker: _,
                 origin: _,
             } = editable;
             LocalEditable { url, path, extras }

--- a/crates/uv/src/commands/pip/editables.rs
+++ b/crates/uv/src/commands/pip/editables.rs
@@ -108,6 +108,7 @@ impl ResolvedEditables {
                     url,
                     path,
                     extras,
+                    marker: _,
                     origin: _,
                 } = editable;
                 LocalEditable {


### PR DESCRIPTION
## Summary

As a follow-up to #3622, we now parse and store (but don't respect) markers on editable requirements.

