### PR TITLE
Lenient handling of relative path dependencies

### DIFF
--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -511,6 +511,14 @@ impl<T: Pep508Url> Requirement<T> {
             reporter,
         )
     }
+
+    /// Parse a [Dependency Specifier](https://packaging.python.org/en/latest/specifications/dependency-specifiers/).
+    pub fn parse_opt_workdir(
+        input: &str,
+        working_dir: Option<&Path>,
+    ) -> Result<Self, Pep508Error<T>> {
+        parse_pep508_requirement(&mut Cursor::new(input), working_dir, &mut TracingReporter)
+    }
 }
 
 /// A list of [`ExtraName`] that can be attached to a [`Requirement`].


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

`uv` doesn't handle relative paths in dependencies very well.

This  came to my attention while using `rye`.
In my `pyproject.toml` files I would have dependencies like
```
"mylib @ ./../mylib"
```
But `uv` would complain about the path not being absolute.

I wrote a unittest to demostrate the problem.

I believe the reason for it failing is in couple of places, deserializing `LenientRequirement` either from a `pyproject.toml` or from wheel metadata. In both cases it ends up calling `Requirement::from_str()` and fails.

I'll try to see if I can write a fix, would welcome any feedback.


## Test Plan

The test currently fails, should turn green when a fix is implemented
