### PR TITLE
Enforce `Requires-Python` when syncing

### DIFF
--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -113,6 +113,11 @@ impl Lock {
         &self.distributions
     }
 
+    /// Returns the supported Python version range for the lockfile, if present.
+    pub fn requires_python(&self) -> Option<&VersionSpecifiers> {
+        self.requires_python.as_ref()
+    }
+
     /// Convert the [`Lock`] to a [`Resolution`] using the given marker environment, tags, and root.
     pub fn to_resolution(
         &self,

--- a/crates/uv-resolver/src/python_requirement.rs
+++ b/crates/uv-resolver/src/python_requirement.rs
@@ -60,13 +60,14 @@ impl PythonRequirement {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum RequiresPython {
-    /// The `RequiresPython` specifier is a single version specifier, as provided via
+    /// The [`RequiresPython`] specifier is a single version specifier, as provided via
     /// `--python-version` on the command line.
     ///
     /// The use of a separate enum variant allows us to use a verbatim representation when reporting
     /// back to the user.
     Specifier(StringVersion),
-    /// The `RequiresPython` specifier is a set of version specifiers.
+    /// The [`RequiresPython`] specifier is a set of version specifiers, as extracted from the
+    /// `Requires-Python` field in a `pyproject.toml` or `METADATA` file.
     Specifiers(VersionSpecifiers),
 }
 
@@ -91,6 +92,14 @@ impl RequiresPython {
 
                 target.subset_of(&requires_python)
             }
+        }
+    }
+
+    /// Returns the [`VersionSpecifiers`] for the [`RequiresPython`] specifier.
+    pub fn as_specifiers(&self) -> Option<&VersionSpecifiers> {
+        match self {
+            RequiresPython::Specifier(_) => None,
+            RequiresPython::Specifiers(specifiers) => Some(specifiers),
         }
     }
 }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -557,7 +557,13 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         for resolution in resolutions {
             combined.union(resolution);
         }
-        ResolutionGraph::from_state(&self.index, &self.preferences, &self.git, combined)
+        ResolutionGraph::from_state(
+            &self.index,
+            &self.preferences,
+            &self.git,
+            &self.python_requirement,
+            combined,
+        )
     }
 
     /// Visit a [`PubGrubPackage`] prior to selection. This should be called on a [`PubGrubPackage`]

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
@@ -73,6 +73,7 @@ Ok(
                 optional_dependencies: {},
             },
         ],
+        requires_python: None,
         by_id: {
             DistributionId {
                 name: PackageName(

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -7,6 +7,7 @@ use tracing::debug;
 
 use distribution_types::{IndexLocations, Resolution};
 use install_wheel_rs::linker::LinkMode;
+use pep440_rs::{Version, VersionSpecifiers};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, RegistryClientBuilder};
 use uv_configuration::{
@@ -32,6 +33,9 @@ pub(crate) mod sync;
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum ProjectError {
+    #[error("The current Python version ({0}) is not compatible with the locked Python requirement ({1})")]
+    RequiresPython(Version, VersionSpecifiers),
+
     #[error(transparent)]
     Interpreter(#[from] uv_interpreter::Error),
 

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -76,6 +76,16 @@ pub(super) async fn do_sync(
     cache: &Cache,
     printer: Printer,
 ) -> Result<(), ProjectError> {
+    // Validate that the Python version is supported by the lockfile.
+    if let Some(requires_python) = lock.requires_python() {
+        if !requires_python.contains(venv.interpreter().python_version()) {
+            return Err(ProjectError::RequiresPython(
+                venv.interpreter().python_version().clone(),
+                requires_python.clone(),
+            ));
+        }
+    }
+
     let markers = venv.interpreter().markers();
     let tags = venv.interpreter().tags()?;
 

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -1038,6 +1038,7 @@ fn lock_requires_python() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        requires-python = ">=3.7"
 
         [[distribution]]
         name = "dataclasses"
@@ -1163,6 +1164,7 @@ fn lock_requires_python() -> Result<()> {
         assert_snapshot!(
             lock, @r###"
         version = 1
+        requires-python = ">=3.7.9, <4"
 
         [[distribution]]
         name = "attrs"


### PR DESCRIPTION
## Summary

Ensures that we raise if the user attempts to use a Python version that wasn't included in the locked range.

Closes https://github.com/astral-sh/uv/issues/4052.
