### PR TITLE
Fix PEP 508 link in preview doc `specifying_dependencies`

### DIFF
--- a/docs/specifying_dependencies.md
+++ b/docs/specifying_dependencies.md
@@ -14,7 +14,7 @@ different index, etc.
 ## `project.dependencies`
 
 The `project.dependencies` table represents the dependencies that are used when uploading to PyPI or
-building a wheel. Individual dependencies are specified using [PEP 508](#PEP 508), and the table as
+building a wheel. Individual dependencies are specified using [PEP 508](https://peps.python.org/pep-0508/), and the table as
 a whole follows the [PEP 621](https://packaging.python.org/en/latest/specifications/pyproject-toml/)
 standard.
 

--- a/docs/specifying_dependencies.md
+++ b/docs/specifying_dependencies.md
@@ -14,7 +14,7 @@ different index, etc.
 ## `project.dependencies`
 
 The `project.dependencies` table represents the dependencies that are used when uploading to PyPI or
-building a wheel. Individual dependencies are specified using [PEP 508](https://peps.python.org/pep-0508/), and the table as
+building a wheel. Individual dependencies are specified using [PEP 508](#pep-508), and the table as
 a whole follows the [PEP 621](https://packaging.python.org/en/latest/specifications/pyproject-toml/)
 standard.
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fix PEP 508 link.

## Test Plan

See preview https://github.com/SigureMo/uv/blob/fix-pep508-link-in-preview-doc/docs/specifying_dependencies.md