### PR TITLE
Fix nightly cfg checker warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ pep508_rs = { path = "crates/pep508-rs" }
 [workspace.lints.rust]
 unsafe_code = "warn"
 unreachable_pub = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(codspeed)'] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -2 }

--- a/crates/uv-extract/src/tar.rs
+++ b/crates/uv-extract/src/tar.rs
@@ -3,7 +3,7 @@ use std::path::{Component, Path, PathBuf};
 /// Determine the path at which the given tar entry will be unpacked, when unpacking into `dst`.
 ///
 /// See: <https://github.com/vorot93/tokio-tar/blob/87338a76092330bc6fe60de95d83eae5597332e1/src/entry.rs#L418>
-#[cfg_attr(not(target_os = "unix"), allow(dead_code))]
+#[cfg_attr(not(unix), allow(dead_code))]
 pub(crate) fn unpacked_at(dst: &Path, entry: &Path) -> Option<PathBuf> {
     let mut file_dst = dst.to_path_buf();
     {


### PR DESCRIPTION
Fixes these two warnings on nightly:

```
warning: unexpected `cfg` condition name: `codspeed`
 --> crates/bench/src/lib.rs:5:15
  |
5 |     #[cfg(not(codspeed))]
  |               ^^^^^^^^ help: found config with similar value: `feature = "codspeed"`
  |
  = help: expected names are: `clippy`, `debug_assertions`, `doc`, `docsrs`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, and `windows`
  = help: consider using a Cargo feature instead
  = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
           [lints.rust]
           unexpected_cfgs = { level = "warn", check-cfg = ['cfg(codspeed)'] }
  = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(codspeed)");` to the top of the `build.rs`
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: `#[warn(unexpected_cfgs)]` on by default

warning: unexpected `cfg` condition name: `codspeed`
 --> crates/bench/src/lib.rs:8:11
  |
8 |     #[cfg(codspeed)]
  |           ^^^^^^^^ help: found config with similar value: `feature = "codspeed"`
  |
  = help: consider using a Cargo feature instead
  = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
           [lints.rust]
           unexpected_cfgs = { level = "warn", check-cfg = ['cfg(codspeed)'] }
  = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(codspeed)");` to the top of the `build.rs`
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

```
warning: unexpected `cfg` condition value: `unix`
 --> crates/uv-extract/src/tar.rs:6:16
  |
6 | #[cfg_attr(not(target_os = "unix"), allow(dead_code))]
  |                ^^^^^^^^^^^^^^^^^^
  |
  = note: expected values for `target_os` are: `aix`, `android`, `cuda`, `dragonfly`, `emscripten`, `espidf`, `freebsd`, `fuchsia`, `haiku`, `hermit`, `horizon`, `hurd`, `illumos`, `ios`, `l4re`, `linux`, `macos`, `netbsd`, `none`, `nto`, `openbsd`, `psp`, `redox`, `solaris`, `solid_asp3`, `teeos`, `tvos`, `uefi`, `unknown`, `visionos`, `vita`, `vxworks`, `wasi`, `watchos`, and `windows` and 2 more
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: requested on the command line with `-W unexpected-cfgs`
```

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->