### PR TITLE
Move concurrency settings to top-level

### DIFF
--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -164,6 +164,39 @@ pub struct GlobalOptions {
         possible_values = true
     )]
     pub python_downloads: Option<PythonDownloads>,
+    /// The maximum number of in-flight concurrent downloads that uv will perform at any given
+    /// time.
+    #[option(
+        default = "50",
+        value_type = "int",
+        example = r#"
+            concurrent-downloads = 4
+        "#
+    )]
+    pub concurrent_downloads: Option<NonZeroUsize>,
+    /// The maximum number of source distributions that uv will build concurrently at any given
+    /// time.
+    ///
+    /// Defaults to the number of available CPU cores.
+    #[option(
+        default = "None",
+        value_type = "int",
+        example = r#"
+            concurrent-builds = 4
+        "#
+    )]
+    pub concurrent_builds: Option<NonZeroUsize>,
+    /// The number of threads used when installing and unzipping packages.
+    ///
+    /// Defaults to the number of available CPU cores.
+    #[option(
+        default = "None",
+        value_type = "int",
+        example = r#"
+            concurrent-installs = 4
+        "#
+    )]
+    pub concurrent_installs: Option<NonZeroUsize>,
 }
 
 /// Settings relevant to all installer operations.
@@ -1172,39 +1205,6 @@ pub struct PipOptions {
         "#
     )]
     pub reinstall_package: Option<Vec<PackageName>>,
