### PR TITLE
Remove Python from available versions

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Formatter;
-use std::ops::Deref;
 use std::sync::Arc;
 
 use indexmap::IndexMap;
@@ -16,7 +15,7 @@ use uv_normalize::PackageName;
 
 use crate::candidate_selector::CandidateSelector;
 use crate::dependency_provider::UvDependencyProvider;
-use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, PubGrubPython, PubGrubReportFormatter};
+use crate::pubgrub::{PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter};
 use crate::python_requirement::PythonRequirement;
 use crate::resolver::{
     FxOnceMap, IncompletePackage, UnavailablePackage, UnavailableReason, VersionsResponse,
@@ -225,7 +224,6 @@ impl NoSolutionError {
     #[must_use]
     pub(crate) fn with_available_versions(
         mut self,
-        python_requirement: &PythonRequirement,
         visited: &FxHashSet<PackageName>,
         package_versions: &FxOnceMap<PackageName, Arc<VersionsResponse>>,
     ) -> Self {
@@ -233,18 +231,7 @@ impl NoSolutionError {
         for package in self.derivation_tree.packages() {
             match &**package {
                 PubGrubPackageInner::Root(_) => {}
-                PubGrubPackageInner::Python(PubGrubPython::Installed) => {
-                    available_versions.insert(
-                        package.clone(),
-                        BTreeSet::from([python_requirement.installed().deref().clone()]),
-                    );
-                }
-                PubGrubPackageInner::Python(PubGrubPython::Target) => {
-                    available_versions.insert(
-                        package.clone(),
-                        BTreeSet::from([python_requirement.target().deref().clone()]),
-                    );
-                }
+                PubGrubPackageInner::Python(_) => {}
                 PubGrubPackageInner::Extra { .. } => {}
                 PubGrubPackageInner::Package { name, .. } => {
                     // Avoid including available versions for packages that exist in the derivation

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -260,16 +260,12 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
                 // Add version information to improve unsat error messages.
                 Err(if let ResolveError::NoSolution(err) = err {
                     ResolveError::NoSolution(
-                        err.with_available_versions(
-                            &state.python_requirement,
-                            &visited,
-                            state.index.packages(),
-                        )
-                        .with_selector(state.selector.clone())
-                        .with_python_requirement(&state.python_requirement)
-                        .with_index_locations(provider.index_locations())
-                        .with_unavailable_packages(&state.unavailable_packages)
-                        .with_incomplete_packages(&state.incomplete_packages),
+                        err.with_available_versions(&visited, state.index.packages())
+                            .with_selector(state.selector.clone())
+                            .with_python_requirement(&state.python_requirement)
+                            .with_index_locations(provider.index_locations())
+                            .with_unavailable_packages(&state.unavailable_packages)
+                            .with_incomplete_packages(&state.incomplete_packages),
                     )
                 } else {
                     err


### PR DESCRIPTION
## Summary

I believe this is no longer necessary. Part of the problem here is that we can't _know_ the full set of available Python versions, especially once we start resolving against a `Requires-Python` rather than a fixed set of two versions.
