### PR TITLE
Add path of the virtual environment interpreter to standard test filters

### DIFF
--- a/crates/uv-toolchain/src/lib.rs
+++ b/crates/uv-toolchain/src/lib.rs
@@ -12,7 +12,9 @@ pub use crate::prefix::Prefix;
 pub use crate::python_version::PythonVersion;
 pub use crate::target::Target;
 pub use crate::toolchain::Toolchain;
-pub use crate::virtualenv::{Error as VirtualEnvError, PyVenvConfiguration, VirtualEnvironment};
+pub use crate::virtualenv::{
+    virtualenv_python_executable, Error as VirtualEnvError, PyVenvConfiguration, VirtualEnvironment,
+};
 
 mod discovery;
 pub mod downloads;

--- a/crates/uv-toolchain/src/virtualenv.rs
+++ b/crates/uv-toolchain/src/virtualenv.rs
@@ -90,7 +90,7 @@ pub(crate) fn virtualenv_from_working_dir() -> Result<Option<PathBuf>, Error> {
 }
 
 /// Returns the path to the `python` executable inside a virtual environment.
-pub(crate) fn virtualenv_python_executable(venv: impl AsRef<Path>) -> PathBuf {
+pub fn virtualenv_python_executable(venv: impl AsRef<Path>) -> PathBuf {
     let venv = venv.as_ref();
     if cfg!(windows) {
         // Search for `python.exe` in the `Scripts` directory.


### PR DESCRIPTION
I'm not sure if this is needed. Posting so I can hunt down the commit later. Cherry-picked from https://github.com/astral-sh/uv/pull/4214