### PR TITLE
find uv binary relative to package root

### DIFF
--- a/python/uv/__init__.py
+++ b/python/uv/__init__.py
@@ -27,6 +27,12 @@ def find_uv_bin() -> str:
     if os.path.isfile(path):
         return path
 
+    # Search in `bin` adjacent to package root (as created by `pip install --target`).
+    pkg_root = os.path.dirname(os.path.dirname(__file__))
+    target_path = os.path.join(pkg_root, "bin", uv_exe)
+    if os.path.isfile(target_path):
+        return target_path
+
     raise FileNotFoundError(path)
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

[ruff's `find_bin` implementation](https://github.com/astral-sh/ruff/blob/19cd9d7d8a849cc6e0da65e58fb8c7b6a7a9cb9f/python/ruff/__main__.py#L31) can find the binary in relative to the package root. It'd be nice to have the same functionality for `uv`.