### PR TITLE
Fix tracing output in `cargo dev` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4586,6 +4586,7 @@ version = "0.0.1"
 dependencies = [
  "anstream",
  "anyhow",
+ "chrono",
  "clap",
  "distribution-filename",
  "distribution-types",

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -16,6 +16,7 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
+chrono = { workspace = true }
 distribution-filename = { workspace = true }
 distribution-types = { workspace = true }
 install-wheel-rs = { workspace = true }


### PR DESCRIPTION
There's probably a more succinct way to do this, but I figure we should have it be similar to `uv::main` so I copied most of the content from there.

Now `cargo dev fetch-python` output is shown again.