### PR TITLE
Revert "Bump version to 0.2.14 (#4431)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## 0.2.14
-
-### Enhancements
-
-- Support toolchain requests with platform-tag style Python implementations and version ([#4407](https://github.com/astral-sh/uv/pull/4407))
-
-### CLI
-
-- Use "Prepared" instead of "Downloaded" in logs ([#4394](https://github.com/astral-sh/uv/pull/4394))
-
-### Bug fixes
-
-- Treat mismatched directory and file urls as unsatisfied requirements ([#4393](https://github.com/astral-sh/uv/pull/4393))
-
 ## 0.2.13
 
 ### Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,7 +4419,7 @@ checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "uv"
-version = "0.2.14"
+version = "0.2.13"
 dependencies = [
  "anstream",
  "anyhow",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.2.14"
+version = "0.2.13"
 
 [[package]]
 name = "uv-virtualenv"

--- a/PREVIEW-CHANGELOG.md
+++ b/PREVIEW-CHANGELOG.md
@@ -1,15 +1,5 @@
 # Changelog
 
-## 0.2.14
-
-### Preview features
-
-- Expose `toolchain-preference` as a CLI and configuration file option ([#4424](https://github.com/astral-sh/uv/pull/4424))
-- Improve handling of command arguments in `uv run` and `uv tool run` ([#4404](https://github.com/astral-sh/uv/pull/4404))
-- Add `tool.uv.sources` support for `uv add` ([#4406](https://github.com/astral-sh/uv/pull/4406))
-- Use correct lock path for workspace dependencies ([#4421](https://github.com/astral-sh/uv/pull/4421))
-- Filter out sibling dependencies in resolver forks ([#4415](https://github.com/astral-sh/uv/pull/4415))
-
 ## 0.2.13
 
 ### Preview features
@@ -136,6 +126,7 @@
 
 <!-- No changes -->
 
+
 ## 0.2.3
 
 ### Preview features
@@ -145,6 +136,7 @@
 ## 0.2.2
 
 <!-- No changes -->
+
 
 ## 0.2.1
 
@@ -182,6 +174,7 @@
 
 <!-- No changes -->
 
+
 ## 0.1.43
 
 ### Preview features
@@ -202,6 +195,7 @@
 ## 0.1.41
 
 <!-- No changes -->
+
 
 ## 0.1.40
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 
 # For a specific version.
-curl -LsSf https://astral.sh/uv/0.2.14/install.sh | sh
-powershell -c "irm https://astral.sh/uv/0.2.14/install.ps1 | iex"
+curl -LsSf https://astral.sh/uv/0.2.13/install.sh | sh
+powershell -c "irm https://astral.sh/uv/0.2.13/install.ps1 | iex"
 
 # With pip.
 pip install uv

--- a/crates/uv-version/Cargo.toml
+++ b/crates/uv-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-version"
-version = "0.2.14"
+version = "0.2.13"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv"
-version = "0.2.14"
+version = "0.2.13"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "uv"
-version = "0.2.14"
+version = "0.2.13"
 description = "An extremely fast Python package installer and resolver, written in Rust."
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 requires-python = ">=3.8"


### PR DESCRIPTION
This reverts commit e0ad649c7449b7f54c0053e409ac6e7bf18a6f68.

We shouldn't be linking to this version in the readme.

See https://github.com/astral-sh/uv/issues/4432
