### PR TITLE
Re-add `aarch64-unknown-linux-gnu` binary to release assets

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -276,6 +276,11 @@ jobs:
     strategy:
       matrix:
         platform:
+          - target: aarch64-unknown-linux-gnu
+            arch: aarch64
+            # see https://github.com/astral-sh/ruff/issues/3791
+            # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: armv7-unknown-linux-gnueabihf
             arch: armv7
           - target: arm-unknown-linux-musleabihf
@@ -294,6 +299,8 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
+          # On `aarch64`, use `manylinux: 2_28`; otherwise, use `manylinux: auto`.
+          manylinux: ${{ matrix.platform.arch == 'aarch64' && '2_28' || 'auto' }}
           docker-options: ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist --features self-update
       - uses: uraimo/run-on-arch-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,6 +214,7 @@ unix-archive = ".tar.gz"
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [
   "aarch64-apple-darwin",
+  "aarch64-unknown-linux-gnu",
   "aarch64-unknown-linux-musl",
   "arm-unknown-linux-musleabihf",
   "armv7-unknown-linux-gnueabihf",


### PR DESCRIPTION
This PR re-adds the `aarch64-unknown-linux-gnu` binary, which will also add the `manylinux_2_28` wheel for `aarch64` (in addition to the now dual-tagged `musllinux_1_1` and `manylinux_2_217` wheel for `aarch64`). We can consider dropping that _wheel_, but in my assessment removing a release asset should now be treated as a breaking change -- so removing it in a patch release was incorrect.

Closes https://github.com/astral-sh/uv/issues/4122.
