### PR TITLE
Ignore query errors during `uv toolchain list`

### DIFF
--- a/crates/uv-toolchain/src/lib.rs
+++ b/crates/uv-toolchain/src/lib.rs
@@ -7,7 +7,7 @@ pub use crate::discovery::{
 };
 pub use crate::environment::PythonEnvironment;
 pub use crate::implementation::ImplementationName;
-pub use crate::interpreter::Interpreter;
+pub use crate::interpreter::{Error as InterpreterError, Interpreter};
 pub use crate::pointer_size::PointerSize;
 pub use crate::prefix::Prefix;
 pub use crate::python_version::PythonVersion;

--- a/crates/uv/src/commands/toolchain/list.rs
+++ b/crates/uv/src/commands/toolchain/list.rs
@@ -59,10 +59,16 @@ pub(crate) async fn list(
         &ToolchainSources::All(PreviewMode::Enabled),
         cache,
     )
-    // Raise any errors encountered during discovery
+    // Raise discovery errors if critical
+    .filter(|result| {
+        result
+            .as_ref()
+            .err()
+            .map_or(true, DiscoveryError::is_critical)
+    })
     .collect::<Result<Vec<Result<Toolchain, ToolchainNotFound>>, DiscoveryError>>()?
     .into_iter()
-    // Then drop any "missing" toolchains
+    // Drop any "missing" toolchains
     .filter_map(std::result::Result::ok);
 
     let mut output = BTreeSet::new();


### PR DESCRIPTION
Closes #4380 

~This is the same logic as `should_stop_discovery` but I changed the log level and duplicated it because I don't really want that method to be public. Maybe it should be though?~