### PR TITLE
Add internal options for managing toolchain discovery preferences

### DIFF
--- a/crates/uv-dev/src/build.rs
+++ b/crates/uv-dev/src/build.rs
@@ -16,7 +16,7 @@ use uv_configuration::{
 use uv_dispatch::BuildDispatch;
 use uv_git::GitResolver;
 use uv_resolver::{FlatIndex, InMemoryIndex};
-use uv_toolchain::Toolchain;
+use uv_toolchain::{EnvironmentPreference, Toolchain, ToolchainPreference};
 use uv_types::{BuildContext, BuildIsolation, InFlight};
 
 #[derive(Parser)]
@@ -65,7 +65,12 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
     let index = InMemoryIndex::default();
     let index_urls = IndexLocations::default();
     let setup_py = SetupPyStrategy::default();
-    let toolchain = Toolchain::find_virtualenv(&cache)?;
+    let toolchain = Toolchain::find(
+        None,
+        EnvironmentPreference::OnlyVirtual,
+        ToolchainPreference::default(),
+        &cache,
+    )?;
     let build_options = BuildOptions::default();
 
     let build_dispatch = BuildDispatch::new(

--- a/crates/uv-dev/src/compile.rs
+++ b/crates/uv-dev/src/compile.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use tracing::info;
 use uv_cache::{Cache, CacheArgs};
-use uv_toolchain::Toolchain;
+use uv_toolchain::{EnvironmentPreference, Toolchain, ToolchainPreference};
 
 #[derive(Parser)]
 pub(crate) struct CompileArgs {
@@ -20,7 +20,13 @@ pub(crate) async fn compile(args: CompileArgs) -> anyhow::Result<()> {
     let interpreter = if let Some(python) = args.python {
         python
     } else {
-        let interpreter = Toolchain::find_virtualenv(&cache)?.into_interpreter();
+        let interpreter = Toolchain::find(
+            None,
+            EnvironmentPreference::OnlyVirtual,
+            ToolchainPreference::default(),
+            &cache,
+        )?
+        .into_interpreter();
         interpreter.sys_executable().to_path_buf()
     };
 

--- a/crates/uv-toolchain/src/discovery.rs
+++ b/crates/uv-toolchain/src/discovery.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::HashSet;
 use std::fmt::{self, Formatter};
 use std::{env, io};
 use std::{path::Path, path::PathBuf, str::FromStr};
@@ -53,17 +52,32 @@ pub enum ToolchainRequest {
     Key(PythonDownloadRequest),
 }
 
-/// The sources to consider when finding a Python toolchain.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ToolchainSources {
-    // Consider all toolchain sources.
-    All(PreviewMode),
-    // Only consider system toolchain sources
-    System(PreviewMode),
-    // Only consider virtual environment sources
-    VirtualEnv,
-    // Only consider a custom set of sources
-    Custom(HashSet<ToolchainSource>),
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ToolchainPreference {
+    /// Only use managed interpreters, never use system interpreters.
+    OnlyManaged,
+    /// Prefer installed managed interpreters, but use system interpreters if not found.
+    #[default]
+    PreferInstalledManaged,
+    /// Prefer managed interpreters, even if one needs to be downloaded, but use system interpreters if found.
+    PreferManaged,
+    /// Prefer system interpreters, only use managed interpreters if no system interpreter is found.
+    PreferSystem,
+    /// Only use system interpreters, never use managed interpreters.
+    OnlySystem,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EnvironmentPreference {
+    /// Only use virtual environments, never allow a system environment.
+    #[default]
+    OnlyVirtual,
+    /// Prefer virtual environments and allow a system environment if explicitly requested.
+    ExplicitSystem,
+    /// Only use a system environment, ignore virtual environments.
+    OnlySystem,
+    /// Allow any environment.
+    Any,
 }
 
 /// A Python toolchain version request.
@@ -102,15 +116,15 @@ type ToolchainResult = Result<Toolchain, ToolchainNotFound>;
 #[derive(Clone, Debug, Error)]
 pub enum ToolchainNotFound {
     /// No Python installations were found.
-    NoPythonInstallation(ToolchainSources, Option<VersionRequest>),
+    NoPythonInstallation(ToolchainPreference, Option<VersionRequest>),
     /// No Python installations with the requested version were found.
-    NoMatchingVersion(ToolchainSources, VersionRequest),
+    NoMatchingVersion(ToolchainPreference, VersionRequest),
     /// No Python installations with the requested key were found.
-    NoMatchingKey(ToolchainSources, PythonDownloadRequest),
+    NoMatchingKey(ToolchainPreference, PythonDownloadRequest),
     /// No Python installations with the requested implementation name were found.
-    NoMatchingImplementation(ToolchainSources, ImplementationName),
+    NoMatchingImplementation(ToolchainPreference, ImplementationName),
     /// No Python installations with the requested implementation name and version were found.
-    NoMatchingImplementationVersion(ToolchainSources, ImplementationName, VersionRequest),
+    NoMatchingImplementationVersion(ToolchainPreference, ImplementationName, VersionRequest),
     /// The requested file path does not exist.
     FileNotFound(PathBuf),
     /// The requested directory path does not exist.
@@ -169,139 +183,119 @@ pub enum Error {
     #[error("Invalid version request: {0}")]
     InvalidVersionRequest(String),
 
-    #[error("Interpreter discovery for `{0}` requires `{1}` but it is not selected; the following are selected: {2}")]
-    SourceNotSelected(ToolchainRequest, ToolchainSource, ToolchainSources),
+    // TODO(zanieb): Is this error case necessary still? We should probably drop it.
+    #[error("Interpreter discovery for `{0}` requires `{1}` but only {2} is allowed")]
+    SourceNotAllowed(ToolchainRequest, ToolchainSource, ToolchainPreference),
 }
 
-/// Lazily iterate over all discoverable Python executables.
+/// Lazily iterate over Python executables in mutable environments.
 ///
-/// In order, we look in:
+/// The following sources are supported:
 ///
-/// - The spawning interpreter
-/// - The active environment
-/// - A discovered environment (e.g. `.venv`)
-/// - Installed managed toolchains
-/// - The search path (i.e. PATH)
-/// - `py` launcher output
+/// - Spawning interpreter (via `UV_INTERNAL__PARENT_INTERPRETER`)
+/// - Active virtual environment (via `VIRTUAL_ENV`)
+/// - Active conda environment (via `CONDA_PREFIX`)
+/// - Discovered virtual environment (e.g. `.venv` in a parent directory)
 ///
-/// Each location is only queried if the previous location is exhausted.
-/// Locations may be omitted using `sources`, sources that are not selected will not be queried.
-///
-/// If a [`VersionRequest`] is provided, we will skip executables that we know do not satisfy the request
-/// and (as discussed in [`python_executables_from_search_path`]) additional version specific executables may
-/// be included. However, the caller MUST query the returned executables to ensure they satisfy the request;
-/// this function does not guarantee that the executables provide any particular version. See
-/// [`find_interpreter`] instead.
-fn python_executables<'a>(
-    version: Option<&'a VersionRequest>,
-    implementation: Option<&'a ImplementationName>,
-    sources: &'a ToolchainSources,
+/// Notably, "system" environments are excluded. See [`python_executables_from_installed`].
+fn python_executables_from_environments<'a>(
 ) -> impl Iterator<Item = Result<(ToolchainSource, PathBuf), Error>> + 'a {
-    // Note we wrap each location in a closure to ensure it is lazy
-
     let from_parent_interpreter = std::iter::once_with(|| {
-        sources
-            .contains(ToolchainSource::ParentInterpreter)
-            .then(|| {
-                std::env::var_os("UV_INTERNAL__PARENT_INTERPRETER")
-                    .into_iter()
-                    .map(|path| Ok((ToolchainSource::ParentInterpreter, PathBuf::from(path))))
-            })
+        std::env::var_os("UV_INTERNAL__PARENT_INTERPRETER")
             .into_iter()
-            .flatten()
+            .map(|path| Ok((ToolchainSource::ParentInterpreter, PathBuf::from(path))))
     })
     .flatten();
 
     let from_virtual_environment = std::iter::once_with(|| {
-        sources
-            .contains(ToolchainSource::ActiveEnvironment)
-            .then(|| {
-                virtualenv_from_env()
-                    .into_iter()
-                    .map(virtualenv_python_executable)
-                    .map(|path| Ok((ToolchainSource::ActiveEnvironment, path)))
-            })
+        virtualenv_from_env()
             .into_iter()
-            .flatten()
+            .map(virtualenv_python_executable)
+            .map(|path| Ok((ToolchainSource::ActiveEnvironment, path)))
     })
     .flatten();
 
     let from_conda_environment = std::iter::once_with(|| {
-        sources
-            .contains(ToolchainSource::CondaPrefix)
-            .then(|| {
-                conda_prefix_from_env()
-                    .into_iter()
-                    .map(virtualenv_python_executable)
-                    .map(|path| Ok((ToolchainSource::CondaPrefix, path)))
-            })
+        conda_prefix_from_env()
             .into_iter()
-            .flatten()
+            .map(virtualenv_python_executable)
+            .map(|path| Ok((ToolchainSource::CondaPrefix, path)))
     })
     .flatten();
 
     let from_discovered_environment = std::iter::once_with(|| {
-        sources
-            .contains(ToolchainSource::DiscoveredEnvironment)
-            .then(|| {
-                virtualenv_from_working_dir()
-                    .map(|path| {
-                        path.map(virtualenv_python_executable)
-                            .map(|path| (ToolchainSource::DiscoveredEnvironment, path))
-                            .into_iter()
-                    })
-                    .map_err(Error::from)
+        virtualenv_from_working_dir()
+            .map(|path| {
+                path.map(virtualenv_python_executable)
+                    .map(|path| (ToolchainSource::DiscoveredEnvironment, path))
+                    .into_iter()
             })
-            .into_iter()
-            .flatten_ok()
+            .map_err(Error::from)
     })
-    .flatten();
+    .flatten_ok();
 
-    let from_installed_toolchains = std::iter::once_with(move || {
-        sources
-            .contains(ToolchainSource::Managed)
-            .then(move || {
-                InstalledToolchains::from_settings()
-                    .map_err(Error::from)
-                    .and_then(|installed_toolchains| {
-                        debug!(
-                            "Searching for managed toolchains at `{}`",
-                            installed_toolchains.root().user_display()
-                        );
-                        let toolchains = installed_toolchains.find_matching_current_platform()?;
-                        // Check that the toolchain version satisfies the request to avoid unnecessary interpreter queries later
-                        Ok(toolchains
-                            .into_iter()
-                            .filter(move |toolchain| {
-                                version.is_none()
-                                    || version.is_some_and(|version| {
-                                        version.matches_version(&toolchain.version())
-                                    })
+    from_parent_interpreter
+        .chain(from_virtual_environment)
+        .chain(from_conda_environment)
+        .chain(from_discovered_environment)
+}
+
+/// Lazily iterate over Python executables installed on the system.
+///
+/// The following sources are supported:
+///
+/// - Managed toolchains (e.g. `uv toolchain install`)
+/// - The search path (i.e. `PATH`)
+/// - The `py` launcher (Windows only)
+///
+/// The ordering and presence of each source is determined by the [`ToolchainPreference`].
+///
+/// If a [`VersionRequest`] is provided, we will skip executables that we know do not satisfy the request
+/// and (as discussed in [`python_executables_from_search_path`]) additional version-specific executables may
+/// be included. However, the caller MUST query the returned executables to ensure they satisfy the request;
+/// this function does not guarantee that the executables provide any particular version. See
+/// [`find_toolchain`] instead.
+///
+/// This function does not guarantee that the executables are valid Python interpreters.
+/// See [`python_interpreters_from_executables`].
+fn python_executables_from_installed<'a>(
+    version: Option<&'a VersionRequest>,
+    implementation: Option<&'a ImplementationName>,
+    preference: ToolchainPreference,
+) -> Box<dyn Iterator<Item = Result<(ToolchainSource, PathBuf), Error>> + 'a> {
+    let from_managed_toolchains = std::iter::once_with(move || {
+        InstalledToolchains::from_settings()
+            .map_err(Error::from)
+            .and_then(|installed_toolchains| {
+                debug!(
+                    "Searching for managed toolchains at `{}`",
+                    installed_toolchains.root().user_display()
+                );
+                let toolchains = installed_toolchains.find_matching_current_platform()?;
+                // Check that the toolchain version satisfies the request to avoid unnecessary interpreter queries later
+                Ok(toolchains
+                    .into_iter()
+                    .filter(move |toolchain| {
+                        version.is_none()
+                            || version.is_some_and(|version| {
+                                version.matches_version(&toolchain.version())
                             })
-                            .inspect(|toolchain| debug!("Found managed toolchain `{toolchain}`"))
-                            .map(|toolchain| (ToolchainSource::Managed, toolchain.executable())))
                     })
+                    .inspect(|toolchain| debug!("Found managed toolchain `{toolchain}`"))
+                    .map(|toolchain| (ToolchainSource::Managed, toolchain.executable())))
             })
-            .into_iter()
-            .flatten_ok()
     })
-    .flatten();
+    .flatten_ok();
 
     let from_search_path = std::iter::once_with(move || {
-        sources
-            .contains(ToolchainSource::SearchPath)
-            .then(move || {
-                python_executables_from_search_path(version, implementation)
-                    .map(|path| Ok((ToolchainSource::SearchPath, path)))
-            })
-            .into_iter()
-            .flatten()
+        python_executables_from_search_path(version, implementation)
+            .map(|path| Ok((ToolchainSource::SearchPath, path)))
     })
     .flatten();
 
     // TODO(konstin): Implement <https://peps.python.org/pep-0514/> to read python installations from the registry instead.
     let from_py_launcher = std::iter::once_with(move || {
-        (sources.contains(ToolchainSource::PyLauncher) && cfg!(windows))
+        (cfg!(windows) && env::var_os("UV_TEST_PYTHON_PATH").is_none())
             .then(|| {
                 py_list_paths()
                     .map(|entries|
@@ -319,13 +313,49 @@ fn python_executables<'a>(
     })
     .flatten();
 
-    from_parent_interpreter
-        .chain(from_virtual_environment)
-        .chain(from_conda_environment)
-        .chain(from_discovered_environment)
-        .chain(from_installed_toolchains)
-        .chain(from_search_path)
-        .chain(from_py_launcher)
+    match preference {
+        ToolchainPreference::OnlyManaged => Box::new(from_managed_toolchains),
+        ToolchainPreference::PreferInstalledManaged => Box::new(
+            from_managed_toolchains
+                .chain(from_search_path)
+                .chain(from_py_launcher),
+        ),
+        ToolchainPreference::PreferManaged => Box::new(
+            from_managed_toolchains
+                .chain(from_search_path)
+                .chain(from_py_launcher),
+        ),
+        ToolchainPreference::PreferSystem => Box::new(
+            from_managed_toolchains
+                .chain(from_search_path)
+                .chain(from_py_launcher),
+        ),
+        ToolchainPreference::OnlySystem => Box::new(from_search_path.chain(from_py_launcher)),
+    }
+}
+
+/// Lazily iterate over all discoverable Python executables.
+///
+/// Note that Python executables may be excluded by the given [`EnvironmentPreference`] and [`ToolchainPreference`].
+///
+/// See [`python_executables_from_installed`] and [`python_executables_from_environments`]
+/// for more information on discovery.
+fn python_executables<'a>(
+    version: Option<&'a VersionRequest>,
+    implementation: Option<&'a ImplementationName>,
+    environments: EnvironmentPreference,
+    preference: ToolchainPreference,
+) -> Box<dyn Iterator<Item = Result<(ToolchainSource, PathBuf), Error>> + 'a> {
+    let from_environments = python_executables_from_environments();
+    let from_installed = python_executables_from_installed(version, implementation, preference);
+
+    match environments {
+        EnvironmentPreference::OnlyVirtual => Box::new(from_environments),
+        EnvironmentPreference::ExplicitSystem | EnvironmentPreference::Any => {
+            Box::new(from_environments.chain(from_installed))
+        }
+        EnvironmentPreference::OnlySystem => Box::new(from_installed),
+    }
 }
 
 /// Lazily iterate over Python executables in the `PATH`.
@@ -399,17 +429,21 @@ fn python_executables_from_search_path<'a>(
 
 /// Lazily iterate over all discoverable Python interpreters.
 ///
+/// Note interpreters may be excluded by the given [`EnvironmentPreference`] and [`ToolchainPreference`].
+///
 /// See [`python_executables`] for more information on discovery.
 fn python_interpreters<'a>(
     version: Option<&'a VersionRequest>,
     implementation: Option<&'a ImplementationName>,
-    sources: &'a ToolchainSources,
+    environments: EnvironmentPreference,
+    preference: ToolchainPreference,
     cache: &'a Cache,
 ) -> impl Iterator<Item = Result<(ToolchainSource, Interpreter), Error>> + 'a {
     python_interpreters_from_executables(
-        python_executables(version, implementation, sources),
+        python_executables(version, implementation, environments, preference),
         cache,
     )
+    .filter(move |result| result_satisfies_environment_preference(result, environments))
 }
 
 /// Lazily convert Python executables into interpreters.
@@ -434,63 +468,63 @@ fn python_interpreters_from_executables<'a>(
     })
 }
 
-/// Returns true if a interpreter matches the system Python policy.
-fn satisfies_system_python(
+/// Returns true if a interpreter matches the [`EnvironmentPreference`].
+fn satisfies_environment_preference(
     source: ToolchainSource,
     interpreter: &Interpreter,
-    system: SystemPython,
+    preference: EnvironmentPreference,
 ) -> bool {
     match (
-        system,
-        // Conda environments are not conformant virtual environments but we should not treat them as system interpreters
+        preference,
+        // Conda environments are not conformant virtual environments but we treat them as such
         interpreter.is_virtualenv() || matches!(source, ToolchainSource::CondaPrefix),
     ) {
-        (SystemPython::Allowed, _) => true,
-        (SystemPython::Explicit, false) => {
+        (EnvironmentPreference::Any, _) => true,
+        (EnvironmentPreference::OnlyVirtual, true) => true,
+        (EnvironmentPreference::OnlyVirtual, false) => {
+            debug!(
+                "Ignoring Python interpreter at `{}`: only virtual environments allowed",
+                interpreter.sys_executable().display()
+            );
+            false
+        }
+        (EnvironmentPreference::ExplicitSystem, true) => true,
+        (EnvironmentPreference::ExplicitSystem, false) => {
             if matches!(
                 source,
                 ToolchainSource::ProvidedPath | ToolchainSource::ParentInterpreter
             ) {
                 debug!(
-                    "Allowing system Python interpreter at `{}`",
+                    "Allowing explicitly requested system Python interpreter at `{}`",
                     interpreter.sys_executable().display()
                 );
                 true
             } else {
                 debug!(
-                    "Ignoring Python interpreter at `{}`: system interpreter not explicit",
+                    "Ignoring Python interpreter at `{}`: system interpreter not explicitly requested",
                     interpreter.sys_executable().display()
                 );
                 false
             }
         }
-        (SystemPython::Explicit, true) => true,
-        (SystemPython::Disallowed, false) => {
-            debug!(
-                "Ignoring Python interpreter at `{}`: system interpreter not allowed",
-                interpreter.sys_executable().display()
-            );
-            false
-        }
-        (SystemPython::Disallowed, true) => true,
-        (SystemPython::Required, true) => {
+        (EnvironmentPreference::OnlySystem, true) => {
             debug!(
                 "Ignoring Python interpreter at `{}`: system interpreter required",
                 interpreter.sys_executable().display()
             );
             false
         }
-        (SystemPython::Required, false) => true,
+        (EnvironmentPreference::OnlySystem, false) => true,
     }
 }
 
-/// Utility for applying [`satisfies_system_python`] to a result type.
-fn result_satisfies_system_python(
+/// Utility for applying [`satisfies_environment_preference`] to a result type.
+fn result_satisfies_environment_preference(
     result: &Result<(ToolchainSource, Interpreter), Error>,
-    system: SystemPython,
+    preference: EnvironmentPreference,
 ) -> bool {
     result.as_ref().ok().map_or(true, |(source, interpreter)| {
-        satisfies_system_python(*source, interpreter, system)
+        satisfies_environment_preference(*source, interpreter, preference)
     })
 }
 
@@ -568,62 +602,60 @@ fn python_interpreters_with_executable_name<'a>(
 /// Iterate over all toolchains that satisfy the given request.
 pub fn find_toolchains<'a>(
     request: &'a ToolchainRequest,
-    system: SystemPython,
-    sources: &'a ToolchainSources,
+    environments: EnvironmentPreference,
+    preference: ToolchainPreference,
     cache: &'a Cache,
 ) -> Box<dyn Iterator<Item = Result<ToolchainResult, Error>> + 'a> {
     match request {
         ToolchainRequest::File(path) => Box::new(std::iter::once({
-            if sources.contains(ToolchainSource::ProvidedPath) {
+            if preference.allows(ToolchainSource::ProvidedPath) {
                 debug!("Checking for Python interpreter at {request}");
                 find_toolchain_at_file(path, cache)
             } else {
-                Err(Error::SourceNotSelected(
+                Err(Error::SourceNotAllowed(
                     request.clone(),
                     ToolchainSource::ProvidedPath,
-                    sources.clone(),
+                    preference,
                 ))
             }
         })),
         ToolchainRequest::Directory(path) => Box::new(std::iter::once({
             debug!("Checking for Python interpreter in {request}");
-            if sources.contains(ToolchainSource::ProvidedPath) {
+            if preference.allows(ToolchainSource::ProvidedPath) {
                 debug!("Checking for Python interpreter at {request}");
                 find_toolchain_at_directory(path, cache)
             } else {
-                Err(Error::SourceNotSelected(
+                Err(Error::SourceNotAllowed(
                     request.clone(),
                     ToolchainSource::ProvidedPath,
-                    sources.clone(),
+                    preference,
                 ))
             }
         })),
         ToolchainRequest::ExecutableName(name) => {
             debug!("Searching for Python interpreter with {request}");
-            if sources.contains(ToolchainSource::SearchPath) {
+            if preference.allows(ToolchainSource::SearchPath) {
                 debug!("Checking for Python interpreter at {request}");
                 Box::new(
                     python_interpreters_with_executable_name(name, cache)
                         .map(|result| result.map(Toolchain::from_tuple).map(ToolchainResult::Ok)),
                 )
             } else {
-                Box::new(std::iter::once(Err(Error::SourceNotSelected(
+                Box::new(std::iter::once(Err(Error::SourceNotAllowed(
                     request.clone(),
                     ToolchainSource::SearchPath,
-                    sources.clone(),
+                    preference,
                 ))))
             }
         }
         ToolchainRequest::Any => Box::new({
-            debug!("Searching for Python interpreter in {sources}");
-            python_interpreters(None, None, sources, cache)
-                .filter(move |result| result_satisfies_system_python(result, system))
+            debug!("Searching for Python interpreter in {preference}");
+            python_interpreters(None, None, environments, preference, cache)
                 .map(|result| result.map(Toolchain::from_tuple).map(ToolchainResult::Ok))
         }),
         ToolchainRequest::Version(version) => Box::new({
-            debug!("Searching for {request} in {sources}");
-            python_interpreters(Some(version), None, sources, cache)
-                .filter(move |result| result_satisfies_system_python(result, system))
+            debug!("Searching for {request} in {preference}");
+            python_interpreters(Some(version), None, environments, preference, cache)
                 .filter(|result| match result {
                     Err(_) => true,
                     Ok((_source, interpreter)) => version.matches_interpreter(interpreter),
@@ -631,9 +663,8 @@ pub fn find_toolchains<'a>(
                 .map(|result| result.map(Toolchain::from_tuple).map(ToolchainResult::Ok))
         }),
         ToolchainRequest::Implementation(implementation) => Box::new({
-            debug!("Searching for a {request} interpreter in {sources}");
-            python_interpreters(None, Some(implementation), sources, cache)
-                .filter(move |result| result_satisfies_system_python(result, system))
+            debug!("Searching for a {request} interpreter in {preference}");
+            python_interpreters(None, Some(implementation), environments, preference, cache)
                 .filter(|result| match result {
                     Err(_) => true,
                     Ok((_source, interpreter)) => interpreter
@@ -643,29 +674,39 @@ pub fn find_toolchains<'a>(
                 .map(|result| result.map(Toolchain::from_tuple).map(ToolchainResult::Ok))
         }),
         ToolchainRequest::ImplementationVersion(implementation, version) => Box::new({
-            debug!("Searching for {request} in {sources}");
-            python_interpreters(Some(version), Some(implementation), sources, cache)
-                .filter(move |result| result_satisfies_system_python(result, system))
-                .filter(|result| match result {
-                    Err(_) => true,
-                    Ok((_source, interpreter)) => {
-                        version.matches_interpreter(interpreter)
-                            && interpreter
-                                .implementation_name()
-                                .eq_ignore_ascii_case(implementation.into())
-                    }
-                })
-                .map(|result| result.map(Toolchain::from_tuple).map(ToolchainResult::Ok))
+            debug!("Searching for {request} in {preference}");
+            python_interpreters(
+                Some(version),
+                Some(implementation),
+                environments,
+                preference,
+                cache,
+            )
+            .filter(|result| match result {
+                Err(_) => true,
+                Ok((_source, interpreter)) => {
+                    version.matches_interpreter(interpreter)
+                        && interpreter
+                            .implementation_name()
+                            .eq_ignore_ascii_case(implementation.into())
+                }
+            })
+            .map(|result| result.map(Toolchain::from_tuple).map(ToolchainResult::Ok))
         }),
         ToolchainRequest::Key(request) => Box::new({
-            debug!("Searching for {request} in {sources}");
-            python_interpreters(request.version(), request.implementation(), sources, cache)
-                .filter(move |result| result_satisfies_system_python(result, system))
-                .filter(|result| match result {
-                    Err(_) => true,
-                    Ok((_source, interpreter)) => request.satisfied_by_interpreter(interpreter),
-                })
-                .map(|result| result.map(Toolchain::from_tuple).map(ToolchainResult::Ok))
+            debug!("Searching for {request} in {preference}");
+            python_interpreters(
+                request.version(),
+                request.implementation(),
+                environments,
+                preference,
+                cache,
+            )
+            .filter(|result| match result {
+                Err(_) => true,
+                Ok((_source, interpreter)) => request.satisfied_by_interpreter(interpreter),
+            })
+            .map(|result| result.map(Toolchain::from_tuple).map(ToolchainResult::Ok))
         }),
     }
 }
@@ -676,11 +717,11 @@ pub fn find_toolchains<'a>(
 /// the error will raised instead of attempting further candidates.
 pub(crate) fn find_toolchain(
     request: &ToolchainRequest,
-    system: SystemPython,
-    sources: &ToolchainSources,
+    environments: EnvironmentPreference,
+    preference: ToolchainPreference,
     cache: &Cache,
 ) -> Result<ToolchainResult, Error> {
-    let mut toolchains = find_toolchains(request, system, sources, cache);
+    let mut toolchains = find_toolchains(request, environments, preference, cache);
     if let Some(result) = toolchains.find(|result| {
         // Return the first critical discovery error or toolchain result
         result.as_ref().err().map_or(true, Error::is_critical)
@@ -689,52 +730,30 @@ pub(crate) fn find_toolchain(
     } else {
         let err = match request {
             ToolchainRequest::Implementation(implementation) => {
-                ToolchainNotFound::NoMatchingImplementation(sources.clone(), *implementation)
+                ToolchainNotFound::NoMatchingImplementation(preference, *implementation)
             }
             ToolchainRequest::ImplementationVersion(implementation, version) => {
                 ToolchainNotFound::NoMatchingImplementationVersion(
-                    sources.clone(),
+                    preference,
                     *implementation,
                     version.clone(),
                 )
             }
             ToolchainRequest::Version(version) => {
-                ToolchainNotFound::NoMatchingVersion(sources.clone(), version.clone())
+                ToolchainNotFound::NoMatchingVersion(preference, version.clone())
             }
             ToolchainRequest::ExecutableName(name) => {
                 ToolchainNotFound::ExecutableNotFoundInSearchPath(name.clone())
             }
-            ToolchainRequest::Key(key) => {
-                ToolchainNotFound::NoMatchingKey(sources.clone(), key.clone())
-            }
+            ToolchainRequest::Key(key) => ToolchainNotFound::NoMatchingKey(preference, key.clone()),
             // TODO(zanieb): As currently implemented, these are unreachable as they are handled in `find_toolchains`
             // We should avoid this duplication
             ToolchainRequest::Directory(path) => ToolchainNotFound::DirectoryNotFound(path.clone()),
             ToolchainRequest::File(path) => ToolchainNotFound::FileNotFound(path.clone()),
-            ToolchainRequest::Any => ToolchainNotFound::NoPythonInstallation(sources.clone(), None),
+            ToolchainRequest::Any => ToolchainNotFound::NoPythonInstallation(preference, None),
         };
         Ok(ToolchainResult::Err(err))
     }
-}
-
-/// Find the default Python toolchain on the system.
-///
-/// Virtual environments are not included in discovery.
-///
-/// See [`find_toolchain`] for more details on toolchain discovery.
-pub(crate) fn find_default_toolchain(
-    preview: PreviewMode,
-    cache: &Cache,
-) -> Result<ToolchainResult, Error> {
-    let request = ToolchainRequest::default();
-    let sources = ToolchainSources::System(preview);
-
-    let result = find_toolchain(&request, SystemPython::Required, &sources, cache)?;
-    if let Ok(ref toolchain) = result {
-        warn_on_unsupported_python(toolchain.interpreter());
-    }
-
-    Ok(result)
 }
 
 /// Find the best-matching Python toolchain.
@@ -750,18 +769,15 @@ pub(crate) fn find_default_toolchain(
 #[instrument(skip_all, fields(request))]
 pub fn find_best_toolchain(
     request: &ToolchainRequest,
-    system: SystemPython,
-    preview: PreviewMode,
+    environments: EnvironmentPreference,
+    preference: ToolchainPreference,
     cache: &Cache,
 ) -> Result<ToolchainResult, Error> {
     debug!("Starting toolchain discovery for {}", request);
 
-    // Determine if we should be allowed to look outside of virtual environments.
-    let sources = ToolchainSources::from_settings(system, preview);
-
     // First, check for an exact match (or the first available version if no Python versfion was provided)
     debug!("Looking for exact match for request {request}");
-    let result = find_toolchain(request, system, &sources, cache)?;
+    let result = find_toolchain(request, environments, preference, cache)?;
     if let Ok(ref toolchain) = result {
         warn_on_unsupported_python(toolchain.interpreter());
         return Ok(result);
@@ -786,7 +802,7 @@ pub fn find_best_toolchain(
         _ => None,
     } {
         debug!("Looking for relaxed patch version {request}");
-        let result = find_toolchain(&request, system, &sources, cache)?;
+        let result = find_toolchain(&request, environments, preference, cache)?;
         if let Ok(ref toolchain) = result {
             warn_on_unsupported_python(toolchain.interpreter());
             return Ok(result);
@@ -796,18 +812,16 @@ pub fn find_best_toolchain(
     // If a Python version was requested but cannot be fulfilled, just take any version
     debug!("Looking for Python toolchain with any version");
     let request = ToolchainRequest::Any;
-    Ok(find_toolchain(
-        // TODO(zanieb): Add a dedicated `Default` variant to `ToolchainRequest`
-        &request, system, &sources, cache,
-    )?
-    .map_err(|err| {
-        // Use a more general error in this case since we looked for multiple versions
-        if matches!(err, ToolchainNotFound::NoMatchingVersion(..)) {
-            ToolchainNotFound::NoPythonInstallation(sources.clone(), None)
-        } else {
-            err
-        }
-    }))
+    Ok(
+        find_toolchain(&request, environments, preference, cache)?.map_err(|err| {
+            // Use a more general error in this case since we looked for multiple versions
+            if matches!(err, ToolchainNotFound::NoMatchingVersion(..)) {
+                ToolchainNotFound::NoPythonInstallation(preference, None)
+            } else {
+                err
+            }
+        }),
+    )
 }
 
 /// Display a warning if the Python version of the [`Interpreter`] is unsupported by uv.
@@ -1134,6 +1148,68 @@ impl ToolchainRequest {
     }
 }
 
+impl ToolchainPreference {
+    fn allows(self, source: ToolchainSource) -> bool {
+        // If not dealing with a system interpreter source, we don't care about the preference
+        if !matches!(
+            source,
+            ToolchainSource::Managed | ToolchainSource::SearchPath | ToolchainSource::PyLauncher
+        ) {
+            return true;
+        }
+
+        match self {
+            ToolchainPreference::OnlyManaged => matches!(source, ToolchainSource::Managed),
+            ToolchainPreference::PreferInstalledManaged
+            | Self::PreferManaged
+            | Self::PreferSystem => matches!(
+                source,
+                ToolchainSource::Managed
+                    | ToolchainSource::SearchPath
+                    | ToolchainSource::PyLauncher
+            ),
+            ToolchainPreference::OnlySystem => {
+                matches!(
+                    source,
+                    ToolchainSource::SearchPath | ToolchainSource::PyLauncher
+                )
+            }
+        }
+    }
+
+    /// Return a [`ToolchainPreference`] based the given settings.
+    pub fn from_settings(preview: PreviewMode) -> Self {
+        if env::var_os("UV_TEST_PYTHON_PATH").is_some() {
+            debug!("Only considering system interpreters due to `UV_TEST_PYTHON_PATH`");
+            Self::OnlySystem
+        } else if preview.is_enabled() {
+            Self::default()
+        } else {
+            Self::OnlySystem
+        }
+    }
+
+    pub(crate) fn allows_managed(self) -> bool {
+        matches!(
+            self,
+            Self::PreferManaged | Self::PreferInstalledManaged | Self::OnlyManaged
+        )
+    }
+}
+
+impl EnvironmentPreference {
+    pub fn from_system_flag(system: bool, mutable: bool) -> Self {
+        match (system, mutable) {
+            // When the system flag is provided, ignore virtual environments.
+            (true, _) => Self::OnlySystem,
+            // For mutable operations, only allow discovery of the system with explicit selection.
+            (false, true) => Self::ExplicitSystem,
+            // For immutable operations, we allow discovery of the system environment
+            (false, false) => Self::Any,
+        }
+    }
+}
+
 impl VersionRequest {
     pub(crate) fn default_names(&self) -> [Option<Cow<'static, str>>; 4] {
         let (python, python3, extension) = if cfg!(windows) {
@@ -1380,80 +1456,6 @@ impl fmt::Display for VersionRequest {
     }
 }
 
-impl ToolchainSources {
-    /// Create a new [`SourceSelector::Some`] from an iterator.
-    pub(crate) fn from_sources(iter: impl IntoIterator<Item = ToolchainSource>) -> Self {
-        let inner = HashSet::from_iter(iter);
-        assert!(!inner.is_empty(), "Source selectors cannot be empty");
-        Self::Custom(inner)
-    }
-
-    /// Return true if this selector includes the given [`ToolchainSource`].
-    fn contains(&self, source: ToolchainSource) -> bool {
-        match self {
-            Self::All(preview) => {
-                // Always return `true` except for `ManagedToolchain` which requires preview mode
-                source != ToolchainSource::Managed || preview.is_enabled()
-            }
-            Self::System(preview) => {
-                [
-                    ToolchainSource::ProvidedPath,
-                    ToolchainSource::SearchPath,
-                    #[cfg(windows)]
-                    ToolchainSource::PyLauncher,
-                    ToolchainSource::ParentInterpreter,
-                ]
-                .contains(&source)
-                    // Allow `ManagedToolchain` in preview
-                    || (source == ToolchainSource::Managed
-                        && preview.is_enabled())
-            }
-            Self::VirtualEnv => [
-                ToolchainSource::DiscoveredEnvironment,
-                ToolchainSource::ActiveEnvironment,
-                ToolchainSource::CondaPrefix,
-            ]
-            .contains(&source),
-            Self::Custom(sources) => sources.contains(&source),
-        }
-    }
-
-    /// Return a [`SourceSelector`] based the settings.
-    pub fn from_settings(system: SystemPython, preview: PreviewMode) -> Self {
-        if env::var_os("UV_FORCE_MANAGED_PYTHON").is_some() {
-            debug!("Only considering managed toolchains due to `UV_FORCE_MANAGED_PYTHON`");
-            Self::from_sources([ToolchainSource::Managed])
-        } else if env::var_os("UV_TEST_PYTHON_PATH").is_some() {
-            debug!(
-                "Only considering search path, provided path, and active environments due to `UV_TEST_PYTHON_PATH`"
-            );
-            Self::from_sources([
-                ToolchainSource::ActiveEnvironment,
-                ToolchainSource::SearchPath,
-                ToolchainSource::ProvidedPath,
-            ])
-        } else {
-            match system {
-                SystemPython::Allowed | SystemPython::Explicit => Self::All(preview),
-                SystemPython::Required => Self::System(preview),
-                SystemPython::Disallowed => Self::VirtualEnv,
-            }
-        }
-    }
-}
-
-impl SystemPython {
-    /// Returns true if a system Python is allowed.
-    pub fn is_allowed(&self) -> bool {
-        matches!(self, SystemPython::Allowed | SystemPython::Required)
-    }
-
-    /// Returns true if a system Python is preferred.
-    pub fn is_preferred(&self) -> bool {
-        matches!(self, SystemPython::Required)
-    }
-}
-
 impl fmt::Display for ToolchainRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
@@ -1484,6 +1486,18 @@ impl fmt::Display for ToolchainSource {
             Self::PyLauncher => f.write_str("`py` launcher output"),
             Self::Managed => f.write_str("managed toolchains"),
             Self::ParentInterpreter => f.write_str("parent interpreter"),
+        }
+    }
+}
+
+impl fmt::Display for ToolchainPreference {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OnlyManaged => f.write_str("managed toolchains"),
+            Self::OnlySystem => f.write_str("system toolchains"),
+            Self::PreferInstalledManaged | Self::PreferManaged | Self::PreferSystem => {
+                f.write_str("managed or system toolchains")
+            }
         }
     }
 }
@@ -1547,59 +1561,6 @@ impl fmt::Display for ToolchainNotFound {
                     "Python interpreter at `{}` is not executable",
                     path.user_display()
                 )
-            }
-        }
-    }
-}
-
-impl fmt::Display for ToolchainSources {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::All(_) => f.write_str("all sources"),
-            Self::VirtualEnv => f.write_str("virtual environments"),
-            Self::System(preview) => {
-                if cfg!(windows) {
-                    if preview.is_disabled() {
-                        write!(
-                            f,
-                            "{} or {}",
-                            ToolchainSource::SearchPath,
-                            ToolchainSource::PyLauncher
-                        )
-                    } else {
-                        write!(
-                            f,
-                            "{}, {}, or {}",
-                            ToolchainSource::SearchPath,
-                            ToolchainSource::PyLauncher,
-                            ToolchainSource::Managed
-                        )
-                    }
-                } else {
-                    if preview.is_disabled() {
-                        write!(f, "{}", ToolchainSource::SearchPath)
-                    } else {
-                        write!(
-                            f,
-                            "{} or {}",
-                            ToolchainSource::SearchPath,
-                            ToolchainSource::Managed
-                        )
-                    }
-                }
-            }
-            Self::Custom(sources) => {
-                let sources: Vec<_> = sources
-                    .iter()
-                    .sorted()
-                    .map(ToolchainSource::to_string)
-                    .collect();
-                match sources[..] {
-                    [] => unreachable!("Source selectors must contain at least one source"),
-                    [ref one] => f.write_str(one),
-                    [ref first, ref second] => write!(f, "{first} or {second}"),
-                    [ref first @ .., ref last] => write!(f, "{}, or {last}", first.join(", ")),
-                }
             }
         }
     }

--- a/crates/uv/src/commands/pip/check.rs
+++ b/crates/uv/src/commands/pip/check.rs
@@ -10,7 +10,9 @@ use uv_cache::Cache;
 use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::{SitePackages, SitePackagesDiagnostic};
-use uv_toolchain::{PythonEnvironment, SystemPython, Toolchain, ToolchainRequest};
+use uv_toolchain::{
+    EnvironmentPreference, PythonEnvironment, Toolchain, ToolchainPreference, ToolchainRequest,
+};
 
 use crate::commands::{elapsed, ExitStatus};
 use crate::printer::Printer;
@@ -26,15 +28,10 @@ pub(crate) fn pip_check(
     let start = Instant::now();
 
     // Detect the current Python interpreter.
-    let system = if system {
-        SystemPython::Required
-    } else {
-        SystemPython::Allowed
-    };
     let environment = PythonEnvironment::from_toolchain(Toolchain::find(
         python.map(ToolchainRequest::parse),
-        system,
-        preview,
+        EnvironmentPreference::from_system_flag(system, false),
+        ToolchainPreference::from_settings(preview),
         cache,
     )?);
 

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -40,7 +40,8 @@ use uv_resolver::{
     Resolver,
 };
 use uv_toolchain::{
-    PythonEnvironment, PythonVersion, SystemPython, Toolchain, ToolchainRequest, VersionRequest,
+    EnvironmentPreference, PythonEnvironment, PythonVersion, Toolchain, ToolchainPreference,
+    ToolchainRequest, VersionRequest,
 };
 use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
 use uv_warnings::warn_user;
@@ -153,14 +154,11 @@ pub(crate) async fn pip_compile(
     }
 
     // Find an interpreter to use for building distributions
-    let system = if system {
-        SystemPython::Required
-    } else {
-        SystemPython::Allowed
-    };
+    let environment = EnvironmentPreference::from_system_flag(system, false);
+    let preference = ToolchainPreference::from_settings(preview);
     let interpreter = if let Some(python) = python.as_ref() {
         let request = ToolchainRequest::parse(python);
-        Toolchain::find_requested(&request, system, preview, &cache)
+        Toolchain::find_requested(&request, environment, preference, &cache)
     } else {
         // TODO(zanieb): The split here hints at a problem with the abstraction; we should be able to use
         // `Toolchain::find(...)` here.
@@ -170,7 +168,7 @@ pub(crate) async fn pip_compile(
         } else {
             ToolchainRequest::default()
         };
-        Toolchain::find_best(&request, system, preview, &cache)
+        Toolchain::find_best(&request, environment, preference, &cache)
     }?
     .into_interpreter();
 

--- a/crates/uv/src/commands/pip/freeze.rs
+++ b/crates/uv/src/commands/pip/freeze.rs
@@ -10,7 +10,9 @@ use uv_cache::Cache;
 use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
-use uv_toolchain::{PythonEnvironment, SystemPython, Toolchain, ToolchainRequest};
+use uv_toolchain::{
+    EnvironmentPreference, PythonEnvironment, Toolchain, ToolchainPreference, ToolchainRequest,
+};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -26,15 +28,10 @@ pub(crate) fn pip_freeze(
     printer: Printer,
 ) -> Result<ExitStatus> {
     // Detect the current Python interpreter.
-    let system = if system {
-        SystemPython::Required
-    } else {
-        SystemPython::Allowed
-    };
     let environment = PythonEnvironment::from_toolchain(Toolchain::find(
         python.map(ToolchainRequest::parse),
-        system,
-        preview,
+        EnvironmentPreference::from_system_flag(system, false),
+        ToolchainPreference::from_settings(preview),
         cache,
     )?);
 

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -26,7 +26,8 @@ use uv_resolver::{
     ResolutionMode,
 };
 use uv_toolchain::{
-    Prefix, PythonEnvironment, PythonVersion, SystemPython, Target, Toolchain, ToolchainRequest,
+    EnvironmentPreference, Prefix, PythonEnvironment, PythonVersion, Target, Toolchain,
+    ToolchainPreference, ToolchainRequest,
 };
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 
@@ -116,15 +117,10 @@ pub(crate) async fn pip_install(
         .collect();
 
     // Detect the current Python interpreter.
-    let system = if system {
-        SystemPython::Required
-    } else {
-        SystemPython::Explicit
-    };
     let environment = PythonEnvironment::from_toolchain(Toolchain::find(
         python.as_deref().map(ToolchainRequest::parse),
-        system,
-        preview,
+        EnvironmentPreference::from_system_flag(system, true),
+        ToolchainPreference::from_settings(preview),
         &cache,
     )?);
 

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -14,7 +14,7 @@ use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
-use uv_toolchain::{PythonEnvironment, SystemPython};
+use uv_toolchain::{EnvironmentPreference, PythonEnvironment, ToolchainPreference};
 use uv_toolchain::{Toolchain, ToolchainRequest};
 
 use crate::commands::ExitStatus;
@@ -36,15 +36,10 @@ pub(crate) fn pip_list(
     printer: Printer,
 ) -> Result<ExitStatus> {
     // Detect the current Python interpreter.
-    let system = if system {
-        SystemPython::Required
-    } else {
-        SystemPython::Allowed
-    };
     let environment = PythonEnvironment::from_toolchain(Toolchain::find(
         python.map(ToolchainRequest::parse),
-        system,
-        preview,
+        EnvironmentPreference::from_system_flag(system, false),
+        ToolchainPreference::from_settings(preview),
         cache,
     )?);
 

--- a/crates/uv/src/commands/pip/show.rs
+++ b/crates/uv/src/commands/pip/show.rs
@@ -12,7 +12,9 @@ use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
-use uv_toolchain::{PythonEnvironment, SystemPython, Toolchain, ToolchainRequest};
+use uv_toolchain::{
+    EnvironmentPreference, PythonEnvironment, Toolchain, ToolchainPreference, ToolchainRequest,
+};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -41,15 +43,10 @@ pub(crate) fn pip_show(
     }
 
     // Detect the current Python interpreter.
-    let system = if system {
-        SystemPython::Required
-    } else {
-        SystemPython::Allowed
-    };
     let environment = PythonEnvironment::from_toolchain(Toolchain::find(
         python.map(ToolchainRequest::parse),
-        system,
-        preview,
+        EnvironmentPreference::from_system_flag(system, false),
+        ToolchainPreference::from_settings(preview),
         cache,
     )?);
 

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -25,7 +25,8 @@ use uv_resolver::{
     ResolutionMode,
 };
 use uv_toolchain::{
-    Prefix, PythonEnvironment, PythonVersion, SystemPython, Target, Toolchain, ToolchainRequest,
+    EnvironmentPreference, Prefix, PythonEnvironment, PythonVersion, Target, Toolchain,
+    ToolchainPreference, ToolchainRequest,
 };
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 
@@ -111,15 +112,10 @@ pub(crate) async fn pip_sync(
     }
 
     // Detect the current Python interpreter.
-    let system = if system {
-        SystemPython::Required
-    } else {
-        SystemPython::Explicit
-    };
     let environment = PythonEnvironment::from_toolchain(Toolchain::find(
         python.as_deref().map(ToolchainRequest::parse),
-        system,
-        preview,
+        EnvironmentPreference::from_system_flag(system, true),
+        ToolchainPreference::from_settings(preview),
         &cache,
     )?);
 

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -14,9 +14,11 @@ use uv_client::{BaseClientBuilder, Connectivity};
 use uv_configuration::{KeyringProviderType, PreviewMode};
 use uv_fs::Simplified;
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
+use uv_toolchain::EnvironmentPreference;
 use uv_toolchain::Toolchain;
+use uv_toolchain::ToolchainPreference;
 use uv_toolchain::ToolchainRequest;
-use uv_toolchain::{Prefix, PythonEnvironment, SystemPython, Target};
+use uv_toolchain::{Prefix, PythonEnvironment, Target};
 
 use crate::commands::{elapsed, ExitStatus};
 use crate::printer::Printer;
@@ -47,15 +49,10 @@ pub(crate) async fn pip_uninstall(
     let spec = RequirementsSpecification::from_simple_sources(sources, &client_builder).await?;
 
     // Detect the current Python interpreter.
-    let system = if system {
-        SystemPython::Required
-    } else {
-        SystemPython::Explicit
-    };
     let environment = PythonEnvironment::from_toolchain(Toolchain::find(
         python.as_deref().map(ToolchainRequest::parse),
-        system,
-        preview,
+        EnvironmentPreference::from_system_flag(system, true),
+        ToolchainPreference::from_settings(preview),
         &cache,
     )?);
 

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -18,8 +18,8 @@ use uv_installer::{SatisfiesResult, SitePackages};
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_resolver::{FlatIndex, InMemoryIndex, OptionsBuilder, RequiresPython};
 use uv_toolchain::{
-    request_from_version_file, Interpreter, PythonEnvironment, SystemPython, Toolchain,
-    ToolchainRequest, VersionRequest,
+    request_from_version_file, EnvironmentPreference, Interpreter, PythonEnvironment, Toolchain,
+    ToolchainPreference, ToolchainRequest, VersionRequest,
 };
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 use uv_warnings::warn_user;
@@ -183,8 +183,8 @@ pub(crate) async fn find_interpreter(
     // Locate the Python interpreter to use in the environment
     let interpreter = Toolchain::find_or_fetch(
         python_request,
-        SystemPython::Required,
-        PreviewMode::Enabled,
+        EnvironmentPreference::OnlySystem,
+        ToolchainPreference::from_settings(PreviewMode::Enabled),
         client_builder,
         cache,
     )

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -12,7 +12,9 @@ use uv_configuration::{Concurrency, ExtrasSpecification, PreviewMode};
 use uv_distribution::{ProjectWorkspace, Workspace};
 use uv_normalize::PackageName;
 use uv_requirements::RequirementsSource;
-use uv_toolchain::{PythonEnvironment, SystemPython, Toolchain, ToolchainRequest};
+use uv_toolchain::{
+    EnvironmentPreference, PythonEnvironment, Toolchain, ToolchainPreference, ToolchainRequest,
+};
 use uv_warnings::warn_user;
 
 use crate::cli::ExternalCommand;
@@ -138,8 +140,8 @@ pub(crate) async fn run(
             // Note we force preview on during `uv run` for now since the entire interface is in preview
             Toolchain::find_or_fetch(
                 python.as_deref().map(ToolchainRequest::parse),
-                SystemPython::Allowed,
-                PreviewMode::Enabled,
+                EnvironmentPreference::Any,
+                ToolchainPreference::from_settings(PreviewMode::Enabled),
                 client_builder,
                 cache,
             )

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -9,7 +9,9 @@ use uv_cache::Cache;
 use uv_client::Connectivity;
 use uv_configuration::{Concurrency, PreviewMode};
 use uv_requirements::RequirementsSource;
-use uv_toolchain::{PythonEnvironment, SystemPython, Toolchain, ToolchainRequest};
+use uv_toolchain::{
+    EnvironmentPreference, PythonEnvironment, Toolchain, ToolchainPreference, ToolchainRequest,
+};
 use uv_warnings::warn_user;
 
 use crate::cli::ExternalCommand;
@@ -67,8 +69,8 @@ pub(crate) async fn run(
     // Note we force preview on during `uv tool run` for now since the entire interface is in preview
     let interpreter = Toolchain::find(
         python.as_deref().map(ToolchainRequest::parse),
-        SystemPython::Allowed,
-        PreviewMode::Enabled,
+        EnvironmentPreference::Any,
+        ToolchainPreference::from_settings(preview),
         cache,
     )?
     .into_interpreter();

--- a/crates/uv/src/commands/toolchain/find.rs
+++ b/crates/uv/src/commands/toolchain/find.rs
@@ -4,7 +4,7 @@ use std::fmt::Write;
 use uv_cache::Cache;
 use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
-use uv_toolchain::{SystemPython, Toolchain, ToolchainRequest};
+use uv_toolchain::{EnvironmentPreference, Toolchain, ToolchainPreference, ToolchainRequest};
 use uv_warnings::warn_user;
 
 use crate::commands::ExitStatus;
@@ -28,8 +28,8 @@ pub(crate) async fn find(
     };
     let toolchain = Toolchain::find_requested(
         &request,
-        SystemPython::Required,
-        PreviewMode::Enabled,
+        EnvironmentPreference::OnlySystem,
+        ToolchainPreference::from_settings(PreviewMode::Enabled),
         cache,
     )?;
 

--- a/crates/uv/src/commands/toolchain/list.rs
+++ b/crates/uv/src/commands/toolchain/list.rs
@@ -8,8 +8,8 @@ use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_toolchain::downloads::PythonDownloadRequest;
 use uv_toolchain::{
-    find_toolchains, DiscoveryError, SystemPython, Toolchain, ToolchainNotFound, ToolchainRequest,
-    ToolchainSource, ToolchainSources,
+    find_toolchains, DiscoveryError, EnvironmentPreference, Toolchain, ToolchainNotFound,
+    ToolchainPreference, ToolchainRequest, ToolchainSource,
 };
 use uv_warnings::warn_user;
 
@@ -55,8 +55,8 @@ pub(crate) async fn list(
 
     let installed = find_toolchains(
         &ToolchainRequest::Any,
-        SystemPython::Required,
-        &ToolchainSources::All(PreviewMode::Enabled),
+        EnvironmentPreference::OnlySystem,
+        ToolchainPreference::from_settings(preview),
         cache,
     )
     // Raise discovery errors if critical

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -23,7 +23,10 @@ use uv_dispatch::BuildDispatch;
 use uv_fs::Simplified;
 use uv_git::GitResolver;
 use uv_resolver::{ExcludeNewer, FlatIndex, InMemoryIndex, OptionsBuilder};
-use uv_toolchain::{request_from_version_file, SystemPython, Toolchain, ToolchainRequest};
+use uv_toolchain::{
+    request_from_version_file, EnvironmentPreference, Toolchain, ToolchainPreference,
+    ToolchainRequest,
+};
 use uv_types::{BuildContext, BuildIsolation, HashStrategy, InFlight};
 
 use crate::commands::{pip, ExitStatus};
@@ -133,8 +136,8 @@ async fn venv_impl(
     // Locate the Python interpreter to use in the environment
     let interpreter = Toolchain::find_or_fetch(
         interpreter_request,
-        SystemPython::Required,
-        preview,
+        EnvironmentPreference::OnlySystem,
+        ToolchainPreference::from_settings(preview),
         client_builder,
         cache,
     )

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -14,12 +14,13 @@ use std::iter::Iterator;
 use std::path::{Path, PathBuf};
 use std::process::Output;
 use std::str::FromStr;
-use uv_configuration::PreviewMode;
 
 use uv_cache::Cache;
 use uv_fs::Simplified;
 use uv_toolchain::managed::InstalledToolchains;
-use uv_toolchain::{PythonVersion, Toolchain, ToolchainRequest};
+use uv_toolchain::{
+    EnvironmentPreference, PythonVersion, Toolchain, ToolchainPreference, ToolchainRequest,
+};
 
 // Exclude any packages uploaded after this date.
 pub static EXCLUDE_NEWER: &str = "2024-03-25T00:00:00Z";
@@ -733,8 +734,8 @@ pub fn python_toolchains_for_versions(
                     Some(ToolchainRequest::parse(python_version)),
                     // Without required, we could pick the current venv here and the test fails
                     // because the venv subcommand requires a system interpreter.
-                    uv_toolchain::SystemPython::Required,
-                    PreviewMode::Enabled,
+                    EnvironmentPreference::OnlySystem,
+                    ToolchainPreference::PreferInstalledManaged,
                     &cache,
                 ) {
                     vec![toolchain

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -1896,7 +1896,7 @@ fn lock_requires_python() -> Result<()> {
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
     Removing virtual environment at: .venv
-    error: No interpreter found for Python >=3.12 in provided path, active virtual environment, or search path
+    error: No interpreter found for Python >=3.12 in system toolchains
     "###);
 
     Ok(())

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -34,6 +34,7 @@ fn check_command(venv: &Path, command: &str, temp_dir: &Path) {
         .success();
 }
 
+// TODO(zanieb): This belongs in the `TestContext`
 /// Create a `pip sync` command with options shared across scenarios.
 fn sync_without_exclude_newer(context: &TestContext) -> Command {
     let mut command = Command::new(get_bin());
@@ -44,6 +45,8 @@ fn sync_without_exclude_newer(context: &TestContext) -> Command {
         .arg(context.cache_dir.path())
         .env("VIRTUAL_ENV", context.venv.as_os_str())
         .env("UV_NO_WRAP", "1")
+        .env("UV_TEST_PYTHON_PATH", &context.python_path())
+        .env("UV_TOOLCHAIN_DIR", "")
         .current_dir(&context.temp_dir);
 
     if cfg!(all(windows, debug_assertions)) {
@@ -71,6 +74,8 @@ fn uninstall_command(context: &TestContext) -> Command {
         .arg("--cache-dir")
         .arg(context.cache_dir.path())
         .env("VIRTUAL_ENV", context.venv.as_os_str())
+        .env("UV_TEST_PYTHON_PATH", &context.python_path())
+        .env("UV_TOOLCHAIN_DIR", "")
         .env("UV_NO_WRAP", "1")
         .current_dir(&context.temp_dir);
 
@@ -116,7 +121,7 @@ fn missing_venv() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No Python interpreters found in virtual environments
+    error: No Python interpreters found in system toolchains
     "###);
 
     assert!(predicates::path::missing().eval(&context.venv));

--- a/crates/uv/tests/toolchain_find.rs
+++ b/crates/uv/tests/toolchain_find.rs
@@ -16,7 +16,7 @@ fn toolchain_find() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No Python interpreters found in provided path, active virtual environment, or search path
+    error: No Python interpreters found in system toolchains
     "###);
 
     // We find the first interpreter on the path
@@ -101,7 +101,7 @@ fn toolchain_find() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No interpreter found for PyPy in provided path, active virtual environment, or search path
+    error: No interpreter found for PyPy in system toolchains
     "###);
 
     // Swap the order of the Python versions

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -264,7 +264,7 @@ fn create_venv_unknown_python_minor() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.100 in search path or `py` launcher output
+          × No interpreter found for Python 3.100 in system toolchains
         "###
         );
     } else {
@@ -274,7 +274,7 @@ fn create_venv_unknown_python_minor() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.100 in search path
+          × No interpreter found for Python 3.100 in system toolchains
         "###
         );
     }
@@ -302,7 +302,7 @@ fn create_venv_unknown_python_patch() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.12.100 in search path or `py` launcher output
+          × No interpreter found for Python 3.12.100 in system toolchains
         "###
         );
     } else {
@@ -312,7 +312,7 @@ fn create_venv_unknown_python_patch() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.12.100 in search path
+          × No interpreter found for Python 3.12.100 in system toolchains
         "###
         );
     }


### PR DESCRIPTION
Adds support for the toolchain discovery preferences outlined in https://github.com/astral-sh/uv/issues/4198 but we don't expose this to users yet, I'll do that next to make it easier to review.

I've made some refactors in the toolchain discovery implementation to enable this behavior and move us towards clearer abstractions. There's still remaining work here, but I'd prefer tackle things in follow-ups instead of expanding this pull request. I plan on opening a couple before merging this.

I'd like to shift the public toolchain API to focus on discovering either an **environment** or a **toolchain**. The first would be used by commands that operate on an environment, while the latter would be used by commands that just need an interpreter to create environments. I haven't changed this here, but some of the refactors are in preparation for supporting this idea.

In brief:

- We now allow different ordering of installed toolchain discovery based on a `ToolchainPreference` type. This is the type we will expose to users.
- `SystemPython` was changed into an `EnvironmentPreference` which is used to determine if we should prefer virtual or system Python environments. 
- We drop the whole `ToolchainSources` selection concept, it was confusing and the error messages from it were awkward. Most of the functionality is now captured by the preference enums, but you can't do things like "only find a toolchain from the parent interpreter" as easily anymore.