### PR TITLE
Update pubgrub to d4795a31be17669aba11eb741b4a9086acc3eb11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "pubgrub"
 version = "0.2.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=0e684a874c9fb8f74738cd8875524c80e3d4820b#0e684a874c9fb8f74738cd8875524c80e3d4820b"
+source = "git+https://github.com/astral-sh/pubgrub?rev=d4795a31be17669aba11eb741b4a9086acc3eb11#d4795a31be17669aba11eb741b4a9086acc3eb11"
 dependencies = [
  "indexmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 petgraph = { version = "0.6.4" }
 platform-info = { version = "2.0.2" }
-pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "0e684a874c9fb8f74738cd8875524c80e3d4820b" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "d4795a31be17669aba11eb741b4a9086acc3eb11" }
 pyo3 = { version = "0.21.0" }
 pyo3-log = { version = "0.10.0" }
 rayon = { version = "1.8.0" }


### PR DESCRIPTION
I trimmed down the diff of our pubgrub fork with upstream and [d4795a31be17669aba11eb741b4a9086acc3eb11](https://github.com/astral-sh/pubgrub/commit/d4795a31be17669aba11eb741b4a9086acc3eb11) (diff: https://github.com/pubgrub-rs/pubgrub/compare/dev...astral-sh:pubgrub:perma-35) is the result.