### PR TITLE
uv/tests: update packse tests

### DIFF
--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -501,7 +501,7 @@ fn dependency_excludes_range_of_compatible_versions() {
 /// There is a non-contiguous range of compatible versions for the requested package
 /// `a`, but another dependency `c` excludes the range. This is the same as
 /// `dependency-excludes-range-of-compatible-versions` but some of the versions of
-/// `a` are incompatible for another reason e.g. dependency on non-existent package
+/// `a` are incompatible for another reason e.g. dependency on non-existant package
 /// `d`.
 ///
 /// ```text
@@ -3530,7 +3530,7 @@ fn package_only_prereleases_boundary() {
     "###);
 
     // Since there are only prerelease versions of `a` available, a prerelease is
-    // allowed. Since the user did not explicitly request a pre-release, pre-releases at
+    // allowed. Since the user did not explictly request a pre-release, pre-releases at
     // the boundary should not be selected.
     assert_installed(
         &context.venv,

--- a/scripts/scenarios/generate.py
+++ b/scripts/scenarios/generate.py
@@ -221,7 +221,7 @@ def main(scenarios: list[Path], snapshot_update: bool = True):
                     "insta",
                     "test",
                     "--features",
-                    "pypi,python",
+                    "pypi,python,python-patch",
                     "--accept",
                     "--test-runner",
                     "nextest",


### PR DESCRIPTION
This is just the result of running

    ./scripts/sync_scenarios.sh

From the root of the `uv` repository.

When I initially ran this, it produced some tests with snapshots that
weren't being updated. It turned out this was because the tests weren't
running, as they were gated behind the `python-patch` feature. In this
commit, we add `python-patch` to our `cargo insta` command, which should
update all relevant snapshots.

There are still some superfluous updates as a result of a spell checker
being run on generated files, but 