### PR TITLE
Refactor editables for supporting them in bluejay commands

### DIFF
--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -548,4 +548,8 @@ impl InstalledPackagesProvider for SitePackages {
     fn get_packages(&self, name: &PackageName) -> Vec<&InstalledDist> {
         self.get_packages(name)
     }
+
+    fn get_editables(&self, url: &Url) -> Vec<&InstalledDist> {
+        self.get_editables(url)
+    }
 }

--- a/crates/uv-resolver/src/editables.rs
+++ b/crates/uv-resolver/src/editables.rs
@@ -1,36 +1,34 @@
-use std::hash::BuildHasherDefault;
-
 use rustc_hash::FxHashMap;
 
 use distribution_types::{LocalEditable, Requirements};
 use pypi_types::Metadata23;
 use uv_normalize::PackageName;
 
+/// A built editable for which we know its dependencies and other static metadata.
+#[derive(Debug, Clone)]
+pub struct BuiltEditableMetadata {
+    pub built: LocalEditable,
+    pub metadata: Metadata23,
+    pub requirements: Requirements,
+}
+
 /// A set of editable packages, indexed by package name.
 #[derive(Debug, Default, Clone)]
-pub(crate) struct Editables(FxHashMap<PackageName, (LocalEditable, Metadata23, Requirements)>);
+pub(crate) struct Editables(FxHashMap<PackageName, BuiltEditableMetadata>);
 
 impl Editables {
     /// Create a new set of editables from a set of requirements.
-    pub(crate) fn from_requirements(
-        requirements: Vec<(LocalEditable, Metadata23, Requirements)>,
-    ) -> Self {
-        let mut editables =
-            FxHashMap::with_capacity_and_hasher(requirements.len(), BuildHasherDefault::default());
-        for (editable_requirement, metadata, requirements) in requirements {
-            editables.insert(
-                metadata.name.clone(),
-                (editable_requirement, metadata, requirements),
-            );
-        }
-        Self(editables)
+    pub(crate) fn from_requirements(requirements: Vec<BuiltEditableMetadata>) -> Self {
+        Self(
+            requirements
+                .into_iter()
+                .map(|editable| (editable.metadata.name.clone(), editable))
+                .collect(),
+        )
     }
 
     /// Get the editable for a package.
-    pub(crate) fn get(
-        &self,
-        name: &PackageName,
-    ) -> Option<&(LocalEditable, Metadata23, Requirements)> {
+    pub(crate) fn get(&self, name: &PackageName) -> Option<&BuiltEditableMetadata> {
         self.0.get(name)
     }
 
@@ -40,7 +38,7 @@ impl Editables {
     }
 
     /// Iterate over all editables.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &(LocalEditable, Metadata23, Requirements)> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &BuiltEditableMetadata> {
         self.0.values()
     }
 }

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -1,4 +1,5 @@
 pub use dependency_mode::DependencyMode;
+pub use editables::BuiltEditableMetadata;
 pub use error::ResolveError;
 pub use exclude_newer::ExcludeNewer;
 pub use exclusions::Exclusions;

--- a/crates/uv-resolver/src/manifest.rs
+++ b/crates/uv-resolver/src/manifest.rs
@@ -1,11 +1,12 @@
-use distribution_types::{LocalEditable, Requirement, Requirements};
 use either::Either;
+
+use distribution_types::Requirement;
 use pep508_rs::MarkerEnvironment;
-use pypi_types::Metadata23;
 use uv_configuration::{Constraints, Overrides};
 use uv_normalize::PackageName;
 use uv_types::RequestedRequirements;
 
+use crate::editables::BuiltEditableMetadata;
 use crate::{preferences::Preference, DependencyMode, Exclusions};
 
 /// A manifest of requirements, constraints, and preferences.
@@ -34,7 +35,7 @@ pub struct Manifest {
     ///
     /// The requirements of the editables should be included in resolution as if they were
     /// direct requirements in their own right.
-    pub(crate) editables: Vec<(LocalEditable, Metadata23, Requirements)>,
+    pub(crate) editables: Vec<BuiltEditableMetadata>,
 
     /// The installed packages to exclude from consideration during resolution.
     ///
@@ -58,7 +59,7 @@ impl Manifest {
         overrides: Overrides,
         preferences: Vec<Preference>,
         project: Option<PackageName>,
-        editables: Vec<(LocalEditable, Metadata23, Requirements)>,
+        editables: Vec<BuiltEditableMetadata>,
         exclusions: Exclusions,
         lookaheads: Vec<RequestedRequirements>,
     ) -> Self {
@@ -112,11 +113,11 @@ impl Manifest {
                             requirement.evaluate_markers(markers, lookahead.extras())
                         })
                 })
