### PR TITLE
Track supported Python range in lockfile

### DIFF
--- a/crates/uv-resolver/src/python_requirement.rs
+++ b/crates/uv-resolver/src/python_requirement.rs
@@ -60,13 +60,14 @@ impl PythonRequirement {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum RequiresPython {
-    /// The `RequiresPython` specifier is a single version specifier, as provided via
+    /// The [`RequiresPython`] specifier is a single version specifier, as provided via
     /// `--python-version` on the command line.
     ///
     /// The use of a separate enum variant allows us to use a verbatim representation when reporting
     /// back to the user.
     Specifier(StringVersion),
-    /// The `RequiresPython` specifier is a set of version specifiers.
+    /// The [`RequiresPython`] specifier is a set of version specifiers, as extracted from the
+    /// `Requires-Python` field in a `pyproject.toml` or `METADATA` file.
     Specifiers(VersionSpecifiers),
 }
 
@@ -91,6 +92,14 @@ impl RequiresPython {
 
                 target.subset_of(&requires_python)
             }
+        }
+    }
+
+    /// Returns the [`VersionSpecifiers`] for the [`RequiresPython`] specifier.
+    pub fn as_specifiers(&self) -> Option<&VersionSpecifiers> {
+        match self {
+            RequiresPython::Specifier(_) => None,
+            RequiresPython::Specifiers(specifiers) => Some(specifiers),
         }
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -557,7 +557,13 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         for resolution in resolutions {
             combined.union(resolution);
         }
-        ResolutionGraph::from_state(&self.index, &self.preferences, &self.git, combined)
+        ResolutionGraph::from_state(
+            &self.index,
+            &self.preferences,
+            &self.git,
+            &self.python_requirement,
+            combined,
+        )
     }
 
     /// Visit a [`PubGrubPackage`] prior to selection. This should be called on a [`PubGrubPackage`]

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
@@ -73,6 +73,7 @@ Ok(
                 optional_dependencies: {},
             },
         ],
+        requires_python: None,
         by_id: {
             DistributionId {
                 name: PackageName(

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -1038,6 +1038,7 @@ fn lock_requires_python() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        requires-python = ">=3.7"
 
         [[distribution]]
         name = "dataclasses"
@@ -1163,6 +1164,7 @@ fn lock_requires_python() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        requires-python = ">=3.7.9, <4"
 
         [[distribution]]
         name = "attrs"


### PR DESCRIPTION
## Summary

This PR adds the `Requires-Python` range to the user's lockfile. This will enable us to validate it when installing.

For now, we repeat the `Requires-Python` back to the user; alternatively, though, we could detect the supported Python range automatically.

See: https://github.com/astral-sh/uv/issues/4052
