### PR TITLE
Remove `aarch64-unknown-linux-gnu` from list of expected binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,6 @@ unix-archive = ".tar.gz"
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [
   "aarch64-apple-darwin",
-  "aarch64-unknown-linux-gnu",
   "aarch64-unknown-linux-musl",
   "arm-unknown-linux-musleabihf",
   "armv7-unknown-linux-gnueabihf",


### PR DESCRIPTION
## Summary

We now only ship the static `aarch64-unknown-linux-musl` binary here.

Closes #3760.
