### PR TITLE
Read Python version files during toolchain installs

### DIFF
--- a/crates/uv/src/cli.rs
+++ b/crates/uv/src/cli.rs
@@ -1756,7 +1756,9 @@ pub(crate) struct ToolchainListArgs {
 pub(crate) struct ToolchainInstallArgs {
     /// The toolchains to install.
     ///
-    /// If not provided, the latest available version will be installed unless a toolchain was previously installed.
+    /// If not provided, the requested toolchain(s) will be read from the `.python-versions`
+    ///  or `.python-version` files. If neither file is present, uv will check if it has
+    /// installed any toolchains. If not, it will install the latest stable version of Python.
     pub(crate) targets: Vec<String>,
 
     /// Force the installation of the toolchain, even if it is already installed.


### PR DESCRIPTION
A bare `uv toolchain install` invocation now reads default requests from Python version files in the working directory. In order, a bare invocation means:

- requests from `.python-versions`
- a single request from`.python-version`
- any installed managed toolchain
- the latest managed toolchain download

This replaces all the functionality of `cargo dev fetch-python`, which we drop in #4337 