### PR TITLE
Add `StateStore` abstraction for persistent state storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5038,6 +5038,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "uv-state"
+version = "0.0.1"
+dependencies = [
+ "directories",
+ "tempfile",
+]
+
+[[package]]
 name = "uv-types"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ uv-interpreter = { path = "crates/uv-interpreter" }
 uv-normalize = { path = "crates/uv-normalize" }
 uv-requirements = { path = "crates/uv-requirements" }
 uv-resolver = { path = "crates/uv-resolver" }
+uv-state = { path = "crates/uv-state" }
 uv-types = { path = "crates/uv-types" }
 uv-version = { path = "crates/uv-version" }
 uv-virtualenv = { path = "crates/uv-virtualenv" }

--- a/crates/uv-state/Cargo.toml
+++ b/crates/uv-state/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "uv-state"
+version = "0.0.1"
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+
+[lints]
+workspace = true
+
+[dependencies]
+directories = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/uv-state/src/lib.rs
+++ b/crates/uv-state/src/lib.rs
@@ -1,0 +1,78 @@
+use std::{
+    fs,
+    io::{self},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use directories::ProjectDirs;
+use tempfile::{tempdir, TempDir};
+
+/// The main state storage abstraction.
+///
+/// This is appropriate
+#[derive(Debug, Clone)]
+pub struct StateStore {
+    /// The state storage.
+    root: PathBuf,
+    /// A temporary state storage.
+    ///
+    /// Included to ensure that the temporary store exists for the length of the operation, but
+    /// is dropped at the end as appropriate.
+    _temp_dir_drop: Option<Arc<TempDir>>,
+}
+
+impl StateStore {
+    /// A persistent state store at `root`.
+    pub fn from_path(root: impl Into<PathBuf>) -> Result<Self, io::Error> {
+        Ok(Self {
+            root: root.into(),
+            _temp_dir_drop: None,
+        })
+    }
+
+    /// Create a temporary state store.
+    pub fn temp() -> Result<Self, io::Error> {
+        let temp_dir = tempdir()?;
+        Ok(Self {
+            root: temp_dir.path().to_path_buf(),
+            _temp_dir_drop: Some(Arc::new(temp_dir)),
+        })
+    }
+
+    /// Return the root of the state store.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Initialize the state store.
+    pub fn init(self) -> Result<Self, io::Error> {
+        let root = &self.root;
+
+        // Create the state store directory, if it doesn't exist.
+        fs::create_dir_all(root)?;
+
+        Ok(Self {
+            root: fs::canonicalize(root)?,
+            ..self
+        })
+    }
+}
+
+impl StateStore {
+    /// Prefer, in order:
+    /// 1. The specific state directory specified by the user.
+    /// 2. The system-appropriate user-level data directory.
+    /// 3. A `.uv` directory in the current working directory.
+    ///
+    /// Returns an absolute cache dir.
+    pub fn from_settings(state_dir: Option<PathBuf>) -> Result<Self, io::Error> {
+        if let Some(state_dir) = state_dir {
+            StateStore::from_path(state_dir)
+        } else if let Some(project_dirs) = ProjectDirs::from("", "", "uv") {
+            StateStore::from_path(project_dirs.data_dir())
+        } else {
+            StateStore::from_path(".uv")
+        }
+    }
+}


### PR DESCRIPTION
In preparation for storing stateful data that is not considered cache or config e.g.

- `uv tool install` environments
- `uv toolchain` downloads

Cribbed from the `uv-cache::Cache` interface.