### PR TITLE
Require pinned version in `Preference` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4496,7 +4496,6 @@ dependencies = [
  "miette",
  "mimalloc",
  "owo-colors",
- "pep440_rs",
  "pep508_rs",
  "platform-tags",
  "predicates",

--- a/crates/uv-resolver/src/preferences.rs
+++ b/crates/uv-resolver/src/preferences.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 use rustc_hash::FxHashMap;
 use tracing::trace;
 
-use distribution_types::{Requirement, RequirementSource};
+use distribution_types::{InstalledDist, InstalledMetadata, InstalledVersion, Name};
 use pep440_rs::{Operator, Version};
-use pep508_rs::MarkerEnvironment;
+use pep508_rs::{MarkerEnvironment, MarkerTree, VersionOrUrl};
 use pypi_types::{HashDigest, HashError};
 use requirements_txt::{RequirementEntry, RequirementsTxtRequirement};
 use uv_normalize::PackageName;
@@ -20,20 +20,49 @@ pub enum PreferenceError {
 /// A pinned requirement, as extracted from a `requirements.txt` file.
 #[derive(Clone, Debug)]
 pub struct Preference {
-    requirement: Requirement,
+    name: PackageName,
+    version: Version,
+    marker: Option<MarkerTree>,
     hashes: Vec<HashDigest>,
 }
 
 impl Preference {
+    /// Create a simple [`Preference`] with no hashes.
+    pub fn simple(name: PackageName, version: Version) -> Self {
+        Self {
+            name,
+            version,
+            marker: None,
+            hashes: Vec::new(),
+        }
+    }
+
     /// Create a [`Preference`] from a [`RequirementEntry`].
     pub fn from_entry(entry: RequirementEntry) -> Result<Option<Self>, PreferenceError> {
+        let RequirementsTxtRequirement::Named(requirement) = entry.requirement else {
+            return Ok(None);
+        };
+
+        let Some(VersionOrUrl::VersionSpecifier(specifier)) = requirement.version_or_url.as_ref()
+        else {
+            trace!("Excluding {requirement} from preferences due to non-version specifier.");
+            return Ok(None);
+        };
+
+        let [specifier] = specifier.as_ref() else {
+            trace!("Excluding {requirement} from preferences due to multiple version specifiers.");
+            return Ok(None);
+        };
+
+        if *specifier.operator() != Operator::Equal {
+            trace!("Excluding {requirement} from preferences due to inexact version specifier.");
+            return Ok(None);
+        }
+
         Ok(Some(Self {
-            requirement: match entry.requirement {
-                RequirementsTxtRequirement::Named(requirement) => Requirement::from(requirement),
-                RequirementsTxtRequirement::Unnamed(_) => {
-                    return Ok(None);
-                }
-            },
+            name: requirement.name,
+            version: specifier.version().clone(),
+            marker: requirement.marker,
             hashes: entry
                 .hashes
                 .iter()
@@ -43,22 +72,28 @@ impl Preference {
         }))
     }
 
-    /// Create a [`Preference`] from a [`Requirement`].
-    pub fn from_requirement(requirement: Requirement) -> Self {
+    /// Create a [`Preference`] from an installed distribution.
+    pub fn from_installed(dist: &InstalledDist) -> Self {
+        let version = match dist.installed_version() {
+            InstalledVersion::Version(version) => version,
+            InstalledVersion::Url(_, version) => version,
+        };
         Self {
-            requirement,
+            name: dist.name().clone(),
+            version: version.clone(),
+            marker: None,
             hashes: Vec::new(),
         }
     }
 
-    /// Return the name of the package for this preference.
+    /// Return the [`PackageName`] of the package for this [`Preference`].
     pub fn name(&self) -> &PackageName {
-        &self.requirement.name
+        &self.name
     }
 
-    /// Return the [`Requirement`] for this preference.
-    pub fn requirement(&self) -> &Requirement {
-        &self.requirement
+    /// Return the [`Version`] of the package for this [`Preference`].
+    pub fn version(&self) -> &Version {
+        &self.version
     }
 }
 
@@ -77,55 +112,27 @@ impl Preferences {
         markers: Option<&MarkerEnvironment>,
     ) -> Self {
         // TODO(zanieb): We should explicitly ensure that when a package name is seen multiple times
-        // that the newest or oldest version is preferred dependning on the resolution strategy;
+        // that the newest or oldest version is preferred depending on the resolution strategy;
         // right now, the order is dependent on the given iterator.
-        let preferences =
-            preferences
-                .into_iter()
-                .filter_map(|preference| {
-                    let Preference {
-                        requirement,
-                        hashes,
-                    } = preference;
-
-                    // Search for, e.g., `flask==1.2.3` entries that match the current environment.
-                    if !requirement.evaluate_markers(markers, &[]) {
-                        trace!(
-                            "Excluding {requirement} from preferences due to unmatched markers."
-                        );
-                        return None;
-                    }
-                    match &requirement.source {
-                        RequirementSource::Registry { specifier, ..} => {
-                            let [version_specifier] = specifier.as_ref() else {
-                                    trace!(
-                                    "Excluding {requirement} from preferences due to multiple version specifiers."
-                                );
-                                    return None;
-                                };
-                                if *version_specifier.operator() != Operator::Equal {
-                                    trace!(
-                                    "Excluding {requirement} from preferences due to inexact version specifier."
-                                );
-                                    return None;
-                                }
-                                Some((
-                                    requirement.name,
-                                    Pin {
-                                        version: version_specifier.version().clone(),
-                                        hashes,
-                                    },
-                                ))
-                            }
-                        RequirementSource::Url {..} | RequirementSource::Git { .. } | RequirementSource::Path { .. }=> {
-                            trace!(
-                                "Excluding {requirement} from preferences due to URL dependency."
-                            );
-                            None
-                        }
-                    }
-                })
-                .collect();
+        let preferences = preferences
+            .into_iter()
+            .filter_map(|preference| {
+                if preference.marker.as_ref().map_or(true, |marker| {
+                    marker.evaluate_optional_environment(markers, &[])
+                }) {
+                    Some((
+                        preference.name,
+                        Pin {
+                            version: preference.version,
+                            hashes: preference.hashes,
+                        },
+                    ))
+                } else {
+                    trace!("Excluding {preference} from preferences due to unmatched markers.");
+                    None
+                }
+            })
+            .collect();
 
         Self(Arc::new(preferences))
     }
@@ -145,6 +152,12 @@ impl Preferences {
             .get(package_name)
             .filter(|pin| pin.version() == version)
             .map(Pin::hashes)
+    }
+}
+
+impl std::fmt::Display for Preference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}=={}", self.name, self.version)
     }
 }
 

--- a/crates/uv-resolver/tests/resolver.rs
+++ b/crates/uv-resolver/tests/resolver.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Utc};
 use once_cell::sync::Lazy;
 
 use distribution_types::{CachedDist, IndexLocations, Requirement, Resolution, SourceDist};
