### PR TITLE
Use correct lock path for workspace dependencies

### DIFF
--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -332,8 +332,9 @@ pub fn relative_to(path: impl AsRef<Path>, base: impl AsRef<Path>) -> Result<Pat
         .as_ref()
         .ancestors()
         .find_map(|ancestor| {
-            path.as_ref()
-                .strip_prefix(ancestor)
+            // Simplifying removes the UNC path prefix on windows.
+            dunce::simplified(path.as_ref())
+                .strip_prefix(dunce::simplified(ancestor))
                 .ok()
                 .map(|stripped| (stripped, ancestor))
         })
@@ -342,8 +343,8 @@ pub fn relative_to(path: impl AsRef<Path>, base: impl AsRef<Path>) -> Result<Pat
                 io::ErrorKind::Other,
                 format!(
                     "Trivial strip failed: {} vs. {}",
-                    path.simplified_display(),
-                    base.simplified_display()
+                    path.as_ref().simplified_display(),
+                    base.as_ref().simplified_display()
                 ),
             )
         })?;

--- a/crates/uv-resolver/src/manifest.rs
+++ b/crates/uv-resolver/src/manifest.rs
@@ -100,39 +100,40 @@ impl Manifest {
     ) -> impl Iterator<Item = &Requirement> + 'a {
         match mode {
             // Include all direct and transitive requirements, with constraints and overrides applied.
-            DependencyMode::Transitive => Either::Left( self
-                .lookaheads
-                .iter()
-                .flat_map(move |lookahead| {
-                    self.overrides
-                        .apply(lookahead.requirements())
-                        .filter(move |requirement| {
-                            requirement.evaluate_markers(markers, lookahead.extras())
-                        })
-                })
-                .chain(
-                    self.overrides
-                        .apply(&self.requirements)
-                        .filter(move |requirement| requirement.evaluate_markers(markers, &[])),
-                )
-                .chain(
-                    self.constraints
-                        .requirements()
-                        .filter(move |requirement| requirement.evaluate_markers(markers, &[])),
-                )
-                .chain(
-                    self.overrides
-                        .requirements()
-                        .filter(move |requirement| requirement.evaluate_markers(markers, &[])),
-                ))
-            ,
-
+            DependencyMode::Transitive => Either::Left(
+                self.lookaheads
+                    .iter()
+                    .flat_map(move |lookahead| {
+                        self.overrides
+                            .apply(lookahead.requirements())
+                            .filter(move |requirement| {
+                                requirement.evaluate_markers(markers, lookahead.extras())
+                            })
+                    })
+                    .chain(
+                        self.overrides
+                            .apply(&self.requirements)
+                            .filter(move |requirement| requirement.evaluate_markers(markers, &[])),
+                    )
+                    .chain(
+                        self.constraints
+                            .requirements()
+                            .filter(move |requirement| requirement.evaluate_markers(markers, &[])),
+                    )
+                    .chain(
+                        self.overrides
+                            .requirements()
+                            .filter(move |requirement| requirement.evaluate_markers(markers, &[])),
+                    ),
+            ),
             // Include direct requirements, with constraints and overrides applied.
             DependencyMode::Direct => Either::Right(
-                self.overrides.apply(&self.requirements)
-                .chain(self.constraints.requirements())
-                .chain(self.overrides.requirements())
-                .filter(move |requirement| requirement.evaluate_markers(markers, &[]))),
+                self.overrides
+                    .apply(&self.requirements)
+                    .chain(self.constraints.requirements())
+                    .chain(self.overrides.requirements())
+                    .filter(move |requirement| requirement.evaluate_markers(markers, &[])),
+            ),
         }
     }
 


### PR DESCRIPTION
Previously, distributions created through `Source::Workspace` would have the absolute path as lock path. This didn't cause any problems, since in `Urls` we would later overwrite those urls with the correct one created from being workspace members by path.

Changing the order surfaced this. This change emits the correct lock path. I've manually checked the difference with `dbg!`, this is not observable on main, but on the diverging urls branch it fixes lockfile creation.