### PR TITLE
Remove `tracing-indicatif` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,6 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "unicode-width",
- "vt100",
 ]
 
 [[package]]
@@ -4237,18 +4236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-indicatif"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069580424efe11d97c3fef4197fa98c004fa26672cc71ad8770d224e23b1951d"
-dependencies = [
- "indicatif",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4719,7 +4706,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-durations-export",
- "tracing-indicatif",
  "tracing-subscriber",
  "uv-build",
  "uv-cache",
@@ -5129,39 +5115,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "vt100"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
-dependencies = [
- "itoa",
- "log",
- "unicode-width",
- "vte",
-]
-
-[[package]]
-name = "vte"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
-dependencies = [
- "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,6 @@ tokio-util = { version = "0.7.10", features = ["compat"] }
 toml = { version = "0.8.12" }
 tracing = { version = "0.1.40" }
 tracing-durations-export = { version = "0.2.0", features = ["plot"] }
-tracing-indicatif = { version = "0.3.6" }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "registry"] }
 tracing-tree = { version = "0.3.0" }
 unicode-width = { version = "0.1.11" }

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -54,7 +54,6 @@ tagu = { version = "0.1.6" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-durations-export = { workspace = true, features = ["plot"] }
-tracing-indicatif = { workspace = true }
 tracing-subscriber = { workspace = true }
 walkdir = { workspace = true }
 

--- a/crates/uv-dev/src/main.rs
+++ b/crates/uv-dev/src/main.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::Instant;
@@ -11,7 +10,6 @@ use owo_colors::OwoColorize;
 use tracing::{debug, instrument};
 use tracing_durations_export::plot::PlotConfig;
 use tracing_durations_export::DurationsLayerBuilder;
-use tracing_indicatif::IndicatifLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
@@ -116,11 +114,6 @@ async fn main() -> ExitCode {
         (None, None)
     };
 
-    let indicatif_layer = IndicatifLayer::new();
-    let indicatif_compatible_writer_layer = tracing_subscriber::fmt::layer()
-        .with_writer(indicatif_layer.get_stderr_writer())
-        .with_ansi(std::io::stderr().is_terminal())
-        .with_target(false);
     let filter_layer = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::builder()
             // Show only the important spans
@@ -130,8 +123,6 @@ async fn main() -> ExitCode {
     tracing_subscriber::registry()
         .with(duration_layer)
         .with(filter_layer)
-        .with(indicatif_compatible_writer_layer)
-        .with(indicatif_layer)
         .init();
 
     let start = Instant::now();


### PR DESCRIPTION
## Summary

It's only used in `uv-dev`; can restore later if important.
