### PR TITLE
Avoid treating direct path archives as always dynamic

### DIFF
--- a/crates/uv-installer/src/satisfies.rs
+++ b/crates/uv-installer/src/satisfies.rs
@@ -200,12 +200,14 @@ impl RequirementSatisfaction {
                     requested_path,
                     ArchiveTarget::Install(distribution),
                 )? {
-                    trace!("Out of date");
+                    trace!("Installed package is out of date");
                     return Ok(Self::OutOfDate);
                 }
 
                 // Does the package have dynamic metadata?
-                if is_dynamic(requested_path) {
+                // TODO(charlie): Separate `RequirementSource` into `Path` and `Directory`.
+                if requested_path.is_dir() && is_dynamic(requested_path) {
+                    trace!("Dependency is dynamic");
                     return Ok(Self::Dynamic);
                 }
 

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -1065,6 +1065,20 @@ fn install_local_wheel() -> Result<()> {
     "###
     );
 
+    // Reinstall into the same virtual environment. The wheel should _not_ be reinstalled.
+    uv_snapshot!(context.filters(), sync_without_exclude_newer(&context)
+        .arg("requirements.txt")
+        .arg("--strict"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Audited 1 package in [TIME]
+    "###
+    );
+
     context.assert_command("import tomli").success();
 
     Ok(())


### PR DESCRIPTION
## Summary

Right now, we're _always_ reinstalling local wheel archives, even if the timestamp didn't change.

I want to fix the TODO properly but I will do so in a separate PR.
