### PR TITLE
Move project commands into their own subcommand struct

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -132,6 +132,9 @@ pub(crate) enum Commands {
     Tool(ToolNamespace),
     /// Manage Python installations.
     Toolchain(ToolchainNamespace),
+    /// Manage Python projects.
+    #[command(flatten)]
+    Project(ProjectCommand),
     /// Create a virtual environment.
     #[command(alias = "virtualenv", alias = "v")]
     Venv(VenvArgs),
@@ -144,21 +147,6 @@ pub(crate) enum Commands {
     /// Clear the cache, removing all entries or those linked to specific packages.
     #[command(hide = true)]
     Clean(CleanArgs),
-    /// Run a command in the project environment.
-    #[clap(hide = true)]
-    Run(RunArgs),
-    /// Sync the project's dependencies with the environment.
-    #[clap(hide = true)]
-    Sync(SyncArgs),
-    /// Resolve the project requirements into a lockfile.
-    #[clap(hide = true)]
-    Lock(LockArgs),
-    /// Add one or more packages to the project requirements.
-    #[clap(hide = true)]
-    Add(AddArgs),
-    /// Remove one or more packages from the project requirements.
-    #[clap(hide = true)]
-    Remove(RemoveArgs),
     /// Display uv's version
     Version {
         #[arg(long, value_enum, default_value = "text")]
@@ -230,6 +218,25 @@ pub(crate) enum PipCommand {
     Show(PipShowArgs),
     /// Verify installed packages have compatible dependencies.
     Check(PipCheckArgs),
+}
+
+#[derive(Subcommand)]
+pub(crate) enum ProjectCommand {
+    /// Run a command in the project environment.
+    #[clap(hide = true)]
+    Run(RunArgs),
+    /// Sync the project's dependencies with the environment.
+    #[clap(hide = true)]
+    Sync(SyncArgs),
+    /// Resolve the project requirements into a lockfile.
+    #[clap(hide = true)]
+    Lock(LockArgs),
+    /// Add one or more packages to the project requirements.
+    #[clap(hide = true)]
+    Add(AddArgs),
+    /// Remove one or more packages from the project requirements.
+    #[clap(hide = true)]
+    Remove(RemoveArgs),
 }
 
 /// A re-implementation of `Option`, used to avoid Clap's automatic `Option` flattening in

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -15,7 +15,9 @@ use uv_cache::Cache;
 use uv_requirements::RequirementsSource;
 use uv_workspace::Combine;
 
-use crate::cli::{CacheCommand, CacheNamespace, Cli, Commands, PipCommand, PipNamespace};
+use crate::cli::{
+    CacheCommand, CacheNamespace, Cli, Commands, PipCommand, PipNamespace, ProjectCommand,
+};
 #[cfg(feature = "self-update")]
 use crate::cli::{SelfCommand, SelfNamespace};
 use crate::commands::ExitStatus;
@@ -555,7 +557,7 @@ async fn run() -> Result<ExitStatus> {
             )
             .await
         }
-        Commands::Run(args) => {
+        Commands::Project(ProjectCommand::Run(args)) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = settings::RunSettings::resolve(args, workspace);
 
@@ -601,7 +603,7 @@ async fn run() -> Result<ExitStatus> {
             )
             .await
         }
-        Commands::Sync(args) => {
+        Commands::Project(ProjectCommand::Sync(args)) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = settings::SyncSettings::resolve(args, workspace);
 
@@ -619,7 +621,7 @@ async fn run() -> Result<ExitStatus> {
             )
             .await
         }
-        Commands::Lock(args) => {
+        Commands::Project(ProjectCommand::Lock(args)) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = settings::LockSettings::resolve(args, workspace);
 
@@ -637,7 +639,7 @@ async fn run() -> Result<ExitStatus> {
             )
             .await
         }
-        Commands::Add(args) => {
+        Commands::Project(ProjectCommand::Add(args)) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = settings::AddSettings::resolve(args, workspace);
 
@@ -653,7 +655,7 @@ async fn run() -> Result<ExitStatus> {
             )
             .await
         }
-        Commands::Remove(args) => {
+        Commands::Project(ProjectCommand::Remove(args)) => {
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = settings::RemoveSettings::resolve(args, workspace);
 


### PR DESCRIPTION
## Summary

No changes to the CLI itself (since this is flattened); just code reorganization.
