### PR TITLE
Represent build tag as `u64`

### DIFF
--- a/crates/distribution-filename/src/build_tag.rs
+++ b/crates/distribution-filename/src/build_tag.rs
@@ -34,7 +34,7 @@ pub enum BuildTagError {
 )]
 #[archive(check_bytes)]
 #[archive_attr(derive(Debug))]
-pub struct BuildTag(u32, Option<Arc<str>>);
+pub struct BuildTag(u64, Option<Arc<str>>);
 
 impl FromStr for BuildTag {
     type Err = BuildTagError;
@@ -58,6 +58,6 @@ impl FromStr for BuildTag {
             None => (s, None),
         };
 
-        Ok(BuildTag(prefix.parse::<u32>()?, suffix.map(Arc::from)))
+        Ok(BuildTag(prefix.parse::<u64>()?, suffix.map(Arc::from)))
     }
 }

--- a/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_build_tag.snap
+++ b/crates/distribution-filename/src/snapshots/distribution_filename__wheel__tests__ok_build_tag.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/distribution-filename/src/wheel.rs
-expression: "WheelFilename::from_str(\"foo-1.2.3-12-python-abi-platform.whl\")"
+expression: "WheelFilename::from_str(\"foo-1.2.3-202206090410-python-abi-platform.whl\")"
 ---
 Ok(
     WheelFilename {
@@ -10,7 +10,7 @@ Ok(
         version: "1.2.3",
         build_tag: Some(
             BuildTag(
-                12,
+                202206090410,
                 None,
             ),
         ),

--- a/crates/distribution-filename/src/wheel.rs
+++ b/crates/distribution-filename/src/wheel.rs
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn ok_build_tag() {
         insta::assert_debug_snapshot!(WheelFilename::from_str(
-            "foo-1.2.3-12-python-abi-platform.whl"
+            "foo-1.2.3-202206090410-python-abi-platform.whl"
         ));
     }
 

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -644,7 +644,7 @@ impl CacheBucket {
             Self::FlatIndex => "flat-index-v0",
             Self::Git => "git-v0",
             Self::Interpreter => "interpreter-v2",
-            Self::Simple => "simple-v8",
+            Self::Simple => "simple-v9",
             Self::Wheels => "wheels-v1",
             Self::Archive => "archive-v0",
             Self::Environments => "environments-v0",


### PR DESCRIPTION
## Summary

The build tags in this case are like, e.g., `202206090410`. That's larger than a `u32`, so we're rejecting the wheel. In theory build tags could be even larger, but we already use `u64` for version segment so I think it's fine to keep that constraint here.

I'm going to look into surfacing these errors separately.

Closes https://github.com/astral-sh/uv/issues/4252.

## Test Plan

`cargo run pip install monailabel`
