### PR TITLE
feat: expose inner marker_env

### DIFF
--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -365,7 +365,7 @@ impl Deref for StringVersion {
 #[cfg_attr(feature = "pyo3", pyclass(module = "pep508"))]
 pub struct MarkerEnvironment {
     #[serde(flatten)]
-    inner: Arc<MarkerEnvironmentInner>,
+    pub inner: Arc<MarkerEnvironmentInner>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
Made the inner public, we used to be able to construct a `MarkerEnvironment` programatically. However, this functionality has seemed to be removed. As there is now public `new` method as far as I can see, we cannot use the `with_*` methods.

We are using this in https://github.com/prefix-dev/pixi/blob/main/src/pypi_marker_env.rs to construct an environment from locked data.

I could also create a `new` method instead, WDYT?
