### PR TITLE
Report yanks for cached and resolved packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4503,7 +4503,6 @@ dependencies = [
  "pep508_rs",
  "platform-tags",
  "predicates",
- "pypi-types",
  "rayon",
  "regex",
  "requirements-txt",

--- a/crates/distribution-types/src/resolved.rs
+++ b/crates/distribution-types/src/resolved.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter};
 
 use pep508_rs::PackageName;
+use pypi_types::Yanked;
 
 use crate::{
     BuiltDist, Dist, DistributionId, DistributionMetadata, Identifier, IndexUrl, InstalledDist,
@@ -48,6 +49,18 @@ impl ResolvedDist {
     pub fn index(&self) -> Option<&IndexUrl> {
         match self {
             Self::Installable(dist) => dist.index(),
+            Self::Installed(_) => None,
+        }
+    }
+
+    /// Returns the [`Yanked`] status of the distribution, if available.
+    pub fn yanked(&self) -> Option<&Yanked> {
+        match self {
+            Self::Installable(dist) => match dist {
+                Dist::Source(SourceDist::Registry(sdist)) => sdist.file.yanked.as_ref(),
+                Dist::Built(BuiltDist::Registry(wheel)) => wheel.best_wheel().file.yanked.as_ref(),
+                _ => None,
+            },
             Self::Installed(_) => None,
         }
     }

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -10,7 +10,7 @@ pub use options::{Options, OptionsBuilder};
 pub use preferences::{Preference, PreferenceError};
 pub use prerelease_mode::PreReleaseMode;
 pub use python_requirement::PythonRequirement;
-pub use resolution::{AnnotationStyle, Diagnostic, DisplayResolutionGraph, ResolutionGraph};
+pub use resolution::{AnnotationStyle, DisplayResolutionGraph, ResolutionGraph};
 pub use resolution_mode::ResolutionMode;
 pub use resolver::{
     BuildId, DefaultResolverProvider, InMemoryIndex, MetadataResponse, PackageVersionsResult,

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -81,7 +81,8 @@ impl Lock {
             let resolved_dist = ResolvedDist::Installable(dist.to_dist(marker_env, tags));
             map.insert(name, resolved_dist);
         }
-        Resolution::new(map)
+        let diagnostics = vec![];
+        Resolution::new(map, diagnostics)
     }
 
     /// Returns the distribution with the given name. If there are multiple

--- a/crates/uv-resolver/src/resolution/mod.rs
+++ b/crates/uv-resolver/src/resolution/mod.rs
@@ -10,7 +10,7 @@ use pypi_types::{HashDigest, Metadata23};
 use uv_normalize::{ExtraName, PackageName};
 
 pub use crate::resolution::display::{AnnotationStyle, DisplayResolutionGraph};
-pub use crate::resolution::graph::{Diagnostic, ResolutionGraph};
+pub use crate::resolution::graph::ResolutionGraph;
 
 mod display;
 mod graph;

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -19,7 +19,6 @@ install-wheel-rs = { workspace = true, features = ["clap"], default-features = f
 pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
 platform-tags = { workspace = true }
-pypi-types = { workspace = true }
 requirements-txt = { workspace = true, features = ["http"] }
 uv-auth = { workspace = true }
 uv-cache = { workspace = true, features = ["clap"] }

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -444,9 +444,12 @@ pub(crate) async fn pip_install(
     )
     .await?;
 
-    // Validate the environment.
-    if strict {
-        operations::report_diagnostics(&resolution, &venv, printer)?;
+    // Notify the user of any resolution diagnostics.
+    operations::diagnose_resolution(resolution.diagnostics(), printer)?;
+
+    // Notify the user of any environment diagnostics.
+    if strict && !dry_run {
+        operations::diagnose_environment(&resolution, &venv, printer)?;
     }
 
     Ok(ExitStatus::Success)

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -389,9 +389,12 @@ pub(crate) async fn pip_sync(
     )
     .await?;
 
-    // Validate the environment.
-    if strict {
-        operations::report_diagnostics(&resolution, &venv, printer)?;
+    // Notify the user of any resolution diagnostics.
+    operations::diagnose_resolution(resolution.diagnostics(), printer)?;
+
+    // Notify the user of any environment diagnostics.
+    if strict && !dry_run {
+        operations::diagnose_environment(&resolution, &venv, printer)?;
     }
 
     Ok(ExitStatus::Success)

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use owo_colors::OwoColorize;
 use tracing::debug;
 
+use crate::commands::pip;
 use distribution_types::{IndexLocations, Resolution};
 use install_wheel_rs::linker::LinkMode;
 use uv_cache::Cache;
@@ -23,7 +24,6 @@ use uv_requirements::{
 use uv_resolver::{FlatIndex, InMemoryIndex, Options};
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 
-use crate::commands::pip;
 use crate::editables::ResolvedEditables;
 use crate::printer::Printer;
 
@@ -291,6 +291,9 @@ pub(crate) async fn update_environment(
         printer,
     )
     .await?;
+
+    // Notify the user of any resolution diagnostics.
+    pip::operations::diagnose_resolution(resolution.diagnostics(), printer)?;
 
     Ok(venv)
 }

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -132,5 +132,8 @@ pub(crate) async fn sync(
     )
     .await?;
 
+    // Notify the user of any resolution diagnostics.
+    pip::operations::diagnose_resolution(resolution.diagnostics(), printer)?;
+
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -2805,6 +2805,7 @@ fn compile_yanked_version_direct() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    warning: `attrs==21.1.0` is yanked (reason: "Installable but not importable on Python 3.4.").
     "###
     );
 

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -708,10 +708,10 @@ fn missing_extra() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    warning: The package `package-a==1.0.0` does not have an extra named `extra`.
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0
+    warning: The package `package-a==1.0.0` does not have an extra named `extra`.
     "###);
 
     // Missing extras are ignored during resolution.
@@ -1081,10 +1081,10 @@ fn extra_does_not_exist_backtrack() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    warning: The package `package-a==3.0.0` does not have an extra named `extra`.
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==3.0.0
+    warning: The package `package-a==3.0.0` does not have an extra named `extra`.
     "###);
 
     // The resolver should not backtrack to `a==1.0.0` because missing extras are
@@ -4779,7 +4779,7 @@ fn transitive_package_only_yanked_in_range_opt_in() {
     Installed 2 packages in [TIME]
      + package-a==0.1.0
      + package-b==1.0.0
-    warning: package-b==1.0.0 is yanked (reason: "Yanked for testing").
+    warning: `package-b==1.0.0` is yanked (reason: "Yanked for testing").
     "###);
 
     // Since the user included a dependency on `b` with an exact specifier, the yanked
@@ -4911,7 +4911,7 @@ fn transitive_yanked_and_unyanked_dependency_opt_in() {
      + package-a==1.0.0
      + package-b==1.0.0
      + package-c==2.0.0
-    warning: package-c==2.0.0 is yanked (reason: "Yanked for testing").
+    warning: `package-c==2.0.0` is yanked (reason: "Yanked for testing").
     "###);
 
     // Since the user explicitly selected the yanked version of `c`, it can be

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -921,7 +921,7 @@ fn warn_on_yanked() -> Result<()> {
     Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
      + colorama==0.4.2
-    warning: colorama==0.4.2 is yanked (reason: "Bad build, missing files, will not install").
+    warning: `colorama==0.4.2` is yanked (reason: "Bad build, missing files, will not install").
     "###
     );
 
@@ -949,7 +949,7 @@ fn warn_on_yanked_dry_run() -> Result<()> {
     Would download 1 package
     Would install 1 package
      + colorama==0.4.2
-    warning: colorama==0.4.2 is yanked (reason: "Bad build, missing files, will not install").
+    warning: `colorama==0.4.2` is yanked (reason: "Bad build, missing files, will not install").
     "###
     );
 


### PR DESCRIPTION
## Summary

We now show yanks as part of the resolution diagnostics, so they now appear for `sync`, `install`, `compile`, and any other operations. Further, they'll also appear for cached packages (but not packages that are _already_ installed).

Closes https://github.com/astral-sh/uv/issues/3768.

Closes #3766.
