### PR TITLE
Add `uv toolchain find`

### DIFF
--- a/crates/uv-toolchain/src/lib.rs
+++ b/crates/uv-toolchain/src/lib.rs
@@ -6,6 +6,7 @@ pub use crate::discovery::{
     ToolchainSource, ToolchainSources, VersionRequest,
 };
 pub use crate::environment::PythonEnvironment;
+pub use crate::implementation::ImplementationName;
 pub use crate::interpreter::Interpreter;
 pub use crate::pointer_size::PointerSize;
 pub use crate::prefix::Prefix;

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1712,6 +1712,10 @@ pub(crate) enum ToolchainCommand {
 
     /// Download and install a specific toolchain.
     Install(ToolchainInstallArgs),
+
+    /// Search for a toolchain
+    #[command(disable_version_flag = true)]
+    Find(ToolchainFindArgs),
 }
 
 #[derive(Args)]
@@ -1741,6 +1745,18 @@ pub(crate) struct ToolchainInstallArgs {
     /// Force the installation of the toolchain, even if it is already installed.
     #[arg(long, short)]
     pub(crate) force: bool,
+}
+
+#[derive(Args)]
+#[allow(clippy::struct_excessive_bools)]
+pub(crate) struct ToolchainFindArgs {
+    /// The version to find.
+    #[arg(long)]
+    pub(crate) version: Option<String>,
+
+    /// The implementation to find.
+    #[arg(long)]
+    pub(crate) implementation: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1750,13 +1750,8 @@ pub(crate) struct ToolchainInstallArgs {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct ToolchainFindArgs {
-    /// The version to find.
-    #[arg(long)]
-    pub(crate) version: Option<String>,
-
-    /// The implementation to find.
-    #[arg(long)]
-    pub(crate) implementation: Option<String>,
+    /// The toolchain request.
+    pub(crate) request: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub(crate) use project::sync::sync;
 #[cfg(feature = "self-update")]
 pub(crate) use self_update::self_update;
 pub(crate) use tool::run::run as run_tool;
+pub(crate) use toolchain::find::find as toolchain_find;
 pub(crate) use toolchain::install::install as toolchain_install;
 pub(crate) use toolchain::list::list as toolchain_list;
 use uv_cache::Cache;

--- a/crates/uv/src/commands/toolchain/find.rs
+++ b/crates/uv/src/commands/toolchain/find.rs
@@ -1,0 +1,59 @@
+use anyhow::Result;
+use std::fmt::Write;
+use std::str::FromStr;
+
+use uv_cache::Cache;
+use uv_configuration::PreviewMode;
+use uv_fs::Simplified;
+use uv_toolchain::{ImplementationName, SystemPython, Toolchain, ToolchainRequest, VersionRequest};
+use uv_warnings::warn_user;
+
+use crate::commands::ExitStatus;
+use crate::printer::Printer;
+
+/// Find a toolchain.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn find(
+    version: Option<String>,
+    implementation: Option<String>,
+    preview: PreviewMode,
+    cache: &Cache,
+    printer: Printer,
+) -> Result<ExitStatus> {
+    if preview.is_disabled() {
+        warn_user!("`uv toolchain find` is experimental and may change without warning.");
+    }
+
+    let implementation = implementation
+        .as_deref()
+        .map(ImplementationName::from_str)
+        .transpose()?;
+    let version = version
+        .as_deref()
+        .map(VersionRequest::from_str)
+        .transpose()?;
+
+    let request = match (version, implementation) {
+        (None, None) => ToolchainRequest::Any,
+        (Some(version), None) => ToolchainRequest::Version(version),
+        (Some(version), Some(implementation)) => {
+            ToolchainRequest::ImplementationVersion(implementation, version)
+        }
+        (None, Some(implementation)) => ToolchainRequest::Implementation(implementation),
+    };
+
+    let toolchain = Toolchain::find_requested(
+        &request,
+        SystemPython::Required,
+        PreviewMode::Enabled,
+        cache,
+    )?;
+
+    writeln!(
+        printer.stdout(),
+        "{}",
+        toolchain.interpreter().sys_executable().user_display()
+    )?;
+
+    Ok(ExitStatus::Success)
+}

--- a/crates/uv/src/commands/toolchain/mod.rs
+++ b/crates/uv/src/commands/toolchain/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod find;
 pub(crate) mod install;
 pub(crate) mod list;

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -797,6 +797,24 @@ async fn run() -> Result<ExitStatus> {
             )
             .await
         }
+        Commands::Toolchain(ToolchainNamespace {
+            command: ToolchainCommand::Find(args),
+        }) => {
+            // Resolve the settings from the command-line arguments and workspace configuration.
+            let args = settings::ToolchainFindSettings::resolve(args, workspace);
+
+            // Initialize the cache.
+            let cache = cache.init()?;
+
+            commands::toolchain_find(
+                args.version,
+                args.implementation,
+                globals.preview,
+                &cache,
+                printer,
+            )
+            .await
+        }
     }
 }
 

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -801,19 +801,12 @@ async fn run() -> Result<ExitStatus> {
             command: ToolchainCommand::Find(args),
         }) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
