### PR TITLE
Unify editable and unnamed URL parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3001,6 +3001,7 @@ dependencies = [
  "reqwest-middleware",
  "tempfile",
  "test-case",
+ "thiserror",
  "tokio",
  "tracing",
  "unscanny",

--- a/crates/requirements-txt/Cargo.toml
+++ b/crates/requirements-txt/Cargo.toml
@@ -26,6 +26,7 @@ fs-err = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, optional = true }
 reqwest-middleware = { workspace = true, optional = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 unscanny = { workspace = true }
 url = { workspace = true }

--- a/crates/requirements-txt/src/requirement.rs
+++ b/crates/requirements-txt/src/requirement.rs
@@ -3,7 +3,29 @@ use std::path::Path;
 use pep508_rs::{
     Pep508Error, Pep508ErrorSource, RequirementOrigin, TracingReporter, UnnamedRequirement,
 };
-use pypi_types::VerbatimParsedUrl;
+use pypi_types::{ParsedPathUrl, ParsedUrl, VerbatimParsedUrl};
+use uv_normalize::PackageName;
+
+#[derive(Debug, thiserror::Error)]
+pub enum EditableError {
+    #[error("Editable `{0}` must refer to a local directory")]
+    MissingVersion(PackageName),
+
+    #[error("Editable `{0}` must refer to a local directory, not a versioned package")]
+    Versioned(PackageName),
+
+    #[error("Editable `{0}` must refer to a local directory, not an HTTPS URL: `{1}`")]
+    Https(PackageName, String),
+
+    #[error("Editable `{0}` must refer to a local directory, not a Git URL: `{1}`")]
+    Git(PackageName, String),
+
+    #[error("Editable must refer to a local directory, not an HTTPS URL: `{0}`")]
+    UnnamedHttps(String),
+
+    #[error("Editable must refer to a local directory, not a Git URL: `{0}`")]
+    UnnamedGit(String),
+}
 
 /// A requirement specifier in a `requirements.txt` file.
 ///
@@ -25,6 +47,69 @@ impl RequirementsTxtRequirement {
         match self {
             Self::Named(requirement) => Self::Named(requirement.with_origin(origin)),
             Self::Unnamed(requirement) => Self::Unnamed(requirement.with_origin(origin)),
+        }
+    }
+
+    /// Convert the [`RequirementsTxtRequirement`] into an editable requirement.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EditableError`] if the requirement cannot be interpreted as editable.
+    /// Specifically, only local directory URLs are supported.
+    pub fn into_editable(self) -> Result<Self, EditableError> {
+        match self {
+            RequirementsTxtRequirement::Named(requirement) => {
+                let Some(version_or_url) = requirement.version_or_url else {
+                    return Err(EditableError::MissingVersion(requirement.name));
+                };
+
+                let pep508_rs::VersionOrUrl::Url(url) = version_or_url else {
+                    return Err(EditableError::Versioned(requirement.name));
+                };
+
+                let parsed_url = match url.parsed_url {
+                    ParsedUrl::Path(parsed_url) => parsed_url,
+                    ParsedUrl::Archive(_) => {
+                        return Err(EditableError::Https(requirement.name, url.to_string()))
+                    }
+                    ParsedUrl::Git(_) => {
+                        return Err(EditableError::Git(requirement.name, url.to_string()))
+                    }
+                };
+
+                Ok(Self::Named(pep508_rs::Requirement {
+                    version_or_url: Some(pep508_rs::VersionOrUrl::Url(VerbatimParsedUrl {
+                        verbatim: url.verbatim,
+                        parsed_url: ParsedUrl::Path(ParsedPathUrl {
+                            editable: true,
+                            ..parsed_url
+                        }),
+                    })),
+                    ..requirement
+                }))
+            }
+            RequirementsTxtRequirement::Unnamed(requirement) => {
+                let parsed_url = match requirement.url.parsed_url {
+                    ParsedUrl::Path(parsed_url) => parsed_url,
+                    ParsedUrl::Archive(_) => {
+                        return Err(EditableError::UnnamedHttps(requirement.to_string()))
+                    }
+                    ParsedUrl::Git(_) => {
+                        return Err(EditableError::UnnamedGit(requirement.to_string()))
+                    }
+                };
+
+                Ok(Self::Unnamed(UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        verbatim: requirement.url.verbatim,
+                        parsed_url: ParsedUrl::Path(ParsedPathUrl {
+                            editable: true,
+                            ..parsed_url
+                        }),
+                    },
+                    ..requirement
+                }))
+            }
         }
     }
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-editable.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-editable.txt.snap
@@ -6,252 +6,390 @@ RequirementsTxt {
     requirements: [],
     constraints: [],
     editables: [
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "<REQUIREMENTS_DIR>/editable",
-                    query: None,
-                    fragment: None,
-                },
-                given: Some(
-                    "./editable",
-                ),
-            },
-            extras: [
-                ExtraName(
-                    "d",
-                ),
-                ExtraName(
-                    "dev",
-                ),
-            ],
-            marker: None,
-            path: "<REQUIREMENTS_DIR>/editable",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
-            ),
-        },
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "<REQUIREMENTS_DIR>/editable",
-                    query: None,
-                    fragment: None,
-                },
-                given: Some(
-                    "./editable",
-                ),
-            },
-            extras: [
-                ExtraName(
-                    "d",
-                ),
-                ExtraName(
-                    "dev",
-                ),
-            ],
-            marker: None,
-            path: "<REQUIREMENTS_DIR>/editable",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
-            ),
-        },
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "<REQUIREMENTS_DIR>/editable",
-                    query: None,
-                    fragment: None,
-                },
-                given: Some(
-                    "./editable",
-                ),
-            },
-            extras: [
-                ExtraName(
-                    "d",
-                ),
-                ExtraName(
-                    "dev",
-                ),
-            ],
-            marker: Some(
-                And(
-                    [
-                        Expression(
-                            Version {
-                                key: PythonVersion,
-                                specifier: VersionSpecifier {
-                                    operator: GreaterThanEqual,
-                                    version: "3.9",
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
                                 },
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
                             },
                         ),
-                        Expression(
-                            String {
-                                key: OsName,
-                                operator: Equal,
-                                value: "posix",
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
                             },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [
+                        ExtraName(
+                            "d",
+                        ),
+                        ExtraName(
+                            "dev",
                         ),
                     ],
-                ),
-            ),
-            path: "<REQUIREMENTS_DIR>/editable",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
-            ),
-        },
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "<REQUIREMENTS_DIR>/editable",
-                    query: None,
-                    fragment: None,
+                    marker: None,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
                 },
