### PR TITLE
Simplify marker expressions in lockfile

### DIFF
--- a/crates/pep440-rs/src/version_specifier.rs
+++ b/crates/pep440-rs/src/version_specifier.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "pyo3")]
 use std::hash::{Hash, Hasher};
+
+use std::cmp::Ordering;
 use std::ops::Bound;
-use std::{cmp::Ordering, str::FromStr};
+use std::str::FromStr;
 
 #[cfg(feature = "pyo3")]
 use pyo3::{

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -1881,30 +1881,6 @@ impl MarkerTree {
             exprs.push(tree);
         }
     }
-
-    /// Normalizes this marker tree such that all conjunctions and disjunctions
-    /// are sorted.
-    ///
-    /// This is useful in cases where creating conjunctions or disjunctions
-    /// might occur in a non-deterministic order. This routine will erase the
-    /// distinction created by such a construction.
-    pub fn normalize(&mut self) {
-        match *self {
-            MarkerTree::Expression(_) => {}
-            MarkerTree::And(ref mut trees) | MarkerTree::Or(ref mut trees) => {
-                // This is kind of cheesy, because we're doing a recursive call
-                // followed by a sort, and that sort is also recursive (due to
-                // the corresponding Ord impl being recursive).
-                //
-                // We should consider refactoring `MarkerTree` to a "smart
-                // constructor" design that normalizes them by construction.
-                for tree in &mut *trees {
-                    tree.normalize();
-                }
-                trees.sort();
-            }
-        }
-    }
 }
 
 impl Display for MarkerTree {

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -511,7 +511,7 @@ impl Distribution {
         // Markers can be combined in an unpredictable order, so normalize them
         // such that the lock file output is consistent and deterministic.
         if let Some(ref mut marker) = marker {
-            marker.normalize();
+            crate::marker::normalize(marker);
         }
         let sdist = SourceDist::from_annotated_dist(annotated_dist)?;
         let wheels = Wheel::from_annotated_dist(annotated_dist)?;

--- a/crates/uv-resolver/src/marker.rs
+++ b/crates/uv-resolver/src/marker.rs
@@ -89,6 +89,8 @@ fn string_is_disjoint(this: &MarkerExpression, other: &MarkerExpression) -> bool
 /// - Simplify expressions. This includes combining overlapping version ranges and removing duplicate
 ///   expressions at the same level of precedence. For example, `(a == 'a' and a == 'a') or b == 'b'` can
 ///   be reduced, but `a == 'a' and (a == 'a' or b == 'b')` cannot.
+/// - Normalize the order of version expressions to the form `<version key> <version op> <version>`
+///  (i.e. not the reverse).
 ///
 /// This is useful in cases where creating conjunctions or disjunctions might occur in a non-deterministic
 /// order. This routine will attempt to erase the distinction created by such a construction.
@@ -350,6 +352,7 @@ mod tests {
             "python_version > '3.12'",
         );
 
+        // a quirk of how pubgrub works, but this is considered part of normalization
         assert_marker_equal(
             "python_version > '3.17.post4' or python_version > '3.18.post4'",
             "python_version >= '3.17.post5'",

--- a/crates/uv-resolver/src/marker.rs
+++ b/crates/uv-resolver/src/marker.rs
@@ -108,7 +108,6 @@ pub(crate) fn normalize(tree: &mut MarkerTree) {
                 if let MarkerTree::Expression(ref expr) = tree {
                     if let Some((key, range)) = keyed_range(expr) {
                         versions.entry(key.clone()).or_default().push(range);
-
                         continue;
                     }
                 }
@@ -124,7 +123,6 @@ pub(crate) fn normalize(tree: &mut MarkerTree) {
                             .fold(PubGrubRange::full(), |acc, range| acc.intersection(range))
                     });
 
-                    // Remove duplicates and sort.
                     reduced.dedup();
                     reduced.sort();
 
@@ -140,7 +138,6 @@ pub(crate) fn normalize(tree: &mut MarkerTree) {
                             .fold(PubGrubRange::empty(), |acc, range| acc.union(range))
                     });
 
-                    // Remove duplicates and sort.
                     reduced.dedup();
                     reduced.sort();
 

--- a/crates/uv-resolver/src/pubgrub/specifier.rs
+++ b/crates/uv-resolver/src/pubgrub/specifier.rs
@@ -22,6 +22,12 @@ impl PubGrubSpecifier {
     }
 }
 
+impl From<Range<Version>> for PubGrubSpecifier {
+    fn from(range: Range<Version>) -> Self {
+        PubGrubSpecifier(range)
+    }
+}
+
 impl From<PubGrubSpecifier> for Range<Version> {
     /// Convert a PubGrub specifier to a range of versions.
     fn from(specifier: PubGrubSpecifier) -> Self {

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -788,7 +788,7 @@ fn lock_dependency_extra() -> Result<()> {
         name = "importlib-metadata"
         version = "7.1.0"
         source = "registry+https://pypi.org/simple"
-        marker = "python_version < '3.8' or python_version < '3.10'"
+        marker = "python_version < '3.10'"
         sdist = { url = "https://files.pythonhosted.org/packages/a0/fc/c4e6078d21fc4fa56300a241b87eae76766aa380a23fc450fc85bb7bf547/importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2", size = 52120 }
         wheels = [{ url = "https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570", size = 24409 }]
 
@@ -1473,7 +1473,7 @@ fn lock_requires_python() -> Result<()> {
         name = "typing-extensions"
         version = "4.7.1"
         source = "registry+https://pypi.org/simple"
-        marker = "python_version < '3.8' or python_version < '3.11'"
+        marker = "python_version < '3.11'"
         sdist = { url = "https://files.pythonhosted.org/packages/3c/8b/0111dd7d6c1478bf83baa1cab85c686426c7a6274119aceb2bd9d35395ad/typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2", size = 72876 }
         wheels = [{ url = "https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36", size = 33232 }]
 

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -1625,7 +1625,7 @@ fn lock_requires_python() -> Result<()> {
         name = "typing-extensions"
         version = "4.7.1"
         source = "registry+https://pypi.org/simple"
-        marker = "python_version < '3.8' or python_version < '3.11'"
+        marker = "python_version < '3.11'"
         sdist = { url = "https://files.pythonhosted.org/packages/3c/8b/0111dd7d6c1478bf83baa1cab85c686426c7a6274119aceb2bd9d35395ad/typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2", size = 72876 }
         wheels = [{ url = "https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36", size = 33232 }]
 

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -1782,7 +1782,7 @@ fn lock_requires_python() -> Result<()> {
         name = "typing-extensions"
         version = "4.10.0"
         source = "registry+https://pypi.org/simple"
-        marker = "python_version < '3.8' or python_version < '3.11'"
+        marker = "python_version < '3.11'"
         sdist = { url = "https://files.pythonhosted.org/packages/16/3a/0d26ce356c7465a19c9ea8814b960f8a36c3b0d07c323176620b7b483e44/typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb", size = 77558 }
         wheels = [{ url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926 }]
 


### PR DESCRIPTION
## Summary

Simplify and normalize marker expressions in the lockfile. Right now this does a simple analysis by only looking at related operators at the same level of precedence. I think anything more complex would be out of scope.

Resolves https://github.com/astral-sh/uv/issues/4002.