### PR TITLE
Improve handling of command arguments in `uv run` and `uv tool run`

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -619,8 +619,7 @@ async fn run() -> Result<ExitStatus> {
             commands::run(
                 args.extras,
                 args.dev,
-                args.target,
-                args.args,
+                args.command,
                 requirements,
                 args.python,
                 args.package,
@@ -745,8 +744,7 @@ async fn run() -> Result<ExitStatus> {
             let cache = cache.init()?.with_refresh(args.refresh);
 
             commands::run_tool(
-                args.target,
-                args.args,
+                args.command,
                 args.python,
                 args.from,
                 args.with,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1,5 +1,4 @@
 use std::env::VarError;
-use std::ffi::OsString;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::process;
@@ -26,11 +25,11 @@ use uv_settings::{
 use uv_toolchain::{Prefix, PythonVersion, Target};
 
 use crate::cli::{
-    AddArgs, BuildArgs, ColorChoice, GlobalArgs, IndexArgs, InstallerArgs, LockArgs, Maybe,
-    PipCheckArgs, PipCompileArgs, PipFreezeArgs, PipInstallArgs, PipListArgs, PipShowArgs,
-    PipSyncArgs, PipUninstallArgs, RefreshArgs, RemoveArgs, ResolverArgs, ResolverInstallerArgs,
-    RunArgs, SyncArgs, ToolRunArgs, ToolchainFindArgs, ToolchainInstallArgs, ToolchainListArgs,
-    VenvArgs,
+    AddArgs, BuildArgs, ColorChoice, ExternalCommand, GlobalArgs, IndexArgs, InstallerArgs,
+    LockArgs, Maybe, PipCheckArgs, PipCompileArgs, PipFreezeArgs, PipInstallArgs, PipListArgs,
+    PipShowArgs, PipSyncArgs, PipUninstallArgs, RefreshArgs, RemoveArgs, ResolverArgs,
+    ResolverInstallerArgs, RunArgs, SyncArgs, ToolRunArgs, ToolchainFindArgs, ToolchainInstallArgs,
+    ToolchainListArgs, VenvArgs,
 };
 use crate::commands::pip::operations::Modifications;
 use crate::commands::ListFormat;
@@ -123,8 +122,7 @@ impl CacheSettings {
 pub(crate) struct RunSettings {
     pub(crate) extras: ExtrasSpecification,
     pub(crate) dev: bool,
-    pub(crate) target: Option<String>,
-    pub(crate) args: Vec<OsString>,
+    pub(crate) command: ExternalCommand,
     pub(crate) with: Vec<String>,
     pub(crate) python: Option<String>,
     pub(crate) package: Option<PackageName>,
@@ -142,8 +140,7 @@ impl RunSettings {
             no_all_extras,
             dev,
             no_dev,
-            target,
-            args,
+            command,
             with,
             installer,
             build,
@@ -158,8 +155,7 @@ impl RunSettings {
                 extra.unwrap_or_default(),
             ),
             dev: flag(dev, no_dev).unwrap_or(true),
-            target,
-            args,
+            command,
             with,
             python,
             package,
@@ -176,8 +172,7 @@ impl RunSettings {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct ToolRunSettings {
-    pub(crate) target: String,
-    pub(crate) args: Vec<OsString>,
+    pub(crate) command: ExternalCommand,
     pub(crate) from: Option<String>,
     pub(crate) with: Vec<String>,
     pub(crate) python: Option<String>,
@@ -190,8 +185,7 @@ impl ToolRunSettings {
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn resolve(args: ToolRunArgs, filesystem: Option<FilesystemOptions>) -> Self {
         let ToolRunArgs {
-            target,
-            args,
+            command,
             from,
             with,
             installer,
@@ -201,8 +195,7 @@ impl ToolRunSettings {
         } = args;
 
         Self {
-            target,
-            args,
+            command,
             from,
             with,
             python,

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -44,7 +44,7 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
     (r"uv.exe", "uv"),
     // uv version display
     (
-        r"uv \d+\.\d+\.\d+( \(.*\))?",
+        r"uv(-.*)? \d+\.\d+\.\d+( \(.*\))?",
         r"uv [VERSION] ([COMMIT] DATE)",
     ),
     // The exact message is host language dependent
@@ -399,6 +399,41 @@ impl TestContext {
     pub fn run_without_exclude_newer(&self) -> std::process::Command {
         let mut command = std::process::Command::new(get_bin());
         command
+            .arg("run")
+            .arg("--cache-dir")
+            .arg(self.cache_dir.path())
+            .env("VIRTUAL_ENV", self.venv.as_os_str())
+            .env("UV_NO_WRAP", "1")
+            .env("UV_TOOLCHAIN_DIR", "")
+            .env("UV_TEST_PYTHON_PATH", &self.python_path())
+            .current_dir(&self.temp_dir);
+
+        if cfg!(all(windows, debug_assertions)) {
+            // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
+            // default windows stack of 1MB
+            command.env("UV_STACK_SIZE", (4 * 1024 * 1024).to_string());
+        }
+
+        command
+    }
+
+    /// Create a `uv tool run` command with options shared across scenarios.
+    pub fn tool_run(&self) -> std::process::Command {
+        let mut command = self.tool_run_without_exclude_newer();
+        command.arg("--exclude-newer").arg(EXCLUDE_NEWER);
+        command
+    }
+
+    /// Create a `uv tool run` command with no `--exclude-newer` option.
+    ///
+    /// One should avoid using this in tests to the extent possible because
+    /// it can result in tests failing when the index state changes. Therefore,
+    /// if you use this, there should be some other kind of mitigation in place.
+    /// For example, pinning package versions.
+    pub fn tool_run_without_exclude_newer(&self) -> std::process::Command {
+        let mut command = std::process::Command::new(get_bin());
+        command
+            .arg("tool")
             .arg("run")
             .arg("--cache-dir")
             .arg(self.cache_dir.path())

--- a/crates/uv/tests/tool_run.rs
+++ b/crates/uv/tests/tool_run.rs
@@ -1,0 +1,55 @@
+#![cfg(all(feature = "python", feature = "pypi"))]
+
+use common::{uv_snapshot, TestContext};
+
+mod common;
+
+#[test]
+fn tool_run_args() {
+    let context = TestContext::new("3.12");
+
+    // We treat arguments before the command as uv arguments
+    uv_snapshot!(context.filters(), context.tool_run().arg("--version").arg("pytest"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    uv [VERSION] ([COMMIT] DATE)
+
+    ----- stderr -----
+    "###);
+
+    // We don't treat arguments after the command as uv arguments
+    uv_snapshot!(context.filters(), context.tool_run().arg("pytest").arg("--version"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    pytest 8.1.1
+
+    ----- stderr -----
+    warning: `uv tool run` is experimental and may change without warning.
+    Resolved 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
+    Installed 4 packages in [TIME]
+     + iniconfig==2.0.0
+     + packaging==24.0
+     + pluggy==1.4.0
+     + pytest==8.1.1
+    "###);
+
+    // Can use `--` to separate uv arguments from the command arguments.
+    uv_snapshot!(context.filters(), context.tool_run().arg("--").arg("pytest").arg("--version"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    pytest 8.1.1
+
+    ----- stderr -----
+    warning: `uv tool run` is experimental and may change without warning.
+    Resolved 4 packages in [TIME]
+    Installed 4 packages in [TIME]
+     + iniconfig==2.0.0
+     + packaging==24.0
+     + pluggy==1.4.0
+     + pytest==8.1.1
+    "###);
+}


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/4390

We no longer require `--` to disambiguate child command options that overlap with uv options.