### PR TITLE
add initial support for universal lock files

### DIFF
--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -1601,17 +1601,42 @@ impl MarkerTree {
     /// For example, if `dev` is a provided extra, given `sys_platform == 'linux' and extra == 'dev'`,
     /// the marker will be simplified to `sys_platform == 'linux'`.
     pub fn simplify_extras(self, extras: &[ExtraName]) -> Option<MarkerTree> {
+        self.simplify_extras_with(|name| extras.contains(name))
+    }
+
+    /// Remove the extras from a marker, returning `None` if the marker tree evaluates to `true`.
+    ///
+    /// Any `extra` markers that are always `true` given the provided predicate will be removed.
+    /// Any `extra` markers that are always `false` given the provided predicate will be left
+    /// unchanged.
+    ///
+    /// For example, if `is_extra('dev')` is true, given
+    /// `sys_platform == 'linux' and extra == 'dev'`, the marker will be simplified to
+    /// `sys_platform == 'linux'`.
+    pub fn simplify_extras_with(self, is_extra: impl Fn(&ExtraName) -> bool) -> Option<MarkerTree> {
+        // Because `simplify_extras_with_impl` is recursive, and we need to use
+        // our predicate in recursive calls, we need the predicate itself to
+        // have some indirection (or else we'd have to clone it). To avoid a
+        // recursive type at codegen time, we just introduce the indirection
+        // here, but keep the calling API ergonomic.
+        self.simplify_extras_with_impl(&is_extra)
+    }
+
+    fn simplify_extras_with_impl(
+        self,
+        is_extra: &impl Fn(&ExtraName) -> bool,
+    ) -> Option<MarkerTree> {
         /// Returns `true` if the given expression is always `true` given the set of extras.
-        fn is_true(expression: &MarkerExpression, extras: &[ExtraName]) -> bool {
+        fn is_true(expression: &MarkerExpression, is_extra: impl Fn(&ExtraName) -> bool) -> bool {
             match expression {
                 MarkerExpression::Extra {
                     operator: ExtraOperator::Equal,
                     name,
-                } => extras.contains(name),
+                } => is_extra(name),
                 MarkerExpression::Extra {
                     operator: ExtraOperator::NotEqual,
                     name,
-                } => !extras.contains(name),
+                } => !is_extra(name),
                 _ => false,
             }
         }
@@ -1619,7 +1644,7 @@ impl MarkerTree {
         match self {
             Self::Expression(expression) => {
                 // If the expression is true, we can remove the marker entirely.
-                if is_true(&expression, extras) {
+                if is_true(&expression, is_extra) {
                     None
                 } else {
                     // If not, return the original marker.
@@ -1630,7 +1655,7 @@ impl MarkerTree {
                 // Remove any expressions that are _true_ due to the presence of an extra.
                 let simplified = expressions
                     .into_iter()
-                    .filter_map(|marker| marker.simplify_extras(extras))
+                    .filter_map(|marker| marker.simplify_extras_with_impl(is_extra))
                     .collect::<Vec<_>>();
 
                 // If there are no expressions left, return None.
@@ -1650,7 +1675,7 @@ impl MarkerTree {
                 // Remove any expressions that are _true_ due to the presence of an extra.
                 let simplified = expressions
                     .into_iter()
-                    .filter_map(|marker| marker.simplify_extras(extras))
+                    .filter_map(|marker| marker.simplify_extras_with_impl(is_extra))
                     .collect::<Vec<_>>();
 
                 // If _any_ of the expressions are true (i.e., if any of the markers were filtered

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -1801,6 +1801,42 @@ impl MarkerTree {
             }
         }
     }
+
+    /// Combine this marker tree with the one given via a conjunction.
+    ///
+    /// This does some shallow flattening. That is, if `self` is a conjunction
+    /// already, then `tree` is added to it instead of creating a new
+    /// conjunction.
+    pub fn and(&mut self, tree: MarkerTree) {
+        match *self {
+            MarkerTree::Expression(_) | MarkerTree::Or(_) => {
+                let this = std::mem::replace(self, MarkerTree::And(vec![]));
+                *self = MarkerTree::And(vec![this]);
+            }
+            _ => {}
+        }
+        if let MarkerTree::And(ref mut exprs) = *self {
+            exprs.push(tree);
+        }
+    }
+
+    /// Combine this marker tree with the one given via a disjunction.
+    ///
+    /// This does some shallow flattening. That is, if `self` is a disjunction
+    /// already, then `tree` is added to it instead of creating a new
+    /// disjunction.
+    pub fn or(&mut self, tree: MarkerTree) {
+        match *self {
+            MarkerTree::Expression(_) | MarkerTree::And(_) => {
+                let this = std::mem::replace(self, MarkerTree::And(vec![]));
+                *self = MarkerTree::Or(vec![this]);
+            }
+            _ => {}
+        }
+        if let MarkerTree::Or(ref mut exprs) = *self {
+            exprs.push(tree);
+        }
+    }
 }
 
 impl Display for MarkerTree {

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -229,9 +229,7 @@ impl Distribution {
         let sdist = SourceDist::from_annotated_dist(annotated_dist)?;
         Ok(Distribution {
             id,
-            // TODO: Refactoring is needed to get the marker expressions for a
-            // particular resolved dist to this point.
-            marker: None,
+            marker: annotated_dist.marker.as_ref().map(ToString::to_string),
             sdist,
             wheels,
             dependencies: vec![],

--- a/crates/uv-resolver/src/pins.rs
+++ b/crates/uv-resolver/src/pins.rs
@@ -29,4 +29,15 @@ impl FilePins {
     ) -> Option<&ResolvedDist> {
         self.0.get(name)?.get(version)
     }
+
+    /// Add the pins in `other` to `self`.
+    ///
+    /// This assumes that if a version for a particular package exists in
+    /// both `self` and `other`, then they will both correspond to identical
+    /// distributions.
+    pub(crate) fn union(&mut self, other: FilePins) {
+        for (name, versions) in other.0 {
+            self.0.entry(name).or_default().extend(versions);
+        }
+    }
 }

--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -49,6 +49,11 @@ impl PubGrubDependencies {
         Ok(Self(dependencies))
     }
 
+    /// Add a [`PubGrubPackage`] and [`PubGrubVersion`] range into the dependencies.
+    pub(crate) fn push(&mut self, package: PubGrubPackage, version: Range<Version>) {
+        self.0.push((package, version));
+    }
+
     /// Iterate over the dependencies.
     pub(crate) fn iter(&self) -> impl Iterator<Item = &(PubGrubPackage, Range<Version>)> {
         self.0.iter()
@@ -221,7 +226,7 @@ impl PubGrubRequirement {
                     package: PubGrubPackage::from_package(
                         requirement.name.clone(),
                         extra,
-                        None,
+                        requirement.marker.clone(),
                         urls,
                     ),
                     version,
@@ -247,7 +252,7 @@ impl PubGrubRequirement {
                     package: PubGrubPackage::from(PubGrubPackageInner::Package {
                         name: requirement.name.clone(),
                         extra,
-                        marker: None,
+                        marker: requirement.marker.clone(),
                         url: Some(expected.clone()),
                     }),
                     version: Range::full(),
@@ -273,7 +278,7 @@ impl PubGrubRequirement {
                     package: PubGrubPackage::from(PubGrubPackageInner::Package {
                         name: requirement.name.clone(),
                         extra,
-                        marker: None,
+                        marker: requirement.marker.clone(),
                         url: Some(expected.clone()),
                     }),
                     version: Range::full(),
@@ -299,7 +304,7 @@ impl PubGrubRequirement {
                     package: PubGrubPackage::from(PubGrubPackageInner::Package {
                         name: requirement.name.clone(),
                         extra,
-                        marker: None,
+                        marker: requirement.marker.clone(),
                         url: Some(expected.clone()),
                     }),
                     version: Range::full(),

--- a/crates/uv-resolver/src/resolution/mod.rs
+++ b/crates/uv-resolver/src/resolution/mod.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use itertools::Itertools;
 
 use distribution_types::{DistributionMetadata, Name, ResolvedDist, Verbatim, VersionOrUrlRef};
-use pep508_rs::{split_scheme, Scheme};
+use pep508_rs::{split_scheme, MarkerTree, Scheme};
 use pypi_types::{HashDigest, Metadata23};
 use uv_normalize::{ExtraName, PackageName};
 
@@ -22,6 +22,7 @@ mod graph;
 pub(crate) struct AnnotatedDist {
     pub(crate) dist: ResolvedDist,
     pub(crate) extra: Option<ExtraName>,
+    pub(crate) marker: Option<MarkerTree>,
     pub(crate) hashes: Vec<HashDigest>,
     pub(crate) metadata: Metadata23,
 }

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -56,7 +56,7 @@ impl BatchPrefetcher {
         let PubGrubPackageInner::Package {
             name,
             extra: None,
-            marker: None,
+            marker: _marker,
             url: None,
         } = &**next
         else {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -337,10 +337,9 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     }
                     let selection = state.pubgrub.partial_solution.extract_solution();
                     resolutions.push(ResolutionGraph::from_state(
+                        &self.index,
                         &selection,
                         &state.pins,
-                        self.index.packages(),
-                        self.index.distributions(),
                         &state.pubgrub,
                         &self.preferences,
                     )?);


### PR DESCRIPTION
This PR implements "resolver forking" in a way that permits us to
generate "universal" lock files. The concrete manifestation of this
requires omitting a `MarkerEnvironment` when calling the resolver, and
as a result, the resolution returned may include multiple versions for
the same package.

As a very basic example, consider this `requirements.in` file:

```
anyio>=4.3.0 ; sys_platform == "linux"
anyio<4 ; sys_platform == "darwin"
```

And while not the final intended command, one can generate a `uv.lock`
with the following:

```
$ cargo run -p uv -- pip compile -p3.10 ~/astral/tmp/reqs/forks/basic.in --unstable-uv-lock-file
```

And the resulting `uv.lock`:

```
version = 1

[[distribution]]
name = "anyio"
version = "3.7.1"
source = "registry+https://pypi.org/simple"
marker = "sys_platform == 'darwin'"

[distribution.sdist]
url = "https://files.pythonhosted.org/packages/28/99/2dfd53fd55ce9838e6ff2d4dac20ce58263798bd1a0dbe18b3a9af3fcfce/anyio-3.7.1.tar.gz"
hash = "sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780"
size = 142927

[[distribution.wheel]]
url = "https://files.pythonhosted.org/packages/19/24/44299477fe7dcc9cb58d0a57d5a7588d6af2ff403fdd2d47a246c91a3246/anyio-3.7.1-py3-none-any.whl"
hash = "sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5"
size = 80896

[[distribution.dependencies]]
name = "exceptiongroup"
version = "1.2.1"
source = "registry+https://pypi.org/simple"

[[distribution.dependencies]]
name = "idna"
version = "3.7"
source = "registry+https://pypi.org/simple"

[[distribution.dependencies]]
name = "sniffio"
version = "1.3.1"
source = "registry+https://pypi.org/simple"

[[distribution.dependencies]]
name = "typing-extensions"
version = "4.12.0"
source = "registry+https://pypi.org/simple"

[[distribution]]
name = "anyio"
version = "4.3.0"
source = "registry+https://pypi.org/simple"
marker = "sys_platform == 'linux'"

[distribution.sdist]
url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz"
hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6"
size = 159642

[[distribution.wheel]]
url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl"
hash = "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8"
size = 85584

[[distribution.dependencies]]
name = "exceptiongroup"
version = "1.2.1"
source = "registry+https://pypi.org/simple"

[[distribution.dependencies]]
name = "idna"
version = "3.7"
source = "registry+https://pypi.org/simple"

[[distribution.dependencies]]
name = "sniffio"
version = "1.3.1"
source = "registry+https://pypi.org/simple"

[[distribution.dependencies]]
name = "typing-extensions"
version = "4.12.0"
source = "registry+https://pypi.org/simple"

[[distribution]]
name = "exceptiongroup"
version = "1.2.1"
source = "registry+https://pypi.org/simple"
marker = "python_version < '3.11'"

[distribution.sdist]
url = "https://files.pythonhosted.org/packages/a0/65/d66b7fbaef021b3c954b3bbb196d21d8a4b97918ea524f82cfae474215af/exceptiongroup-1.2.1.tar.gz"
hash = "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"
size = 28717

[[distribution.wheel]]
url = "https://files.pythonhosted.org/packages/01/90/79fe92dd413a9cab314ef5c591b5aa9b9ba787ae4cadab75055b0ae00b33/exceptiongroup-1.2.1-py3-none-any.whl"
hash = "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad"
size = 16458

[[distribution]]
name = "idna"
version = "3.7"
source = "registry+https://pypi.org/simple"

[distribution.sdist]
url = "https://files.pythonhosted.org/packages/21/ed/f86a79a07470cb07819390452f178b3bef1d375f2ec021ecfc709fc7cf07/idna-3.7.tar.gz"
hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"
size = 189575

[[distribution.wheel]]
url = "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl"
hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
size = 66836

[[distribution]]
name = "sniffio"
version = "1.3.1"
source = "registry+https://pypi.org/simple"

[distribution.sdist]
url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz"
hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
size = 20372

[[distribution.wheel]]
url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl"
hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"
size = 10235

[[distribution]]
name = "typing-extensions"
version = "4.12.0"
source = "registry+https://pypi.org/simple"
marker = "python_version < '3.8' or python_version < '3.11'"

[distribution.sdist]
url = "https://files.pythonhosted.org/packages/ce/6a/aa0a40b0889ec2eb81a02ee0daa6a34c6697a605cf62e6e857eead9e4f85/typing_extensions-4.12.0.tar.gz"
hash = "sha256:8cbcdc8606ebcb0d95453ad7dc5065e6237b6aa230a31e81d0f440c30fed5fd8"
size = 84291

[[distribution.wheel]]
url = "https://files.pythonhosted.org/packages/e1/4d/d612de852a0bc64a64418e1cef25fe1914c5b1611e34cc271ed7e36174c8/typing_extensions-4.12.0-py3-none-any.whl"
hash = "sha256:b349c66bea9016ac22978d800cfff206d5f9816951f12a7d0ec5578b0a819594"
size = 37104
```

In particular, notice that there are two `anyio` distribution entries:

```
[[distribution]]
name = "anyio"
version = "3.7.1"
source = "registry+https://pypi.org/simple"
marker = "sys_platform == 'darwin'"

[[distribution]]
name = "anyio"
version = "4.3.0"
source = "registry+https://pypi.org/simple"
marker = "sys_platform == 'linux'"
```

The intent here is that, on install, a `MarkerEnvironment` would be
used to do a graph traversal while filtering out distributions whose
marker expressions don't match the marker environment. In order to
work, this does require that we only permit multiple versions of the
same package when their marker expressions have an empty intersection.

This is a draft because there is still some work to be done:

* There are some test failures that need to be investigated.
* This doesn't yet limit forking to cases where the marker expressions
have an empty intersection.
* We should include tests, although I might do those in a follow-up PR
since this one is already pretty big.

I'm also a little uneasy with how we're handling marker expressions in
the `PubGrubPackage`. Careful scrutiny there would be appreciated!

Closes #3358, Closes #3360