### PR TITLE
Add support for requesting `pypy` interpreters by implementation name

### DIFF
--- a/crates/uv-interpreter/src/implementation.rs
+++ b/crates/uv-interpreter/src/implementation.rs
@@ -10,20 +10,24 @@ pub enum Error {
     UnknownImplementation(String),
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Default)]
 pub enum ImplementationName {
+    #[default]
     CPython,
+    PyPy,
 }
 
 impl ImplementationName {
     pub(crate) fn iter() -> impl Iterator<Item = &'static ImplementationName> {
-        static NAMES: &[ImplementationName] = &[ImplementationName::CPython];
+        static NAMES: &[ImplementationName] =
+            &[ImplementationName::CPython, ImplementationName::PyPy];
         NAMES.iter()
     }
 
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::CPython => "cpython",
+            Self::PyPy => "pypy",
         }
     }
 }
@@ -34,6 +38,7 @@ impl FromStr for ImplementationName {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_ascii_lowercase().as_str() {
             "cpython" => Ok(Self::CPython),
+            "pypy" => Ok(Self::PyPy),
             _ => Err(Error::UnknownImplementation(s.to_string())),
         }
     }


### PR DESCRIPTION
Updates our executable name searches to support implementation names i.e. `cpython` and `pypy` and adds support for PyPy.

We might want to _not_ support searching for `cpython` because that's non-standard?