### PR TITLE
add `Option<MarkerTree>` to `PubGrubPackage`

### DIFF
--- a/crates/distribution-types/src/parsed_url.rs
+++ b/crates/distribution-types/src/parsed_url.rs
@@ -23,7 +23,7 @@ pub enum ParsedUrlError {
     UrlParse(String, #[source] url::ParseError),
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, PartialOrd, Eq, Ord)]
 pub struct VerbatimParsedUrl {
     pub parsed_url: ParsedUrl,
     pub verbatim: VerbatimUrl,
@@ -36,7 +36,7 @@ pub struct VerbatimParsedUrl {
 /// * A remote archive (`https://`), optional with a subdirectory (source dist only).
 ///
 /// A URL in a requirement `foo @ <url>` must be one of the above.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Ord)]
 pub enum ParsedUrl {
     /// The direct URL is a path to a local directory or file.
     Path(ParsedPathUrl),
@@ -51,7 +51,7 @@ pub enum ParsedUrl {
 ///
 /// Examples:
 /// * `file:///home/ferris/my_project`
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Ord)]
 pub struct ParsedPathUrl {
     pub url: Url,
     pub path: PathBuf,
@@ -63,7 +63,7 @@ pub struct ParsedPathUrl {
 /// Examples:
 /// * `git+https://git.example.com/MyProject.git`
 /// * `git+https://git.example.com/MyProject.git@v1.0#egg=pkg&subdirectory=pkg_dir`
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Ord)]
 pub struct ParsedGitUrl {
     pub url: GitUrl,
     pub subdirectory: Option<PathBuf>,
@@ -96,7 +96,7 @@ impl TryFrom<Url> for ParsedGitUrl {
 /// * A built distribution: `https://files.pythonhosted.org/packages/62/06/d5604a70d160f6a6ca5fd2ba25597c24abd5c5ca5f437263d177ac242308/tqdm-4.66.1-py2.py3-none-any.whl`
 /// * A source distribution with a valid name: `https://files.pythonhosted.org/packages/62/06/d5604a70d160f6a6ca5fd2ba25597c24abd5c5ca5f437263d177ac242308/tqdm-4.66.1.tar.gz`
 /// * A source dist with a recognizable extension but invalid name: `https://github.com/foo-labs/foo/archive/master.zip#egg=pkg&subdirectory=packages/bar`
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct ParsedArchiveUrl {
     pub url: Url,
     pub subdirectory: Option<PathBuf>,

--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -15,7 +15,17 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 /// One of `~=` `==` `!=` `<=` `>=` `<` `>` `===`
 #[derive(
-    Eq, PartialEq, Debug, Hash, Clone, Copy, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Debug,
+    Hash,
+    Clone,
+    Copy,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
 )]
 #[archive(check_bytes)]
 #[archive_attr(derive(Debug, Eq, PartialEq, PartialOrd, Ord))]

--- a/crates/pep440-rs/src/version_specifier.rs
+++ b/crates/pep440-rs/src/version_specifier.rs
@@ -250,7 +250,18 @@ impl std::error::Error for VersionSpecifiersParseError {}
 /// let version_specifier = VersionSpecifier::from_str("== 1.*").unwrap();
 /// assert!(version_specifier.contains(&version));
 /// ```
-#[derive(Eq, PartialEq, Debug, Clone, Hash, rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)]
+#[derive(
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Debug,
+    Clone,
+    Hash,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
 #[archive(check_bytes)]
 #[archive_attr(derive(Debug))]
 #[cfg_attr(feature = "pyo3", pyclass(get_all))]

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -63,7 +63,7 @@ impl MarkerWarningKind {
 }
 
 /// Those environment markers with a PEP 440 version as value such as `python_version`
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[allow(clippy::enum_variant_names)]
 pub enum MarkerValueVersion {
     /// `implementation_version`
@@ -85,7 +85,7 @@ impl Display for MarkerValueVersion {
 }
 
 /// Those environment markers with an arbitrary string as value such as `sys_platform`
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum MarkerValueString {
     /// `implementation_name`
     ImplementationName,
@@ -142,7 +142,7 @@ impl Display for MarkerValueString {
 /// One of the predefined environment values
 ///
 /// <https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers>
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum MarkerValue {
     /// Those environment markers with a PEP 440 version as value such as `python_version`
     MarkerEnvVersion(MarkerValueVersion),
@@ -214,7 +214,7 @@ impl Display for MarkerValue {
 }
 
 /// How to compare key and value, such as by `==`, `>` or `not in`
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum MarkerOperator {
     /// `==`
     Equal,
@@ -900,7 +900,7 @@ impl<'a> TryFrom<MarkerEnvironmentBuilder<'a>> for MarkerEnvironment {
 }
 
 /// Represents one clause such as `python_version > "3.8"`.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[allow(missing_docs)]
 pub enum MarkerExpression {
     /// A version expression, e.g. `<version key> <version op> <quoted PEP 440 version>`.
@@ -943,7 +943,7 @@ pub enum MarkerExpression {
 }
 
 /// The operator for an extra expression, either '==' or '!='.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum ExtraOperator {
     /// `==`
     Equal,
@@ -1529,7 +1529,7 @@ impl Display for MarkerExpression {
 }
 
 /// Represents one of the nested marker expressions with and/or/parentheses
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum MarkerTree {
     /// A simple expression such as `python_version > "3.8"`
     Expression(MarkerExpression),

--- a/crates/pep508-rs/src/verbatim_url.rs
+++ b/crates/pep508-rs/src/verbatim_url.rs
@@ -14,7 +14,7 @@ use crate::Pep508Url;
 
 /// A wrapper around [`Url`] that preserves the original string.
 #[derive(Debug, Clone, Eq, derivative::Derivative, serde::Deserialize, serde::Serialize)]
-#[derivative(PartialEq, Hash)]
+#[derivative(PartialEq, Hash, Ord)]
 pub struct VerbatimUrl {
     /// The parsed URL.
     #[serde(
@@ -24,6 +24,7 @@ pub struct VerbatimUrl {
     url: Url,
     /// The URL as it was provided by the user.
     #[derivative(PartialEq = "ignore")]
+    #[derivative(Ord = "ignore")]
     #[derivative(Hash = "ignore")]
     given: Option<String>,
 }
@@ -160,6 +161,16 @@ impl VerbatimUrl {
     /// verbatim representation.
     pub fn unknown(url: Url) -> Self {
         Self { given: None, url }
+    }
+}
+
+// This impl is written out because the `derive` doesn't seem to get it right.
+// Or does it in a way where Clippy complains about non-canonical `PartialOrd`
+// impls. So we just do it by hand by deferring to the derived `Ord` impl. This
+// guarantees they are consistent.
+impl PartialOrd for VerbatimUrl {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -23,7 +23,7 @@ use crate::FetchStrategy;
 const CHECKOUT_READY_LOCK: &str = ".ok";
 
 /// A reference to commit or commit-ish.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum GitReference {
     /// A specific branch.
     Branch(String),

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -12,7 +12,7 @@ mod source;
 mod util;
 
 /// A URL reference to a Git repository.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Hash, Ord)]
 pub struct GitUrl {
     /// The URL of the Git repository, with any query parameters, fragments, and leading `git+`
     /// removed.

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -127,7 +127,7 @@ fn collapse_extra_proxies(
             ) {
                 (
                     DerivationTree::External(External::FromDependencyOf(
-                        PubGrubPackage::Extra(..),
+                        PubGrubPackage::Extra { .. },
                         ..,
                     )),
                     ref mut cause,
@@ -138,7 +138,7 @@ fn collapse_extra_proxies(
                 (
                     ref mut cause,
                     DerivationTree::External(External::FromDependencyOf(
-                        PubGrubPackage::Extra(..),
+                        PubGrubPackage::Extra { .. },
                         ..,
                     )),
                 ) => {
@@ -255,8 +255,8 @@ impl NoSolutionError {
                         BTreeSet::from([python_requirement.target().deref().clone()]),
                     );
                 }
-                PubGrubPackage::Extra(_, _, _) => {}
-                PubGrubPackage::Package(name, _, _) => {
+                PubGrubPackage::Extra { .. } => {}
+                PubGrubPackage::Package { name, .. } => {
                     // Avoid including available versions for packages that exist in the derivation
                     // tree, but were never visited during resolution. We _may_ have metadata for
                     // these packages, but it's non-deterministic, and omitting them ensures that
@@ -304,7 +304,7 @@ impl NoSolutionError {
     ) -> Self {
         let mut new = FxHashMap::default();
         for package in self.derivation_tree.packages() {
-            if let PubGrubPackage::Package(name, _, _) = package {
+            if let PubGrubPackage::Package { name, .. } = package {
                 if let Some(reason) = unavailable_packages.get(name) {
                     new.insert(name.clone(), reason.clone());
                 }
@@ -322,7 +322,7 @@ impl NoSolutionError {
     ) -> Self {
         let mut new = FxHashMap::default();
         for package in self.derivation_tree.packages() {
-            if let PubGrubPackage::Package(name, _, _) = package {
+            if let PubGrubPackage::Package { name, .. } = package {
                 if let Some(versions) = incomplete_packages.get(name) {
                     for entry in versions.iter() {
                         let (version, reason) = entry.pair();

--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -223,7 +223,12 @@ impl PubGrubRequirement {
                 };
 
                 Ok(Self {
-                    package: PubGrubPackage::from_package(requirement.name.clone(), extra, urls),
+                    package: PubGrubPackage::from_package(
+                        requirement.name.clone(),
+                        extra,
+                        None,
+                        urls,
+                    ),
                     version,
                 })
             }
@@ -247,6 +252,7 @@ impl PubGrubRequirement {
                     package: PubGrubPackage::Package {
                         name: requirement.name.clone(),
                         extra,
+                        marker: None,
                         url: Some(expected.clone()),
                     },
                     version: Range::full(),
@@ -272,6 +278,7 @@ impl PubGrubRequirement {
                     package: PubGrubPackage::Package {
                         name: requirement.name.clone(),
                         extra,
+                        marker: None,
                         url: Some(expected.clone()),
                     },
                     version: Range::full(),
@@ -297,6 +304,7 @@ impl PubGrubRequirement {
                     package: PubGrubPackage::Package {
                         name: requirement.name.clone(),
                         extra,
+                        marker: None,
                         url: Some(expected.clone()),
                     },
                     version: Range::full(),

--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -103,7 +103,7 @@ fn add_requirements(
             let PubGrubRequirement { package, version } = result?;
 
             match &package {
-                PubGrubPackage::Package(name, ..) => {
+                PubGrubPackage::Package { name, .. } => {
                     // Detect self-dependencies.
                     if source_name.is_some_and(|source_name| source_name == name) {
                         warn!("{name} has a dependency on itself");
@@ -112,7 +112,7 @@ fn add_requirements(
 
                     dependencies.push((package.clone(), version.clone()));
                 }
-                PubGrubPackage::Extra(name, extra, ..) => {
+                PubGrubPackage::Extra { name, extra, .. } => {
                     // Recursively add the dependencies of the current package (e.g., `black` depending on
                     // `black[colorama]`).
                     if source_name.is_some_and(|source_name| source_name == name) {
@@ -158,7 +158,7 @@ fn add_requirements(
                     PubGrubRequirement::from_constraint(constraint, urls, locals)?;
 
                 // Ignore self-dependencies.
-                if let PubGrubPackage::Package(name, ..) = &package {
+                if let PubGrubPackage::Package { name, .. } = &package {
                     // Detect self-dependencies.
                     if source_name.is_some_and(|source_name| source_name == name) {
                         warn!("{name} has a dependency on itself");
@@ -244,11 +244,11 @@ impl PubGrubRequirement {
                 }
 
                 Ok(Self {
-                    package: PubGrubPackage::Package(
-                        requirement.name.clone(),
+                    package: PubGrubPackage::Package {
+                        name: requirement.name.clone(),
                         extra,
-                        Some(expected.clone()),
-                    ),
+                        url: Some(expected.clone()),
+                    },
                     version: Range::full(),
                 })
             }
@@ -269,11 +269,11 @@ impl PubGrubRequirement {
                 }
 
                 Ok(Self {
-                    package: PubGrubPackage::Package(
-                        requirement.name.clone(),
+                    package: PubGrubPackage::Package {
+                        name: requirement.name.clone(),
                         extra,
-                        Some(expected.clone()),
-                    ),
+                        url: Some(expected.clone()),
+                    },
                     version: Range::full(),
                 })
             }
@@ -294,11 +294,11 @@ impl PubGrubRequirement {
                 }
 
                 Ok(Self {
-                    package: PubGrubPackage::Package(
-                        requirement.name.clone(),
+                    package: PubGrubPackage::Package {
+                        name: requirement.name.clone(),
                         extra,
-                        Some(expected.clone()),
-                    ),
+                        url: Some(expected.clone()),
+                    },
                     version: Range::full(),
                 })
             }

--- a/crates/uv-resolver/src/pubgrub/package.rs
+++ b/crates/uv-resolver/src/pubgrub/package.rs
@@ -10,7 +10,7 @@ use crate::resolver::Urls;
 /// 2. Uses the same strategy as pip and posy to handle extras: for each extra, we create a virtual
 ///    package (e.g., `black[colorama]`), and mark it as a dependency of the real package (e.g.,
 ///    `black`). We then discard the virtual packages at the end of the resolution process.
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum PubGrubPackage {
     /// The root package, which is used to start the resolution process.
     Root(Option<PackageName>),
@@ -90,7 +90,7 @@ impl PubGrubPackage {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Hash, Ord)]
 pub enum PubGrubPython {
     /// The Python version installed in the current environment.
     Installed,

--- a/crates/uv-resolver/src/pubgrub/package.rs
+++ b/crates/uv-resolver/src/pubgrub/package.rs
@@ -1,5 +1,3 @@
-use derivative::Derivative;
-
 use distribution_types::VerbatimParsedUrl;
 use uv_normalize::{ExtraName, PackageName};
 
@@ -12,8 +10,7 @@ use crate::resolver::Urls;
 /// 2. Uses the same strategy as pip and posy to handle extras: for each extra, we create a virtual
 ///    package (e.g., `black[colorama]`), and mark it as a dependency of the real package (e.g.,
 ///    `black`). We then discard the virtual packages at the end of the resolution process.
-#[derive(Debug, Clone, Eq, Derivative)]
-#[derivative(PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum PubGrubPackage {
     /// The root package, which is used to start the resolution process.
     Root(Option<PackageName>),

--- a/crates/uv-resolver/src/pubgrub/priority.rs
+++ b/crates/uv-resolver/src/pubgrub/priority.rs
@@ -28,7 +28,12 @@ impl PubGrubPriorities {
             PubGrubPackage::Root(_) => {}
             PubGrubPackage::Python(_) => {}
 
-            PubGrubPackage::Extra(name, _, None) | PubGrubPackage::Package(name, _, None) => {
+            PubGrubPackage::Extra {
+                name, url: None, ..
+            }
+            | PubGrubPackage::Package {
+                name, url: None, ..
+            } => {
                 match self.0.entry(name.clone()) {
                     std::collections::hash_map::Entry::Occupied(mut entry) => {
                         // Preserve the original index.
@@ -61,7 +66,12 @@ impl PubGrubPriorities {
                     }
                 }
             }
-            PubGrubPackage::Extra(name, _, Some(_)) | PubGrubPackage::Package(name, _, Some(_)) => {
+            PubGrubPackage::Extra {
+                name, url: Some(_), ..
+            }
+            | PubGrubPackage::Package {
+                name, url: Some(_), ..
+            } => {
                 match self.0.entry(name.clone()) {
                     std::collections::hash_map::Entry::Occupied(mut entry) => {
                         // Preserve the original index.
@@ -94,8 +104,8 @@ impl PubGrubPriorities {
         match package {
             PubGrubPackage::Root(_) => Some(PubGrubPriority::Root),
             PubGrubPackage::Python(_) => Some(PubGrubPriority::Root),
-            PubGrubPackage::Extra(name, _, _) => self.0.get(name).copied(),
-            PubGrubPackage::Package(name, _, _) => self.0.get(name).copied(),
+            PubGrubPackage::Extra { name, .. } => self.0.get(name).copied(),
+            PubGrubPackage::Package { name, .. } => self.0.get(name).copied(),
         }
     }
 }

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -155,14 +155,14 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
         let terms_vec: Vec<_> = terms.iter().collect();
         match terms_vec.as_slice() {
             [] | [(PubGrubPackage::Root(_), _)] => "the requirements are unsatisfiable".into(),
-            [(package @ PubGrubPackage::Package(..), Term::Positive(range))] => {
+            [(package @ PubGrubPackage::Package { .. }, Term::Positive(range))] => {
                 let range = self.simplify_set(range, package);
                 format!(
                     "{} cannot be used",
                     PackageRange::compatibility(package, &range)
                 )
             }
-            [(package @ PubGrubPackage::Package(..), Term::Negative(range))] => {
+            [(package @ PubGrubPackage::Package { .. }, Term::Negative(range))] => {
                 let range = self.simplify_set(range, package);
                 format!(
                     "{} must be used",
@@ -399,10 +399,10 @@ impl PubGrubReportFormatter<'_> {
     ) -> IndexSet<PubGrubHint> {
         /// Returns `true` if pre-releases were allowed for a package.
         fn allowed_prerelease(package: &PubGrubPackage, selector: &CandidateSelector) -> bool {
-            let PubGrubPackage::Package(package, ..) = package else {
+            let PubGrubPackage::Package { name, .. } = package else {
                 return false;
             };
-            selector.prerelease_strategy().allows(package)
+            selector.prerelease_strategy().allows(name)
         }
 
         let mut hints = IndexSet::default();
@@ -457,7 +457,7 @@ impl PubGrubReportFormatter<'_> {
                         let no_find_links =
                             index_locations.flat_index().peekable().peek().is_none();
 
-                        if let PubGrubPackage::Package(name, ..) = package {
+                        if let PubGrubPackage::Package { name, .. } = package {
                             // Add hints due to the package being entirely unavailable.
                             match unavailable_packages.get(name) {
                                 Some(UnavailablePackage::NoIndex) => {

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -152,7 +152,10 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
 
     /// Try to print terms of an incompatibility in a human-readable way.
     fn format_terms(&self, terms: &Map<PubGrubPackage, Term<Range<Version>>>) -> String {
-        let terms_vec: Vec<_> = terms.iter().collect();
+        let mut terms_vec: Vec<_> = terms.iter().collect();
+        // We avoid relying on hashmap iteration order here by always sorting
+        // by package first.
+        terms_vec.sort_by(|&(pkg1, _), &(pkg2, _)| pkg1.cmp(pkg2));
         match terms_vec.as_slice() {
             [] | [(PubGrubPackage::Root(_), _)] => "the requirements are unsatisfiable".into(),
             [(package @ PubGrubPackage::Package { .. }, Term::Positive(range))] => {

--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -59,6 +59,7 @@ impl ResolutionGraph {
                 PubGrubPackage::Package {
                     name,
                     extra: Some(extra),
+                    marker: None,
                     url: None,
                 } => {
                     let dist = PubGrubDistribution::from_registry(name, version);
@@ -97,6 +98,7 @@ impl ResolutionGraph {
                 PubGrubPackage::Package {
                     name,
                     extra: Some(extra),
+                    marker: None,
                     url: Some(url),
                 } => {
                     if let Some(editable) = editables.get(name) {
@@ -161,6 +163,7 @@ impl ResolutionGraph {
                 PubGrubPackage::Package {
                     name,
                     extra: None,
+                    marker: None,
                     url: None,
                 } => {
                     // Create the distribution.
@@ -229,6 +232,7 @@ impl ResolutionGraph {
                 PubGrubPackage::Package {
                     name,
                     extra: None,
+                    marker: None,
                     url: Some(url),
                 } => {
                     // Create the distribution.

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -56,6 +56,7 @@ impl BatchPrefetcher {
         let PubGrubPackage::Package {
             name,
             extra: None,
+            marker: None,
             url: None,
         } = &next
         else {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -687,6 +687,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             let PubGrubPackage::Package {
                 name,
                 extra: None,
+                marker: None,
                 url: None,
             } = package
             else {
@@ -974,6 +975,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     let package = PubGrubPackage::from_package(
                         editable.metadata.name.clone(),
                         None,
+                        None,
                         &self.urls,
                     );
                     let version = Range::singleton(editable.metadata.version.clone());
@@ -990,6 +992,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             PubGrubPackage::from_package(
                                 editable.metadata.name.clone(),
                                 Some(extra.clone()),
+                                None,
                                 &self.urls,
                             ),
                             Range::singleton(editable.metadata.version.clone()),
@@ -1020,7 +1023,12 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
             PubGrubPackage::Python(_) => Ok(Dependencies::Available(Vec::default())),
 
-            PubGrubPackage::Package { name, extra, url } => {
+            PubGrubPackage::Package {
+                name,
+                extra,
+                marker: _marker,
+                url,
+            } => {
                 // If we're excluding transitive dependencies, short-circuit.
                 if self.dependency_mode.is_direct() {
                     // If an extra is provided, wait for the metadata to be available, since it's
@@ -1184,11 +1192,17 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             }
 
             // Add a dependency on both the extra and base package.
-            PubGrubPackage::Extra { name, extra, url } => Ok(Dependencies::Available(vec![
+            PubGrubPackage::Extra {
+                name,
+                extra,
+                marker: _marker,
+                url,
+            } => Ok(Dependencies::Available(vec![
                 (
                     PubGrubPackage::Package {
                         name: name.clone(),
                         extra: None,
+                        marker: None,
                         url: url.clone(),
                     },
                     Range::singleton(version.clone()),
@@ -1197,6 +1211,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     PubGrubPackage::Package {
                         name: name.clone(),
                         extra: Some(extra.clone()),
+                        marker: None,
                         url: url.clone(),
                     },
                     Range::singleton(version.clone()),

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -470,7 +470,7 @@ fn dependency_excludes_range_of_compatible_versions() {
               package-a<2.0.0
               package-a>=3.0.0
 
-          And because we know from (1) that package-a<2.0.0 depends on package-b==1.0.0, we can conclude that package-a!=3.0.0, all versions of package-c, package-b!=1.0.0 are incompatible.
+          And because we know from (1) that package-a<2.0.0 depends on package-b==1.0.0, we can conclude that package-a!=3.0.0, package-b!=1.0.0, all versions of package-c are incompatible.
           And because package-a==3.0.0 depends on package-b==3.0.0, we can conclude that all versions of package-c depend on one of:
               package-b<=1.0.0
               package-b>=3.0.0
@@ -595,7 +595,7 @@ fn dependency_excludes_non_contiguous_range_of_compatible_versions() {
               package-a<2.0.0
               package-a>=3.0.0
 
-          And because we know from (1) that package-a<2.0.0 depends on package-b==1.0.0, we can conclude that all versions of package-c, package-a!=3.0.0, package-b!=1.0.0 are incompatible.
+          And because we know from (1) that package-a<2.0.0 depends on package-b==1.0.0, we can conclude that package-a!=3.0.0, package-b!=1.0.0, all versions of package-c are incompatible.
           And because package-a==3.0.0 depends on package-b==3.0.0, we can conclude that all versions of package-c depend on one of:
               package-b<=1.0.0
               package-b>=3.0.0
@@ -3378,7 +3378,7 @@ fn transitive_prerelease_and_stable_dependency_many_versions() {
       × No solution found when resolving dependencies:
       ╰─▶ Because only package-a==1.0.0 is available and package-a==1.0.0 depends on package-c>=2.0.0b1, we can conclude that all versions of package-a depend on package-c>=2.0.0b1.
           And because only package-c<2.0.0b1 is available, we can conclude that all versions of package-a depend on package-c>3.0.0.
-          And because package-b==1.0.0 depends on package-c and only package-b==1.0.0 is available, we can conclude that all versions of package-b and all versions of package-a are incompatible.
+          And because package-b==1.0.0 depends on package-c and only package-b==1.0.0 is available, we can conclude that all versions of package-a and all versions of package-b are incompatible.
           And because you require package-a and package-b, we can conclude that the requirements are unsatisfiable.
 
           hint: package-c was requested with a pre-release marker (e.g., package-c>=2.0.0b1), but pre-releases weren't enabled (try: `--prerelease=allow`)


### PR DESCRIPTION
I'm plucking this off my WIP of resolver forking since it grew to
a fairly sizable change on its own. In this PR, all we do is add
`Option<MarkerTree>` to `PubGrubPackage`, but otherwise don't do any
semantic changes.

While conceptually simple, adding this tripped some test failures as a
result of the output depending on hashmap iteration order. So part of
this PR is devoted to removing that dependency and making the output
independent of hashmap iteration order.

I took the approach of making `PubGrubPackage` implement `Ord`. This in
turn required implementing `Ord` for a number of other types. So this
feels like a somewhat invasive change, although I did feel like all of
the `Ord` impls "made sense" for the types they were being added to.

Reviewing this PR commit-by-commit should be much easier than looking
at the full diff.

Closes #3359
