### PR TITLE
Use `PythonEnvironment` API in `uv venv`

### DIFF
--- a/crates/uv-interpreter/src/environment.rs
+++ b/crates/uv-interpreter/src/environment.rs
@@ -26,7 +26,9 @@ struct PythonEnvironmentShared {
 }
 
 impl PythonEnvironment {
-    /// Create a [`PythonEnvironment`] from a user request.
+    /// Find a [`PythonEnvironment`].
+    ///
+    /// This is the standard interface for discovering a Python environment for use with uv.
     pub fn find(
         python: Option<&str>,
         system: SystemPython,


### PR DESCRIPTION
There's no reason to be reaching into the lower-level `find_interpreter` manually here.