### PR TITLE
Omit project name from workspace errors

### DIFF
--- a/crates/uv-distribution/src/workspace.rs
+++ b/crates/uv-distribution/src/workspace.rs
@@ -192,13 +192,6 @@ impl Workspace {
             .collect()
     }
 
-    /// If there is a package at the workspace root, return it.
-    pub fn root_member(&self) -> Option<&WorkspaceMember> {
-        self.packages
-            .values()
-            .find(|package| package.root == self.root)
-    }
-
     /// The path to the workspace root, the directory containing the top level `pyproject.toml` with
     /// the `uv.tool.workspace`, or the `pyproject.toml` in an implicit single workspace project.
     pub fn root(&self) -> &PathBuf {

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -53,15 +53,7 @@ pub(crate) async fn add(
     let upgrade = Upgrade::default();
 
     // Lock and sync the environment.
-    let root_project_name = project
-        .current_project()
-        .pyproject_toml()
-        .project
-        .as_ref()
-        .map(|project| project.name.clone());
-
     let lock = project::lock::do_lock(
-        root_project_name,
         project.workspace(),
         venv.interpreter(),
         upgrade,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -55,15 +55,7 @@ pub(crate) async fn remove(
     let upgrade = Upgrade::default();
 
     // Lock and sync the environment.
-    let root_project_name = project
-        .current_project()
-        .pyproject_toml()
-        .project
-        .as_ref()
-        .map(|project| project.name.clone());
-
     let lock = project::lock::do_lock(
-        root_project_name,
         project.workspace(),
         venv.interpreter(),
         upgrade,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -64,14 +64,7 @@ pub(crate) async fn run(
             project::init_environment(project.workspace(), python.as_deref(), cache, printer)?;
 
         // Lock and sync the environment.
-        let root_project_name = project
-            .current_project()
-            .pyproject_toml()
-            .project
-            .as_ref()
-            .map(|project| project.name.clone());
         let lock = project::lock::do_lock(
-            root_project_name,
             project.workspace(),
             venv.interpreter(),
             upgrade,

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -1453,7 +1453,7 @@ fn lock_requires_python() -> Result<()> {
               pygls>1.3.0
            cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
           And because project==0.1.0 depends on pygls>=1.1.0, we can conclude that project==0.1.0 cannot be used.
-          And because only project==0.1.0 is available and project depends on project, we can conclude that the requirements are unsatisfiable.
+          And because only project==0.1.0 is available and you require project, we can conclude that the requirements are unsatisfiable.
 
           hint: The `Requires-Python` requirement (>=3.7) defined in your `pyproject.toml` includes Python versions that are not supported by your dependencies (e.g., pygls>=1.1.0,<=1.2.1 only supports >=3.7.9, <4). Consider using a more restrictive `Requires-Python` requirement (like >=3.7.9, <4).
     "###);
@@ -2149,7 +2149,7 @@ fn lock_requires_python_unbounded() -> Result<()> {
 
     ----- stderr -----
     warning: `uv lock` is experimental and may change without warning.
-    warning: The `requires-python` field found in `project` does not contain a lower bound: `<=3.12`. Set a lower bound to indicate the minimum compatible Python version (e.g., `>=3.11`).
+    warning: The workspace `requires-python` field does not contain a lower bound: `<=3.12`. Set a lower bound to indicate the minimum compatible Python version (e.g., `>=3.11`).
     Resolved 2 packages in [TIME]
     "###);
 

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -298,7 +298,7 @@ fn fork_marker_disjoint() -> Result<()> {
     warning: `uv lock` is experimental and may change without warning.
       × No solution found when resolving dependencies:
       ╰─▶ Because project==0.1.0 depends on package-a{sys_platform == 'linux'}>=2 and package-a{sys_platform == 'linux'}<2, we can conclude that project==0.1.0 cannot be used.
-          And because only project==0.1.0 is available and project depends on project, we can conclude that the requirements are unsatisfiable.
+          And because only project==0.1.0 is available and you require project, we can conclude that the requirements are unsatisfiable.
     "###
     );
 
@@ -795,7 +795,7 @@ fn fork_non_local_fork_marker_direct() -> Result<()> {
       × No solution found when resolving dependencies:
       ╰─▶ Because package-b{sys_platform == 'darwin'}==1.0.0 depends on package-c>=2.0.0 and package-a{sys_platform == 'linux'}==1.0.0 depends on package-c<2.0.0, we can conclude that package-a{sys_platform == 'linux'}==1.0.0 and package-b{sys_platform == 'darwin'}==1.0.0 are incompatible.
           And because project==0.1.0 depends on package-a{sys_platform == 'linux'}==1.0.0 and package-b{sys_platform == 'darwin'}==1.0.0, we can conclude that project==0.1.0 cannot be used.
-          And because only project==0.1.0 is available and project depends on project, we can conclude that the requirements are unsatisfiable.
+          And because only project==0.1.0 is available and you require project, we can conclude that the requirements are unsatisfiable.
     "###
     );
 
@@ -873,7 +873,7 @@ fn fork_non_local_fork_marker_transitive() -> Result<()> {
               package-c{sys_platform == 'linux'}>=2.0.0
           and package-a==1.0.0 depends on package-c{sys_platform == 'linux'}<2.0.0, we can conclude that package-a==1.0.0 and package-b==1.0.0 are incompatible.
           And because project==0.1.0 depends on package-a==1.0.0 and package-b==1.0.0, we can conclude that project==0.1.0 cannot be used.
-          And because only project==0.1.0 is available and project depends on project, we can conclude that the requirements are unsatisfiable.
+          And because only project==0.1.0 is available and you require project, we can conclude that the requirements are unsatisfiable.
     "###
     );
 


### PR DESCRIPTION
## Summary

Because the workspace member itself is part of the resolution, adding the workspace name for the project leads to confusing errors, like:

```
❯ cargo run lock --preview
   Compiling uv v0.2.11 (/Users/crmarsh/workspace/puffin/crates/uv)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.79s
     Running `/Users/crmarsh/workspace/puffin/target/debug/uv lock --preview`
  × No solution found when resolving dependencies:
  ╰─▶ Because only albatross==0.1.0 is available and albatross==0.1.0 depends on anyio<=3, we can conclude that all versions of albatross depend on anyio<=3.
      And because bird-feeder==1.0.0 depends on anyio>=4.3.0,<5 and only bird-feeder==1.0.0 is available, we can conclude that all versions of albatross and all versions of bird-feeder are incompatible.
      And because albatross depends on albatross and bird-feeder, we can conclude that the requirements are unsatisfiable.
```

(Notice "albatross depends on albatross".)
