### PR TITLE
Respect `.python-version` files and fetch manged toolchains in uv project commands

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -32,7 +32,7 @@ pub struct BaseClientBuilder<'a> {
     keyring: KeyringProviderType,
     native_tls: bool,
     retries: u32,
-    connectivity: Connectivity,
+    pub connectivity: Connectivity,
     client: Option<Client>,
     markers: Option<&'a MarkerEnvironment>,
     platform: Option<&'a Platform>,

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -929,6 +929,16 @@ pub enum Connectivity {
     Offline,
 }
 
+impl Connectivity {
+    pub fn is_online(&self) -> bool {
+        matches!(self, Self::Online)
+    }
+
+    pub fn is_offline(&self) -> bool {
+        matches!(self, Self::Offline)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/crates/uv-toolchain/src/toolchain.rs
+++ b/crates/uv-toolchain/src/toolchain.rs
@@ -144,7 +144,11 @@ impl Toolchain {
         // Perform a find first
         match Self::find(python.clone(), system, preview, cache) {
             Ok(venv) => Ok(venv),
-            Err(Error::NotFound(_)) if system.is_allowed() && preview.is_enabled() => {
+            Err(Error::NotFound(_))
+                if system.is_allowed()
+                    && preview.is_enabled()
+                    && client_builder.connectivity.is_online() =>
+            {
                 debug!("Requested Python not found, checking for available download...");
                 let request = if let Some(request) = python {
                     request

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -5,6 +5,7 @@ use uv_distribution::pyproject_mut::PyProjectTomlMut;
 use uv_git::GitResolver;
 use uv_requirements::{NamedRequirementsResolver, RequirementsSource, RequirementsSpecification};
 use uv_resolver::{FlatIndex, InMemoryIndex, OptionsBuilder};
+use uv_toolchain::ToolchainRequest;
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 
 use uv_cache::Cache;
@@ -41,7 +42,15 @@ pub(crate) async fn add(
     let project = ProjectWorkspace::discover(&std::env::current_dir()?, None).await?;
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(project.workspace(), python.as_deref(), cache, printer)?;
+    let venv = project::init_environment(
+        project.workspace(),
+        python.as_deref().map(ToolchainRequest::parse),
+        connectivity,
+        native_tls,
+        cache,
+        printer,
+    )
+    .await?;
 
     let client_builder = BaseClientBuilder::new()
         .connectivity(connectivity)

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -18,7 +18,7 @@ use uv_resolver::{
     ExcludeNewer, FlatIndex, InMemoryIndex, Lock, OptionsBuilder, PreReleaseMode, RequiresPython,
     ResolutionMode,
 };
-use uv_toolchain::Interpreter;
+use uv_toolchain::{Interpreter, ToolchainRequest};
 use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
 use uv_warnings::warn_user;
 
@@ -47,7 +47,15 @@ pub(crate) async fn lock(
     let workspace = Workspace::discover(&std::env::current_dir()?, None).await?;
 
     // Find an interpreter for the project
-    let interpreter = project::find_interpreter(&workspace, python.as_deref(), cache, printer)?;
+    let interpreter = project::find_interpreter(
+        &workspace,
+        python.as_deref().map(ToolchainRequest::parse),
+        connectivity,
+        native_tls,
+        cache,
+        printer,
+    )
+    .await?;
 
     // Perform the lock operation.
     match do_lock(

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -6,6 +6,7 @@ use uv_client::Connectivity;
 use uv_configuration::{Concurrency, ExtrasSpecification, PreviewMode};
 use uv_distribution::pyproject_mut::PyProjectTomlMut;
 use uv_distribution::ProjectWorkspace;
+use uv_toolchain::ToolchainRequest;
 use uv_warnings::warn_user;
 
 use crate::commands::pip::operations::Modifications;
@@ -81,7 +82,15 @@ pub(crate) async fn remove(
     )?;
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(project.workspace(), python.as_deref(), cache, printer)?;
+    let venv = project::init_environment(
+        project.workspace(),
+        python.as_deref().map(ToolchainRequest::parse),
+        connectivity,
+        native_tls,
+        cache,
+        printer,
+    )
+    .await?;
 
     // Use the default settings.
     let settings = ResolverSettings::default();

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -60,8 +60,15 @@ pub(crate) async fn run(
         } else {
             ProjectWorkspace::discover(&std::env::current_dir()?, None).await?
         };
-        let venv =
-            project::init_environment(project.workspace(), python.as_deref(), cache, printer)?;
+        let venv = project::init_environment(
+            project.workspace(),
+            python.as_deref().map(ToolchainRequest::parse),
+            connectivity,
+            native_tls,
+            cache,
+            printer,
+        )
+        .await?;
 
         // Lock and sync the environment.
         let lock = project::lock::do_lock(

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -16,7 +16,7 @@ use uv_git::GitResolver;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
 use uv_resolver::{FlatIndex, InMemoryIndex, Lock};
-use uv_toolchain::PythonEnvironment;
+use uv_toolchain::{PythonEnvironment, ToolchainRequest};
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 use uv_warnings::warn_user;
 
@@ -49,7 +49,15 @@ pub(crate) async fn sync(
     let project = ProjectWorkspace::discover(&std::env::current_dir()?, None).await?;
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(project.workspace(), python.as_deref(), cache, printer)?;
+    let venv = project::init_environment(
+        project.workspace(),
+        python.as_deref().map(ToolchainRequest::parse),
+        connectivity,
+        native_tls,
+        cache,
+        printer,
+    )
+    .await?;
 
     // Read the lockfile.
     let lock: Lock = {

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -302,9 +302,7 @@ impl TestContext {
             .arg(self.cache_dir.path())
             .env("VIRTUAL_ENV", self.venv.as_os_str())
             .env("UV_TOOLCHAIN_DIR", "")
-            .env("UV_TEST_PYTHON_PATH", &self.python_path())
             .env("UV_NO_WRAP", "1")
-            .env("UV_TOOLCHAIN_DIR", "")
             .env("UV_TEST_PYTHON_PATH", &self.python_path())
             .current_dir(&self.temp_dir);
 

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -1887,7 +1887,8 @@ fn lock_requires_python() -> Result<()> {
         .collect();
 
     // Install from the lockfile.
-    uv_snapshot!(filters, context38.sync(), @r###"
+    // Note we need `--offline` otherwise we'll just fetch a 3.12 interpreter!
+    uv_snapshot!(filters, context38.sync().arg("--offline"), @r###"
     success: false
     exit_code: 2
     ----- stdout -----


### PR DESCRIPTION
As in #4360, updates the uv project CLI to respect `.python-version` files as default Python version requests. Additionally, updates project interpreter discovery to fetch managed toolchains as in `uv venv --preview`.