-    /// The maximum number of in-flight concurrent downloads that uv will perform at any given
-    /// time.
-    #[option(
-        default = "50",
-        value_type = "int",
-        example = r#"
-            concurrent-downloads = 4
-        "#
-    )]
-    pub concurrent_downloads: Option<NonZeroUsize>,
-    /// The maximum number of source distributions that uv will build concurrently at any given
-    /// time.
-    ///
-    /// Defaults to the number of available CPU cores.
-    #[option(
-        default = "None",
-        value_type = "int",
-        example = r#"
-            concurrent-builds = 4
-        "#
-    )]
-    pub concurrent_builds: Option<NonZeroUsize>,
-    /// The number of threads used when installing and unzipping packages.
-    ///
-    /// Defaults to the number of available CPU cores.
-    #[option(
-        default = "None",
-        value_type = "int",
-        example = r#"
-            concurrent-installs = 4
-        "#
-    )]
-    pub concurrent_installs: Option<NonZeroUsize>,
 }
 
 impl From<ResolverInstallerOptions> for ResolverOptions {

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -55,6 +55,7 @@ pub(crate) async fn venv(
     seed: bool,
     allow_existing: bool,
     exclude_newer: Option<ExcludeNewer>,
+    concurrency: Concurrency,
     native_tls: bool,
     cache: &Cache,
     printer: Printer,
@@ -75,6 +76,7 @@ pub(crate) async fn venv(
         python_downloads,
         allow_existing,
         exclude_newer,
+        concurrency,
         native_tls,
         cache,
         printer,
@@ -126,6 +128,7 @@ async fn venv_impl(
     python_downloads: PythonDownloads,
     allow_existing: bool,
     exclude_newer: Option<ExcludeNewer>,
+    concurrency: Concurrency,
     native_tls: bool,
     cache: &Cache,
     printer: Printer,
@@ -268,9 +271,8 @@ async fn venv_impl(
         // Initialize any shared state.
         let state = SharedState::default();
 
-        // For seed packages, assume a bunch of default settings and concurrency are sufficient.
+        // For seed packages, assume a bunch of default settings are sufficient.
         let build_constraints = [];
-        let concurrency = Concurrency::default();
         let config_settings = ConfigSettings::default();
         let setup_py = SetupPyStrategy::default();
         let sources = SourceStrategy::Disabled;

--- a/crates/uv/tests/show_settings.rs
+++ b/crates/uv/tests/show_settings.rs
@@ -52,6 +52,11 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -163,11 +168,6 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -188,6 +188,11 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -299,11 +304,6 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -325,6 +325,11 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -436,11 +441,6 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -494,6 +494,11 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -605,11 +610,6 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -632,6 +632,11 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -720,11 +725,6 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -756,6 +756,11 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -867,11 +872,6 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -917,6 +917,11 @@ fn resolve_index_url() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -1051,11 +1056,6 @@ fn resolve_index_url() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -1078,6 +1078,11 @@ fn resolve_index_url() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -1234,11 +1239,6 @@ fn resolve_index_url() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -1284,6 +1284,11 @@ fn resolve_find_links() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -1395,11 +1400,6 @@ fn resolve_find_links() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -1444,6 +1444,11 @@ fn resolve_top_level() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -1532,11 +1537,6 @@ fn resolve_top_level() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -1574,6 +1574,11 @@ fn resolve_top_level() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -1707,11 +1712,6 @@ fn resolve_top_level() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -1732,6 +1732,11 @@ fn resolve_top_level() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -1865,11 +1870,6 @@ fn resolve_top_level() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -1914,6 +1914,11 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -2002,11 +2007,6 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -2034,6 +2034,11 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -2122,11 +2127,6 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -2154,6 +2154,11 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -2242,11 +2247,6 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -2276,6 +2276,11 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -2364,11 +2369,6 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -2417,6 +2417,11 @@ fn resolve_tool() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -2563,6 +2568,11 @@ fn resolve_poetry_toml() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -2651,11 +2661,6 @@ fn resolve_poetry_toml() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -2711,6 +2716,11 @@ fn resolve_both() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -2822,11 +2832,6 @@ fn resolve_both() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -2874,6 +2879,11 @@ fn resolve_config_file() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -2985,11 +2995,6 @@ fn resolve_config_file() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -3112,6 +3117,11 @@ fn resolve_skip_empty() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -3200,11 +3210,6 @@ fn resolve_skip_empty() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 
@@ -3235,6 +3240,11 @@ fn resolve_skip_empty() -> anyhow::Result<()> {
         verbose: 0,
         color: Auto,
         native_tls: false,
+        concurrency: Concurrency {
+            downloads: 50,
+            builds: 16,
+            installs: 8,
+        },
         connectivity: Online,
         show_settings: true,
         preview: Disabled,
@@ -3323,11 +3333,6 @@ fn resolve_skip_empty() -> anyhow::Result<()> {
             hash_checking: None,
             upgrade: None,
             reinstall: None,
-            concurrency: Concurrency {
-                downloads: 50,
-                builds: 16,
-                installs: 8,
-            },
         },
     }
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -61,6 +61,87 @@ ignore errors.
 
 ---
 
+#### [`concurrent-builds`](#concurrent-builds) {: #concurrent-builds }
+
+The maximum number of source distributions that uv will build concurrently at any given
+time.
+
+Defaults to the number of available CPU cores.
+
+**Default value**: `None`
+
+**Type**: `int`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.uv]
+    concurrent-builds = 4
+    ```
+=== "uv.toml"
+
+    ```toml
+    
+    concurrent-builds = 4
+    ```
+
+---
+
+#### [`concurrent-downloads`](#concurrent-downloads) {: #concurrent-downloads }
+
+The maximum number of in-flight concurrent downloads that uv will perform at any given
+time.
+
+**Default value**: `50`
+
+**Type**: `int`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.uv]
+    concurrent-downloads = 4
+    ```
+=== "uv.toml"
+
+    ```toml
+    
+    concurrent-downloads = 4
+    ```
+
+---
+
+#### [`concurrent-installs`](#concurrent-installs) {: #concurrent-installs }
+
+The number of threads used when installing and unzipping packages.
+
+Defaults to the number of available CPU cores.
+
+**Default value**: `None`
+
+**Type**: `int`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.uv]
+    concurrent-installs = 4
+    ```
+=== "uv.toml"
+
+    ```toml
+    
+    concurrent-installs = 4
+    ```
+
+---
+
 #### [`config-settings`](#config-settings) {: #config-settings }
 
 Settings to pass to the [PEP 517](https://peps.python.org/pep-0517/) build backend,
@@ -1044,90 +1125,6 @@ ignore errors.
     ```toml
     [pip]
     compile-bytecode = true
-    ```
-
----
-
-#### [`concurrent-builds`](#pip_concurrent-builds) {: #pip_concurrent-builds }
-<span id="concurrent-builds"></span>
-
-The maximum number of source distributions that uv will build concurrently at any given
-time.
-
-Defaults to the number of available CPU cores.
-
-**Default value**: `None`
-
-**Type**: `int`
-
-**Example usage**:
-
-=== "pyproject.toml"
-
-    ```toml
-    [tool.uv.pip]
-    concurrent-builds = 4
-    ```
-=== "uv.toml"
-
-    ```toml
-    [pip]
-    concurrent-builds = 4
-    ```
-
----
-
-#### [`concurrent-downloads`](#pip_concurrent-downloads) {: #pip_concurrent-downloads }
-<span id="concurrent-downloads"></span>
-
-The maximum number of in-flight concurrent downloads that uv will perform at any given
-time.
-
-**Default value**: `50`
-
-**Type**: `int`
-
-**Example usage**:
-
-=== "pyproject.toml"
-
-    ```toml
-    [tool.uv.pip]
-    concurrent-downloads = 4
-    ```
-=== "uv.toml"
-
-    ```toml
-    [pip]
-    concurrent-downloads = 4
-    ```
-
----
-
-#### [`concurrent-installs`](#pip_concurrent-installs) {: #pip_concurrent-installs }
-<span id="concurrent-installs"></span>
-
-The number of threads used when installing and unzipping packages.
-
-Defaults to the number of available CPU cores.
-
-**Default value**: `None`
-
-**Type**: `int`
-
-**Example usage**:
-
-=== "pyproject.toml"
-
-    ```toml
-    [tool.uv.pip]
-    concurrent-installs = 4
-    ```
-=== "uv.toml"
-
-    ```toml
-    [pip]
-    concurrent-installs = 4
     ```
 
 ---

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -18,6 +18,33 @@
         "null"
       ]
     },
+    "concurrent-builds": {
+      "description": "The maximum number of source distributions that uv will build concurrently at any given time.\n\nDefaults to the number of available CPU cores.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint",
+      "minimum": 1.0
+    },
+    "concurrent-downloads": {
+      "description": "The maximum number of in-flight concurrent downloads that uv will perform at any given time.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint",
+      "minimum": 1.0
+    },
+    "concurrent-installs": {
+      "description": "The number of threads used when installing and unzipping packages.\n\nDefaults to the number of available CPU cores.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint",
+      "minimum": 1.0
+    },
     "config-settings": {
       "description": "Settings to pass to the [PEP 517](https://peps.python.org/pep-0517/) build backend, specified as `KEY=VALUE` pairs.",
       "anyOf": [
@@ -549,33 +576,6 @@
             "boolean",
             "null"
           ]
-        },
-        "concurrent-builds": {
-          "description": "The maximum number of source distributions that uv will build concurrently at any given time.\n\nDefaults to the number of available CPU cores.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 1.0
-        },
-        "concurrent-downloads": {
-          "description": "The maximum number of in-flight concurrent downloads that uv will perform at any given time.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 1.0
-        },
-        "concurrent-installs": {
-          "description": "The number of threads used when installing and unzipping packages.\n\nDefaults to the number of available CPU cores.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 1.0
         },
         "config-settings": {
           "description": "Settings to pass to the [PEP 517](https://peps.python.org/pep-0517/) build backend, specified as `KEY=VALUE` pairs.",


### PR DESCRIPTION
## Summary

These are global and non-specific to the `pip` API, so I think they should be elevated.

## Test Plan

- Ran `UV_CONCURRENT_DOWNLOADS=1 cargo run pip list`; verified that `downloads` resolved to 1.
- Added `concurrent-downloads = 5` under `[tool.uv]` in `pyproject.toml`; ran `cargo run pip list`; verified that `downloads` resolved to 5.
- Ran `UV_CONCURRENT_DOWNLOADS=1 cargo run pip list`; verified that `downloads` resolved to 1.
