### PR TITLE
Improve display of selected interpreter sources

### DIFF
--- a/crates/uv-interpreter/src/environment.rs
+++ b/crates/uv-interpreter/src/environment.rs
@@ -51,10 +51,7 @@ impl PythonEnvironment {
 
     /// Create a [`PythonEnvironment`] for an existing virtual environment.
     pub fn from_virtualenv(cache: &Cache) -> Result<Self, Error> {
-        let sources = SourceSelector::from_sources([
-            InterpreterSource::DiscoveredEnvironment,
-            InterpreterSource::ActiveEnvironment,
-        ]);
+        let sources = SourceSelector::VirtualEnv;
         let request = InterpreterRequest::Version(VersionRequest::Default);
         let found = find_interpreter(&request, SystemPython::Disallowed, &sources, cache)??;
 
@@ -109,7 +106,7 @@ impl PythonEnvironment {
         system: SystemPython,
         cache: &Cache,
     ) -> Result<Self, Error> {
-        let sources = SourceSelector::from_env(system);
+        let sources = SourceSelector::from_settings(system);
         let request = InterpreterRequest::parse(request);
         let interpreter = find_interpreter(&request, system, &sources, cache)??.into_interpreter();
         Ok(Self(Arc::new(PythonEnvironmentShared {

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -700,12 +700,7 @@ mod tests {
     fn find_interpreter_version_minor() -> Result<()> {
         let tempdir = TempDir::new()?;
         let cache = Cache::temp()?;
-        let sources = SourceSelector::from_sources([
-            InterpreterSource::ProvidedPath,
-            InterpreterSource::ActiveEnvironment,
-            InterpreterSource::DiscoveredEnvironment,
-            InterpreterSource::SearchPath,
-        ]);
+        let sources = SourceSelector::All;
 
         with_vars(
             [
@@ -757,12 +752,7 @@ mod tests {
     fn find_interpreter_version_patch() -> Result<()> {
         let tempdir = TempDir::new()?;
         let cache = Cache::temp()?;
-        let sources = SourceSelector::from_sources([
-            InterpreterSource::ProvidedPath,
-            InterpreterSource::ActiveEnvironment,
-            InterpreterSource::DiscoveredEnvironment,
-            InterpreterSource::SearchPath,
-        ]);
+        let sources = SourceSelector::All;
 
         with_vars(
             [
@@ -814,12 +804,7 @@ mod tests {
     fn find_interpreter_version_minor_no_match() -> Result<()> {
         let tempdir = TempDir::new()?;
         let cache = Cache::temp()?;
-        let sources = SourceSelector::from_sources([
-            InterpreterSource::ProvidedPath,
-            InterpreterSource::ActiveEnvironment,
-            InterpreterSource::DiscoveredEnvironment,
-            InterpreterSource::SearchPath,
-        ]);
+        let sources = SourceSelector::All;
 
         with_vars(
             [
@@ -861,12 +846,7 @@ mod tests {
     fn find_interpreter_version_patch_no_match() -> Result<()> {
         let tempdir = TempDir::new()?;
         let cache = Cache::temp()?;
-        let sources = SourceSelector::from_sources([
-            InterpreterSource::ProvidedPath,
-            InterpreterSource::ActiveEnvironment,
-            InterpreterSource::DiscoveredEnvironment,
-            InterpreterSource::SearchPath,
-        ]);
+        let sources = SourceSelector::All;
 
         with_vars(
             [

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -170,7 +170,7 @@ pub(crate) async fn pip_compile(
     };
     let interpreter = if let Some(python) = python.as_ref() {
         let request = InterpreterRequest::parse(python);
-        let sources = SourceSelector::from_env(system);
+        let sources = SourceSelector::from_settings(system);
         find_interpreter(&request, system, &sources, &cache)??
     } else {
         let request = if let Some(version) = python_version.as_ref() {

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -121,7 +121,7 @@ async fn venv_impl(
     let interpreter = if let Some(python) = python_request.as_ref() {
         let system = uv_interpreter::SystemPython::Required;
         let request = InterpreterRequest::parse(python);
-        let sources = SourceSelector::from_env(system);
+        let sources = SourceSelector::from_settings(system);
         find_interpreter(&request, system, &sources, cache)
     } else {
         find_default_interpreter(cache)

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -218,20 +218,33 @@ fn create_venv_unknown_python_minor() {
     let mut command = context.venv_command();
     command
         .arg(context.venv.as_os_str())
+        // Request a version we know we'll never see
         .arg("--python")
-        .arg("3.15");
+        .arg("3.100")
+        // Unset this variable to force what the user would see
+        .env_remove("UV_TEST_PYTHON_PATH");
 
-    // Note the `py` launcher is not included in the search in Windows due to
-    // `UV_TEST_PYTHON_PATH` being set
-    uv_snapshot!(&mut command, @r###"
-    success: false
-    exit_code: 1
-    ----- stdout -----
+    if cfg!(windows) {
+        uv_snapshot!(&mut command, @r###"
+        success: false
+        exit_code: 1
+        ----- stdout -----
 
-    ----- stderr -----
-      × No interpreter found for Python 3.15 in active virtual environment or search path
-    "###
-    );
+        ----- stderr -----
+          × No interpreter found for Python 3.100 in search path or `py` launcher output
+        "###
+        );
+    } else {
+        uv_snapshot!(&mut command, @r###"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+
+        ----- stderr -----
+          × No interpreter found for Python 3.100 in search path
+        "###
+        );
+    }
 
     context.venv.assert(predicates::path::missing());
 }
@@ -240,18 +253,36 @@ fn create_venv_unknown_python_minor() {
 fn create_venv_unknown_python_patch() {
     let context = VenvTestContext::new(&["3.12"]);
 
-    uv_snapshot!(context.filters(), context.venv_command()
+    let mut command = context.venv_command();
+    command
         .arg(context.venv.as_os_str())
+        // Request a version we know we'll never see
         .arg("--python")
-        .arg("3.8.0"), @r###"
-    success: false
-    exit_code: 1
-    ----- stdout -----
+        .arg("3.12.100")
+        // Unset this variable to force what the user would see
+        .env_remove("UV_TEST_PYTHON_PATH");
 
-    ----- stderr -----
-      × No interpreter found for Python 3.8.0 in active virtual environment or search path
-    "###
-    );
+    if cfg!(windows) {
+        uv_snapshot!(&mut command, @r###"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+
+        ----- stderr -----
+          × No interpreter found for Python 3.12.100 in search path or `py` launcher output
+        "###
+        );
+    } else {
+        uv_snapshot!(&mut command, @r###"
+        success: false
+        exit_code: 1
+        ----- stdout -----
+
+        ----- stderr -----
+          × No interpreter found for Python 3.12.100 in search path
+        "###
+        );
+    }
 
     context.venv.assert(predicates::path::missing());
 }


### PR DESCRIPTION
e.g. this error message is not great

```
❯ uv venv --python 3.12.2
  × No interpreter found for Python 3.12.2 in provided path, search path, managed toolchains, or parent interpreter
```