### PR TITLE
fix: remove unused `Result` in uv-cache

### DIFF
--- a/crates/bench/benches/uv.rs
+++ b/crates/bench/benches/uv.rs
@@ -14,7 +14,7 @@ fn resolve_warm_jupyter(c: &mut Criterion<WallTime>) {
         .build()
         .unwrap();
 
-    let cache = &Cache::from_path("../../.cache").unwrap().init().unwrap();
+    let cache = &Cache::from_path("../../.cache").init().unwrap();
     let venv = PythonEnvironment::from_virtualenv(cache).unwrap();
     let client = &RegistryClientBuilder::new(cache.clone()).build();
     let manifest = &Manifest::simple(vec![Requirement::from(
@@ -43,7 +43,7 @@ fn resolve_warm_airflow(c: &mut Criterion<WallTime>) {
         .build()
         .unwrap();
 
-    let cache = &Cache::from_path("../../.cache").unwrap().init().unwrap();
+    let cache = &Cache::from_path("../../.cache").init().unwrap();
     let venv = PythonEnvironment::from_virtualenv(cache).unwrap();
     let client = &RegistryClientBuilder::new(cache.clone()).build();
     let manifest = &Manifest::simple(vec![

--- a/crates/uv-cache/src/cli.rs
+++ b/crates/uv-cache/src/cli.rs
@@ -39,11 +39,11 @@ impl Cache {
         if no_cache {
             Cache::temp()
         } else if let Some(cache_dir) = cache_dir {
-            Cache::from_path(cache_dir)
+            Ok(Cache::from_path(cache_dir))
         } else if let Some(project_dirs) = ProjectDirs::from("", "", "uv") {
-            Cache::from_path(project_dirs.cache_dir())
+            Ok(Cache::from_path(project_dirs.cache_dir()))
         } else {
-            Cache::from_path(".uv_cache")
+            Ok(Cache::from_path(".uv_cache"))
         }
     }
 }

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -126,12 +126,12 @@ pub struct Cache {
 
 impl Cache {
     /// A persistent cache directory at `root`.
-    pub fn from_path(root: impl Into<PathBuf>) -> Result<Self, io::Error> {
-        Ok(Self {
+    pub fn from_path(root: impl Into<PathBuf>) -> Self {
+        Self {
             root: root.into(),
             refresh: Refresh::None,
             _temp_dir_drop: None,
-        })
+        }
     }
 
     /// Create a temporary cache directory.

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -396,7 +396,7 @@ pub fn python_path_with_versions(
     temp_dir: &assert_fs::TempDir,
     python_versions: &[&str],
 ) -> anyhow::Result<OsString> {
-    let cache = Cache::from_path(temp_dir.child("cache").to_path_buf())?.init()?;
+    let cache = Cache::from_path(temp_dir.child("cache").to_path_buf()).init()?;
     let selected_pythons = python_versions
         .iter()
         .flat_map(|python_version| {


### PR DESCRIPTION

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
It removes the unused result when creating the Cache with the `from_path` constructor. I don't believe it does any io operations any more at least.