-                given: Some(
-                    "./editable",
-                ),
-            },
-            extras: [
-                ExtraName(
-                    "d",
-                ),
-                ExtraName(
-                    "dev",
-                ),
-            ],
-            marker: Some(
-                And(
-                    [
-                        Expression(
-                            Version {
-                                key: PythonVersion,
-                                specifier: VersionSpecifier {
-                                    operator: GreaterThanEqual,
-                                    version: "3.9",
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
                                 },
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
                             },
                         ),
-                        Expression(
-                            String {
-                                key: OsName,
-                                operator: Equal,
-                                value: "posix",
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
                             },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [
+                        ExtraName(
+                            "d",
+                        ),
+                        ExtraName(
+                            "dev",
                         ),
                     ],
-                ),
-            ),
-            path: "<REQUIREMENTS_DIR>/editable",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
-            ),
-        },
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "<REQUIREMENTS_DIR>/editable",
-                    query: None,
-                    fragment: None,
+                    marker: None,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
                 },
-                given: Some(
-                    "./editable",
-                ),
-            },
-            extras: [],
-            marker: Some(
-                And(
-                    [
-                        Expression(
-                            Version {
-                                key: PythonVersion,
-                                specifier: VersionSpecifier {
-                                    operator: GreaterThanEqual,
-                                    version: "3.9",
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
                                 },
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
                             },
                         ),
-                        Expression(
-                            String {
-                                key: OsName,
-                                operator: Equal,
-                                value: "posix",
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
                             },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [
+                        ExtraName(
+                            "d",
+                        ),
+                        ExtraName(
+                            "dev",
                         ),
                     ],
-                ),
-            ),
-            path: "<REQUIREMENTS_DIR>/editable",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
-            ),
-        },
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "<REQUIREMENTS_DIR>/editable;%20python_version%20%3E=%20%223.9%22%20and%20os_name%20==%20%22posix%22",
-                    query: None,
-                    fragment: None,
+                    marker: Some(
+                        And(
+                            [
+                                Expression(
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.9",
+                                        },
+                                    },
+                                ),
+                                Expression(
+                                    String {
+                                        key: OsName,
+                                        operator: Equal,
+                                        value: "posix",
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
                 },
-                given: Some(
-                    "./editable; python_version >= \"3.9\" and os_name == \"posix\"",
-                ),
-            },
-            extras: [],
-            marker: None,
-            path: "<REQUIREMENTS_DIR>/editable; python_version >= \"3.9\" and os_name == \"posix\"",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
             ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [
+                        ExtraName(
+                            "d",
+                        ),
+                        ExtraName(
+                            "dev",
+                        ),
+                    ],
+                    marker: Some(
+                        And(
+                            [
+                                Expression(
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.9",
+                                        },
+                                    },
+                                ),
+                                Expression(
+                                    String {
+                                        key: OsName,
+                                        operator: Equal,
+                                        value: "posix",
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: Some(
+                        And(
+                            [
+                                Expression(
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.9",
+                                        },
+                                    },
+                                ),
+                                Expression(
+                                    String {
+                                        key: OsName,
+                                        operator: Equal,
+                                        value: "posix",
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "<REQUIREMENTS_DIR>/editable[d",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                path: "<REQUIREMENTS_DIR>/editable[d",
+                                editable: true,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "<REQUIREMENTS_DIR>/editable[d",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./editable[d",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: None,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
         },
     ],
     index_url: None,

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-semicolon.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-semicolon.txt.snap
@@ -1,0 +1,19 @@
+---
+source: crates/requirements-txt/src/lib.rs
+expression: actual
+---
+RequirementsTxtFileError {
+    file: "<REQUIREMENTS_DIR>/semicolon.txt",
+    error: Pep508 {
+        source: Pep508Error {
+            message: String(
+                "Missing space before ';', the end of the URL is ambiguous",
+            ),
+            start: 11,
+            len: 1,
+            input: "./editable; python_version >= \"3.9\" and os_name == \"posix\"",
+        },
+        start: 50,
+        end: 108,
+    },
+}

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-editable.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-editable.txt.snap
@@ -6,252 +6,390 @@ RequirementsTxt {
     requirements: [],
     constraints: [],
     editables: [
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "/<REQUIREMENTS_DIR>/editable",
-                    query: None,
-                    fragment: None,
-                },
-                given: Some(
-                    "./editable",
-                ),
-            },
-            extras: [
-                ExtraName(
-                    "d",
-                ),
-                ExtraName(
-                    "dev",
-                ),
-            ],
-            marker: None,
-            path: "<REQUIREMENTS_DIR>/editable",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
-            ),
-        },
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "/<REQUIREMENTS_DIR>/editable",
-                    query: None,
-                    fragment: None,
-                },
-                given: Some(
-                    "./editable",
-                ),
-            },
-            extras: [
-                ExtraName(
-                    "d",
-                ),
-                ExtraName(
-                    "dev",
-                ),
-            ],
-            marker: None,
-            path: "<REQUIREMENTS_DIR>/editable",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
-            ),
-        },
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "/<REQUIREMENTS_DIR>/editable",
-                    query: None,
-                    fragment: None,
-                },
-                given: Some(
-                    "./editable",
-                ),
-            },
-            extras: [
-                ExtraName(
-                    "d",
-                ),
-                ExtraName(
-                    "dev",
-                ),
-            ],
-            marker: Some(
-                And(
-                    [
-                        Expression(
-                            Version {
-                                key: PythonVersion,
-                                specifier: VersionSpecifier {
-                                    operator: GreaterThanEqual,
-                                    version: "3.9",
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "/<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
                                 },
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
                             },
                         ),
-                        Expression(
-                            String {
-                                key: OsName,
-                                operator: Equal,
-                                value: "posix",
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
                             },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [
+                        ExtraName(
+                            "d",
+                        ),
+                        ExtraName(
+                            "dev",
                         ),
                     ],
-                ),
-            ),
-            path: "<REQUIREMENTS_DIR>/editable",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
-            ),
-        },
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "/<REQUIREMENTS_DIR>/editable",
-                    query: None,
-                    fragment: None,
+                    marker: None,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
                 },
