### PR TITLE
Revert "Support editables in `uv sync` (#3692)"

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -111,8 +111,7 @@ pub(crate) async fn lock(
         .build();
 
     // Build all editable distributions. The editables are shared between resolution and
-    // installation, and should live for the duration of the command. If an editable is already
-    // installed in the environment, we'll still re-build it here.
+    // installation, and should live for the duration of the command.
     let editables = ResolvedEditables::resolve(
         spec.editables.clone(),
         &EmptyInstalledPackages,

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -165,7 +165,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
     let requirements = {
         // Convert from unnamed to named requirements.
         let mut requirements = NamedRequirementsResolver::new(
-            requirements.clone(),
+            requirements,
             hasher,
             index,
             DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
@@ -178,7 +178,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
         if !source_trees.is_empty() {
             requirements.extend(
                 SourceTreeResolver::new(
-                    source_trees.clone(),
+                    source_trees,
                     &ExtrasSpecification::None,
                     hasher,
                     index,
@@ -214,7 +214,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
         constraints,
         overrides,
         preferences,
-        project.clone(),
+        project,
         editable_metadata,
         exclusions,
         lookaheads,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -5,7 +5,7 @@ use install_wheel_rs::linker::LinkMode;
 use uv_cache::Cache;
 use uv_client::RegistryClientBuilder;
 use uv_configuration::{
-    Concurrency, ConfigSettings, NoBinary, NoBuild, PreviewMode, Reinstall, SetupPyStrategy,
+    Concurrency, ConfigSettings, NoBinary, NoBuild, PreviewMode, SetupPyStrategy,
 };
 use uv_dispatch::BuildDispatch;
 use uv_installer::SitePackages;
@@ -55,8 +55,6 @@ pub(crate) async fn sync(
         .platform(venv.interpreter().platform())
         .build();
 
-    let site_packages = SitePackages::from_executable(&venv)?;
-
     // TODO(charlie): Respect project configuration.
     let build_isolation = BuildIsolation::default();
     let config_settings = ConfigSettings::default();
@@ -70,7 +68,6 @@ pub(crate) async fn sync(
     let no_build = NoBuild::default();
     let setup_py = SetupPyStrategy::default();
     let concurrency = Concurrency::default();
-    let reinstall = Reinstall::None;
 
     // Create a build dispatch.
     let build_dispatch = BuildDispatch::new(
@@ -90,20 +87,8 @@ pub(crate) async fn sync(
         concurrency,
     );
 
-    let editables = ResolvedEditables::resolve(
-        Vec::new(), // TODO(konsti): Read editables from lockfile
-        &site_packages,
-        &reinstall,
-        &hasher,
-        venv.interpreter(),
-        tags,
-        cache,
-        &client,
-        &build_dispatch,
-        concurrency,
-        printer,
-    )
-    .await?;
+    // TODO(konsti): Read editables from lockfile.
+    let editables = ResolvedEditables::default();
 
     let site_packages = SitePackages::from_executable(&venv)?;
 


### PR DESCRIPTION
This reverts commit #3692 until we get the editables from the lockfile.