### PR TITLE
Bump test timeout to 120s

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,4 @@
 [profile.default]
 # Mark tests that take longer than 10s as slow.
-# Terminate after 90s as a stop-gap measure to terminate on deadlock.
-slow-timeout =  { period = "10s", terminate-after = 9 }
+# Terminate after 120s as a stop-gap measure to terminate on deadlock.
+slow-timeout =  { period = "10s", terminate-after = 12 }


### PR DESCRIPTION
90s is too low in our test suite :sob:
