### PR TITLE
Use colon more consistently in error messages

### DIFF
--- a/crates/uv-requirements/src/pyproject.rs
+++ b/crates/uv-requirements/src/pyproject.rs
@@ -680,7 +680,7 @@ mod test {
             path.as_ref(),
             PreviewMode::Enabled,
         )
-        .with_context(|| format!("Failed to parse `{}`", path.user_display()))
+        .with_context(|| format!("Failed to parse: `{}`", path.user_display()))
     }
 
     fn format_err(input: &str) -> String {
@@ -709,7 +709,7 @@ mod test {
         "#};
 
         assert_snapshot!(format_err(input), @r###"
-        error: Failed to parse `pyproject.toml`
+        error: Failed to parse: `pyproject.toml`
           Caused by: Failed to parse entry for: `tqdm`
           Caused by: Can't combine URLs from both `project.dependencies` and `tool.uv.sources`
         "###);
@@ -730,7 +730,7 @@ mod test {
         "#};
 
         assert_snapshot!(format_err(input), @r###"
-        error: Failed to parse `pyproject.toml`
+        error: Failed to parse: `pyproject.toml`
           Caused by: Failed to parse entry for: `tqdm`
           Caused by: Can only specify one of rev, tag, or branch
         "###);
@@ -752,7 +752,7 @@ mod test {
 
         // TODO(konsti): This should tell you the set of valid fields
         assert_snapshot!(format_err(input), @r###"
-        error: Failed to parse `pyproject.toml`
+        error: Failed to parse: `pyproject.toml`
           Caused by: TOML parse error at line 9, column 8
           |
         9 | tqdm = { git = "https://github.com/tqdm/tqdm", ref = "baaaaaab" }
@@ -778,7 +778,7 @@ mod test {
 
         // TODO(konsti): This should tell you the set of valid fields
         assert_snapshot!(format_err(input), @r###"
-        error: Failed to parse `pyproject.toml`
+        error: Failed to parse: `pyproject.toml`
           Caused by: TOML parse error at line 9, column 8
           |
         9 | tqdm = { path = "tqdm", index = "torch" }
@@ -817,7 +817,7 @@ mod test {
         "#};
 
         assert_snapshot!(format_err(input), @r###"
-        error: Failed to parse `pyproject.toml`
+        error: Failed to parse: `pyproject.toml`
           Caused by: TOML parse error at line 9, column 16
           |
         9 | tqdm = { url = invalid url to tqdm-4.66.0-py3-none-any.whl" }
@@ -843,7 +843,7 @@ mod test {
         "#};
 
         assert_snapshot!(format_err(input), @r###"
-        error: Failed to parse `pyproject.toml`
+        error: Failed to parse: `pyproject.toml`
           Caused by: TOML parse error at line 9, column 8
           |
         9 | tqdm = { url = "§invalid#+#*Ä" }
@@ -868,7 +868,7 @@ mod test {
         "#};
 
         assert_snapshot!(format_err(input), @r###"
-        error: Failed to parse `pyproject.toml`
+        error: Failed to parse: `pyproject.toml`
           Caused by: Failed to parse entry for: `tqdm`
           Caused by: Can't combine URLs from both `project.dependencies` and `tool.uv.sources`
         "###);
@@ -889,7 +889,7 @@ mod test {
         "#};
 
         assert_snapshot!(format_err(input), @r###"
-        error: Failed to parse `pyproject.toml`
+        error: Failed to parse: `pyproject.toml`
           Caused by: Failed to parse entry for: `tqdm`
           Caused by: Package is not included as workspace package in `tool.uv.workspace`
         "###);
@@ -910,7 +910,7 @@ mod test {
         "#};
 
         assert_snapshot!(format_err(input), @r###"
-        error: Failed to parse `pyproject.toml`
+        error: Failed to parse: `pyproject.toml`
           Caused by: pyproject.toml section is declared as dynamic, but must be static: `project.dependencies`
         "###);
     }
@@ -923,7 +923,7 @@ mod test {
         "};
 
         assert_snapshot!(format_err(input), @r###"
-        error: Failed to parse `pyproject.toml`
+        error: Failed to parse: `pyproject.toml`
           Caused by: Must specify a `[project]` section alongside `[tool.uv.sources]`
         "###);
     }

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -65,7 +65,7 @@ impl RequirementsSpecification {
         Ok(match source {
             RequirementsSource::Package(name) => {
                 let requirement = RequirementsTxtRequirement::parse(name, std::env::current_dir()?)
-                    .with_context(|| format!("Failed to parse `{name}`"))?;
+                    .with_context(|| format!("Failed to parse: `{name}`"))?;
                 Self {
                     requirements: vec![UnresolvedRequirementSpecification::try_from(
                         RequirementEntry {
@@ -78,7 +78,7 @@ impl RequirementsSpecification {
             }
             RequirementsSource::Editable(name) => {
                 let requirement = EditableRequirement::parse(name, None, std::env::current_dir()?)
-                    .with_context(|| format!("Failed to parse `{name}`"))?;
+                    .with_context(|| format!("Failed to parse: `{name}`"))?;
                 Self {
                     editables: vec![requirement],
                     ..Self::default()
@@ -122,7 +122,7 @@ impl RequirementsSpecification {
             RequirementsSource::PyprojectToml(path) => {
                 let contents = uv_fs::read_to_string(&path).await?;
                 Self::parse_direct_pyproject_toml(&contents, extras, path.as_ref(), preview)
-                    .with_context(|| format!("Failed to parse `{}`", path.user_display()))?
+                    .with_context(|| format!("Failed to parse: `{}`", path.user_display()))?
             }
             RequirementsSource::SetupPy(path) | RequirementsSource::SetupCfg(path) => Self {
                 source_trees: vec![path.clone()],

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -152,9 +152,9 @@ pub enum WorkspaceError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
-    #[error("Failed to parse `{0}`")]
+    #[error("Failed to parse: `{0}`")]
     PyprojectToml(String, #[source] toml::de::Error),
 
-    #[error("Failed to parse `{0}`")]
+    #[error("Failed to parse: `{0}`")]
     UvToml(String, #[source] toml::de::Error),
 }

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -765,7 +765,7 @@ dependencies = [
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to parse `pyproject.toml`
+    error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 5, column 8
       |
     5 | name = "!project"

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -144,7 +144,7 @@ fn invalid_pyproject_toml_syntax() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to parse `pyproject.toml`
+    error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 1, column 5
       |
     1 | 123 - 456
@@ -171,7 +171,7 @@ fn invalid_pyproject_toml_schema() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to parse `pyproject.toml`
+    error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 1, column 1
       |
     1 | [project]
@@ -209,7 +209,7 @@ dependencies = ["flask==1.0.x"]
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to parse `pyproject.toml`
+    error: Failed to parse: `pyproject.toml`
       Caused by: after parsing '1.0', found '.x', which is not part of a valid version
     flask==1.0.x
          ^^^^^^^
@@ -5014,7 +5014,7 @@ fn tool_uv_sources_is_in_preview() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to parse `pyproject.toml`
+    error: Failed to parse: `pyproject.toml`
       Caused by: Failed to parse entry for: `tqdm`
       Caused by: `tool.uv.sources` is a preview feature; use `--preview` or set `UV_PREVIEW=1` to enable it
     "###

--- a/crates/uv/tests/pip_uninstall.rs
+++ b/crates/uv/tests/pip_uninstall.rs
@@ -92,7 +92,7 @@ fn invalid_requirement() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to parse `flask==1.0.x`
+    error: Failed to parse: `flask==1.0.x`
       Caused by: after parsing '1.0', found '.x', which is not part of a valid version
     flask==1.0.x
          ^^^^^^^


### PR DESCRIPTION
Make the error messages more consistent with the format use elsewhere. Split out from https://github.com/astral-sh/uv/pull/3705