### PR TITLE
Lock all packages in workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4910,6 +4910,7 @@ dependencies = [
  "requirements-txt",
  "rkyv",
  "rustc-hash",
+ "same-file",
  "schemars",
  "serde",
  "textwrap",

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -222,17 +222,12 @@ fn path_source(
     editable: bool,
 ) -> Result<RequirementSource, LoweringError> {
     let url = VerbatimUrl::parse_path(path.as_ref(), project_dir)?
-        .with_given(path.as_ref().to_string_lossy().to_string());
+        .with_given(path.as_ref().to_string_lossy());
     let path_buf = path.as_ref().to_path_buf();
     let path_buf = path_buf
         .absolutize_from(project_dir)
         .map_err(|err| LoweringError::Absolutize(path.as_ref().to_path_buf(), err))?
         .to_path_buf();
-    //if !editable {
-    //    // TODO(konsti): Support this. Currently we support `{ workspace = true }`, but we don't
-    //    //  support `{ workspace = true, editable = false }` since we only collect editables.
-    //    return Err(LoweringError::NonEditableWorkspaceDependency);
-    //}
     Ok(RequirementSource::Path {
         path: path_buf,
         url,

--- a/crates/uv-distribution/src/pyproject.rs
+++ b/crates/uv-distribution/src/pyproject.rs
@@ -18,7 +18,7 @@ use pypi_types::VerbatimParsedUrl;
 use uv_normalize::{ExtraName, PackageName};
 
 /// A `pyproject.toml` as specified in PEP 517.
-#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct PyProjectToml {
     /// PEP 621-compliant project metadata.

--- a/crates/uv-distribution/src/pyproject.rs
+++ b/crates/uv-distribution/src/pyproject.rs
@@ -18,7 +18,7 @@ use pypi_types::VerbatimParsedUrl;
 use uv_normalize::{ExtraName, PackageName};
 
 /// A `pyproject.toml` as specified in PEP 517.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct PyProjectToml {
     /// PEP 621-compliant project metadata.
@@ -63,7 +63,7 @@ pub struct ToolUv {
     pub dev_dependencies: Option<Vec<pep508_rs::Requirement<VerbatimParsedUrl>>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ToolUvWorkspace {
     pub members: Option<Vec<SerdePattern>>,

--- a/crates/uv-distribution/src/workspace.rs
+++ b/crates/uv-distribution/src/workspace.rs
@@ -108,7 +108,7 @@ impl Workspace {
                 (
                     project_path.clone(),
                     ToolUvWorkspace::default(),
-                    PyProjectToml::default(),
+                    pyproject_toml.clone(),
                 )
             };
 

--- a/crates/uv-distribution/src/workspace.rs
+++ b/crates/uv-distribution/src/workspace.rs
@@ -98,13 +98,17 @@ impl Workspace {
 
         let (workspace_root, workspace_definition, workspace_pyproject_toml) =
             if let Some(workspace) = explicit_root {
+                // We have found the explicit root immediately.
                 workspace
             } else if pyproject_toml.project.is_none() {
+                // Without a project, it can't be an implicit root
                 return Err(WorkspaceError::MissingProject(project_path));
             } else if let Some(workspace) = find_workspace(&project_path, stop_discovery_at).await?
             {
+                // We have found an explicit root above.
                 workspace
             } else {
+                // Support implicit single project workspaces.
                 (
                     project_path.clone(),
                     ToolUvWorkspace::default(),

--- a/crates/uv-distribution/src/workspace.rs
+++ b/crates/uv-distribution/src/workspace.rs
@@ -165,6 +165,9 @@ impl Workspace {
                     })
                     .unwrap_or_default();
 
+                let url = VerbatimUrl::from_path(&member.root)
+                    .expect("path is valid URL")
+                    .with_given(member.root.to_string_lossy());
                 Some(Requirement {
                     name: project.name.clone(),
                     extras,
@@ -172,7 +175,7 @@ impl Workspace {
                     source: RequirementSource::Path {
                         path: member.root.clone(),
                         editable: true,
-                        url: VerbatimUrl::from_path(&member.root).expect("path is valid URL"),
+                        url,
                     },
                     origin: None,
                 })
@@ -530,30 +533,6 @@ impl ProjectWorkspace {
     /// Returns the current project as a [`WorkspaceMember`].
     pub fn current_project(&self) -> &WorkspaceMember {
         &self.workspace().packages[&self.project_name]
-    }
-
-    /// Return the [`Requirement`] entries for the project, which is the current project as
-    /// editable.
-    pub fn requirements(&self) -> Vec<Requirement> {
-        vec![Requirement {
-            name: self.project_name.clone(),
-            extras: self.workspace().packages[&self.project_name]
-                .pyproject_toml
-                .project
-                .as_ref()
-                .and_then(|project| project.optional_dependencies.as_ref())
-                .map(|optional_dependencies| {
-                    optional_dependencies.keys().cloned().collect::<Vec<_>>()
-                })
-                .unwrap_or_default(),
-            marker: None,
-            source: RequirementSource::Path {
-                path: self.project_root.clone(),
-                editable: true,
-                url: VerbatimUrl::from_path(&self.project_root).expect("path is valid URL"),
-            },
-            origin: None,
-        }]
     }
 
     /// Find the workspace for a project.

--- a/crates/uv-requirements/src/upgrade.rs
+++ b/crates/uv-requirements/src/upgrade.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use requirements_txt::RequirementsTxt;
 use uv_client::{BaseClientBuilder, Connectivity};
 use uv_configuration::Upgrade;
-use uv_distribution::ProjectWorkspace;
+use uv_distribution::Workspace;
 use uv_git::ResolvedRepositoryReference;
 use uv_resolver::{Lock, Preference, PreferenceError};
 
@@ -64,17 +64,14 @@ pub async fn read_requirements_txt(
 }
 
 /// Load the preferred requirements from an existing lockfile, applying the upgrade strategy.
-pub async fn read_lockfile(
-    project: &ProjectWorkspace,
-    upgrade: &Upgrade,
-) -> Result<LockedRequirements> {
+pub async fn read_lockfile(workspace: &Workspace, upgrade: &Upgrade) -> Result<LockedRequirements> {
     // As an optimization, skip reading the lockfile is we're upgrading all packages anyway.
     if upgrade.is_all() {
         return Ok(LockedRequirements::default());
     }
 
     // If an existing lockfile exists, build up a set of preferences.
-    let lockfile = project.workspace().root().join("uv.lock");
+    let lockfile = workspace.root().join("uv.lock");
     let lock = match fs_err::tokio::read_to_string(&lockfile).await {
         Ok(encoded) => match toml::from_str::<Lock>(&encoded) {
             Ok(lock) => lock,

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -46,6 +46,7 @@ petgraph = { workspace = true }
 pubgrub = { workspace = true }
 rkyv = { workspace = true }
 rustc-hash = { workspace = true }
+same-file = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 textwrap = { workspace = true }

--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -4,12 +4,13 @@ use either::Either;
 use itertools::Itertools;
 use pubgrub::range::Range;
 use rustc_hash::FxHashSet;
+use same_file::is_same_file;
 use tracing::warn;
 
 use distribution_types::Verbatim;
 use pep440_rs::Version;
 use pep508_rs::MarkerEnvironment;
-use pypi_types::{Requirement, RequirementSource};
+use pypi_types::{ParsedUrl, Requirement, RequirementSource, VerbatimParsedUrl};
 use uv_configuration::{Constraints, Overrides};
 use uv_git::GitResolver;
 use uv_normalize::{ExtraName, GroupName, PackageName};
@@ -310,7 +311,7 @@ impl PubGrubRequirement {
                     version: Range::full(),
                 })
             }
-            RequirementSource::Path { url, .. } => {
+            RequirementSource::Path { url, path, .. } => {
                 let Some(expected) = urls.get(&requirement.name) else {
                     return Err(ResolveError::DisallowedUrl(
                         requirement.name.clone(),
@@ -318,7 +319,22 @@ impl PubGrubRequirement {
                     ));
                 };
 
-                if !Urls::is_allowed(&expected.verbatim, url, git) {
+                let mut is_allowed = Urls::is_allowed(&expected.verbatim, url, git);
+                if !is_allowed {
+                    if let VerbatimParsedUrl {
+                        parsed_url: ParsedUrl::Path(previous_path),
+                        ..
+                    } = &expected
+                    {
+                        // On Windows, we can have two versions of the same path, e.g.
+                        // `C:\Users\KONSTA~1` and `C:\Users\Konstantin`.
+                        if is_same_file(path, &previous_path.path).unwrap_or(false) {
+                            is_allowed = true;
+                        }
+                    }
+                }
+
+                if !is_allowed {
                     return Err(ResolveError::ConflictingUrlsTransitive(
                         requirement.name.clone(),
                         expected.verbatim.verbatim().to_string(),

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -117,13 +117,15 @@ pub(super) async fn do_lock(
         let requires_python = VersionSpecifiers::from(
             VersionSpecifier::greater_than_equal_version(venv.interpreter().python_minor_version()),
         );
-        warn_user!(
-            "No `requires-python` field found in `{}`. Defaulting to `{requires_python}`.",
-            root_project_name
-                .as_ref()
-                .map(ToString::to_string)
-                .unwrap_or("workspace".to_string()),
-        );
+        if let Some(root_project_name) = root_project_name.as_ref() {
+            warn_user!(
+                "No `requires-python` field found in `{root_project_name}`. Defaulting to `{requires_python}`.",
+            );
+        } else {
+            warn_user!(
+                "No `requires-python` field found in workspace. Defaulting to `{requires_python}`.",
+            );
+        }
         Cow::Owned(requires_python)
     };
 

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -106,8 +106,11 @@ pub(super) async fn do_lock(
 
     // Determine the supported Python range. If no range is defined, and warn and default to the
     // current minor version.
+    let project = root_project_name
+        .as_ref()
+        .and_then(|name| workspace.packages().get(name));
     let requires_python = if let Some(requires_python) =
-        project.current_project().project().requires_python.as_ref()
+        project.and_then(|root_project| root_project.project().requires_python.as_ref())
     {
         Cow::Borrowed(requires_python)
     } else {
@@ -116,7 +119,10 @@ pub(super) async fn do_lock(
         );
         warn_user!(
             "No `requires-python` field found in `{}`. Defaulting to `{requires_python}`.",
-            project.current_project().project().name,
+            root_project_name
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or("workspace".to_string()),
         );
         Cow::Owned(requires_python)
     };

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -15,7 +15,7 @@ use uv_configuration::{
     SetupPyStrategy, Upgrade,
 };
 use uv_dispatch::BuildDispatch;
-use uv_distribution::ProjectWorkspace;
+use uv_distribution::Workspace;
 use uv_fs::Simplified;
 use uv_git::GitResolver;
 use uv_installer::{SatisfiesResult, SitePackages};
@@ -66,12 +66,12 @@ pub(crate) enum ProjectError {
 
 /// Initialize a virtual environment for the current project.
 pub(crate) fn init_environment(
-    project: &ProjectWorkspace,
+    workspace: &Workspace,
     preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<PythonEnvironment, ProjectError> {
-    let venv = project.workspace().root().join(".venv");
+    let venv = workspace.root().join(".venv");
 
     // Discover or create the virtual environment.
     // TODO(charlie): If the environment isn't compatible with `--python`, recreate it.

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -61,11 +61,18 @@ pub(crate) async fn run(
         } else {
             ProjectWorkspace::discover(&std::env::current_dir()?, None).await?
         };
-        let venv = project::init_environment(&project, preview, cache, printer)?;
+        let venv = project::init_environment(project.workspace(), preview, cache, printer)?;
 
         // Lock and sync the environment.
+        let root_project_name = project
+            .current_project()
+            .pyproject_toml()
+            .project
+            .as_ref()
+            .map(|project| project.name.clone());
         let lock = project::lock::do_lock(
-            &project,
+            root_project_name,
+            project.workspace(),
             &venv,
             &index_locations,
             upgrade,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -40,7 +40,7 @@ pub(crate) async fn sync(
     let project = ProjectWorkspace::discover(&std::env::current_dir()?, None).await?;
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(&project, preview, cache, printer)?;
+    let venv = project::init_environment(project.workspace(), preview, cache, printer)?;
 
     // Read the lockfile.
     let lock: Lock = {

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -547,12 +547,19 @@ fn workspace_lock_idempotence(workspace: &str, subdirectories: &[&str]) -> Resul
         let raw_lock = fs_err::read_to_string(work_dir.join("uv.lock"))?;
         // Remove temp paths from lock.
         // TODO(konsti): There shouldn't be absolute paths in the lock to begin with.
-        let redacted_lock = raw_lock.replace(
-            Url::from_directory_path(&context.temp_dir)
-                .unwrap()
-                .as_str(),
-            "file:///tmp",
-        );
+        let redacted_lock = raw_lock
+            .replace(
+                Url::from_directory_path(&context.temp_dir)
+                    .unwrap()
+                    .as_str(),
+                "file:///tmp",
+            )
+            .replace(
+                Url::from_directory_path(fs_err::canonicalize(&context.temp_dir)?)
+                    .unwrap()
+                    .as_str(),
+                "file:///tmp",
+            );
         // Check the lockfile is the same for all resolutions.
         if let Some(shared_lock) = &shared_lock {
             assert_eq!(shared_lock, &redacted_lock);

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -533,11 +533,22 @@ fn test_uv_run_with_package_root_workspace() -> Result<()> {
 /// Check that the resolution is the same no matter where in the workspace we are.
 fn workspace_lock_idempotence(workspace: &str, subdirectories: &[&str]) -> Result<()> {
     let mut shared_lock = None;
+
     for dir in subdirectories {
         let context = TestContext::new("3.12");
         let work_dir = context.temp_dir.join(workspace);
 
         copy_dir_ignore(workspaces_dir().join(workspace), &work_dir)?;
+
+        // TODO(konsti): `--python` is being ignored atm, so we need to create the correct venv
+        // ourselves and add the output filters.
+        let venv = work_dir.join(".venv");
+        assert_cmd::Command::new(get_bin())
+            .arg("venv")
+            .arg("-p")
+            .arg(context.interpreter())
+            .arg(&venv)
+            .assert();
 
         lock_workspace(&context)
             .current_dir(&work_dir.join(dir))


### PR DESCRIPTION
When creating a lockfile, lock the combined dependencies for all packages in a workspace. This make the lockfile independent of where you are in the workspace.

Fixes #3983