+use pep440_rs::Version;
 use pep508_rs::{MarkerEnvironment, MarkerEnvironmentBuilder};
 use platform_tags::{Arch, Os, Platform, Tags};
 use uv_cache::Cache;
@@ -20,6 +21,7 @@ use uv_configuration::{
 };
 use uv_distribution::DistributionDatabase;
 use uv_interpreter::{find_default_interpreter, Interpreter, PythonEnvironment};
+use uv_normalize::PackageName;
 use uv_resolver::{
     DisplayResolutionGraph, ExcludeNewer, Exclusions, FlatIndex, InMemoryIndex, Manifest, Options,
     OptionsBuilder, PreReleaseMode, Preference, PythonRequirement, ResolutionGraph, ResolutionMode,
@@ -473,9 +475,10 @@ async fn black_respect_preference() -> Result<()> {
         )?)],
         Constraints::default(),
         Overrides::default(),
-        vec![Preference::from_requirement(Requirement::from(
-            pep508_rs::Requirement::from_str("black==23.9.0")?,
-        ))],
+        vec![Preference::simple(
+            PackageName::from_str("black")?,
+            Version::from_str("23.9.0")?,
+        )],
         None,
         vec![],
         Exclusions::default(),
@@ -513,9 +516,10 @@ async fn black_ignore_preference() -> Result<()> {
         )?)],
         Constraints::default(),
         Overrides::default(),
-        vec![Preference::from_requirement(Requirement::from(
-            pep508_rs::Requirement::from_str("black==23.9.2")?,
-        ))],
+        vec![Preference::simple(
+            PackageName::from_str("black")?,
+            Version::from_str("23.9.2")?,
+        )],
         None,
         vec![],
         Exclusions::default(),

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 [dependencies]
 distribution-types = { workspace = true }
 install-wheel-rs = { workspace = true, features = ["clap"], default-features = false }
-pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
 platform-tags = { workspace = true }
 pypi-types = { workspace = true }


### PR DESCRIPTION
## Summary

This PR makes a variety of invalid states unrepresentable by changing `Preference` to require a `PackageName` and `Version`, rather than accepting a generic `Requirement`. There should be no meaningful behavior changes.
