### PR TITLE
Change arbitrary comment in `marker.rs`

### DIFF
--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -934,7 +934,7 @@ pub enum MarkerExpression {
     },
     /// An invalid or meaningless expression, such as '...' == '...'.
     ///
-    /// Invalid expressions always evaluate to `false`, and are warned for during parsing.
+    /// Invalid expressions always evaluate to `true`, and are warned for during parsing.
     Arbitrary {
         l_value: MarkerValue,
         operator: MarkerOperator,


### PR DESCRIPTION
## Summary

My read of the code is that these are always evaluated to `true`, such that they're effectively ignored?
