### PR TITLE
Add support for listing system toolchains

### DIFF
--- a/crates/uv-toolchain/src/downloads.rs
+++ b/crates/uv-toolchain/src/downloads.rs
@@ -279,6 +279,10 @@ impl PythonDownload {
         )
     }
 
+    pub fn os(&self) -> &Os {
+        &self.os
+    }
+
     pub fn sha256(&self) -> Option<&str> {
         self.sha256
     }

--- a/crates/uv-toolchain/src/implementation.rs
+++ b/crates/uv-toolchain/src/implementation.rs
@@ -18,7 +18,7 @@ pub enum ImplementationName {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub(crate) enum LenientImplementationName {
+pub enum LenientImplementationName {
     Known(ImplementationName),
     Unknown(String),
 }

--- a/crates/uv-toolchain/src/lib.rs
+++ b/crates/uv-toolchain/src/lib.rs
@@ -2,8 +2,8 @@
 use thiserror::Error;
 
 pub use crate::discovery::{
-    Error as DiscoveryError, SystemPython, ToolchainNotFound, ToolchainRequest, ToolchainSource,
-    ToolchainSources, VersionRequest,
+    find_toolchains, Error as DiscoveryError, SystemPython, ToolchainNotFound, ToolchainRequest,
+    ToolchainSource, ToolchainSources, VersionRequest,
 };
 pub use crate::environment::PythonEnvironment;
 pub use crate::interpreter::Interpreter;

--- a/crates/uv-toolchain/src/platform.rs
+++ b/crates/uv-toolchain/src/platform.rs
@@ -127,3 +127,54 @@ impl Deref for Os {
         &self.0
     }
 }
+
+impl From<&platform_tags::Arch> for Arch {
+    fn from(value: &platform_tags::Arch) -> Self {
+        match value {
+            platform_tags::Arch::Aarch64 => Self(target_lexicon::Architecture::Aarch64(
+                target_lexicon::Aarch64Architecture::Aarch64,
+            )),
+            platform_tags::Arch::Armv6L => Self(target_lexicon::Architecture::Arm(
+                target_lexicon::ArmArchitecture::Armv6,
+            )),
+            platform_tags::Arch::Armv7L => Self(target_lexicon::Architecture::Arm(
+                target_lexicon::ArmArchitecture::Armv7,
+            )),
+            platform_tags::Arch::S390X => Self(target_lexicon::Architecture::S390x),
+            platform_tags::Arch::Powerpc64 => Self(target_lexicon::Architecture::Powerpc64),
+            platform_tags::Arch::Powerpc64Le => Self(target_lexicon::Architecture::Powerpc64le),
+            platform_tags::Arch::X86 => Self(target_lexicon::Architecture::X86_32(
+                target_lexicon::X86_32Architecture::I686,
+            )),
+            platform_tags::Arch::X86_64 => Self(target_lexicon::Architecture::X86_64),
+        }
+    }
+}
+
+impl From<&platform_tags::Os> for Libc {
+    fn from(value: &platform_tags::Os) -> Self {
+        match value {
+            platform_tags::Os::Manylinux { .. } => Self::Some(target_lexicon::Environment::Gnu),
+            platform_tags::Os::Musllinux { .. } => Self::Some(target_lexicon::Environment::Musl),
+            _ => Self::None,
+        }
+    }
+}
+
+impl From<&platform_tags::Os> for Os {
+    fn from(value: &platform_tags::Os) -> Self {
+        match value {
+            platform_tags::Os::Dragonfly { .. } => Self(target_lexicon::OperatingSystem::Dragonfly),
+            platform_tags::Os::FreeBsd { .. } => Self(target_lexicon::OperatingSystem::Freebsd),
+            platform_tags::Os::Haiku { .. } => Self(target_lexicon::OperatingSystem::Haiku),
+            platform_tags::Os::Illumos { .. } => Self(target_lexicon::OperatingSystem::Illumos),
+            platform_tags::Os::Macos { .. } => Self(target_lexicon::OperatingSystem::Darwin),
+            platform_tags::Os::Manylinux { .. } | platform_tags::Os::Musllinux { .. } => {
+                Self(target_lexicon::OperatingSystem::Linux)
+            }
+            platform_tags::Os::NetBsd { .. } => Self(target_lexicon::OperatingSystem::Netbsd),
+            platform_tags::Os::OpenBsd { .. } => Self(target_lexicon::OperatingSystem::Openbsd),
+            platform_tags::Os::Windows => Self(target_lexicon::OperatingSystem::Windows),
+        }
+    }
+}

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -2047,12 +2047,16 @@ pub(crate) enum ToolchainCommand {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct ToolchainListArgs {
-    /// List all available toolchains, including those that do not match the current platform.
-    #[arg(long, conflicts_with = "only_installed")]
-    pub(crate) all: bool,
+    /// List all toolchain versions, including outdated patch versions.
+    #[arg(long)]
+    pub(crate) all_versions: bool,
 
-    /// Only list installed toolchains.
-    #[arg(long, conflicts_with = "all")]
+    /// List toolchains for all platforms.
+    #[arg(long)]
+    pub(crate) all_platforms: bool,
+
+    /// Only show installed toolchains, exclude available downloads.
+    #[arg(long)]
     pub(crate) only_installed: bool,
 }
 

--- a/crates/uv/src/commands/toolchain/list.rs
+++ b/crates/uv/src/commands/toolchain/list.rs
@@ -1,35 +1,50 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::fmt::Write;
 
 use anyhow::Result;
-use itertools::Itertools;
 
 use uv_cache::Cache;
 use uv_configuration::PreviewMode;
+use uv_fs::Simplified;
 use uv_toolchain::downloads::PythonDownloadRequest;
-use uv_toolchain::managed::InstalledToolchains;
+use uv_toolchain::{
+    find_toolchains, DiscoveryError, SystemPython, Toolchain, ToolchainNotFound, ToolchainRequest,
+    ToolchainSource, ToolchainSources,
+};
 use uv_warnings::warn_user;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
-use crate::settings::ToolchainListIncludes;
+use crate::settings::ToolchainListKinds;
+
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
+enum Kind {
+    Download,
+    Managed,
+    System,
+}
 
 /// List available toolchains.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn list(
-    includes: ToolchainListIncludes,
+    kinds: ToolchainListKinds,
+    all_versions: bool,
+    all_platforms: bool,
     preview: PreviewMode,
-    _cache: &Cache,
+    cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
         warn_user!("`uv toolchain list` is experimental and may change without warning.");
     }
 
-    let download_request = match includes {
-        ToolchainListIncludes::All => Some(PythonDownloadRequest::default()),
-        ToolchainListIncludes::Installed => None,
-        ToolchainListIncludes::Default => Some(PythonDownloadRequest::from_env()?),
+    let download_request = match kinds {
+        ToolchainListKinds::Installed => None,
+        ToolchainListKinds::Default => Some(if all_platforms {
+            PythonDownloadRequest::default()
+        } else {
+            PythonDownloadRequest::from_env()?
+        }),
     };
 
     let downloads = download_request
@@ -38,27 +53,68 @@ pub(crate) async fn list(
         .into_iter()
         .flatten();
 
-    let installed = {
-        InstalledToolchains::from_settings()?
-            .init()?
-            .find_all()?
-            .collect_vec()
-    };
+    let installed = find_toolchains(
+        &ToolchainRequest::Any,
+        SystemPython::Required,
+        &ToolchainSources::All(PreviewMode::Enabled),
+        cache,
+    )
+    // Raise any errors encountered during discovery
+    .collect::<Result<Vec<Result<Toolchain, ToolchainNotFound>>, DiscoveryError>>()?
+    .into_iter()
+    // Then drop any "missing" toolchains
+    .filter_map(std::result::Result::ok);
 
-    // Sort and de-duplicate the output.
     let mut output = BTreeSet::new();
     for toolchain in installed {
+        let kind = if matches!(toolchain.source(), ToolchainSource::Managed) {
+            Kind::Managed
+        } else {
+            Kind::System
+        };
         output.insert((
-            toolchain.python_version().version().clone(),
-            toolchain.key().to_owned(),
+            toolchain.python_version().clone(),
+            toolchain.os().to_string(),
+            toolchain.key().clone(),
+            kind,
+            Some(toolchain.interpreter().sys_executable().to_path_buf()),
         ));
     }
     for download in downloads {
-        output.insert((download.python_version().version().clone(), download.key()));
+        output.insert((
+            download.python_version().version().clone(),
+            download.os().to_string(),
+            download.key().clone(),
+            Kind::Download,
+            None,
+        ));
     }
 
-    for (version, key) in output {
-        writeln!(printer.stdout(), "{:<8} ({key})", version.to_string())?;
+    let mut seen_minor = HashSet::new();
+    let mut seen_patch = HashSet::new();
+    for (version, os, key, kind, path) in output.iter().rev() {
+        // Only show the latest patch version for each download unless all were requested
+        if !matches!(kind, Kind::System) {
+            if let [major, minor, ..] = version.release() {
+                if !seen_minor.insert((os.clone(), *major, *minor)) {
+                    if matches!(kind, Kind::Download) && !all_versions {
+                        continue;
+                    }
+                }
+            }
+            if let [major, minor, patch] = version.release() {
+                if !seen_patch.insert((os.clone(), *major, *minor, *patch)) {
+                    if matches!(kind, Kind::Download) {
+                        continue;
+                    }
+                }
+            }
+        }
+        if let Some(path) = path {
+            writeln!(printer.stdout(), "{key}\t{}", path.user_display())?;
+        } else {
+            writeln!(printer.stdout(), "{key}\t<download available>")?;
+        }
     }
 
     Ok(ExitStatus::Success)

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -718,7 +718,15 @@ async fn run() -> Result<ExitStatus> {
             // Initialize the cache.
             let cache = cache.init()?;
 
-            commands::toolchain_list(args.includes, globals.preview, &cache, printer).await
+            commands::toolchain_list(
+                args.kinds,
+                args.all_versions,
+                args.all_platforms,
+                globals.preview,
+                &cache,
+                printer,
+            )
+            .await
         }
         Commands::Toolchain(ToolchainNamespace {
             command: ToolchainCommand::Install(args),

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -205,10 +205,9 @@ impl ToolRunSettings {
 }
 
 #[derive(Debug, Clone, Default)]
-pub(crate) enum ToolchainListIncludes {
+pub(crate) enum ToolchainListKinds {
     #[default]
     Default,
-    All,
     Installed,
 }
 
@@ -216,7 +215,9 @@ pub(crate) enum ToolchainListIncludes {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct ToolchainListSettings {
-    pub(crate) includes: ToolchainListIncludes,
+    pub(crate) kinds: ToolchainListKinds,
+    pub(crate) all_platforms: bool,
+    pub(crate) all_versions: bool,
 }
 
 impl ToolchainListSettings {
@@ -224,19 +225,22 @@ impl ToolchainListSettings {
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn resolve(args: ToolchainListArgs, _workspace: Option<Workspace>) -> Self {
         let ToolchainListArgs {
-            all,
+            all_versions,
+            all_platforms,
             only_installed,
         } = args;
 
-        let includes = if all {
-            ToolchainListIncludes::All
-        } else if only_installed {
-            ToolchainListIncludes::Installed
+        let kinds = if only_installed {
+            ToolchainListKinds::Installed
         } else {
-            ToolchainListIncludes::default()
+            ToolchainListKinds::default()
         };
 
-        Self { includes }
+        Self {
+            kinds,
+            all_platforms,
+            all_versions,
+        }
     }
 }
 


### PR DESCRIPTION
Includes system interpreters in `uv toolchain list`.

This includes a refactor of `find_toolchain` to support iterating over all toolchains
that match a request rather than ending earlier.
