### PR TITLE
Add PEP 714 support for HTML API client

### DIFF
--- a/crates/uv-client/src/html.rs
+++ b/crates/uv-client/src/html.rs
@@ -185,10 +185,14 @@ impl SimpleHtml {
             None
         };
 
-        // Extract the `data-dist-info-metadata` field, which should be set on
-        // the `data-dist-info-metadata` attribute.
-        let dist_info_metadata = if let Some(dist_info_metadata) =
-            link.attributes().get("data-dist-info-metadata").flatten()
+        // Extract the `core-metadata` field, which is either set on:
+        // - `data-core-metadata`, per PEP 714.
+        // - `data-dist-info-metadata`, per PEP 658.
+        let core_metadata = if let Some(dist_info_metadata) = link
+            .attributes()
+            .get("data-core-metadata")
+            .flatten()
+            .or_else(|| link.attributes().get("data-dist-info-metadata").flatten())
         {
             let dist_info_metadata = std::str::from_utf8(dist_info_metadata.as_bytes())?;
             let dist_info_metadata = html_escape::decode_html_entities(dist_info_metadata);
@@ -212,7 +216,7 @@ impl SimpleHtml {
         };
 
         Ok(File {
-            core_metadata: dist_info_metadata,
+            core_metadata,
             dist_info_metadata: None,
             data_dist_info_metadata: None,
             yanked,
@@ -936,9 +940,9 @@ mod tests {
             </head>
             <body>
                 <h1>Links for flask</h1>
-                <a href="0.1/Flask-0.1.tar.gz#sha256=9da884457e910bf0847d396cb4b778ad9f3c3d17db1c5997cb861937bd284237"  data-gpg-sig="false" >Flask-0.1.tar.gz</a>
+                <a href="0.1/Flask-0.1.tar.gz#sha256=9da884457e910bf0847d396cb4b778ad9f3c3d17db1c5997cb861937bd284237" data-gpg-sig="false" >Flask-0.1.tar.gz</a>
                 <br/>
-                <a href="0.10.1/Flask-0.10.1.tar.gz#sha256=4c83829ff83d408b5e1d4995472265411d2c414112298f2eb4b359d9e4563373"  data-gpg-sig="false" >Flask-0.10.1.tar.gz</a>
+                <a href="0.10.1/Flask-0.10.1.tar.gz#sha256=4c83829ff83d408b5e1d4995472265411d2c414112298f2eb4b359d9e4563373" data-gpg-sig="false" >Flask-0.10.1.tar.gz</a>
                 <br/>
                 <a href="3.0.1/flask-3.0.1.tar.gz#sha256=6489f51bb3666def6f314e15f19d50a1869a19ae0e8c9a3641ffe66c77d42403" data-requires-python="&gt;=3.8" data-gpg-sig="false" >flask-3.0.1.tar.gz</a>
                 <br/>
@@ -1102,6 +1106,155 @@ mod tests {
                     size: None,
                     upload_time: None,
                     url: "/whl/Jinja2-3.1.2-py3-none-any.whl#sha256=6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61",
+                    yanked: None,
+                },
+            ],
+        }
+        "###);
+    }
+
+    /// Respect PEP 714 (see: <https://peps.python.org/pep-0714/>).
+    #[test]
+    fn parse_core_metadata() {
+        let text = r#"
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Links for jinja2</h1>
+    <a href="/whl/Jinja2-3.1.2-py3-none-any.whl" data-dist-info-metadata="true">Jinja2-3.1.2-py3-none-any.whl</a><br/>
+    <a href="/whl/Jinja2-3.1.3-py3-none-any.whl" data-core-metadata="true">Jinja2-3.1.3-py3-none-any.whl</a><br/>
+    <a href="/whl/Jinja2-3.1.4-py3-none-any.whl" data-dist-info-metadata="false">Jinja2-3.1.4-py3-none-any.whl</a><br/>
+    <a href="/whl/Jinja2-3.1.5-py3-none-any.whl" data-core-metadata="false">Jinja2-3.1.5-py3-none-any.whl</a><br/>
+    <a href="/whl/Jinja2-3.1.6-py3-none-any.whl" data-core-metadata="true" data-dist-info-metadata="false">Jinja2-3.1.6-py3-none-any.whl</a><br/>
+  </body>
+</html>
+        "#;
+        let base = Url::parse("https://account.d.codeartifact.us-west-2.amazonaws.com/pypi/shared-packages-pypi/simple/flask/")
+            .unwrap();
+        let result = SimpleHtml::parse(text, &base).unwrap();
+        insta::assert_debug_snapshot!(result, @r###"
+        SimpleHtml {
+            base: BaseUrl(
+                Url {
+                    scheme: "https",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: Some(
+                        Domain(
+                            "account.d.codeartifact.us-west-2.amazonaws.com",
+                        ),
+                    ),
+                    port: None,
+                    path: "/pypi/shared-packages-pypi/simple/flask/",
+                    query: None,
+                    fragment: None,
+                },
+            ),
+            files: [
+                File {
+                    core_metadata: Some(
+                        Bool(
+                            true,
+                        ),
+                    ),
+                    dist_info_metadata: None,
+                    data_dist_info_metadata: None,
+                    filename: "Jinja2-3.1.2-py3-none-any.whl",
+                    hashes: Hashes {
+                        md5: None,
+                        sha256: None,
+                        sha384: None,
+                        sha512: None,
+                    },
+                    requires_python: None,
+                    size: None,
+                    upload_time: None,
+                    url: "/whl/Jinja2-3.1.2-py3-none-any.whl",
+                    yanked: None,
+                },
+                File {
+                    core_metadata: Some(
+                        Bool(
+                            true,
+                        ),
+                    ),
+                    dist_info_metadata: None,
+                    data_dist_info_metadata: None,
+                    filename: "Jinja2-3.1.3-py3-none-any.whl",
+                    hashes: Hashes {
+                        md5: None,
+                        sha256: None,
+                        sha384: None,
+                        sha512: None,
+                    },
+                    requires_python: None,
+                    size: None,
+                    upload_time: None,
+                    url: "/whl/Jinja2-3.1.3-py3-none-any.whl",
+                    yanked: None,
+                },
+                File {
+                    core_metadata: Some(
+                        Bool(
+                            false,
+                        ),
+                    ),
+                    dist_info_metadata: None,
+                    data_dist_info_metadata: None,
+                    filename: "Jinja2-3.1.4-py3-none-any.whl",
+                    hashes: Hashes {
+                        md5: None,
+                        sha256: None,
+                        sha384: None,
+                        sha512: None,
+                    },
+                    requires_python: None,
+                    size: None,
+                    upload_time: None,
+                    url: "/whl/Jinja2-3.1.4-py3-none-any.whl",
+                    yanked: None,
+                },
+                File {
+                    core_metadata: Some(
+                        Bool(
+                            false,
+                        ),
+                    ),
+                    dist_info_metadata: None,
+                    data_dist_info_metadata: None,
+                    filename: "Jinja2-3.1.5-py3-none-any.whl",
+                    hashes: Hashes {
+                        md5: None,
+                        sha256: None,
+                        sha384: None,
+                        sha512: None,
+                    },
+                    requires_python: None,
+                    size: None,
+                    upload_time: None,
+                    url: "/whl/Jinja2-3.1.5-py3-none-any.whl",
+                    yanked: None,
+                },
+                File {
+                    core_metadata: Some(
+                        Bool(
+                            true,
+                        ),
+                    ),
+                    dist_info_metadata: None,
+                    data_dist_info_metadata: None,
+                    filename: "Jinja2-3.1.6-py3-none-any.whl",
+                    hashes: Hashes {
+                        md5: None,
+                        sha256: None,
+                        sha384: None,
+                        sha512: None,
+                    },
+                    requires_python: None,
+                    size: None,
+                    upload_time: None,
+                    url: "/whl/Jinja2-3.1.6-py3-none-any.whl",
                     yanked: None,
                 },
             ],


### PR DESCRIPTION
## Summary

If `data-core-metadata` is set, we need to respect that over `data-dist-info-metadata` in the HTML client.

See: https://github.com/astral-sh/uv/issues/3689

