### PR TITLE
Allow direct URLs for dev dependencies

### DIFF
--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -437,6 +437,7 @@ pub(crate) async fn pip_compile(
                 &requirements,
                 &constraints,
                 &overrides,
+                &dev,
                 &hasher,
                 &top_level_index,
                 DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads, preview),

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -197,6 +197,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 &requirements,
                 &constraints,
                 &overrides,
+                &dev,
                 hasher,
                 index,
                 DistributionDatabase::new(client, build_dispatch, concurrency.downloads, preview),

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -2443,7 +2443,7 @@ fn lock_dev() -> Result<()> {
         dependencies = ["iniconfig"]
 
         [tool.uv]
-        dev-dependencies = ["typing-extensions"]
+        dev-dependencies = ["typing-extensions @ https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"]
         "#,
     )?;
 
@@ -2489,15 +2489,14 @@ fn lock_dev() -> Result<()> {
 
         [[distribution.dev-dependencies.dev]]
         name = "typing-extensions"
-        version = "4.10.0"
-        source = "registry+https://pypi.org/simple"
+        version = "4.12.2"
+        source = "direct+https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"
 
         [[distribution]]
         name = "typing-extensions"
-        version = "4.10.0"
-        source = "registry+https://pypi.org/simple"
-        sdist = { url = "https://files.pythonhosted.org/packages/16/3a/0d26ce356c7465a19c9ea8814b960f8a36c3b0d07c323176620b7b483e44/typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb", size = 77558 }
-        wheels = [{ url = "https://files.pythonhosted.org/packages/f9/de/dc04a3ea60b22624b51c703a84bbe0184abcd1d0b9bc8074b5d6b7ab90bb/typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475", size = 33926 }]
+        version = "4.12.2"
+        source = "direct+https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"
+        wheels = [{ url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d" }]
         "###
         );
     });
@@ -2524,9 +2523,8 @@ fn lock_dev() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 1 package in [TIME]
     Installed 1 package in [TIME]
-     + typing-extensions==4.10.0
+     + typing-extensions==4.12.2 (from https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl)
     "###);
 
     Ok(())


### PR DESCRIPTION
## Summary

Ensures that they're included in the lookahead resolver.

Closes https://github.com/astral-sh/uv/issues/4230.
