### PR TITLE
Incorporate build tag into wheel prioritization

### DIFF
--- a/crates/distribution-filename/src/build_tag.rs
+++ b/crates/distribution-filename/src/build_tag.rs
@@ -1,0 +1,63 @@
+use std::num::ParseIntError;
+use std::str::FromStr;
+use std::sync::Arc;
+
+#[derive(thiserror::Error, Debug)]
+pub enum BuildTagError {
+    #[error("must not be empty")]
+    Empty,
+    #[error("must start with a digit")]
+    NoLeadingDigit,
+    #[error(transparent)]
+    ParseInt(#[from] ParseIntError),
+}
+
+/// The optional build tag for a wheel:
+///
+/// > Must start with a digit. Acts as a tie-breaker if two wheel file names are the same in all
+/// > other respects (i.e. name, version, and other tags). Sort as an empty tuple if unspecified,
+/// > else sort as a two-item tuple with the first item being the initial digits as an int, and the
+/// > second item being the remainder of the tag as a str.
+///
+/// See: <https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention>
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Ord,
+    PartialOrd,
+    rkyv::Archive,
+    rkyv::Deserialize,
+    rkyv::Serialize,
+)]
+#[archive(check_bytes)]
+#[archive_attr(derive(Debug))]
+pub struct BuildTag(u32, Option<Arc<str>>);
+
+impl FromStr for BuildTag {
+    type Err = BuildTagError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // A build tag must not be empty.
+        if s.is_empty() {
+            return Err(BuildTagError::Empty);
+        }
+
+        // A build tag must start with a digit.
+        let (prefix, suffix) = match s.find(|c: char| !c.is_ascii_digit()) {
+            // Ex) `abc`
+            Some(0) => return Err(BuildTagError::NoLeadingDigit),
+            // Ex) `123abc`
+            Some(split) => {
+                let (prefix, suffix) = s.split_at(split);
+                (prefix, Some(suffix))
+            }
+            // Ex) `123`
+            None => (s, None),
+        };
+
+        Ok(BuildTag(prefix.parse::<u32>()?, suffix.map(Arc::from)))
+    }
+}

--- a/crates/distribution-filename/src/lib.rs
+++ b/crates/distribution-filename/src/lib.rs
@@ -3,9 +3,11 @@ use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 use uv_normalize::PackageName;
 
+pub use build_tag::{BuildTag, BuildTagError};
 pub use source_dist::{SourceDistExtension, SourceDistFilename, SourceDistFilenameError};
 pub use wheel::{WheelFilename, WheelFilenameError};
 
+mod build_tag;
 mod source_dist;
 mod wheel;
 

--- a/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_build_tag.snap
+++ b/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_build_tag.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/distribution-filename/src/wheel.rs
-expression: "WheelFilename::from_str(\"foo-1.2.3-build-python-abi-platform.whl\")"
+expression: "WheelFilename::from_str(\"foo-1.2.3-12-python-abi-platform.whl\")"
 ---
 Ok(
     WheelFilename {
@@ -8,6 +8,12 @@ Ok(
             "foo",
         ),
         version: "1.2.3",
+        build_tag: Some(
+            BuildTag(
+                12,
+                None,
+            ),
+        ),
         python_tag: [
             "python",
         ],

--- a/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_multiple_tags.snap
+++ b/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_multiple_tags.snap
@@ -8,6 +8,7 @@ Ok(
             "foo",
         ),
         version: "1.2.3",
+        build_tag: None,
         python_tag: [
             "ab",
             "cd",

--- a/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_single_tags.snap
+++ b/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_single_tags.snap
@@ -8,6 +8,7 @@ Ok(
             "foo",
         ),
         version: "1.2.3",
+        build_tag: None,
         python_tag: [
             "foo",
         ],

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -614,7 +614,7 @@ impl CacheBucket {
             Self::FlatIndex => "flat-index-v0",
             Self::Git => "git-v0",
             Self::Interpreter => "interpreter-v1",
-            Self::Simple => "simple-v7",
+            Self::Simple => "simple-v8",
             Self::Wheels => "wheels-v1",
             Self::Archive => "archive-v0",
         }

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -175,7 +175,7 @@ impl FlatIndex {
             TagCompatibility::Compatible(priority) => priority,
         };
 
-        // Check if hashes line up
+        // Check if hashes line up.
         let hash = if let HashPolicy::Validate(required) = hasher.get_package(&filename.name) {
             if hashes.is_empty() {
                 HashComparison::Missing
@@ -188,7 +188,10 @@ impl FlatIndex {
             HashComparison::Matched
         };
 
-        WheelCompatibility::Compatible(hash, priority)
+        // Break ties with the build tag.
+        let build_tag = filename.build_tag.clone();
+
+        WheelCompatibility::Compatible(hash, priority, build_tag)
     }
 
     /// Get the [`FlatDistributions`] for the given package name.

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
@@ -56,6 +56,7 @@ Ok(
                                 "anyio",
                             ),
                             version: "4.3.0",
+                            build_tag: None,
                             python_tag: [
                                 "py3",
                             ],

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -554,7 +554,10 @@ impl VersionMapLazy {
             }
         };
 
-        WheelCompatibility::Compatible(hash, priority)
+        // Break ties with the build tag.
+        let build_tag = filename.build_tag.clone();
+
+        WheelCompatibility::Compatible(hash, priority, build_tag)
     }
 }
 


### PR DESCRIPTION
## Summary

It turns out that in the [spec](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention), if a wheel filename includes a build tag, then we need to use it to break ties. This PR implements that behavior. (Previously, we dropped the build tag entirely.)

Closes #3779.

## Test Plan

Run: `cargo run pip install -i https://pypi.anaconda.org/intel/simple mkl_fft==1.3.8 --python-platform linux --python-version 3.10`. This now resolves without error. Previously, we selected build tag 63 of `mkl_fft==1.3.8`, which led to an incompatibility with NumPy. Now, we select build tag 70.
