### PR TITLE
Gate discovery of managed toolchains with preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4925,6 +4925,7 @@ dependencies = [
  "url",
  "uv-cache",
  "uv-client",
+ "uv-configuration",
  "uv-extract",
  "uv-fs",
  "uv-state",

--- a/crates/uv-interpreter/Cargo.toml
+++ b/crates/uv-interpreter/Cargo.toml
@@ -20,6 +20,7 @@ pep508_rs = { workspace = true }
 platform-tags = { workspace = true }
 pypi-types = { workspace = true }
 uv-cache = { workspace = true }
+uv-configuration = { workspace = true }
 uv-client = { workspace = true }
 uv-extract = { workspace = true }
 uv-fs = { workspace = true }

--- a/crates/uv-interpreter/src/lib.rs
+++ b/crates/uv-interpreter/src/lib.rs
@@ -70,6 +70,7 @@ mod tests {
     };
     use temp_env::with_vars;
     use test_log::test;
+    use uv_configuration::PreviewMode;
 
     use assert_fs::{prelude::*, TempDir};
     use uv_cache::Cache;
@@ -301,7 +302,7 @@ mod tests {
                 ("PATH", Some("")),
             ],
             || {
-                let result = find_default_interpreter(&cache);
+                let result = find_default_interpreter(PreviewMode::Disabled, &cache);
                 assert!(
                     matches!(
                         result,
@@ -319,7 +320,7 @@ mod tests {
                 ("PATH", None::<OsString>),
             ],
             || {
-                let result = find_default_interpreter(&cache);
+                let result = find_default_interpreter(PreviewMode::Disabled, &cache);
                 assert!(
                     matches!(
                         result,
@@ -348,7 +349,7 @@ mod tests {
                 ("PATH", Some(tempdir.path().as_os_str())),
             ],
             || {
-                let result = find_default_interpreter(&cache);
+                let result = find_default_interpreter(PreviewMode::Disabled, &cache);
                 assert!(
                 matches!(
                     result,
@@ -382,7 +383,7 @@ mod tests {
                 ("PATH", Some(tempdir.path().as_os_str())),
             ],
             || {
-                let result = find_default_interpreter(&cache);
+                let result = find_default_interpreter(PreviewMode::Disabled, &cache);
                 assert!(
                     matches!(
                         result,
@@ -460,7 +461,7 @@ mod tests {
                 ("PWD", Some(tempdir.path().into())),
             ],
             || {
-                let result = find_default_interpreter(&cache);
+                let result = find_default_interpreter(PreviewMode::Disabled, &cache);
                 assert!(
                     matches!(
                         result,
@@ -499,7 +500,7 @@ mod tests {
                 ("PWD", Some(pwd.path().as_os_str())),
             ],
             || {
-                let result = find_default_interpreter(&cache);
+                let result = find_default_interpreter(PreviewMode::Disabled, &cache);
                 assert!(
                 matches!(
                     result,
@@ -552,7 +553,7 @@ mod tests {
                 ("PWD", Some(pwd.path().into())),
             ],
             || {
-                let result = find_default_interpreter(&cache);
+                let result = find_default_interpreter(PreviewMode::Disabled, &cache);
                 assert!(
                     matches!(
                         result,
@@ -599,7 +600,7 @@ mod tests {
                 let result = find_interpreter(
                     &InterpreterRequest::Any,
                     SystemPython::Allowed,
-                    &SourceSelector::All,
+                    &SourceSelector::All(PreviewMode::Disabled),
                     &cache,
                 )
                 .unwrap()
@@ -633,7 +634,7 @@ mod tests {
                 let result = find_interpreter(
                     &InterpreterRequest::Any,
                     SystemPython::Allowed,
-                    &SourceSelector::All,
+                    &SourceSelector::All(PreviewMode::Disabled),
                     &cache,
                 )
                 .unwrap()
@@ -675,7 +676,7 @@ mod tests {
                 let result = find_interpreter(
                     &InterpreterRequest::Any,
                     SystemPython::Required,
-                    &SourceSelector::All,
+                    &SourceSelector::All(PreviewMode::Disabled),
                     &cache,
                 )
                 .unwrap()
@@ -717,7 +718,7 @@ mod tests {
                 let result = find_interpreter(
                     &InterpreterRequest::Any,
                     SystemPython::Disallowed,
-                    &SourceSelector::All,
+                    &SourceSelector::All(PreviewMode::Disabled),
                     &cache,
                 )
                 .unwrap()
@@ -738,7 +739,7 @@ mod tests {
         let tempdir = TempDir::new()?;
         let toolchains = InstalledToolchains::temp()?;
         let cache = Cache::temp()?;
-        let sources = SourceSelector::All;
+        let sources = SourceSelector::All(PreviewMode::Disabled);
 
         with_vars(
             [
@@ -791,7 +792,7 @@ mod tests {
         let tempdir = TempDir::new()?;
         let toolchains = InstalledToolchains::temp()?;
         let cache = Cache::temp()?;
-        let sources = SourceSelector::All;
+        let sources = SourceSelector::All(PreviewMode::Disabled);
 
         with_vars(
             [
@@ -844,7 +845,7 @@ mod tests {
         let tempdir = TempDir::new()?;
         let toolchains = InstalledToolchains::temp()?;
         let cache = Cache::temp()?;
-        let sources = SourceSelector::All;
+        let sources = SourceSelector::All(PreviewMode::Disabled);
 
         with_vars(
             [
@@ -887,7 +888,7 @@ mod tests {
         let tempdir = TempDir::new()?;
         let toolchains = InstalledToolchains::temp()?;
         let cache = Cache::temp()?;
-        let sources = SourceSelector::All;
+        let sources = SourceSelector::All(PreviewMode::Disabled);
 
         with_vars(
             [
@@ -948,6 +949,7 @@ mod tests {
                 let result = find_best_interpreter(
                     &InterpreterRequest::parse("3.11.9"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 );
                 assert!(
@@ -999,6 +1001,7 @@ mod tests {
                 let result = find_best_interpreter(
                     &InterpreterRequest::parse("3.11.9"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 );
                 assert!(
@@ -1041,6 +1044,7 @@ mod tests {
                 let result = find_best_interpreter(
                     &InterpreterRequest::parse("3.11.9"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 );
                 assert!(
@@ -1095,6 +1099,7 @@ mod tests {
                     // TODO(zanieb): Consider moving this test to `PythonEnvironment::find` instead
                     &InterpreterRequest::parse("3.12"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 );
                 assert!(
@@ -1147,6 +1152,7 @@ mod tests {
                     // TODO(zanieb): Consider moving this test to `PythonEnvironment::find` instead
                     &InterpreterRequest::parse("3.10"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 );
                 assert!(
@@ -1199,6 +1205,7 @@ mod tests {
                     // TODO(zanieb): Consider moving this test to `PythonEnvironment::find` instead
                     &InterpreterRequest::parse("3.10.2"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 );
                 assert!(
@@ -1252,6 +1259,7 @@ mod tests {
                     // Request the search path Python with a matching minor
                     &InterpreterRequest::parse("3.11.2"),
                     crate::SystemPython::Disallowed,
+                    PreviewMode::Disabled,
                     &cache,
                 );
                 assert!(
@@ -1294,6 +1302,7 @@ mod tests {
                     // Request the search path Python with a matching minor
                     &InterpreterRequest::parse("3.10.2"),
                     crate::SystemPython::Disallowed,
+                    PreviewMode::Disabled,
                     &cache,
                 );
                 assert!(
@@ -1342,9 +1351,13 @@ mod tests {
                 ("PWD", Some(tempdir.path().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(None, crate::SystemPython::Allowed, &cache)
-                        .expect("An environment is found");
+                let environment = PythonEnvironment::find(
+                    None,
+                    crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("An environment is found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.12.0",
@@ -1377,7 +1390,7 @@ mod tests {
             || {
                 let environment =
                     // Note this environment is not treated as a system interpreter
-                    PythonEnvironment::find(None, SystemPython::Disallowed, &cache)
+                    PythonEnvironment::find(None, SystemPython::Disallowed, PreviewMode::Disabled, &cache)
                         .expect("An environment is found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
@@ -1413,7 +1426,7 @@ mod tests {
             || {
                 let environment =
                     // Note this environment is not treated as a system interpreter
-                    PythonEnvironment::find(None, SystemPython::Disallowed, &cache)
+                    PythonEnvironment::find(None, SystemPython::Disallowed, PreviewMode::Disabled, &cache)
                         .expect("An environment is found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
@@ -1445,9 +1458,13 @@ mod tests {
                 ("PWD", Some(tempdir.path().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(None, crate::SystemPython::Allowed, &cache)
-                        .expect("An environment is found");
+                let environment = PythonEnvironment::find(
+                    None,
+                    crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("An environment is found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.12.0",
@@ -1488,9 +1505,13 @@ mod tests {
                 ("PWD", Some(pwd.path().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(None, crate::SystemPython::Allowed, &cache)
-                        .expect("An environment is found");
+                let environment = PythonEnvironment::find(
+                    None,
+                    crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("An environment is found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.12.1",
@@ -1531,9 +1552,13 @@ mod tests {
                 ("PWD", Some(pwd.path().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(None, crate::SystemPython::Explicit, &cache)
-                        .expect("An environment is found");
+                let environment = PythonEnvironment::find(
+                    None,
+                    crate::SystemPython::Explicit,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("An environment is found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.12.1",
@@ -1574,9 +1599,13 @@ mod tests {
                 ("PWD", Some(pwd.path().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(None, crate::SystemPython::Disallowed, &cache)
-                        .expect("An environment is found");
+                let environment = PythonEnvironment::find(
+                    None,
+                    crate::SystemPython::Disallowed,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("An environment is found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.12.0",
@@ -1617,9 +1646,13 @@ mod tests {
                 ("PWD", Some(pwd.path().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(None, crate::SystemPython::Required, &cache)
-                        .expect("An environment is found");
+                let environment = PythonEnvironment::find(
+                    None,
+                    crate::SystemPython::Required,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("An environment is found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.12.2",
@@ -1651,9 +1684,13 @@ mod tests {
                 ("VIRTUAL_ENV", Some(venv.clone().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(None, crate::SystemPython::Required, &cache)
-                        .expect("Environment should be found");
+                let environment = PythonEnvironment::find(
+                    None,
+                    crate::SystemPython::Required,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("Environment should be found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.10.1",
@@ -1674,9 +1711,13 @@ mod tests {
                 ("VIRTUAL_ENV", Some(venv.clone().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(Some("3.12"), crate::SystemPython::Required, &cache)
-                        .expect("Environment should be found");
+                let environment = PythonEnvironment::find(
+                    Some("3.12"),
+                    crate::SystemPython::Required,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("Environment should be found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.12.2",
@@ -1698,8 +1739,12 @@ mod tests {
                 ("PWD", Some(tempdir.path().into())),
             ],
             || {
-                let result =
-                    PythonEnvironment::find(Some("3.12.3"), crate::SystemPython::Required, &cache);
+                let result = PythonEnvironment::find(
+                    Some("3.12.3"),
+                    crate::SystemPython::Required,
+                    PreviewMode::Disabled,
+                    &cache,
+                );
                 assert!(
                     result.is_err(),
                     "We should not find an environment; got {result:?}"
@@ -1727,7 +1772,12 @@ mod tests {
                 ("PWD", Some(tempdir.path().into())),
             ],
             || {
-                let result = PythonEnvironment::find(None, crate::SystemPython::Disallowed, &cache);
+                let result = PythonEnvironment::find(
+                    None,
+                    crate::SystemPython::Disallowed,
+                    PreviewMode::Disabled,
+                    &cache,
+                );
                 assert!(
                     result.is_err(),
                     "We should not find an environment; got {result:?}"
@@ -1759,9 +1809,13 @@ mod tests {
                 ("PWD", Some(tempdir.path().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(Some("foobar"), crate::SystemPython::Allowed, &cache)
-                        .expect("Environment should be found");
+                let environment = PythonEnvironment::find(
+                    Some("foobar"),
+                    crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("Environment should be found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.10.0",
@@ -1798,6 +1852,7 @@ mod tests {
                 let environment = PythonEnvironment::find(
                     Some("./foo/bar"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 )
                 .expect("Environment should be found");
@@ -1837,6 +1892,7 @@ mod tests {
                 let environment = PythonEnvironment::find(
                     Some(python.to_str().expect("Test path is valid unicode")),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 )
                 .expect("Environment should be found");
@@ -1871,6 +1927,7 @@ mod tests {
                 let environment = PythonEnvironment::find(
                     Some(venv.to_str().expect("Test path is valid unicode")),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 )
                 .expect("Environment should be found");
@@ -1910,6 +1967,7 @@ mod tests {
                 let environment = PythonEnvironment::find(
                     Some(python.to_str().expect("Test path is valid unicode")),
                     crate::SystemPython::Explicit,
+                    PreviewMode::Disabled,
                     &cache,
                 )
                 .expect("Environment should be found");
@@ -1949,6 +2007,7 @@ mod tests {
                 let result = PythonEnvironment::find(
                     Some(python.to_str().expect("Test path is valid unicode")),
                     crate::SystemPython::Disallowed,
+                    PreviewMode::Disabled,
                     &cache,
                 );
                 assert!(
@@ -1986,6 +2045,7 @@ mod tests {
                     PythonEnvironment::find(
                         Some("./foo/bar"),
                         crate::SystemPython::Allowed,
+                        PreviewMode::Disabled,
                         &cache,
                     );
                 assert!(
@@ -2024,9 +2084,13 @@ mod tests {
                 ("PWD", Some(pwd.path().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(Some("foobar"), crate::SystemPython::Required, &cache)
-                        .expect("Environment should be found");
+                let environment = PythonEnvironment::find(
+                    Some("foobar"),
+                    crate::SystemPython::Required,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("Environment should be found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.10.0",
@@ -2058,9 +2122,13 @@ mod tests {
                 ("PWD", Some(tempdir.path().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(Some("pypy"), crate::SystemPython::Allowed, &cache)
-                        .expect("Environment should be found");
+                let environment = PythonEnvironment::find(
+                    Some("pypy"),
+                    crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("Environment should be found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.10.1",
@@ -2095,9 +2163,13 @@ mod tests {
                 ("PWD", Some(tempdir.path().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(Some("pypy"), crate::SystemPython::Allowed, &cache)
-                        .expect("Environment should be found");
+                let environment = PythonEnvironment::find(
+                    Some("pypy"),
+                    crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("Environment should be found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.10.1",
@@ -2133,9 +2205,13 @@ mod tests {
                 ("PWD", Some(tempdir.path().into())),
             ],
             || {
-                let environment =
-                    PythonEnvironment::find(Some("pypy3.10"), crate::SystemPython::Allowed, &cache)
-                        .expect("Environment should be found");
+                let environment = PythonEnvironment::find(
+                    Some("pypy3.10"),
+                    crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
+                    &cache,
+                )
+                .expect("Environment should be found");
                 assert_eq!(
                     environment.interpreter().python_full_version().to_string(),
                     "3.10.1",
@@ -2175,6 +2251,7 @@ mod tests {
                 let environment = PythonEnvironment::find(
                     Some("pypy@3.10"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 )
                 .expect("Environment should be found");
@@ -2219,6 +2296,7 @@ mod tests {
                 let environment = PythonEnvironment::find(
                     Some("pypy@3.10"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 )
                 .expect("Environment should be found");
@@ -2250,6 +2328,7 @@ mod tests {
                 let environment = PythonEnvironment::find(
                     Some("pypy@3.10"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 )
                 .expect("Environment should be found");
@@ -2293,6 +2372,7 @@ mod tests {
                 let environment = PythonEnvironment::find(
                     Some("pypy@3.10"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 )
                 .expect("Environment should be found");
@@ -2328,6 +2408,7 @@ mod tests {
                 let environment = PythonEnvironment::find(
                     Some("pypy@3.10"),
                     crate::SystemPython::Allowed,
+                    PreviewMode::Disabled,
                     &cache,
                 )
                 .expect("Environment should be found");

--- a/crates/uv-resolver/tests/resolver.rs
+++ b/crates/uv-resolver/tests/resolver.rs
@@ -17,7 +17,7 @@ use platform_tags::{Arch, Os, Platform, Tags};
 use uv_cache::Cache;
 use uv_client::RegistryClientBuilder;
 use uv_configuration::{
-    BuildKind, Concurrency, Constraints, NoBinary, NoBuild, Overrides, SetupPyStrategy,
+    BuildKind, Concurrency, Constraints, NoBinary, NoBuild, Overrides, PreviewMode, SetupPyStrategy,
 };
 use uv_distribution::DistributionDatabase;
 use uv_interpreter::{find_default_interpreter, Interpreter, PythonEnvironment};
@@ -133,7 +133,7 @@ async fn resolve(
     let client = RegistryClientBuilder::new(cache).build();
     let flat_index = FlatIndex::default();
     let index = InMemoryIndex::default();
-    let real_interpreter = find_default_interpreter(&Cache::temp().unwrap())
+    let real_interpreter = find_default_interpreter(PreviewMode::Disabled, &Cache::temp().unwrap())
         .unwrap()
         .expect("Python should be installed")
         .into_interpreter();

--- a/crates/uv/src/commands/pip/check.rs
+++ b/crates/uv/src/commands/pip/check.rs
@@ -7,6 +7,7 @@ use tracing::debug;
 
 use distribution_types::{Diagnostic, InstalledDist};
 use uv_cache::Cache;
+use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::{SitePackages, SitePackagesDiagnostic};
 use uv_interpreter::{PythonEnvironment, SystemPython};
@@ -18,6 +19,7 @@ use crate::printer::Printer;
 pub(crate) fn pip_check(
     python: Option<&str>,
     system: bool,
+    preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -29,7 +31,7 @@ pub(crate) fn pip_check(
     } else {
         SystemPython::Allowed
     };
-    let venv = PythonEnvironment::find(python, system, cache)?;
+    let venv = PythonEnvironment::find(python, system, preview, cache)?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -170,7 +170,7 @@ pub(crate) async fn pip_compile(
     };
     let interpreter = if let Some(python) = python.as_ref() {
         let request = InterpreterRequest::parse(python);
-        let sources = SourceSelector::from_settings(system);
+        let sources = SourceSelector::from_settings(system, preview);
         find_interpreter(&request, system, &sources, &cache)??
     } else {
         let request = if let Some(version) = python_version.as_ref() {
@@ -179,7 +179,7 @@ pub(crate) async fn pip_compile(
         } else {
             InterpreterRequest::default()
         };
-        find_best_interpreter(&request, system, &cache)??
+        find_best_interpreter(&request, system, preview, &cache)??
     }
     .into_interpreter();
 

--- a/crates/uv/src/commands/pip/freeze.rs
+++ b/crates/uv/src/commands/pip/freeze.rs
@@ -7,6 +7,7 @@ use tracing::debug;
 
 use distribution_types::{Diagnostic, InstalledDist, Name};
 use uv_cache::Cache;
+use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_interpreter::{PythonEnvironment, SystemPython};
@@ -20,6 +21,7 @@ pub(crate) fn pip_freeze(
     strict: bool,
     python: Option<&str>,
     system: bool,
+    preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -29,7 +31,7 @@ pub(crate) fn pip_freeze(
     } else {
         SystemPython::Allowed
     };
-    let venv = PythonEnvironment::find(python, system, cache)?;
+    let venv = PythonEnvironment::find(python, system, preview, cache)?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -114,7 +114,7 @@ pub(crate) async fn pip_install(
     } else {
         SystemPython::Explicit
     };
-    let venv = PythonEnvironment::find(python.as_deref(), system, &cache)?;
+    let venv = PythonEnvironment::find(python.as_deref(), system, preview, &cache)?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -10,6 +10,7 @@ use unicode_width::UnicodeWidthStr;
 
 use distribution_types::{Diagnostic, InstalledDist, Name};
 use uv_cache::Cache;
+use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_interpreter::{PythonEnvironment, SystemPython};
@@ -29,6 +30,7 @@ pub(crate) fn pip_list(
     strict: bool,
     python: Option<&str>,
     system: bool,
+    preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -38,7 +40,7 @@ pub(crate) fn pip_list(
     } else {
         SystemPython::Allowed
     };
-    let venv = PythonEnvironment::find(python, system, cache)?;
+    let venv = PythonEnvironment::find(python, system, preview, cache)?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/show.rs
+++ b/crates/uv/src/commands/pip/show.rs
@@ -8,6 +8,7 @@ use tracing::debug;
 
 use distribution_types::{Diagnostic, Name};
 use uv_cache::Cache;
+use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_interpreter::{PythonEnvironment, SystemPython};
@@ -22,6 +23,7 @@ pub(crate) fn pip_show(
     strict: bool,
     python: Option<&str>,
     system: bool,
+    preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -44,7 +46,7 @@ pub(crate) fn pip_show(
     } else {
         SystemPython::Allowed
     };
-    let venv = PythonEnvironment::find(python, system, cache)?;
+    let venv = PythonEnvironment::find(python, system, preview, cache)?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -118,7 +118,7 @@ pub(crate) async fn pip_sync(
     } else {
         SystemPython::Explicit
     };
-    let venv = PythonEnvironment::find(python.as_deref(), system, &cache)?;
+    let venv = PythonEnvironment::find(python.as_deref(), system, preview, &cache)?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -49,7 +49,7 @@ pub(crate) async fn pip_uninstall(
     } else {
         SystemPython::Explicit
     };
-    let venv = PythonEnvironment::find(python.as_deref(), system, &cache)?;
+    let venv = PythonEnvironment::find(python.as_deref(), system, preview, &cache)?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -34,7 +34,7 @@ pub(crate) async fn lock(
     let project = ProjectWorkspace::discover(std::env::current_dir()?)?;
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(&project, cache, printer)?;
+    let venv = project::init_environment(&project, preview, cache, printer)?;
 
     // TODO(zanieb): Support client configuration
     let client_builder = BaseClientBuilder::default();

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -46,6 +46,7 @@ pub(crate) enum Error {
 /// Initialize a virtual environment for the current project.
 pub(crate) fn init_environment(
     project: &ProjectWorkspace,
+    preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<PythonEnvironment, Error> {
@@ -57,7 +58,7 @@ pub(crate) fn init_environment(
         Ok(venv) => Ok(venv),
         Err(uv_interpreter::Error::NotFound(_)) => {
             // TODO(charlie): Respect `--python`; if unset, respect `Requires-Python`.
-            let interpreter = find_default_interpreter(cache)
+            let interpreter = find_default_interpreter(preview, cache)
                 .map_err(uv_interpreter::Error::from)?
                 .map_err(uv_interpreter::Error::from)?
                 .into_interpreter();

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -58,7 +58,7 @@ pub(crate) async fn run(
 
         let project = ProjectWorkspace::discover(std::env::current_dir()?)?;
 
-        let venv = project::init_environment(&project, cache, printer)?;
+        let venv = project::init_environment(&project, preview, cache, printer)?;
 
         // Install the project requirements.
         Some(
@@ -85,10 +85,10 @@ pub(crate) async fn run(
         let interpreter = if let Some(project_env) = &project_env {
             project_env.interpreter().clone()
         } else if let Some(python) = python.as_ref() {
-            PythonEnvironment::from_requested_python(python, SystemPython::Allowed, cache)?
+            PythonEnvironment::from_requested_python(python, SystemPython::Allowed, preview, cache)?
                 .into_interpreter()
         } else {
-            PythonEnvironment::from_default_python(cache)?.into_interpreter()
+            PythonEnvironment::from_default_python(preview, cache)?.into_interpreter()
         };
 
         // TODO(charlie): If the environment satisfies the requirements, skip creation.

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -34,7 +34,7 @@ pub(crate) async fn sync(
     let project = ProjectWorkspace::discover(std::env::current_dir()?)?;
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(&project, cache, printer)?;
+    let venv = project::init_environment(&project, preview, cache, printer)?;
     let markers = venv.interpreter().markers();
     let tags = venv.interpreter().tags()?;
 

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -51,10 +51,10 @@ pub(crate) async fn run(
 
     // Discover an interpreter.
     let interpreter = if let Some(python) = python.as_ref() {
-        PythonEnvironment::from_requested_python(python, SystemPython::Allowed, cache)?
+        PythonEnvironment::from_requested_python(python, SystemPython::Allowed, preview, cache)?
             .into_interpreter()
     } else {
-        PythonEnvironment::from_default_python(cache)?.into_interpreter()
+        PythonEnvironment::from_default_python(preview, cache)?.into_interpreter()
     };
 
     // Create a virtual environment

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -14,7 +14,7 @@ use install_wheel_rs::linker::LinkMode;
 use uv_auth::store_credentials_from_url;
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
-use uv_configuration::{Concurrency, KeyringProviderType};
+use uv_configuration::{Concurrency, KeyringProviderType, PreviewMode};
 use uv_configuration::{ConfigSettings, IndexStrategy, NoBinary, NoBuild, SetupPyStrategy};
 use uv_dispatch::BuildDispatch;
 use uv_fs::Simplified;
@@ -48,6 +48,7 @@ pub(crate) async fn venv(
     allow_existing: bool,
     exclude_newer: Option<ExcludeNewer>,
     native_tls: bool,
+    preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -62,6 +63,7 @@ pub(crate) async fn venv(
         system_site_packages,
         connectivity,
         seed,
+        preview,
         allow_existing,
         exclude_newer,
         native_tls,
@@ -110,6 +112,7 @@ async fn venv_impl(
     system_site_packages: bool,
     connectivity: Connectivity,
     seed: bool,
+    preview: PreviewMode,
     allow_existing: bool,
     exclude_newer: Option<ExcludeNewer>,
     native_tls: bool,
@@ -120,10 +123,10 @@ async fn venv_impl(
     let interpreter = if let Some(python) = python_request.as_ref() {
         let system = uv_interpreter::SystemPython::Required;
         let request = InterpreterRequest::parse(python);
-        let sources = SourceSelector::from_settings(system);
+        let sources = SourceSelector::from_settings(system, preview);
         find_interpreter(&request, system, &sources, cache)
     } else {
-        find_default_interpreter(cache)
+        find_default_interpreter(preview, cache)
     }
     .into_diagnostic()?
     .into_diagnostic()?

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -430,6 +430,7 @@ async fn run() -> Result<ExitStatus> {
                 args.shared.strict,
                 args.shared.python.as_deref(),
                 args.shared.system,
+                globals.preview,
                 &cache,
                 printer,
             )
@@ -453,6 +454,7 @@ async fn run() -> Result<ExitStatus> {
                 args.shared.strict,
                 args.shared.python.as_deref(),
                 args.shared.system,
+                globals.preview,
                 &cache,
                 printer,
             )
@@ -471,6 +473,7 @@ async fn run() -> Result<ExitStatus> {
                 args.shared.strict,
                 args.shared.python.as_deref(),
                 args.shared.system,
+                globals.preview,
                 &cache,
                 printer,
             )
@@ -487,6 +490,7 @@ async fn run() -> Result<ExitStatus> {
             commands::pip_check(
                 args.shared.python.as_deref(),
                 args.shared.system,
+                globals.preview,
                 &cache,
                 printer,
             )
@@ -536,6 +540,7 @@ async fn run() -> Result<ExitStatus> {
                 args.allow_existing,
                 args.shared.exclude_newer,
                 globals.native_tls,
+                globals.preview,
                 &cache,
                 printer,
             )

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -13,6 +13,7 @@ use std::iter::Iterator;
 use std::path::{Path, PathBuf};
 use std::process::Output;
 use std::str::FromStr;
+use uv_configuration::PreviewMode;
 
 use uv_cache::Cache;
 use uv_fs::Simplified;
@@ -412,7 +413,7 @@ pub fn python_path_with_versions(
                     VersionRequest::from_str(python_version)
                         .expect("The test version request must be valid"),
                 );
-                let sources = SourceSelector::All;
+                let sources = SourceSelector::All(PreviewMode::Enabled);
                 if let Ok(found) = find_interpreter(
                     &request,
                     // Without required, we could pick the current venv here and the test fails


### PR DESCRIPTION
Prepares for merge of https://github.com/astral-sh/uv/pull/3797, gating managed toolchain discovery with the preview flag to lower risk of releasing.

e.g.

```
❯ cargo dev -q fetch-python         
❯ cargo run -q -- venv --python 3.11
Using Python 3.11.9 interpreter at: /opt/homebrew/opt/python@3.11/bin/python3.11
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
❯ cargo run -q -- venv --preview --python 3.11
Using Python 3.11.7 interpreter at: /Users/zb/Library/Application Support/uv/toolchains/cpython-3.11.7-macos-aarch64-none/install/bin/python3
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
```

We'll add automatic fetching of managed interpreters later.