### PR TITLE
Allow multiple toolchains to be requested in `uv toolchain install`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,7 @@ dependencies = [
  "filetime",
  "flate2",
  "fs-err",
+ "futures",
  "ignore",
  "indicatif",
  "indoc",

--- a/crates/uv-toolchain/src/toolchain.rs
+++ b/crates/uv-toolchain/src/toolchain.rs
@@ -82,7 +82,6 @@ impl Toolchain {
     ) -> Result<Self, Error> {
         let sources = ToolchainSources::from_settings(system, preview);
         let toolchain = find_toolchain(request, system, &sources, cache)??;
-
         Ok(toolchain)
     }
 

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -46,6 +46,7 @@ clap = { workspace = true, features = ["derive", "string", "wrap_help"] }
 clap_complete_command = { workspace = true }
 flate2 = { workspace = true, default-features = false }
 fs-err = { workspace = true, features = ["tokio"] }
+futures = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true, features = ["fancy"] }

--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1754,10 +1754,10 @@ pub(crate) struct ToolchainListArgs {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct ToolchainInstallArgs {
-    /// The toolchain to install.
+    /// The toolchains to install.
     ///
     /// If not provided, the latest available version will be installed unless a toolchain was previously installed.
-    pub(crate) target: Option<String>,
+    pub(crate) targets: Vec<String>,
 
     /// Force the installation of the toolchain, even if it is already installed.
     #[arg(long, short)]

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -796,7 +796,7 @@ async fn run() -> Result<ExitStatus> {
             let cache = cache.init()?;
 
             commands::toolchain_install(
-                args.target,
+                args.targets,
                 args.force,
                 globals.native_tls,
                 globals.connectivity,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -257,7 +257,7 @@ impl ToolchainListSettings {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct ToolchainInstallSettings {
-    pub(crate) target: Option<String>,
+    pub(crate) targets: Vec<String>,
     pub(crate) force: bool,
 }
 
@@ -268,9 +268,9 @@ impl ToolchainInstallSettings {
         args: ToolchainInstallArgs,
         _filesystem: Option<FilesystemOptions>,
     ) -> Self {
-        let ToolchainInstallArgs { target, force } = args;
+        let ToolchainInstallArgs { targets, force } = args;
 
-        Self { target, force }
+        Self { targets, force }
     }
 }
 


### PR DESCRIPTION
Allows installation of multiple toolchains in a single invocation because I don't want to be limited to one! Most of the implementation for concurrent downloads ported from `cargo dev fetch-python`.