### PR TITLE
Flatten ORs and ANDs in marker construction

### DIFF
--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -1860,7 +1860,11 @@ impl MarkerTree {
             _ => {}
         }
         if let MarkerTree::And(ref mut exprs) = *self {
-            exprs.push(tree);
+            if let MarkerTree::And(tree) = tree {
+                exprs.extend(tree);
+            } else {
+                exprs.push(tree);
+            }
         }
     }
 
@@ -1878,7 +1882,11 @@ impl MarkerTree {
             _ => {}
         }
         if let MarkerTree::Or(ref mut exprs) = *self {
-            exprs.push(tree);
+            if let MarkerTree::Or(tree) = tree {
+                exprs.extend(tree);
+            } else {
+                exprs.push(tree);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

If we're ORing an OR, we should just append rather than nesting in another OR.

In my branch, this let us simplify:

```
python_version < '3.10' or python_version > '3.12' or (python_version < '3.8' or python_version > '3.12')
```

To:

```
python_version < '3.10' or python_version > '3.12
```
