### PR TITLE
Replace `toolchain fetch` with `toolchain install`

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -2014,7 +2014,7 @@ pub(crate) struct ToolchainListArgs {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct ToolchainInstallArgs {
-    /// The toolchain to fetch.
+    /// The toolchain to install.
     ///
     /// If not provided, the latest available version will be installed.
     pub(crate) target: Option<String>,

--- a/crates/uv/src/commands/toolchain/install.rs
+++ b/crates/uv/src/commands/toolchain/install.rs
@@ -23,7 +23,7 @@ pub(crate) async fn install(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user!("`uv toolchain fetch` is experimental and may change without warning.");
+        warn_user!("`uv toolchain install` is experimental and may change without warning.");
     }
 
     let toolchains = InstalledToolchains::from_settings()?.init()?;

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -266,7 +266,7 @@ impl ToolchainListSettings {
     }
 }
 
-/// The resolved settings to use for a `toolchain fetch` invocation.
+/// The resolved settings to use for a `toolchain install` invocation.
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct ToolchainInstallSettings {


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Something that looks like it was forgotten to replace in #4164.

## Test Plan

<!-- How was it tested? -->

Run `cargo run toolchain install` should display the warning: ``warning: `uv toolchain install` is experimental and may change without warning.``