### PR TITLE
Fix copy-paste error

### DIFF
--- a/crates/uv-installer/src/installer.rs
+++ b/crates/uv-installer/src/installer.rs
@@ -79,7 +79,7 @@ impl<'a> Installer<'a> {
 }
 
 pub trait Reporter: Send + Sync {
-    /// Callback to invoke when a dependency is resolved.
+    /// Callback to invoke when a dependency is installed.
     fn on_install_progress(&self, wheel: &CachedDist);
 
     /// Callback to invoke when the resolution is complete.


### PR DESCRIPTION
There was an error in the docs for the installer's `Reporter`. I assume it's a copy-paste error from the `Reporter` in `resolver.rs`.