### PR TITLE
Update pubgrub to new `add_incompatibility_from_dependencies`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "pubgrub"
 version = "0.2.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=d4795a31be17669aba11eb741b4a9086acc3eb11#d4795a31be17669aba11eb741b4a9086acc3eb11"
+source = "git+https://github.com/astral-sh/pubgrub?rev=a68cbd1a26e43986a31563e1d127e83bafca3a0c#a68cbd1a26e43986a31563e1d127e83bafca3a0c"
 dependencies = [
  "indexmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 petgraph = { version = "0.6.4" }
 platform-info = { version = "2.0.2" }
-pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "d4795a31be17669aba11eb741b4a9086acc3eb11" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "a68cbd1a26e43986a31563e1d127e83bafca3a0c" }
 pyo3 = { version = "0.21.0" }
 pyo3-log = { version = "0.10.0" }
 rayon = { version = "1.8.0" }

--- a/crates/uv-resolver/src/dependency_provider.rs
+++ b/crates/uv-resolver/src/dependency_provider.rs
@@ -38,7 +38,7 @@ impl DependencyProvider for UvDependencyProvider {
         &self,
         _package: &Self::P,
         _version: &Self::V,
-    ) -> Result<Dependencies<Vec<(Self::P, Self::VS)>, Self::M>, Self::Err> {
+    ) -> Result<Dependencies<Self::P, Self::VS, Self::M>, Self::Err> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
We had previously changed the signature of `DependencyProvider::get_dependencies` to return an iterator instead of a hashmap to avoid the conversion cost from our dependencies `Vec` to the pubgrub's hashmap. These changes are difficult to make in pubgrub since they complicate the public api. But we don't actually use `DependencyProvider::get_dependencies`, so we rolled those customizations back in https://github.com/pubgrub-rs/pubgrub/pull/226 and instead opted to change only the internal `add_incompatibility_from_dependencies` method that we exposed in our fork. This aligns us closer with upstream, removes the design questions about `DependencyProvider` from our concerns and reduces our diff (not counting the github action) to +36 -12.