### PR TITLE
Remove `SourceDistFilename` from `RegistrySourceDist`

### DIFF
--- a/crates/distribution-types/src/buildable.rs
+++ b/crates/distribution-types/src/buildable.rs
@@ -32,7 +32,7 @@ impl BuildableSource<'_> {
     /// Return the [`Version`] of the source, if available.
     pub fn version(&self) -> Option<&Version> {
         match self {
-            Self::Dist(SourceDist::Registry(dist)) => Some(&dist.filename.version),
+            Self::Dist(SourceDist::Registry(dist)) => Some(&dist.version),
             Self::Dist(_) => None,
             Self::Url(_) => None,
         }

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -39,7 +39,7 @@ use std::str::FromStr;
 use anyhow::Result;
 use url::Url;
 
-use distribution_filename::{SourceDistFilename, WheelFilename};
+use distribution_filename::WheelFilename;
 use pep440_rs::Version;
 use pep508_rs::{Pep508Url, VerbatimUrl};
 use uv_git::GitUrl;
@@ -219,7 +219,8 @@ pub struct PathBuiltDist {
 /// A source distribution that exists in a registry, like `PyPI`.
 #[derive(Debug, Clone)]
 pub struct RegistrySourceDist {
-    pub filename: SourceDistFilename,
+    pub name: PackageName,
+    pub version: Version,
     pub file: Box<File>,
     pub index: IndexUrl,
     /// When an sdist is selected, it may be the case that there were
@@ -489,7 +490,7 @@ impl SourceDist {
 
     pub fn version(&self) -> Option<&Version> {
         match self {
-            Self::Registry(source_dist) => Some(&source_dist.filename.version),
+            Self::Registry(source_dist) => Some(&source_dist.version),
             Self::DirectUrl(_) | Self::Git(_) | Self::Path(_) | Self::Directory(_) => None,
         }
     }
@@ -545,7 +546,7 @@ impl Name for PathBuiltDist {
 
 impl Name for RegistrySourceDist {
     fn name(&self) -> &PackageName {
-        &self.filename.name
+        &self.name
     }
 }
 
@@ -630,7 +631,7 @@ impl DistributionMetadata for PathBuiltDist {
 
 impl DistributionMetadata for RegistrySourceDist {
     fn version_or_url(&self) -> VersionOrUrlRef {
-        VersionOrUrlRef::Version(&self.filename.version)
+        VersionOrUrlRef::Version(&self.version)
     }
 }
 

--- a/crates/distribution-types/src/resolution.rs
+++ b/crates/distribution-types/src/resolution.rs
@@ -98,7 +98,7 @@ impl From<&ResolvedDist> for Requirement {
                 },
                 Dist::Source(SourceDist::Registry(sdist)) => RequirementSource::Registry {
                     specifier: pep440_rs::VersionSpecifiers::from(
-                        pep440_rs::VersionSpecifier::equals_version(sdist.filename.version.clone()),
+                        pep440_rs::VersionSpecifier::equals_version(sdist.version.clone()),
                     ),
                     index: None,
                 },

--- a/crates/distribution-types/src/resolved.rs
+++ b/crates/distribution-types/src/resolved.rs
@@ -61,7 +61,8 @@ impl ResolvedDistRef<'_> {
                 // has an sdist, so this always succeeds.
                 let source = prioritized.source_dist().expect("a source distribution");
                 assert_eq!(
-                    sdist.filename, source.filename,
+                    (&sdist.name, &sdist.version),
+                    (&source.name, &source.version),
                     "expected chosen sdist to match prioritized sdist"
                 );
                 ResolvedDist::Installable(Dist::Source(SourceDist::Registry(source)))

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -93,8 +93,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 let cache_shard = self.build_context.cache().shard(
                     CacheBucket::BuiltWheels,
                     WheelCache::Index(&dist.index)
-                        .wheel_dir(dist.filename.name.as_ref())
-                        .join(dist.filename.version.to_string()),
+                        .wheel_dir(dist.name.as_ref())
+                        .join(dist.version.to_string()),
                 );
 
                 let url = match &dist.file.url {
@@ -250,8 +250,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 let cache_shard = self.build_context.cache().shard(
                     CacheBucket::BuiltWheels,
                     WheelCache::Index(&dist.index)
-                        .wheel_dir(dist.filename.name.as_ref())
-                        .join(dist.filename.version.to_string()),
+                        .wheel_dir(dist.name.as_ref())
+                        .join(dist.version.to_string()),
                 );
 
                 let url = match &dist.file.url {

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -98,7 +98,8 @@ impl FlatIndex {
                 let compatibility =
                     Self::source_dist_compatibility(&filename, &file.hashes, hasher, no_build);
                 let dist = RegistrySourceDist {
-                    filename: filename.clone(),
+                    name: filename.name.clone(),
+                    version: filename.version.clone(),
                     file: Box::new(file),
                     index,
                     wheels: vec![],

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use rustc_hash::FxHashMap;
 use url::Url;
 
-use distribution_filename::{SourceDistFilename, WheelFilename};
+use distribution_filename::WheelFilename;
 use distribution_types::{
     BuiltDist, DirectUrlBuiltDist, DirectUrlSourceDist, DirectorySourceDist, Dist, FileLocation,
     GitSourceDist, IndexUrl, ParsedArchiveUrl, ParsedGitUrl, PathBuiltDist, PathSourceDist,
@@ -340,13 +340,9 @@ impl Distribution {
                     Dist::Source(source_dist)
                 }
                 SourceKind::Registry => {
-                    // TODO(charlie): Introduce an error type to the conversion functions.
-                    let filename =
-                        SourceDistFilename::parse(&sdist.url.filename().unwrap(), &self.id.name)
-                            .unwrap();
                     let file = Box::new(distribution_types::File {
                         dist_info_metadata: false,
-                        filename: filename.to_string(),
+                        filename: sdist.url.filename().unwrap().to_string(),
                         hashes: vec![],
                         requires_python: None,
                         size: None,
@@ -356,7 +352,8 @@ impl Distribution {
                     });
                     let index = IndexUrl::Url(VerbatimUrl::from_url(self.id.source.url.clone()));
                     let reg_dist = RegistrySourceDist {
-                        filename,
+                        name: self.id.name.clone(),
+                        version: self.id.version.clone(),
                         file,
                         index,
                         wheels: vec![],

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1468,7 +1468,8 @@ impl<'a> From<ResolvedDistRef<'a>> for Request {
                 // has an sdist, so this always succeeds.
                 let source = prioritized.source_dist().expect("a source distribution");
                 assert_eq!(
-                    sdist.filename, source.filename,
+                    (&sdist.name, &sdist.version),
+                    (&source.name, &source.version),
                     "expected chosen sdist to match prioritized sdist"
                 );
                 Request::Dist(Dist::Source(SourceDist::Registry(source)))

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -413,7 +413,8 @@ impl VersionMapLazy {
                             upload_time,
                         );
                         let dist = RegistrySourceDist {
-                            filename,
+                            name: filename.name.clone(),
+                            version: filename.version.clone(),
                             file: Box::new(file),
                             index: self.index.clone(),
                             wheels: vec![],


### PR DESCRIPTION
## Summary

Uncertain about this, but we don't actually need the full `SourceDistFilename`, only the name and version -- and we often have that information already (as in the lockfile routines). So by flattening the fields onto `RegistrySourceDist`, we can avoid re-parsing for information we already have.
