### PR TITLE
Use pip "operations" API in project commands

### DIFF
--- a/crates/uv/src/commands/pip/check.rs
+++ b/crates/uv/src/commands/pip/check.rs
@@ -1,11 +1,11 @@
 use std::fmt::Write;
+use std::time::Instant;
 
 use anyhow::Result;
-use distribution_types::InstalledDist;
 use owo_colors::OwoColorize;
-use std::time::Instant;
 use tracing::debug;
 
+use distribution_types::InstalledDist;
 use uv_cache::Cache;
 use uv_fs::Simplified;
 use uv_installer::{Diagnostic, SitePackages};

--- a/crates/uv/src/commands/pip/mod.rs
+++ b/crates/uv/src/commands/pip/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod compile;
 pub(crate) mod freeze;
 pub(crate) mod install;
 pub(crate) mod list;
-mod operations;
+pub(crate) mod operations;
 pub(crate) mod show;
 pub(crate) mod sync;
 pub(crate) mod uninstall;

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1,38 +1,29 @@
 use std::fmt::Write;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-
-use distribution_types::{IndexLocations, InstalledMetadata, LocalDist, Name, Resolution};
-use install_wheel_rs::linker::LinkMode;
-use pep508_rs::MarkerEnvironment;
-use platform_tags::Tags;
-use pypi_types::Yanked;
 use tracing::debug;
+
+use distribution_types::{IndexLocations, Resolution};
+use install_wheel_rs::linker::LinkMode;
 use uv_cache::Cache;
-use uv_client::{BaseClientBuilder, Connectivity, RegistryClient, RegistryClientBuilder};
+use uv_client::{BaseClientBuilder, Connectivity, RegistryClientBuilder};
 use uv_configuration::{
-    Concurrency, ConfigSettings, Constraints, NoBinary, NoBuild, Overrides, PreviewMode, Reinstall,
-    SetupPyStrategy,
+    Concurrency, ConfigSettings, NoBinary, NoBuild, PreviewMode, Reinstall, SetupPyStrategy,
+    Upgrade,
 };
 use uv_dispatch::BuildDispatch;
-use uv_distribution::DistributionDatabase;
 use uv_fs::Simplified;
-use uv_installer::{Downloader, Plan, Planner, SatisfiesResult, SitePackages};
-use uv_interpreter::{find_default_interpreter, Interpreter, PythonEnvironment};
+use uv_installer::{SatisfiesResult, SitePackages};
+use uv_interpreter::{find_default_interpreter, PythonEnvironment};
 use uv_requirements::{
-    ExtrasSpecification, LookaheadResolver, NamedRequirementsResolver, ProjectWorkspace,
-    RequirementsSource, RequirementsSpecification, SourceTreeResolver,
+    ExtrasSpecification, ProjectWorkspace, RequirementsSource, RequirementsSpecification,
 };
-use uv_resolver::{
-    Exclusions, FlatIndex, InMemoryIndex, Manifest, Options, OptionsBuilder, PythonRequirement,
-    ResolutionGraph, Resolver,
-};
-use uv_types::{BuildIsolation, HashStrategy, InFlight, InstalledPackagesProvider};
+use uv_resolver::{FlatIndex, InMemoryIndex, Options};
+use uv_types::{BuildIsolation, HashStrategy, InFlight};
 
-use crate::commands::reporters::{DownloadReporter, InstallReporter, ResolverReporter};
-use crate::commands::{elapsed, ChangeEvent, ChangeEventKind};
+use crate::commands::pip;
 use crate::editables::ResolvedEditables;
 use crate::printer::Printer;
 