-                .chain(self.editables.iter().flat_map(move |(editable, _metadata, requirements)| {
+                .chain(self.editables.iter().flat_map(move |editable| {
                     self.overrides
-                        .apply(&requirements.dependencies)
+                        .apply(&editable.requirements.dependencies)
                         .filter(move |requirement| {
-                            requirement.evaluate_markers(markers, &editable.extras)
+                            requirement.evaluate_markers(markers, &editable.built.extras)
                         })
                 }))
                 .chain(
@@ -174,15 +175,13 @@ impl Manifest {
                                 requirement.evaluate_markers(markers, lookahead.extras())
                             })
                     })
-                    .chain(self.editables.iter().flat_map(
-                        move |(editable, _metadata, uv_requirements)| {
-                            self.overrides.apply(&uv_requirements.dependencies).filter(
-                                move |requirement| {
-                                    requirement.evaluate_markers(markers, &editable.extras)
-                                },
-                            )
-                        },
-                    ))
+                    .chain(self.editables.iter().flat_map(move |editable| {
+                        self.overrides
+                            .apply(&editable.requirements.dependencies)
+                            .filter(move |requirement| {
+                                requirement.evaluate_markers(markers, &editable.built.extras)
+                            })
+                    }))
                     .chain(
                         self.overrides
                             .apply(&self.requirements)

--- a/crates/uv-resolver/src/resolution/display.rs
+++ b/crates/uv-resolver/src/resolution/display.rs
@@ -137,8 +137,8 @@ impl std::fmt::Display for DisplayResolutionGraph<'_> {
                     return None;
                 }
 
-                let node = if let Some((editable, _, _)) = self.resolution.editables.get(name) {
-                    Node::Editable(editable)
+                let node = if let Some(editable) = self.resolution.editables.get(name) {
+                    Node::Editable(&editable.built)
                 } else {
                     Node::Distribution(dist)
                 };

--- a/crates/uv-resolver/src/resolver/urls.rs
+++ b/crates/uv-resolver/src/resolver/urls.rs
@@ -25,16 +25,18 @@ impl Urls {
         let mut urls: FxHashMap<PackageName, VerbatimParsedUrl> = FxHashMap::default();
 
         // Add the editables themselves to the list of required URLs.
-        for (editable, metadata, _) in &manifest.editables {
+        for editable in &manifest.editables {
             let editable_url = VerbatimParsedUrl {
                 parsed_url: ParsedUrl::Path(ParsedPathUrl {
-                    url: editable.url.to_url(),
-                    path: editable.path.clone(),
+                    url: editable.built.url.to_url(),
+                    path: editable.built.path.clone(),
                     editable: true,
                 }),
-                verbatim: editable.url.clone(),
+                verbatim: editable.built.url.clone(),
             };
-            if let Some(previous) = urls.insert(metadata.name.clone(), editable_url.clone()) {
+            if let Some(previous) =
+                urls.insert(editable.metadata.name.clone(), editable_url.clone())
+            {
                 if !is_equal(&previous.verbatim, &editable_url.verbatim) {
                     if is_same_reference(&previous.verbatim, &editable_url.verbatim) {
                         debug!(
@@ -43,7 +45,7 @@ impl Urls {
                         );
                     } else {
                         return Err(ResolveError::ConflictingUrlsDirect(
-                            metadata.name.clone(),
+                            editable.metadata.name.clone(),
                             previous.verbatim.verbatim().to_string(),
                             editable_url.verbatim.verbatim().to_string(),
                         ));

--- a/crates/uv-types/src/traits.rs
+++ b/crates/uv-types/src/traits.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use url::Url;
 
 use distribution_types::{IndexLocations, InstalledDist, Requirement, Resolution, SourceDist};
 use pep508_rs::PackageName;
@@ -131,6 +132,7 @@ pub trait SourceBuildTrait {
 pub trait InstalledPackagesProvider: Clone + Send + Sync + 'static {
     fn iter(&self) -> impl Iterator<Item = &InstalledDist>;
     fn get_packages(&self, name: &PackageName) -> Vec<&InstalledDist>;
+    fn get_editables(&self, url: &Url) -> Vec<&InstalledDist>;
 }
 
 /// An [`InstalledPackagesProvider`] with no packages in it.
@@ -144,5 +146,9 @@ impl InstalledPackagesProvider for EmptyInstalledPackages {
 
     fn iter(&self) -> impl Iterator<Item = &InstalledDist> {
         std::iter::empty()
+    }
+
+    fn get_editables(&self, _url: &Url) -> Vec<&InstalledDist> {
+        Vec::new()
     }
 }

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -36,7 +36,7 @@ mod cache_dir;
 mod cache_prune;
 mod pip;
 mod project;
-mod reporters;
+pub(crate) mod reporters;
 #[cfg(feature = "self-update")]
 mod self_update;
 mod venv;

--- a/crates/uv/src/commands/pip/mod.rs
+++ b/crates/uv/src/commands/pip/mod.rs
@@ -1,6 +1,5 @@
 pub(crate) mod check;
 pub(crate) mod compile;
-mod editables;
 pub(crate) mod freeze;
 pub(crate) mod install;
 pub(crate) mod list;

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -34,9 +34,9 @@ use uv_resolver::{
 use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
 use uv_warnings::warn_user;
 
-use crate::commands::pip::editables::ResolvedEditables;
 use crate::commands::reporters::{DownloadReporter, InstallReporter, ResolverReporter};
 use crate::commands::{compile_bytecode, elapsed, ChangeEvent, ChangeEventKind, ExitStatus};
+use crate::editables::ResolvedEditables;
 use crate::printer::Printer;
 
 /// Install a set of locked requirements into the current Python environment.

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -15,6 +15,7 @@ use uv_warnings::warn_user;
 
 use crate::commands::project::discovery::Project;
 use crate::commands::{project, ExitStatus};
+use crate::editables::ResolvedEditables;
 use crate::printer::Printer;
 
 /// Sync the project environment.
@@ -86,10 +87,16 @@ pub(crate) async fn sync(
         concurrency,
     );
 
+    // TODO(konsti): Read editables from lockfile.
+    let editables = ResolvedEditables::default();
+
+    let site_packages = SitePackages::from_executable(&venv)?;
+
     // Sync the environment.
     project::install(
         &resolution,
-        SitePackages::from_executable(&venv)?,
+        editables,
+        site_packages,
         &no_binary,
         link_mode,
         &index_locations,

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -43,6 +43,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 mod cli;
 mod commands;
 mod compat;
+mod editables;
 mod logging;
 mod printer;
 mod settings;


### PR DESCRIPTION
This is split out from workspaces support, which needs editables in the bluejay commands. It consists mainly of refactorings:

* Move the `editable` module one level up.
* Introduce a `BuiltEditableMetadata` type for `(LocalEditable, Metadata23, Requirements)`.
* Add editables to `InstalledPackagesProvider` so we can use `EmptyInstalledPackages` for them.