### PR TITLE
Fix incorrect parsing of requested Python version as empty version specifiers

### DIFF
--- a/crates/uv-toolchain/src/discovery.rs
+++ b/crates/uv-toolchain/src/discovery.rs
@@ -1237,6 +1237,9 @@ impl FromStr for VersionRequest {
             Ok(selector)
         // e.g. `>=3.12.1,<3.12`
         } else if let Ok(specifiers) = VersionSpecifiers::from_str(s) {
+            if specifiers.is_empty() {
+                return Err(Error::InvalidVersionRequest(s.to_string()));
+            }
             Ok(Self::Range(specifiers))
         } else {
             Err(Error::InvalidVersionRequest(s.to_string()))


### PR DESCRIPTION
Before 0.2.10 we would parse `--python=python` as an executable name. After https://github.com/astral-sh/uv/pull/4214, we started treating this as a Python version range request (with an empty version range). This is not entirely unreasonable, but it was an unexpected regression and I don't think `VersionRequest` should support empty ranges in its `from_str` implementation without more consideration.