### PR TITLE
Discover and prefer the parent interpreter when invoked with `python -m uv`

### DIFF
--- a/crates/uv-interpreter/src/environment.rs
+++ b/crates/uv-interpreter/src/environment.rs
@@ -2,6 +2,7 @@ use itertools::Either;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use tracing::warn;
 
 use same_file::is_same_file;
 
@@ -10,7 +11,9 @@ use uv_fs::{LockedFile, Simplified};
 
 use crate::discovery::{InterpreterRequest, SourceSelector, SystemPython, VersionRequest};
 use crate::virtualenv::{virtualenv_python_executable, PyVenvConfiguration};
-use crate::{find_default_interpreter, find_interpreter, Error, Interpreter, Target};
+use crate::{
+    find_default_interpreter, find_interpreter, Error, Interpreter, InterpreterSource, Target,
+};
 
 /// A Python environment, consisting of a Python [`Interpreter`] and its associated paths.
 #[derive(Debug, Clone)]
@@ -31,6 +34,21 @@ impl PythonEnvironment {
         } else if system.is_preferred() {
             Self::from_default_python(cache)
         } else {
+            // First check for a parent intepreter
+            match Self::from_parent_interpreter(cache) {
+                Ok(env) => {
+                    if !system.is_allowed()
+                        && env.interpreter().base_prefix() != env.interpreter().base_exec_prefix()
+                    {
+                        warn!("Allowing system interpreter without `--system` since uv was invoked from Python");
+                    }
+                    return Ok(env);
+                }
+                Err(Error::NotFound(_)) => {}
+                Err(err) => return Err(err),
+            }
+
+            // Then a virtual environment
             match Self::from_virtualenv(cache) {
                 Ok(venv) => Ok(venv),
                 Err(Error::NotFound(_)) if system.is_allowed() => Self::from_default_python(cache),
@@ -41,7 +59,10 @@ impl PythonEnvironment {
 
     /// Create a [`PythonEnvironment`] for an existing virtual environment.
     pub fn from_virtualenv(cache: &Cache) -> Result<Self, Error> {
-        let sources = SourceSelector::virtualenvs();
+        let sources = SourceSelector::from_sources([
+            InterpreterSource::DiscoveredEnvironment,
+            InterpreterSource::ActiveEnvironment,
+        ]);
         let request = InterpreterRequest::Version(VersionRequest::Default);
         let found = find_interpreter(&request, SystemPython::Disallowed, &sources, cache)??;
 
@@ -51,6 +72,18 @@ impl PythonEnvironment {
             found.source(),
             found.interpreter().base_prefix().display()
         );
+
+        Ok(Self(Arc::new(PythonEnvironmentShared {
+            root: found.interpreter().prefix().to_path_buf(),
+            interpreter: found.into_interpreter(),
+        })))
+    }
+
+    /// Create a [`PythonEnvironment`] for the parent interpreter i.e. the executable in `python -m uv ...`
+    pub fn from_parent_interpreter(cache: &Cache) -> Result<Self, Error> {
+        let sources = SourceSelector::from_sources([InterpreterSource::ParentInterpreter]);
+        let request = InterpreterRequest::Version(VersionRequest::Default);
+        let found = find_interpreter(&request, &sources, cache)??;
 
         Ok(Self(Arc::new(PythonEnvironmentShared {
             root: found.interpreter().prefix().to_path_buf(),

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -1372,6 +1372,7 @@ mod tests {
             &python,
             &PythonVersion::from_str("3.12.1").unwrap(),
             ImplementationName::CPython,
+            true,
         )?;
 
         with_vars(
@@ -1382,7 +1383,7 @@ mod tests {
                     "PATH",
                     Some(simple_mock_interpreters(&tempdir, &["3.12.2", "3.12.3"])?),
                 ),
-                ("UV__PARENT_INTERPRETER", Some(python.into())),
+                ("UV_INTERNAL__PARENT_INTERPRETER", Some(python.into())),
                 ("VIRTUAL_ENV", Some(venv.into())),
                 ("PWD", Some(pwd.path().into())),
             ],
@@ -1402,7 +1403,7 @@ mod tests {
     }
 
     #[test]
-    fn find_environment_from_parent_interpreter_system_not_allowed() -> Result<()> {
+    fn find_environment_from_parent_interpreter_system_explicit() -> Result<()> {
         let tempdir = TempDir::new()?;
         let cache = Cache::temp()?;
         let pwd = tempdir.child("pwd");
@@ -1413,6 +1414,7 @@ mod tests {
             &python,
             &PythonVersion::from_str("3.12.1").unwrap(),
             ImplementationName::CPython,
+            true,
         )?;
 
         with_vars(
@@ -1423,7 +1425,49 @@ mod tests {
                     "PATH",
                     Some(simple_mock_interpreters(&tempdir, &["3.12.2", "3.12.3"])?),
                 ),
-                ("UV__PARENT_INTERPRETER", Some(python.into())),
+                ("UV_INTERNAL__PARENT_INTERPRETER", Some(python.into())),
+                ("VIRTUAL_ENV", Some(venv.into())),
+                ("PWD", Some(pwd.path().into())),
+            ],
+            || {
+                let environment =
+                    PythonEnvironment::find(None, crate::SystemPython::Explicit, &cache)
+                        .expect("An environment is found");
+                assert_eq!(
+                    environment.interpreter().python_full_version().to_string(),
+                    "3.12.1",
+                    "We prefer the parent interpreter even though it is system"
+                );
+            },
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn find_environment_from_parent_interpreter_system_disallowed() -> Result<()> {
+        let tempdir = TempDir::new()?;
+        let cache = Cache::temp()?;
+        let pwd = tempdir.child("pwd");
+        pwd.create_dir_all()?;
+        let venv = mock_venv(&tempdir, "3.12.0")?;
+        let python = tempdir.child("python").to_path_buf();
+        create_mock_interpreter(
+            &python,
+            &PythonVersion::from_str("3.12.1").unwrap(),
+            ImplementationName::CPython,
+            true,
+        )?;
+
+        with_vars(
+            [
+                ("UV_TEST_PYTHON_PATH", None),
+                ("UV_BOOTSTRAP_DIR", None),
+                (
+                    "PATH",
+                    Some(simple_mock_interpreters(&tempdir, &["3.12.2", "3.12.3"])?),
+                ),
+                ("UV_INTERNAL__PARENT_INTERPRETER", Some(python.into())),
                 ("VIRTUAL_ENV", Some(venv.into())),
                 ("PWD", Some(pwd.path().into())),
             ],
@@ -1433,8 +1477,50 @@ mod tests {
                         .expect("An environment is found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
-                    "3.12.1",
-                    "We should prefer parent interpreter"
+                    "3.12.0",
+                    "We find the virtual environment Python because the system is explicitly not allowed"
+                );
+            },
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn find_environment_from_parent_interpreter_system_required() -> Result<()> {
+        let tempdir = TempDir::new()?;
+        let cache = Cache::temp()?;
+        let pwd = tempdir.child("pwd");
+        pwd.create_dir_all()?;
+        let venv = mock_venv(&tempdir, "3.12.0")?;
+        let python = tempdir.child("python").to_path_buf();
+        create_mock_interpreter(
+            &python,
+            &PythonVersion::from_str("3.12.1").unwrap(),
+            ImplementationName::CPython,
+            false,
+        )?;
+
+        with_vars(
+            [
+                ("UV_TEST_PYTHON_PATH", None),
+                ("UV_BOOTSTRAP_DIR", None),
+                (
+                    "PATH",
+                    Some(simple_mock_interpreters(&tempdir, &["3.12.2", "3.12.3"])?),
+                ),
+                ("UV_INTERNAL__PARENT_INTERPRETER", Some(python.into())),
+                ("VIRTUAL_ENV", Some(venv.into())),
+                ("PWD", Some(pwd.path().into())),
+            ],
+            || {
+                let environment =
+                    PythonEnvironment::find(None, crate::SystemPython::Required, &cache)
+                        .expect("An environment is found");
+                assert_eq!(
+                    environment.interpreter().python_full_version().to_string(),
+                    "3.12.2",
+                    "We should skip the parent interpreter since its in a virtual environment"
                 );
             },
         );
@@ -1679,6 +1765,43 @@ mod tests {
                     environment.interpreter().python_full_version().to_string(),
                     "3.10.0",
                     "We should find the venv interpreter"
+                );
+            },
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn find_environment_allows_file_path_with_system_explicit() -> Result<()> {
+        let tempdir = TempDir::new()?;
+        let cache = Cache::temp()?;
+        tempdir.child("foo").create_dir_all()?;
+        let python = tempdir.child("foo").join("bar");
+        create_mock_interpreter(
+            &python,
+            &PythonVersion::from_str("3.10.0").unwrap(),
+            ImplementationName::default(),
+            true,
+        )?;
+
+        with_vars(
+            [
+                ("UV_TEST_PYTHON_PATH", None::<OsString>),
+                ("PATH", None),
+                ("PWD", Some(tempdir.path().into())),
+            ],
+            || {
+                let environment = PythonEnvironment::find(
+                    Some(python.to_str().expect("Test path is valid unicode")),
+                    crate::SystemPython::Explicit,
+                    &cache,
+                )
+                .expect("Environment should be found");
+                assert_eq!(
+                    environment.interpreter().python_full_version().to_string(),
+                    "3.10.0",
+                    "We should find the interpreter"
                 );
             },
         );

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -117,7 +117,7 @@ pub(crate) async fn pip_install(
     let system = if system {
         SystemPython::Required
     } else {
-        SystemPython::Disallowed
+        SystemPython::Explicit
     };
     let venv = PythonEnvironment::find(python.as_deref(), system, &cache)?;
 

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -121,7 +121,7 @@ pub(crate) async fn pip_sync(
     let system = if system {
         SystemPython::Required
     } else {
-        SystemPython::Disallowed
+        SystemPython::Explicit
     };
     let venv = PythonEnvironment::find(python.as_deref(), system, &cache)?;
 

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -46,7 +46,7 @@ pub(crate) async fn pip_uninstall(
     let system = if system {
         SystemPython::Required
     } else {
-        SystemPython::Disallowed
+        SystemPython::Explicit
     };
     let venv = PythonEnvironment::find(python.as_deref(), system, &cache)?;
 

--- a/python/uv/__main__.py
+++ b/python/uv/__main__.py
@@ -31,6 +31,9 @@ def _run() -> None:
     if venv:
         env.setdefault("VIRTUAL_ENV", venv)
 
+    # Let `uv` know that it was spawned by this Python interpreter
+    env["UV__PARENT_INTERPRETER"] = sys.executable
+
     if sys.platform == "win32":
         import subprocess
 

--- a/python/uv/__main__.py
+++ b/python/uv/__main__.py
@@ -32,7 +32,7 @@ def _run() -> None:
         env.setdefault("VIRTUAL_ENV", venv)
 
     # Let `uv` know that it was spawned by this Python interpreter
-    env["UV__PARENT_INTERPRETER"] = sys.executable
+    env["UV_INTERNAL__PARENT_INTERPRETER"] = sys.executable
 
     if sys.platform == "win32":
         import subprocess


### PR DESCRIPTION
Closes #2222
Closes https://github.com/astral-sh/uv/issues/2058
Replaces https://github.com/astral-sh/uv/pull/2338
See also https://github.com/astral-sh/uv/issues/2649

We use an environment variable (`UV_INTERNAL__PARENT_INTERPRETER`) to track the invoking interpreter when `python -m uv` is used. The parent interpreter is preferred over all other sources (though it will be skipped if it does not meet a `--python` request or if `--system` is used and it belongs to a virtual environment). We warn if `--system` is not provided and this interpreter would mutate system packages, but allow it.