### PR TITLE
Support lossless serialization for Git dependencies in lockfile

### DIFF
--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -38,10 +38,6 @@ impl GitUrl {
         self
     }
 
-    pub fn set_precise(&mut self, precise: GitSha) {
-        self.precise = Some(precise);
-    }
-
     /// Return the [`Url`] of the Git repository.
     pub fn repository(&self) -> &Url {
         &self.repository

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -38,6 +38,10 @@ impl GitUrl {
         self
     }
 
+    pub fn set_precise(&mut self, precise: GitSha) {
+        self.precise = Some(precise);
+    }
+
     /// Return the [`Url`] of the Git repository.
     pub fn repository(&self) -> &Url {
         &self.repository

--- a/crates/uv-git/src/sha.rs
+++ b/crates/uv-git/src/sha.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 /// A complete Git SHA, i.e., a 40-character hexadecimal representation of a Git commit.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GitSha(git2::Oid);
 
 impl GitSha {

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -212,10 +212,10 @@ fn lock_git() -> Result<()> {
     [[distribution]]
     name = "anyio"
     version = "3.7.0"
-    source = "git+https://github.com/agronholm/anyio"
+    source = "git+https://github.com/agronholm/anyio?rev=3.7.0#f7a880ffac4766efb39e6fb60fc28d944f5d2f65"
 
     [distribution.sdist]
-    url = "git+https://github.com/agronholm/anyio@f7a880ffac4766efb39e6fb60fc28d944f5d2f65"
+    url = "https://github.com/agronholm/anyio?rev=3.7.0#f7a880ffac4766efb39e6fb60fc28d944f5d2f65"
 
     [[distribution.dependencies]]
     name = "exceptiongroup"
@@ -290,6 +290,22 @@ fn lock_git() -> Result<()> {
     hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"
     "###
     );
+
+    // Install from the lockfile.
+    uv_snapshot!(context.install().arg("--unstable-uv-lock-file").arg("anyio"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Downloaded 4 packages in [TIME]
+    Installed 5 packages in [TIME]
+     + anyio==3.7.0 (from https://github.com/agronholm/anyio@f7a880ffac4766efb39e6fb60fc28d944f5d2f65)
+     + exceptiongroup==1.2.0
+     + idna==3.6
+     + sniffio==1.3.1
+     + typing-extensions==4.10.0
+    "###);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

This PR adds lossless deserialization for `GitSourceDist` distributions in the lockfile. Specifically, we now properly preserve the requested revision, the subdirectory, and the precise Git commit SHA.

## Test Plan

`cargo test`
