### PR TITLE
Add filtering of interpreter names for tests with multiple Python versions

### DIFF
--- a/crates/uv/tests/toolchain_find.rs
+++ b/crates/uv/tests/toolchain_find.rs
@@ -7,110 +7,85 @@ mod common;
 
 #[test]
 fn toolchain_find() {
-    let context: TestContext = TestContext::new("3.12");
+    let context: TestContext = TestContext::new_with_versions(&["3.11", "3.12"]);
 
     // No interpreters on the path
     uv_snapshot!(context.filters(), context.toolchain_find(), @r###"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: No Python interpreters found in provided path, active virtual environment, or search path
-    "###);
-
-    let python_path = python_path_with_versions(&context.temp_dir, &["3.11", "3.12"])
-        .expect("Failed to create Python test path");
-
-    // Create some filters for the test interpreters, otherwise they'll be a path on the dev's machine
-    // TODO(zanieb): Standardize this when writing more tests
-    let python_path_filters = std::env::split_paths(&python_path)
-        .zip(["3.11", "3.12"])
-        .flat_map(|(path, version)| {
-            TestContext::path_patterns(path)
-                .into_iter()
-                .map(move |pattern| {
-                    (
-                        format!("{pattern}python.*"),
-                        format!("[PYTHON-PATH-{version}]"),
-                    )
-                })
-        })
-        .collect::<Vec<_>>();
-
-    let filters = python_path_filters
-        .iter()
-        .map(|(pattern, replacement)| (pattern.as_str(), replacement.as_str()))
-        .chain(context.filters())
-        .collect::<Vec<_>>();
-
-    // We find the first interpreter on the path
-    uv_snapshot!(filters, context.toolchain_find()
-        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    [PYTHON-PATH-3.11]
+    [PYTHON-3.11]
+
+    ----- stderr -----
+    "###);
+
+    // We find the first interpreter on the path
+    uv_snapshot!(context.filters(), context.toolchain_find()
+        , @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [PYTHON-3.11]
 
     ----- stderr -----
     "###);
 
     // Request Python 3.12
-    uv_snapshot!(filters, context.toolchain_find()
+    uv_snapshot!(context.filters(), context.toolchain_find()
         .arg("3.12")
-        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+        , @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    [PYTHON-PATH-3.12]
+    [PYTHON-3.12]
 
     ----- stderr -----
     "###);
 
     // Request Python 3.11
-    uv_snapshot!(filters, context.toolchain_find()
+    uv_snapshot!(context.filters(), context.toolchain_find()
         .arg("3.11")
-        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+        , @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    [PYTHON-PATH-3.11]
+    [PYTHON-3.11]
 
     ----- stderr -----
     "###);
 
     // Request CPython
-    uv_snapshot!(filters, context.toolchain_find()
+    uv_snapshot!(context.filters(), context.toolchain_find()
         .arg("cpython")
-        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+        , @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    [PYTHON-PATH-3.11]
+    [PYTHON-3.11]
 
     ----- stderr -----
     "###);
 
     // Request CPython 3.12
-    uv_snapshot!(filters, context.toolchain_find()
+    uv_snapshot!(context.filters(), context.toolchain_find()
         .arg("cpython@3.12")
-        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+        , @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    [PYTHON-PATH-3.12]
+    [PYTHON-3.12]
 
     ----- stderr -----
     "###);
 
     // Request CPython 3.12 via partial key syntax
-    uv_snapshot!(filters, context.toolchain_find()
+    uv_snapshot!(context.filters(), context.toolchain_find()
         .arg("cpython-3.12")
-        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+        , @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    [PYTHON-PATH-3.12]
+    [PYTHON-3.12]
 
     ----- stderr -----
     "###);
@@ -119,21 +94,21 @@ fn toolchain_find() {
     let os = Os::from_env();
     let arch = Arch::from_env();
 
-    uv_snapshot!(filters, context.toolchain_find()
+    uv_snapshot!(context.filters(), context.toolchain_find()
     .arg(format!("cpython-3.12-{os}-{arch}"))
-    .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+    , @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    [PYTHON-PATH-3.12]
+    [PYTHON-3.12]
 
     ----- stderr -----
     "###);
 
     // Request PyPy
-    uv_snapshot!(filters, context.toolchain_find()
+    uv_snapshot!(context.filters(), context.toolchain_find()
         .arg("pypy")
-        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+        , @r###"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -142,28 +117,27 @@ fn toolchain_find() {
     error: No interpreter found for PyPy in provided path, active virtual environment, or search path
     "###);
 
-    // Swap the order (but don't change the filters to preserve our indices)
+    // Swap the order of the Python versions
     let python_path = python_path_with_versions(&context.temp_dir, &["3.12", "3.11"])
         .expect("Failed to create Python test path");
 
-    uv_snapshot!(filters, context.toolchain_find()
-        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+    uv_snapshot!(context.filters(), context.toolchain_find().env("UV_TEST_PYTHON_PATH", python_path), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    [PYTHON-PATH-3.12]
+    [PYTHON-3.12]
 
     ----- stderr -----
     "###);
 
     // Request Python 3.11
-    uv_snapshot!(filters, context.toolchain_find()
+    uv_snapshot!(context.filters(), context.toolchain_find()
         .arg("3.11")
-        .env("UV_TEST_PYTHON_PATH", &python_path), @r###"
+        , @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    [PYTHON-PATH-3.11]
+    [PYTHON-3.11]
 
     ----- stderr -----
     "###);


### PR DESCRIPTION
Extends new filters for interpreter paths to apply to tests with multiple Python versions. Adds patch version filtering for them as well, which is needed for #4360 tests.