### PR TITLE
Allow users to specify a custom source package to `uv tool run`

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1945,6 +1945,12 @@ pub(crate) struct ToolRunArgs {
     #[arg(allow_hyphen_values = true)]
     pub(crate) args: Vec<OsString>,
 
+    /// Use the given package to provide the command.
+    ///
+    /// By default, the package name is assumed to match the command name.
+    #[arg(long)]
+    pub(crate) from: Option<String>,
+
     /// The Python interpreter to use to build the run environment.
     #[arg(
         long,

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -23,6 +23,7 @@ pub(crate) async fn run(
     target: String,
     args: Vec<OsString>,
     python: Option<String>,
+    from: Option<String>,
     _isolated: bool,
     preview: PreviewMode,
     cache: &Cache,
@@ -32,9 +33,10 @@ pub(crate) async fn run(
         warn_user!("`uv tool run` is experimental and may change without warning.");
     }
 
-    // TODO(zanieb): Allow users to pass an explicit package name different than the target
-    // as well as additional requirements
-    let requirements = [RequirementsSource::from_package(target.clone())];
+    // TODO(zanieb): Allow users to pass additional requirements
+    let requirements = [RequirementsSource::from_package(
+        from.unwrap_or_else(|| target.clone()),
+    )];
 
     // TODO(zanieb): When implementing project-level tools, discover the project and check if it has the tool
     // TOOD(zanieb): Determine if we sould layer on top of the project environment if it is present

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -607,6 +607,7 @@ async fn run() -> Result<ExitStatus> {
                 args.target,
                 args.args,
                 args.python,
+                args.from,
                 globals.isolated,
                 globals.preview,
                 &cache,


### PR DESCRIPTION
We usually infer the package the tool is pulled from to be the same name as the tool itself, but that's not always the case. This allows users to provide a custom package.