### PR TITLE
uv {lock,sync}: propagate index URLs to registry client

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -99,6 +99,7 @@ pub(super) async fn do_lock(
     // Initialize the registry client.
     // TODO(zanieb): Support client options e.g. offline, tls, etc.
     let client = RegistryClientBuilder::new(cache.clone())
+        .index_urls(index_locations.index_urls())
         .markers(markers)
         .platform(venv.interpreter().platform())
         .build();

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -157,6 +157,7 @@ pub(crate) async fn update_environment(
     // TODO(zanieb): Support client options e.g. offline, tls, etc.
     let client = RegistryClientBuilder::new(cache.clone())
         .connectivity(connectivity)
+        .index_urls(index_locations.index_urls())
         .markers(markers)
         .platform(venv.interpreter().platform())
         .build();

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -90,6 +90,7 @@ pub(super) async fn do_sync(
     // Initialize the registry client.
     // TODO(zanieb): Support client options e.g. offline, tls, etc.
     let client = RegistryClientBuilder::new(cache.clone())
+        .index_urls(index_locations.index_urls())
         .markers(markers)
         .platform(venv.interpreter().platform())
         .build();


### PR DESCRIPTION
Otherwise the `uv lock` command wasn't respecting the index URL option.

This is a follow-up to #3984, and I believe should now allow #3970 to be
merged.
