### PR TITLE
feat: support `NO_COLOR` and `FORCE_COLOR` env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,8 @@ In addition, uv respects the following environment variables:
 - `MACOSX_DEPLOYMENT_TARGET`: Used with `--python-platform macos` and related variants to set the
   deployment target (i.e., the minimum supported macOS version). Defaults to `12.0`, the
   least-recent non-EOL macOS version at time of writing.
+- `NO_COLOR`: Disable colors. Takes precedence over `FORCE_COLOR`. See [no-color.org](https://no-color.org).
+- `FORCE_COLOR`: Enforce colors regardless of TTY support. See [force-color.org](https://force-color.org).
 
 ## Versioning
 

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -46,8 +46,12 @@ impl GlobalSettings {
         Self {
             quiet: args.quiet,
             verbose: args.verbose,
-            color: if args.no_color {
+            color: if args.no_color || std::env::var_os("NO_COLOR").is_some() {
                 ColorChoice::Never
+            } else if std::env::var_os("FORCE_COLOR").is_some()
+                || std::env::var_os("CLICOLOR_FORCE").is_some()
+            {
+                ColorChoice::Always
             } else {
                 args.color
             },

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -46,10 +46,18 @@ impl GlobalSettings {
         Self {
             quiet: args.quiet,
             verbose: args.verbose,
-            color: if args.no_color || std::env::var_os("NO_COLOR").is_some() {
+            color: if args.no_color
+                || std::env::var_os("NO_COLOR")
+                    .filter(|v| !v.is_empty())
+                    .is_some()
+            {
                 ColorChoice::Never
-            } else if std::env::var_os("FORCE_COLOR").is_some()
-                || std::env::var_os("CLICOLOR_FORCE").is_some()
+            } else if std::env::var_os("FORCE_COLOR")
+                .filter(|v| !v.is_empty())
+                .is_some()
+                || std::env::var_os("CLICOLOR_FORCE")
+                    .filter(|v| !v.is_empty())
+                    .is_some()
             {
                 ColorChoice::Always
             } else {


### PR DESCRIPTION
## Summary

Closes #3955

Adds explicit support to `NO_COLOR` and `FORCE_COLOR` via GlobalSettings.

The order, per specs is now `NO_COLOR` > `FORCE_COLOR` > `color`.

This PR is a backup plan pending rust-cli/anstyle#192.

## Test Plan

Tested all cases locally for now; I didn't see existing tests for GlobalSettings parsing.