### PR TITLE
Add `PythonEnvironment::find` API

### DIFF
--- a/crates/uv-dev/src/build.rs
+++ b/crates/uv-dev/src/build.rs
@@ -16,7 +16,7 @@ use uv_configuration::{
 use uv_dispatch::BuildDispatch;
 use uv_git::GitResolver;
 use uv_resolver::{FlatIndex, InMemoryIndex};
-use uv_toolchain::{EnvironmentPreference, Toolchain, ToolchainPreference};
+use uv_toolchain::{EnvironmentPreference, PythonEnvironment, ToolchainRequest};
 use uv_types::{BuildContext, BuildIsolation, InFlight};
 
 #[derive(Parser)]
@@ -65,10 +65,9 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
     let index = InMemoryIndex::default();
     let index_urls = IndexLocations::default();
     let setup_py = SetupPyStrategy::default();
-    let toolchain = Toolchain::find(
-        None,
+    let toolchain = PythonEnvironment::find(
+        &ToolchainRequest::default(),
         EnvironmentPreference::OnlyVirtual,
-        ToolchainPreference::default(),
         &cache,
     )?;
     let build_options = BuildOptions::default();

--- a/crates/uv-dev/src/compile.rs
+++ b/crates/uv-dev/src/compile.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::Parser;
 use tracing::info;
 use uv_cache::{Cache, CacheArgs};
-use uv_toolchain::{EnvironmentPreference, Toolchain, ToolchainPreference};
+use uv_toolchain::{EnvironmentPreference, PythonEnvironment, ToolchainRequest};
 
 #[derive(Parser)]
 pub(crate) struct CompileArgs {
@@ -20,10 +20,9 @@ pub(crate) async fn compile(args: CompileArgs) -> anyhow::Result<()> {
     let interpreter = if let Some(python) = args.python {
         python
     } else {
-        let interpreter = Toolchain::find(
-            None,
+        let interpreter = PythonEnvironment::find(
+            &ToolchainRequest::default(),
             EnvironmentPreference::OnlyVirtual,
-            ToolchainPreference::default(),
             &cache,
         )?
         .into_interpreter();

--- a/crates/uv-toolchain/src/environment.rs
+++ b/crates/uv-toolchain/src/environment.rs
@@ -6,9 +6,13 @@ use std::sync::Arc;
 use uv_cache::Cache;
 use uv_fs::{LockedFile, Simplified};
 
+use crate::discovery::find_toolchain;
 use crate::toolchain::Toolchain;
 use crate::virtualenv::{virtualenv_python_executable, PyVenvConfiguration};
-use crate::{Error, Interpreter, Prefix, Target};
+use crate::{
+    EnvironmentPreference, Error, Interpreter, Prefix, Target, ToolchainPreference,
+    ToolchainRequest,
+};
 
 /// A Python environment, consisting of a Python [`Interpreter`] and its associated paths.
 #[derive(Debug, Clone)]
@@ -21,6 +25,25 @@ struct PythonEnvironmentShared {
 }
 
 impl PythonEnvironment {
+    /// Find a [`PythonEnvironment`] matching the given request and preference.
+    ///
+    /// If looking for a Python toolchain to create a new environment, use [`Toolchain::find`]
+    /// instead.
+    pub fn find(
+        request: &ToolchainRequest,
+        preference: EnvironmentPreference,
+        cache: &Cache,
+    ) -> Result<Self, Error> {
+        let toolchain = find_toolchain(
+            request,
+            preference,
+            // Ignore managed toolchains when looking for environments
+            ToolchainPreference::OnlySystem,
+            cache,
+        )??;
+        Ok(Self::from_toolchain(toolchain))
+    }
+
     /// Create a [`PythonEnvironment`] from the virtual environment at the given root.
     pub fn from_root(root: impl AsRef<Path>, cache: &Cache) -> Result<Self, Error> {
         let venv = match fs_err::canonicalize(root.as_ref()) {

--- a/crates/uv/src/commands/pip/check.rs
+++ b/crates/uv/src/commands/pip/check.rs
@@ -10,9 +10,7 @@ use uv_cache::Cache;
 use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::{SitePackages, SitePackagesDiagnostic};
-use uv_toolchain::{
-    EnvironmentPreference, PythonEnvironment, Toolchain, ToolchainPreference, ToolchainRequest,
-};
+use uv_toolchain::{EnvironmentPreference, PythonEnvironment, ToolchainRequest};
 
 use crate::commands::{elapsed, ExitStatus};
 use crate::printer::Printer;
@@ -21,19 +19,18 @@ use crate::printer::Printer;
 pub(crate) fn pip_check(
     python: Option<&str>,
     system: bool,
-    preview: PreviewMode,
+    _preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
     let start = Instant::now();
 
     // Detect the current Python interpreter.
-    let environment = PythonEnvironment::from_toolchain(Toolchain::find(
-        python.map(ToolchainRequest::parse),
+    let environment = PythonEnvironment::find(
+        &python.map(ToolchainRequest::parse).unwrap_or_default(),
         EnvironmentPreference::from_system_flag(system, false),
-        ToolchainPreference::from_settings(preview),
         cache,
-    )?);
+    )?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -154,11 +154,11 @@ pub(crate) async fn pip_compile(
     }
 
     // Find an interpreter to use for building distributions
-    let environment = EnvironmentPreference::from_system_flag(system, false);
     let preference = ToolchainPreference::from_settings(preview);
+    let environments = EnvironmentPreference::from_system_flag(system, false);
     let interpreter = if let Some(python) = python.as_ref() {
         let request = ToolchainRequest::parse(python);
-        Toolchain::find_requested(&request, environment, preference, &cache)
+        Toolchain::find(&request, environments, preference, &cache)
     } else {
         // TODO(zanieb): The split here hints at a problem with the abstraction; we should be able to use
         // `Toolchain::find(...)` here.
@@ -168,7 +168,7 @@ pub(crate) async fn pip_compile(
         } else {
             ToolchainRequest::default()
         };
-        Toolchain::find_best(&request, environment, preference, &cache)
+        Toolchain::find_best(&request, environments, preference, &cache)
     }?
     .into_interpreter();
 

--- a/crates/uv/src/commands/pip/freeze.rs
+++ b/crates/uv/src/commands/pip/freeze.rs
@@ -10,9 +10,7 @@ use uv_cache::Cache;
 use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
-use uv_toolchain::{
-    EnvironmentPreference, PythonEnvironment, Toolchain, ToolchainPreference, ToolchainRequest,
-};
+use uv_toolchain::{EnvironmentPreference, PythonEnvironment, ToolchainRequest};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -23,17 +21,16 @@ pub(crate) fn pip_freeze(
     strict: bool,
     python: Option<&str>,
     system: bool,
-    preview: PreviewMode,
+    _preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
     // Detect the current Python interpreter.
-    let environment = PythonEnvironment::from_toolchain(Toolchain::find(
-        python.map(ToolchainRequest::parse),
+    let environment = PythonEnvironment::find(
+        &python.map(ToolchainRequest::parse).unwrap_or_default(),
         EnvironmentPreference::from_system_flag(system, false),
-        ToolchainPreference::from_settings(preview),
         cache,
-    )?);
+    )?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -26,8 +26,7 @@ use uv_resolver::{
     ResolutionMode,
 };
 use uv_toolchain::{
-    EnvironmentPreference, Prefix, PythonEnvironment, PythonVersion, Target, Toolchain,
-    ToolchainPreference, ToolchainRequest,
+    EnvironmentPreference, Prefix, PythonEnvironment, PythonVersion, Target, ToolchainRequest,
 };
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 
@@ -117,12 +116,14 @@ pub(crate) async fn pip_install(
         .collect();
 
     // Detect the current Python interpreter.
-    let environment = PythonEnvironment::from_toolchain(Toolchain::find(
-        python.as_deref().map(ToolchainRequest::parse),
+    let environment = PythonEnvironment::find(
+        &python
+            .as_deref()
+            .map(ToolchainRequest::parse)
+            .unwrap_or_default(),
         EnvironmentPreference::from_system_flag(system, true),
-        ToolchainPreference::from_settings(preview),
         &cache,
-    )?);
+    )?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -14,8 +14,8 @@ use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
-use uv_toolchain::{EnvironmentPreference, PythonEnvironment, ToolchainPreference};
-use uv_toolchain::{Toolchain, ToolchainRequest};
+use uv_toolchain::ToolchainRequest;
+use uv_toolchain::{EnvironmentPreference, PythonEnvironment};
 
 use crate::commands::ExitStatus;
 use crate::commands::ListFormat;
@@ -31,17 +31,16 @@ pub(crate) fn pip_list(
     strict: bool,
     python: Option<&str>,
     system: bool,
-    preview: PreviewMode,
+    _preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
     // Detect the current Python interpreter.
-    let environment = PythonEnvironment::from_toolchain(Toolchain::find(
-        python.map(ToolchainRequest::parse),
+    let environment = PythonEnvironment::find(
+        &python.map(ToolchainRequest::parse).unwrap_or_default(),
         EnvironmentPreference::from_system_flag(system, false),
-        ToolchainPreference::from_settings(preview),
         cache,
-    )?);
+    )?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/show.rs
+++ b/crates/uv/src/commands/pip/show.rs
@@ -12,9 +12,7 @@ use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
-use uv_toolchain::{
-    EnvironmentPreference, PythonEnvironment, Toolchain, ToolchainPreference, ToolchainRequest,
-};
+use uv_toolchain::{EnvironmentPreference, PythonEnvironment, ToolchainRequest};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -25,7 +23,7 @@ pub(crate) fn pip_show(
     strict: bool,
     python: Option<&str>,
     system: bool,
-    preview: PreviewMode,
+    _preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -43,12 +41,11 @@ pub(crate) fn pip_show(
     }
 
     // Detect the current Python interpreter.
-    let environment = PythonEnvironment::from_toolchain(Toolchain::find(
-        python.map(ToolchainRequest::parse),
+    let environment = PythonEnvironment::find(
+        &python.map(ToolchainRequest::parse).unwrap_or_default(),
         EnvironmentPreference::from_system_flag(system, false),
-        ToolchainPreference::from_settings(preview),
         cache,
-    )?);
+    )?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -25,8 +25,7 @@ use uv_resolver::{
     ResolutionMode,
 };
 use uv_toolchain::{
-    EnvironmentPreference, Prefix, PythonEnvironment, PythonVersion, Target, Toolchain,
-    ToolchainPreference, ToolchainRequest,
+    EnvironmentPreference, Prefix, PythonEnvironment, PythonVersion, Target, ToolchainRequest,
 };
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
 
@@ -112,12 +111,14 @@ pub(crate) async fn pip_sync(
     }
 
     // Detect the current Python interpreter.
-    let environment = PythonEnvironment::from_toolchain(Toolchain::find(
-        python.as_deref().map(ToolchainRequest::parse),
+    let environment = PythonEnvironment::find(
+        &python
+            .as_deref()
+            .map(ToolchainRequest::parse)
+            .unwrap_or_default(),
         EnvironmentPreference::from_system_flag(system, true),
-        ToolchainPreference::from_settings(preview),
         &cache,
-    )?);
+    )?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -15,8 +15,6 @@ use uv_configuration::{KeyringProviderType, PreviewMode};
 use uv_fs::Simplified;
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_toolchain::EnvironmentPreference;
-use uv_toolchain::Toolchain;
-use uv_toolchain::ToolchainPreference;
 use uv_toolchain::ToolchainRequest;
 use uv_toolchain::{Prefix, PythonEnvironment, Target};
 
@@ -35,7 +33,7 @@ pub(crate) async fn pip_uninstall(
     cache: Cache,
     connectivity: Connectivity,
     native_tls: bool,
-    preview: PreviewMode,
+    _preview: PreviewMode,
     keyring_provider: KeyringProviderType,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -49,12 +47,14 @@ pub(crate) async fn pip_uninstall(
     let spec = RequirementsSpecification::from_simple_sources(sources, &client_builder).await?;
 
     // Detect the current Python interpreter.
-    let environment = PythonEnvironment::from_toolchain(Toolchain::find(
-        python.as_deref().map(ToolchainRequest::parse),
+    let environment = PythonEnvironment::find(
+        &python
+            .as_deref()
+            .map(ToolchainRequest::parse)
+            .unwrap_or_default(),
         EnvironmentPreference::from_system_flag(system, true),
-        ToolchainPreference::from_settings(preview),
         &cache,
-    )?);
+    )?;
 
     debug!(
         "Using Python {} environment at {}",

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -183,7 +183,7 @@ pub(crate) async fn find_interpreter(
     // Locate the Python interpreter to use in the environment
     let interpreter = Toolchain::find_or_fetch(
         python_request,
-        EnvironmentPreference::OnlySystem,
+        EnvironmentPreference::Any,
         ToolchainPreference::from_settings(PreviewMode::Enabled),
         client_builder,
         cache,

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -68,8 +68,11 @@ pub(crate) async fn run(
     // Discover an interpreter.
     // Note we force preview on during `uv tool run` for now since the entire interface is in preview
     let interpreter = Toolchain::find(
-        python.as_deref().map(ToolchainRequest::parse),
-        EnvironmentPreference::Any,
+        &python
+            .as_deref()
+            .map(ToolchainRequest::parse)
+            .unwrap_or_default(),
+        EnvironmentPreference::OnlySystem,
         ToolchainPreference::from_settings(preview),
         cache,
     )?

--- a/crates/uv/src/commands/toolchain/find.rs
+++ b/crates/uv/src/commands/toolchain/find.rs
@@ -26,7 +26,7 @@ pub(crate) async fn find(
         Some(request) => ToolchainRequest::parse(&request),
         None => ToolchainRequest::Any,
     };
-    let toolchain = Toolchain::find_requested(
+    let toolchain = Toolchain::find(
         &request,
         EnvironmentPreference::OnlySystem,
         ToolchainPreference::from_settings(PreviewMode::Enabled),

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -729,9 +729,10 @@ pub fn python_toolchains_for_versions(
                 })
                 .unwrap_or_default();
             if inner.is_empty() {
+                // TODO(zanieb): Collapse these two cases now that we support `ToolchainPreference`
                 // Fallback to a system lookup if we failed to find one in the toolchain directory
                 if let Ok(toolchain) = Toolchain::find(
-                    Some(ToolchainRequest::parse(python_version)),
+                    &ToolchainRequest::parse(python_version),
                     // Without required, we could pick the current venv here and the test fails
                     // because the venv subcommand requires a system interpreter.
                     EnvironmentPreference::OnlySystem,


### PR DESCRIPTION
Restores the `PythonEnvironment::find` API which was removed a while back in favor of `Toolchain::find`. As mentioned in #4416, I'm attempting to separate the case where you want an active environment from the case where you want an installed toolchain in order to create environments.

I wanted to drop `EnvironmentPreference` from `Toolchain::find` and just have us consistently consider (or not consider) virtual environments when discovering toolchains for creating environments. Unfortunately this caused a few things to break so I reverted that change and will explore it separately. Because I was exploring that change, there are some minor changes to the `Toolchain` API here.