### PR TITLE
Move `render-benchmarks` under a Cargo feature

### DIFF
--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -43,14 +43,14 @@ fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 itertools = { workspace = true }
 owo-colors = { workspace = true }
-poloto = { version = "19.1.2" }
+poloto = { version = "19.1.2", optional = true }
 pretty_assertions = { version = "1.4.0" }
-resvg = { version = "0.29.0" }
+resvg = { version = "0.29.0", optional = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tagu = { version = "0.1.6" }
+tagu = { version = "0.1.6", optional = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-durations-export = { workspace = true, features = ["plot"] }
@@ -63,3 +63,7 @@ mimalloc = { version = "0.1.39" }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
 tikv-jemallocator = { version = "0.5.4" }
+
+[features]
+default = []
+render = ["poloto", "resvg", "tagu"]

--- a/crates/uv-dev/src/main.rs
+++ b/crates/uv-dev/src/main.rs
@@ -21,6 +21,7 @@ use crate::clear_compile::ClearCompileArgs;
 use crate::compile::CompileArgs;
 use crate::fetch_python::FetchPythonArgs;
 use crate::generate_json_schema::GenerateJsonSchemaArgs;
+#[cfg(feature = "render")]
 use crate::render_benchmarks::RenderBenchmarksArgs;
 use crate::wheel_metadata::WheelMetadataArgs;
 
@@ -56,8 +57,6 @@ enum Cli {
     Build(BuildArgs),
     /// Display the metadata for a `.whl` at a given URL.
     WheelMetadata(WheelMetadataArgs),
-    /// Render the benchmarks.
-    RenderBenchmarks(RenderBenchmarksArgs),
     /// Compile all `.py` to `.pyc` files in the tree.
     Compile(CompileArgs),
     /// Remove all `.pyc` in the tree.
@@ -66,6 +65,9 @@ enum Cli {
     FetchPython(FetchPythonArgs),
     /// Generate JSON schema for the TOML configuration file.
     GenerateJSONSchema(GenerateJsonSchemaArgs),
+    #[cfg(feature = "render")]
+    /// Render the benchmarks.
+    RenderBenchmarks(RenderBenchmarksArgs),
 }
 
 #[instrument] // Anchor span to check for overhead
@@ -77,11 +79,12 @@ async fn run() -> Result<()> {
             println!("Wheel built to {}", target.display());
         }
         Cli::WheelMetadata(args) => wheel_metadata::wheel_metadata(args).await?,
-        Cli::RenderBenchmarks(args) => render_benchmarks::render_benchmarks(&args)?,
         Cli::Compile(args) => compile::compile(args).await?,
         Cli::ClearCompile(args) => clear_compile::clear_compile(&args)?,
         Cli::FetchPython(args) => fetch_python::fetch_python(args).await?,
         Cli::GenerateJSONSchema(args) => generate_json_schema::main(&args)?,
+        #[cfg(feature = "render")]
+        Cli::RenderBenchmarks(args) => render_benchmarks::render_benchmarks(&args)?,
     }
     Ok(())
 }

--- a/crates/uv-dev/src/render_benchmarks.rs
+++ b/crates/uv-dev/src/render_benchmarks.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "render")]
+
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};


### PR DESCRIPTION
## Summary

Avoid compiling these large dependencies when we typically don't need them.