### PR TITLE
Add changelog for preview changes

### DIFF
--- a/CHANGELOG-PREVIEW.md
+++ b/CHANGELOG-PREVIEW.md
@@ -1,0 +1,157 @@
+# Changelog
+
+## 0.2.10
+
+### Preview features
+
+- Add `uv toolchain install` ([#4164](https://github.com/astral-sh/uv/pull/4164))
+- Add `uv toolchain list` ([#4163](https://github.com/astral-sh/uv/pull/4163))
+- Add extra and dev dependency validation to lockfile ([#4112](https://github.com/astral-sh/uv/pull/4112))
+- Add markers to edges rather than distributions ([#4166](https://github.com/astral-sh/uv/pull/4166))
+- Cap `Requires-Python` comparisons at the patch version ([#4150](https://github.com/astral-sh/uv/pull/4150))
+- Do not create a virtual environment when locking ([#4147](https://github.com/astral-sh/uv/pull/4147))
+- Don't panic with invalid wheel source ([#4191](https://github.com/astral-sh/uv/pull/4191))
+- Fetch managed toolchains in `uv run` ([#4143](https://github.com/astral-sh/uv/pull/4143))
+- Fix PEP 508 link in preview doc `specifying_dependencies` ([#4158](https://github.com/astral-sh/uv/pull/4158))
+- Ignore tags in universal resolution ([#4174](https://github.com/astral-sh/uv/pull/4174))
+- Implement `Toolchain::find_or_fetch` and use in `uv venv --preview` ([#4138](https://github.com/astral-sh/uv/pull/4138))
+- Lock all packages in workspace ([#4016](https://github.com/astral-sh/uv/pull/4016))
+- Recreate project environment if `--python` or `requires-python` doesn't match ([#3945](https://github.com/astral-sh/uv/pull/3945))
+- Respect `--find-links` in `lock` and `sync` ([#4183](https://github.com/astral-sh/uv/pull/4183))
+- Set `--dev` to default for `uv run` and `uv sync` ([#4118](https://github.com/astral-sh/uv/pull/4118))
+- Track `Markers` via a PubGrub package variant ([#4123](https://github.com/astral-sh/uv/pull/4123))
+- Use union of `requires-python` in workspace ([#4041](https://github.com/astral-sh/uv/pull/4041))
+- make universal resolver fork only when markers are disjoint ([#4135](https://github.com/astral-sh/uv/pull/4135))
+
+## 0.2.9
+
+### Preview features
+
+- Add support for development dependencies ([#4036](https://github.com/astral-sh/uv/pull/4036))
+- Avoid enforcing distribution ID uniqueness for extras ([#4104](https://github.com/astral-sh/uv/pull/4104))
+- Ignore upper-bounds on `Requires-Python` ([#4086](https://github.com/astral-sh/uv/pull/4086))
+
+## 0.2.8
+
+### Preview features
+
+- Default to current Python minor if `Requires-Python` is absent ([#4070](https://github.com/astral-sh/uv/pull/4070))
+- Enforce `Requires-Python` when syncing ([#4068](https://github.com/astral-sh/uv/pull/4068))
+- Track supported Python range in lockfile ([#4065](https://github.com/astral-sh/uv/pull/4065))
+
+## 0.2.7
+
+### Preview features
+
+- Fix a bug where no warning is output when parsing of workspace settings fails. ([#4014](https://github.com/astral-sh/uv/pull/4014))
+- Normalize extras in lockfile ([#3958](https://github.com/astral-sh/uv/pull/3958))
+- Respect `Requires-Python` in universal resolution ([#3998](https://github.com/astral-sh/uv/pull/3998))
+
+## 0.2.6
+
+### Preview features
+
+- Add `uv run --package` ([#3864](https://github.com/astral-sh/uv/pull/3864))
+- Add index URL parameters to Project CLI ([#3984](https://github.com/astral-sh/uv/pull/3984))
+- Avoid re-adding solutions to forked state ([#3967](https://github.com/astral-sh/uv/pull/3967))
+- Draft for user docs for workspaces ([#3866](https://github.com/astral-sh/uv/pull/3866))
+- Include all extras when generating lockfile ([#3912](https://github.com/astral-sh/uv/pull/3912))
+- Remove unstable uv lock from pip interface ([#3970](https://github.com/astral-sh/uv/pull/3970))
+- Respect resolved Git SHAs in `uv lock` ([#3956](https://github.com/astral-sh/uv/pull/3956))
+- Use lockfile in `uv run` ([#3894](https://github.com/astral-sh/uv/pull/3894))
+- Use lockfile versions as resolution preferences ([#3921](https://github.com/astral-sh/uv/pull/3921))
+- Use universal resolution in `uv lock` ([#3969](https://github.com/astral-sh/uv/pull/3969))
+
+## 0.2.5
+
+### Preview features
+
+- Add context to failed `uv tool run` ([#3882](https://github.com/astral-sh/uv/pull/3882))
+- Add persistent storage of installed toolchains ([#3797](https://github.com/astral-sh/uv/pull/3797))
+- Gate discovery of managed toolchains with preview ([#3835](https://github.com/astral-sh/uv/pull/3835))
+- Initial workspace support ([#3705](https://github.com/astral-sh/uv/pull/3705))
+- Move editable discovery behind `--preview` for now ([#3884](https://github.com/astral-sh/uv/pull/3884))
+
+## 0.2.4
+
+<!-- No changes -->
+
+## 0.2.3
+
+### Preview features
+
+- Allow specification of additional requirements in `uv tool run` ([#3678](https://github.com/astral-sh/uv/pull/3678))
+
+## 0.2.2
+
+<!-- No changes -->
+
+## 0.2.1
+
+### Preview features
+
+- Allow users to specify a custom source package to `uv tool run` ([#3677](https://github.com/astral-sh/uv/pull/3677))
+
+## 0.2.0
+
+### Preview features
+
+- Add initial implementation of `uv tool run` ([#3657](https://github.com/astral-sh/uv/pull/3657))
+- Add offline support to `uv tool run` and `uv run` ([#3676](https://github.com/astral-sh/uv/pull/3676))
+- Better error message for `uv run` failures ([#3691](https://github.com/astral-sh/uv/pull/3691))
+- Discover workspaces without using them in resolution ([#3585](https://github.com/astral-sh/uv/pull/3585))
+- Support editables in `uv sync` ([#3692](https://github.com/astral-sh/uv/pull/3692))
+- Track editable requirements in lockfile ([#3725](https://github.com/astral-sh/uv/pull/3725))
+
+## 0.1.45
+
+### Preview features
+
+- Add direct URL conversion to lockfile ([#3633](https://github.com/astral-sh/uv/pull/3633))
+- Add hashes and versions to all distributions ([#3589](https://github.com/astral-sh/uv/pull/3589))
+- Add local path conversions from lockfile ([#3609](https://github.com/astral-sh/uv/pull/3609))
+- Add missing `"directory"` branch in source match ([#3608](https://github.com/astral-sh/uv/pull/3608))
+- Add registry file size to lockfile ([#3652](https://github.com/astral-sh/uv/pull/3652))
+- Add registry source distribution support to lockfile ([#3649](https://github.com/astral-sh/uv/pull/3649))
+- Refactor editables for supporting them in bluejay commands ([#3639](https://github.com/astral-sh/uv/pull/3639))
+- Rename `sourcedist` to `sdist` in lockfile ([#3590](https://github.com/astral-sh/uv/pull/3590))
+- Respect installed packages in `uv run` ([#3603](https://github.com/astral-sh/uv/pull/3603))
+- Support lossless serialization for Git dependencies in lockfile ([#3630](https://github.com/astral-sh/uv/pull/3630))
+
+## 0.1.44
+
+<!-- No changes -->
+
+## 0.1.43
+
+### Preview features
+
+- Create virtualenv if it doesn't exist in project API ([#3499](https://github.com/astral-sh/uv/pull/3499))
+- Discover `uv run` projects hierarchically ([#3494](https://github.com/astral-sh/uv/pull/3494))
+- Read and write `uv.lock` based on project root ([#3497](https://github.com/astral-sh/uv/pull/3497))
+- Read package name from `pyproject.toml` in `uv run` ([#3496](https://github.com/astral-sh/uv/pull/3496))
+- Rebrand workspace API as project API ([#3489](https://github.com/astral-sh/uv/pull/3489))
+
+## 0.1.42
+
+### Preview features
+
+- Use environment layering for `uv run --with` ([#3447](https://github.com/astral-sh/uv/pull/3447))
+- Warn when missing minimal bounds when using `tool.uv.sources` ([#3452](https://github.com/astral-sh/uv/pull/3452))
+
+## 0.1.41
+
+<!-- No changes -->
+
+## 0.1.40
+
+### Preview features
+
+- Add basic `tool.uv.sources` support ([#3263](https://github.com/astral-sh/uv/pull/3263))
+- Improve non-git error message ([#3403](https://github.com/astral-sh/uv/pull/3403))
+- Preserve given for `tool.uv.sources` paths ([#3412](https://github.com/astral-sh/uv/pull/3412))
+- Restore verbatim in error message ([#3402](https://github.com/astral-sh/uv/pull/3402))
+- Use preview mode for tool.uv.sources ([#3277](https://github.com/astral-sh/uv/pull/3277))
+- Use top-level `--isolated` for `uv run` ([#3431](https://github.com/astral-sh/uv/pull/3431))
+- add basic "install from lock file" operation ([#3340](https://github.com/astral-sh/uv/pull/3340))
+- uv-resolver: add initial version of universal lock file format ([#3314](https://github.com/astral-sh/uv/pull/3314))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,11 @@ include = [{ path = "rust-toolchain.toml", format = ["sdist", "wheel"] }, { path
 [tool.rooster]
 major_labels = []  # We do not use the major version number yet
 minor_labels = ["breaking"]
-changelog_ignore_labels = ["internal", "ci", "testing", "preview"]
+changelog_ignore_labels = ["internal", "ci", "testing"]
 changelog_sections.breaking = "Breaking changes"
 changelog_sections.enhancement = "Enhancements"
 changelog_sections.compatibility = "Enhancements"
+changelog_sections.preview = "Preview features"
 changelog_sections.cli = "CLI"
 changelog_sections.configuration = "Configuration"
 changelog_sections.performance = "Performance"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,7 +9,17 @@ project_root="$(dirname "$script_root")"
 
 echo "Updating metadata with rooster..."
 cd "$project_root"
-uv tool run --from rooster-blue --isolated -- rooster release "$@"
+
+# Update the preview changelog
+uv tool run --from 'rooster-blue>=0.0.7' --isolated -- \
+    rooster release "$@" \
+    --only-sections preview \
+    --changelog-file CHANGELOG-PREVIEW.md \
+    --no-update-pyproject --no-update-version-files
+
+# Update the real changelog
+uv tool run --from 'rooster-blue>=0.0.7' --isolated -- \
+    rooster release "$@" --without-sections preview
 
 echo "Updating lockfile..."
 cargo update -p uv


### PR DESCRIPTION
I tweaked rooster to allow sections to be overridden from the CLI so we can generate a separate preview changelog

See https://github.com/zanieb/rooster/pull/43 for the rooster changes needed

I tested `./scripts/release.sh` as well.