### PR TITLE
Improve logging of interpreter implementation

### DIFF
--- a/crates/uv-interpreter/src/discovery.rs
+++ b/crates/uv-interpreter/src/discovery.rs
@@ -6,7 +6,7 @@ use uv_fs::Simplified;
 use uv_warnings::warn_user_once;
 use which::which;
 
-use crate::implementation::ImplementationName;
+use crate::implementation::{ImplementationName, LenientImplementationName};
 use crate::interpreter::Error as InterpreterError;
 use crate::managed::toolchains_for_current_platform;
 use crate::py_launcher::py_list_paths;
@@ -363,7 +363,7 @@ fn python_interpreters<'a>(
                 .inspect(|(source, interpreter)| {
                     trace!(
                         "Found Python interpreter {} {} at {} from {source}",
-                        interpreter.implementation_name(),
+                        LenientImplementationName::from(interpreter.implementation_name()),
                         interpreter.python_full_version(),
                         path.display()
                     );

--- a/crates/uv-interpreter/src/implementation.rs
+++ b/crates/uv-interpreter/src/implementation.rs
@@ -17,6 +17,12 @@ pub enum ImplementationName {
     PyPy,
 }
 
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub(crate) enum LenientImplementationName {
+    Known(ImplementationName),
+    Unknown(String),
+}
+
 impl ImplementationName {
     pub(crate) fn iter() -> impl Iterator<Item = &'static ImplementationName> {
         static NAMES: &[ImplementationName] =
@@ -49,6 +55,24 @@ impl Display for ImplementationName {
         match self {
             Self::CPython => f.write_str("CPython"),
             Self::PyPy => f.write_str("PyPy"),
+        }
+    }
+}
+
+impl From<&str> for LenientImplementationName {
+    fn from(s: &str) -> Self {
+        match ImplementationName::from_str(s) {
+            Ok(implementation) => Self::Known(implementation),
+            Err(_) => Self::Unknown(s.to_string()),
+        }
+    }
+}
+
+impl Display for LenientImplementationName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Known(implementation) => implementation.fmt(f),
+            Self::Unknown(name) => f.write_str(name),
         }
     }
 }


### PR DESCRIPTION
```
Found Python interpreter CPython 3.12.3 at...
```

instead of

```
Found Python interpreter cpython 3.12.3 at
```