### PR TITLE
uv lock to use overrides from tool.uv (#4108)

### DIFF
--- a/crates/uv-distribution/src/pyproject.rs
+++ b/crates/uv-distribution/src/pyproject.rs
@@ -83,6 +83,14 @@ pub struct ToolUv {
         )
     )]
     pub dev_dependencies: Option<Vec<pep508_rs::Requirement<VerbatimParsedUrl>>>,
+    #[cfg_attr(
+        feature = "schemars",
+        schemars(
+            with = "Option<Vec<String>>",
+            description = "PEP 508 style requirements, e.g. `flask==3.0.0`, or `black @ https://...`."
+        )
+    )]
+    pub override_dependencies: Option<Vec<pep508_rs::Requirement<VerbatimParsedUrl>>>,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This will make `uv lock` read `override-dependencies` from  the `[tool.uv]` section of `pyproject.toml`.
Resolves #4108

This [other](https://github.com/astral-sh/uv/pull/4446)  implementation touches more code but seems more consistent.

## Test Plan

Unit test