### PR TITLE
Improve output when an older toolchain version is already installed

### DIFF
--- a/crates/uv/src/commands/toolchain/install.rs
+++ b/crates/uv/src/commands/toolchain/install.rs
@@ -45,7 +45,6 @@ pub(crate) async fn install(
         }
         request
     } else {
-        writeln!(printer.stderr(), "Using latest Python version")?;
         ToolchainRequest::default()
     };
 
@@ -58,11 +57,19 @@ pub(crate) async fn install(
             "Found installed toolchain '{}'",
             toolchain.key()
         )?;
-        writeln!(
-            printer.stderr(),
-            "Already installed at {}",
-            toolchain.path().user_display()
-        )?;
+
+        if matches!(request, ToolchainRequest::Any) {
+            writeln!(
+                printer.stderr(),
+                "A toolchain is already installed. Use `uv toolchain install <request>` to install a specific toolchain.",
+            )?;
+        } else {
+            writeln!(
+                printer.stderr(),
+                "Already installed at {}",
+                toolchain.path().user_display()
+            )?;
+        }
         return Ok(ExitStatus::Success);
     }
 


### PR DESCRIPTION
e.g.

```
❯ uv toolchain install
Found installed toolchain 'cpython-3.9.19-macos-aarch64-none'
A toolchain is already installed. Use `uv toolchain install <request>` to install a specific toolchain
```

instead of

```
❯ uv toolchain install
Using latest Python version
Found installed toolchain 'cpython-3.9.19-macos-aarch64-none'
Already installed at /Users/zb/Library/Application Support/uv/toolchains/cpython-3.9.19-macos-aarch64-none
```