### PR TITLE
Override range to avoid patching pubgrub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "pubgrub"
 version = "0.2.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=0e684a874c9fb8f74738cd8875524c80e3d4820b#0e684a874c9fb8f74738cd8875524c80e3d4820b"
+source = "git+https://github.com/astral-sh/pubgrub?rev=beedf96be817543bb4f357a305a382ff19e6382a#beedf96be817543bb4f357a305a382ff19e6382a"
 dependencies = [
  "indexmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 petgraph = { version = "0.6.4" }
 platform-info = { version = "2.0.2" }
-pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "0e684a874c9fb8f74738cd8875524c80e3d4820b" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "beedf96be817543bb4f357a305a382ff19e6382a" }
 pyo3 = { version = "0.21.0" }
 pyo3-log = { version = "0.10.0" }
 rayon = { version = "1.8.0" }

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use pubgrub::range::Range;
+use pubgrub::version_set::VersionSet;
 use tracing::debug;
 
 use distribution_types::{CompatibleDist, IncompatibleDist, IncompatibleSource};
@@ -12,6 +12,7 @@ use uv_types::InstalledPackagesProvider;
 
 use crate::preferences::Preferences;
 use crate::prerelease_mode::PreReleaseStrategy;
+use crate::pubgrub::PubGrubRange;
 use crate::resolution_mode::ResolutionStrategy;
 use crate::version_map::{VersionMap, VersionMapDistHandle};
 use crate::{Exclusions, Manifest, Options};
