### PR TITLE
Propagate URL errors in verbatim parsing

### DIFF
--- a/crates/pep508-rs/src/unnamed.rs
+++ b/crates/pep508-rs/src/unnamed.rs
@@ -236,6 +236,12 @@ fn preprocess_unnamed_url(
                 #[cfg(feature = "non-pep508-extensions")]
                 if let Some(working_dir) = working_dir {
                     let url = VerbatimUrl::parse_path(path.as_ref(), working_dir)
+                        .map_err(|err| Pep508Error {
+                            message: Pep508ErrorSource::<VerbatimUrl>::UrlError(err),
+                            start,
+                            len,
+                            input: cursor.to_string(),
+                        })?
                         .with_given(url.to_string());
                     return Ok((url, extras));
                 }
@@ -270,6 +276,12 @@ fn preprocess_unnamed_url(
             _ => {
                 if let Some(working_dir) = working_dir {
                     let url = VerbatimUrl::parse_path(expanded.as_ref(), working_dir)
+                        .map_err(|err| Pep508Error {
+                            message: Pep508ErrorSource::<VerbatimUrl>::UrlError(err),
+                            start,
+                            len,
+                            input: cursor.to_string(),
+                        })?
                         .with_given(url.to_string());
                     return Ok((url, extras));
                 }
@@ -288,8 +300,14 @@ fn preprocess_unnamed_url(
     } else {
         // Ex) `../editable/`
         if let Some(working_dir) = working_dir {
-            let url =
-                VerbatimUrl::parse_path(expanded.as_ref(), working_dir).with_given(url.to_string());
+            let url = VerbatimUrl::parse_path(expanded.as_ref(), working_dir)
+                .map_err(|err| Pep508Error {
+                    message: Pep508ErrorSource::<VerbatimUrl>::UrlError(err),
+                    start,
+                    len,
+                    input: cursor.to_string(),
+                })?
+                .with_given(url.to_string());
             return Ok((url, extras));
         }
 

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
     // Network error
     #[error("Failed to parse URL: {0}")]
     Url(String, #[source] url::ParseError),
+    #[error("Expected an absolute path, but received: {}", _0.user_display())]
+    RelativePath(PathBuf),
     #[error(transparent)]
     JoinRelativeUrl(#[from] pypi_types::JoinRelativeError),
     #[error("Git operation failed")]

--- a/crates/uv-distribution/src/index/registry_wheel_index.rs
+++ b/crates/uv-distribution/src/index/registry_wheel_index.rs
@@ -94,10 +94,10 @@ impl<'a> RegistryWheelIndex<'a> {
             .filter_map(|flat_index| match flat_index {
                 FlatIndexLocation::Path(path) => {
                     let path = fs_err::canonicalize(path).ok()?;
-                    Some(IndexUrl::Path(VerbatimUrl::from_path(path)))
+                    Some(IndexUrl::Path(VerbatimUrl::from_path(path).ok()?))
                 }
                 FlatIndexLocation::Url(url) => {
-                    Some(IndexUrl::Url(VerbatimUrl::unknown(url.clone())))
+                    Some(IndexUrl::Url(VerbatimUrl::from_url(url.clone())))
                 }
             })
             .collect();

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -105,7 +105,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                         Url::parse(url).map_err(|err| Error::Url(url.clone(), err))?
                     }
                     FileLocation::Path(path) => {
-                        let url = Url::from_file_path(path).expect("path is absolute");
+                        let url = Url::from_file_path(path)
+                            .map_err(|()| Error::RelativePath(path.clone()))?;
                         return self
                             .archive(
                                 source,
@@ -262,7 +263,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                         Url::parse(url).map_err(|err| Error::Url(url.clone(), err))?
                     }
                     FileLocation::Path(path) => {
-                        let url = Url::from_file_path(path).expect("path is absolute");
+                        let url = Url::from_file_path(path)
+                            .map_err(|()| Error::RelativePath(path.clone()))?;
                         return self
                             .archive_metadata(
                                 source,

--- a/crates/uv-requirements/src/pyproject.rs
+++ b/crates/uv-requirements/src/pyproject.rs
@@ -59,6 +59,8 @@ pub enum LoweringError {
     InvalidEntry,
     #[error(transparent)]
     InvalidUrl(#[from] url::ParseError),
+    #[error(transparent)]
+    InvalidVerbatimUrl(#[from] pep508_rs::VerbatimUrlError),
     #[error("Can't combine URLs from both `project.dependencies` and `tool.uv.sources`")]
     ConflictingUrls,
     #[error("Could not normalize path: `{0}`")]
@@ -551,7 +553,7 @@ fn path_source(
     project_dir: &Path,
     editable: bool,
 ) -> Result<RequirementSource, LoweringError> {
-    let url = VerbatimUrl::parse_path(&path, project_dir).with_given(path.clone());
+    let url = VerbatimUrl::parse_path(&path, project_dir)?.with_given(path.clone());
     let path_buf = PathBuf::from(&path);
     let path_buf = path_buf
         .absolutize_from(project_dir)

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -132,7 +132,7 @@ impl RequirementsSpecification {
                 project: None,
                 requirements: vec![UnresolvedRequirementSpecification {
                     requirement: UnresolvedRequirement::Unnamed(UnnamedRequirement {
-                        url: VerbatimUrl::from_path(path),
+                        url: VerbatimUrl::from_path(path)?,
                         extras: vec![],
                         marker: None,
                         origin: None,


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/3715.

## Test Plan

```
❯ echo "/../test" | cargo run pip compile -
error: Couldn't parse requirement in `-` at position 0
  Caused by: path could not be normalized: /../test
/../test
^^^^^^^^

❯ echo "-e /../test" | cargo run pip compile -
error: Invalid URL in `-`: `/../test`
  Caused by: path could not be normalized: /../test
  Caused by: cannot normalize a relative path beyond the base directory
```
