### PR TITLE
Add uv version to debug output

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use clap::error::{ContextKind, ContextValue};
 use clap::{CommandFactory, Parser};
 use owo_colors::OwoColorize;
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use cli::{ToolCommand, ToolNamespace, ToolchainCommand, ToolchainNamespace};
 use uv_cache::Cache;
@@ -171,6 +171,8 @@ async fn run() -> Result<ExitStatus> {
                 .build(),
         )
     }))?;
+
+    debug!("uv {}", version::version());
 
     // Resolve the cache settings.
     let cache = CacheSettings::resolve(cli.cache_args, workspace.as_ref());

--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -68,12 +68,19 @@ fn prune_no_op() -> Result<()> {
         .assert()
         .success();
 
-    uv_snapshot!(context.filters(), prune_command(&context).arg("--verbose"), @r###"
+    let filters: Vec<_> = context
+        .filters()
+        .into_iter()
+        .chain([(r"uv \d+\.\d+\.\d+ \(.*\)", r"uv [VERSION] ([COMMIT] DATE)")])
+        .collect();
+
+    uv_snapshot!(filters, prune_command(&context).arg("--verbose"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     No unused entries found
     "###);
@@ -99,12 +106,19 @@ fn prune_stale_directory() -> Result<()> {
     let simple = context.cache_dir.child("simple-v4");
     simple.create_dir_all()?;
 
-    uv_snapshot!(context.filters(), prune_command(&context).arg("--verbose"), @r###"
+    let filters: Vec<_> = context
+        .filters()
+        .into_iter()
+        .chain([(r"uv \d+\.\d+\.\d+ \(.*\)", r"uv [VERSION] ([COMMIT] DATE)")])
+        .collect();
+
+    uv_snapshot!(filters, prune_command(&context).arg("--verbose"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache entry: [CACHE_DIR]/simple-v4
     Removed 1 directory
@@ -135,6 +149,7 @@ fn prune_stale_symlink() -> Result<()> {
         .filters()
         .into_iter()
         .chain([
+            (r"uv \d+\.\d+\.\d+ \(.*\)", r"uv [VERSION] ([COMMIT] DATE)"),
             // The cache entry does not have a stable key, so we filter it out
             (
                 r"\[CACHE_DIR\](\\|\/)(.+)(\\|\/).*",
@@ -149,6 +164,7 @@ fn prune_stale_symlink() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache entry: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed 44 files ([SIZE])


### PR DESCRIPTION
## Summary

I think this is a useful piece of connective tissue that will let us avoid back-and-forths when folks include traces.

## Test Plan

```
❯ cargo run pip list --verbose
DEBUG uv 0.2.11 (44041bccd 2024-06-11)
DEBUG Searching for Python interpreter in virtual environments
DEBUG Found CPython 3.12.3 at `/Users/crmarsh/workspace/puffin/.venv/bin/python3` (virtual environment)
DEBUG Using Python 3.12.3 environment at .venv/bin/python3
```
