### PR TITLE
Do not discover virtual environment interpreters in `uv venv --python ...`

### DIFF
--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -120,7 +120,7 @@ async fn venv_impl(
     // Locate the Python interpreter.
     let interpreter = if let Some(python) = python_request.as_ref() {
         let request = InterpreterRequest::parse(python);
-        let sources = SourceSelector::from_env(uv_interpreter::SystemPython::Allowed);
+        let sources = SourceSelector::from_env(uv_interpreter::SystemPython::Required);
         find_interpreter(&request, &sources, cache)
     } else {
         find_default_interpreter(cache)


### PR DESCRIPTION
Otherwise `uv venv --python 3.12` can prefer `.venv/bin/python` over the system Python (which is always used if you don't provide a `--python` flag). I would find this confusing as a user.