### PR TITLE
feat: display keyring stderr

### DIFF
--- a/crates/uv-auth/src/keyring.rs
+++ b/crates/uv-auth/src/keyring.rs
@@ -1,3 +1,4 @@
+use std::process::Stdio;
 use tokio::process::Command;
 use tracing::{instrument, trace, warn};
 use url::Url;
@@ -83,13 +84,22 @@ impl KeyringProvider {
 
     #[instrument(skip(self))]
     async fn fetch_subprocess(&self, service_name: &str, username: &str) -> Option<String> {
-        let output = Command::new("keyring")
+        // https://github.com/pypa/pip/blob/24.0/src/pip/_internal/network/auth.py#L136-L141
+        let child = Command::new("keyring")
             .arg("get")
             .arg(service_name)
             .arg(username)
-            .output()
-            .await
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
             .inspect_err(|err| warn!("Failure running `keyring` command: {err}"))
+            .ok()?;
+
+        let output = child
+            .wait_with_output()
+            .await
+            .inspect_err(|err| warn!("Failed to wait for `keyring` output: {err}"))
             .ok()?;
 
         if output.status.success() {

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -3960,6 +3960,8 @@ fn install_package_basic_auth_from_keyring() {
     ----- stdout -----
 
     ----- stderr -----
+    Request for public@https://pypi-proxy.fly.dev/basic-auth/simple/anyio/
+    Request for public@pypi-proxy.fly.dev
     Resolved 3 packages in [TIME]
     Downloaded 3 packages in [TIME]
     Installed 3 packages in [TIME]
@@ -4005,6 +4007,8 @@ fn install_package_basic_auth_from_keyring_wrong_password() {
     ----- stdout -----
 
     ----- stderr -----
+    Request for public@https://pypi-proxy.fly.dev/basic-auth/simple/anyio/
+    Request for public@pypi-proxy.fly.dev
     error: Failed to download `anyio==4.3.0`
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl.metadata)
     "###
@@ -4044,6 +4048,8 @@ fn install_package_basic_auth_from_keyring_wrong_username() {
     ----- stdout -----
 
     ----- stderr -----
+    Request for public@https://pypi-proxy.fly.dev/basic-auth/simple/anyio/
+    Request for public@pypi-proxy.fly.dev
     error: Failed to download `anyio==4.3.0`
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl.metadata)
     "###


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/4162

Changes keyring subprocess to allow display of stderr.
This aligns with pip's behavior since pip 23.1.

## Test Plan

* Tested using gnome-keyring-backend on a self-hosted private registry as well as the keyring script described in #4162 to confirm both existing functionality and the new stderr display.
* Existing tests using `scripts/packages/keyring_test_plugin` are now showing its stderr output as well.