-            let args = settings::ToolchainFindSettings::resolve(args, workspace);
+            let args = settings::ToolchainFindSettings::resolve(args, filesystem);
 
             // Initialize the cache.
             let cache = cache.init()?;
 
-            commands::toolchain_find(
-                args.version,
-                args.implementation,
-                globals.preview,
-                &cache,
-                printer,
-            )
-            .await
+            commands::toolchain_find(args.request, globals.preview, &cache, printer).await
         }
     }
 }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -28,7 +28,8 @@ use crate::cli::{
     AddArgs, BuildArgs, ColorChoice, GlobalArgs, IndexArgs, InstallerArgs, LockArgs, Maybe,
     PipCheckArgs, PipCompileArgs, PipFreezeArgs, PipInstallArgs, PipListArgs, PipShowArgs,
     PipSyncArgs, PipUninstallArgs, RefreshArgs, RemoveArgs, ResolverArgs, ResolverInstallerArgs,
-    RunArgs, SyncArgs, ToolRunArgs, ToolchainInstallArgs, ToolchainListArgs, VenvArgs,
+    RunArgs, SyncArgs, ToolRunArgs, ToolchainFindArgs, ToolchainInstallArgs, ToolchainListArgs,
+    VenvArgs,
 };
 use crate::commands::ListFormat;
 