@@ -43,41 +34,17 @@ pub(crate) mod sync;
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum Error {
     #[error(transparent)]
-    Resolve(#[from] uv_resolver::ResolveError),
-
-    #[error(transparent)]
-    Client(#[from] uv_client::Error),
-
-    #[error(transparent)]
-    Platform(#[from] platform_tags::PlatformError),
-
-    #[error(transparent)]
     Interpreter(#[from] uv_interpreter::Error),
 
     #[error(transparent)]
     Virtualenv(#[from] uv_virtualenv::Error),
 
     #[error(transparent)]
-    Hash(#[from] uv_types::HashStrategyError),
-
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-
-    #[error(transparent)]
     Fmt(#[from] std::fmt::Error),
-
-    #[error(transparent)]
-    Lookahead(#[from] uv_requirements::LookaheadError),
-
-    #[error(transparent)]
-    ParsedUrl(#[from] Box<distribution_types::ParsedUrlError>),
-
-    #[error(transparent)]
-    Anyhow(#[from] anyhow::Error),
 }
 
 /// Initialize a virtual environment for the current project.
-pub(crate) fn init(
+pub(crate) fn init_environment(
     project: &ProjectWorkspace,
     cache: &Cache,
     printer: Printer,
@@ -118,349 +85,6 @@ pub(crate) fn init(
         }
         Err(e) => Err(e.into()),
     }
-}
-
-/// Resolve a set of requirements, similar to running `pip compile`.
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
-    spec: RequirementsSpecification,
-    installed_packages: InstalledPackages,
-    editables: &ResolvedEditables,
-    hasher: &HashStrategy,
-    interpreter: &Interpreter,
-    tags: &Tags,
-    markers: &MarkerEnvironment,
-    client: &RegistryClient,
-    flat_index: &FlatIndex,
-    index: &InMemoryIndex,
-    build_dispatch: &BuildDispatch<'_>,
-    options: Options,
-    printer: Printer,
-    concurrency: Concurrency,
-) -> Result<ResolutionGraph, Error> {
-    let start = std::time::Instant::now();
-
-    let exclusions = Exclusions::None;
-    let preferences = Vec::new();
-    let constraints = Constraints::default();
-    let overrides = Overrides::default();
-    let python_requirement = PythonRequirement::from_marker_environment(interpreter, markers);
-
-    let RequirementsSpecification {
-        project,
-        requirements,
-        constraints: _,
-        overrides: _,
-        editables: _,
-        source_trees,
-        extras: _,
-        index_url: _,
-        extra_index_urls: _,
-        no_index: _,
-        find_links: _,
-        no_binary: _,
-        no_build: _,
-    } = spec;
-
-    // Resolve the requirements from the provided sources.
-    let requirements = {
-        // Convert from unnamed to named requirements.
-        let mut requirements = NamedRequirementsResolver::new(
-            requirements,
-            hasher,
-            index,
-            DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
-        )
-        .with_reporter(ResolverReporter::from(printer))
-        .resolve()
-        .await?;
-
-        // Resolve any source trees into requirements.
-        if !source_trees.is_empty() {
-            requirements.extend(
-                SourceTreeResolver::new(
-                    source_trees,
-                    &ExtrasSpecification::None,
-                    hasher,
-                    index,
-                    DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
-                )
-                .with_reporter(ResolverReporter::from(printer))
-                .resolve()
-                .await?,
-            );
-        }
-
-        requirements
-    };
-
-    // Determine any lookahead requirements.
-    let editable_metadata = editables.as_metadata().map_err(Error::ParsedUrl)?;
-    let lookaheads = LookaheadResolver::new(
-        &requirements,
-        &constraints,
-        &overrides,
-        &editable_metadata,
-        hasher,
-        index,
-        DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
-    )
-    .with_reporter(ResolverReporter::from(printer))
-    .resolve(Some(markers))
-    .await?;
-
-    // Create a manifest of the requirements.
-    let manifest = Manifest::new(
-        requirements,
-        constraints,
-        overrides,
-        preferences,
-        project,
-        editable_metadata,
-        exclusions,
-        lookaheads,
-    );
-
-    // Resolve the dependencies.
-    let resolver = Resolver::new(
-        manifest,
-        options,
-        &python_requirement,
-        Some(markers),
-        tags,
-        flat_index,
-        index,
-        hasher,
-        build_dispatch,
-        installed_packages,
-        DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
-    )?
-    .with_reporter(ResolverReporter::from(printer));
-    let resolution = resolver.resolve().await?;
-
-    let s = if resolution.len() == 1 { "" } else { "s" };
-    writeln!(
-        printer.stderr(),
-        "{}",
-        format!(
-            "Resolved {} in {}",
-            format!("{} package{}", resolution.len(), s).bold(),
-            elapsed(start.elapsed())
-        )
-        .dimmed()
-    )?;
-
-    // Notify the user of any diagnostics.
-    for diagnostic in resolution.diagnostics() {
-        writeln!(
-            printer.stderr(),
-            "{}{} {}",
-            "warning".yellow().bold(),
-            ":".bold(),
-            diagnostic.message().bold()
-        )?;
-    }
-
-    Ok(resolution)
-}
-
-/// Install a set of requirements into the current environment.
-#[allow(clippy::too_many_arguments)]
-pub(crate) async fn install(
-    resolution: &Resolution,
-    resolved_editables: ResolvedEditables,
-    site_packages: SitePackages,
-    no_binary: &NoBinary,
-    link_mode: LinkMode,
-    index_urls: &IndexLocations,
-    hasher: &HashStrategy,
-    tags: &Tags,
-    client: &RegistryClient,
-    in_flight: &InFlight,
-    build_dispatch: &BuildDispatch<'_>,
-    cache: &Cache,
-    venv: &PythonEnvironment,
-    printer: Printer,
-    concurrency: Concurrency,
-) -> Result<(), Error> {
-    let start = std::time::Instant::now();
-
-    let requirements = resolution.requirements().collect::<Vec<_>>();
-
-    // Partition into those that should be linked from the cache (`local`), those that need to be
-    // downloaded (`remote`), and those that should be removed (`extraneous`).
-    let plan = Planner::with_requirements(&requirements)
-        .with_editable_requirements(&resolved_editables.editables)
-        .build(
-            site_packages,
-            &Reinstall::None,
-            no_binary,
-            hasher,
-            index_urls,
-            cache,
-            venv,
-            tags,
-        )
-        .context("Failed to determine installation plan")?;
-
-    let Plan {
-        cached,
-        remote,
-        reinstalls,
-        extraneous: _,
-    } = plan;
-
-    // Nothing to do.
-    if remote.is_empty() && cached.is_empty() {
-        let s = if resolution.len() == 1 { "" } else { "s" };
-        writeln!(
-            printer.stderr(),
-            "{}",
-            format!(
-                "Audited {} in {}",
-                format!("{} package{}", resolution.len(), s).bold(),
-                elapsed(start.elapsed())
-            )
-            .dimmed()
-        )?;
-        return Ok(());
-    }
-
-    // Map any registry-based requirements back to those returned by the resolver.
-    let remote = remote
-        .iter()
-        .map(|dist| {
-            resolution
-                .get_remote(&dist.name)
-                .cloned()
-                .expect("Resolution should contain all packages")
-        })
-        .collect::<Vec<_>>();
-
-    // Download, build, and unzip any missing distributions.
-    let wheels = if remote.is_empty() {
-        vec![]
-    } else {
-        let start = std::time::Instant::now();
-
-        let downloader = Downloader::new(
-            cache,
-            tags,
-            hasher,
-            DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
-        )
-        .with_reporter(DownloadReporter::from(printer).with_length(remote.len() as u64));
-
-        let wheels = downloader
-            .download(remote.clone(), in_flight)
-            .await
-            .context("Failed to download distributions")?;
-
-        let s = if wheels.len() == 1 { "" } else { "s" };
-        writeln!(
-            printer.stderr(),
-            "{}",
-            format!(
-                "Downloaded {} in {}",
-                format!("{} package{}", wheels.len(), s).bold(),
-                elapsed(start.elapsed())
-            )
-            .dimmed()
-        )?;
-
-        wheels
-    };
-
-    // Install the resolved distributions.
-    let wheels = wheels.into_iter().chain(cached).collect::<Vec<_>>();
-    if !wheels.is_empty() {
-        let start = std::time::Instant::now();
-        uv_installer::Installer::new(venv)
-            .with_link_mode(link_mode)
-            .with_reporter(InstallReporter::from(printer).with_length(wheels.len() as u64))
-            .install(&wheels)?;
-
-        let s = if wheels.len() == 1 { "" } else { "s" };
-        writeln!(
-            printer.stderr(),
-            "{}",
-            format!(
-                "Installed {} in {}",
-                format!("{} package{}", wheels.len(), s).bold(),
-                elapsed(start.elapsed())
-            )
-            .dimmed()
-        )?;
-    }
-
-    for event in reinstalls
-        .into_iter()
-        .map(|distribution| ChangeEvent {
-            dist: LocalDist::from(distribution),
-            kind: ChangeEventKind::Removed,
-        })
-        .chain(wheels.into_iter().map(|distribution| ChangeEvent {
-            dist: LocalDist::from(distribution),
-            kind: ChangeEventKind::Added,
-        }))
-        .sorted_unstable_by(|a, b| {
-            a.dist
-                .name()
-                .cmp(b.dist.name())
-                .then_with(|| a.kind.cmp(&b.kind))
-                .then_with(|| a.dist.installed_version().cmp(&b.dist.installed_version()))
-        })
-    {
-        match event.kind {
-            ChangeEventKind::Added => {
-                writeln!(
-                    printer.stderr(),
-                    " {} {}{}",
-                    "+".green(),
-                    event.dist.name().as_ref().bold(),
-                    event.dist.installed_version().to_string().dimmed()
-                )?;
-            }
-            ChangeEventKind::Removed => {
-                writeln!(
-                    printer.stderr(),
-                    " {} {}{}",
-                    "-".red(),
-                    event.dist.name().as_ref().bold(),
-                    event.dist.installed_version().to_string().dimmed()
-                )?;
-            }
-        }
-    }
-
-    // TODO(konstin): Also check the cache whether any cached or installed dist is already known to
-    // have been yanked, we currently don't show this message on the second run anymore
-    for dist in &remote {
-        let Some(file) = dist.file() else {
-            continue;
-        };
-        match &file.yanked {
-            None | Some(Yanked::Bool(false)) => {}
-            Some(Yanked::Bool(true)) => {
-                writeln!(
-                    printer.stderr(),
-                    "{}{} {dist} is yanked.",
-                    "warning".yellow().bold(),
-                    ":".bold(),
-                )?;
-            }
-            Some(Yanked::Reason(reason)) => {
-                writeln!(
-                    printer.stderr(),
-                    "{}{} {dist} is yanked (reason: \"{reason}\").",
-                    "warning".yellow().bold(),
-                    ":".bold(),
-                )?;
-            }
-        }
-    }
-
-    Ok(())
 }
 
 /// Update a [`PythonEnvironment`] to satisfy a set of [`RequirementsSource`]s.
@@ -543,10 +167,15 @@ pub(crate) async fn update_environment(
     let no_build = NoBuild::default();
     let setup_py = SetupPyStrategy::default();
     let concurrency = Concurrency::default();
-    let reinstall = Reinstall::None;
+    let reinstall = Reinstall::default();
+    let compile = false;
+    let dry_run = false;
+    let extras = ExtrasSpecification::default();
+    let upgrade = Upgrade::default();
+    let options = Options::default();
 
     // Create a build dispatch.
-    let build_dispatch = BuildDispatch::new(
+    let resolve_dispatch = BuildDispatch::new(
         &client,
         cache,
         &interpreter,
@@ -563,14 +192,6 @@ pub(crate) async fn update_environment(
         concurrency,
     );
 
-    let options = OptionsBuilder::new()
-        // TODO(zanieb): Support resolver options
-        // .resolution_mode(resolution_mode)
-        // .prerelease_mode(prerelease_mode)
-        // .dependency_mode(dependency_mode)
-        // .exclude_newer(exclude_newer)
-        .build();
-
     // Build all editable distributions. The editables are shared between resolution and
     // installation, and should live for the duration of the command.
     let editables = ResolvedEditables::resolve(
@@ -585,28 +206,35 @@ pub(crate) async fn update_environment(
         tags,
         cache,
         &client,
-        &build_dispatch,
+        &resolve_dispatch,
         concurrency,
         printer,
     )
     .await?;
 
     // Resolve the requirements.
-    let resolution = match resolve(
-        spec,
-        site_packages.clone(),
+    let resolution = match pip::operations::resolve(
+        spec.requirements,
+        spec.constraints,
+        spec.overrides,
+        spec.source_trees,
+        spec.project,
+        &extras,
         &editables,
+        site_packages.clone(),
         &hasher,
+        &reinstall,
+        &upgrade,
         &interpreter,
         tags,
         markers,
         &client,
         &flat_index,
         &index,
-        &build_dispatch,
+        &resolve_dispatch,
+        concurrency,
         options,
         printer,
-        concurrency,
     )
     .await
     {
@@ -617,23 +245,50 @@ pub(crate) async fn update_environment(
     // Re-initialize the in-flight map.
     let in_flight = InFlight::default();
 
+    // If we're running with `--reinstall`, initialize a separate `BuildDispatch`, since we may
+    // end up removing some distributions from the environment.
+    let install_dispatch = if reinstall.is_none() {
+        resolve_dispatch
+    } else {
+        BuildDispatch::new(
+            &client,
+            cache,
+            &interpreter,
+            &index_locations,
+            &flat_index,
+            &index,
+            &in_flight,
+            setup_py,
+            &config_settings,
+            build_isolation,
+            link_mode,
+            &no_build,
+            &no_binary,
+            concurrency,
+        )
+    };
+
     // Sync the environment.
-    install(
+    pip::operations::install(
         &resolution,
-        editables,
+        &editables,
         site_packages,
+        pip::operations::Modifications::Sufficient,
+        &reinstall,
         &no_binary,
         link_mode,
+        compile,
         &index_locations,
         &hasher,
         tags,
         &client,
         &in_flight,
-        &build_dispatch,
+        concurrency,
+        &install_dispatch,
         cache,
         &venv,
+        dry_run,
         printer,
-        concurrency,
     )
     .await?;
 

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -58,7 +58,7 @@ pub(crate) async fn run(
 
         let project = ProjectWorkspace::discover(std::env::current_dir()?)?;
 
-        let venv = project::init(&project, cache, printer)?;
+        let venv = project::init_environment(&project, cache, printer)?;
 
         // Install the project requirements.
         Some(


### PR DESCRIPTION
## Summary

This PR removes most of the code in `project/mod.rs` in favor of the routines exposed in `pip/operations.rs`.

I think we can do a lot more to add more abstraction here and reduce the verbosity, but for now it deduplicates a _ton_ of logic. The remaining logic is just instantiating settings etc.
