### PR TITLE
Reduce `uv-toolchain` discovery API to `Toolchain`

### DIFF
--- a/crates/uv-toolchain/src/discovery.rs
+++ b/crates/uv-toolchain/src/discovery.rs
@@ -445,7 +445,7 @@ fn should_stop_discovery(err: &Error) -> bool {
 ///
 /// If an error is encountered while locating or inspecting a candidate toolchain,
 /// the error will raised instead of attempting further candidates.
-pub fn find_toolchain(
+pub(crate) fn find_toolchain(
     request: &ToolchainRequest,
     system: SystemPython,
     sources: &ToolchainSources,
@@ -627,7 +627,7 @@ pub fn find_toolchain(
 /// Virtual environments are not included in discovery.
 ///
 /// See [`find_toolchain`] for more details on toolchain discovery.
-pub fn find_default_toolchain(
+pub(crate) fn find_default_toolchain(
     preview: PreviewMode,
     cache: &Cache,
 ) -> Result<ToolchainResult, Error> {

--- a/crates/uv-toolchain/src/lib.rs
+++ b/crates/uv-toolchain/src/lib.rs
@@ -2,9 +2,8 @@
 use thiserror::Error;
 
 pub use crate::discovery::{
-    find_best_toolchain, find_default_toolchain, find_toolchain, Error as DiscoveryError,
-    SystemPython, ToolchainNotFound, ToolchainRequest, ToolchainSource, ToolchainSources,
-    VersionRequest,
+    Error as DiscoveryError, SystemPython, ToolchainNotFound, ToolchainRequest, ToolchainSource,
+    ToolchainSources, VersionRequest,
 };
 pub use crate::environment::PythonEnvironment;
 pub use crate::interpreter::Interpreter;
@@ -81,9 +80,9 @@ mod tests {
     use uv_cache::Cache;
     use uv_configuration::PreviewMode;
 
+    use crate::discovery::{find_default_toolchain, find_toolchain};
     use crate::{
-        find_default_toolchain, find_toolchain, implementation::ImplementationName,
-        managed::InstalledToolchains, toolchain::Toolchain,
+        implementation::ImplementationName, managed::InstalledToolchains, toolchain::Toolchain,
         virtualenv::virtualenv_python_executable, Error, PythonVersion, SystemPython,
         ToolchainNotFound, ToolchainRequest, ToolchainSource, ToolchainSources, VersionRequest,
     };

--- a/crates/uv-toolchain/src/toolchain.rs
+++ b/crates/uv-toolchain/src/toolchain.rs
@@ -2,11 +2,11 @@ use uv_configuration::PreviewMode;
 
 use uv_cache::Cache;
 
-use crate::discovery::{SystemPython, ToolchainRequest, ToolchainSources};
-use crate::{
-    find_best_toolchain, find_default_toolchain, find_toolchain, Error, Interpreter,
-    ToolchainSource,
+use crate::discovery::{
+    find_best_toolchain, find_default_toolchain, find_toolchain, SystemPython, ToolchainRequest,
+    ToolchainSources,
 };
+use crate::{Error, Interpreter, ToolchainSource};
 
 /// A Python interpreter and accompanying tools.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Drops `find_toolchain`, `find_best_toolchain`, etc. in favor of `Toolchain::find_...`

We can change this in the future, but there should only be one "right" way to do it not two redundant ways in the public interface.