### PR TITLE
Drop "registry" prefix from request timeout log

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -131,7 +131,7 @@ impl<'a> BaseClientBuilder<'a> {
                     })
             })
             .unwrap_or(default_timeout);
-        debug!("Using registry request timeout of {timeout}s");
+        debug!("Using request timeout of {timeout}s");
 
         // Initialize the base client.
         let client = self.client.clone().unwrap_or_else(|| {


### PR DESCRIPTION
We use this base client for more than registry requests
