### PR TITLE
Enable workspace lint configuration in remaining crates

### DIFF
--- a/crates/pep440-rs/Cargo.toml
+++ b/crates/pep440-rs/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.6.0"
 description = "A library for python version numbers and specifiers, implementing PEP 440"
 license = "Apache-2.0 OR BSD-2-Clause"
 include = ["/src", "Changelog.md", "License-Apache", "License-BSD", "Readme.md", "pyproject.toml"]
-
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }
@@ -15,6 +14,9 @@ authors = { workspace = true }
 [lib]
 name = "pep440_rs"
 crate-type = ["rlib", "cdylib"]
+
+[lints]
+workspace = true
 
 [dependencies]
 once_cell = { workspace = true }

--- a/crates/pep440-rs/src/version_specifier.rs
+++ b/crates/pep440-rs/src/version_specifier.rs
@@ -480,11 +480,11 @@ impl VersionSpecifier {
         // "Except where specifically noted below, local version identifiers MUST NOT be permitted
         // in version specifiers, and local version labels MUST be ignored entirely when checking
         // if candidate versions match a given version specifier."
-        let (this, other) = if !self.version.local().is_empty() {
-            (self.version.clone(), version.clone())
-        } else {
+        let (this, other) = if self.version.local().is_empty() {
             // self is already without local
             (self.version.clone(), version.clone().without_local())
+        } else {
+            (self.version.clone(), version.clone())
         };
 
         match self.operator {
@@ -650,7 +650,7 @@ impl std::fmt::Display for VersionSpecifierBuildError {
                 let local = version
                     .local()
                     .iter()
-                    .map(|segment| segment.to_string())
+                    .map(ToString::to_string)
                     .collect::<Vec<String>>()
                     .join(".");
                 write!(

--- a/crates/pep508-rs/Cargo.toml
+++ b/crates/pep508-rs/Cargo.toml
@@ -16,13 +16,13 @@ authors = { workspace = true }
 name = "pep508_rs"
 crate-type = ["cdylib", "rlib"]
 
-[dependencies]
-pep440_rs = { workspace = true }
-uv-fs = { workspace = true }
-uv-normalize = { workspace = true }
+[lints]
+workspace = true
 
+[dependencies]
 derivative = { workspace = true }
 once_cell = { workspace = true }
+pep440_rs = { workspace = true }
 pyo3 = { workspace = true, optional = true, features = ["abi3", "extension-module"] }
 pyo3-log = { workspace = true, optional = true }
 regex = { workspace = true }
@@ -32,6 +32,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true, optional = true }
 unicode-width = { workspace = true }
 url = { workspace = true, features = ["serde"] }
+uv-fs = { workspace = true }
+uv-normalize = { workspace = true }
 
 [dev-dependencies]
 insta = { version = "1.36.1" }

--- a/crates/pep508-rs/src/unnamed.rs
+++ b/crates/pep508-rs/src/unnamed.rs
@@ -137,7 +137,7 @@ impl<Url: UnnamedRequirementUrl> Display for UnnamedRequirement<Url> {
             )?;
         }
         if let Some(marker) = &self.marker {
-            write!(f, " ; {}", marker)?;
+            write!(f, " ; {marker}")?;
         }
         Ok(())
     }

--- a/crates/pep508-rs/src/verbatim_url.rs
+++ b/crates/pep508-rs/src/verbatim_url.rs
@@ -50,7 +50,7 @@ impl VerbatimUrl {
 
         // Convert to a URL.
         let mut url = Url::from_file_path(path.clone())
-            .map_err(|_| VerbatimUrlError::UrlConversion(path.to_path_buf()))?;
+            .map_err(|()| VerbatimUrlError::UrlConversion(path.to_path_buf()))?;
 
         // Set the fragment, if it exists.
         if let Some(fragment) = fragment {
@@ -84,14 +84,14 @@ impl VerbatimUrl {
 
         // Normalize the path.
         let path = normalize_path(&path)
-            .map_err(|err| VerbatimUrlError::Normalization(path.to_path_buf(), err))?;
+            .map_err(|err| VerbatimUrlError::Normalization(path.clone(), err))?;
 
         // Extract the fragment, if it exists.
         let (path, fragment) = split_fragment(&path);
 
         // Convert to a URL.
         let mut url = Url::from_file_path(path.clone())
-            .map_err(|_| VerbatimUrlError::UrlConversion(path.to_path_buf()))?;
+            .map_err(|()| VerbatimUrlError::UrlConversion(path.to_path_buf()))?;
 
         // Set the fragment, if it exists.
         if let Some(fragment) = fragment {
@@ -122,7 +122,7 @@ impl VerbatimUrl {
 
         // Convert to a URL.
         let mut url = Url::from_file_path(path.clone())
-            .unwrap_or_else(|_| panic!("path is absolute: {}", path.display()));
+            .unwrap_or_else(|()| panic!("path is absolute: {}", path.display()));
 
         // Set the fragment, if it exists.
         if let Some(fragment) = fragment {
@@ -160,7 +160,7 @@ impl VerbatimUrl {
     pub fn as_path(&self) -> Result<PathBuf, VerbatimUrlError> {
         self.url
             .to_file_path()
-            .map_err(|_| VerbatimUrlError::UrlConversion(self.url.to_file_path().unwrap()))
+            .map_err(|()| VerbatimUrlError::UrlConversion(self.url.to_file_path().unwrap()))
     }
 }
 

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -3,6 +3,9 @@ name = "uv-auth"
 version = "0.0.1"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -24,7 +24,7 @@ impl Username {
     /// Create a new username.
     ///
     /// Unlike `reqwest`, empty usernames are be encoded as `None` instead of an empty string.
-    pub fn new(value: Option<String>) -> Self {
+    pub(crate) fn new(value: Option<String>) -> Self {
         // Ensure empty strings are `None`
         if let Some(value) = value {
             if value.is_empty() {
@@ -37,19 +37,19 @@ impl Username {
         }
     }
 
-    pub fn none() -> Self {
+    pub(crate) fn none() -> Self {
         Self::new(None)
     }
 
-    pub fn is_none(&self) -> bool {
+    pub(crate) fn is_none(&self) -> bool {
         self.0.is_none()
     }
 
-    pub fn is_some(&self) -> bool {
+    pub(crate) fn is_some(&self) -> bool {
         self.0.is_some()
     }
 
-    pub fn as_deref(&self) -> Option<&str> {
+    pub(crate) fn as_deref(&self) -> Option<&str> {
         self.0.as_deref()
     }
 }
@@ -67,33 +67,33 @@ impl From<Option<String>> for Username {
 }
 
 impl Credentials {
-    pub fn new(username: Option<String>, password: Option<String>) -> Self {
+    pub(crate) fn new(username: Option<String>, password: Option<String>) -> Self {
         Self {
             username: Username::new(username),
             password,
         }
     }
 
-    pub fn username(&self) -> Option<&str> {
+    pub(crate) fn username(&self) -> Option<&str> {
         self.username.as_deref()
     }
 
-    pub fn to_username(&self) -> Username {
+    pub(crate) fn to_username(&self) -> Username {
         self.username.clone()
     }
 
-    pub fn password(&self) -> Option<&str> {
+    pub(crate) fn password(&self) -> Option<&str> {
         self.password.as_deref()
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.password.is_none() && self.username.is_none()
     }
 
     /// Return [`Credentials`] for a [`Url`] from a [`Netrc`] file, if any.
     ///
     /// If a username is provided, it must match the login in the netrc file or [`None`] is returned.
-    pub fn from_netrc(netrc: &Netrc, url: &Url, username: Option<&str>) -> Option<Self> {
+    pub(crate) fn from_netrc(netrc: &Netrc, url: &Url, username: Option<&str>) -> Option<Self> {
         let host = url.host_str()?;
         let entry = netrc
             .hosts
@@ -114,7 +114,7 @@ impl Credentials {
     /// Parse [`Credentials`] from a URL, if any.
     ///
     /// Returns [`None`] if both [`Url::username`] and [`Url::password`] are not populated.
-    pub fn from_url(url: &Url) -> Option<Self> {
+    pub(crate) fn from_url(url: &Url) -> Option<Self> {
         if url.username().is_empty() && url.password().is_none() {
             return None;
         }
@@ -142,7 +142,7 @@ impl Credentials {
     /// Parse [`Credentials`] from an HTTP request, if any.
     ///
     /// Only HTTP Basic Authentication is supported.
-    pub fn from_request(request: &Request) -> Option<Self> {
+    pub(crate) fn from_request(request: &Request) -> Option<Self> {
         // First, attempt to retrieve the credentials from the URL
         Self::from_url(request.url()).or(
             // Then, attempt to pull the credentials from the headers
@@ -195,7 +195,7 @@ impl Credentials {
             write!(encoder, "{}:", self.username().unwrap_or_default())
                 .expect("Write to base64 encoder should succeed");
             if let Some(password) = self.password() {
-                write!(encoder, "{}", password).expect("Write to base64 encoder should succeed");
+                write!(encoder, "{password}").expect("Write to base64 encoder should succeed");
             }
         }
         let mut header = HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue");
@@ -207,7 +207,7 @@ impl Credentials {
     ///
     /// Any existing credentials will be overridden.
     #[must_use]
-    pub fn authenticate(&self, mut request: reqwest::Request) -> reqwest::Request {
+    pub(crate) fn authenticate(&self, mut request: reqwest::Request) -> reqwest::Request {
         request
             .headers_mut()
             .insert(reqwest::header::AUTHORIZATION, Self::to_header_value(self));

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -3,6 +3,9 @@ name = "uv-client"
 version = "0.0.1"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 cache-key = { workspace = true }
 distribution-filename = { workspace = true }

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -113,7 +113,7 @@ impl<'a> BaseClientBuilder<'a> {
         if let Some(markers) = self.markers {
             let linehaul = LineHaul::new(markers, self.platform);
             if let Ok(output) = serde_json::to_string(&linehaul) {
-                user_agent_string += &format!(" {}", output);
+                user_agent_string += &format!(" {output}");
             }
         }
 
@@ -267,7 +267,7 @@ impl RetryableStrategy for LoggingRetryableStrategy {
                         .join("\n");
                     debug!(
                         "Transient request failure for {}, retrying: {err}\n{context}",
-                        err.url().map(|url| url.as_str()).unwrap_or("unknown URL")
+                        err.url().map(reqwest::Url::as_str).unwrap_or("unknown URL")
                     );
                 }
             }

--- a/crates/uv-client/src/html.rs
+++ b/crates/uv-client/src/html.rs
@@ -929,7 +929,8 @@ mod tests {
     }
 
     /// Test for AWS Code Artifact
-    /// From https://github.com/astral-sh/uv/issues/1388#issuecomment-1947659088
+    ///
+    /// See: <https://github.com/astral-sh/uv/issues/1388#issuecomment-1947659088>
     #[test]
     fn parse_code_artifact_index_html() {
         let text = r#"

--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -122,17 +122,17 @@ actually need to make an HTTP request).
 
 # Additional reading
 
-* Short introduction to `Cache-Control`: https://csswizardry.com/2019/03/cache-control-for-civilians/
-* Caching best practcies: https://jakearchibald.com/2016/caching-best-practices/
-* Overview of HTTP caching: https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching
-* MDN docs for `Cache-Control`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
-* THe 1997 RFC for HTTP 1.1: https://www.rfc-editor.org/rfc/rfc2068#section-13
-* The 1999 update to HTTP 1.1: https://www.rfc-editor.org/rfc/rfc2616.html#section-13
-* The "stale content" cache-control extension: https://httpwg.org/specs/rfc5861.html
-* HTTP 1.1 caching (superseded by RFC 9111): https://httpwg.org/specs/rfc7234.html
-* The "immutable" cache-control extension: https://httpwg.org/specs/rfc8246.html
-* HTTP semantics (If-None-Match, etc.): https://www.rfc-editor.org/rfc/rfc9110#section-8.8.3
-* HTTP caching (obsoletes RFC 7234): https://www.rfc-editor.org/rfc/rfc9111.html
+* Short introduction to `Cache-Control`: <https://csswizardry.com/2019/03/cache-control-for-civilians/>
+* Caching best practcies: <https://jakearchibald.com/2016/caching-best-practices/>
+* Overview of HTTP caching: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching>
+* MDN docs for `Cache-Control`: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control>
+* The 1997 RFC for HTTP 1.1: <https://www.rfc-editor.org/rfc/rfc2068#section-13>
+* The 1999 update to HTTP 1.1: <https://www.rfc-editor.org/rfc/rfc2616.html#section-13>
+* The "stale content" cache-control extension: <https://httpwg.org/specs/rfc5861.html>
+* HTTP 1.1 caching (superseded by RFC 9111): <https://httpwg.org/specs/rfc7234.html>
+* The "immutable" cache-control extension: <https://httpwg.org/specs/rfc8246.html>
+* HTTP semantics (If-None-Match, etc.): <https://www.rfc-editor.org/rfc/rfc9110#section-8.8.3>
+* HTTP caching (obsoletes RFC 7234): <https://www.rfc-editor.org/rfc/rfc9111.html>
 */
 
 use std::time::{Duration, SystemTime};
@@ -1193,7 +1193,7 @@ impl<'a> From<&'a http::HeaderMap> for ResponseHeaders {
 #[archive(check_bytes)]
 #[archive_attr(derive(Debug))]
 struct ETag {
-    /// The actual ETag validator value.
+    /// The actual `ETag` validator value.
     ///
     /// This is received in the response, recorded as part of the cache policy
     /// and then sent back in a re-validation request. This is the "best"
@@ -1219,7 +1219,7 @@ struct ETag {
 }
 
 impl ETag {
-    /// Parses an ETag from a header value.
+    /// Parses an `ETag` from a header value.
     ///
     /// We are a little permissive here and allow arbitrary bytes,
     /// where as [RFC 9110 S8.8.3] is a bit more restrictive.

--- a/crates/uv-client/src/linehaul.rs
+++ b/crates/uv-client/src/linehaul.rs
@@ -68,7 +68,7 @@ impl LineHaul {
             .iter()
             .find_map(|&var_name| env::var(var_name).ok().map(|_| true));
 
-        let libc = match platform.map(|platform| platform.os()) {
+        let libc = match platform.map(platform_tags::Platform::os) {
             Some(Os::Manylinux { major, minor }) => Some(Libc {
                 lib: Some("glibc".to_string()),
                 version: Some(format!("{major}.{minor}")),
@@ -94,7 +94,7 @@ impl LineHaul {
                 libc,
             })
         } else if cfg!(target_os = "macos") {
-            let version = match platform.map(|platform| platform.os()) {
+            let version = match platform.map(platform_tags::Platform::os) {
                 Some(Os::Macos { major, minor }) => Some(format!("{major}.{minor}")),
                 _ => None,
             };

--- a/crates/uv-client/src/middleware.rs
+++ b/crates/uv-client/src/middleware.rs
@@ -13,7 +13,7 @@ pub(crate) struct OfflineError {
 
 impl OfflineError {
     /// Returns the URL that caused the error.
-    pub fn url(&self) -> &Url {
+    pub(crate) fn url(&self) -> &Url {
         &self.url
     }
 }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -130,15 +130,15 @@ impl<'a> RegistryClientBuilder<'a> {
         let mut builder = BaseClientBuilder::new();
 
         if let Some(client) = self.client {
-            builder = builder.client(client)
+            builder = builder.client(client);
         }
 
         if let Some(markers) = self.markers {
-            builder = builder.markers(markers)
+            builder = builder.markers(markers);
         }
 
         if let Some(platform) = self.platform {
-            builder = builder.platform(platform)
+            builder = builder.platform(platform);
         }
 
         let client = builder
@@ -380,7 +380,7 @@ impl RegistryClient {
     ) -> Result<OwnedArchive<SimpleMetadata>, Error> {
         let path = url
             .to_file_path()
-            .map_err(|_| ErrorKind::NonFileUrl(url.clone()))?
+            .map_err(|()| ErrorKind::NonFileUrl(url.clone()))?
             .join("index.html");
         let text = fs_err::tokio::read_to_string(&path)
             .await
@@ -416,7 +416,7 @@ impl RegistryClient {
                         if url.scheme() == "file" {
                             let path = url
                                 .to_file_path()
-                                .map_err(|_| ErrorKind::NonFileUrl(url.clone()))?;
+                                .map_err(|()| ErrorKind::NonFileUrl(url.clone()))?;
                             WheelLocation::Path(path)
                         } else {
                             WheelLocation::Url(url)
@@ -427,7 +427,7 @@ impl RegistryClient {
                         if url.scheme() == "file" {
                             let path = url
                                 .to_file_path()
-                                .map_err(|_| ErrorKind::NonFileUrl(url.clone()))?;
+                                .map_err(|()| ErrorKind::NonFileUrl(url.clone()))?;
                             WheelLocation::Path(path)
                         } else {
                             WheelLocation::Url(url)
@@ -769,7 +769,7 @@ impl VersionFiles {
         match filename {
             DistFilename::WheelFilename(name) => self.wheels.push(VersionWheel { name, file }),
             DistFilename::SourceDistFilename(name) => {
-                self.source_dists.push(VersionSourceDist { name, file })
+                self.source_dists.push(VersionSourceDist { name, file });
             }
         }
     }
@@ -990,7 +990,8 @@ mod tests {
     }
 
     /// Test for AWS Code Artifact registry
-    /// Regression coverage of https://github.com/astral-sh/uv/issues/1388
+    ///
+    /// See: <https://github.com/astral-sh/uv/issues/1388>
     #[test]
     fn relative_urls_code_artifact() -> Result<(), JoinRelativeError> {
         let text = r#"
@@ -1021,7 +1022,7 @@ mod tests {
             .iter()
             .map(|file| pypi_types::base_url_join_relative(base.as_url().as_str(), &file.url))
             .collect::<Result<Vec<_>, JoinRelativeError>>()?;
-        let urls = urls.iter().map(|url| url.as_str()).collect::<Vec<_>>();
+        let urls = urls.iter().map(reqwest::Url::as_str).collect::<Vec<_>>();
         insta::assert_debug_snapshot!(urls, @r###"
         [
             "https://account.d.codeartifact.us-west-2.amazonaws.com/pypi/shared-packages-pypi/simple/0.1/Flask-0.1.tar.gz#sha256=9da884457e910bf0847d396cb4b778ad9f3c3d17db1c5997cb861937bd284237",

--- a/crates/uv-client/src/rkyvutil.rs
+++ b/crates/uv-client/src/rkyvutil.rs
@@ -172,7 +172,10 @@ where
         // archive for SimpleMetadata in the constructor, so we can skip
         // validation here. Since we don't mutate the buffer, this conversion
         // is guaranteed to be correct.
-        unsafe { rkyv::archived_root::<A>(&self.raw) }
+        #[allow(unsafe_code)]
+        unsafe {
+            rkyv::archived_root::<A>(&self.raw)
+        }
     }
 }
 
@@ -230,6 +233,7 @@ impl<const N: usize> rkyv::ser::Serializer for Serializer<N> {
     }
 
     #[inline]
+    #[allow(unsafe_code)]
     unsafe fn resolve_aligned<T: Archive + ?Sized>(
         &mut self,
         value: &T,
@@ -241,6 +245,7 @@ impl<const N: usize> rkyv::ser::Serializer for Serializer<N> {
     }
 
     #[inline]
+    #[allow(unsafe_code)]
     unsafe fn resolve_unsized_aligned<T: ArchiveUnsized + ?Sized>(
         &mut self,
         value: &T,
@@ -255,6 +260,7 @@ impl<const N: usize> rkyv::ser::Serializer for Serializer<N> {
 
 impl<const N: usize> rkyv::ser::ScratchSpace for Serializer<N> {
     #[inline]
+    #[allow(unsafe_code)]
     unsafe fn push_scratch(
         &mut self,
         layout: std::alloc::Layout,
@@ -265,6 +271,7 @@ impl<const N: usize> rkyv::ser::ScratchSpace for Serializer<N> {
     }
 
     #[inline]
+    #[allow(unsafe_code)]
     unsafe fn pop_scratch(
         &mut self,
         ptr: std::ptr::NonNull<u8>,
@@ -325,7 +332,7 @@ impl std::error::Error for SerializerError {
 ///
 /// > Regular serializers don’t support the custom error handling needed for
 /// > this type by default. To use this wrapper, a custom serializer with an
-/// > error type satisfying <S as Fallible>::Error: From<AsStringError> must be
+/// > error type satisfying <S as Fallible>`::Error`: From<AsStringError> must be
 /// > provided.
 ///
 /// If we didn't need to use `rkyv::with::AsString` (which we do for

--- a/crates/uv-client/tests/user_agent_version.rs
+++ b/crates/uv-client/tests/user_agent_version.rs
@@ -31,7 +31,7 @@ async fn test_user_agent_has_version() -> Result<()> {
                 .headers()
                 .get(USER_AGENT)
                 .and_then(|v| v.to_str().ok())
-                .map(|s| s.to_string())
+                .map(ToString::to_string)
                 .unwrap_or_default(); // Empty Default
             future::ok::<_, hyper::Error>(Response::new(Full::new(Bytes::from(user_agent))))
         });
@@ -89,7 +89,7 @@ async fn test_user_agent_has_linehaul() -> Result<()> {
                 .headers()
                 .get(USER_AGENT)
                 .and_then(|v| v.to_str().ok())
-                .map(|s| s.to_string())
+                .map(ToString::to_string)
                 .unwrap_or_default(); // Empty Default
             future::ok::<_, hyper::Error>(Response::new(Full::new(Bytes::from(user_agent))))
         });

--- a/crates/uv-macros/Cargo.toml
+++ b/crates/uv-macros/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 quote = { workspace = true }
 syn = { workspace = true }

--- a/crates/uv-normalize/Cargo.toml
+++ b/crates/uv-normalize/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.1"
 edition = "2021"
 description = "Normalization for distribution, package and extra anmes"
 
+[lints]
+workspace = true
+
 [dependencies]
 rkyv = { workspace = true }
 schemars = { workspace = true, optional = true }

--- a/crates/uv-requirements/Cargo.toml
+++ b/crates/uv-requirements/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 authors.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 cache-key = { workspace = true }
 distribution-filename = { workspace = true }
@@ -39,6 +42,3 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-
-[lints]
-workspace = true

--- a/crates/uv-resolver/src/resolution/display.rs
+++ b/crates/uv-resolver/src/resolution/display.rs
@@ -189,7 +189,7 @@ impl std::fmt::Display for DisplayResolutionGraph<'_> {
                             let deps = edges
                                 .iter()
                                 .map(|dependency| format!("{}", dependency.name()))
-                                .chain(source.iter().map(std::string::ToString::to_string))
+                                .chain(source.iter().map(ToString::to_string))
                                 .collect::<Vec<_>>()
                                 .join(", ");
                             let comment = format!("# via {deps}").green().to_string();
@@ -214,7 +214,7 @@ impl std::fmt::Display for DisplayResolutionGraph<'_> {
                             let separator = "\n";
                             let deps = source
                                 .iter()
-                                .map(std::string::ToString::to_string)
+                                .map(ToString::to_string)
                                 .chain(
                                     edges
                                         .iter()


### PR DESCRIPTION
## Summary

A change I did a while back but just pushing it before I lose context. We didn't have Clippy enabled (to match our workspace settings) in a few crates.
