### PR TITLE
Use "Prepared" instead of "Downloaded" in logs

### DIFF
--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -393,7 +393,7 @@ pub(crate) async fn install(
             printer.stderr(),
             "{}",
             format!(
-                "Downloaded {} in {}",
+                "Prepared {} in {}",
                 format!("{} package{}", wheels.len(), s).bold(),
                 elapsed(start.elapsed())
             )

--- a/crates/uv/src/commands/reporters.rs
+++ b/crates/uv/src/commands/reporters.rs
@@ -135,7 +135,7 @@ impl ProgressReporter {
         state.sizes.insert(position, size.unwrap_or(0));
 
         let progress = multi_progress.insert(
-            // Make sure not to reorder the initial "Downloading..." bar, or any previous bars.
+            // Make sure not to reorder the initial "Preparing..." bar, or any previous bars.
             position + 1 + state.headers,
             ProgressBar::with_draw_target(size, self.printer.target()),
         );
@@ -243,7 +243,7 @@ impl From<Printer> for DownloadReporter {
                 .unwrap()
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
         );
-        root.set_message("Downloading packages...");
+        root.set_message("Preparing packages...");
 
         let reporter = ProgressReporter::new(root, multi_progress, printer);
         Self { reporter }

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -800,10 +800,10 @@ pub fn run_and_format<T: AsRef<str>>(
                 for i in 1..20 {
                     for verb in match windows_filters {
                         WindowsFilters::Platform => {
-                            ["Resolved", "Downloaded", "Installed", "Uninstalled"].iter()
+                            ["Resolved", "Prepared", "Installed", "Uninstalled"].iter()
                         }
                         WindowsFilters::Universal => {
-                            ["Downloaded", "Installed", "Uninstalled"].iter()
+                            ["Prepared", "Installed", "Uninstalled"].iter()
                         }
                     } {
                         snapshot = snapshot.replace(

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -32,7 +32,7 @@ fn add_registry() -> Result<()> {
     ----- stderr -----
     warning: `uv add` is experimental and may change without warning.
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
      + idna==3.7
@@ -159,7 +159,7 @@ fn add_git() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
      + idna==3.6
@@ -175,7 +175,7 @@ fn add_git() -> Result<()> {
     ----- stderr -----
     warning: `uv add` is experimental and may change without warning.
     Resolved 5 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 2 packages in [TIME]
      - project==0.1.0 (from file://[TEMP_DIR]/)
@@ -305,7 +305,7 @@ fn add_unnamed() -> Result<()> {
     ----- stderr -----
     warning: `uv add` is experimental and may change without warning.
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
      + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979?rev=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
@@ -396,7 +396,7 @@ fn add_remove_dev() -> Result<()> {
     ----- stderr -----
     warning: `uv add` is experimental and may change without warning.
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
      + idna==3.7
@@ -515,7 +515,7 @@ fn add_remove_dev() -> Result<()> {
     ----- stderr -----
     warning: `uv remove` is experimental and may change without warning.
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 4 packages in [TIME]
     Installed 1 package in [TIME]
      - anyio==3.7.0
@@ -620,7 +620,7 @@ fn add_remove_workspace() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + child1==0.1.0 (from file://[TEMP_DIR]/child1)
      + child2==0.1.0 (from file://[TEMP_DIR]/child2)
@@ -698,7 +698,7 @@ fn add_remove_workspace() -> Result<()> {
     ----- stderr -----
     warning: `uv remove` is experimental and may change without warning.
     Resolved 2 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 2 packages in [TIME]
     Installed 1 package in [TIME]
      - child1==0.1.0 (from file://[TEMP_DIR]/child1)
@@ -797,7 +797,7 @@ fn update_registry() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
      + idna==3.6
@@ -813,7 +813,7 @@ fn update_registry() -> Result<()> {
     ----- stderr -----
     warning: `uv add` is experimental and may change without warning.
     Resolved 4 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Uninstalled 2 packages in [TIME]
     Installed 2 packages in [TIME]
      - anyio==3.7.0
@@ -942,7 +942,7 @@ fn add_no_clean() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
      + idna==3.6
@@ -967,7 +967,7 @@ fn add_no_clean() -> Result<()> {
     ----- stderr -----
     warning: `uv add` is experimental and may change without warning.
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 2 packages in [TIME]
      + iniconfig==2.0.0
@@ -1083,7 +1083,7 @@ fn remove_registry() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
      + idna==3.6
@@ -1099,7 +1099,7 @@ fn remove_registry() -> Result<()> {
     ----- stderr -----
     warning: `uv remove` is experimental and may change without warning.
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 4 packages in [TIME]
     Installed 1 package in [TIME]
      - anyio==3.7.0

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -98,7 +98,7 @@ fn lock_wheel_registry() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
      + idna==3.6
@@ -173,7 +173,7 @@ fn lock_sdist_registry() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
      + source-distribution==0.0.1
@@ -246,7 +246,7 @@ fn lock_sdist_git() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
      + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
@@ -343,7 +343,7 @@ fn lock_wheel_url() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0 (from https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl)
      + idna==3.6
@@ -442,7 +442,7 @@ fn lock_sdist_url() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0 (from https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz)
      + idna==3.6
@@ -559,7 +559,7 @@ fn lock_project_extra() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
      + idna==3.6
@@ -575,7 +575,7 @@ fn lock_project_extra() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###);
@@ -818,7 +818,7 @@ fn lock_dependency_extra() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 9 packages in [TIME]
+    Prepared 9 packages in [TIME]
     Installed 9 packages in [TIME]
      + blinker==1.7.0
      + click==8.1.7
@@ -1060,7 +1060,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 6 packages in [TIME]
+    Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + certifi==2024.2.2
      + charset-normalizer==3.0.1
@@ -1084,7 +1084,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + certifi==2024.2.2
      + charset-normalizer==3.0.1
@@ -2269,7 +2269,7 @@ fn lock_dev() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + iniconfig==2.0.0
      + project==0.1.0 (from file://[TEMP_DIR]/)

--- a/crates/uv/tests/pip_check.rs
+++ b/crates/uv/tests/pip_check.rs
@@ -65,7 +65,7 @@ fn check_compatible_packages() -> Result<()> {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    Downloaded 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
      + certifi==2024.2.2
      + charset-normalizer==3.3.2
@@ -108,7 +108,7 @@ fn check_incompatible_packages() -> Result<()> {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    Downloaded 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
      + certifi==2024.2.2
      + charset-normalizer==3.3.2
@@ -131,7 +131,7 @@ fn check_incompatible_packages() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - idna==3.6
@@ -175,7 +175,7 @@ fn check_multiple_incompatible_packages() -> Result<()> {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    Downloaded 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
      + certifi==2024.2.2
      + charset-normalizer==3.3.2
@@ -198,7 +198,7 @@ fn check_multiple_incompatible_packages() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Uninstalled 2 packages in [TIME]
     Installed 2 packages in [TIME]
      - idna==3.6

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -7998,7 +7998,7 @@ fn local_version_of_remote_package() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.3.0+foo (from file://[WORKSPACE]/scripts/packages/anyio_local)
     "###

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -330,7 +330,7 @@ fn install_package() {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + blinker==1.7.0
      + click==8.1.7
@@ -364,7 +364,7 @@ fn install_requirements_txt() -> Result<()> {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + blinker==1.7.0
      + click==8.1.7
@@ -477,7 +477,7 @@ build-backend = "poetry.core.masonry.api"
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.1
      + idna==3.6
@@ -508,7 +508,7 @@ fn respect_installed_and_reinstall() -> Result<()> {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + blinker==1.7.0
      + click==8.1.7
@@ -565,7 +565,7 @@ fn respect_installed_and_reinstall() -> Result<()> {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - flask==2.3.2
@@ -589,7 +589,7 @@ fn respect_installed_and_reinstall() -> Result<()> {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - flask==2.3.3
@@ -642,7 +642,7 @@ fn reinstall_extras() -> Result<()> {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + anyio==4.3.0
      + certifi==2024.2.2
@@ -670,7 +670,7 @@ fn reinstall_extras() -> Result<()> {
 
     ----- stderr -----
     Resolved 10 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + h2==4.1.0
      + hpack==4.0.0
@@ -701,7 +701,7 @@ fn reinstall_incomplete() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==3.7.0
      + idna==3.6
@@ -725,7 +725,7 @@ fn reinstall_incomplete() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     warning: Failed to uninstall package at [SITE_PACKAGES]/anyio-3.7.0.dist-info due to missing RECORD file. Installation may result in an incomplete environment.
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -756,7 +756,7 @@ fn allow_incompatibilities() -> Result<()> {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + blinker==1.7.0
      + click==8.1.7
@@ -784,7 +784,7 @@ fn allow_incompatibilities() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - jinja2==3.1.3
@@ -813,7 +813,7 @@ fn install_editable() {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -846,7 +846,7 @@ fn install_editable() {
 
     ----- stderr -----
     Resolved 10 packages in [TIME]
-    Downloaded 6 packages in [TIME]
+    Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + black==24.3.0
      + click==8.1.7
@@ -871,7 +871,7 @@ fn install_editable_and_registry() {
 
     ----- stderr -----
     Resolved 6 packages in [TIME]
-    Downloaded 6 packages in [TIME]
+    Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + black==24.3.0
      + click==8.1.7
@@ -892,7 +892,7 @@ fn install_editable_and_registry() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - black==24.3.0
@@ -932,7 +932,7 @@ fn install_editable_and_registry() {
 
     ----- stderr -----
     Resolved 6 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
@@ -957,7 +957,7 @@ fn install_editable_no_binary() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
     "###
@@ -983,7 +983,7 @@ fn install_editable_compatible_constraint() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
     "###
@@ -1065,7 +1065,7 @@ fn install_editable_pep_508_requirements_txt() -> Result<()> {
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Downloaded 8 packages in [TIME]
+    Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
      + aiohttp==3.9.3
      + aiosignal==1.3.1
@@ -1094,7 +1094,7 @@ fn install_editable_pep_508_cli() {
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Downloaded 8 packages in [TIME]
+    Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
      + aiohttp==3.9.3
      + aiosignal==1.3.1
@@ -1124,7 +1124,7 @@ fn install_editable_bare_cli() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
     "###
@@ -1150,7 +1150,7 @@ fn install_editable_bare_requirements_txt() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
     "###
@@ -1253,7 +1253,7 @@ fn reinstall_build_system() -> Result<()> {
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Downloaded 8 packages in [TIME]
+    Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
      + blinker==1.7.0
      + click==8.1.7
@@ -1355,7 +1355,7 @@ fn install_extra_index_url_has_priority() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==24.2.0
     "###
@@ -1381,7 +1381,7 @@ fn install_git_public_https() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
     "###);
@@ -1480,7 +1480,7 @@ fn install_git_private_https_pat() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + uv-private-pypackage==0.1.0 (from git+https://***@github.com/astral-test/uv-private-pypackage@d780faf0ac91257d4d5a4f0c5a0e4509608c0071)
     "###);
@@ -1513,7 +1513,7 @@ fn install_git_private_https_pat_mixed_with_public() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + uv-private-pypackage==0.1.0 (from git+https://***@github.com/astral-test/uv-private-pypackage@d780faf0ac91257d4d5a4f0c5a0e4509608c0071)
      + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
@@ -1550,7 +1550,7 @@ fn install_git_private_https_multiple_pat() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + uv-private-pypackage==0.1.0 (from git+https://***_1@github.com/astral-test/uv-private-pypackage@d780faf0ac91257d4d5a4f0c5a0e4509608c0071)
      + uv-private-pypackage-2==0.1.0 (from git+https://***_2@github.com/astral-test/uv-private-pypackage-2@45c0bec7365710f09b1f4dbca61c86dde9537e4e)
@@ -1590,7 +1590,7 @@ fn install_git_private_https_pat_at_ref() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + uv-private-pypackage==0.1.0 (from ***@github.com/astral-test/uv-private-pypackage@6c09ce9ae81f50670a60abd7d95f30dd416d00ac)
     "###);
@@ -1624,7 +1624,7 @@ fn install_git_private_https_pat_and_username() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + uv-private-pypackage==0.1.0 (from git+https://astral-test-bot:***@github.com/astral-test/uv-private-pypackage@6c09ce9ae81f50670a60abd7d95f30dd416d00ac)
     "###);
@@ -1693,7 +1693,7 @@ fn install_github_artifact_private_https_pat_mixed_with_public() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + uv-private-pypackage==0.1.0 (from https://***@raw.githubusercontent.com/astral-test/uv-private-pypackage/main/dist/uv_private_pypackage-0.1.0-py3-none-any.whl)
      + uv-public-pypackage==0.1.0 (from https://raw.githubusercontent.com/astral-test/uv-public-pypackage/main/dist/uv_public_pypackage-0.1.0-py3-none-any.whl)
@@ -1731,7 +1731,7 @@ fn install_github_artifact_private_https_multiple_pat() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + uv-private-pypackage==0.1.0 (from https://astral-test-bot:***_1@raw.githubusercontent.com/astral-test/uv-private-pypackage/main/dist/uv_private_pypackage-0.1.0-py3-none-any.whl)
      + uv-private-pypackage-2==0.1.0 (from https://astral-test-bot:***_2@raw.githubusercontent.com/astral-test/uv-private-pypackage-2/main/dist/uv_private_pypackage_2-0.1.0-py3-none-any.whl)
@@ -1757,7 +1757,7 @@ fn reinstall_no_binary() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -1847,7 +1847,7 @@ fn install_no_binary_overrides_only_binary_all() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -1881,7 +1881,7 @@ fn install_only_binary_overrides_no_binary_all() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -2065,7 +2065,7 @@ fn only_binary_editable() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.3.0+foo (from file://[WORKSPACE]/scripts/packages/anyio_local)
     "###
@@ -2094,7 +2094,7 @@ fn only_binary_dependent_editables() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + first-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/first_local)
      + second-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/second_local)
@@ -2119,7 +2119,7 @@ fn only_binary_editable_setup_py() {
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Downloaded 8 packages in [TIME]
+    Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
      + anyio==4.3.0
      + certifi==2024.2.2
@@ -2149,7 +2149,7 @@ fn install_executable() {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + astroid==3.0.3
      + dill==0.3.8
@@ -2185,7 +2185,7 @@ fn install_executable_copy() {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + astroid==3.0.3
      + dill==0.3.8
@@ -2221,7 +2221,7 @@ fn install_executable_hardlink() {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + astroid==3.0.3
      + dill==0.3.8
@@ -2257,7 +2257,7 @@ fn no_deps() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + flask==3.0.2
     warning: The package `flask` requires `werkzeug>=3.0.0`, but it's not installed.
@@ -2288,7 +2288,7 @@ fn no_deps_editable() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
     "###
@@ -2314,7 +2314,7 @@ fn install_upgrade() {
 
     ----- stderr -----
     Resolved 6 packages in [TIME]
-    Downloaded 6 packages in [TIME]
+    Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + anyio==3.6.2
      + certifi==2024.2.2
@@ -2338,7 +2338,7 @@ fn install_upgrade() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==3.6.2
@@ -2386,7 +2386,7 @@ fn install_upgrade() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - httpcore==0.16.3
@@ -2416,7 +2416,7 @@ fn install_constraints_txt() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==3.7.0
      + idna==3.3
@@ -2446,7 +2446,7 @@ fn install_constraints_inline() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==3.7.0
      + idna==3.3
@@ -2472,7 +2472,7 @@ fn install_constraints_remote() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + typing-extensions==4.7.1
     "###
@@ -2496,7 +2496,7 @@ fn install_constraints_inline_remote() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + typing-extensions==4.7.1
     "### // would yield typing-extensions==4.8.2 without constraint file
@@ -2527,7 +2527,7 @@ fn install_constraints_extra() -> Result<()> {
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Downloaded 8 packages in [TIME]
+    Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
      + blinker==1.7.0
      + click==8.1.7
@@ -2584,7 +2584,7 @@ fn install_pinned_polars_invalid_metadata() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + polars==0.14.0
     "###
@@ -2611,7 +2611,7 @@ fn install_sdist_resolution_lowest() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.2.0 (from https://files.pythonhosted.org/packages/2d/b8/7333d87d5f03247215d86a86362fd3e324111788c6cdd8d2e6196a6ba833/anyio-4.2.0.tar.gz)
      + idna==3.6
@@ -2644,7 +2644,7 @@ fn direct_url_zip_file_bunk_permissions() -> Result<()> {
 
     ----- stderr -----
     Resolved 6 packages in [TIME]
-    Downloaded 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
     Installed 6 packages in [TIME]
      + distro==1.9.0
      + opensafely-pipeline==2023.11.6.145820 (from https://github.com/opensafely-core/pipeline/archive/refs/tags/v2023.11.06.145820.zip)
@@ -2682,7 +2682,7 @@ fn launcher() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + simple_launcher.whl
     "###
@@ -2728,7 +2728,7 @@ fn launcher_with_symlink() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + simple_launcher.whl
     "###
@@ -2785,7 +2785,7 @@ fn config_settings() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + iniconfig==2.0.0
      + setuptools-editable==0.1.0 (from file://[WORKSPACE]/scripts/packages/setuptools_editable)
@@ -2813,7 +2813,7 @@ fn config_settings() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + iniconfig==2.0.0
      + setuptools-editable==0.1.0 (from file://[WORKSPACE]/scripts/packages/setuptools_editable)
@@ -2875,7 +2875,7 @@ fn reinstall_duplicate() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 2 packages in [TIME]
     Installed 1 package in [TIME]
      - pip==21.3.1
@@ -2901,7 +2901,7 @@ fn install_symlink() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + pgpdump==1.5
     "###
@@ -2950,7 +2950,7 @@ requires-python = ">=3.8"
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.0.0
      + example==0.0.0 (from file://[TEMP_DIR]/editable)
@@ -2994,7 +2994,7 @@ requires-python = ">=3.8"
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Uninstalled 2 packages in [TIME]
     Installed 2 packages in [TIME]
      - anyio==4.0.0
@@ -3040,7 +3040,7 @@ dependencies = {file = ["requirements.txt"]}
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.0.0
      + example==0.1.0 (from file://[TEMP_DIR]/editable)
@@ -3059,7 +3059,7 @@ dependencies = {file = ["requirements.txt"]}
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - example==0.1.0 (from file://[TEMP_DIR]/editable)
@@ -3080,7 +3080,7 @@ dependencies = {file = ["requirements.txt"]}
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Uninstalled 2 packages in [TIME]
     Installed 2 packages in [TIME]
      - anyio==4.0.0
@@ -3121,7 +3121,7 @@ requires-python = ">=3.8"
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.0.0
      + example==0.0.0 (from file://[TEMP_DIR]/editable)
@@ -3165,7 +3165,7 @@ requires-python = ">=3.8"
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Uninstalled 2 packages in [TIME]
     Installed 2 packages in [TIME]
      - anyio==4.0.0
@@ -3208,7 +3208,7 @@ requires-python = ">=3.11,<3.13"
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.0.0
      + example==0.1.0 (from file://[TEMP_DIR]/editable)
@@ -3300,7 +3300,7 @@ fn no_build_isolation() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + setuptools==69.2.0
      + wheel==0.43.0
@@ -3317,7 +3317,7 @@ fn no_build_isolation() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==0.0.0 (from https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz)
      + idna==3.6
@@ -3371,7 +3371,7 @@ fn respect_no_build_isolation_env_var() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + setuptools==69.2.0
      + wheel==0.43.0
@@ -3388,7 +3388,7 @@ fn respect_no_build_isolation_env_var() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==0.0.0 (from https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz)
      + idna==3.6
@@ -3417,7 +3417,7 @@ fn install_utf16le_requirements() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tomli==2.0.1
     "###
@@ -3443,7 +3443,7 @@ fn install_utf16be_requirements() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tomli==2.0.1
     "###
@@ -3548,7 +3548,7 @@ fn dry_run_uninstall_url_dependency() -> std::result::Result<(), Box<dyn std::er
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.2.0 (from https://files.pythonhosted.org/packages/2d/b8/7333d87d5f03247215d86a86362fd3e324111788c6cdd8d2e6196a6ba833/anyio-4.2.0.tar.gz)
      + idna==3.6
@@ -3599,7 +3599,7 @@ fn dry_run_install_already_installed() -> std::result::Result<(), Box<dyn std::e
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + anyio==4.3.0
      + certifi==2024.2.2
@@ -3649,7 +3649,7 @@ fn dry_run_install_transitive_dependency_already_installed(
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + certifi==2024.2.2
      + h11==0.14.0
@@ -3699,7 +3699,7 @@ fn dry_run_install_then_upgrade() -> std::result::Result<(), Box<dyn std::error:
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + anyio==4.3.0
      + certifi==2024.2.2
@@ -3786,7 +3786,7 @@ fn install_package_basic_auth_from_url() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -3816,7 +3816,7 @@ fn install_package_basic_auth_from_netrc_default() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -3848,7 +3848,7 @@ fn install_package_basic_auth_from_netrc() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -3888,7 +3888,7 @@ anyio
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -3917,7 +3917,7 @@ fn install_index_with_relative_links() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -3963,7 +3963,7 @@ fn install_package_basic_auth_from_keyring() {
     Request for public@https://pypi-proxy.fly.dev/basic-auth/simple/anyio/
     Request for public@pypi-proxy.fly.dev
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -4072,7 +4072,7 @@ fn install_index_with_relative_links_authenticated() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -4108,7 +4108,7 @@ fn install_site_packages_mtime_updated() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -4149,7 +4149,7 @@ fn deptry_gitignore() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + cffi==1.16.0
      + deptry-reproducer==0.1.0 (from file://[WORKSPACE]/scripts/packages/deptry_reproducer/deptry_reproducer-0.1.0.tar.gz)
@@ -4178,7 +4178,7 @@ fn reinstall_no_index() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -4236,7 +4236,7 @@ fn already_installed_remote_dependencies() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + idna==3.6
      + sniffio==1.3.1
@@ -4253,7 +4253,7 @@ fn already_installed_remote_dependencies() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.3.0
     "###
@@ -4278,7 +4278,7 @@ fn already_installed_dependent_editable() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + first-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/first_local)
     "###
@@ -4299,7 +4299,7 @@ fn already_installed_dependent_editable() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + second-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/second_local)
     "###
@@ -4354,7 +4354,7 @@ fn already_installed_dependent_editable() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - first-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/first_local)
@@ -4380,7 +4380,7 @@ fn already_installed_local_path_dependent() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + first-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/first_local)
     "###
@@ -4400,7 +4400,7 @@ fn already_installed_local_path_dependent() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + second-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/second_local)
     "###
@@ -4453,7 +4453,7 @@ fn already_installed_local_path_dependent() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - first-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/first_local)
@@ -4519,7 +4519,7 @@ fn already_installed_local_version_of_remote_package() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.3.0+foo (from file://[WORKSPACE]/scripts/packages/anyio_local)
     "###
@@ -4582,7 +4582,7 @@ fn already_installed_local_version_of_remote_package() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==4.3.0+foo (from file://[WORKSPACE]/scripts/packages/anyio_local)
@@ -4601,7 +4601,7 @@ fn already_installed_local_version_of_remote_package() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 3 packages in [TIME]
      - anyio==4.3.0+foo (from file://[WORKSPACE]/scripts/packages/anyio_local)
@@ -4620,7 +4620,7 @@ fn already_installed_local_version_of_remote_package() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==4.3.0
@@ -4653,7 +4653,7 @@ fn already_installed_local_version_of_remote_package() {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + certifi==2024.2.2
      + h11==0.14.0
@@ -4705,7 +4705,7 @@ fn already_installed_multiple_versions() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 2 packages in [TIME]
     Installed 1 package in [TIME]
      - anyio==3.7.0
@@ -4727,7 +4727,7 @@ fn already_installed_multiple_versions() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 2 packages in [TIME]
     Installed 1 package in [TIME]
      - anyio==3.7.0
@@ -4753,7 +4753,7 @@ fn already_installed_remote_url() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
     "###);
@@ -4882,7 +4882,7 @@ fn find_links() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tqdm==1000.0.0
     "###
@@ -4913,7 +4913,7 @@ fn find_links_no_binary() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tqdm==999.0.0
     "###
@@ -4953,7 +4953,7 @@ fn require_hashes() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.0.0
      + idna==3.6
@@ -4988,7 +4988,7 @@ fn require_hashes_no_deps() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.0.0
     "###
@@ -5167,7 +5167,7 @@ fn require_hashes_unnamed() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.0.0 (from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl)
      + idna==3.6
@@ -5212,7 +5212,7 @@ fn require_hashes_unnamed_repeated() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.0.0 (from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl)
      + idna==3.6
@@ -5340,7 +5340,7 @@ fn tool_uv_sources() -> Result<()> {
 
     ----- stderr -----
     Resolved 9 packages in [TIME]
-    Downloaded 9 packages in [TIME]
+    Prepared 9 packages in [TIME]
     Installed 9 packages in [TIME]
      + anyio==4.3.0
      + boltons==24.0.1.dev0 (from git+https://github.com/mahmoud/boltons@57fbaa9b673ed85b32458b31baeeae230520e4a0)
@@ -5437,7 +5437,7 @@ fn recursive_extra_transitive_url() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + iniconfig==2.0.0 (from https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
      + project==0.0.0 (from file://[TEMP_DIR]/)
@@ -5461,7 +5461,7 @@ fn prefer_editable() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
     "###
@@ -5490,7 +5490,7 @@ fn prefer_editable() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
     "###
@@ -5543,7 +5543,7 @@ fn local_index() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tqdm==1000.0.0
     "###

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -658,7 +658,7 @@ fn extra_required() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + package-a==1.0.0
      + package-b==1.0.0
@@ -708,7 +708,7 @@ fn missing_extra() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0
     warning: The package `package-a==1.0.0` does not have an extra named `extra`.
@@ -759,7 +759,7 @@ fn multiple_extras_required() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + package-a==1.0.0
      + package-b==1.0.0
@@ -839,7 +839,7 @@ fn all_extras_required() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + package-a==1.0.0
      + package-b==1.0.0
@@ -961,7 +961,7 @@ fn extra_incompatible_with_extra_not_requested() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + package-a==1.0.0
      + package-b==2.0.0
@@ -1081,7 +1081,7 @@ fn extra_does_not_exist_backtrack() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==3.0.0
     warning: The package `package-a==3.0.0` does not have an extra named `extra`.
@@ -1372,7 +1372,7 @@ fn local_not_used_with_sdist() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.2.3
     "###);
@@ -1464,7 +1464,7 @@ fn local_not_latest() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.2.1+foo
     "###);
@@ -1514,7 +1514,7 @@ fn local_transitive() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + package-a==1.0.0
      + package-b==2.0.0+foo
@@ -1625,7 +1625,7 @@ fn local_transitive_greater_than_or_equal() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + package-a==1.0.0
      + package-b==2.0.0+foo
@@ -1736,7 +1736,7 @@ fn local_transitive_less_than_or_equal() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + package-a==1.0.0
      + package-b==2.0.0+foo
@@ -1901,7 +1901,7 @@ fn local_transitive_backtrack() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + package-a==1.0.0
      + package-b==2.0.0+foo
@@ -1986,7 +1986,7 @@ fn local_greater_than_or_equal() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.2.3+foo
     "###);
@@ -2139,7 +2139,7 @@ fn post_greater_than_or_equal() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.2.3.post1
     "###);
@@ -2219,7 +2219,7 @@ fn post_greater_than_post() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.2.3.post1
     "###);
@@ -2265,7 +2265,7 @@ fn post_greater_than_or_equal_post() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.2.3.post1
     "###);
@@ -2507,7 +2507,7 @@ fn post_equal_available() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.2.3.post0
     "###);
@@ -2593,7 +2593,7 @@ fn package_only_prereleases() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0a1
     "###);
@@ -2689,7 +2689,7 @@ fn requires_package_only_prereleases_in_range_global_opt_in() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0a1
     "###);
@@ -2733,7 +2733,7 @@ fn requires_package_prerelease_and_final_any() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==0.1.0
     "###);
@@ -2785,7 +2785,7 @@ fn package_prerelease_specified_only_final_available() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==0.3.0
     "###);
@@ -2836,7 +2836,7 @@ fn package_prerelease_specified_only_prerelease_available() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==0.3.0a1
     "###);
@@ -2886,7 +2886,7 @@ fn package_prerelease_specified_mixed_available() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0a1
     "###);
@@ -2935,7 +2935,7 @@ fn package_multiple_prereleases_kinds() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0rc1
     "###);
@@ -2982,7 +2982,7 @@ fn package_multiple_prereleases_numbers() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0a3
     "###);
@@ -3030,7 +3030,7 @@ fn transitive_package_only_prereleases() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + package-a==0.1.0
      + package-b==1.0.0a1
@@ -3145,7 +3145,7 @@ fn transitive_package_only_prereleases_in_range_opt_in() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + package-a==0.1.0
      + package-b==1.0.0a1
@@ -3278,7 +3278,7 @@ fn transitive_prerelease_and_stable_dependency_opt_in() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + package-a==1.0.0
      + package-b==1.0.0
@@ -3524,7 +3524,7 @@ fn package_only_prereleases_boundary() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==0.1.0a1
     "###);
@@ -3573,7 +3573,7 @@ fn package_prereleases_boundary() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==0.1.0
     "###);
@@ -3621,7 +3621,7 @@ fn package_prereleases_global_boundary() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==0.1.0
     "###);
@@ -3671,7 +3671,7 @@ fn package_prereleases_specifier_boundary() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==0.2.0a1
     "###);
@@ -3956,7 +3956,7 @@ fn python_greater_than_current_backtrack() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0
     "###);
@@ -4063,7 +4063,7 @@ fn specific_tag_and_default() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0
     "###);
@@ -4098,7 +4098,7 @@ fn only_wheels() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0
     "###);
@@ -4133,7 +4133,7 @@ fn no_wheels() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0
     "###);
@@ -4168,7 +4168,7 @@ fn no_wheels_with_matching_platform() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0
     "###);
@@ -4407,7 +4407,7 @@ fn no_build() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0
     "###);
@@ -4447,7 +4447,7 @@ fn no_binary() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0
     "###);
@@ -4571,7 +4571,7 @@ fn requires_package_yanked_and_unyanked_any() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==0.1.0
     "###);
@@ -4619,7 +4619,7 @@ fn package_yanked_specified_mixed_available() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==0.3.0
     "###);
@@ -4775,7 +4775,7 @@ fn transitive_package_only_yanked_in_range_opt_in() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + package-a==0.1.0
      + package-b==1.0.0
@@ -4906,7 +4906,7 @@ fn transitive_yanked_and_unyanked_dependency_opt_in() {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + package-a==1.0.0
      + package-b==1.0.0

--- a/crates/uv/tests/pip_list.rs
+++ b/crates/uv/tests/pip_list.rs
@@ -122,7 +122,7 @@ fn list_single_no_editable() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + markupsafe==2.1.3
     "###
@@ -166,7 +166,7 @@ fn list_editable() {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -218,7 +218,7 @@ fn list_editable_only() {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -308,7 +308,7 @@ fn list_exclude() {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -411,7 +411,7 @@ fn list_format_json() {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -517,7 +517,7 @@ fn list_format_freeze() {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6

--- a/crates/uv/tests/pip_show.rs
+++ b/crates/uv/tests/pip_show.rs
@@ -75,7 +75,7 @@ fn show_requires_multiple() -> Result<()> {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    Downloaded 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
      + certifi==2024.2.2
      + charset-normalizer==3.3.2
@@ -130,7 +130,7 @@ fn show_python_version_marker() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + click==8.1.7
     "###
@@ -185,7 +185,7 @@ fn show_found_single_package() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + markupsafe==2.1.3
     "###
@@ -239,7 +239,7 @@ fn show_found_multiple_packages() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + markupsafe==2.1.3
      + pip==21.3.1
@@ -301,7 +301,7 @@ fn show_found_one_out_of_three() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + markupsafe==2.1.3
      + pip==21.3.1
@@ -359,7 +359,7 @@ fn show_found_one_out_of_two_quiet() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + markupsafe==2.1.3
      + pip==21.3.1
@@ -412,7 +412,7 @@ fn show_empty_quiet() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + markupsafe==2.1.3
      + pip==21.3.1
@@ -506,7 +506,7 @@ fn show_required_by_multiple() -> Result<()> {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + anyio==4.0.0
      + certifi==2024.2.2

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -142,7 +142,7 @@ fn install() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + markupsafe==2.1.3
     "###
@@ -185,7 +185,7 @@ fn install_copy() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + markupsafe==2.1.3
     "###
@@ -220,7 +220,7 @@ fn install_hardlink() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + markupsafe==2.1.3
     "###
@@ -253,7 +253,7 @@ fn install_many() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + markupsafe==2.1.3
      + tomli==2.0.1
@@ -379,7 +379,7 @@ fn add_remove() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - iniconfig==2.0.0
@@ -420,7 +420,7 @@ fn install_sequential() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tomli==2.0.1
     "###
@@ -460,7 +460,7 @@ fn upgrade() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - tomli==2.0.0
@@ -490,7 +490,7 @@ fn install_url() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + werkzeug==2.0.0 (from https://files.pythonhosted.org/packages/ff/1d/960bb4017c68674a1cb099534840f18d3def3ce44aed12b5ed8b78e0153e/Werkzeug-2.0.0-py3-none-any.whl)
     "###
@@ -519,7 +519,7 @@ fn install_git_commit() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
     "###
@@ -552,7 +552,7 @@ fn install_git_tag() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
     "###
@@ -583,7 +583,7 @@ fn install_git_subdirectories() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + example-pkg-a==1 (from git+https://github.com/pypa/sample-namespace-packages.git@df7530eeb8fa0cb7dbb8ecb28363e8e36bfa2f45#subdirectory=pkg_resources/pkg_a)
      + example-pkg-b==1 (from git+https://github.com/pypa/sample-namespace-packages.git@df7530eeb8fa0cb7dbb8ecb28363e8e36bfa2f45#subdirectory=pkg_resources/pkg_b)
@@ -614,7 +614,7 @@ fn install_sdist() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + source-distribution==0.0.1
     "###
@@ -644,7 +644,7 @@ fn install_sdist_url() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + source-distribution==0.0.1 (from https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz)
     "###
@@ -680,7 +680,7 @@ fn install_sdist_archive_type_bz2() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + bz2==1.0.0 (from file://[WORKSPACE]/scripts/links/bz2-1.0.0.tar.bz2)
     "###
@@ -785,7 +785,7 @@ fn install_version_then_install_url() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - werkzeug==2.0.0
@@ -816,7 +816,7 @@ fn install_numpy_py38() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + numpy==1.24.4
     "###
@@ -874,7 +874,7 @@ fn install_no_index_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###
@@ -925,7 +925,7 @@ fn warn_on_yanked() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + colorama==0.4.2
     warning: `colorama==0.4.2` is yanked (reason: "Bad build, missing files, will not install").
@@ -989,7 +989,7 @@ fn install_local_wheel() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tomli==2.0.1 (from file://[TEMP_DIR]/tomli-2.0.1-py3-none-any.whl)
     "###
@@ -1036,7 +1036,7 @@ fn install_local_wheel() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tomli==2.0.1 (from file://[TEMP_DIR]/tomli-2.0.1-py3-none-any.whl)
     "###
@@ -1057,7 +1057,7 @@ fn install_local_wheel() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - tomli==2.0.1 (from file://[TEMP_DIR]/tomli-2.0.1-py3-none-any.whl)
@@ -1129,7 +1129,7 @@ fn mismatched_version() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     error: Failed to install: tomli-3.7.2-py3-none-any.whl (tomli==3.7.2 (from file://[TEMP_DIR]/tomli-3.7.2-py3-none-any.whl))
       Caused by: Wheel version does not match filename: 2.0.1 != 3.7.2
     "###
@@ -1200,7 +1200,7 @@ fn install_local_source_distribution() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + wheel==0.42.0 (from file://[TEMP_DIR]/wheel-0.42.0.tar.gz)
     "###
@@ -1239,7 +1239,7 @@ fn install_build_system_no_backend() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + build-system-no-backend==0.1.0 (from https://files.pythonhosted.org/packages/ec/25/1e531108ca027dc3a3b37d351f4b86d811df4884c6a81cd99e73b8b589f5/build-system-no-backend-0.1.0.tar.gz)
     "###
@@ -1269,7 +1269,7 @@ fn install_url_source_dist_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + source-distribution==0.0.1 (from https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz)
     "###
@@ -1330,7 +1330,7 @@ fn install_url_source_dist_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + source-distribution==0.0.1 (from https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz)
     "###
@@ -1361,7 +1361,7 @@ fn install_git_source_dist_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
     "###
@@ -1459,7 +1459,7 @@ fn install_registry_source_dist_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + source-distribution==0.0.1
     "###
@@ -1533,7 +1533,7 @@ fn install_registry_source_dist_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + source-distribution==0.0.1
     "###
@@ -1572,7 +1572,7 @@ fn install_path_source_dist_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + source-distribution==0.0.1 (from file://[TEMP_DIR]/source_distribution-0.0.1.tar.gz)
     "###
@@ -1633,7 +1633,7 @@ fn install_path_source_dist_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + source-distribution==0.0.1 (from file://[TEMP_DIR]/source_distribution-0.0.1.tar.gz)
     "###
@@ -1670,7 +1670,7 @@ fn install_path_built_dist_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tomli==2.0.1 (from file://[TEMP_DIR]/tomli-2.0.1-py3-none-any.whl)
     "###
@@ -1739,7 +1739,7 @@ fn install_path_built_dist_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tomli==2.0.1 (from file://[TEMP_DIR]/tomli-2.0.1-py3-none-any.whl)
     "###
@@ -1775,7 +1775,7 @@ fn install_url_built_dist_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tqdm==4.66.1 (from https://files.pythonhosted.org/packages/00/e5/f12a80907d0884e6dff9c16d0c0114d81b8cd07dc3ae54c5e962cc83037e/tqdm-4.66.1-py3-none-any.whl)
     "###
@@ -1832,7 +1832,7 @@ fn install_url_built_dist_cached() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tqdm==4.66.1 (from https://files.pythonhosted.org/packages/00/e5/f12a80907d0884e6dff9c16d0c0114d81b8cd07dc3ae54c5e962cc83037e/tqdm-4.66.1-py3-none-any.whl)
     "###
@@ -1884,7 +1884,7 @@ fn duplicate_package_disjoint() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + markupsafe==2.1.3
     "###
@@ -1910,7 +1910,7 @@ fn reinstall() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + markupsafe==2.1.3
      + tomli==2.0.1
@@ -1963,7 +1963,7 @@ fn reinstall_package() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + markupsafe==2.1.3
      + tomli==2.0.1
@@ -2016,7 +2016,7 @@ fn reinstall_git() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
     "###
@@ -2069,7 +2069,7 @@ fn refresh() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + markupsafe==2.1.3
      + tomli==2.0.1
@@ -2094,7 +2094,7 @@ fn refresh() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + markupsafe==2.1.3
      + tomli==2.0.1
@@ -2124,7 +2124,7 @@ fn refresh_package() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + markupsafe==2.1.3
      + tomli==2.0.1
@@ -2150,7 +2150,7 @@ fn refresh_package() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 2 packages in [TIME]
      + markupsafe==2.1.3
      + tomli==2.0.1
@@ -2194,7 +2194,7 @@ fn sync_editable() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 3 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + boltons==23.1.1
      + numpy==1.26.2
@@ -2213,7 +2213,7 @@ fn sync_editable() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - poetry-editable==0.1.0 (from file://[TEMP_DIR]/poetry_editable)
@@ -2297,7 +2297,7 @@ fn sync_editable_and_registry() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==24.1.0
     warning: The package `black` requires `click>=8.0.0`, but it's not installed.
@@ -2324,7 +2324,7 @@ fn sync_editable_and_registry() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - black==24.1.0
@@ -2368,7 +2368,7 @@ fn sync_editable_and_registry() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - black==0.1.0 (from file://[TEMP_DIR]/black_editable)
@@ -2411,7 +2411,7 @@ fn sync_editable_and_local() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==0.1.0 (from file://[TEMP_DIR]/black_editable)
     "###
@@ -2432,7 +2432,7 @@ fn sync_editable_and_local() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - black==0.1.0 (from file://[TEMP_DIR]/black_editable)
@@ -2455,7 +2455,7 @@ fn sync_editable_and_local() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - black==0.1.0 (from file://[TEMP_DIR]/black_editable)
@@ -2508,7 +2508,7 @@ fn sync_legacy_sdist_pep_517() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + flake8==6.0.0 (from https://files.pythonhosted.org/packages/66/53/3ad4a3b74d609b3b9008a10075c40e7c8909eae60af53623c3888f7a529a/flake8-6.0.0.tar.gz)
     "###
@@ -2534,7 +2534,7 @@ fn sync_legacy_sdist_setuptools() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + flake8==6.0.0 (from https://files.pythonhosted.org/packages/66/53/3ad4a3b74d609b3b9008a10075c40e7c8909eae60af53623c3888f7a529a/flake8-6.0.0.tar.gz)
     "###
@@ -2566,7 +2566,7 @@ fn find_links() -> Result<()> {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + markupsafe==2.1.3
      + numpy==1.26.3
@@ -2599,7 +2599,7 @@ fn find_links_no_index_match() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tqdm==1000.0.0
     "###
@@ -2629,7 +2629,7 @@ fn find_links_offline_match() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tqdm==1000.0.0
     "###
@@ -2690,7 +2690,7 @@ fn find_links_wheel_cache() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tqdm==1000.0.0
     "###
@@ -2740,7 +2740,7 @@ fn find_links_source_cache() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tqdm==999.0.0
     "###
@@ -2800,7 +2800,7 @@ fn offline() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==23.10.1
     "###
@@ -2847,7 +2847,7 @@ fn compatible_constraint() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==3.7.0
     "###
@@ -2903,7 +2903,7 @@ fn irrelevant_constraint() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==3.7.0
     "###
@@ -2927,7 +2927,7 @@ fn repeat_requirement_identical() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.3.0
     "###);
@@ -2950,7 +2950,7 @@ fn repeat_requirement_compatible() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.0.0
     "###);
@@ -2996,7 +2996,7 @@ fn tar_dont_preserve_mtime() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tomli==2.0.1 (from https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz)
     "###);
@@ -3019,7 +3019,7 @@ fn set_read_permissions() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + databricks==0.2
     "###);
@@ -3098,7 +3098,7 @@ requires-python = ">=3.8"
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + example==0.0.0 (from file://[TEMP_DIR]/editable)
     "###
@@ -3138,7 +3138,7 @@ requires-python = ">=3.8"
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - example==0.0.0 (from file://[TEMP_DIR]/editable)
@@ -3167,7 +3167,7 @@ fn compile() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
     Bytecode compiled 3 files in [TIME]
      + markupsafe==2.1.3
@@ -3231,7 +3231,7 @@ fn compile_invalid_pyc_invalidation_mode() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
     error: Failed to bytecode-compile Python file in: [SITE_PACKAGES]/
       Caused by: Python process stderr:
@@ -3304,7 +3304,7 @@ fn no_stream() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + hashb-foxglove-protocolbuffers-python==25.3.0.1.20240226043130+465630478360
     "###
@@ -3395,7 +3395,7 @@ fn require_hashes_missing_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.0.0
     "###
@@ -3436,7 +3436,7 @@ fn require_hashes_missing_version() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.3.0
     "###
@@ -3477,7 +3477,7 @@ fn require_hashes_invalid_operator() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.3.0
     "###
@@ -3554,7 +3554,7 @@ fn require_hashes_wheel_only_binary() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.0.0
     "###
@@ -3583,7 +3583,7 @@ fn require_hashes_source_no_binary() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + source-distribution==0.0.1
     "###
@@ -3711,7 +3711,7 @@ fn require_hashes_source_url() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + source-distribution==0.0.1 (from https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz)
     "###
@@ -3812,7 +3812,7 @@ fn require_hashes_wheel_url() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.0.0 (from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl)
     "###
@@ -3879,7 +3879,7 @@ fn require_hashes_wheel_url() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###
@@ -3993,7 +3993,7 @@ fn require_hashes_re_download() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.0.0
     "###
@@ -4074,7 +4074,7 @@ fn require_hashes_wheel_path() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tqdm==1000.0.0 (from file://[WORKSPACE]/scripts/links/tqdm-1000.0.0-py3-none-any.whl)
     "###
@@ -4144,7 +4144,7 @@ fn require_hashes_source_path() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + tqdm==999.0.0 (from file://[WORKSPACE]/scripts/links/tqdm-999.0.0.tar.gz)
     "###
@@ -4209,7 +4209,7 @@ fn require_hashes_unnamed() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.0.0 (from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl)
     "###
@@ -4309,7 +4309,7 @@ fn require_hashes_repeated_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.0.0 (from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl)
     "###
@@ -4333,7 +4333,7 @@ fn require_hashes_repeated_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==4.0.0 (from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl)
@@ -4359,7 +4359,7 @@ fn require_hashes_repeated_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==4.0.0 (from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl)
@@ -4419,7 +4419,7 @@ fn require_hashes_at_least_one() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.0.0
     "###
@@ -4495,7 +4495,7 @@ fn require_hashes_find_links_no_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + example-a-961b4c22==1.0.0
     "###
@@ -4578,7 +4578,7 @@ fn require_hashes_find_links_no_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - example-a-961b4c22==1.0.0
@@ -4609,7 +4609,7 @@ fn require_hashes_find_links_valid_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + example-a-961b4c22==1.0.0
     "###
@@ -4722,7 +4722,7 @@ fn require_hashes_find_links_invalid_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - example-a-961b4c22==1.0.0
@@ -4783,7 +4783,7 @@ fn require_hashes_registry_no_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + example-a-961b4c22==1.0.0
     "###
@@ -4923,7 +4923,7 @@ fn require_hashes_registry_invalid_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - example-a-961b4c22==1.0.0
@@ -4983,7 +4983,7 @@ fn target_built_distribution() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###);
@@ -5018,7 +5018,7 @@ fn target_built_distribution() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - iniconfig==2.0.0
@@ -5039,7 +5039,7 @@ fn target_built_distribution() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      + flask==3.0.3
@@ -5077,7 +5077,7 @@ fn target_source_distribution() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###);
@@ -5122,7 +5122,7 @@ fn target_no_build_isolation() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + flit-core==3.9.0
     "###);
@@ -5144,7 +5144,7 @@ fn target_no_build_isolation() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + wheel==0.43.0
     "###);
@@ -5190,7 +5190,7 @@ fn prefix() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###);
@@ -5225,7 +5225,7 @@ fn prefix() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - iniconfig==2.0.0
@@ -5251,7 +5251,7 @@ fn preserve_markers() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Downloaded 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.4.0
     "###

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -54,7 +54,7 @@ fn run_with_python_version() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: .venv
     Resolved 5 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
      + foo==1.0.0 (from file://[TEMP_DIR]/)
@@ -106,7 +106,7 @@ fn run_with_python_version() -> Result<()> {
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtualenv at: .venv
     Resolved 5 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.6.0
      + foo==1.0.0 (from file://[TEMP_DIR]/)

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -108,7 +108,7 @@ fn test_albatross_in_examples_bird_feeder() {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0
      + bird-feeder==1.0.0 (from file://[WORKSPACE]/scripts/workspaces/albatross-in-example/examples/bird-feeder)
@@ -143,7 +143,7 @@ fn test_albatross_in_examples() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + albatross==0.1.0 (from file://[WORKSPACE]/scripts/workspaces/albatross-in-example)
      + tqdm==4.66.2
@@ -176,7 +176,7 @@ fn test_albatross_just_project() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + albatross==0.1.0 (from file://[WORKSPACE]/scripts/workspaces/albatross-just-project)
      + tqdm==4.66.2
@@ -212,7 +212,7 @@ fn test_albatross_project_in_excluded() {
 
     ----- stderr -----
     Resolved 4 packages in [TIME]
-    Downloaded 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0
      + bird-feeder==1.0.0 (from file://[WORKSPACE]/scripts/workspaces/albatross-project-in-excluded/excluded/bird-feeder)
@@ -247,7 +247,7 @@ fn test_albatross_root_workspace() {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    Downloaded 7 packages in [TIME]
+    Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + albatross==0.1.0 (from file://[WORKSPACE]/scripts/workspaces/albatross-root-workspace)
      + anyio==4.3.0
@@ -288,7 +288,7 @@ fn test_albatross_root_workspace_bird_feeder() {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    Downloaded 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
      + anyio==4.3.0
      + bird-feeder==1.0.0 (from file://[WORKSPACE]/scripts/workspaces/albatross-root-workspace/packages/bird-feeder)
@@ -327,7 +327,7 @@ fn test_albatross_root_workspace_albatross() {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    Downloaded 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
      + anyio==4.3.0
      + bird-feeder==1.0.0 (from file://[WORKSPACE]/scripts/workspaces/albatross-root-workspace/packages/bird-feeder)
@@ -366,7 +366,7 @@ fn test_albatross_virtual_workspace() {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    Downloaded 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
      + anyio==4.3.0
      + bird-feeder==1.0.0 (from file://[WORKSPACE]/scripts/workspaces/albatross-virtual-workspace/packages/bird-feeder)
@@ -421,7 +421,7 @@ fn test_uv_run_with_package_virtual_workspace() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON]
     Creating virtualenv at: .venv
     Resolved 8 packages in [TIME]
-    Downloaded 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
      + anyio==4.3.0
      + bird-feeder==1.0.0 (from file://[TEMP_DIR]/albatross-virtual-workspace/packages/bird-feeder)
@@ -443,7 +443,7 @@ fn test_uv_run_with_package_virtual_workspace() -> Result<()> {
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + albatross==0.1.0 (from file://[TEMP_DIR]/albatross-virtual-workspace/packages/albatross)
      + tqdm==4.66.2
@@ -481,7 +481,7 @@ fn test_uv_run_with_package_root_workspace() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON]
     Creating virtualenv at: .venv
     Resolved 8 packages in [TIME]
-    Downloaded 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
      + anyio==4.3.0
      + bird-feeder==1.0.0 (from file://[TEMP_DIR]/albatross-root-workspace/packages/bird-feeder)
@@ -503,7 +503,7 @@ fn test_uv_run_with_package_root_workspace() -> Result<()> {
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Downloaded 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + albatross==0.1.0 (from file://[TEMP_DIR]/albatross-root-workspace)
      + tqdm==4.66.2


### PR DESCRIPTION
We download, build, and unzip packages in this stage. The current name is very misleading.

Closes https://github.com/astral-sh/uv/issues/4011