### PR TITLE
Improve display of root package in range errors

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -796,7 +796,13 @@ impl PackageRange<'_> {
 
 impl std::fmt::Display for PackageRange<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let package = fmt_package(self.package);
+        // Exit early for the root package — the range is not meaningful
+        let package = match &**self.package {
+            PubGrubPackageInner::Root(Some(name)) => return write!(f, "{name}"),
+            PubGrubPackageInner::Root(None) => return write!(f, "your requirements"),
+            _ => self.package,
+        };
+
         if self.range.is_empty() {
             return write!(f, "{package} ∅");
         }
@@ -973,13 +979,5 @@ impl<T: std::fmt::Display> std::fmt::Display for Padded<'_, T> {
         }
 
         write!(f, "{result}")
-    }
-}
-
-fn fmt_package(package: &PubGrubPackage) -> String {
-    match &**package {
-        PubGrubPackageInner::Root(Some(name)) => name.to_string(),
-        PubGrubPackageInner::Root(None) => "you require".to_string(),
-        _ => format!("{package}"),
     }
 }


### PR DESCRIPTION
Instead of saying 

> we can conclude that you require==0a0.dev0 and pandas-stubs==2.0.3.230814 are incompatible.

we'll say

> we can conclude that your requirements and pandas-stubs==2.0.3.230814 are incompatible.

Closes #3710 

I'm not sure how to get unit test coverage for this, might look into that. Ideally we'd skip this branch entirely?