### PR TITLE
Add `uv toolchain list`

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -130,6 +130,8 @@ pub(crate) enum Commands {
     Pip(PipNamespace),
     /// Run and manage executable Python packages.
     Tool(ToolNamespace),
+    /// Manage Python installations.
+    Toolchain(ToolchainNamespace),
     /// Create a virtual environment.
     #[command(alias = "virtualenv", alias = "v")]
     Venv(VenvArgs),
@@ -1974,6 +1976,30 @@ pub(crate) struct ToolRunArgs {
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
     #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub(crate) python: Option<String>,
+}
+
+#[derive(Args)]
+pub(crate) struct ToolchainNamespace {
+    #[command(subcommand)]
+    pub(crate) command: ToolchainCommand,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum ToolchainCommand {
+    /// List the available toolchains.
+    List(ToolchainListArgs),
+}
+
+#[derive(Args)]
+#[allow(clippy::struct_excessive_bools)]
+pub(crate) struct ToolchainListArgs {
+    /// List all available toolchains, including those that do not match the current platform.
+    #[arg(long, conflicts_with = "only_installed")]
+    pub(crate) all: bool,
+
+    /// Only list installed toolchains.
+    #[arg(long, conflicts_with = "all")]
+    pub(crate) only_installed: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub(crate) use project::sync::sync;
 #[cfg(feature = "self-update")]
 pub(crate) use self_update::self_update;
 pub(crate) use tool::run::run as run_tool;
+pub(crate) use toolchain::list::list as toolchain_list;
 use uv_cache::Cache;
 use uv_fs::Simplified;
 use uv_installer::compile_tree;
@@ -39,6 +40,7 @@ mod pip;
 mod project;
 pub(crate) mod reporters;
 mod tool;
+mod toolchain;
 
 #[cfg(feature = "self-update")]
 mod self_update;

--- a/crates/uv/src/commands/toolchain/list.rs
+++ b/crates/uv/src/commands/toolchain/list.rs
@@ -1,0 +1,70 @@
+use std::fmt::Write;
+use std::ops::Deref;
+
+use anyhow::Result;
+use itertools::Itertools;
+
+use uv_cache::Cache;
+use uv_configuration::PreviewMode;
+use uv_toolchain::downloads::PythonDownloadRequest;
+use uv_toolchain::managed::InstalledToolchains;
+use uv_warnings::warn_user;
+
+use crate::commands::ExitStatus;
+use crate::printer::Printer;
+use crate::settings::ToolchainListIncludes;
+
+/// List available toolchains.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn list(
+    includes: ToolchainListIncludes,
+    preview: PreviewMode,
+    _cache: &Cache,
+    printer: Printer,
+) -> Result<ExitStatus> {
+    if preview.is_disabled() {
+        warn_user!("`uv toolchain list` is experimental and may change without warning.");
+    }
+
+    let downloads = match includes {
+        ToolchainListIncludes::All => {
+            let request = PythonDownloadRequest::default();
+            request.iter_downloads().collect()
+        }
+        ToolchainListIncludes::Installed => Vec::new(),
+        ToolchainListIncludes::Default => {
+            let request = PythonDownloadRequest::from_env()?;
+            request.iter_downloads().collect()
+        }
+    };
+
+    let installed = {
+        InstalledToolchains::from_settings()?
+            .init()?
+            .find_all()?
+            .collect_vec()
+    };
+
+    let mut output = Vec::new();
+    for toolchain in installed {
+        output.push((
+            toolchain.python_version().deref().version.clone(),
+            toolchain.key().to_owned(),
+        ));
+    }
+    for download in downloads {
+        output.push((
+            download.python_version().deref().version.clone(),
+            download.key().to_owned(),
+        ));
+    }
+
+    output.sort();
+    output.dedup();
+
+    for (version, key) in output {
+        writeln!(printer.stdout(), "{:<8} ({key})", version.to_string())?;
+    }
+
+    Ok(ExitStatus::Success)
+}

--- a/crates/uv/src/commands/toolchain/mod.rs
+++ b/crates/uv/src/commands/toolchain/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod list;

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -10,7 +10,7 @@ use clap::{CommandFactory, Parser};
 use owo_colors::OwoColorize;
 use tracing::instrument;
 
-use cli::{ToolCommand, ToolNamespace};
+use cli::{ToolCommand, ToolNamespace, ToolchainCommand, ToolchainNamespace};
 use uv_cache::Cache;
 use uv_requirements::RequirementsSource;
 use uv_workspace::Combine;
@@ -670,6 +670,17 @@ async fn run() -> Result<ExitStatus> {
                 printer,
             )
             .await
+        }
+        Commands::Toolchain(ToolchainNamespace {
+            command: ToolchainCommand::List(args),
+        }) => {
+            // Resolve the settings from the command-line arguments and workspace configuration.
+            let args = settings::ToolchainListSettings::resolve(args, workspace);
+
+            // Initialize the cache.
+            let cache = cache.init()?;
+
+            commands::toolchain_list(args.includes, globals.preview, &cache, printer).await
         }
     }
 }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -23,7 +23,7 @@ use uv_workspace::{Combine, PipOptions, Workspace};
 use crate::cli::{
     ColorChoice, GlobalArgs, LockArgs, Maybe, PipCheckArgs, PipCompileArgs, PipFreezeArgs,
     PipInstallArgs, PipListArgs, PipShowArgs, PipSyncArgs, PipUninstallArgs, RunArgs, SyncArgs,
-    ToolRunArgs, VenvArgs,
+    ToolRunArgs, ToolchainListArgs, VenvArgs,
 };
 use crate::commands::ListFormat;
 
