### PR TITLE
Improve logging for environment locking

### DIFF
--- a/crates/uv-interpreter/src/environment.rs
+++ b/crates/uv-interpreter/src/environment.rs
@@ -200,18 +200,15 @@ impl PythonEnvironment {
     pub fn lock(&self) -> Result<LockedFile, std::io::Error> {
         if let Some(target) = self.0.interpreter.target() {
             // If we're installing into a `--target`, use a target-specific lock file.
-            LockedFile::acquire(
-                target.root().join(".lock"),
-                target.root().simplified_display(),
-            )
+            LockedFile::acquire(target.root().join(".lock"), target.root().user_display())
         } else if self.0.interpreter.is_virtualenv() {
             // If the environment a virtualenv, use a virtualenv-specific lock file.
-            LockedFile::acquire(self.0.root.join(".lock"), self.0.root.simplified_display())
+            LockedFile::acquire(self.0.root.join(".lock"), self.0.root.user_display())
         } else {
             // Otherwise, use a global lock file.
             LockedFile::acquire(
                 env::temp_dir().join(format!("uv-{}.lock", cache_key::digest(&self.0.root))),
-                self.0.root.simplified_display(),
+                self.0.root.user_display(),
             )
         }
     }


### PR DESCRIPTION
```
DEBUG Acquired lock for `.venv`
```

instead of

```
DEBUG Trying to lock if free: .venv/.lock
```

At trace level, this includes the pre-lock message as well

```
TRACE Checking lock for `.venv`
DEBUG Acquired lock for `.venv`
```

We'll still display the lock file path when something goes wrong