### PR TITLE
Move PEP 440 and PEP 508 parsing out of TOML deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "indexmap",
+ "itertools 0.13.0",
  "mailparse",
  "once_cell",
  "pep440_rs",

--- a/crates/pypi-types/Cargo.toml
+++ b/crates/pypi-types/Cargo.toml
@@ -20,6 +20,7 @@ uv-git = { workspace = true }
 
 chrono = { workspace = true, features = ["serde"] }
 indexmap = { workspace = true, features = ["serde"] }
+itertools = { workspace = true }
 mailparse = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }


### PR DESCRIPTION
## Summary

If we want more granular control over how these errors are handled, then we need to move them out of the TOML deserialization.

No actual behavior changes here.

Part of https://github.com/astral-sh/uv/issues/4142.
