### PR TITLE
Use `FxHasher` in resolver

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -6,11 +6,10 @@ use std::sync::Arc;
 use indexmap::IndexMap;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, DerivationTree, External, Reporter};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
-use dashmap::{DashMap, DashSet};
+use dashmap::DashMap;
 use distribution_types::{BuiltDist, IndexLocations, InstalledDist, ParsedUrlError, SourceDist};
-use once_map::OnceMap;
 use pep440_rs::Version;
 use pep508_rs::Requirement;
 use uv_normalize::PackageName;
@@ -19,7 +18,9 @@ use crate::candidate_selector::CandidateSelector;
 use crate::dependency_provider::UvDependencyProvider;
 use crate::pubgrub::{PubGrubPackage, PubGrubPython, PubGrubReportFormatter};
 use crate::python_requirement::PythonRequirement;
-use crate::resolver::{IncompletePackage, UnavailablePackage, UnavailableReason, VersionsResponse};
+use crate::resolver::{
+    FxOnceMap, IncompletePackage, UnavailablePackage, UnavailableReason, VersionsResponse,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ResolveError {
@@ -235,8 +236,8 @@ impl NoSolutionError {
     pub(crate) fn with_available_versions(
         mut self,
         python_requirement: &PythonRequirement,
-        visited: &DashSet<PackageName>,
-        package_versions: &OnceMap<PackageName, Arc<VersionsResponse>>,
+        visited: &FxHashSet<PackageName>,
+        package_versions: &FxOnceMap<PackageName, Arc<VersionsResponse>>,
     ) -> Self {
         let mut available_versions = IndexMap::default();
         for package in self.derivation_tree.packages() {

--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -10,7 +10,6 @@ use distribution_types::{
     Dist, DistributionMetadata, Name, ParsedUrlError, Requirement, ResolvedDist, VersionId,
     VersionOrUrlRef,
 };
-use once_map::OnceMap;
 use pep440_rs::{Version, VersionSpecifier};
 use pep508_rs::MarkerEnvironment;
 use uv_normalize::{ExtraName, PackageName};
@@ -22,6 +21,7 @@ use crate::preferences::Preferences;
 use crate::pubgrub::{PubGrubDistribution, PubGrubPackage};
 use crate::redirect::url_to_precise;
 use crate::resolution::AnnotatedDist;
+use crate::resolver::FxOnceMap;
 use crate::{
     lock, InMemoryIndex, Lock, LockError, Manifest, MetadataResponse, ResolveError,
     VersionsResponse,
@@ -45,8 +45,8 @@ impl ResolutionGraph {
     pub(crate) fn from_state(
         selection: &SelectedDependencies<UvDependencyProvider>,
         pins: &FilePins,
-        packages: &OnceMap<PackageName, Arc<VersionsResponse>>,
-        distributions: &OnceMap<VersionId, Arc<MetadataResponse>>,
+        packages: &FxOnceMap<PackageName, Arc<VersionsResponse>>,
+        distributions: &FxOnceMap<VersionId, Arc<MetadataResponse>>,
         state: &State<UvDependencyProvider>,
         preferences: &Preferences,
         editables: Editables,

--- a/crates/uv-resolver/src/resolver/index.rs
+++ b/crates/uv-resolver/src/resolver/index.rs
@@ -1,7 +1,9 @@
+use std::hash::BuildHasherDefault;
 use std::sync::Arc;
 
 use distribution_types::VersionId;
 use once_map::OnceMap;
+use rustc_hash::FxHasher;
 use uv_normalize::PackageName;
 
 use crate::resolver::provider::{MetadataResponse, VersionsResponse};
@@ -14,20 +16,22 @@ pub struct InMemoryIndex(Arc<SharedInMemoryIndex>);
 struct SharedInMemoryIndex {
     /// A map from package name to the metadata for that package and the index where the metadata
     /// came from.
-    packages: OnceMap<PackageName, Arc<VersionsResponse>>,
+    packages: FxOnceMap<PackageName, Arc<VersionsResponse>>,
 
     /// A map from package ID to metadata for that distribution.
-    distributions: OnceMap<VersionId, Arc<MetadataResponse>>,
+    distributions: FxOnceMap<VersionId, Arc<MetadataResponse>>,
 }
+
+pub(crate) type FxOnceMap<K, V> = OnceMap<K, V, BuildHasherDefault<FxHasher>>;
 
 impl InMemoryIndex {
     /// Returns a reference to the package metadata map.
-    pub fn packages(&self) -> &OnceMap<PackageName, Arc<VersionsResponse>> {
+    pub fn packages(&self) -> &FxOnceMap<PackageName, Arc<VersionsResponse>> {
         &self.0.packages
     }
 
     /// Returns a reference to the distribution metadata map.
-    pub fn distributions(&self) -> &OnceMap<VersionId, Arc<MetadataResponse>> {
+    pub fn distributions(&self) -> &FxOnceMap<VersionId, Arc<MetadataResponse>> {
         &self.0.distributions
     }
 }


### PR DESCRIPTION
## Summary

We can use `FxHasher` in a few more places for string and version keys. This gives a consistent ~2% improvement to warm resolves.