### PR TITLE
Rename source tree to dynamic requirements files

### DIFF
--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -23,9 +23,9 @@ use crate::ExtrasSpecification;
 ///
 /// Used, e.g., to determine the input requirements when a user specifies a `pyproject.toml`
 /// file, which may require running PEP 517 build hooks to extract metadata.
-pub struct SourceTreeResolver<'a, Context: BuildContext> {
+pub struct DynamicRequirementsResolver<'a, Context: BuildContext> {
     /// The requirements for the project.
-    source_trees: Vec<PathBuf>,
+    dynamic_requirements_files: Vec<PathBuf>,
     /// The extras to include when resolving requirements.
     extras: &'a ExtrasSpecification,
     /// The hash policy to enforce.
@@ -36,17 +36,17 @@ pub struct SourceTreeResolver<'a, Context: BuildContext> {
     database: DistributionDatabase<'a, Context>,
 }
 
-impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
-    /// Instantiate a new [`SourceTreeResolver`] for a given set of `source_trees`.
+impl<'a, Context: BuildContext> DynamicRequirementsResolver<'a, Context> {
+    /// Instantiate a new [`DynamicRequirementsResolver`] for a given set of `dynamic_requirements_files`.
     pub fn new(
-        source_trees: Vec<PathBuf>,
+        dynamic_requirements_files: Vec<PathBuf>,
         extras: &'a ExtrasSpecification,
         hasher: &'a HashStrategy,
         index: &'a InMemoryIndex,
         database: DistributionDatabase<'a, Context>,
     ) -> Self {
         Self {
-            source_trees,
+            dynamic_requirements_files,
             extras,
             hasher,
             index,
@@ -66,7 +66,7 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
     /// Resolve the requirements from the provided source trees.
     pub async fn resolve(self) -> Result<Vec<Requirement>> {
         let requirements: Vec<_> = self
-            .source_trees
+            .dynamic_requirements_files
             .iter()
             .map(|source_tree| async { self.resolve_source_tree(source_tree).await })
             .collect::<FuturesOrdered<_>>()

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -36,8 +36,8 @@ pub struct RequirementsSpecification {
     pub overrides: Vec<UnresolvedRequirementSpecification>,
     /// Package to install as editable installs
     pub editables: Vec<EditableRequirement>,
-    /// The source trees from which to extract requirements.
-    pub source_trees: Vec<PathBuf>,
+    /// The source trees from which to extract requirements, without including the package itself.
+    pub dynamic_requirements_files: Vec<PathBuf>,
     /// The extras used to collect requirements.
     pub extras: FxHashSet<ExtraName>,
     /// The index URL to use for fetching packages.
@@ -126,7 +126,7 @@ impl RequirementsSpecification {
                     .with_context(|| format!("Failed to parse: `{}`", path.user_display()))?
             }
             RequirementsSource::SetupPy(path) | RequirementsSource::SetupCfg(path) => Self {
-                source_trees: vec![path.clone()],
+                dynamic_requirements_files: vec![path.clone()],
                 ..Self::default()
             },
             RequirementsSource::SourceTree(path) => Self {
@@ -220,7 +220,7 @@ impl RequirementsSpecification {
                 Ok(Self {
                     project: None,
                     requirements: vec![],
-                    source_trees: vec![pyproject_path.to_path_buf()],
+                    dynamic_requirements_files: vec![pyproject_path.to_path_buf()],
                     ..Self::default()
                 })
             }
@@ -249,7 +249,8 @@ impl RequirementsSpecification {
             spec.overrides.extend(source.overrides);
             spec.extras.extend(source.extras);
             spec.editables.extend(source.editables);
-            spec.source_trees.extend(source.source_trees);
+            spec.dynamic_requirements_files
+                .extend(source.dynamic_requirements_files);
 
             // Use the first project name discovered.
             if spec.project.is_none() {

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -41,8 +41,8 @@ use uv_interpreter::{
 use uv_interpreter::{PythonVersion, SourceSelector};
 use uv_normalize::{ExtraName, PackageName};
 use uv_requirements::{
-    upgrade::read_lockfile, ExtrasSpecification, LookaheadResolver, NamedRequirementsResolver,
-    RequirementsSource, RequirementsSpecification, SourceTreeResolver,
+    upgrade::read_lockfile, DynamicRequirementsResolver, ExtrasSpecification, LookaheadResolver,
+    NamedRequirementsResolver, RequirementsSource, RequirementsSpecification,
 };
 use uv_resolver::{
     AnnotationStyle, BuiltEditableMetadata, DependencyMode, DisplayResolutionGraph, ExcludeNewer,
@@ -124,7 +124,7 @@ pub(crate) async fn pip_compile(
         constraints,
         overrides,
         editables,
-        source_trees,
+        dynamic_requirements_files,
         extras: used_extras,
         index_url,
         extra_index_urls,
@@ -144,7 +144,7 @@ pub(crate) async fn pip_compile(
 
     // If all the metadata could be statically resolved, validate that every extra was used. If we
     // need to resolve metadata via PEP 517, we don't know which extras are used until much later.
-    if source_trees.is_empty() {
+    if dynamic_requirements_files.is_empty() {
         if let ExtrasSpecification::Some(extras) = &extras {
             let mut unused_extras = extras
                 .iter()
@@ -351,10 +351,10 @@ pub(crate) async fn pip_compile(
         .await?;
 
         // Resolve any source trees into requirements.
-        if !source_trees.is_empty() {
+        if !dynamic_requirements_files.is_empty() {
             requirements.extend(
-                SourceTreeResolver::new(
-                    source_trees,
+                DynamicRequirementsResolver::new(
+                    dynamic_requirements_files,
                     &extras,
                     &hasher,
                     &top_level_index,

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -90,7 +90,7 @@ pub(crate) async fn pip_install(
         constraints,
         overrides,
         editables,
-        source_trees,
+        dynamic_requirements_files,
         index_url,
         extra_index_urls,
         no_index,
@@ -164,7 +164,7 @@ pub(crate) async fn pip_install(
     // it's an order of magnitude faster to validate the environment than to resolve the requirements.
     if reinstall.is_none()
         && upgrade.is_none()
-        && source_trees.is_empty()
+        && dynamic_requirements_files.is_empty()
         && overrides.is_empty()
         && uv_lock.is_none()
     {
@@ -363,7 +363,7 @@ pub(crate) async fn pip_install(
             requirements,
             constraints,
             overrides,
-            source_trees,
+            dynamic_requirements_files,
             project,
             extras,
             &editables,

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -30,8 +30,8 @@ use uv_installer::{Downloader, Plan, Planner, ResolvedEditable, SitePackages};
 use uv_interpreter::{Interpreter, PythonEnvironment};
 use uv_normalize::PackageName;
 use uv_requirements::{
-    ExtrasSpecification, LookaheadResolver, NamedRequirementsResolver, RequirementsSource,
-    RequirementsSpecification, SourceTreeResolver,
+    DynamicRequirementsResolver, ExtrasSpecification, LookaheadResolver, NamedRequirementsResolver,
+    RequirementsSource, RequirementsSpecification,
 };
 use uv_resolver::{
     DependencyMode, Exclusions, FlatIndex, InMemoryIndex, Manifest, Options, Preference,
@@ -77,7 +77,7 @@ pub(crate) async fn read_requirements(
 
     // If all the metadata could be statically resolved, validate that every extra was used. If we
     // need to resolve metadata via PEP 517, we don't know which extras are used until much later.
-    if spec.source_trees.is_empty() {
+    if spec.dynamic_requirements_files.is_empty() {
         if let ExtrasSpecification::Some(extras) = extras {
             let mut unused_extras = extras
                 .iter()
@@ -105,7 +105,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
     requirements: Vec<UnresolvedRequirementSpecification>,
     constraints: Vec<Requirement>,
     overrides: Vec<UnresolvedRequirementSpecification>,
-    source_trees: Vec<PathBuf>,
+    dynamic_requirements_files: Vec<PathBuf>,
     project: Option<PackageName>,
     extras: &ExtrasSpecification,
     editables: &ResolvedEditables,
@@ -140,10 +140,10 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
         .await?;
 
         // Resolve any source trees into requirements.
-        if !source_trees.is_empty() {
+        if !dynamic_requirements_files.is_empty() {
             requirements.extend(
-                SourceTreeResolver::new(
-                    source_trees,
+                DynamicRequirementsResolver::new(
+                    dynamic_requirements_files,
                     extras,
                     hasher,
                     index,

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -87,7 +87,7 @@ pub(crate) async fn pip_sync(
         constraints,
         overrides,
         editables,
-        source_trees,
+        dynamic_requirements_files,
         index_url,
         extra_index_urls,
         no_index,
@@ -106,7 +106,7 @@ pub(crate) async fn pip_sync(
     .await?;
 
     // Validate that the requirements are non-empty.
-    let num_requirements = requirements.len() + source_trees.len() + editables.len();
+    let num_requirements = requirements.len() + dynamic_requirements_files.len() + editables.len();
     if num_requirements == 0 {
         writeln!(printer.stderr(), "No requirements found")?;
         return Ok(ExitStatus::Success);
@@ -307,7 +307,7 @@ pub(crate) async fn pip_sync(
         requirements,
         constraints,
         overrides,
-        source_trees,
+        dynamic_requirements_files,
         project,
         &extras,
         &editables,

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -125,7 +125,7 @@ pub(crate) async fn lock(
         spec.requirements,
         spec.constraints,
         spec.overrides,
-        spec.source_trees,
+        spec.dynamic_requirements_files,
         spec.project,
         &extras,
         &editables,

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -115,7 +115,7 @@ pub(crate) async fn update_environment(
 
     // Check if the current environment satisfies the requirements
     let site_packages = SitePackages::from_executable(&venv)?;
-    if spec.source_trees.is_empty() {
+    if spec.dynamic_requirements_files.is_empty() {
         match site_packages.satisfies(&spec.requirements, &spec.editables, &spec.constraints)? {
             // If the requirements are already satisfied, we're done.
             SatisfiesResult::Fresh {
@@ -219,7 +219,7 @@ pub(crate) async fn update_environment(
         spec.requirements,
         spec.constraints,
         spec.overrides,
-        spec.source_trees,
+        spec.dynamic_requirements_files,
         spec.project,
         &extras,
         &editables,


### PR DESCRIPTION
The function of `source_trees` got me confused a good bit since the term sounds like we're installing the package, not just reading requirements from it. I'm trying to make this clearer by renaming them to `dynamic_requirements_files`.

No functional changes, purely a renaming plus docs change.