### PR TITLE
Respect `--find-links` in `lock` and `sync`

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -46,6 +46,9 @@ pub(crate) enum ProjectError {
     Tags(#[from] platform_tags::TagsError),
 
     #[error(transparent)]
+    FlatIndex(#[from] uv_client::FlatIndexError),
+
+    #[error(transparent)]
     Lock(#[from] uv_resolver::LockError),
 
     #[error(transparent)]


### PR DESCRIPTION
## Summary

We already respect this command-line argument, I just forgot to wire it up to the resolver.
