### PR TITLE
Fix workspace settings - remove deny unknown fields

### DIFF
--- a/crates/uv-workspace/src/settings.rs
+++ b/crates/uv-workspace/src/settings.rs
@@ -28,7 +28,7 @@ pub(crate) struct Tools {
 /// A `[tool.uv]` section.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Default, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Options {
     pub native_tls: Option<bool>,


### PR DESCRIPTION
## Summary

This PR addresses an issue where `tool.uv` settings are not read if `tool.uv.sources` or `tool.uv.workspaces` are present in the TOML file. 

## Test Plan

Tested locally.