### PR TITLE
Bias towards local directories for bare editable requirements

### DIFF
--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -86,16 +86,18 @@ impl RequirementsSpecification {
     ) -> Result<Self> {
         Ok(match source {
             RequirementsSource::Package(name) => {
-                let requirement = RequirementsTxtRequirement::parse(name, std::env::current_dir()?)
-                    .with_context(|| format!("Failed to parse: `{name}`"))?;
+                let requirement =
+                    RequirementsTxtRequirement::parse(name, std::env::current_dir()?, false)
+                        .with_context(|| format!("Failed to parse: `{name}`"))?;
                 Self {
                     requirements: vec![UnresolvedRequirementSpecification::from(requirement)],
                     ..Self::default()
                 }
             }
             RequirementsSource::Editable(name) => {
-                let requirement = RequirementsTxtRequirement::parse(name, std::env::current_dir()?)
-                    .with_context(|| format!("Failed to parse: `{name}`"))?;
+                let requirement =
+                    RequirementsTxtRequirement::parse(name, std::env::current_dir()?, true)
+                        .with_context(|| format!("Failed to parse: `{name}`"))?;
                 Self {
                     requirements: vec![UnresolvedRequirementSpecification::from(
                         requirement.into_editable()?,

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1114,22 +1114,50 @@ fn install_editable_pep_508_cli() {
 }
 
 #[test]
-fn invalid_editable_no_version() -> Result<()> {
+fn install_editable_bare_cli() {
     let context = TestContext::new("3.12");
 
-    let requirements_txt = context.temp_dir.child("requirements.txt");
-    requirements_txt.write_str("-e black")?;
+    let packages_dir = context.workspace_root.join("scripts/packages");
 
     uv_snapshot!(context.filters(), context.install()
-        .arg("-r")
-        .arg("requirements.txt"), @r###"
-    success: false
-    exit_code: 2
+        .arg("-e")
+        .arg("black_editable")
+        .current_dir(&packages_dir), @r###"
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    error: Unsupported editable requirement in `requirements.txt`
-      Caused by: Editable `black` must refer to a local directory
+    Resolved 1 package in [TIME]
+    Downloaded 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
+    "###
+    );
+}
+
+#[test]
+fn install_editable_bare_requirements_txt() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("-e black_editable")?;
+
+    let packages_dir = context.workspace_root.join("scripts/packages");
+
+    uv_snapshot!(context.filters(), context.install()
+        .arg("-r")
+        .arg(requirements_txt.path())
+        .current_dir(&packages_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Downloaded 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
     "###
     );
 


### PR DESCRIPTION
## Summary

Given `install -e dagster`, we need to assume that the user meant `install -e ./dagster`, even though `install dagster` should _not_ be treated as `install ./dagster`. I suspect pip will change this in the future (since `pip install dagster` does _not_ meant `pip install ./dagster`) but for now it's what users expect.

Closes https://github.com/astral-sh/uv/issues/3994.