-                given: Some(
-                    "./editable",
-                ),
-            },
-            extras: [
-                ExtraName(
-                    "d",
-                ),
-                ExtraName(
-                    "dev",
-                ),
-            ],
-            marker: Some(
-                And(
-                    [
-                        Expression(
-                            Version {
-                                key: PythonVersion,
-                                specifier: VersionSpecifier {
-                                    operator: GreaterThanEqual,
-                                    version: "3.9",
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "/<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
                                 },
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
                             },
                         ),
-                        Expression(
-                            String {
-                                key: OsName,
-                                operator: Equal,
-                                value: "posix",
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
                             },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [
+                        ExtraName(
+                            "d",
+                        ),
+                        ExtraName(
+                            "dev",
                         ),
                     ],
-                ),
-            ),
-            path: "<REQUIREMENTS_DIR>/editable",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
-            ),
-        },
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "/<REQUIREMENTS_DIR>/editable",
-                    query: None,
-                    fragment: None,
+                    marker: None,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
                 },
-                given: Some(
-                    "./editable",
-                ),
-            },
-            extras: [],
-            marker: Some(
-                And(
-                    [
-                        Expression(
-                            Version {
-                                key: PythonVersion,
-                                specifier: VersionSpecifier {
-                                    operator: GreaterThanEqual,
-                                    version: "3.9",
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "/<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
                                 },
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
                             },
                         ),
-                        Expression(
-                            String {
-                                key: OsName,
-                                operator: Equal,
-                                value: "posix",
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
                             },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [
+                        ExtraName(
+                            "d",
+                        ),
+                        ExtraName(
+                            "dev",
                         ),
                     ],
-                ),
-            ),
-            path: "<REQUIREMENTS_DIR>/editable",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
-            ),
-        },
-        EditableRequirement {
-            url: VerbatimUrl {
-                url: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "/<REQUIREMENTS_DIR>/editable;%20python_version%20%3E=%20%223.9%22%20and%20os_name%20==%20%22posix%22",
-                    query: None,
-                    fragment: None,
+                    marker: Some(
+                        And(
+                            [
+                                Expression(
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.9",
+                                        },
+                                    },
+                                ),
+                                Expression(
+                                    String {
+                                        key: OsName,
+                                        operator: Equal,
+                                        value: "posix",
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
                 },
-                given: Some(
-                    "./editable; python_version >= \"3.9\" and os_name == \"posix\"",
-                ),
-            },
-            extras: [],
-            marker: None,
-            path: "<REQUIREMENTS_DIR>/editable; python_version >= \"3.9\" and os_name == \"posix\"",
-            origin: Some(
-                File(
-                    "<REQUIREMENTS_DIR>/editable.txt",
-                ),
             ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "/<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [
+                        ExtraName(
+                            "d",
+                        ),
+                        ExtraName(
+                            "dev",
+                        ),
+                    ],
+                    marker: Some(
+                        And(
+                            [
+                                Expression(
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.9",
+                                        },
+                                    },
+                                ),
+                                Expression(
+                                    String {
+                                        key: OsName,
+                                        operator: Equal,
+                                        value: "posix",
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "/<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: Some(
+                        And(
+                            [
+                                Expression(
+                                    Version {
+                                        key: PythonVersion,
+                                        specifier: VersionSpecifier {
+                                            operator: GreaterThanEqual,
+                                            version: "3.9",
+                                        },
+                                    },
+                                ),
+                                Expression(
+                                    String {
+                                        key: OsName,
+                                        operator: Equal,
+                                        value: "posix",
+                                    },
+                                ),
+                            ],
+                        ),
+                    ),
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Path(
+                            ParsedPathUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "/<REQUIREMENTS_DIR>/editable[d",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                path: "<REQUIREMENTS_DIR>/editable[d",
+                                editable: true,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/<REQUIREMENTS_DIR>/editable[d",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./editable[d",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: None,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
         },
     ],
     index_url: None,

--- a/crates/requirements-txt/test-data/requirements-txt/editable.txt
+++ b/crates/requirements-txt/test-data/requirements-txt/editable.txt
@@ -13,5 +13,5 @@
 # OK
 -e ./editable ; python_version >= "3.9" and os_name == "posix"
 
-# Disallowed (missing whitespace before colon)
--e ./editable; python_version >= "3.9" and os_name == "posix"
+# OK (unterminated)
+-e ./editable[d

--- a/crates/requirements-txt/test-data/requirements-txt/semicolon.txt
+++ b/crates/requirements-txt/test-data/requirements-txt/semicolon.txt
@@ -1,0 +1,2 @@
+# Disallowed (missing whitespace before colon)
+-e ./editable; python_version >= "3.9" and os_name == "posix"

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -40,9 +40,7 @@ use distribution_types::{
 use pep508_rs::{UnnamedRequirement, UnnamedRequirementUrl};
 use pypi_types::Requirement;
 use pypi_types::VerbatimParsedUrl;
-use requirements_txt::{
-    EditableRequirement, FindLink, RequirementEntry, RequirementsTxt, RequirementsTxtRequirement,
-};
+use requirements_txt::{FindLink, RequirementsTxt, RequirementsTxtRequirement};
 use uv_client::BaseClientBuilder;
 use uv_configuration::{NoBinary, NoBuild};
 use uv_distribution::pyproject::PyProjectToml;
@@ -91,20 +89,17 @@ impl RequirementsSpecification {
                 let requirement = RequirementsTxtRequirement::parse(name, std::env::current_dir()?)
                     .with_context(|| format!("Failed to parse: `{name}`"))?;
                 Self {
-                    requirements: vec![UnresolvedRequirementSpecification::from(
-                        RequirementEntry {
-                            requirement,
-                            hashes: vec![],
-                        },
-                    )],
+                    requirements: vec![UnresolvedRequirementSpecification::from(requirement)],
                     ..Self::default()
                 }
             }
             RequirementsSource::Editable(name) => {
-                let requirement = EditableRequirement::parse(name, None, std::env::current_dir()?)
+                let requirement = RequirementsTxtRequirement::parse(name, std::env::current_dir()?)
                     .with_context(|| format!("Failed to parse: `{name}`"))?;
                 Self {
-                    requirements: vec![UnresolvedRequirementSpecification::from(requirement)],
+                    requirements: vec![UnresolvedRequirementSpecification::from(
+                        requirement.into_editable()?,
+                    )],
                     ..Self::default()
                 }
             }


### PR DESCRIPTION
## Summary

This will help prevent bugs like #3934 by unifying the implementations for editables and non-editable unnamed requirements. Specifically, both of these now go through the same parsing paths and use the same struct representations (with the exception that the editable flag is flipped in the first case):

```
-e ./foo/bar
./foo/bar
```

We also now support PEP 508 in editable URLs. It turns out this is just a limitation in pip, so it's correct to support it. For example, this now works:

```
-e black[d] @ file://${PROJECT_ROOT}/scripts/packages/black_editable
```

Closes #3941.

Closes #3942.
