### PR TITLE
Use registry URL for fetching source distributions from lockfile

### DIFF
--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -190,6 +190,20 @@ fn lock_sdist_registry() -> Result<()> {
         );
     });
 
+    // Install from the lockfile.
+    uv_snapshot!(context.filters(), context.sync(), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv sync` is experimental and may change without warning.
+    Downloaded 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     + project==0.1.0 (from file://[TEMP_DIR]/)
+     + source-distribution==0.0.1
+    "###);
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

This is just a logic bug with no testing. We were using the registry URL (like `https://pypi.org/simple`) as the URL from which a source distribution should be downloaded.

Closes https://github.com/astral-sh/uv/issues/4281.

## Test Plan

`cargo test`
