### PR TITLE
Respect resolved Git SHAs in `uv lock`

### DIFF
--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -2,7 +2,9 @@ use std::str::FromStr;
 use url::Url;
 
 pub use crate::git::GitReference;
-pub use crate::resolver::{GitResolver, GitResolverError, RepositoryReference};
+pub use crate::resolver::{
+    GitResolver, GitResolverError, RepositoryReference, ResolvedRepositoryReference,
+};
 pub use crate::sha::{GitOid, GitSha, OidParseError};
 pub use crate::source::{Fetch, GitSource, Reporter};
 

--- a/crates/uv-git/src/resolver.rs
+++ b/crates/uv-git/src/resolver.rs
@@ -27,6 +27,15 @@ pub enum GitResolverError {
 pub struct GitResolver(Arc<DashMap<RepositoryReference, GitSha>>);
 
 impl GitResolver {
+    /// Initialize a [`GitResolver`] with a set of resolved references.
+    pub fn from_refs(refs: Vec<ResolvedRepositoryReference>) -> Self {
+        Self(Arc::new(
+            refs.into_iter()
+                .map(|ResolvedRepositoryReference { reference, sha }| (reference, sha))
+                .collect(),
+        ))
+    }
+
     /// Returns the [`GitSha`] for the given [`RepositoryReference`], if it exists.
     pub fn get(&self, reference: &RepositoryReference) -> Option<Ref<RepositoryReference, GitSha>> {
         self.0.get(reference)
@@ -137,10 +146,19 @@ impl GitResolver {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ResolvedRepositoryReference {
+    /// An abstract reference to a Git repository, including the URL and the commit (e.g., a branch,
+    /// tag, or revision).
+    pub reference: RepositoryReference,
+    /// The precise commit SHA of the reference.
+    pub sha: GitSha,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RepositoryReference {
     /// The URL of the Git repository, with any query parameters and fragments removed.
     pub url: RepositoryUrl,
-    /// The reference to the commit to use, which could be a branch, tag or revision.
+    /// The reference to the commit to use, which could be a branch, tag, or revision.
     pub reference: GitReference,
 }
 


### PR DESCRIPTION
## Summary

This PR ensures that if a lockfile already contains a resolved reference (e.g., you locked with `main` previously, and it locked to a specific commit), and you run `uv lock`, we use the same SHA, even if it's not the latest SHA for that tag. This avoids upgrading Git dependencies without `--upgrade`.

Closes #3920.
