### PR TITLE
Add test case for Conda CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,6 +438,36 @@ jobs:
           ./uv venv
           ./${{ matrix.command }}
 
+  integration-test-conda:
+    needs: build-binary-linux
+    name: "integration test | conda on ubuntu"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniconda-version: latest
+          activate-environment: uv
+          python-version: "3.12"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-linux-${{ github.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: Conda info
+        shell: bash -el {0}
+        run: conda info
+
+      - name: "Install a package"
+        shell: bash -el {0}
+        run: |
+          echo "$CONDA_PREFIX"
+          ./uv pip install anyio
+
   cache-test-ubuntu:
     needs: build-binary-linux
     name: "check cache | ubuntu"


### PR DESCRIPTION
Integration test coverage for #3769 

Failure against `main` on https://github.com/astral-sh/uv/actions/runs/9198224186/job/25300510016?pr=3773

Rebased against #3771 to check for fix