### PR TITLE
Fix cache-prune-test to work outside the git repository

### DIFF
--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -71,7 +71,10 @@ fn prune_no_op() -> Result<()> {
     let filters: Vec<_> = context
         .filters()
         .into_iter()
-        .chain([(r"uv \d+\.\d+\.\d+ \(.*\)", r"uv [VERSION] ([COMMIT] DATE)")])
+        .chain([(
+            r"uv \d+\.\d+\.\d+( \(.*\))?",
+            r"uv [VERSION] ([COMMIT] DATE)",
+        )])
         .collect();
 
     uv_snapshot!(filters, prune_command(&context).arg("--verbose"), @r###"
@@ -109,7 +112,10 @@ fn prune_stale_directory() -> Result<()> {
     let filters: Vec<_> = context
         .filters()
         .into_iter()
-        .chain([(r"uv \d+\.\d+\.\d+ \(.*\)", r"uv [VERSION] ([COMMIT] DATE)")])
+        .chain([(
+            r"uv \d+\.\d+\.\d+( \(.*\))?",
+            r"uv [VERSION] ([COMMIT] DATE)",
+        )])
         .collect();
 
     uv_snapshot!(filters, prune_command(&context).arg("--verbose"), @r###"
@@ -149,7 +155,10 @@ fn prune_stale_symlink() -> Result<()> {
         .filters()
         .into_iter()
         .chain([
-            (r"uv \d+\.\d+\.\d+ \(.*\)", r"uv [VERSION] ([COMMIT] DATE)"),
+            (
+                r"uv \d+\.\d+\.\d+( \(.*\))?",
+                r"uv [VERSION] ([COMMIT] DATE)",
+            ),
             // The cache entry does not have a stable key, so we filter it out
             (
                 r"\[CACHE_DIR\](\\|\/)(.+)(\\|\/).*",


### PR DESCRIPTION
## Summary

Make the git commit/date part of the version string matched in cache_prune optional, so that the test also works correctly when uv is built from an unpacked release tarball rather than a git repository.

Fixes #4374

## Test Plan

Ran `cargo test` inside the git repository and inside unpacked archive for `0.2.12` release with the patch applied on top.