@@ -227,6 +227,42 @@ impl ToolRunSettings {
             with,
             python,
         }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) enum ToolchainListIncludes {
+    #[default]
+    Default,
+    All,
+    Installed,
+}
+
+/// The resolved settings to use for a `tool run` invocation.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone)]
+pub(crate) struct ToolchainListSettings {
+    pub(crate) includes: ToolchainListIncludes,
+}
+
+impl ToolchainListSettings {
+    /// Resolve the [`ToolchainListSettings`] from the CLI and workspace configuration.
+    #[allow(clippy::needless_pass_by_value)]
+    pub(crate) fn resolve(args: ToolchainListArgs, _workspace: Option<Workspace>) -> Self {
+        let ToolchainListArgs {
+            all,
+            only_installed,
+        } = args;
+
+        let includes = if all {
+            ToolchainListIncludes::All
+        } else if only_installed {
+            ToolchainListIncludes::Installed
+        } else {
+            ToolchainListIncludes::default()
+        };
+
+        Self { includes }
     }
 }
 


### PR DESCRIPTION
Adds the `uv toolchain` namespace and a `list` command to get us started.

```
❯ cargo run -q -- toolchain list
warning: `uv toolchain list` is experimental and may change without warning.
3.8.12   (cpython-3.8.12-macos-aarch64-none)
3.8.13   (cpython-3.8.13-macos-aarch64-none)
3.8.14   (cpython-3.8.14-macos-aarch64-none)
3.8.15   (cpython-3.8.15-macos-aarch64-none)
3.8.16   (cpython-3.8.16-macos-aarch64-none)
3.8.17   (cpython-3.8.17-macos-aarch64-none)
3.8.18   (cpython-3.8.18-macos-aarch64-none)
3.8.18   (cpython-3.8.18-macos-aarch64-none)
3.8.19   (cpython-3.8.19-macos-aarch64-none)
3.9.2    (cpython-3.9.2-macos-aarch64-none)
3.9.3    (cpython-3.9.3-macos-aarch64-none)
3.9.4    (cpython-3.9.4-macos-aarch64-none)
3.9.5    (cpython-3.9.5-macos-aarch64-none)
3.9.6    (cpython-3.9.6-macos-aarch64-none)
3.9.7    (cpython-3.9.7-macos-aarch64-none)
3.9.10   (cpython-3.9.10-macos-aarch64-none)
3.9.11   (cpython-3.9.11-macos-aarch64-none)
3.9.12   (cpython-3.9.12-macos-aarch64-none)
3.9.13   (cpython-3.9.13-macos-aarch64-none)
3.9.14   (cpython-3.9.14-macos-aarch64-none)
3.9.15   (cpython-3.9.15-macos-aarch64-none)
3.9.16   (cpython-3.9.16-macos-aarch64-none)
3.9.17   (cpython-3.9.17-macos-aarch64-none)
3.9.18   (cpython-3.9.18-macos-aarch64-none)
3.9.19   (cpython-3.9.19-macos-aarch64-none)
3.10.0   (cpython-3.10.0-macos-aarch64-none)
3.10.2   (cpython-3.10.2-macos-aarch64-none)
3.10.3   (cpython-3.10.3-macos-aarch64-none)
3.10.4   (cpython-3.10.4-macos-aarch64-none)
3.10.5   (cpython-3.10.5-macos-aarch64-none)
3.10.6   (cpython-3.10.6-macos-aarch64-none)
3.10.7   (cpython-3.10.7-macos-aarch64-none)
3.10.8   (cpython-3.10.8-macos-aarch64-none)
3.10.9   (cpython-3.10.9-macos-aarch64-none)
3.10.11  (cpython-3.10.11-macos-aarch64-none)
3.10.12  (cpython-3.10.12-macos-aarch64-none)
3.10.13  (cpython-3.10.13-macos-aarch64-none)
3.10.14  (cpython-3.10.14-macos-aarch64-none)
3.11.1   (cpython-3.11.1-macos-aarch64-none)
3.11.3   (cpython-3.11.3-macos-aarch64-none)
3.11.4   (cpython-3.11.4-macos-aarch64-none)
3.11.5   (cpython-3.11.5-macos-aarch64-none)
3.11.6   (cpython-3.11.6-macos-aarch64-none)
3.11.7   (cpython-3.11.7-macos-aarch64-none)
3.11.8   (cpython-3.11.8-macos-aarch64-none)
3.11.9   (cpython-3.11.9-macos-aarch64-none)
3.12.0   (cpython-3.12.0-macos-aarch64-none)
3.12.1   (cpython-3.12.1-macos-aarch64-none)
3.12.2   (cpython-3.12.2-macos-aarch64-none)
3.12.3   (cpython-3.12.3-macos-aarch64-none)
```

Closes https://github.com/astral-sh/uv/issues/4189