### PR TITLE
Improve logging during interpreter discovery

### DIFF
--- a/crates/uv-interpreter/src/discovery.rs
+++ b/crates/uv-interpreter/src/discovery.rs
@@ -364,8 +364,8 @@ fn python_interpreters<'a>(
             Ok((source, path)) => Interpreter::query(&path, cache)
                 .map(|interpreter| (source, interpreter))
                 .inspect(|(source, interpreter)| {
-                    trace!(
-                        "Found Python interpreter {} {} at {} from {source}",
+                    debug!(
+                        "Found {} {} at `{}` ({source})",
                         LenientImplementationName::from(interpreter.implementation_name()),
                         interpreter.python_full_version(),
                         path.display()
@@ -456,9 +456,9 @@ pub fn find_interpreter(
     sources: &SourceSelector,
     cache: &Cache,
 ) -> Result<InterpreterResult, Error> {
-    debug!("Searching for interpreter that fulfills {request}");
     let result = match request {
         InterpreterRequest::File(path) => {
+            debug!("Checking for Python interpreter at {request}");
             if !sources.contains(InterpreterSource::ProvidedPath) {
                 return Err(Error::SourceNotSelected(
                     request.clone(),
@@ -476,6 +476,7 @@ pub fn find_interpreter(
             }
         }
         InterpreterRequest::Directory(path) => {
+            debug!("Checking for Python interpreter in {request}");
             if !sources.contains(InterpreterSource::ProvidedPath) {
                 return Err(Error::SourceNotSelected(
                     request.clone(),
@@ -499,6 +500,7 @@ pub fn find_interpreter(
             }
         }
         InterpreterRequest::ExecutableName(name) => {
+            debug!("Searching for Python interpreter with {request}");
             if !sources.contains(InterpreterSource::SearchPath) {
                 return Err(Error::SourceNotSelected(
                     request.clone(),
@@ -516,6 +518,7 @@ pub fn find_interpreter(
             }
         }
         InterpreterRequest::Implementation(implementation) => {
+            debug!("Searching for a {request} interpreter in {sources}");
             let Some((source, interpreter)) =
                 python_interpreters(None, Some(implementation), system, sources, cache)
                     .find(|result| {
@@ -539,6 +542,7 @@ pub fn find_interpreter(
             }
         }
         InterpreterRequest::ImplementationVersion(implementation, version) => {
+            debug!("Searching for {request} in {sources}");
             let Some((source, interpreter)) =
                 python_interpreters(Some(version), Some(implementation), system, sources, cache)
                     .find(|result| {
@@ -569,6 +573,7 @@ pub fn find_interpreter(
             }
         }
         InterpreterRequest::Any => {
+            debug!("Searching for Python interpreter in {sources}");
             let Some((source, interpreter)) =
                 python_interpreters(None, None, system, sources, cache)
                     .find(|result| {
@@ -590,6 +595,7 @@ pub fn find_interpreter(
             }
         }
         InterpreterRequest::Version(version) => {
+            debug!("Searching for {request} in {sources}");
             let Some((source, interpreter)) =
                 python_interpreters(Some(version), None, system, sources, cache)
                     .find(|result| {
@@ -1186,15 +1192,15 @@ impl fmt::Display for InterpreterRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::Any => write!(f, "any Python"),
-            Self::Version(version) => write!(f, "Python @ {version}"),
-            Self::Directory(path) => write!(f, "directory {}", path.user_display()),
-            Self::File(path) => write!(f, "file {}", path.user_display()),
+            Self::Version(version) => write!(f, "Python {version}"),
+            Self::Directory(path) => write!(f, "directory `{}`", path.user_display()),
+            Self::File(path) => write!(f, "path `{}`", path.user_display()),
             Self::ExecutableName(name) => write!(f, "executable name `{name}`"),
             Self::Implementation(implementation) => {
                 write!(f, "{implementation}")
             }
             Self::ImplementationVersion(implementation, version) => {
-                write!(f, "{implementation} @ {version}")
+                write!(f, "{implementation} {version}")
             }
         }
     }

--- a/crates/uv-interpreter/src/environment.rs
+++ b/crates/uv-interpreter/src/environment.rs
@@ -34,10 +34,13 @@ impl PythonEnvironment {
             Self::from_default_python(cache)
         } else {
             // First check for a parent intepreter
-            match Self::from_parent_interpreter(system, cache) {
-                Ok(env) => return Ok(env),
-                Err(Error::NotFound(_)) => {}
-                Err(err) => return Err(err),
+            // We gate this check to avoid an extra log message when it is not set
+            if std::env::var_os("UV_INTERNAL__PARENT_INTERPRETER").is_some() {
+                match Self::from_parent_interpreter(system, cache) {
+                    Ok(env) => return Ok(env),
+                    Err(Error::NotFound(_)) => {}
+                    Err(err) => return Err(err),
+                }
             }
 
             // Then a virtual environment

--- a/crates/uv-interpreter/src/virtualenv.rs
+++ b/crates/uv-interpreter/src/virtualenv.rs
@@ -6,7 +6,6 @@ use std::{
 use fs_err as fs;
 use pypi_types::Scheme;
 use thiserror::Error;
-use tracing::{debug, info};
 
 /// The layout of a virtual environment.
 #[derive(Debug)]
@@ -46,10 +45,6 @@ pub enum Error {
 /// Supports `VIRTUAL_ENV`.
 pub(crate) fn virtualenv_from_env() -> Option<PathBuf> {
     if let Some(dir) = env::var_os("VIRTUAL_ENV").filter(|value| !value.is_empty()) {
-        info!(
-            "Found active virtual environment (via VIRTUAL_ENV) at: {}",
-            Path::new(&dir).display()
-        );
         return Some(PathBuf::from(dir));
     }
 
@@ -61,10 +56,6 @@ pub(crate) fn virtualenv_from_env() -> Option<PathBuf> {
 /// Supports `CONDA_PREFIX`.
 pub(crate) fn conda_prefix_from_env() -> Option<PathBuf> {
     if let Some(dir) = env::var_os("CONDA_PREFIX").filter(|value| !value.is_empty()) {
-        info!(
-            "Found active virtual environment (via CONDA_PREFIX) at: {}",
-            Path::new(&dir).display()
-        );
         return Some(PathBuf::from(dir));
     }
 
@@ -82,7 +73,6 @@ pub(crate) fn virtualenv_from_working_dir() -> Result<Option<PathBuf>, Error> {
     for dir in current_dir.ancestors() {
         // If we're _within_ a virtualenv, return it.
         if dir.join("pyvenv.cfg").is_file() {
-            debug!("Found a virtual environment at: {}", dir.display());
             return Ok(Some(dir.to_path_buf()));
         }
 
@@ -92,7 +82,6 @@ pub(crate) fn virtualenv_from_working_dir() -> Result<Option<PathBuf>, Error> {
             if !dot_venv.join("pyvenv.cfg").is_file() {
                 return Err(Error::MissingPyVenvCfg(dot_venv));
             }
-            debug!("Found a virtual environment at: {}", dot_venv.display());
             return Ok(Some(dot_venv));
         }
     }


### PR DESCRIPTION
```
❯ VIRTUAL_ENV=.venv cargo run -q -- pip install anyio -v
DEBUG Searching for interpreter that fulfills Python @ default in virtual environments
DEBUG Found Python interpreter cpython 3.12.3 at `.venv/bin/python` (active virtual environment)
DEBUG Using Python 3.12.3 environment at .venv/bin/python
DEBUG Trying to lock if free: .venv/.lock
DEBUG Requirement satisfied: anyio
DEBUG Requirement satisfied: idna>=2.8
DEBUG Requirement satisfied: sniffio>=1.1
DEBUG All editables satisfied: 
Audited 1 package in 14ms
```

instead of

```
❯ VIRTUAL_ENV=.venv cargo run -q -- pip install anyio -v
DEBUG Searching for interpreter that fulfills Python @ default
DEBUG Searching for interpreter that fulfills Python @ default
INFO Found active virtual environment (via VIRTUAL_ENV) at: .venv
DEBUG Found a virtual environment at: /Users/zb/workspace/uv/.venv
DEBUG Using Python 3.12.3 environment at .venv/bin/python
DEBUG Trying to lock if free: .venv/.lock
DEBUG Requirement satisfied: anyio
DEBUG Requirement satisfied: idna>=2.8
DEBUG Requirement satisfied: sniffio>=1.1
DEBUG All editables satisfied: 
Audited 1 package in 16ms
```