### PR TITLE
Avoid race condition in `OnceMap`

### DIFF
--- a/crates/once-map/src/lib.rs
+++ b/crates/once-map/src/lib.rs
@@ -55,11 +55,11 @@ impl<K: Eq + Hash, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
             }
         };
 
-        // Prepare to wait.
-        let mut notification = pin!(notify.notified());
-        notification.as_mut().enable();
+        // Register the waiter for calls to `notify_waiters`.
+        let notification = pin!(notify.notified());
 
-        // Make sure the value wasn't inserted in-between us checking the map and preparing to wait.
+        // Make sure the value wasn't inserted in-between us checking the map and registering the
+        // waiter.
         if let Value::Filled(value) = self.items.get(key).expect("map is append-only").value() {
             return Some(value.clone());
         };
@@ -86,11 +86,11 @@ impl<K: Eq + Hash, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
             }
         };
 
-        // Prepare to wait.
-        let mut notification = pin!(notify.notified());
-        notification.as_mut().enable();
+        // Register the waiter for calls to `notify_waiters`.
+        let notification = pin!(notify.notified());
 
-        // Make sure the value wasn't inserted in-between us checking the map and preparing to wait.
+        // Make sure the value wasn't inserted in-between us checking the map and registering the
+        // waiter.
         if let Value::Filled(value) = self.items.get(key).expect("map is append-only").value() {
             return Some(value.clone());
         };

--- a/crates/once-map/src/lib.rs
+++ b/crates/once-map/src/lib.rs
@@ -58,8 +58,7 @@ impl<K: Eq + Hash, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
         // Register the waiter for calls to `notify_waiters`.
         let notification = pin!(notify.notified());
 
-        // Make sure the value wasn't inserted in-between us checking the map and registering the
-        // waiter.
+        // Make sure the value wasn't inserted in-between us checking the map and registering the waiter.
         if let Value::Filled(value) = self.items.get(key).expect("map is append-only").value() {
             return Some(value.clone());
         };
@@ -89,8 +88,7 @@ impl<K: Eq + Hash, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
         // Register the waiter for calls to `notify_waiters`.
         let notification = pin!(notify.notified());
 
-        // Make sure the value wasn't inserted in-between us checking the map and registering the
-        // waiter.
+        // Make sure the value wasn't inserted in-between us checking the map and registering the waiter.
         if let Value::Filled(value) = self.items.get(key).expect("map is append-only").value() {
             return Some(value.clone());
         };


### PR DESCRIPTION
## Summary

Fixes a race condition in `OnceMap::wait_blocking` where the inserted value could potentially be missed, leading to a deadlock. Fairly certain this will resolve https://github.com/astral-sh/uv/issues/3724.