### PR TITLE
Ignore libc on other platforms

### DIFF
--- a/crates/uv-interpreter/src/managed/downloads.rs
+++ b/crates/uv-interpreter/src/managed/downloads.rs
@@ -125,7 +125,7 @@ impl PythonDownloadRequest {
             self.os = Some(Os::from_env()?);
         }
         if self.libc.is_none() {
-            self.libc = Some(Libc::from_env()?);
+            self.libc = Some(Libc::from_env());
         }
         Ok(self)
     }

--- a/crates/uv-interpreter/src/managed/find.rs
+++ b/crates/uv-interpreter/src/managed/find.rs
@@ -169,6 +169,6 @@ pub fn toolchains_for_version(version: &PythonVersion) -> Result<Vec<Toolchain>,
 fn platform_key_from_env() -> Result<String, Error> {
     let os = Os::from_env()?;
     let arch = Arch::from_env()?;
-    let libc = Libc::from_env()?;
+    let libc = Libc::from_env();
     Ok(format!("{os}-{arch}-{libc}").to_lowercase())
 }

--- a/crates/uv-interpreter/src/platform.rs
+++ b/crates/uv-interpreter/src/platform.rs
@@ -63,7 +63,7 @@ impl Platform {
         Ok(Self::new(
             Os::from_env()?,
             Arch::from_env()?,
-            Libc::from_env()?,
+            Libc::from_env(),
         ))
     }
 }
@@ -149,12 +149,14 @@ impl Arch {
 }
 
 impl Libc {
-    pub(crate) fn from_env() -> Result<Self, Error> {
+    pub(crate) fn from_env() -> Self {
         // TODO(zanieb): Perform this lookup
         match std::env::consts::OS {
-            "linux" => Ok(Libc::Gnu),
-            "windows" | "macos" => Ok(Libc::None),
-            _ => Err(Error::LibcNotDetected()),
+            // Supported platforms.
+            "linux" => Libc::Gnu,
+            "windows" | "macos" => Libc::None,
+            // Platforms without explicit support.
+            _ => Libc::None,
         }
     }
 }


### PR DESCRIPTION
Libc variants are only relevant on linux, we can ignore it on non {linux, windows, mac}.

Closes #3824