### PR TITLE
Implement `Toolchain::find_or_fetch` and use in `uv venv --preview`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
 dependencies = [
  "anstream",
  "anstyle",
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2933,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4274,9 +4274,9 @@ checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unindent"
@@ -4592,7 +4592,6 @@ dependencies = [
  "fs-err",
  "futures",
  "install-wheel-rs",
- "itertools 0.13.0",
  "mimalloc",
  "owo-colors",
  "pep508_rs",

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -42,7 +42,6 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "wrap_help"] }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
-itertools = { workspace = true }
 owo-colors = { workspace = true }
 poloto = { version = "19.1.2", optional = true }
 pretty_assertions = { version = "1.4.0" }

--- a/crates/uv-dev/src/fetch_python.rs
+++ b/crates/uv-dev/src/fetch_python.rs
@@ -1,16 +1,10 @@
 use anyhow::Result;
 use clap::Parser;
 use fs_err as fs;
-#[cfg(unix)]
-use fs_err::tokio::symlink;
 use futures::StreamExt;
-#[cfg(unix)]
-use itertools::Itertools;
-use std::str::FromStr;
-#[cfg(unix)]
-use std::{collections::HashMap, path::PathBuf};
 use tokio::time::Instant;
 use tracing::{info, info_span, Instrument};
+use uv_toolchain::ToolchainRequest;
 
 use uv_fs::Simplified;
 use uv_toolchain::downloads::{DownloadResult, Error, PythonDownload, PythonDownloadRequest};
@@ -37,17 +31,16 @@ pub(crate) async fn fetch_python(args: FetchPythonArgs) -> Result<()> {
     let requests = versions
         .iter()
         .map(|version| {
-            PythonDownloadRequest::from_str(version).and_then(PythonDownloadRequest::fill)
+            PythonDownloadRequest::from_request(ToolchainRequest::parse(version))
+                // Populate platform information on the request
+                .and_then(PythonDownloadRequest::fill)
         })
         .collect::<Result<Vec<_>, Error>>()?;
 
     let downloads = requests
         .iter()
-        .map(|request| match PythonDownload::from_request(request) {
-            Some(download) => download,
-            None => panic!("No download found for request {request:?}"),
-        })
-        .collect::<Vec<_>>();
+        .map(PythonDownload::from_request)
+        .collect::<Result<Vec<_>, Error>>()?;
 
     let client = uv_client::BaseClientBuilder::new().build();
 
@@ -89,40 +82,6 @@ pub(crate) async fn fetch_python(args: FetchPythonArgs) -> Result<()> {
         );
     } else {
         info!("All versions downloaded already.");
-    };
-
-    // Order matters here, as we overwrite previous links
-    info!("Installing to `{}`...", toolchain_dir.user_display());
-
-    // On Windows, linking the executable generally results in broken installations
-    // and each toolchain path will need to be added to the PATH separately in the
-    // desired order
-    #[cfg(unix)]
-    {
-        let mut links: HashMap<PathBuf, PathBuf> = HashMap::new();
-        for (version, path) in results {
-            // TODO(zanieb): This path should be a part of the download metadata
-            let executable = path.join("install").join("bin").join("python3");
-            for target in [
-                toolchain_dir.join(format!("python{}", version.python_full_version())),
-                toolchain_dir.join(format!("python{}.{}", version.major(), version.minor())),
-                toolchain_dir.join(format!("python{}", version.major())),
-                toolchain_dir.join("python"),
-            ] {
-                // Attempt to remove it, we'll fail on link if we couldn't remove it for some reason
-                // but if it's missing we don't want to error
-                let _ = fs::remove_file(&target);
-                symlink(&executable, &target).await?;
-                links.insert(target, executable.clone());
-            }
-        }
-        for (target, executable) in links.iter().sorted() {
-            info!(
-                "Linked `{}` to `{}`",
-                target.user_display(),
-                executable.user_display()
-            );
-        }
     };
 
     info!("Installed {} versions", requests.len());

--- a/crates/uv-toolchain/src/discovery.rs
+++ b/crates/uv-toolchain/src/discovery.rs
@@ -1059,6 +1059,17 @@ impl VersionRequest {
         }
     }
 
