### PR TITLE
Add `InterpreterRequest::Any` instead of using `VersionRequest::Any`

### DIFF
--- a/crates/uv-interpreter/src/environment.rs
+++ b/crates/uv-interpreter/src/environment.rs
@@ -8,7 +8,7 @@ use same_file::is_same_file;
 use uv_cache::Cache;
 use uv_fs::{LockedFile, Simplified};
 
-use crate::discovery::{InterpreterRequest, SourceSelector, SystemPython, VersionRequest};
+use crate::discovery::{InterpreterRequest, SourceSelector, SystemPython};
 use crate::virtualenv::{virtualenv_python_executable, PyVenvConfiguration};
 use crate::{
     find_default_interpreter, find_interpreter, Error, Interpreter, InterpreterSource, Target,
@@ -54,7 +54,7 @@ impl PythonEnvironment {
     /// Allows Conda environments (via `CONDA_PREFIX`) though they are not technically virtual environments.
     pub fn from_virtualenv(cache: &Cache) -> Result<Self, Error> {
         let sources = SourceSelector::VirtualEnv;
-        let request = InterpreterRequest::Version(VersionRequest::Default);
+        let request = InterpreterRequest::Any;
         let found = find_interpreter(&request, SystemPython::Disallowed, &sources, cache)??;
 
         debug_assert!(
@@ -74,7 +74,7 @@ impl PythonEnvironment {
     /// Create a [`PythonEnvironment`] for the parent interpreter i.e. the executable in `python -m uv ...`
     pub fn from_parent_interpreter(system: SystemPython, cache: &Cache) -> Result<Self, Error> {
         let sources = SourceSelector::from_sources([InterpreterSource::ParentInterpreter]);
-        let request = InterpreterRequest::Version(VersionRequest::Default);
+        let request = InterpreterRequest::Any;
         let found = find_interpreter(&request, system, &sources, cache)??;
 
         Ok(Self(Arc::new(PythonEnvironmentShared {

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -586,7 +586,7 @@ mod tests {
             ],
             || {
                 let result = find_interpreter(
-                    &InterpreterRequest::Version(VersionRequest::Default),
+                    &InterpreterRequest::Any,
                     SystemPython::Allowed,
                     &SourceSelector::All,
                     &cache,
@@ -620,7 +620,7 @@ mod tests {
             ],
             || {
                 let result = find_interpreter(
-                    &InterpreterRequest::Version(VersionRequest::Default),
+                    &InterpreterRequest::Any,
                     SystemPython::Allowed,
                     &SourceSelector::All,
                     &cache,
@@ -661,7 +661,7 @@ mod tests {
             ],
             || {
                 let result = find_interpreter(
-                    &InterpreterRequest::Version(VersionRequest::Default),
+                    &InterpreterRequest::Any,
                     SystemPython::Required,
                     &SourceSelector::All,
                     &cache,
@@ -701,7 +701,7 @@ mod tests {
             ],
             || {
                 let result = find_interpreter(
-                    &InterpreterRequest::Version(VersionRequest::Default),
+                    &InterpreterRequest::Any,
                     SystemPython::Disallowed,
                     &SourceSelector::All,
                     &cache,

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -178,7 +178,7 @@ pub(crate) async fn pip_compile(
             // TODO(zanieb): We should consolidate `VersionRequest` and `PythonVersion`
             InterpreterRequest::Version(VersionRequest::from(version))
         } else {
-            InterpreterRequest::Version(VersionRequest::Default)
+            InterpreterRequest::default()
         };
         find_best_interpreter(&request, system, &cache)??
     }


### PR DESCRIPTION
A follow-up to #3266 addressing some awkwardness where there was no "empty" or default interpreter request kind.