@@ -270,6 +271,30 @@ impl ToolchainInstallSettings {
         let ToolchainInstallArgs { target, force } = args;
 
         Self { target, force }
+    }
+}
+
+/// The resolved settings to use for a `toolchain find` invocation.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone)]
+pub(crate) struct ToolchainFindSettings {
+    pub(crate) version: Option<String>,
+    pub(crate) implementation: Option<String>,
+}
+
+impl ToolchainFindSettings {
+    /// Resolve the [`ToolchainFindSettings`] from the CLI and workspace configuration.
+    #[allow(clippy::needless_pass_by_value)]
+    pub(crate) fn resolve(args: ToolchainFindArgs, _workspace: Option<Workspace>) -> Self {
+        let ToolchainFindArgs {
+            version,
+            implementation,
+        } = args;
+
+        Self {
+            version,
+            implementation,
+        }
     }
 }
 

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -278,23 +278,16 @@ impl ToolchainInstallSettings {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct ToolchainFindSettings {
-    pub(crate) version: Option<String>,
-    pub(crate) implementation: Option<String>,
+    pub(crate) request: Option<String>,
 }
 
 impl ToolchainFindSettings {
     /// Resolve the [`ToolchainFindSettings`] from the CLI and workspace configuration.
     #[allow(clippy::needless_pass_by_value)]
-    pub(crate) fn resolve(args: ToolchainFindArgs, _workspace: Option<Workspace>) -> Self {
-        let ToolchainFindArgs {
-            version,
-            implementation,
-        } = args;
+    pub(crate) fn resolve(args: ToolchainFindArgs, _filesystem: Option<FilesystemOptions>) -> Self {
+        let ToolchainFindArgs { request } = args;
 
-        Self {
-            version,
-            implementation,
-        }
+        Self { request }
     }
 }
 

--- a/crates/uv/tests/toolchain_find.rs
+++ b/crates/uv/tests/toolchain_find.rs
@@ -56,7 +56,6 @@ fn toolchain_find() {
 
     // Request Python 3.12
     uv_snapshot!(filters, context.toolchain_find()
-        .arg("--version")
         .arg("3.12")
         .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
     success: true
@@ -69,7 +68,6 @@ fn toolchain_find() {
 
     // Request Python 3.11
     uv_snapshot!(filters, context.toolchain_find()
-        .arg("--version")
         .arg("3.11")
         .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
     success: true
@@ -82,7 +80,6 @@ fn toolchain_find() {
 
     // Request CPython
     uv_snapshot!(filters, context.toolchain_find()
-        .arg("--implementation")
         .arg("cpython")
         .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
     success: true
@@ -95,10 +92,7 @@ fn toolchain_find() {
 
     // Request CPython 3.12
     uv_snapshot!(filters, context.toolchain_find()
-        .arg("--implementation")
-        .arg("cpython")
-        .arg("--version")
-        .arg("3.12")
+        .arg("cpython@3.12")
         .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
     success: true
     exit_code: 0
@@ -110,7 +104,6 @@ fn toolchain_find() {
 
     // Request PyPy
     uv_snapshot!(filters, context.toolchain_find()
-        .arg("--implementation")
         .arg("pypy")
         .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
     success: false
@@ -137,7 +130,6 @@ fn toolchain_find() {
 
     // Request Python 3.11
     uv_snapshot!(filters, context.toolchain_find()
-        .arg("--version")
         .arg("3.11")
         .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
     success: true
@@ -146,35 +138,5 @@ fn toolchain_find() {
     [PYTHON-PATH-3.11]
 
     ----- stderr -----
-    "###);
-}
-
-#[test]
-fn toolchain_find_invalid_implementation() {
-    let context = TestContext::new("3.12");
-
-    // No interpreters on the path
-    uv_snapshot!(context.filters(), context.toolchain_find().arg("--implementation").arg("foobar"), @r###"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: Unknown Python implementation `foobar`
-    "###);
-}
-
-#[test]
-fn toolchain_find_invalid_version() {
-    let context = TestContext::new("3.12");
-
-    // No interpreters on the path
-    uv_snapshot!(context.filters(), context.toolchain_find().arg("--version").arg("foobar"), @r###"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: Invalid version request: foobar
     "###);
 }

--- a/crates/uv/tests/toolchain_find.rs
+++ b/crates/uv/tests/toolchain_find.rs
@@ -1,0 +1,180 @@
+#![cfg(all(feature = "python", feature = "pypi"))]
+
+use common::{python_path_with_versions, uv_snapshot, TestContext};
+
+mod common;
+
+#[test]
+fn toolchain_find() {
+    let context: TestContext = TestContext::new("3.12");
+
+    // No interpreters on the path
+    uv_snapshot!(context.filters(), context.toolchain_find(), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No Python interpreters found in provided path, active virtual environment, or search path
+    "###);
+
+    let python_path = python_path_with_versions(&context.temp_dir, &["3.11", "3.12"])
+        .expect("Failed to create Python test path");
+
+    // Create some filters for the test interpreters, otherwise they'll be a path on the dev's machine
+    // TODO(zanieb): Standardize this when writing more tests
+    let python_path_filters = std::env::split_paths(&python_path)
+        .zip(["3.11", "3.12"])
+        .flat_map(|(path, version)| {
+            TestContext::path_patterns(path)
+                .into_iter()
+                .map(move |pattern| {
+                    (
+                        format!("{pattern}python.*"),
+                        format!("[PYTHON-PATH-{version}]"),
+                    )
+                })
+        })
+        .collect::<Vec<_>>();
+
+    let filters = python_path_filters
+        .iter()
+        .map(|(pattern, replacement)| (pattern.as_str(), replacement.as_str()))
+        .chain(context.filters())
+        .collect::<Vec<_>>();
+
+    // We find the first interpreter on the path
+    uv_snapshot!(filters, context.toolchain_find()
+        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [PYTHON-PATH-3.11]
+
+    ----- stderr -----
+    "###);
+
+    // Request Python 3.12
+    uv_snapshot!(filters, context.toolchain_find()
+        .arg("--version")
+        .arg("3.12")
+        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [PYTHON-PATH-3.12]
+
+    ----- stderr -----
+    "###);
+
+    // Request Python 3.11
+    uv_snapshot!(filters, context.toolchain_find()
+        .arg("--version")
+        .arg("3.11")
+        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [PYTHON-PATH-3.11]
+
+    ----- stderr -----
+    "###);
+
+    // Request CPython
+    uv_snapshot!(filters, context.toolchain_find()
+        .arg("--implementation")
+        .arg("cpython")
+        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [PYTHON-PATH-3.11]
+
+    ----- stderr -----
+    "###);
+
+    // Request CPython 3.12
+    uv_snapshot!(filters, context.toolchain_find()
+        .arg("--implementation")
+        .arg("cpython")
+        .arg("--version")
+        .arg("3.12")
+        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [PYTHON-PATH-3.12]
+
+    ----- stderr -----
+    "###);
+
+    // Request PyPy
+    uv_snapshot!(filters, context.toolchain_find()
+        .arg("--implementation")
+        .arg("pypy")
+        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: No interpreter found for PyPy in provided path, active virtual environment, or search path
+    "###);
+
+    // Swap the order (but don't change the filters to preserve our indices)
+    let python_path = python_path_with_versions(&context.temp_dir, &["3.12", "3.11"])
+        .expect("Failed to create Python test path");
+
+    uv_snapshot!(filters, context.toolchain_find()
+        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [PYTHON-PATH-3.12]
+
+    ----- stderr -----
+    "###);
+
+    // Request Python 3.11
+    uv_snapshot!(filters, context.toolchain_find()
+        .arg("--version")
+        .arg("3.11")
+        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [PYTHON-PATH-3.11]
+
+    ----- stderr -----
+    "###);
+}
+
+#[test]
+fn toolchain_find_invalid_implementation() {
+    let context = TestContext::new("3.12");
+
+    // No interpreters on the path
+    uv_snapshot!(context.filters(), context.toolchain_find().arg("--implementation").arg("foobar"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Unknown Python implementation `foobar`
+    "###);
+}
+
+#[test]
+fn toolchain_find_invalid_version() {
+    let context = TestContext::new("3.12");
+
+    // No interpreters on the path
+    uv_snapshot!(context.filters(), context.toolchain_find().arg("--version").arg("foobar"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Invalid version request: foobar
+    "###);
+}


### PR DESCRIPTION
Adds a command to find a toolchain on the system. Right now, it displays the path to the first matching toolchain. We'll probably have more rich output in the future (after implementing `toolchain show`).

The eventual plan (separate from here) is to port all of the toolchain discovery tests to use this command. I'll add a few tests for this command here anyway.