### PR TITLE
Use standard path filters for `uv venv` tests

### DIFF
--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -313,7 +313,7 @@ impl TestContext {
     }
 
     /// Generate various escaped regex patterns for the given path.
-    fn path_patterns(path: impl AsRef<Path>) -> Vec<String> {
+    pub(crate) fn path_patterns(path: impl AsRef<Path>) -> Vec<String> {
         let mut patterns = Vec::new();
 
         // We can only canonicalize paths that exist already


### PR DESCRIPTION
Over in #4045 the existing filters were insufficient. We should use the same strategy we use for our standard `TestContext` instead.