### PR TITLE
Rename `DistInfoMetadata` to `CoreMetadata`

### DIFF
--- a/crates/distribution-types/src/file.rs
+++ b/crates/distribution-types/src/file.rs
@@ -7,7 +7,7 @@ use url::Url;
 
 use pep440_rs::{VersionSpecifiers, VersionSpecifiersParseError};
 use pep508_rs::split_scheme;
-use pypi_types::{DistInfoMetadata, HashDigest, Yanked};
+use pypi_types::{CoreMetadata, HashDigest, Yanked};
 
 /// Error converting [`pypi_types::File`] to [`distribution_type::File`].
 #[derive(Debug, Error)]
@@ -48,7 +48,7 @@ impl File {
                 .as_ref()
                 .or(file.dist_info_metadata.as_ref())
                 .or(file.data_dist_info_metadata.as_ref())
-                .is_some_and(DistInfoMetadata::is_available),
+                .is_some_and(CoreMetadata::is_available),
             filename: file.filename,
             hashes: file.hashes.into_digests(),
             requires_python: file

--- a/crates/pypi-types/src/simple_json.rs
+++ b/crates/pypi-types/src/simple_json.rs
@@ -39,9 +39,9 @@ fn sorted_simple_json_files<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<File>
 pub struct File {
     // PEP 714-renamed field, followed by PEP 691-compliant field, followed by non-PEP 691-compliant
     // alias used by PyPI.
-    pub core_metadata: Option<DistInfoMetadata>,
-    pub dist_info_metadata: Option<DistInfoMetadata>,
-    pub data_dist_info_metadata: Option<DistInfoMetadata>,
+    pub core_metadata: Option<CoreMetadata>,
+    pub dist_info_metadata: Option<CoreMetadata>,
+    pub data_dist_info_metadata: Option<CoreMetadata>,
     pub filename: String,
     pub hashes: Hashes,
     /// There are a number of invalid specifiers on PyPI, so we first try to parse it into a
@@ -73,12 +73,12 @@ where
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
-pub enum DistInfoMetadata {
+pub enum CoreMetadata {
     Bool(bool),
     Hashes(Hashes),
 }
 
-impl DistInfoMetadata {
+impl CoreMetadata {
     pub fn is_available(&self) -> bool {
         match self {
             Self::Bool(is_available) => *is_available,

--- a/crates/uv-client/src/html.rs
+++ b/crates/uv-client/src/html.rs
@@ -6,7 +6,7 @@ use url::Url;
 
 use pep440_rs::VersionSpecifiers;
 use pypi_types::LenientVersionSpecifiers;
-use pypi_types::{BaseUrl, DistInfoMetadata, File, Hashes, Yanked};
+use pypi_types::{BaseUrl, CoreMetadata, File, Hashes, Yanked};
 
 /// A parsed structure from PyPI "HTML" index format for a single package.
 #[derive(Debug, Clone)]
@@ -197,9 +197,9 @@ impl SimpleHtml {
             let dist_info_metadata = std::str::from_utf8(dist_info_metadata.as_bytes())?;
             let dist_info_metadata = html_escape::decode_html_entities(dist_info_metadata);
             match dist_info_metadata.as_ref() {
-                "true" => Some(DistInfoMetadata::Bool(true)),
-                "false" => Some(DistInfoMetadata::Bool(false)),
-                fragment => Some(DistInfoMetadata::Hashes(Self::parse_hash(fragment)?)),
+                "true" => Some(CoreMetadata::Bool(true)),
+                "false" => Some(CoreMetadata::Bool(false)),
+                fragment => Some(CoreMetadata::Hashes(Self::parse_hash(fragment)?)),
             }
         } else {
             None


### PR DESCRIPTION
## Summary

This reflects the change codified in PEP 714.
