### PR TITLE
Use `PubGrubPython` type in Python incompatibility reporting

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -45,14 +45,20 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
             }
             External::NoVersions(package, set) => {
                 if let Some(python) = self.python_requirement {
-                    if matches!(&**package, PubGrubPackageInner::Python(PubGrubPython::Target)) {
+                    if matches!(
+                        &**package,
+                        PubGrubPackageInner::Python(PubGrubPython::Target)
+                    ) {
                         return format!(
                             "the requested {package} version ({}) does not satisfy {}",
                             python.target(),
                             PackageRange::compatibility(package, set)
                         );
                     }
-                    if matches!(&**package, PubGrubPackageInner::Python(PubGrubPython::Installed)) {
+                    if matches!(
+                        &**package,
+                        PubGrubPackageInner::Python(PubGrubPython::Installed)
+                    ) {
                         return format!(
                             "the current {package} version ({}) does not satisfy {}",
                             python.installed(),


### PR DESCRIPTION
## Summary

Rather than re-testing compatibility, I think we can just rely on the types directly.