### PR TITLE
Use filename trait for `WheelWire` conversion

### DIFF
--- a/crates/distribution-types/src/error.rs
+++ b/crates/distribution-types/src/error.rs
@@ -17,8 +17,8 @@ pub enum Error {
     #[error("Unable to extract file path from URL: {0}")]
     MissingFilePath(Url),
 
-    #[error("Could not extract path segments")]
-    MissingPathSegments,
+    #[error("Could not extract path segments from URL: {0}")]
+    MissingPathSegments(Url),
 
     #[error("Distribution not found at: {0}")]
     NotFound(Url),

--- a/crates/distribution-types/src/error.rs
+++ b/crates/distribution-types/src/error.rs
@@ -14,8 +14,11 @@ pub enum Error {
     #[error(transparent)]
     WheelFilename(#[from] distribution_filename::WheelFilenameError),
 
-    #[error("Unable to extract filename from URL: {0}")]
-    UrlFilename(Url),
+    #[error("Unable to extract file path from URL: {0}")]
+    MissingFilePath(Url),
+
+    #[error("Could not extract path segments")]
+    MissingPathSegments,
 
     #[error("Distribution not found at: {0}")]
     NotFound(Url),

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -702,13 +702,15 @@ impl RemoteSource for File {
 impl RemoteSource for Url {
     fn filename(&self) -> Result<Cow<'_, str>, Error> {
         // Identify the last segment of the URL as the filename.
-        let filename = self
+        let path_segments = self
             .path_segments()
-            .and_then(Iterator::last)
-            .ok_or_else(|| Error::UrlFilename(self.clone()))?;
+            .ok_or_else(|| Error::MissingPathSegments)?;
+
+        // This is guaranteed by the contract of `Url::path_segments`.
+        let last = path_segments.last().expect("path segments is non-empty");
 
         // Decode the filename, which may be percent-encoded.
-        let filename = urlencoding::decode(filename)?;
+        let filename = urlencoding::decode(last)?;
 
         Ok(filename)
     }

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -704,7 +704,7 @@ impl RemoteSource for Url {
         // Identify the last segment of the URL as the filename.
         let path_segments = self
             .path_segments()
-            .ok_or_else(|| Error::MissingPathSegments)?;
+            .ok_or_else(|| Error::MissingPathSegments(self.clone()))?;
 
         // This is guaranteed by the contract of `Url::path_segments`.
         let last = path_segments.last().expect("path segments is non-empty");

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -337,7 +337,7 @@ impl<'a> Planner<'a> {
                     // Store the canonicalized path, which also serves to validate that it exists.
                     let path = match url
                         .to_file_path()
-                        .map_err(|()| Error::UrlFilename(url.to_url()))?
+                        .map_err(|()| Error::MissingFilePath(url.to_url()))?
                         .canonicalize()
                     {
                         Ok(path) => path,

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -1076,10 +1076,7 @@ impl TryFrom<WheelWire> for Wheel {
 
     fn try_from(wire: WheelWire) -> Result<Wheel, String> {
         // Extract the filename segment from the URL.
-        let filename = wire
-            .url
-            .filename()
-            .map_err(|err| format!("failed to extract filename from URL `{}`: {err}", wire.url))?;
+        let filename = wire.url.filename().map_err(|err| err.to_string())?;
 
         // Parse the filename as a wheel filename.
         let filename = filename

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -1075,15 +1075,17 @@ impl TryFrom<WheelWire> for Wheel {
     type Error = String;
 
     fn try_from(wire: WheelWire) -> Result<Wheel, String> {
-        let path_segments = wire
+        // Extract the filename segment from the URL.
+        let filename = wire
             .url
-            .path_segments()
-            .ok_or_else(|| format!("could not extract path from URL `{}`", wire.url))?;
-        // This is guaranteed by the contract of Url::path_segments.
-        let last = path_segments.last().expect("path segments is non-empty");
-        let filename = last
+            .filename()
+            .map_err(|err| format!("failed to extract filename from URL `{}`: {err}", wire.url))?;
+
+        // Parse the filename as a wheel filename.
+        let filename = filename
             .parse::<WheelFilename>()
-            .map_err(|err| format!("failed to parse `{last}` as wheel filename: {err}"))?;
+            .map_err(|err| format!("failed to parse `{filename}` as wheel filename: {err}"))?;
+
         Ok(Wheel {
             url: wire.url,
             hash: wire.hash,


### PR DESCRIPTION
## Summary

The main motivation here is that the `.filename()` method that we implement on `Url` will do URL decoding for the last segment, which we were missing here.

The errors are a bit awkward, because in `crates/uv-resolver/src/lock.rs`, we wrap in `failed to extract filename from URL: {url}`, so in theory we want the underlying errors to _omit_ the URL? But sometimes they use `#[error(transparent)]`?
