### PR TITLE
Fix interpreter discovery for tests

### DIFF
--- a/crates/uv-interpreter/src/discovery.rs
+++ b/crates/uv-interpreter/src/discovery.rs
@@ -392,7 +392,7 @@ fn python_interpreters<'a>(
                         true
                     } else {
                         debug!(
-                            "Ignoring Python interpreter at `{}`: system intepreter not explicit",
+                            "Ignoring Python interpreter at `{}`: system interpreter not explicit",
                             interpreter.sys_executable().display()
                         );
                         false
@@ -401,7 +401,7 @@ fn python_interpreters<'a>(
                 (SystemPython::Explicit, true) => true,
                 (SystemPython::Disallowed, false) => {
                     debug!(
-                        "Ignoring Python interpreter at `{}`: system intepreter not allowed",
+                        "Ignoring Python interpreter at `{}`: system interpreter not allowed",
                         interpreter.sys_executable().display()
                     );
                     false
@@ -409,7 +409,7 @@ fn python_interpreters<'a>(
                 (SystemPython::Disallowed, true) => true,
                 (SystemPython::Required, true) => {
                     debug!(
-                        "Ignoring Python interpreter at `{}`: system intepreter required",
+                        "Ignoring Python interpreter at `{}`: system interpreter required",
                         interpreter.sys_executable().display()
                     );
                     false
@@ -423,7 +423,7 @@ fn python_interpreters<'a>(
 
 /// Check if an encountered error should stop discovery.
 ///
-/// Returns false when an error could be due to a faulty intepreter and we should continue searching for a working one.
+/// Returns false when an error could be due to a faulty interpreter and we should continue searching for a working one.
 fn should_stop_discovery(err: &Error) -> bool {
     match err {
         // When querying the interpreter fails, we will only raise errors that demonstrate that something is broken

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -403,7 +403,7 @@ pub fn python_path_with_versions(
                 let sources = SourceSelector::All;
                 if let Ok(found) = find_interpreter(
                     &request,
-                    // Without required, we could pick the curren venv here and the test fails
+                    // Without required, we could pick the current venv here and the test fails
                     // because the venv subcommand requires a system interpreter.
                     uv_interpreter::SystemPython::Required,
                     &sources,

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -403,7 +403,9 @@ pub fn python_path_with_versions(
                 let sources = SourceSelector::All;
                 if let Ok(found) = find_interpreter(
                     &request,
-                    uv_interpreter::SystemPython::Allowed,
+                    // Without required, we could pick the curren venv here and the test fails
+                    // because the venv subcommand requires a system interpreter.
+                    uv_interpreter::SystemPython::Required,
                     &sources,
                     &cache,
                 )


### PR DESCRIPTION
The venv subcommand requires a system interpreter. The tests python path discovery would previously allow a venv interpreter, failing the venv tests that don't have system interpreter anymore.
