### PR TITLE
Remove extraneous installations in `uv sync` by default

### DIFF
--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -188,7 +188,7 @@ pub(super) async fn do_sync(
     pip::operations::install(
         &resolution,
         site_packages,
-        Modifications::Sufficient,
+        Modifications::Exact,
         reinstall,
         build_options,
         *link_mode,

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -691,10 +691,13 @@ fn remove_registry() -> Result<()> {
     warning: `uv remove` is experimental and may change without warning.
     Resolved 1 package in [TIME]
     Downloaded 1 package in [TIME]
-    Uninstalled 1 package in [TIME]
+    Uninstalled 4 packages in [TIME]
     Installed 1 package in [TIME]
+     - anyio==3.7.0
+     - idna==3.6
      - project==0.1.0 (from file://[TEMP_DIR]/)
      + project==0.1.0 (from file://[TEMP_DIR]/)
+     - sniffio==1.3.1
     "###);
 
     let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
@@ -808,10 +811,13 @@ fn remove_dev() -> Result<()> {
     warning: `uv remove` is experimental and may change without warning.
     Resolved 1 package in [TIME]
     Downloaded 1 package in [TIME]
-    Uninstalled 1 package in [TIME]
+    Uninstalled 4 packages in [TIME]
     Installed 1 package in [TIME]
+     - anyio==3.7.0
+     - idna==3.6
      - project==0.1.0 (from file://[TEMP_DIR]/)
      + project==0.1.0 (from file://[TEMP_DIR]/)
+     - sniffio==1.3.1
     "###);
 
     let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
@@ -917,10 +923,13 @@ fn remove_all_registry() -> Result<()> {
     warning: `uv remove` is experimental and may change without warning.
     Resolved 1 package in [TIME]
     Downloaded 1 package in [TIME]
-    Uninstalled 1 package in [TIME]
+    Uninstalled 4 packages in [TIME]
     Installed 1 package in [TIME]
+     - anyio==3.7.0
+     - idna==3.6
      - project==0.1.0 (from file://[TEMP_DIR]/)
      + project==0.1.0 (from file://[TEMP_DIR]/)
+     - sniffio==1.3.1
     "###);
 
     let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;


### PR DESCRIPTION
## Summary

First step of https://github.com/astral-sh/uv/issues/4358. `uv sync` will now remove any extraneous installations by default.