### PR TITLE
Add `UV_CONCURRENT_INSTALLS` variable in favor of `RAYON_NUM_THREADS`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4518,6 +4518,7 @@ dependencies = [
  "platform-tags",
  "predicates",
  "pypi-types",
+ "rayon",
  "regex",
  "requirements-txt",
  "reqwest",

--- a/README.md
+++ b/README.md
@@ -560,6 +560,8 @@ uv accepts the following command-line arguments as environment variables:
   will perform at any given time.
 - `UV_CONCURRENT_BUILDS`: Sets the maximum number of source distributions that `uv` will build
   concurrently at any given time.
+- `UV_CONCURRENT_INSTALLS`: Used to control the number of threads used when installing and unzipping
+  packages.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 
@@ -583,8 +585,6 @@ In addition, uv respects the following environment variables:
 - `FISH_VERSION`: Used to detect the use of the Fish shell.
 - `BASH_VERSION`: Used to detect the use of the Bash shell.
 - `ZSH_VERSION`: Used to detect the use of the Zsh shell.
-- `RAYON_NUM_THREADS`: Used to control the number of threads used when unzipping and installing
-  packages. See the [rayon documentation](https://docs.rs/rayon/latest/rayon/) for more.
 - `MACOSX_DEPLOYMENT_TARGET`: Used with `--python-platform macos` and related variants to set the
   deployment target (i.e., the minimum supported macOS version). Defaults to `12.0`, the
   least-recent non-EOL macOS version at time of writing.

--- a/crates/uv-configuration/src/concurrency.rs
+++ b/crates/uv-configuration/src/concurrency.rs
@@ -11,13 +11,18 @@ pub struct Concurrency {
     ///
     /// Note this value must be non-zero.
     pub builds: usize,
+    /// The maximum number of concurrent installs.
+    ///
+    /// Note this value must be non-zero.
+    pub installs: usize,
 }
 
 impl Default for Concurrency {
     fn default() -> Self {
         Concurrency {
             downloads: Concurrency::DEFAULT_DOWNLOADS,
-            builds: Concurrency::default_builds(),
+            builds: Concurrency::threads(),
+            installs: Concurrency::threads(),
         }
     }
 }
@@ -26,8 +31,8 @@ impl Concurrency {
     // The default concurrent downloads limit.
     pub const DEFAULT_DOWNLOADS: usize = 50;
 
-    // The default concurrent builds limit.
-    pub fn default_builds() -> usize {
+    // The default concurrent builds and install limit.
+    pub fn threads() -> usize {
         std::thread::available_parallelism()
             .map(NonZeroUsize::get)
             .unwrap_or(1)

--- a/crates/uv-workspace/src/combine.rs
+++ b/crates/uv-workspace/src/combine.rs
@@ -115,6 +115,7 @@ impl Combine for PipOptions {
                 .concurrent_downloads
                 .combine(other.concurrent_downloads),
             concurrent_builds: self.concurrent_builds.combine(other.concurrent_builds),
+            concurrent_installs: self.concurrent_installs.combine(other.concurrent_installs),
         }
     }
 }

--- a/crates/uv-workspace/src/settings.rs
+++ b/crates/uv-workspace/src/settings.rs
@@ -87,4 +87,5 @@ pub struct PipOptions {
     pub require_hashes: Option<bool>,
     pub concurrent_downloads: Option<NonZeroUsize>,
     pub concurrent_builds: Option<NonZeroUsize>,
+    pub concurrent_installs: Option<NonZeroUsize>,
 }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -51,6 +51,7 @@ indicatif = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }
 owo-colors = { workspace = true }
+rayon = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -176,6 +176,10 @@ async fn run() -> Result<ExitStatus> {
 
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = PipCompileSettings::resolve(args, workspace);
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(args.shared.concurrency.installs)
+                .build_global()
+                .expect("failed to initialize global rayon pool");
 
             // Initialize the cache.
             let cache = cache.init()?.with_refresh(args.refresh);
@@ -247,6 +251,10 @@ async fn run() -> Result<ExitStatus> {
 
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = PipSyncSettings::resolve(args, workspace);
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(args.shared.concurrency.installs)
+                .build_global()
+                .expect("failed to initialize global rayon pool");
 
             // Initialize the cache.
             let cache = cache.init()?.with_refresh(args.refresh);
@@ -293,6 +301,10 @@ async fn run() -> Result<ExitStatus> {
 
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = PipInstallSettings::resolve(args, workspace);
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(args.shared.concurrency.installs)
+                .build_global()
+                .expect("failed to initialize global rayon pool");
 
             // Initialize the cache.
             let cache = cache.init()?.with_refresh(args.refresh);

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -263,6 +263,14 @@
           "format": "uint",
           "minimum": 1.0
         },
+        "concurrent-installs": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 1.0
+        },
         "config-settings": {
           "anyOf": [
             {


### PR DESCRIPTION
## Summary

Continuation of https://github.com/astral-sh/uv/pull/3493. This gives us more flexibility in case we decide to move away from `rayon` in the future.

Should this be named something else? We also use `rayon` for unzipping files, and maybe other things in the future?