### PR TITLE
Add `EXTERNALLY-MANAGED` markers to managed toolchains

### DIFF
--- a/crates/uv-dev/src/fetch_python.rs
+++ b/crates/uv-dev/src/fetch_python.rs
@@ -8,7 +8,7 @@ use uv_toolchain::ToolchainRequest;
 
 use uv_fs::Simplified;
 use uv_toolchain::downloads::{DownloadResult, Error, PythonDownload, PythonDownloadRequest};
-use uv_toolchain::managed::InstalledToolchains;
+use uv_toolchain::managed::{InstalledToolchain, InstalledToolchains};
 
 #[derive(Parser, Debug)]
 pub(crate) struct FetchPythonArgs {
@@ -71,6 +71,11 @@ pub(crate) async fn fetch_python(args: FetchPythonArgs) -> Result<()> {
             }
         };
         results.push((version, path));
+    }
+
+    for (_, path) in results {
+        let installed = InstalledToolchain::new(path)?;
+        installed.ensure_externally_managed()?;
     }
 
     if downloaded > 0 {

--- a/crates/uv-toolchain/src/managed.rs
+++ b/crates/uv-toolchain/src/managed.rs
@@ -196,6 +196,10 @@ impl InstalledToolchains {
     }
 }
 
+static EXTERNALLY_MANAGED: &str = "[externally-managed]
+Error=This toolchain is managed by uv and should not be modified.
+";
+
 /// A uv-managed Python toolchain installed on the current system..
 #[derive(Debug, Clone)]
 pub struct InstalledToolchain {
@@ -282,6 +286,20 @@ impl InstalledToolchain {
             }
             ToolchainRequest::Version(version) => version.matches_version(&self.python_version),
         }
+    }
+
+    /// Ensure the toolchain is marked as externally managed with the
+    /// standard `EXTERNALLY-MANAGED` file.
+    pub fn ensure_externally_managed(&self) -> Result<(), Error> {
+        let lib = if cfg!(windows) { "Lib" } else { "lib" };
+        let file = self
+            .path
+            .join("install")
+            .join(lib)
+            .join(format!("python{}", self.python_version.python_version()))
+            .join("EXTERNALLY-MANAGED");
+        fs_err::write(file, EXTERNALLY_MANAGED)?;
+        Ok(())
     }
 }
 

--- a/crates/uv-toolchain/src/toolchain.rs
+++ b/crates/uv-toolchain/src/toolchain.rs
@@ -178,6 +178,7 @@ impl Toolchain {
         };
 
         let installed = InstalledToolchain::new(path)?;
+        installed.ensure_externally_managed()?;
 
         Ok(Self {
             source: ToolchainSource::Managed,

--- a/crates/uv/src/commands/toolchain/install.rs
+++ b/crates/uv/src/commands/toolchain/install.rs
@@ -5,7 +5,7 @@ use uv_client::Connectivity;
 use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_toolchain::downloads::{DownloadResult, PythonDownload, PythonDownloadRequest};
-use uv_toolchain::managed::InstalledToolchains;
+use uv_toolchain::managed::{InstalledToolchain, InstalledToolchains};
 use uv_toolchain::ToolchainRequest;
 use uv_warnings::warn_user;
 
@@ -96,10 +96,13 @@ pub(crate) async fn install(
         DownloadResult::Fetched(path) => path,
     };
 
+    let installed = InstalledToolchain::new(path)?;
+    installed.ensure_externally_managed()?;
+
     writeln!(
         printer.stderr(),
         "Installed Python {version} to {}",
-        path.user_display()
+        installed.path().user_display()
     )?;
 
     Ok(ExitStatus::Success)


### PR DESCRIPTION
Closes #4240 

e.g.

```
❯ cargo run -q -- pip install anyio --python "/Users/zb/Library/Application Support/uv/toolchains/cpython-3.12.0-macos-aarch64-none/install/bin/python3"
error: The interpreter at /Users/zb/Library/Application Support/uv/toolchains/cpython-3.12.0-macos-aarch64-none/install is externally managed, and indicates the following:

  This toolchain is managed by uv and should not be modified.

Consider creating a virtual environment with `uv venv`.
```