### PR TITLE
Rename `Dependency.id` to `Dependency.distribution_id`

### DIFF
--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_required_present.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_required_present.snap
@@ -6,7 +6,7 @@ Err(
     Error {
         inner: Error {
             inner: TomlError {
-                message: "since the distribution `anyio 4.3.0 registry+https://pypi.org/simple` comes from a registry dependency, a hash was expected but one was not found for wheel",
+                message: "since the distribution `anyio==4.3.0 @ registry+https://pypi.org/simple` comes from a registry dependency, a hash was expected but one was not found for wheel",
                 raw: None,
                 keys: [],
                 span: None,


### PR DESCRIPTION
## Summary

I think this makes clearer that the `Dependency.id` is not an identifier for the dependency itself.

No functional changes.
