### PR TITLE
Filter discovered Python interpreters by system preference

### DIFF
--- a/crates/uv-interpreter/src/discovery.rs
+++ b/crates/uv-interpreter/src/discovery.rs
@@ -322,24 +322,50 @@ fn python_executables_from_search_path<'a>(
 fn python_interpreters<'a>(
     version: Option<&'a VersionRequest>,
     implementation: Option<&'a ImplementationName>,
+    system: SystemPython,
     sources: &SourceSelector,
     cache: &'a Cache,
 ) -> impl Iterator<Item = Result<(InterpreterSource, Interpreter), Error>> + 'a {
-    python_executables(version, implementation, sources).map(|result| match result {
-        Ok((source, path)) => Interpreter::query(&path, cache)
-            .map(|interpreter| (source, interpreter))
-            .inspect(|(source, interpreter)| {
-                trace!(
-                    "Found Python interpreter {} {} at {} from {source}",
-                    interpreter.implementation_name(),
-                    interpreter.python_full_version(),
-                    path.display()
-                );
-            })
-            .map_err(Error::from)
-            .inspect_err(|err| trace!("{err}")),
-        Err(err) => Err(err),
-    })
+    python_executables(version, implementation, sources)
+        .map(|result| match result {
+            Ok((source, path)) => Interpreter::query(&path, cache)
+                .map(|interpreter| (source, interpreter))
+                .inspect(|(source, interpreter)| {
+                    trace!(
+                        "Found Python interpreter {} {} at {} from {source}",
+                        interpreter.implementation_name(),
+                        interpreter.python_full_version(),
+                        path.display()
+                    );
+                })
+                .map_err(Error::from)
+                .inspect_err(|err| trace!("{err}")),
+            Err(err) => Err(err),
+        })
+        .filter(move |result| match result {
+            // Filter the returned interpreters to conform to the system request
+            Ok((_, interpreter)) => match (system, interpreter.is_virtualenv()) {
+                (SystemPython::Allowed, _) => true,
+                (SystemPython::Disallowed, false) => {
+                    debug!(
+                        "Ignoring Python interpreter at `{}`: system intepreter not allowed",
+                        interpreter.sys_executable().display()
+                    );
+                    false
+                }
+                (SystemPython::Disallowed, true) => true,
+                (SystemPython::Required, true) => {
+                    debug!(
+                        "Ignoring Python interpreter at `{}`: system intepreter required",
+                        interpreter.sys_executable().display()
+                    );
+                    false
+                }
+                (SystemPython::Required, false) => true,
+            },
+            // Do not drop any errors
+            Err(_) => true,
+        })
 }
 
 /// Check if an encountered error should stop discovery.
