### PR TITLE
Add extra dependency annotations to lockfile and sync commands

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -853,7 +853,6 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 if self.dependency_mode.is_direct() {
                     // If an extra is provided, wait for the metadata to be available, since it's
                     // still required for generating the lock file.
-
                     let dist = match url {
                         Some(url) => PubGrubDistribution::from_url(name, url),
                         None => PubGrubDistribution::from_registry(name, version),

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
@@ -12,6 +12,7 @@ Ok(
                         "anyio",
                     ),
                     version: "4.3.0",
+                    extra: None,
                     source: Source {
                         kind: Path,
                         url: Url {
@@ -78,6 +79,7 @@ Ok(
                     "anyio",
                 ),
                 version: "4.3.0",
+                extra: None,
                 source: Source {
                     kind: Path,
                     url: Url {

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1764,6 +1764,17 @@ pub(crate) struct VenvArgs {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct RunArgs {
+    /// Include optional dependencies in the given extra group name; may be provided more than once.
+    #[arg(long, conflicts_with = "all_extras", value_parser = extra_name_with_clap_error)]
+    pub(crate) extra: Option<Vec<ExtraName>>,
+
+    /// Include all optional dependencies.
+    #[arg(long, conflicts_with = "extra")]
+    pub(crate) all_extras: bool,
+
+    #[arg(long, overrides_with("all_extras"), hide = true)]
+    pub(crate) no_all_extras: bool,
+
     /// The command to run.
     pub(crate) target: Option<String>,
 
@@ -1800,6 +1811,17 @@ pub(crate) struct RunArgs {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct SyncArgs {
+    /// Include optional dependencies in the given extra group name; may be provided more than once.
+    #[arg(long, conflicts_with = "all_extras", value_parser = extra_name_with_clap_error)]
+    pub(crate) extra: Option<Vec<ExtraName>>,
+
+    /// Include all optional dependencies.
+    #[arg(long, conflicts_with = "extra")]
+    pub(crate) all_extras: bool,
+
+    #[arg(long, overrides_with("all_extras"), hide = true)]
+    pub(crate) no_all_extras: bool,
+
     /// The Python interpreter to use to build the run environment.
     ///
     /// By default, `uv` uses the virtual environment in the current working directory or any parent

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -323,7 +323,7 @@ pub(crate) async fn pip_install(
         let root = PackageName::new(root.to_string())?;
         let encoded = fs::tokio::read_to_string("uv.lock").await?;
         let lock: Lock = toml::from_str(&encoded)?;
-        lock.to_resolution(&markers, &tags, &root)
+        lock.to_resolution(&markers, &tags, &root, &[])
     } else {
         let options = OptionsBuilder::new()
             .resolution_mode(resolution_mode)

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use uv_cache::Cache;
 use uv_client::Connectivity;
-use uv_configuration::PreviewMode;
+use uv_configuration::{ExtrasSpecification, PreviewMode};
 use uv_interpreter::{PythonEnvironment, SystemPython};
 use uv_requirements::{ProjectWorkspace, RequirementsSource};
 use uv_resolver::ExcludeNewer;
@@ -21,6 +21,7 @@ use crate::printer::Printer;
 /// Run a command.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run(
+    extras: ExtrasSpecification,
     target: Option<String>,
     mut args: Vec<OsString>,
     requirements: Vec<RequirementsSource>,
@@ -47,7 +48,7 @@ pub(crate) async fn run(
 
         // Lock and sync the environment.
         let lock = project::lock::do_lock(&project, &venv, exclude_newer, cache, printer).await?;
-        project::sync::do_sync(&project, &venv, &lock, cache, printer).await?;
+        project::sync::do_sync(&project, &venv, &lock, extras, cache, printer).await?;
 
         Some(venv)
     };

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -573,6 +573,7 @@ async fn run() -> Result<ExitStatus> {
                 .collect::<Vec<_>>();
 
             commands::run(
+                args.extras,
                 args.target,
                 args.args,
                 requirements,
@@ -588,12 +589,12 @@ async fn run() -> Result<ExitStatus> {
         }
         Commands::Sync(args) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
-            let _args = settings::SyncSettings::resolve(args, workspace);
+            let args = settings::SyncSettings::resolve(args, workspace);
 
             // Initialize the cache.
             let cache = cache.init()?;
 
-            commands::sync(globals.preview, &cache, printer).await
+            commands::sync(args.extras, globals.preview, &cache, printer).await
         }
         Commands::Lock(args) => {
             // Resolve the settings from the command-line arguments and workspace configuration.

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -97,6 +97,7 @@ impl CacheSettings {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct RunSettings {
+    pub(crate) extras: ExtrasSpecification,
     pub(crate) target: Option<String>,
     pub(crate) args: Vec<OsString>,
     pub(crate) with: Vec<String>,
@@ -109,6 +110,9 @@ impl RunSettings {
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn resolve(args: RunArgs, _workspace: Option<Workspace>) -> Self {
         let RunArgs {
+            extra,
+            all_extras,
+            no_all_extras,
             target,
             args,
             with,
@@ -117,6 +121,10 @@ impl RunSettings {
         } = args;
 
         Self {
+            extras: ExtrasSpecification::from_args(
+                flag(all_extras, no_all_extras).unwrap_or_default(),
+                extra.unwrap_or_default(),
+            ),
             target,
             args,
             with,
@@ -130,6 +138,7 @@ impl RunSettings {
 #[allow(clippy::struct_excessive_bools, dead_code)]
 #[derive(Debug, Clone)]
 pub(crate) struct SyncSettings {
+    pub(crate) extras: ExtrasSpecification,
     pub(crate) python: Option<String>,
 }
 
@@ -137,9 +146,20 @@ impl SyncSettings {
     /// Resolve the [`SyncSettings`] from the CLI and workspace configuration.
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn resolve(args: SyncArgs, _workspace: Option<Workspace>) -> Self {
-        let SyncArgs { python } = args;
+        let SyncArgs {
+            extra,
+            all_extras,
+            no_all_extras,
+            python,
+        } = args;
 
-        Self { python }
+        Self {
+            extras: ExtrasSpecification::from_args(
+                flag(all_extras, no_all_extras).unwrap_or_default(),
+                extra.unwrap_or_default(),
+            ),
+            python,
+        }
     }
 }
 

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -576,7 +576,7 @@ fn lock_extra() -> Result<()> {
         dependencies = ["anyio==3.7.0"]
 
         [project.optional-dependencies]
-        test = ["pytest"]
+        test = ["iniconfig"]
         "#,
     )?;
 
@@ -587,7 +587,7 @@ fn lock_extra() -> Result<()> {
 
     ----- stderr -----
     warning: `uv lock` is experimental and may change without warning.
-    Resolved 8 packages in [TIME]
+    Resolved 5 packages in [TIME]
     "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock"))?;
@@ -655,36 +655,6 @@ fn lock_extra() -> Result<()> {
         size = 5892
 
         [[distribution]]
-        name = "packaging"
-        version = "24.0"
-        source = "registry+https://pypi.org/simple"
-
-        [distribution.sdist]
-        url = "https://files.pythonhosted.org/packages/ee/b5/b43a27ac7472e1818c4bafd44430e69605baefe1f34440593e0332ec8b4d/packaging-24.0.tar.gz"
-        hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
-        size = 147882
-
-        [[distribution.wheel]]
-        url = "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl"
-        hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"
-        size = 53488
-
-        [[distribution]]
-        name = "pluggy"
-        version = "1.4.0"
-        source = "registry+https://pypi.org/simple"
-
-        [distribution.sdist]
-        url = "https://files.pythonhosted.org/packages/54/c6/43f9d44d92aed815e781ca25ba8c174257e27253a94630d21be8725a2b59/pluggy-1.4.0.tar.gz"
-        hash = "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"
-        size = 65812
-
-        [[distribution.wheel]]
-        url = "https://files.pythonhosted.org/packages/a5/5b/0cc789b59e8cc1bf288b38111d002d8c5917123194d45b29dcdac64723cc/pluggy-1.4.0-py3-none-any.whl"
-        hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981"
-        size = 20120
-
-        [[distribution]]
         name = "project"
         version = "0.1.0"
         source = "editable+file://[TEMP_DIR]/"
@@ -698,33 +668,22 @@ fn lock_extra() -> Result<()> {
         source = "registry+https://pypi.org/simple"
 
         [[distribution]]
-        name = "pytest"
-        version = "8.1.1"
-        source = "registry+https://pypi.org/simple"
+        name = "project"
+        version = "0.1.0"
+        extra = "test"
+        source = "editable+file://[TEMP_DIR]/"
 
         [distribution.sdist]
-        url = "https://files.pythonhosted.org/packages/30/b7/7d44bbc04c531dcc753056920e0988032e5871ac674b5a84cb979de6e7af/pytest-8.1.1.tar.gz"
-        hash = "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044"
-        size = 1409703
+        url = "file://[TEMP_DIR]/"
 
-        [[distribution.wheel]]
-        url = "https://files.pythonhosted.org/packages/4d/7e/c79cecfdb6aa85c6c2e3cf63afc56d0f165f24f5c66c03c695c4d9b84756/pytest-8.1.1-py3-none-any.whl"
-        hash = "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7"
-        size = 337359
+        [[distribution.dependencies]]
+        name = "anyio"
+        version = "3.7.0"
+        source = "registry+https://pypi.org/simple"
 
         [[distribution.dependencies]]
         name = "iniconfig"
         version = "2.0.0"
-        source = "registry+https://pypi.org/simple"
-
-        [[distribution.dependencies]]
-        name = "packaging"
-        version = "24.0"
-        source = "registry+https://pypi.org/simple"
-
-        [[distribution.dependencies]]
-        name = "pluggy"
-        version = "1.4.0"
         source = "registry+https://pypi.org/simple"
 
         [[distribution]]
@@ -745,7 +704,7 @@ fn lock_extra() -> Result<()> {
         );
     });
 
-    // Install from the lockfile.
+    // Install the base dependencies from the lockfile.
     uv_snapshot!(context.filters(), context.sync(), @r###"
     success: true
     exit_code: 0
@@ -759,6 +718,19 @@ fn lock_extra() -> Result<()> {
      + idna==3.6
      + project==0.1.0 (from file://[TEMP_DIR]/)
      + sniffio==1.3.1
+    "###);
+
+    // Install the extras from the lockfile.
+    uv_snapshot!(context.filters(), context.sync().arg("--extra").arg("test"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv sync` is experimental and may change without warning.
+    Downloaded 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
     "###);
 
     Ok(())


### PR DESCRIPTION
## Summary

This PR adds extras to the lockfile, and enables users to selectively sync extras in `uv sync` and `uv run`. The end result here was fairly simple, though it required a few refactors to get here. The basic idea is that `DistributionId` now includes `extra: Option<ExtraName>`, so we effectively treat extras as separate packages. Generating the lockfile, and generating the resolution from the lockfile, fall out of this naturally with no special-casing or additional changes.

The main downside here is that it bloats the lockfile significantly. Specifically:

- We include _all_ distribution URLs and hashes for _every_ extra variant.
- We include all dependencies for the extra variant, even though that are dependencies of the base package.

We could normalize this representation by changing each distribution have an `optional-dependencies` hash map that keys on extras, but we actually don't have the information we need to create that right now (specifically, we can't differentiate between dependencies that _require_ the extra and dependencies on the base package).

Closes #3700.
