### PR TITLE
Remove installed packages from preferences

### DIFF
--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -26,7 +26,7 @@ use uv_normalize::PackageName;
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_resolver::{
     DependencyMode, ExcludeNewer, FlatIndex, InMemoryIndex, Lock, OptionsBuilder, PreReleaseMode,
-    Preference, ResolutionMode,
+    ResolutionMode,
 };
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 
@@ -255,11 +255,8 @@ pub(crate) async fn pip_install(
         HashStrategy::None
     };
 
-    // When resolving, prefer current site packages.
-    let preferences = site_packages
-        .iter()
-        .map(Preference::from_installed)
-        .collect::<Vec<_>>();
+    // When resolving, don't take any external preferences into account.
+    let preferences = Vec::default();
 
     // Incorporate any index locations from the provided sources.
     let index_locations =

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -24,7 +24,7 @@ use uv_interpreter::{PythonEnvironment, PythonVersion, SystemPython, Target};
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_resolver::{
     DependencyMode, ExcludeNewer, FlatIndex, InMemoryIndex, OptionsBuilder, PreReleaseMode,
-    Preference, ResolutionMode,
+    ResolutionMode,
 };
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 
@@ -275,11 +275,8 @@ pub(crate) async fn pip_sync(
     // Determine the set of installed packages.
     let site_packages = SitePackages::from_executable(&venv)?;
 
-    // When resolving, prefer current site packages.
-    let preferences = site_packages
-        .iter()
-        .map(Preference::from_installed)
-        .collect::<Vec<_>>();
+    // When resolving, don't take any external preferences into account.
+    let preferences = Vec::default();
 
     let options = OptionsBuilder::new()
         .resolution_mode(resolution_mode)

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -4341,11 +4341,12 @@ fn already_installed_multiple_versions() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
+    Downloaded 1 package in [TIME]
     Uninstalled 2 packages in [TIME]
     Installed 1 package in [TIME]
      - anyio==3.7.0
      - anyio==4.0.0
-     + anyio==4.0.0
+     + anyio==4.3.0
     "###
     );
 


### PR DESCRIPTION
## Summary

I believe that this is not necessary, as the installer packages are already considered in `CandidateSelector::get_preferred`.

Firstly, note that we never pass both non-empty installed packages _and_ non-empty preferences (the installer routines pass site packages and no preferences; the resolver routines pass no site packages but lockfile preferences).

However, in general, if you look at `CandidateSelector::get_preferred`, and consider what's changing, we now skip the `if let Some(version) = preferences.version(package_name)` case for installed packages. But we then check installed packages within that `if`, and in the `else`. So it seems like we'll still return them in either case?

The only behavior change is in the case that you have multiple versions of a package installed. Previously, we'd respect one of them, because `Preferences` takes the last winner (it's a hash map, so we just replace the package key with the last version we see); but in installed packages, we always ignore distributions with multiple versions, since it's indicative of a broken environment. That's a fine change IMO. We could change `CandidateSelector::get_preferred` to support this if we wanted to.
