### PR TITLE
Avoid joining globs in workspace discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4692,6 +4692,7 @@ dependencies = [
  "uv-normalize",
  "uv-types",
  "uv-warnings",
+ "walkdir",
  "zip",
 ]
 

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -49,6 +49,7 @@ tokio-util = { workspace = true, features = ["compat"] }
 toml =  { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+walkdir = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

The current approach feels not-quite-right to me. We already have a valid glob, and then we join it onto the path and have to re-parse the pattern. This PR instead uses `WalkDir` to manually recurse over the entries and find matches. We can also avoid testing against files, since we know we're only looking for directories.
