### PR TITLE
Support unnamed requirements in `uv add`

### DIFF
--- a/crates/pypi-types/src/requirement.rs
+++ b/crates/pypi-types/src/requirement.rs
@@ -43,6 +43,27 @@ impl Requirement {
     }
 }
 
+impl From<Requirement> for pep508_rs::Requirement<VerbatimUrl> {
+    /// Convert a [`Requirement`] to a [`pep508_rs::Requirement`].
+    fn from(requirement: Requirement) -> Self {
+        pep508_rs::Requirement {
+            name: requirement.name,
+            extras: requirement.extras,
+            marker: requirement.marker,
+            origin: requirement.origin,
+            version_or_url: match requirement.source {
+                RequirementSource::Registry { specifier, .. } => {
+                    Some(VersionOrUrl::VersionSpecifier(specifier))
+                }
+                RequirementSource::Url { url, .. }
+                | RequirementSource::Git { url, .. }
+                | RequirementSource::Path { url, .. }
+                | RequirementSource::Directory { url, .. } => Some(VersionOrUrl::Url(url)),
+            },
+        }
+    }
+}
+
 impl From<pep508_rs::Requirement<VerbatimParsedUrl>> for Requirement {
     /// Convert a [`pep508_rs::Requirement`] to a [`Requirement`].
     fn from(requirement: pep508_rs::Requirement<VerbatimParsedUrl>) -> Self {

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1602,6 +1602,15 @@ pub(crate) struct AddArgs {
     #[arg(required = true)]
     pub(crate) requirements: Vec<String>,
 
+    #[command(flatten)]
+    pub(crate) resolver: ResolverArgs,
+
+    #[command(flatten)]
+    pub(crate) build: BuildArgs,
+
+    #[command(flatten)]
+    pub(crate) refresh: RefreshArgs,
+
     /// The Python interpreter into which packages should be installed.
     ///
     /// By default, `uv` installs into the virtual environment in the current working directory or

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -683,11 +683,18 @@ async fn run() -> Result<ExitStatus> {
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache.init()?;
+            let cache = cache.init()?.with_refresh(args.refresh);
+
+            let requirements = args
+                .requirements
+                .into_iter()
+                .map(RequirementsSource::Package)
+                .collect::<Vec<_>>();
 
             commands::add(
-                args.requirements,
+                requirements,
                 args.python,
+                args.settings,
                 globals.preview,
                 globals.connectivity,
                 Concurrency::default(),

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -347,20 +347,27 @@ impl LockSettings {
 pub(crate) struct AddSettings {
     pub(crate) requirements: Vec<String>,
     pub(crate) python: Option<String>,
+    pub(crate) refresh: Refresh,
+    pub(crate) settings: ResolverSettings,
 }
 
 impl AddSettings {
     /// Resolve the [`AddSettings`] from the CLI and filesystem configuration.
     #[allow(clippy::needless_pass_by_value)]
-    pub(crate) fn resolve(args: AddArgs, _filesystem: Option<FilesystemOptions>) -> Self {
+    pub(crate) fn resolve(args: AddArgs, filesystem: Option<FilesystemOptions>) -> Self {
         let AddArgs {
             requirements,
+            resolver,
+            build,
+            refresh,
             python,
         } = args;
 
         Self {
             requirements,
             python,
+            refresh: Refresh::from(refresh),
+            settings: ResolverSettings::combine(resolver_options(resolver, build), filesystem),
         }
     }
 }


### PR DESCRIPTION
## Summary

Support unnamed URL requirements in `uv add`. For example, `uv add git+https://github.com/pallets/flask`.

Part of https://github.com/astral-sh/uv/issues/3959.