### PR TITLE
Fetch git trees on demand

### DIFF
--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -364,8 +364,8 @@ impl GitCheckout {
         ProcessBuilder::new("git")
             .arg("clone")
             .arg("--local")
-            // Propagate the treeless clone.
-            .arg("--filter=tree:0")
+            // Propagate the blobless clone.
+            .arg("--filter=blob:none")
             // Make sure to pass the local file path and not a file://... url. If given a url,
             // Git treats the repository as a remote origin and gets confused because we don't
             // have a HEAD checked out.
@@ -592,11 +592,11 @@ fn fetch_refspecs(
     }
     cmd.arg("--force") // handle force pushes
         .arg("--update-head-ok") // see discussion in #2078
-        // Perform a treeless fetch, fetching trees and blobs on-demand.
+        // Perform a blobless fetch, fetching blobs on-demand.
         // We cannot perform a shallow clone because build tools such as
         // setuptools-scm may require access to git history, but we only
         // need the contents of the specific commit we are fetching.
-        .arg("--filter=tree:0")
+        .arg("--filter=blob:none")
         .arg(url)
         .args(refspecs)
         // If cargo is run by git (for example, the `exec` command in `git

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -9203,7 +9203,7 @@ fn git_source_missing_tag() -> Result<()> {
       Caused by: Git operation failed
       Caused by: failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
       Caused by: failed to fetch tag `missing`
-      Caused by: process didn't exit successfully: `git fetch --force --update-head-ok 'https://github.com/astral-test/uv-public-pypackage' '+refs/tags/missing:refs/remotes/origin/tags/missing'` (exit status: 128)
+      Caused by: process didn't exit successfully: `git fetch --force --update-head-ok '--filter=tree:0' 'https://github.com/astral-test/uv-public-pypackage' '+refs/tags/missing:refs/remotes/origin/tags/missing'` (exit status: 128)
     --- stderr
     fatal: couldn't find remote ref refs/tags/missing
 

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1473,7 +1473,7 @@ fn install_git_private_https_pat_not_authorized() {
     error: Failed to download and build: `uv-private-pypackage @ git+https://git:***@github.com/astral-test/uv-private-pypackage`
       Caused by: Git operation failed
       Caused by: failed to clone into: [CACHE_DIR]/git-v0/db/8401f5508e3e612d
-      Caused by: process didn't exit successfully: `git fetch --force --update-head-ok 'https://git:***@github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
+      Caused by: process didn't exit successfully: `git fetch --force --update-head-ok '--filter=tree:0' 'https://git:***@github.com/astral-test/uv-private-pypackage' '+HEAD:refs/remotes/origin/HEAD'` (exit status: 128)
     --- stderr
     remote: Support for password authentication was removed on August 13, 2021.
     remote: Please see https://docs.github.com/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls for information on currently recommended modes of authentication.


### PR DESCRIPTION
## Summary

Pass `--filter=tree:0` when fetching from a git repository. This allows us to load trees and blobs lazily on checkout, which can drastically reduce the amount of data transferred, especially for large/old repositories.

This seems to be supported [since Git 2.20](https://github.com/git/git/commit/77d503757d6328703f9571a4432dd83800bc26bb), released late 2018.