### PR TITLE
Fix python3.13 on windows CI job by pinning older version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,7 +898,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13b1"
+          python-version: "3.13.0-beta.1"
           allow-prereleases: true
           cache: pip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,7 +898,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.13b1"
           allow-prereleases: true
           cache: pip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,6 +898,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
+          # TODO(konsti): https://github.com/actions/setup-python/issues/888
           python-version: "3.13.0-beta.1"
           allow-prereleases: true
           cache: pip


### PR DESCRIPTION
See https://github.com/actions/setup-python/issues/888