### PR TITLE
Avoid dropping `pip sync` requirements with markers

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -954,6 +954,20 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             } => {
                 // If we're excluding transitive dependencies, short-circuit.
                 if self.dependency_mode.is_direct() {
+                    // If a package has a marker, add a dependency from it to the
+                    // same package without markers.
+                    if marker.is_some() {
+                        return Ok(Dependencies::Available(vec![(
+                            PubGrubPackage::from(PubGrubPackageInner::Package {
+                                name: name.clone(),
+                                extra: extra.clone(),
+                                marker: None,
+                                url: url.clone(),
+                            }),
+                            Range::singleton(version.clone()),
+                        )]));
+                    }
+
                     // If an extra is provided, wait for the metadata to be available, since it's
                     // still required for generating the lock file.
                     let dist = match url {

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -5164,3 +5164,28 @@ fn target_no_build_isolation() -> Result<()> {
 
     Ok(())
 }
+
+/// Ensure that we install packages with markers on them.
+#[test]
+fn preserve_markers() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("anyio ; python_version > '3.7'")?;
+
+    uv_snapshot!(sync_without_exclude_newer(&context)
+        .arg("requirements.txt"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Downloaded 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + anyio==4.4.0
+    "###
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Thankfully this is pretty rare since `pip sync` is usually run on `pip compile` output, and `pip compile` never outputs markers.

Closes https://github.com/astral-sh/uv/issues/4044
