### PR TITLE
Re-add lowering unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4659,6 +4659,7 @@ dependencies = [
  "fs-err",
  "futures",
  "glob",
+ "indoc",
  "insta",
  "install-wheel-rs",
  "nanoid",

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -54,6 +54,7 @@ url = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]
+indoc = { version = "2.0.5" }
 insta = { version = "1.39.0", features = ["filters", "json", "redactions"] }
 regex = { workspace = true }
 

--- a/crates/uv-distribution/src/requirement_lowering.rs
+++ b/crates/uv-distribution/src/requirement_lowering.rs
@@ -239,3 +239,258 @@ fn path_source(
         editable,
     })
 }
+
+#[cfg(test)]
+mod test {
+    use std::path::Path;
+    use std::str::FromStr;
+
+    use indoc::indoc;
+    use insta::assert_snapshot;
+
+    use pypi_types::Metadata23;
+    use uv_configuration::PreviewMode;
+    use uv_normalize::PackageName;
+
+    use crate::pyproject::PyProjectToml;
+    use crate::{Metadata, ProjectWorkspace};
+
+    async fn metadata_from_pyproject_toml(contents: &str) -> anyhow::Result<Metadata> {
+        let pyproject_toml: PyProjectToml = toml::from_str(contents)?;
+        let path = Path::new("pyproject.toml");
+        let project_name = PackageName::from_str("foo").unwrap();
+        let project_workspace =
+            ProjectWorkspace::from_project(path, &pyproject_toml, project_name, Some(path)).await?;
+        let metadata = Metadata23::parse_pyproject_toml(contents)?;
+        Ok(Metadata::from_project_workspace(
+            metadata,
+            &project_workspace,
+            PreviewMode::Enabled,
+        )?)
+    }
+
+    async fn format_err(input: &str) -> String {
+        let err = metadata_from_pyproject_toml(input).await.unwrap_err();
+        let mut causes = err.chain();
+        let mut message = String::new();
+        message.push_str(&format!("error: {}\n", causes.next().unwrap()));
+        for err in causes {
+            message.push_str(&format!("  Caused by: {err}\n"));
+        }
+        message
+    }
+
+    #[tokio::test]
+    async fn conflict_project_and_sources() {
+        let input = indoc! {r#"
+            [project]
+            name = "foo"
+            version = "0.0.0"
+            dependencies = [
+              "tqdm @ git+https://github.com/tqdm/tqdm",
+            ]
+            [tool.uv.sources]
+            tqdm = { url = "https://files.pythonhosted.org/packages/a5/d6/502a859bac4ad5e274255576cd3e15ca273cdb91731bc39fb840dd422ee9/tqdm-4.66.0-py3-none-any.whl" }
+        "#};
+
+        assert_snapshot!(format_err(input).await, @r###"
+        error: Failed to parse entry for: `tqdm`
+          Caused by: Can't combine URLs from both `project.dependencies` and `tool.uv.sources`
+        "###);
+    }
+
+    #[tokio::test]
+    async fn too_many_git_specs() {
+        let input = indoc! {r#"
+            [project]
+            name = "foo"
+            version = "0.0.0"
+            dependencies = [
+              "tqdm",
+            ]
+            [tool.uv.sources]
+            tqdm = { git = "https://github.com/tqdm/tqdm", rev = "baaaaaab", tag = "v1.0.0" }
+        "#};
+
+        assert_snapshot!(format_err(input).await, @r###"
+        error: Failed to parse entry for: `tqdm`
+          Caused by: Can only specify one of: `rev`, `tag`, or `branch`
+        "###);
+    }
+
+    #[tokio::test]
+    async fn too_many_git_typo() {
+        let input = indoc! {r#"
+            [project]
+            name = "foo"
+            version = "0.0.0"
+            dependencies = [
+              "tqdm",
+            ]
+            [tool.uv.sources]
+            tqdm = { git = "https://github.com/tqdm/tqdm", ref = "baaaaaab" }
+        "#};
+
+        // TODO(konsti): This should tell you the set of valid fields
+        assert_snapshot!(format_err(input).await, @r###"
+        error: TOML parse error at line 8, column 8
+          |
+        8 | tqdm = { git = "https://github.com/tqdm/tqdm", ref = "baaaaaab" }
+          |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        data did not match any variant of untagged enum Source
+
+        "###);
+    }
+
+    #[tokio::test]
+    async fn you_cant_mix_those() {
+        let input = indoc! {r#"
+            [project]
+            name = "foo"
+            version = "0.0.0"
+            dependencies = [
+              "tqdm",
+            ]
+            [tool.uv.sources]
+            tqdm = { path = "tqdm", index = "torch" }
+        "#};
+
+        // TODO(konsti): This should tell you the set of valid fields
+        assert_snapshot!(format_err(input).await, @r###"
+        error: TOML parse error at line 8, column 8
+          |
+        8 | tqdm = { path = "tqdm", index = "torch" }
+          |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        data did not match any variant of untagged enum Source
+
+        "###);
+    }
+
+    #[tokio::test]
+    async fn missing_constraint() {
+        let input = indoc! {r#"
+            [project]
+            name = "foo"
+            version = "0.0.0"
+            dependencies = [
+              "tqdm",
+            ]
+        "#};
+        assert!(metadata_from_pyproject_toml(input).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn invalid_syntax() {
+        let input = indoc! {r#"
+            [project]
+            name = "foo"
+            version = "0.0.0"
+            dependencies = [
+              "tqdm ==4.66.0",
+            ]
+            [tool.uv.sources]
+            tqdm = { url = invalid url to tqdm-4.66.0-py3-none-any.whl" }
+        "#};
+
+        assert_snapshot!(format_err(input).await, @r###"
+        error: TOML parse error at line 8, column 16
+          |
+        8 | tqdm = { url = invalid url to tqdm-4.66.0-py3-none-any.whl" }
+          |                ^
+        invalid string
+        expected `"`, `'`
+
+        "###);
+    }
+
+    #[tokio::test]
+    async fn invalid_url() {
+        let input = indoc! {r#"
+            [project]
+            name = "foo"
+            version = "0.0.0"
+            dependencies = [
+              "tqdm ==4.66.0",
+            ]
+            [tool.uv.sources]
+            tqdm = { url = "§invalid#+#*Ä" }
+        "#};
+
+        assert_snapshot!(format_err(input).await, @r###"
+        error: TOML parse error at line 8, column 8
+          |
+        8 | tqdm = { url = "§invalid#+#*Ä" }
+          |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        data did not match any variant of untagged enum Source
+
+        "###);
+    }
+
+    #[tokio::test]
+    async fn workspace_and_url_spec() {
+        let input = indoc! {r#"
+            [project]
+            name = "foo"
+            version = "0.0.0"
+            dependencies = [
+              "tqdm @ git+https://github.com/tqdm/tqdm",
+            ]
+            [tool.uv.sources]
+            tqdm = { workspace = true }
+        "#};
+
+        assert_snapshot!(format_err(input).await, @r###"
+        error: Failed to parse entry for: `tqdm`
+          Caused by: Can't combine URLs from both `project.dependencies` and `tool.uv.sources`
+        "###);
+    }
+
+    #[tokio::test]
+    async fn missing_workspace_package() {
+        let input = indoc! {r#"
+            [project]
+            name = "foo"
+            version = "0.0.0"
+            dependencies = [
+              "tqdm ==4.66.0",
+            ]
+            [tool.uv.sources]
+            tqdm = { workspace = true }
+        "#};
+
+        assert_snapshot!(format_err(input).await, @r###"
+        error: Failed to parse entry for: `tqdm`
+          Caused by: Package is not included as workspace package in `tool.uv.workspace`
+        "###);
+    }
+
+    #[tokio::test]
+    async fn cant_be_dynamic() {
+        let input = indoc! {r#"
+            [project]
+            name = "foo"
+            version = "0.0.0"
+            dynamic = [
+                "dependencies"
+            ]
+            [tool.uv.sources]
+            tqdm = { workspace = true }
+        "#};
+
+        assert_snapshot!(format_err(input).await, @r###"
+        error: The following field was marked as dynamic: dependencies
+        "###);
+    }
+
+    #[tokio::test]
+    async fn missing_project_section() {
+        let input = indoc! {"
+            [tool.uv.sources]
+            tqdm = { workspace = true }
+        "};
+
+        assert_snapshot!(format_err(input).await, @r###"
+        error: metadata field project not found
+        "###);
+    }
+}

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -35,7 +35,7 @@ pub(crate) async fn lock(
     }
 
     // Find the project requirements.
-    let project = ProjectWorkspace::discover(std::env::current_dir()?).await?;
+    let project = ProjectWorkspace::discover(std::env::current_dir()?, None).await?;
 
     // Discover or create the virtual environment.
     let venv = project::init_environment(&project, preview, cache, printer)?;

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -45,7 +45,7 @@ pub(crate) async fn run(
     } else {
         debug!("Syncing project environment.");
 
-        let project = ProjectWorkspace::discover(std::env::current_dir()?).await?;
+        let project = ProjectWorkspace::discover(std::env::current_dir()?, None).await?;
         let venv = project::init_environment(&project, preview, cache, printer)?;
 
         // Lock and sync the environment.

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -34,7 +34,7 @@ pub(crate) async fn sync(
     }
 
     // Find the project requirements.
-    let project = ProjectWorkspace::discover(std::env::current_dir()?).await?;
+    let project = ProjectWorkspace::discover(std::env::current_dir()?, None).await?;
 
     // Discover or create the virtual environment.
     let venv = project::init_environment(&project, preview, cache, printer)?;

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -4977,7 +4977,8 @@ fn tool_uv_sources_is_in_preview() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: `tool.uv.sources` is a preview feature; use `--preview` or set `UV_PREVIEW=1` to enable it
+    error: Failed to parse entry for: `tqdm`
+      Caused by: `tool.uv.sources` is a preview feature; use `--preview` or set `UV_PREVIEW=1` to enable it
     "###
     );
 


### PR DESCRIPTION
Re-add the lowering unit tests removed in #3904. This also adds a `stop_discovery_at` feature to avoid running actual workspace discovery.