### PR TITLE
Respect existing `.egg-link` files in site packages

### DIFF
--- a/crates/distribution-types/src/traits.rs
+++ b/crates/distribution-types/src/traits.rs
@@ -7,9 +7,9 @@ use crate::error::Error;
 use crate::{
     BuiltDist, CachedDirectUrlDist, CachedDist, CachedRegistryDist, DirectUrlBuiltDist,
     DirectUrlSourceDist, Dist, DistributionId, GitSourceDist, InstalledDirectUrlDist,
-    InstalledDist, InstalledRegistryDist, InstalledVersion, LocalDist, PackageId, PathBuiltDist,
-    PathSourceDist, RegistryBuiltWheel, RegistrySourceDist, ResourceId, SourceDist, VersionId,
-    VersionOrUrlRef,
+    InstalledDist, InstalledEggInfoDirectory, InstalledEggInfoFile, InstalledLegacyEditable,
+    InstalledRegistryDist, InstalledVersion, LocalDist, PackageId, PathBuiltDist, PathSourceDist,
+    RegistryBuiltWheel, RegistrySourceDist, ResourceId, SourceDist, VersionId, VersionOrUrlRef,
 };
 
 pub trait Name {
@@ -184,6 +184,24 @@ impl std::fmt::Display for InstalledDirectUrlDist {
 }
 
 impl std::fmt::Display for InstalledRegistryDist {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", self.name(), self.installed_version())
+    }
+}
+
+impl std::fmt::Display for InstalledEggInfoFile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", self.name(), self.installed_version())
+    }
+}
+
+impl std::fmt::Display for InstalledEggInfoDirectory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}{}", self.name(), self.installed_version())
+    }
+}
+
+impl std::fmt::Display for InstalledLegacyEditable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}{}", self.name(), self.installed_version())
     }

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -52,10 +52,9 @@ impl SitePackages {
                         .filter_map(|read_dir| match read_dir {
                             Ok(entry) => match entry.file_type() {
                                 Ok(file_type) => (file_type.is_dir()
-                                    || entry
-                                        .path()
-                                        .extension()
-                                        .map_or(false, |ext| ext == "egg-link"))
+                                    || entry.path().extension().map_or(false, |ext| {
+                                        ext == "egg-link" || ext == "egg-info"
+                                    }))
                                 .then_some(Ok(entry.path())),
                                 Err(err) => Some(Err(err)),
                             },

--- a/crates/uv-installer/src/uninstall.rs
+++ b/crates/uv-installer/src/uninstall.rs
@@ -1,4 +1,4 @@
-use distribution_types::InstalledDist;
+use distribution_types::{InstalledDist, InstalledEggInfoFile};
 
 /// Uninstall a package from the specified Python environment.
 pub async fn uninstall(
@@ -8,12 +8,13 @@ pub async fn uninstall(
         let dist = dist.clone();
         move || match dist {
             InstalledDist::Registry(_) | InstalledDist::Url(_) => {
-                install_wheel_rs::uninstall_wheel(dist.path())
+                Ok(install_wheel_rs::uninstall_wheel(dist.path())?)
             }
-            InstalledDist::EggInfo(_) => install_wheel_rs::uninstall_egg(dist.path()),
+            InstalledDist::EggInfoDirectory(_) => Ok(install_wheel_rs::uninstall_egg(dist.path())?),
             InstalledDist::LegacyEditable(dist) => {
-                install_wheel_rs::uninstall_legacy_editable(&dist.egg_link)
+                Ok(install_wheel_rs::uninstall_legacy_editable(&dist.egg_link)?)
             }
+            InstalledDist::EggInfoFile(dist) => Err(UninstallError::Distutils(dist)),
         }
     })
     .await??;
@@ -23,6 +24,8 @@ pub async fn uninstall(
 
 #[derive(thiserror::Error, Debug)]
 pub enum UninstallError {
+    #[error("Unable to uninstall `{0}`. distutils-installed distributions do not include the metadata required to uninstall safely.")]
+    Distutils(InstalledEggInfoFile),
     #[error(transparent)]
     Uninstall(#[from] install_wheel_rs::Error),
     #[error(transparent)]

--- a/crates/uv/src/commands/pip/freeze.rs
+++ b/crates/uv/src/commands/pip/freeze.rs
@@ -57,7 +57,10 @@ pub(crate) fn pip_freeze(
                     writeln!(printer.stdout(), "{} @ {}", dist.name().bold(), dist.url)?;
                 }
             }
-            InstalledDist::EggInfo(dist) => {
+            InstalledDist::EggInfoFile(dist) => {
+                writeln!(printer.stdout(), "{}=={}", dist.name().bold(), dist.version)?;
+            }
+            InstalledDist::EggInfoDirectory(dist) => {
                 writeln!(printer.stdout(), "{}=={}", dist.name().bold(), dist.version)?;
             }
             InstalledDist::LegacyEditable(dist) => {


### PR DESCRIPTION
## Summary

As with other `.egg-info` and `.egg-link` distributions, it's easy to support _existing_ `.egg-link` files. Like pip, we refuse to uninstall these, since there's no way to know which files are part of the distribution.

Closes https://github.com/astral-sh/uv/issues/4059.

## Test Plan

Verify that `vtk` is included here, which is installed as a `.egg-link` file:

```
> conda create -c conda-forge -n uv-test python h5py vtk pyside6 cftime psutil

> cargo run pip freeze --python /opt/homebrew/Caskroom/miniforge/base/envs/uv-test/bin/python
aiohttp @ file:///Users/runner/miniforge3/conda-bld/aiohttp_1713964997382/work
aiosignal @ file:///home/conda/feedstock_root/build_artifacts/aiosignal_1667935791922/work
attrs @ file:///home/conda/feedstock_root/build_artifacts/attrs_1704011227531/work
cached-property @ file:///home/conda/feedstock_root/build_artifacts/cached_property_1615209429212/work
cftime @ file:///Users/runner/miniforge3/conda-bld/cftime_1715919201099/work
frozenlist @ file:///Users/runner/miniforge3/conda-bld/frozenlist_1702645558715/work
h5py @ file:///Users/runner/miniforge3/conda-bld/h5py_1715968397721/work
idna @ file:///home/conda/feedstock_root/build_artifacts/idna_1713279365350/work
loguru @ file:///Users/runner/miniforge3/conda-bld/loguru_1695547410953/work
msgpack @ file:///Users/runner/miniforge3/conda-bld/msgpack-python_1715670632250/work
multidict @ file:///Users/runner/miniforge3/conda-bld/multidict_1707040780513/work
numpy @ file:///Users/runner/miniforge3/conda-bld/numpy_1707225421156/work/dist/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl
pip==24.0
psutil @ file:///Users/runner/miniforge3/conda-bld/psutil_1705722460205/work
pyside6==6.7.1
setuptools==70.0.0
shiboken6==6.7.1
vtk==9.2.6
wheel==0.43.0
wslink @ file:///home/conda/feedstock_root/build_artifacts/wslink_1716591560747/work
yarl @ file:///Users/runner/miniforge3/conda-bld/yarl_1705508643525/work
```
