### PR TITLE
Ignore `compile_invalid_pyc_invalidation_mode` on macOS

### DIFF
--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -3214,6 +3214,7 @@ fn compile() -> Result<()> {
 
 /// Test that the `PYC_INVALIDATION_MODE` option is recognized and that the error handling works.
 #[test]
+#[cfg_attr(target_os = "macos", ignore = "Fails spuriously on macOS")]
 fn compile_invalid_pyc_invalidation_mode() -> Result<()> {
     let context = TestContext::new("3.12");
 


### PR DESCRIPTION
## Summary

This keeps failing in CI.
