### PR TITLE
Allow version specifiers to be used in Python version requests

### DIFF
--- a/crates/uv-toolchain/src/discovery.rs
+++ b/crates/uv-toolchain/src/discovery.rs
@@ -1504,7 +1504,7 @@ mod tests {
             ToolchainRequest::Version(VersionRequest::from_str(">=3.12").unwrap())
         );
         assert_eq!(
-            ToolchainRequest::parse(">=3.12"),
+            ToolchainRequest::parse(">=3.12,<3.13"),
             ToolchainRequest::Version(VersionRequest::from_str(">=3.12,<3.13").unwrap())
         );
         assert_eq!(

--- a/crates/uv-toolchain/src/downloads.rs
+++ b/crates/uv-toolchain/src/downloads.rs
@@ -1,6 +1,5 @@
 use std::fmt::Display;
 use std::io;
-use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -26,7 +25,7 @@ pub enum Error {
     #[error(transparent)]
     ImplementationError(#[from] ImplementationError),
     #[error("Invalid python version: {0}")]
-    InvalidPythonVersion(ParseIntError),
+    InvalidPythonVersion(String),
     #[error("Download failed")]
     NetworkError(#[from] BetterReqwestError),
     #[error("Download failed")]
@@ -215,7 +214,7 @@ impl PythonDownloadRequest {
 impl Display for PythonDownloadRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut parts = Vec::new();
-        if let Some(version) = self.version {
+        if let Some(version) = &self.version {
             parts.push(version.to_string());
         }
         if let Some(implementation) = self.implementation {
@@ -239,7 +238,8 @@ impl FromStr for PythonDownloadRequest {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // TODO(zanieb): Implement parsing of additional request parts
-        let version = VersionRequest::from_str(s).map_err(Error::InvalidPythonVersion)?;
+        let version =
+            VersionRequest::from_str(s).map_err(|_| Error::InvalidPythonVersion(s.to_string()))?;
         Ok(Self::new(Some(version), None, None, None, None))
     }
 }

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -234,6 +234,7 @@ impl TestContext {
             .arg("--cache-dir")
             .arg(self.cache_dir.path())
             .env("VIRTUAL_ENV", self.venv.as_os_str())
+            .env("UV_TEST_PYTHON_PATH", "/dev/null")
             .env("UV_NO_WRAP", "1")
             .env("UV_TEST_PYTHON_PATH", "/dev/null")
             .current_dir(&self.temp_dir);
@@ -250,7 +251,10 @@ impl TestContext {
     /// Create a `uv lock` command with options shared across scenarios.
     pub fn lock(&self) -> std::process::Command {
         let mut command = self.lock_without_exclude_newer();
-        command.arg("--exclude-newer").arg(EXCLUDE_NEWER);
+        command
+            .arg("--exclude-newer")
+            .arg(EXCLUDE_NEWER)
+            .env("UV_TEST_PYTHON_PATH", "/dev/null");
         command
     }
 

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -2065,29 +2065,27 @@ fn lock_requires_python() -> Result<()> {
     });
 
     // Validate that attempting to install with an unsupported Python version raises an error.
-    let context = TestContext::new("3.8");
+    let context38 = TestContext::new("3.8");
 
-    fs_err::copy(pyproject_toml, context.temp_dir.join("pyproject.toml"))?;
-    fs_err::copy(&lockfile, context.temp_dir.join("uv.lock"))?;
+    fs_err::copy(pyproject_toml, context38.temp_dir.join("pyproject.toml"))?;
+    fs_err::copy(&lockfile, context38.temp_dir.join("uv.lock"))?;
+
+    let filters: Vec<_> = context38
+        .filters()
+        .into_iter()
+        .chain(context.filters())
+        .collect();
 
     // Install from the lockfile.
-    uv_snapshot!(context.filters(), context.sync(), @r###"
-    success: true
-    exit_code: 0
+    uv_snapshot!(filters, context38.sync(), @r###"
+    success: false
+    exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
     Removing virtual environment at: [VENV]/
-    Using Python 3.12.3 interpreter at: /opt/homebrew/opt/python@3.12/bin/python3.12
-    Creating virtualenv at: [VENV]/
-    Downloaded 5 packages in [TIME]
-    Installed 5 packages in [TIME]
-     + attrs==23.2.0
-     + cattrs==23.2.3
-     + lsprotocol==2023.0.1
-     + project==0.1.0 (from file://private/var/folders/6p/k5sd5z7j31b31pq4lhn0l8d80000gn/T/.tmp2LoTc2)
-     + pygls==1.3.0
+    error: No interpreter found for Python >=3.12 in provided path, active virtual environment, or search path
     "###);
 
     Ok(())

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -2072,14 +2072,22 @@ fn lock_requires_python() -> Result<()> {
 
     // Install from the lockfile.
     uv_snapshot!(context.filters(), context.sync(), @r###"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
     Removing virtual environment at: [VENV]/
-    error: Requested Python executable `>=3.12` not found in PATH
+    Using Python 3.12.3 interpreter at: /opt/homebrew/opt/python@3.12/bin/python3.12
+    Creating virtualenv at: [VENV]/
+    Downloaded 5 packages in [TIME]
+    Installed 5 packages in [TIME]
+     + attrs==23.2.0
+     + cattrs==23.2.3
+     + lsprotocol==2023.0.1
+     + project==0.1.0 (from file://private/var/folders/6p/k5sd5z7j31b31pq4lhn0l8d80000gn/T/.tmp2LoTc2)
+     + pygls==1.3.0
     "###);
 
     Ok(())


### PR DESCRIPTION
In service of https://github.com/astral-sh/uv/issues/4212 but this is user-facing e.g. Python discovery will support version specifiers everywhere now.

Closes https://github.com/astral-sh/uv/issues/4212 