### PR TITLE
Make `from_rev` take an owned value

### DIFF
--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -54,17 +54,17 @@ enum RefspecStrategy {
 impl GitReference {
     /// Creates a [`GitReference`] from an arbitrary revision string, which could represent a
     /// branch, tag, commit, or named ref.
-    pub fn from_rev(rev: &str) -> Self {
+    pub fn from_rev(rev: String) -> Self {
         if rev.starts_with("refs/") {
-            Self::NamedRef(rev.to_owned())
-        } else if looks_like_commit_hash(rev) {
+            Self::NamedRef(rev)
+        } else if looks_like_commit_hash(&rev) {
             if rev.len() == 40 {
-                Self::FullCommit(rev.to_owned())
+                Self::FullCommit(rev)
             } else {
-                Self::BranchOrTagOrCommit(rev.to_owned())
+                Self::BranchOrTagOrCommit(rev)
             }
         } else {
-            Self::BranchOrTag(rev.to_owned())
+            Self::BranchOrTag(rev)
         }
     }
 

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -76,7 +76,7 @@ impl TryFrom<Url> for GitUrl {
             .rsplit_once('@')
             .map(|(prefix, suffix)| (prefix.to_string(), suffix.to_string()))
         {
-            reference = GitReference::from_rev(&suffix);
+            reference = GitReference::from_rev(suffix);
             url.set_path(&prefix);
         }
 

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -874,7 +874,7 @@ impl From<GitSourceKind> for GitReference {
         match value {
             GitSourceKind::Branch(branch) => GitReference::Branch(branch),
             GitSourceKind::Tag(tag) => GitReference::Tag(tag),
-            GitSourceKind::Rev(rev) => GitReference::from_rev(&rev),
+            GitSourceKind::Rev(rev) => GitReference::from_rev(rev),
             GitSourceKind::DefaultBranch => GitReference::DefaultBranch,
         }
     }

--- a/crates/uv-resolver/src/redirect.rs
+++ b/crates/uv-resolver/src/redirect.rs
@@ -53,7 +53,7 @@ pub(crate) fn url_to_precise(url: VerbatimParsedUrl) -> VerbatimParsedUrl {
         .reference()
         .as_str()
         .map_or(GitReference::DefaultBranch, |rev| {
-            GitReference::from_rev(rev)
+            GitReference::from_rev(rev.to_string())
         });
     let git_url = GitUrl::new(git_url.repository().clone(), lowered_git_ref);
 


### PR DESCRIPTION
## Summary

We always clone internally, and in most case we're already passing `&String`.

