### PR TITLE
Fix `uv venv` handling when `VIRTUAL_ENV` refers to an non-existant environment

### DIFF
--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -120,16 +120,10 @@ async fn venv_impl(
     printer: Printer,
 ) -> miette::Result<ExitStatus> {
     // Locate the Python interpreter to use in the environment
-    // If a specific interpreter is requested, it is required to come from the system.
-    // Otherwise, we'll allow the interpeter from a virtual environment to be used.
-    let system = if python_request.is_some() {
-        SystemPython::Required
-    } else {
-        SystemPython::Allowed
-    };
-    let interpreter = PythonEnvironment::find(python_request, system, preview, cache)
-        .into_diagnostic()?
-        .into_interpreter();
+    let interpreter =
+        PythonEnvironment::find(python_request, SystemPython::Required, preview, cache)
+            .into_diagnostic()?
+            .into_interpreter();
 
     // Add all authenticated sources to the cache.
     for url in index_locations.urls() {


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/4072

This was an accidental change in https://github.com/astral-sh/uv/pull/4029 in which I had updated the pull request to support virtual environments as requested in review and forgot to revert it.

Separately, we shouldn't fail if `VIRTUAL_ENV` points to an empty directory and `SystemPython::Allowed` is used, will address that separately.