### PR TITLE
Store explicit project on workspace member

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -95,12 +95,7 @@ pub(super) async fn do_lock(
     let interpreter = venv.interpreter();
     let tags = venv.interpreter().tags()?;
     let markers = venv.interpreter().markers();
-    let requires_python = project
-        .current_project()
-        .pyproject_toml()
-        .project
-        .as_ref()
-        .and_then(|project| project.requires_python.as_ref());
+    let requires_python = project.current_project().project().requires_python.as_ref();
 
     // Initialize the registry client.
     // TODO(zanieb): Support client options e.g. offline, tls, etc.


### PR DESCRIPTION
We know that `[project]` must exist for each workspace member, so we can store it directly and avoid going through the `.and_then()` when we need to access it. This requires cloning the struct due to lack of self-referential structs. An alternative would taking the `Project` from `PyProjectToml` instead, but this could be confusing when passing the `PyProjectToml` around.