### PR TITLE
Fix doc for `uv add` cli command s/remove/add/

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1936,7 +1936,7 @@ pub(crate) struct LockArgs {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct AddArgs {
-    /// The packages to remove, as PEP 508 requirements (e.g., `flask==2.2.3`).
+    /// The packages to add, as PEP 508 requirements (e.g., `flask==2.2.3`).
     #[arg(required = true)]
     pub(crate) requirements: Vec<String>,
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fix the docsting where `remove` was used instead of `add` in the context of `uv add` command.

## Test Plan

```
cargo run -- add --help
```
```
Add one or more packages to the project requirements

Usage: uv add [OPTIONS] <REQUIREMENTS>...

Arguments:
  <REQUIREMENTS>...
          The packages to add, as PEP 508 requirements (e.g., `flask==2.2.3`)

```