@@ -370,6 +396,7 @@ fn should_stop_discovery(err: &Error) -> bool {
 /// the error will raised instead of attempting further candidates.
 pub fn find_interpreter(
     request: &InterpreterRequest,
+    system: SystemPython,
     sources: &SourceSelector,
     cache: &Cache,
 ) -> Result<InterpreterResult, Error> {
@@ -433,7 +460,7 @@ pub fn find_interpreter(
         }
         InterpreterRequest::Implementation(implementation) => {
             let Some((source, interpreter)) =
-                python_interpreters(None, Some(implementation), sources, cache)
+                python_interpreters(None, Some(implementation), system, sources, cache)
                     .find(|result| {
                         match result {
                             // Return the first critical error or matching interpreter
@@ -456,7 +483,7 @@ pub fn find_interpreter(
         }
         InterpreterRequest::ImplementationVersion(implementation, version) => {
             let Some((source, interpreter)) =
-                python_interpreters(Some(version), Some(implementation), sources, cache)
+                python_interpreters(Some(version), Some(implementation), system, sources, cache)
                     .find(|result| {
                         match result {
                             // Return the first critical error or matching interpreter
@@ -486,7 +513,7 @@ pub fn find_interpreter(
         }
         InterpreterRequest::Version(version) => {
             let Some((source, interpreter)) =
-                python_interpreters(Some(version), None, sources, cache)
+                python_interpreters(Some(version), None, system, sources, cache)
                     .find(|result| {
                         match result {
                             // Return the first critical error or matching interpreter
@@ -525,7 +552,7 @@ pub fn find_default_interpreter(cache: &Cache) -> Result<InterpreterResult, Erro
         InterpreterSource::PyLauncher,
     ]);
 
-    let result = find_interpreter(&request, &sources, cache)?;
+    let result = find_interpreter(&request, SystemPython::Required, &sources, cache)?;
     if let Ok(ref found) = result {
         warn_on_unsupported_python(found.interpreter());
     }
@@ -556,7 +583,7 @@ pub fn find_best_interpreter(
 
     // First, check for an exact match (or the first available version if no Python versfion was provided)
     debug!("Looking for exact match for request {request}");
-    let result = find_interpreter(request, &sources, cache)?;
+    let result = find_interpreter(request, system, &sources, cache)?;
     if let Ok(ref found) = result {
         warn_on_unsupported_python(found.interpreter());
         return Ok(result);
@@ -578,7 +605,7 @@ pub fn find_best_interpreter(
         _ => None,
     } {
         debug!("Looking for relaxed patch version {request}");
-        let result = find_interpreter(&request, &sources, cache)?;
+        let result = find_interpreter(&request, system, &sources, cache)?;
         if let Ok(ref found) = result {
             warn_on_unsupported_python(found.interpreter());
             return Ok(result);
@@ -590,7 +617,7 @@ pub fn find_best_interpreter(
     let request = InterpreterRequest::Version(VersionRequest::Default);
     Ok(find_interpreter(
         // TODO(zanieb): Add a dedicated `Default` variant to `InterpreterRequest`
-        &request, &sources, cache,
+        &request, system, &sources, cache,
     )?
     .map_err(|err| {
         // Use a more general error in this case since we looked for multiple versions

--- a/crates/uv-interpreter/src/environment.rs
+++ b/crates/uv-interpreter/src/environment.rs
@@ -43,7 +43,7 @@ impl PythonEnvironment {
     pub fn from_virtualenv(cache: &Cache) -> Result<Self, Error> {
         let sources = SourceSelector::virtualenvs();
         let request = InterpreterRequest::Version(VersionRequest::Default);
-        let found = find_interpreter(&request, &sources, cache)??;
+        let found = find_interpreter(&request, SystemPython::Disallowed, &sources, cache)??;
 
         debug_assert!(
             found.interpreter().base_prefix() == found.interpreter().base_exec_prefix(),
@@ -86,7 +86,7 @@ impl PythonEnvironment {
     ) -> Result<Self, Error> {
         let sources = SourceSelector::from_env(system);
         let request = InterpreterRequest::parse(request);
-        let interpreter = find_interpreter(&request, &sources, cache)??.into_interpreter();
+        let interpreter = find_interpreter(&request, system, &sources, cache)??.into_interpreter();
         Ok(Self(Arc::new(PythonEnvironmentShared {
             root: interpreter.prefix().to_path_buf(),
             interpreter,

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -171,7 +171,7 @@ pub(crate) async fn pip_compile(
     let interpreter = if let Some(python) = python.as_ref() {
         let request = InterpreterRequest::parse(python);
         let sources = SourceSelector::from_env(system);
-        find_interpreter(&request, &sources, &cache)??
+        find_interpreter(&request, system, &sources, &cache)??
     } else {
         let request = if let Some(version) = python_version.as_ref() {
             // TODO(zanieb): We should consolidate `VersionRequest` and `PythonVersion`

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -119,9 +119,10 @@ async fn venv_impl(
 ) -> miette::Result<ExitStatus> {
     // Locate the Python interpreter.
     let interpreter = if let Some(python) = python_request.as_ref() {
+        let system = uv_interpreter::SystemPython::Required;
         let request = InterpreterRequest::parse(python);
-        let sources = SourceSelector::from_env(uv_interpreter::SystemPython::Required);
-        find_interpreter(&request, &sources, cache)
+        let sources = SourceSelector::from_env(system);
+        find_interpreter(&request, system, &sources, cache)
     } else {
         find_default_interpreter(cache)
     }

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -401,7 +401,14 @@ pub fn python_path_with_versions(
                         .expect("The test version request must be valid"),
                 );
                 let sources = SourceSelector::All;
-                if let Ok(found) = find_interpreter(&request, &sources, &cache).unwrap() {
+                if let Ok(found) = find_interpreter(
+                    &request,
+                    uv_interpreter::SystemPython::Allowed,
+                    &sources,
+                    &cache,
+                )
+                .unwrap()
+                {
                     vec![found
                         .into_interpreter()
                         .sys_executable()


### PR DESCRIPTION
Previously, we enforced `SystemPython` outside of the interpreter discovery exclusively with source selection. Now, we perform additional filtering of interpreters depending on if they are a virtual environment. This should not change any existing behavior, but will make it much easier to have consistent behavior in ambiguous cases like https://github.com/astral-sh/uv/pull/3736#discussion_r1610072262 where a source could provide either a system interpreter or virtual environment interpreter.