### PR TITLE
Allow `--constraint` files in `pip sync`

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -639,6 +639,16 @@ pub(crate) struct PipSyncArgs {
     #[arg(required(true))]
     pub(crate) src_file: Vec<PathBuf>,
 
+    /// Constrain versions using the given requirements files.
+    ///
+    /// Constraints files are `requirements.txt`-like files that only control the _version_ of a
+    /// requirement that's installed. However, including a package in a constraints file will _not_
+    /// trigger the installation of that package.
+    ///
+    /// This is equivalent to pip's `--constraint` option.
+    #[arg(long, short, env = "UV_CONSTRAINT", value_delimiter = ' ', value_parser = parse_file_path)]
+    pub(crate) constraint: Vec<Maybe<PathBuf>>,
+
     /// Reinstall all packages, regardless of whether they're already installed.
     #[arg(long, alias = "force-reinstall", overrides_with("no_reinstall"))]
     pub(crate) reinstall: bool,

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -42,7 +42,8 @@ use crate::printer::Printer;
 /// Install a set of locked requirements into the current Python environment.
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) async fn pip_sync(
-    sources: &[RequirementsSource],
+    requirements: &[RequirementsSource],
+    constraints: &[RequirementsSource],
     reinstall: &Reinstall,
     link_mode: LinkMode,
     compile: bool,
@@ -77,7 +78,6 @@ pub(crate) async fn pip_sync(
         .keyring(keyring_provider);
 
     // Initialize a few defaults.
-    let constraints = &[];
     let overrides = &[];
     let extras = ExtrasSpecification::default();
     let upgrade = Upgrade::default();
@@ -101,7 +101,7 @@ pub(crate) async fn pip_sync(
         no_build: specified_no_build,
         extras: _,
     } = operations::read_requirements(
-        sources,
+        requirements,
         constraints,
         overrides,
         &ExtrasSpecification::default(),

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -185,6 +185,7 @@ async fn run() -> Result<ExitStatus> {
 
             // Initialize the cache.
             let cache = cache.init()?.with_refresh(args.refresh);
+
             let requirements = args
                 .src_file
                 .into_iter()
@@ -260,14 +261,21 @@ async fn run() -> Result<ExitStatus> {
 
             // Initialize the cache.
             let cache = cache.init()?.with_refresh(args.refresh);
-            let sources = args
+
+            let requirements = args
                 .src_file
                 .into_iter()
                 .map(RequirementsSource::from_requirements_file)
                 .collect::<Vec<_>>();
+            let constraints = args
+                .constraint
+                .into_iter()
+                .map(RequirementsSource::from_constraints_txt)
+                .collect::<Vec<_>>();
 
             commands::pip_sync(
-                &sources,
+                &requirements,
+                &constraints,
                 &args.reinstall,
                 args.shared.link_mode,
                 args.shared.compile_bytecode,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -330,6 +330,7 @@ impl PipCompileSettings {
 pub(crate) struct PipSyncSettings {
     // CLI-only settings.
     pub(crate) src_file: Vec<PathBuf>,
+    pub(crate) constraint: Vec<PathBuf>,
     pub(crate) reinstall: Reinstall,
     pub(crate) refresh: Refresh,
     pub(crate) dry_run: bool,
@@ -343,6 +344,7 @@ impl PipSyncSettings {
     pub(crate) fn resolve(args: PipSyncArgs, workspace: Option<Workspace>) -> Self {
         let PipSyncArgs {
             src_file,
+            constraint,
             reinstall,
             no_reinstall,
             reinstall_package,
@@ -387,6 +389,10 @@ impl PipSyncSettings {
         Self {
             // CLI-only settings.
             src_file,
+            constraint: constraint
+                .into_iter()
+                .filter_map(Maybe::into_option)
+                .collect(),
             reinstall: Reinstall::from_args(flag(reinstall, no_reinstall), reinstall_package),
             refresh: Refresh::from_args(flag(refresh, no_refresh), refresh_package),
             dry_run,


### PR DESCRIPTION
## Summary

Trivial now that this follows the same strategy and internals as `pip install`.

Closes https://github.com/astral-sh/uv/issues/3438.
