### PR TITLE
Remove `discovery` group from CLI

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -465,7 +465,7 @@ pub(crate) struct PipCompileArgs {
     ///   `python3.10` on Linux and macOS.
     /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
-    #[arg(long, verbatim_doc_comment, group = "discovery")]
+    #[arg(long, verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 
     /// Install packages into the system Python.
@@ -478,7 +478,6 @@ pub(crate) struct PipCompileArgs {
         long,
         env = "UV_SYSTEM_PYTHON",
         value_parser = clap::builder::BoolishValueParser::new(),
-        group = "discovery",
         overrides_with("no_system")
     )]
     pub(crate) system: bool,
@@ -768,13 +767,7 @@ pub(crate) struct PipSyncArgs {
     ///   `python3.10` on Linux and macOS.
     /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 
     /// Install packages into the system Python.
@@ -789,7 +782,6 @@ pub(crate) struct PipSyncArgs {
         long,
         env = "UV_SYSTEM_PYTHON",
         value_parser = clap::builder::BoolishValueParser::new(),
-        group = "discovery",
         overrides_with("no_system")
     )]
     pub(crate) system: bool,
@@ -807,7 +799,6 @@ pub(crate) struct PipSyncArgs {
         long,
         env = "UV_BREAK_SYSTEM_PACKAGES",
         value_parser = clap::builder::BoolishValueParser::new(),
-        requires = "discovery",
         overrides_with("no_break_system_packages")
     )]
     pub(crate) break_system_packages: bool,
@@ -1163,13 +1154,7 @@ pub(crate) struct PipInstallArgs {
     ///   `python3.10` on Linux and macOS.
     /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 
     /// Install packages into the system Python.
@@ -1184,7 +1169,6 @@ pub(crate) struct PipInstallArgs {
         long,
         env = "UV_SYSTEM_PYTHON",
         value_parser = clap::builder::BoolishValueParser::new(),
-        group = "discovery",
         overrides_with("no_system")
     )]
     pub(crate) system: bool,
@@ -1202,7 +1186,6 @@ pub(crate) struct PipInstallArgs {
         long,
         env = "UV_BREAK_SYSTEM_PACKAGES",
         value_parser = clap::builder::BoolishValueParser::new(),
-        requires = "discovery",
         overrides_with("no_break_system_packages")
     )]
     pub(crate) break_system_packages: bool,
@@ -1379,13 +1362,7 @@ pub(crate) struct PipUninstallArgs {
     ///   `python3.10` on Linux and macOS.
     /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 
     /// Attempt to use `keyring` for authentication for remote requirements files.
@@ -1409,7 +1386,6 @@ pub(crate) struct PipUninstallArgs {
         long,
         env = "UV_SYSTEM_PYTHON",
         value_parser = clap::builder::BoolishValueParser::new(),
-        group = "discovery",
         overrides_with("no_system")
     )]
     pub(crate) system: bool,
@@ -1427,7 +1403,6 @@ pub(crate) struct PipUninstallArgs {
         long,
         env = "UV_BREAK_SYSTEM_PACKAGES",
         value_parser = clap::builder::BoolishValueParser::new(),
-        requires = "discovery",
         overrides_with("no_break_system_packages")
     )]
     pub(crate) break_system_packages: bool,
@@ -1467,13 +1442,7 @@ pub(crate) struct PipFreezeArgs {
     ///   `python3.10` on Linux and macOS.
     /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 
     /// List packages for the system Python.
@@ -1489,7 +1458,6 @@ pub(crate) struct PipFreezeArgs {
         long,
         env = "UV_SYSTEM_PYTHON",
         value_parser = clap::builder::BoolishValueParser::new(),
-        group = "discovery",
         overrides_with("no_system")
     )]
     pub(crate) system: bool,
@@ -1536,13 +1504,7 @@ pub(crate) struct PipListArgs {
     ///   `python3.10` on Linux and macOS.
     /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 
     /// List packages for the system Python.
@@ -1558,7 +1520,6 @@ pub(crate) struct PipListArgs {
         long,
         env = "UV_SYSTEM_PYTHON",
         value_parser = clap::builder::BoolishValueParser::new(),
-        group = "discovery",
         overrides_with("no_system")
     )]
     pub(crate) system: bool,
@@ -1584,13 +1545,7 @@ pub(crate) struct PipCheckArgs {
     ///   `python3.10` on Linux and macOS.
     /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 
     /// List packages for the system Python.
@@ -1606,7 +1561,6 @@ pub(crate) struct PipCheckArgs {
         long,
         env = "UV_SYSTEM_PYTHON",
         value_parser = clap::builder::BoolishValueParser::new(),
-        group = "discovery",
         overrides_with("no_system")
     )]
     pub(crate) system: bool,
@@ -1640,13 +1594,7 @@ pub(crate) struct PipShowArgs {
     ///   `python3.10` on Linux and macOS.
     /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 
     /// List packages for the system Python.
@@ -1662,7 +1610,6 @@ pub(crate) struct PipShowArgs {
         long,
         env = "UV_SYSTEM_PYTHON",
         value_parser = clap::builder::BoolishValueParser::new(),
-        group = "discovery",
         overrides_with("no_system")
     )]
     pub(crate) system: bool,
@@ -1684,13 +1631,7 @@ pub(crate) struct VenvArgs {
     ///
     /// Note that this is different from `--python-version` in `pip compile`, which takes `3.10` or `3.10.13` and
     /// doesn't look for a Python interpreter on disk.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 
     /// Use the system Python to uninstall packages.
@@ -1705,7 +1646,6 @@ pub(crate) struct VenvArgs {
         long,
         env = "UV_SYSTEM_PYTHON",
         value_parser = clap::builder::BoolishValueParser::new(),
-        group = "discovery",
         overrides_with("no_system")
     )]
     pub(crate) system: bool,
@@ -1846,13 +1786,7 @@ pub(crate) struct RunArgs {
     ///   `python3.10` on Linux and macOS.
     /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 }
 
@@ -1870,13 +1804,7 @@ pub(crate) struct SyncArgs {
     ///   `python3.10` on Linux and macOS.
     /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 }
 
@@ -1894,13 +1822,7 @@ pub(crate) struct LockArgs {
     ///   `python3.10` on Linux and macOS.
     /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 }
 
@@ -1951,12 +1873,6 @@ pub(crate) struct ToolRunArgs {
     pub(crate) with: Vec<String>,
 
     /// The Python interpreter to use to build the run environment.
-    #[arg(
-        long,
-        short,
-        env = "UV_PYTHON",
-        verbatim_doc_comment,
-        group = "discovery"
-    )]
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
 }


### PR DESCRIPTION
## Summary

Allows, e.g., `UV_SYSTEM_PYTHON=false uv pip install --python .venv/bin/python`.

This was intended to work after fixing https://github.com/astral-sh/uv/issues/3000, but I think I misdiagnosed the scope when closing that issue, and the linked PR there only fixed some _other_ problems around index URLs.

The only thing we really lose here is we no longer error when `--break-system-packages` is provided without `--system`, but we can enforce that elsewhere if we want.

Closes https://github.com/astral-sh/uv/issues/3829.
