### PR TITLE
Arc-wrap `PubGrubPackage` for cheap cloning in pubgrub

### DIFF
--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -37,6 +37,7 @@ anstream = { workspace = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"], optional = true }
+dashmap = { workspace = true }
 derivative = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
@@ -56,7 +57,6 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-dashmap = { workspace = true }
 
 [dev-dependencies]
 uv-interpreter = { workspace = true }

--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -10,7 +10,7 @@ use uv_configuration::{Constraints, Overrides};
 use uv_normalize::{ExtraName, PackageName};
 
 use crate::pubgrub::specifier::PubGrubSpecifier;
-use crate::pubgrub::PubGrubPackage;
+use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner};
 use crate::resolver::{Locals, Urls};
 use crate::ResolveError;
 
@@ -102,8 +102,8 @@ fn add_requirements(
         })) {
             let PubGrubRequirement { package, version } = result?;
 
-            match &package {
-                PubGrubPackage::Package { name, .. } => {
+            match &*package {
+                PubGrubPackageInner::Package { name, .. } => {
                     // Detect self-dependencies.
                     if source_name.is_some_and(|source_name| source_name == name) {
                         warn!("{name} has a dependency on itself");
@@ -112,7 +112,7 @@ fn add_requirements(
 
                     dependencies.push((package.clone(), version.clone()));
                 }
-                PubGrubPackage::Extra { name, extra, .. } => {
+                PubGrubPackageInner::Extra { name, extra, .. } => {
                     // Recursively add the dependencies of the current package (e.g., `black` depending on
                     // `black[colorama]`).
                     if source_name.is_some_and(|source_name| source_name == name) {
@@ -158,7 +158,7 @@ fn add_requirements(
                     PubGrubRequirement::from_constraint(constraint, urls, locals)?;
 
                 // Ignore self-dependencies.
-                if let PubGrubPackage::Package { name, .. } = &package {
+                if let PubGrubPackageInner::Package { name, .. } = &*package {
                     // Detect self-dependencies.
                     if source_name.is_some_and(|source_name| source_name == name) {
                         warn!("{name} has a dependency on itself");
@@ -249,12 +249,12 @@ impl PubGrubRequirement {
                 }
 
                 Ok(Self {
-                    package: PubGrubPackage::Package {
+                    package: PubGrubPackage::from(PubGrubPackageInner::Package {
                         name: requirement.name.clone(),
                         extra,
                         marker: None,
                         url: Some(expected.clone()),
-                    },
+                    }),
                     version: Range::full(),
                 })
             }
@@ -275,12 +275,12 @@ impl PubGrubRequirement {
                 }
 
                 Ok(Self {
-                    package: PubGrubPackage::Package {
+                    package: PubGrubPackage::from(PubGrubPackageInner::Package {
                         name: requirement.name.clone(),
                         extra,
                         marker: None,
                         url: Some(expected.clone()),
-                    },
+                    }),
                     version: Range::full(),
                 })
             }
@@ -301,12 +301,12 @@ impl PubGrubRequirement {
                 }
 
                 Ok(Self {
-                    package: PubGrubPackage::Package {
+                    package: PubGrubPackage::from(PubGrubPackageInner::Package {
                         name: requirement.name.clone(),
                         extra,
                         marker: None,
                         url: Some(expected.clone()),
-                    },
+                    }),
                     version: Range::full(),
                 })
             }

--- a/crates/uv-resolver/src/pubgrub/mod.rs
+++ b/crates/uv-resolver/src/pubgrub/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) use crate::pubgrub::dependencies::{PubGrubDependencies, PubGrubRequirement};
 pub(crate) use crate::pubgrub::distribution::PubGrubDistribution;
-pub(crate) use crate::pubgrub::package::{PubGrubPackage, PubGrubPython};
+pub(crate) use crate::pubgrub::package::{PubGrubPackage, PubGrubPackageInner, PubGrubPython};
 pub(crate) use crate::pubgrub::priority::{PubGrubPriorities, PubGrubPriority};
 pub(crate) use crate::pubgrub::report::PubGrubReportFormatter;
 pub(crate) use crate::pubgrub::specifier::PubGrubSpecifier;

--- a/crates/uv-resolver/src/pubgrub/priority.rs
+++ b/crates/uv-resolver/src/pubgrub/priority.rs
@@ -7,6 +7,7 @@ use pep440_rs::Version;
 use uv_normalize::PackageName;
 
 use crate::pubgrub::package::PubGrubPackage;
+use crate::pubgrub::PubGrubPackageInner;
 
 /// A prioritization map to guide the PubGrub resolution process.
 ///
@@ -24,14 +25,14 @@ impl PubGrubPriorities {
     /// Add a [`PubGrubPackage`] to the priority map.
     pub(crate) fn insert(&mut self, package: &PubGrubPackage, version: &Range<Version>) {
         let next = self.0.len();
-        match package {
-            PubGrubPackage::Root(_) => {}
-            PubGrubPackage::Python(_) => {}
+        match &**package {
+            PubGrubPackageInner::Root(_) => {}
+            PubGrubPackageInner::Python(_) => {}
 
-            PubGrubPackage::Extra {
+            PubGrubPackageInner::Extra {
                 name, url: None, ..
             }
-            | PubGrubPackage::Package {
+            | PubGrubPackageInner::Package {
                 name, url: None, ..
             } => {
                 match self.0.entry(name.clone()) {
@@ -66,10 +67,10 @@ impl PubGrubPriorities {
                     }
                 }
             }
-            PubGrubPackage::Extra {
+            PubGrubPackageInner::Extra {
                 name, url: Some(_), ..
             }
-            | PubGrubPackage::Package {
+            | PubGrubPackageInner::Package {
                 name, url: Some(_), ..
             } => {
                 match self.0.entry(name.clone()) {
@@ -101,11 +102,11 @@ impl PubGrubPriorities {
 
     /// Return the [`PubGrubPriority`] of the given package, if it exists.
     pub(crate) fn get(&self, package: &PubGrubPackage) -> Option<PubGrubPriority> {
-        match package {
-            PubGrubPackage::Root(_) => Some(PubGrubPriority::Root),
-            PubGrubPackage::Python(_) => Some(PubGrubPriority::Root),
-            PubGrubPackage::Extra { name, .. } => self.0.get(name).copied(),
-            PubGrubPackage::Package { name, .. } => self.0.get(name).copied(),
+        match &**package {
+            PubGrubPackageInner::Root(_) => Some(PubGrubPriority::Root),
+            PubGrubPackageInner::Python(_) => Some(PubGrubPriority::Root),
+            PubGrubPackageInner::Extra { name, .. } => self.0.get(name).copied(),
+            PubGrubPackageInner::Package { name, .. } => self.0.get(name).copied(),
         }
     }
 }

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -19,7 +19,7 @@ use crate::candidate_selector::CandidateSelector;
 use crate::python_requirement::PythonRequirement;
 use crate::resolver::{IncompletePackage, UnavailablePackage, UnavailableReason};
 
-use super::PubGrubPackage;
+use super::{PubGrubPackage, PubGrubPackageInner};
 
 #[derive(Debug)]
 pub(crate) struct PubGrubReportFormatter<'a> {
@@ -44,7 +44,7 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                 format!("we are solving dependencies of {package} {version}")
             }
             External::NoVersions(package, set) => {
-                if matches!(package, PubGrubPackage::Python(_)) {
+                if matches!(&**package, PubGrubPackageInner::Python(_)) {
                     if let Some(python) = self.python_requirement {
                         if python.target() == python.installed() {
                             // Simple case, the installed version is the same as the target version
@@ -107,11 +107,11 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                     }
                 }
             }
-            External::Custom(package, set, reason) => match package {
-                PubGrubPackage::Root(Some(name)) => {
+            External::Custom(package, set, reason) => match &**package {
+                PubGrubPackageInner::Root(Some(name)) => {
                     format!("{name} cannot be used because {reason}")
                 }
-                PubGrubPackage::Root(None) => {
+                PubGrubPackageInner::Root(None) => {
                     format!("your requirements cannot be used because {reason}")
                 }
                 _ => match reason {
@@ -131,12 +131,12 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
             External::FromDependencyOf(package, package_set, dependency, dependency_set) => {
                 let package_set = self.simplify_set(package_set, package);
                 let dependency_set = self.simplify_set(dependency_set, dependency);
-                match package {
-                    PubGrubPackage::Root(Some(name)) => format!(
+                match &**package {
+                    PubGrubPackageInner::Root(Some(name)) => format!(
                         "{name} depends on {}",
                         PackageRange::dependency(dependency, &dependency_set)
                     ),
-                    PubGrubPackage::Root(None) => format!(
+                    PubGrubPackageInner::Root(None) => format!(
                         "you require {}",
                         PackageRange::dependency(dependency, &dependency_set)
                     ),
@@ -157,15 +157,22 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
         // by package first.
         terms_vec.sort_by(|&(pkg1, _), &(pkg2, _)| pkg1.cmp(pkg2));
         match terms_vec.as_slice() {
-            [] | [(PubGrubPackage::Root(_), _)] => "the requirements are unsatisfiable".into(),
-            [(package @ PubGrubPackage::Package { .. }, Term::Positive(range))] => {
+            [] => "the requirements are unsatisfiable".into(),
+            [(root, _)] if matches!(&**(*root), PubGrubPackageInner::Root(_)) => {
+                "the requirements are unsatisfiable".into()
+            }
+            [(package, Term::Positive(range))]
+                if matches!(&**(*package), PubGrubPackageInner::Package { .. }) =>
+            {
                 let range = self.simplify_set(range, package);
                 format!(
                     "{} cannot be used",
                     PackageRange::compatibility(package, &range)
                 )
             }
-            [(package @ PubGrubPackage::Package { .. }, Term::Negative(range))] => {
+            [(package, Term::Negative(range))]
+                if matches!(&**(*package), PubGrubPackageInner::Package { .. }) =>
+            {
                 let range = self.simplify_set(range, package);
                 format!(
                     "{} must be used",
@@ -339,13 +346,13 @@ impl PubGrubReportFormatter<'_> {
                 let dependency_set2 = self.simplify_set(dependency_set2, dependency2);
                 let dependency2 = PackageRange::dependency(dependency2, &dependency_set2);
 
-                match package1 {
-                    PubGrubPackage::Root(Some(name)) => format!(
+                match &**package1 {
+                    PubGrubPackageInner::Root(Some(name)) => format!(
                         "{name} depends on {}and {}",
                         Padded::new("", &dependency1, " "),
                         dependency2,
                     ),
-                    PubGrubPackage::Root(None) => format!(
+                    PubGrubPackageInner::Root(None) => format!(
                         "you require {}and {}",
                         Padded::new("", &dependency1, " "),
                         dependency2,
@@ -402,7 +409,7 @@ impl PubGrubReportFormatter<'_> {
     ) -> IndexSet<PubGrubHint> {
         /// Returns `true` if pre-releases were allowed for a package.
         fn allowed_prerelease(package: &PubGrubPackage, selector: &CandidateSelector) -> bool {
-            let PubGrubPackage::Package { name, .. } = package else {
+            let PubGrubPackageInner::Package { name, .. } = &**package else {
                 return false;
             };
             selector.prerelease_strategy().allows(name)
@@ -460,7 +467,7 @@ impl PubGrubReportFormatter<'_> {
                         let no_find_links =
                             index_locations.flat_index().peekable().peek().is_none();
 
-                        if let PubGrubPackage::Package { name, .. } = package {
+                        if let PubGrubPackageInner::Package { name, .. } = &**package {
                             // Add hints due to the package being entirely unavailable.
                             match unavailable_packages.get(name) {
                                 Some(UnavailablePackage::NoIndex) => {
@@ -970,9 +977,9 @@ impl<T: std::fmt::Display> std::fmt::Display for Padded<'_, T> {
 }
 
 fn fmt_package(package: &PubGrubPackage) -> String {
-    match package {
-        PubGrubPackage::Root(Some(name)) => name.to_string(),
-        PubGrubPackage::Root(None) => "you require".to_string(),
+    match &**package {
+        PubGrubPackageInner::Root(Some(name)) => name.to_string(),
+        PubGrubPackageInner::Root(None) => "you require".to_string(),
         _ => format!("{package}"),
     }
 }

--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -18,7 +18,7 @@ use crate::dependency_provider::UvDependencyProvider;
 use crate::editables::Editables;
 use crate::pins::FilePins;
 use crate::preferences::Preferences;
-use crate::pubgrub::{PubGrubDistribution, PubGrubPackage};
+use crate::pubgrub::{PubGrubDistribution, PubGrubPackageInner};
 use crate::redirect::url_to_precise;
 use crate::resolution::AnnotatedDist;
 use crate::resolver::FxOnceMap;
@@ -55,8 +55,8 @@ impl ResolutionGraph {
         let mut extras = FxHashMap::default();
         let mut diagnostics = Vec::new();
         for (package, version) in selection {
-            match package {
-                PubGrubPackage::Package {
+            match &**package {
+                PubGrubPackageInner::Package {
                     name,
                     extra: Some(extra),
                     marker: None,
@@ -95,7 +95,7 @@ impl ResolutionGraph {
                         });
                     }
                 }
-                PubGrubPackage::Package {
+                PubGrubPackageInner::Package {
                     name,
                     extra: Some(extra),
                     marker: None,
@@ -159,8 +159,8 @@ impl ResolutionGraph {
             FxHashMap::with_capacity_and_hasher(selection.len(), BuildHasherDefault::default());
 
         for (package, version) in selection {
-            match package {
-                PubGrubPackage::Package {
+            match &**package {
+                PubGrubPackageInner::Package {
                     name,
                     extra: None,
                     marker: None,
@@ -229,7 +229,7 @@ impl ResolutionGraph {
                     });
                     inverse.insert(name, index);
                 }
-                PubGrubPackage::Package {
+                PubGrubPackageInner::Package {
                     name,
                     extra: None,
                     marker: None,
@@ -328,16 +328,16 @@ impl ResolutionGraph {
                         continue;
                     }
 
-                    let PubGrubPackage::Package {
+                    let PubGrubPackageInner::Package {
                         name: self_name, ..
-                    } = self_package
+                    } = &**self_package
                     else {
                         continue;
                     };
-                    let PubGrubPackage::Package {
+                    let PubGrubPackageInner::Package {
                         name: dependency_name,
                         ..
-                    } = dependency_package
+                    } = &**dependency_package
                     else {
                         continue;
                     };


### PR DESCRIPTION
Pubgrub stores incompatibilities as (package name, version range) tuples, meaning it needs to clone the package name for each incompatibility, and each non-borrowed operation on incompatibilities. https://github.com/astral-sh/uv/pull/3673 made me realize that `PubGrubPackage` has gotten large (expensive to copy), so like `Version` and other structs, i've added an `Arc` wrapper around it.

It's a pity clippy forbids `.deref()`, it's less opaque than `&**` and has IDE support (clicking on `.deref()` jumps to the right impl).

## Benchmarks

It looks like this matters most for complex resolutions which, i assume because they carry larger `PubGrubPackageInner::Package` and `PubGrubPackageInner::Extra` types.

```bash
hyperfine --warmup 5 "./uv-main pip compile -q ./scripts/requirements/jupyter.in" "./uv-branch pip compile -q ./scripts/requirements/jupyter.in"
hyperfine --warmup 5 "./uv-main pip compile -q ./scripts/requirements/airflow.in" "./uv-branch pip compile -q ./scripts/requirements/airflow.in"
hyperfine --warmup 5 "./uv-main pip compile -q ./scripts/requirements/boto3.in" "./uv-branch pip compile -q ./scripts/requirements/boto3.in"
```

```
Benchmark 1: ./uv-main pip compile -q ./scripts/requirements/jupyter.in
  Time (mean ± σ):      18.2 ms ±   1.6 ms    [User: 14.4 ms, System: 26.0 ms]
  Range (min … max):    15.8 ms …  22.5 ms    181 runs

Benchmark 2: ./uv-branch pip compile -q ./scripts/requirements/jupyter.in
  Time (mean ± σ):      17.8 ms ±   1.4 ms    [User: 14.4 ms, System: 25.3 ms]
  Range (min … max):    15.4 ms …  23.1 ms    159 runs

Summary
  ./uv-branch pip compile -q ./scripts/requirements/jupyter.in ran
    1.02 ± 0.12 times faster than ./uv-main pip compile -q ./scripts/requirements/jupyter.in
```

```
Benchmark 1: ./uv-main pip compile -q ./scripts/requirements/airflow.in
  Time (mean ± σ):     153.7 ms ±   3.5 ms    [User: 165.2 ms, System: 157.6 ms]
  Range (min … max):   150.4 ms … 163.0 ms    19 runs

Benchmark 2: ./uv-branch pip compile -q ./scripts/requirements/airflow.in
  Time (mean ± σ):     123.9 ms ±   4.6 ms    [User: 152.4 ms, System: 133.8 ms]
  Range (min … max):   118.4 ms … 138.1 ms    24 runs

Summary
  ./uv-branch pip compile -q ./scripts/requirements/airflow.in ran
    1.24 ± 0.05 times faster than ./uv-main pip compile -q ./scripts/requirements/airflow.in
```

```
Benchmark 1: ./uv-main pip compile -q ./scripts/requirements/boto3.in
  Time (mean ± σ):     327.0 ms ±   3.8 ms    [User: 344.5 ms, System: 71.6 ms]
  Range (min … max):   322.7 ms … 334.6 ms    10 runs

Benchmark 2: ./uv-branch pip compile -q ./scripts/requirements/boto3.in
  Time (mean ± σ):     311.2 ms ±   3.1 ms    [User: 339.3 ms, System: 63.1 ms]
  Range (min … max):   307.8 ms … 317.0 ms    10 runs

Summary
  ./uv-branch pip compile -q ./scripts/requirements/boto3.in ran
    1.05 ± 0.02 times faster than ./uv-main pip compile -q ./scripts/requirements/boto3.in
```

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