+    pub(crate) fn matches_major_minor_patch(self, major: u8, minor: u8, patch: u8) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Major(self_major) => self_major == major,
+            Self::MajorMinor(self_major, self_minor) => (self_major, self_minor) == (major, minor),
+            Self::MajorMinorPatch(self_major, self_minor, self_patch) => {
+                (self_major, self_minor, self_patch) == (major, minor, patch)
+            }
+        }
+    }
+
     /// Return true if a patch version is present in the request.
     fn has_patch(self) -> bool {
         match self {

--- a/crates/uv-toolchain/src/lib.rs
+++ b/crates/uv-toolchain/src/lib.rs
@@ -57,6 +57,12 @@ pub enum Error {
     PyLauncher(#[from] py_launcher::Error),
 
     #[error(transparent)]
+    ManagedToolchain(#[from] managed::Error),
+
+    #[error(transparent)]
+    Download(#[from] downloads::Error),
+
+    #[error(transparent)]
     NotFound(#[from] ToolchainNotFound),
 }
 

--- a/crates/uv-toolchain/src/toolchain.rs
+++ b/crates/uv-toolchain/src/toolchain.rs
@@ -1,3 +1,5 @@
+use tracing::{debug, info};
+use uv_client::BaseClientBuilder;
 use uv_configuration::PreviewMode;
 
 use uv_cache::Cache;
@@ -6,6 +8,8 @@ use crate::discovery::{
     find_best_toolchain, find_default_toolchain, find_toolchain, SystemPython, ToolchainRequest,
     ToolchainSources,
 };
+use crate::downloads::{DownloadResult, PythonDownload, PythonDownloadRequest};
+use crate::managed::{InstalledToolchain, InstalledToolchains};
 use crate::{Error, Interpreter, ToolchainSource};
 
 /// A Python interpreter and accompanying tools.
@@ -112,6 +116,60 @@ impl Toolchain {
     pub fn find_default(preview: PreviewMode, cache: &Cache) -> Result<Self, Error> {
         let toolchain = find_default_toolchain(preview, cache)??;
         Ok(toolchain)
+    }
+
+    /// Find or fetch a [`Toolchain`].
+    ///
+    /// Unlike [`Toolchain::find`], if the toolchain is not installed it will be installed automatically.
+    pub async fn find_or_fetch<'a>(
+        python: Option<&str>,
+        system: SystemPython,
+        preview: PreviewMode,
+        client_builder: BaseClientBuilder<'a>,
+        cache: &Cache,
+    ) -> Result<Self, Error> {
+        // Perform a find first
+        match Self::find(python, system, preview, cache) {
+            Ok(venv) => Ok(venv),
+            Err(Error::NotFound(_)) if system.is_allowed() && preview.is_enabled() => {
+                debug!("Requested Python not found, checking for available download...");
+                let request = if let Some(request) = python {
+                    ToolchainRequest::parse(request)
+                } else {
+                    ToolchainRequest::default()
+                };
+                Self::fetch(request, client_builder, cache).await
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    pub async fn fetch<'a>(
+        request: ToolchainRequest,
+        client_builder: BaseClientBuilder<'a>,
+        cache: &Cache,
+    ) -> Result<Self, Error> {
+        let toolchains = InstalledToolchains::from_settings()?.init()?;
+        let toolchain_dir = toolchains.root();
+
+        let request = PythonDownloadRequest::from_request(request)?.fill()?;
+        let download = PythonDownload::from_request(&request)?;
+        let client = client_builder.build();
+
+        info!("Fetching requested toolchain...");
+        let result = download.fetch(&client, toolchain_dir).await?;
+
+        let path = match result {
+            DownloadResult::AlreadyAvailable(path) => path,
+            DownloadResult::Fetched(path) => path,
+        };
+
+        let installed = InstalledToolchain::new(path)?;
+
+        Ok(Self {
+            source: ToolchainSource::Managed,
+            interpreter: Interpreter::query(installed.executable(), cache)?,
+        })
     }
 
     /// Create a [`Toolchain`] from an existing [`Interpreter`].

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -14,7 +14,7 @@ use install_wheel_rs::linker::LinkMode;
 use pypi_types::Requirement;
 use uv_auth::store_credentials_from_url;
 use uv_cache::Cache;
-use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
+use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{Concurrency, KeyringProviderType, PreviewMode};
 use uv_configuration::{ConfigSettings, IndexStrategy, NoBinary, NoBuild, SetupPyStrategy};
 use uv_dispatch::BuildDispatch;
@@ -119,10 +119,21 @@ async fn venv_impl(
     cache: &Cache,
     printer: Printer,
 ) -> miette::Result<ExitStatus> {
+    let client_builder = BaseClientBuilder::default()
+        .connectivity(connectivity)
+        .native_tls(native_tls);
+
     // Locate the Python interpreter to use in the environment
-    let interpreter = Toolchain::find(python_request, SystemPython::Required, preview, cache)
-        .into_diagnostic()?
-        .into_interpreter();
+    let interpreter = Toolchain::find_or_fetch(
+        python_request,
+        SystemPython::Required,
+        preview,
+        client_builder,
+        cache,
+    )
+    .await
+    .into_diagnostic()?
+    .into_interpreter();
 
     // Add all authenticated sources to the cache.
     for url in index_locations.urls() {


### PR DESCRIPTION
Extends https://github.com/astral-sh/uv/pull/4121
Part of #2607 

Adds support for managed toolchain fetching to `uv venv`, e.g.

```
❯ cargo run -q -- venv --python 3.9.18 --preview -v
DEBUG Searching for Python 3.9.18 in search path or managed toolchains
DEBUG Searching for managed toolchains at `/Users/zb/Library/Application Support/uv/toolchains`
DEBUG Found CPython 3.12.3 at `/opt/homebrew/bin/python3` (search path)
DEBUG Found CPython 3.9.6 at `/usr/bin/python3` (search path)
DEBUG Found CPython 3.12.3 at `/opt/homebrew/bin/python3` (search path)
DEBUG Requested Python not found, checking for available download...
DEBUG Using registry request timeout of 30s
INFO Fetching requested toolchain...
DEBUG Downloading https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst to temporary location /Users/zb/Library/Application Support/uv/toolchains/.tmpgohKwp
DEBUG Extracting cpython-3.9.18%2B20240224-aarch64-apple-darwin-pgo%2Blto-full.tar.zst
DEBUG Moving /Users/zb/Library/Application Support/uv/toolchains/.tmpgohKwp/python to /Users/zb/Library/Application Support/uv/toolchains/cpython-3.9.18-macos-aarch64-none
Using Python 3.9.18 interpreter at: /Users/zb/Library/Application Support/uv/toolchains/cpython-3.9.18-macos-aarch64-none/install/bin/python3
Creating virtualenv at: .venv
INFO Removing existing directory
Activate with: source .venv/bin/activate
```

The preview flag is required. The fetch is performed if we can't find an interpreter that satisfies the request. Once fetched, the toolchain will be available for later invocations that include the `--preview` flag. There will be follow-ups to improve toolchain management in general, there is still outstanding work from the initial implementation.
 