@@ -83,7 +84,7 @@ impl CandidateSelector {
     pub(crate) fn select<'a, InstalledPackages: InstalledPackagesProvider>(
         &'a self,
         package_name: &'a PackageName,
-        range: &Range<Version>,
+        range: &PubGrubRange,
         version_maps: &'a [VersionMap],
         preferences: &'a Preferences,
         installed_packages: &'a InstalledPackages,
@@ -107,7 +108,7 @@ impl CandidateSelector {
     /// installed version.
     fn get_preferred<'a, InstalledPackages: InstalledPackagesProvider>(
         package_name: &'a PackageName,
-        range: &Range<Version>,
+        range: &PubGrubRange,
         version_maps: &'a [VersionMap],
         preferences: &'a Preferences,
         installed_packages: &'a InstalledPackages,
@@ -209,7 +210,7 @@ impl CandidateSelector {
     pub(crate) fn select_no_preference<'a>(
         &'a self,
         package_name: &'a PackageName,
-        range: &Range<Version>,
+        range: &PubGrubRange,
         version_maps: &'a [VersionMap],
     ) -> Option<Candidate> {
         tracing::trace!(
@@ -281,7 +282,7 @@ impl CandidateSelector {
     fn select_candidate<'a>(
         versions: impl Iterator<Item = (&'a Version, VersionMapDistHandle<'a>)>,
         package_name: &'a PackageName,
-        range: &Range<Version>,
+        range: &PubGrubRange,
         allow_prerelease: AllowPreRelease,
     ) -> Option<Candidate<'a>> {
         #[derive(Debug)]

--- a/crates/uv-resolver/src/dependency_provider.rs
+++ b/crates/uv-resolver/src/dependency_provider.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use pubgrub::range::Range;
+use crate::pubgrub::PubGrubRange;
 use pubgrub::solver::{Dependencies, DependencyProvider};
 
 use pep440_rs::Version;
@@ -16,7 +16,7 @@ pub(crate) struct UvDependencyProvider;
 impl DependencyProvider for UvDependencyProvider {
     type P = PubGrubPackage;
     type V = Version;
-    type VS = Range<Version>;
+    type VS = PubGrubRange;
     type M = UnavailableReason;
 
     fn prioritize(&self, _package: &Self::P, _range: &Self::VS) -> Self::Priority {

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -3,8 +3,8 @@ use std::fmt::Formatter;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use crate::pubgrub::PubGrubRange;
 use indexmap::IndexMap;
-use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, DerivationTree, External, Reporter};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -112,7 +112,7 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for ResolveError {
 /// Given a [`DerivationTree`], collapse any [`External::FromDependencyOf`] incompatibilities
 /// wrap an [`PubGrubPackageInner::Extra`] package.
 fn collapse_extra_proxies(
-    derivation_tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+    derivation_tree: &mut DerivationTree<PubGrubPackage, PubGrubRange, UnavailableReason>,
 ) {
     match derivation_tree {
         DerivationTree::External(_) => {}
@@ -181,7 +181,7 @@ impl From<pubgrub::error::PubGrubError<UvDependencyProvider>> for ResolveError {
 /// A wrapper around [`pubgrub::error::PubGrubError::NoSolution`] that displays a resolution failure report.
 #[derive(Debug)]
 pub struct NoSolutionError {
-    derivation_tree: DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+    derivation_tree: DerivationTree<PubGrubPackage, PubGrubRange, UnavailableReason>,
     available_versions: IndexMap<PubGrubPackage, BTreeSet<Version>>,
     selector: Option<CandidateSelector>,
     python_requirement: Option<PythonRequirement>,

--- a/crates/uv-resolver/src/marker.rs
+++ b/crates/uv-resolver/src/marker.rs
@@ -3,13 +3,13 @@
 use std::ops::Bound::{self, *};
 use std::ops::RangeBounds;
 
-use pep440_rs::{Operator, Version, VersionSpecifier};
+use pep440_rs::{Operator, VersionSpecifier};
 use pep508_rs::{
     ExtraName, ExtraOperator, MarkerExpression, MarkerOperator, MarkerTree, MarkerValueString,
     MarkerValueVersion,
 };
 
-use crate::pubgrub::PubGrubSpecifier;
+use crate::pubgrub::{PubGrubRange, PubGrubSpecifier};
 
 /// Returns `true` if there is no environment in which both marker trees can both apply, i.e.
 /// the expression `first and second` is always false.
@@ -164,9 +164,7 @@ fn version_is_disjoint(this: &MarkerExpression, other: &MarkerExpression) -> boo
 }
 
 /// Returns the key and version range for a version expression.
-fn keyed_range(
-    expr: &MarkerExpression,
-) -> Result<Option<(&MarkerValueVersion, pubgrub::range::Range<Version>)>, ()> {
+fn keyed_range(expr: &MarkerExpression) -> Result<Option<(&MarkerValueVersion, PubGrubRange)>, ()> {
     let (key, specifier) = match expr {
         MarkerExpression::Version { key, specifier } => (key, specifier.clone()),
         MarkerExpression::VersionInverted {

--- a/crates/uv-resolver/src/pubgrub/mod.rs
+++ b/crates/uv-resolver/src/pubgrub/mod.rs
@@ -2,6 +2,7 @@ pub(crate) use crate::pubgrub::dependencies::PubGrubDependencies;
 pub(crate) use crate::pubgrub::distribution::PubGrubDistribution;
 pub(crate) use crate::pubgrub::package::{PubGrubPackage, PubGrubPackageInner, PubGrubPython};
 pub(crate) use crate::pubgrub::priority::{PubGrubPriorities, PubGrubPriority};
+pub(crate) use crate::pubgrub::range::PubGrubRange;
 pub(crate) use crate::pubgrub::report::PubGrubReportFormatter;
 pub(crate) use crate::pubgrub::specifier::PubGrubSpecifier;
 
@@ -9,5 +10,6 @@ mod dependencies;
 mod distribution;
 mod package;
 mod priority;
+mod range;
 mod report;
 mod specifier;

--- a/crates/uv-resolver/src/pubgrub/priority.rs
+++ b/crates/uv-resolver/src/pubgrub/priority.rs
@@ -1,9 +1,8 @@
 use std::cmp::Reverse;
 
-use pubgrub::range::Range;
+use crate::pubgrub::PubGrubRange;
 use rustc_hash::FxHashMap;
 
-use pep440_rs::Version;
 use uv_normalize::PackageName;
 
 use crate::pubgrub::package::PubGrubPackage;
@@ -23,7 +22,7 @@ pub(crate) struct PubGrubPriorities(FxHashMap<PackageName, PubGrubPriority>);
 
 impl PubGrubPriorities {
     /// Add a [`PubGrubPackage`] to the priority map.
-    pub(crate) fn insert(&mut self, package: &PubGrubPackage, version: &Range<Version>) {
+    pub(crate) fn insert(&mut self, package: &PubGrubPackage, version: &PubGrubRange) {
         let next = self.0.len();
         match &**package {
             PubGrubPackageInner::Root(_) => {}

--- a/crates/uv-resolver/src/pubgrub/range.rs
+++ b/crates/uv-resolver/src/pubgrub/range.rs
@@ -1,0 +1,156 @@
+use pubgrub::range::Range;
+use pubgrub::version_set::VersionSet;
+use std::borrow::Borrow;
+use std::collections::Bound;
+use std::fmt::{Display, Formatter};
+use std::ops::{Deref, RangeBounds};
+
+use pep440_rs::Version;
+
+/// A [`R<Version>`] with a Python-specific `Display` implementation.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub(crate) struct PubGrubRange(Range<Version>);
+
+impl VersionSet for PubGrubRange {
+    type V = Version;
+
+    fn empty() -> Self {
+        Self(Range::empty())
+    }
+
+    fn singleton(v: Self::V) -> Self {
+        Self(Range::singleton(v))
+    }
+
+    fn complement(&self) -> Self {
+        Self(self.0.complement())
+    }
+
+    fn intersection(&self, other: &Self) -> Self {
+        Self(self.0.intersection(&other.0))
+    }
+
+    fn contains(&self, v: &Self::V) -> bool {
+        self.0.contains(v)
+    }
+
+    fn full() -> Self {
+        Self(Range::full())
+    }
+
+    fn union(&self, other: &Self) -> Self {
+        Self(self.0.union(&other.0))
+    }
+
+    fn is_disjoint(&self, other: &Self) -> bool {
+        self.0.is_disjoint(&other.0)
+    }
+
+    fn subset_of(&self, other: &Self) -> bool {
+        self.0.subset_of(&other.0)
+    }
+}
+
+impl PubGrubRange {
+    /// Set of all possible versions
+    pub(crate) fn full() -> Self {
+        Self(Range::full())
+    }
+
+    /// Set of all versions higher or equal to some version
+    pub(crate) fn higher_than(v: impl Into<Version>) -> Self {
+        Self(Range::higher_than(v))
+    }
+
+    /// Set of all versions higher to some version
+    pub(crate) fn strictly_higher_than(v: impl Into<Version>) -> Self {
+        Self(Range::strictly_higher_than(v))
+    }
+
+    /// Set of all versions lower to some version
+    pub(crate) fn strictly_lower_than(v: impl Into<Version>) -> Self {
+        Self(Range::strictly_lower_than(v))
+    }
+
+    /// Set of all versions lower or equal to some version
+    pub(crate) fn lower_than(v: impl Into<Version>) -> Self {
+        Self(Range::lower_than(v))
+    }
+
+    pub(crate) fn complement(&self) -> Self {
+        Self(self.0.complement())
+    }
+
+    pub(crate) fn simplify<'s, I, BV>(&self, versions: I) -> Self
+    where
+        I: Iterator<Item = BV> + 's,
+        BV: Borrow<Version> + 's,
+    {
+        Self(self.0.simplify(versions))
+    }
+
+    pub(crate) fn from_range_bounds<R, IV>(bounds: R) -> Self
+    where
+        R: RangeBounds<IV>,
+        IV: Clone + Into<Version>,
+    {
+        Self(Range::from_range_bounds(bounds))
+    }
+}
+
+impl From<Range<Version>> for PubGrubRange {
+    fn from(range: Range<Version>) -> Self {
+        Self(range)
+    }
+}
+
+impl From<PubGrubRange> for Range<Version> {
+    fn from(range: PubGrubRange) -> Self {
+        range.0
+    }
+}
+
+impl Deref for PubGrubRange {
+    type Target = Range<Version>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Python-specific [`Display`] implementation.
+///
+/// `|` is used as OR-operator instead of `,` since PEP 440 uses `,` as AND-operator. `==` is used
+/// for single version specifiers instead of an empty prefix, again for PEP 440 where a specifier
+/// needs an operator.
+impl Display for PubGrubRange {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_empty() {
+            write!(f, "∅")?;
+        } else {
+            for (idx, segment) in self.0.iter().enumerate() {
+                if idx > 0 {
+                    write!(f, " | ")?;
+                }
+                match segment {
+                    (Bound::Unbounded, Bound::Unbounded) => write!(f, "*")?,
+                    (Bound::Unbounded, Bound::Included(v)) => write!(f, "<={v}")?,
+                    (Bound::Unbounded, Bound::Excluded(v)) => write!(f, "<{v}")?,
+                    (Bound::Included(v), Bound::Unbounded) => write!(f, ">={v}")?,
+                    (Bound::Included(v), Bound::Included(b)) => {
+                        if v == b {
+                            write!(f, "=={v}")?;
+                        } else {
+                            write!(f, ">={v}, <={b}")?;
+                        }
+                    }
+                    (Bound::Included(v), Bound::Excluded(b)) => write!(f, ">={v}, <{b}")?,
+                    (Bound::Excluded(v), Bound::Unbounded) => write!(f, ">{v}")?,
+                    (Bound::Excluded(v), Bound::Included(b)) => write!(f, ">{v}, <={b}")?,
+                    (Bound::Excluded(v), Bound::Excluded(b)) => write!(f, ">{v}, <{b}")?,
+                };
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Create a newtype `struct PubGrubRange(pubgrub::range::Range<Version>)` to avoid overriding the `Display` implementation on `Range` in pubgrub itself, reducing our diff with upstream. Used methods taking an `&Self` or returning `Self` were overridden, the rest of the methods succeeds through deref.

An additional advantage is that we can start using the range type in more places without depending on pubgrub directly (https://github.com/astral-sh/uv/pull/4041).

The alternative would be moving range formatting into the error formatter, but this would make pubgrub's api strange, deviating from rust's `Display` standard.
