### PR TITLE
Respect `requires-python` in `uv lock`

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -41,13 +41,7 @@ pub(crate) async fn add(
     )?;
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(
-        project.workspace(),
-        python.as_deref(),
-        preview,
-        cache,
-        printer,
-    )?;
+    let venv = project::init_environment(project.workspace(), python.as_deref(), cache, printer)?;
 
     let index_locations = IndexLocations::default();
     let upgrade = Upgrade::default();

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -44,13 +44,7 @@ pub(crate) async fn remove(
     )?;
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(
-        project.workspace(),
-        python.as_deref(),
-        preview,
-        cache,
-        printer,
-    )?;
+    let venv = project::init_environment(project.workspace(), python.as_deref(), cache, printer)?;
 
     let index_locations = IndexLocations::default();
     let upgrade = Upgrade::None;

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -62,13 +62,8 @@ pub(crate) async fn run(
         } else {
             ProjectWorkspace::discover(&std::env::current_dir()?, None).await?
         };
-        let venv = project::init_environment(
-            project.workspace(),
-            python.as_deref(),
-            preview,
-            cache,
-            printer,
-        )?;
+        let venv =
+            project::init_environment(project.workspace(), python.as_deref(), cache, printer)?;
 
         // Lock and sync the environment.
         let root_project_name = project

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -43,13 +43,7 @@ pub(crate) async fn sync(
     let project = ProjectWorkspace::discover(&std::env::current_dir()?, None).await?;
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(
-        project.workspace(),
-        python.as_deref(),
-        preview,
-        cache,
-        printer,
-    )?;
+    let venv = project::init_environment(project.workspace(), python.as_deref(), cache, printer)?;
 
     // Read the lockfile.
     let lock: Lock = {


### PR DESCRIPTION
We weren't using the common interface in `uv lock` because it didn't support finding an interpreter without touching the virtual environment. Here I refactor the project interface to support what we need and update `uv lock` to use the shared implementation.