### PR TITLE
feat: add back the use of extra env vars to the build dispatch

### DIFF
--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -2,7 +2,7 @@
 //! [installer][`uv_installer`] and [build][`uv_build`] through [`BuildDispatch`]
 //! implementing [`BuildContext`].
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -97,6 +97,21 @@ impl<'a> BuildDispatch<'a> {
         self.options = options;
         self
     }
+
+    /// Set the environment variables to be used when building a source distribution.
+    #[must_use]
+    pub fn with_build_extra_env_vars<I, K, V>(mut self, sdist_build_env_variables: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.build_extra_env_vars = sdist_build_env_variables
+            .into_iter()
+            .map(|(key, value)| (key.as_ref().to_owned(), value.as_ref().to_owned()))
+            .collect();
+        self
+    }
 }
 
 impl<'a> BuildContext for BuildDispatch<'a> {


### PR DESCRIPTION
Seems like a recent Pull removed this, couldn't directly find out which. I'm adding it back as we rely on this API, and I do not see another way of accessing this, or am I mistaken?

Thanks!