### PR TITLE
Allow specification of additional requirements in `uv tool run`

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1946,6 +1946,10 @@ pub(crate) struct ToolRunArgs {
     #[arg(long)]
     pub(crate) from: Option<String>,
 
+    /// Include the following extra requirements.
+    #[arg(long)]
+    pub(crate) with: Vec<String>,
+
     /// The Python interpreter to use to build the run environment.
     #[arg(
         long,

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -25,6 +25,7 @@ pub(crate) async fn run(
     args: Vec<OsString>,
     python: Option<String>,
     from: Option<String>,
+    with: Vec<String>,
     _isolated: bool,
     preview: PreviewMode,
     connectivity: Connectivity,
@@ -35,10 +36,12 @@ pub(crate) async fn run(
         warn_user!("`uv tool run` is experimental and may change without warning.");
     }
 
-    // TODO(zanieb): Allow users to pass additional requirements
     let requirements = [RequirementsSource::from_package(
         from.unwrap_or_else(|| target.clone()),
-    )];
+    )]
+    .into_iter()
+    .chain(with.into_iter().map(RequirementsSource::from_package))
+    .collect::<Vec<_>>();
 
     // TODO(zanieb): When implementing project-level tools, discover the project and check if it has the tool
     // TOOD(zanieb): Determine if we sould layer on top of the project environment if it is present

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -622,6 +622,7 @@ async fn run() -> Result<ExitStatus> {
                 args.args,
                 args.python,
                 args.from,
+                args.with,
                 globals.isolated,
                 globals.preview,
                 globals.connectivity,


### PR DESCRIPTION
Allows requesting additional transitive dependencies when running a tool.

e.g. `uv tool run -v --with anyio ruff check example.py` (Why would you want anyio with ruff? Who knows 😄)

The motivation for doing this now is that I think the first implementation of `uv tool install` might just shim into `uv tool run` with pinned dependencies? Regardless this is something we need in the long run and is a trivial addition right now.

