### PR TITLE
Normalize extras in lockfile 

### DIFF
--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -84,6 +84,9 @@ fn add_requirements(
         // If the requirement isn't relevant for the current platform, skip it.
         match source_extra {
             Some(source_extra) => {
+                if requirement.evaluate_markers(env, &[]) {
+                    continue;
+                }
                 if !requirement.evaluate_markers(env, std::slice::from_ref(source_extra)) {
                     continue;
                 }
@@ -149,6 +152,9 @@ fn add_requirements(
                 // If the requirement isn't relevant for the current platform, skip it.
                 match source_extra {
                     Some(source_extra) => {
+                        if constraint.evaluate_markers(env, &[]) {
+                            continue;
+                        }
                         if !constraint.evaluate_markers(env, std::slice::from_ref(source_extra)) {
                             continue;
                         }

--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -20,10 +20,7 @@ use crate::pubgrub::{PubGrubDistribution, PubGrubPackageInner};
 use crate::redirect::url_to_precise;
 use crate::resolution::AnnotatedDist;
 use crate::resolver::Resolution;
-use crate::{
-    lock, InMemoryIndex, Lock, LockError, Manifest, MetadataResponse, ResolveError,
-    VersionsResponse,
-};
+use crate::{InMemoryIndex, Manifest, MetadataResponse, ResolveError, VersionsResponse};
 
 /// A complete resolution graph in which every node represents a pinned package and every edge
 /// represents a dependency between two pinned packages.
@@ -440,21 +437,6 @@ impl ResolutionGraph {
             conjuncts.push(MarkerTree::Expression(expr));
         }
         Ok(MarkerTree::And(conjuncts))
-    }
-
-    pub fn lock(&self) -> anyhow::Result<Lock, LockError> {
-        let mut locked_dists = vec![];
-        for node_index in self.petgraph.node_indices() {
-            let dist = &self.petgraph[node_index];
-            let mut locked_dist = lock::Distribution::from_annotated_dist(dist)?;
-            for neighbor in self.petgraph.neighbors(node_index) {
-                let dependency_dist = &self.petgraph[neighbor];
-                locked_dist.add_dependency(dependency_dist);
-            }
-            locked_dists.push(locked_dist);
-        }
-        let lock = Lock::new(locked_dists)?;
-        Ok(lock)
     }
 }
 

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
@@ -12,7 +12,6 @@ Ok(
                         "anyio",
                     ),
                     version: "4.3.0",
-                    extra: None,
                     source: Source {
                         kind: Path,
                         url: Url {
@@ -71,6 +70,7 @@ Ok(
                     },
                 ],
                 dependencies: [],
+                optional_dependencies: {},
             },
         ],
         by_id: {
@@ -79,7 +79,6 @@ Ok(
                     "anyio",
                 ),
                 version: "4.3.0",
-                extra: None,
                 source: Source {
                     kind: Path,
                     url: Url {

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -178,7 +178,7 @@ pub(super) async fn do_lock(
     pip::operations::diagnose_resolution(resolution.diagnostics(), printer)?;
 
     // Write the lockfile to disk.
-    let lock = resolution.lock()?;
+    let lock = Lock::from_resolution_graph(&resolution)?;
     let encoded = lock.to_toml()?;
     fs_err::tokio::write(
         project.workspace().root().join("uv.lock"),

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -611,11 +611,6 @@ fn lock_extra() -> Result<()> {
         sdist = { url = "file://[TEMP_DIR]/" }
 
         [[distribution.dependencies]]
-        name = "anyio"
-        version = "3.7.0"
-        source = "registry+https://pypi.org/simple"
-
-        [[distribution.dependencies]]
         name = "iniconfig"
         version = "2.0.0"
         source = "registry+https://pypi.org/simple"

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -603,14 +603,9 @@ fn lock_extra() -> Result<()> {
         version = "3.7.0"
         source = "registry+https://pypi.org/simple"
 
-        [[distribution]]
-        name = "project"
-        version = "0.1.0"
-        source = "editable+file://[TEMP_DIR]/"
-        extra = "test"
-        sdist = { url = "file://[TEMP_DIR]/" }
+        [distribution.optional-dependencies]
 
-        [[distribution.dependencies]]
+        [[distribution.optional-dependencies.test]]
         name = "iniconfig"
         version = "2.0.0"
         source = "registry+https://pypi.org/simple"


### PR DESCRIPTION
## Summary

Previously, when we locked something like `flask[dotenv]`, we created two separate distributions in the lockfile: one for `flask`, which included the base dependencies, and one for `flask[dotenv]`, which included the base dependencies _and_ the `dotenv` dependencies. This was easy to implement, but it meant that we were duplicating all of the distribution files for every extra, and duplicating all of the base dependencies for every extra.

This PR normalizes the data such that we now have one entry per distribution (i.e., `ExtraName` was removed from `DistributionId`), with an optional dependencies table with an entry per extra, like:

```toml
[[distribution]]
name = "project"
version = "0.1.0"
source = "editable+file://[TEMP_DIR]/"
sdist = { url = "file://[TEMP_DIR]/" }

[[distribution.dependencies]]
name = "anyio"
version = "3.7.0"
source = "registry+https://pypi.org/simple"

[distribution.optional-dependencies]

[[distribution.optional-dependencies.test]]
name = "iniconfig"
version = "2.0.0"
source = "registry+https://pypi.org/simple"
```

This requires a bit more work upfront, because we now need to merge multiple packages from the `PetGraph` representation when creating the lockfile.

Closes https://github.com/astral-sh/uv/issues/3916.
