### PR TITLE
Avoid extra-only filtering for constraints

### DIFF
--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -97,6 +97,7 @@ fn add_requirements(
         // If the requirement isn't relevant for the current platform, skip it.
         match source_extra {
             Some(source_extra) => {
+                // Only include requirements that are relevant for the current extra.
                 if requirement.evaluate_markers(env, &[]) {
                     continue;
                 }
@@ -167,9 +168,6 @@ fn add_requirements(
                 // If the requirement isn't relevant for the current platform, skip it.
                 match source_extra {
                     Some(source_extra) => {
-                        if constraint.evaluate_markers(env, &[]) {
-                            continue;
-                        }
                         if !constraint.evaluate_markers(env, std::slice::from_ref(source_extra)) {
                             continue;
                         }

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -2315,6 +2315,44 @@ fn install_constraints_inline_remote() -> Result<()> {
     Ok(())
 }
 
+/// Constrain a package that's included via an extra.
+#[test]
+fn install_constraints_extra() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("flask[dotenv]")?;
+
+    let constraints_txt = context.temp_dir.child("constraints.txt");
+    constraints_txt.write_str("python-dotenv==1.0.0")?;
+
+    uv_snapshot!(context.install()
+        .arg("-r")
+        .arg("requirements.txt")
+        .arg("-c")
+        .arg("constraints.txt"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 8 packages in [TIME]
+    Downloaded 8 packages in [TIME]
+    Installed 8 packages in [TIME]
+     + blinker==1.7.0
+     + click==8.1.7
+     + flask==3.0.2
+     + itsdangerous==2.1.2
+     + jinja2==3.1.3
+     + markupsafe==2.1.5
+     + python-dotenv==1.0.0
+     + werkzeug==3.0.1
+    "###
+    );
+
+    Ok(())
+}
+
 #[test]
 fn install_constraints_respects_offline_mode() {
     let context = TestContext::new("3.12");


### PR DESCRIPTION
## Summary

The "only include if relevant for the extra" filtering should _not_ be applied to constraints. Otherwise, we'd only constrain when the extra was included in the constraints file itself, which is incorrect.

Closes https://github.com/astral-sh/uv/issues/4091.
