### PR TITLE
De-duplicate Linux builds with priority of MUSL targets

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -199,77 +199,6 @@ jobs:
             *.zip
             *.sha256
 
-  linux:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - i686-unknown-linux-gnu
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          architecture: x64
-      - name: "Prep README.md"
-        run: python scripts/transform_readme.py --target pypi
-      - name: "Build wheels"
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          manylinux: auto
-          args: --release --locked --out dist --features self-update
-          # See: https://github.com/sfackler/rust-openssl/issues/2036#issuecomment-1724324145
-          before-script-linux: |
-            # If we're running on rhel centos, install needed packages.
-            if command -v yum &> /dev/null; then
-                yum update -y && yum install -y perl-core openssl openssl-devel pkgconfig libatomic
-
-                # If we're running on i686 we need to symlink libatomic
-                # in order to build openssl with -latomic flag.
-                if [[ ! -d "/usr/lib64" ]]; then
-                    ln -s /usr/lib/libatomic.so.1 /usr/lib/libatomic.so
-                fi
-            else
-                # If we're running on debian-based system.
-                apt update -y && apt-get install -y libssl-dev openssl pkg-config
-            fi
-      - name: "Test wheel"
-        if: ${{ startsWith(matrix.target, 'x86_64') }}
-        run: |
-          pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
-          ${{ env.MODULE_NAME }} --help
-          python -m ${{ env.MODULE_NAME }} --help
-      - name: "Upload wheels"
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-${{ matrix.target }}
-          path: dist
-      - name: "Archive binary"
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          TARGET=${{ matrix.target }}
-          ARCHIVE_NAME=uv-$TARGET
-          ARCHIVE_FILE=$ARCHIVE_NAME.tar.gz
-
-          mkdir -p $ARCHIVE_NAME
-          cp target/$TARGET/release/uv $ARCHIVE_NAME/uv
-          tar czvf $ARCHIVE_FILE $ARCHIVE_NAME
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifacts-${{ matrix.target }}
-          path: |
-            *.tar.gz
-            *.sha256
-
   linux-arm:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
     runs-on: ubuntu-latest
@@ -363,7 +292,6 @@ jobs:
           docker-options: ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist --no-default-features --features flate2/rust_backend --features self-update
       - uses: uraimo/run-on-arch-action@v2
-        if: matrix.platform.arch != 'ppc64'
         name: Test wheel
         with:
           arch: ${{ matrix.platform.arch }}
@@ -410,8 +338,6 @@ jobs:
     strategy:
       matrix:
         platform:
-          - target: powerpc64le-unknown-linux-gnu
-            arch: ppc64le
           - target: powerpc64-unknown-linux-gnu
             arch: ppc64
 
@@ -438,20 +364,6 @@ jobs:
                 yum repolist
                 yum install -y gcc-powerpc64-linux-gnu
             fi
-      - uses: uraimo/run-on-arch-action@v2
-        if: matrix.platform.arch != 'ppc64'
-        name: Test wheel
-        with:
-          arch: ${{ matrix.platform.arch }}
-          distro: ubuntu20.04
-          githubToken: ${{ github.token }}
-          install: |
-            apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip
-            pip3 install -U pip
-          run: |
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
-            ${{ env.MODULE_NAME }} --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,17 +216,13 @@ targets = [
   "aarch64-apple-darwin",
   "aarch64-unknown-linux-musl",
   "arm-unknown-linux-musleabihf",
-  "armv7-unknown-linux-gnueabihf",
   "armv7-unknown-linux-musleabihf",
   "i686-pc-windows-msvc",
-  "i686-unknown-linux-gnu",
   "i686-unknown-linux-musl",
   "powerpc64-unknown-linux-gnu",
-  "powerpc64le-unknown-linux-gnu",
   "s390x-unknown-linux-gnu",
   "x86_64-apple-darwin",
   "x86_64-pc-windows-msvc",
-  "x86_64-unknown-linux-gnu",
   "x86_64-unknown-linux-musl",
 ]
 # Whether to auto-include files like READMEs, LICENSEs, and CHANGELOGs (default true)

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ uv has Tier 2 support (["guaranteed to build"](https://doc.rust-lang.org/beta/ru
 - Linux (i686)
 - Linux (s390x)
 
-The ABI used for Linux platform is MUSL, except for _PPC64_ and _s390x_ archs used GNU ABI.
+The ABI used for Linux platform is MUSL with statically linked C-Runtime, except for _PPC64_ and _s390x_ archs which are only available with dynamically linked GNU ABI.
 
 The ABI used for Windows platform is MSVC with statically linked C-Runtime.
 

--- a/README.md
+++ b/README.md
@@ -506,6 +506,10 @@ uv has Tier 2 support (["guaranteed to build"](https://doc.rust-lang.org/beta/ru
 - Linux (i686)
 - Linux (s390x)
 
+The ABI used for Linux platform is MUSL, except for _PPC64_ and _s390x_ archs used GNU ABI.
+
+The ABI used for Windows platform is MSVC with statically linked C-Runtime.
+
 uv ships pre-built wheels to [PyPI](https://pypi.org/project/uv/) for its Tier 1 and
 Tier 2 platforms. However, while Tier 2 platforms are continuously built, they are not continuously
 tested or developed against, and so stability may vary in practice.


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Ref https://github.com/astral-sh/uv/issues/4122#issuecomment-2154280414 musllinux targets are superset of gnu targets.

Should we document it that why we use musl builds?

## Test Plan
https://github.com/T-256/uv/actions/runs/9416773652/job/25940621883