### PR TITLE
implement `--depth`, `--prune` for `pip tree`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1389,6 +1389,10 @@ pub struct PipTreeArgs {
     #[arg(long, short, default_value_t = 255)]
     pub depth: u8,
 
+    /// Prune the given package from the display of the dependency tree.
+    #[arg(long)]
+    pub(crate) prune: Vec<PackageName>,
+
     /// Validate the virtual environment, to detect packages with missing dependencies or other
     /// issues.
     #[arg(long, overrides_with("no_strict"))]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1385,6 +1385,10 @@ pub struct PipShowArgs {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct PipTreeArgs {
+    /// Maximum display depth of the dependency tree
+    #[arg(long, short, default_value_t = 255)]
+    pub depth: u8,
+
     /// Validate the virtual environment, to detect packages with missing dependencies or other
     /// issues.
     #[arg(long, overrides_with("no_strict"))]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1391,7 +1391,7 @@ pub struct PipTreeArgs {
 
     /// Prune the given package from the display of the dependency tree.
     #[arg(long)]
-    pub(crate) prune: Vec<PackageName>,
+    pub prune: Vec<PackageName>,
 
     /// Validate the virtual environment, to detect packages with missing dependencies or other
     /// issues.

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -19,6 +19,7 @@ use std::collections::{HashMap, HashSet};
 use pypi_types::VerbatimParsedUrl;
 
 /// Display the installed packages in the current environment as a dependency tree.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn pip_tree(
     depth: u8,
     prune: Vec<PackageName>,

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -46,7 +46,7 @@ pub(crate) fn pip_tree(
     // Build the installed index.
     let site_packages = SitePackages::from_executable(&environment)?;
 
-    let rendered_tree = DisplayDependencyGraph::new(&site_packages, depth, prune)
+    let rendered_tree = DisplayDependencyGraph::new(&site_packages, depth.into(), prune)
         .render()
         .join("\n");
     writeln!(printer.stdout(), "{rendered_tree}").unwrap();
@@ -121,7 +121,7 @@ struct DisplayDependencyGraph<'a> {
     required_packages: HashSet<PackageName>,
 
     // Maximum display depth of the dependency tree
-    depth: u8,
+    depth: usize,
 
     // Prune the given package from the display of the dependency tree.
     prune: Vec<PackageName>,
@@ -131,7 +131,7 @@ impl<'a> DisplayDependencyGraph<'a> {
     /// Create a new [`DisplayDependencyGraph`] for the set of installed distributions.
     fn new(
         site_packages: &'a SitePackages,
-        depth: u8,
+        depth: usize,
         prune: Vec<PackageName>,
     ) -> DisplayDependencyGraph<'a> {
         let mut dist_by_package_name = HashMap::new();
@@ -162,7 +162,7 @@ impl<'a> DisplayDependencyGraph<'a> {
         path: &mut Vec<String>,
     ) -> Vec<String> {
         // Short-circuit if the current path is longer than the provided depth.
-        if path.len() > self.depth.into() {
+        if path.len() > self.depth {
             return Vec::new();
         }
 

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -150,6 +150,7 @@ impl<'a> DisplayDependencyGraph<'a> {
         visited: &mut HashSet<String>,
         path: &mut Vec<String>,
     ) -> Vec<String> {
+        // Short-circuit if the current path is longer than the provided depth.
         if path.len() > self.depth.into() {
             return Vec::new();
         }

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -546,6 +546,7 @@ async fn run() -> Result<ExitStatus> {
             let cache = cache.init()?;
 
             commands::pip_tree(
+                args.depth,
                 args.shared.strict,
                 args.shared.python.as_deref(),
                 args.shared.system,

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -547,6 +547,7 @@ async fn run() -> Result<ExitStatus> {
 
             commands::pip_tree(
                 args.depth,
+                args.prune,
                 args.shared.strict,
                 args.shared.python.as_deref(),
                 args.shared.system,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -955,6 +955,7 @@ impl PipShowSettings {
 #[derive(Debug, Clone)]
 pub(crate) struct PipTreeSettings {
     pub(crate) depth: u8,
+    pub(crate) prune: Vec<PackageName>,
     // CLI-only settings.
     pub(crate) shared: PipSettings,
 }
@@ -964,6 +965,7 @@ impl PipTreeSettings {
     pub(crate) fn resolve(args: PipTreeArgs, filesystem: Option<FilesystemOptions>) -> Self {
         let PipTreeArgs {
             depth,
+            prune,
             strict,
             no_strict,
             python,
@@ -973,6 +975,7 @@ impl PipTreeSettings {
 
         Self {
             depth,
+            prune,
             // Shared settings.
             shared: PipSettings::combine(
                 PipOptions {

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -954,6 +954,7 @@ impl PipShowSettings {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct PipTreeSettings {
+    pub(crate) depth: u8,
     // CLI-only settings.
     pub(crate) shared: PipSettings,
 }
@@ -962,6 +963,7 @@ impl PipTreeSettings {
     /// Resolve the [`PipTreeSettings`] from the CLI and workspace configuration.
     pub(crate) fn resolve(args: PipTreeArgs, filesystem: Option<FilesystemOptions>) -> Self {
         let PipTreeArgs {
+            depth,
             strict,
             no_strict,
             python,
@@ -970,6 +972,7 @@ impl PipTreeSettings {
         } = args;
 
         Self {
+            depth,
             // Shared settings.
             shared: PipSettings::combine(
                 PipOptions {

--- a/crates/uv/tests/pip_tree.rs
+++ b/crates/uv/tests/pip_tree.rs
@@ -258,6 +258,106 @@ fn depth() {
 }
 
 #[test]
+fn prune() {
+    let context = TestContext::new("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt
+        .write_str("scikit-learn==1.4.1.post1")
+        .unwrap();
+
+    uv_snapshot!(install_command(&context)
+        .arg("-r")
+        .arg("requirements.txt")
+        .arg("--strict"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
+    Installed 5 packages in [TIME]
+     + joblib==1.3.2
+     + numpy==1.26.4
+     + scikit-learn==1.4.1.post1
+     + scipy==1.12.0
+     + threadpoolctl==3.4.0
+    "###
+    );
+
+    uv_snapshot!(context.filters(), Command::new(get_bin())
+        .arg("pip")
+        .arg("tree")
+        .arg("--cache-dir")
+        .arg(context.cache_dir.path())
+        .arg("--prune")
+        .arg("numpy")
+        .env("VIRTUAL_ENV", context.venv.as_os_str())
+        .env("UV_NO_WRAP", "1")
+        .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    scikit-learn v1.4.1.post1
+    ├── scipy v1.12.0
+    ├── joblib v1.3.2
+    └── threadpoolctl v3.4.0
+
+    ----- stderr -----
+
+    "###
+    );
+
+    uv_snapshot!(context.filters(), Command::new(get_bin())
+        .arg("pip")
+        .arg("tree")
+        .arg("--cache-dir")
+        .arg(context.cache_dir.path())
+        .arg("--prune")
+        .arg("numpy")
+        .arg("--prune")
+        .arg("joblib")
+        .env("VIRTUAL_ENV", context.venv.as_os_str())
+        .env("UV_NO_WRAP", "1")
+        .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    scikit-learn v1.4.1.post1
+    ├── scipy v1.12.0
+    └── threadpoolctl v3.4.0
+
+    ----- stderr -----
+
+    "###
+    );
+
+    uv_snapshot!(context.filters(), Command::new(get_bin())
+        .arg("pip")
+        .arg("tree")
+        .arg("--cache-dir")
+        .arg(context.cache_dir.path())
+        .arg("--prune")
+        .arg("scipy")
+        .env("VIRTUAL_ENV", context.venv.as_os_str())
+        .env("UV_NO_WRAP", "1")
+        .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    scikit-learn v1.4.1.post1
+    ├── numpy v1.26.4
+    ├── joblib v1.3.2
+    └── threadpoolctl v3.4.0
+
+    ----- stderr -----
+
+    "###
+    );
+}
+
+#[test]
 #[cfg(target_os = "macos")]
 fn nested_dependencies_more_complex() {
     let context = TestContext::new("3.12");
@@ -360,6 +460,113 @@ fn nested_dependencies_more_complex() {
             │   └── mdurl v0.1.2
             └── pygments v2.17.2 (*)
     (*) Package tree already displayed
+
+    ----- stderr -----
+    "###
+    );
+}
+
+#[test]
+#[cfg(target_os = "macos")]
+fn prune_big_tree() {
+    let context = TestContext::new("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("packse").unwrap();
+
+    uv_snapshot!(install_command(&context)
+        .arg("-r")
+        .arg("requirements.txt")
+        .arg("--strict"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 32 packages in [TIME]
+    Prepared 32 packages in [TIME]
+    Installed 32 packages in [TIME]
+     + certifi==2024.2.2
+     + charset-normalizer==3.3.2
+     + chevron-blue==0.2.1
+     + docutils==0.20.1
+     + hatchling==1.22.4
+     + idna==3.6
+     + importlib-metadata==7.1.0
+     + jaraco-classes==3.3.1
+     + jaraco-context==4.3.0
+     + jaraco-functools==4.0.0
+     + keyring==25.0.0
+     + markdown-it-py==3.0.0
+     + mdurl==0.1.2
+     + more-itertools==10.2.0
+     + msgspec==0.18.6
+     + nh3==0.2.15
+     + packaging==24.0
+     + packse==0.3.12
+     + pathspec==0.12.1
+     + pkginfo==1.10.0
+     + pluggy==1.4.0
+     + pygments==2.17.2
+     + readme-renderer==43.0
+     + requests==2.31.0
+     + requests-toolbelt==1.0.0
+     + rfc3986==2.0.0
+     + rich==13.7.1
+     + setuptools==69.2.0
+     + trove-classifiers==2024.3.3
+     + twine==4.0.2
+     + urllib3==2.2.1
+     + zipp==3.18.1
+    "###
+    );
+
+    uv_snapshot!(context.filters(), Command::new(get_bin())
+        .arg("pip")
+        .arg("tree")
+        .arg("--cache-dir")
+        .arg(context.cache_dir.path())
+        .arg("--prune")
+        .arg("hatchling")
+        .env("VIRTUAL_ENV", context.venv.as_os_str())
+        .env("UV_NO_WRAP", "1")
+        .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    packse v0.3.12
+    ├── chevron-blue v0.2.1
+    ├── msgspec v0.18.6
+    ├── setuptools v69.2.0
+    └── twine v4.0.2
+        ├── pkginfo v1.10.0
+        ├── readme-renderer v43.0
+        │   ├── nh3 v0.2.15
+        │   ├── docutils v0.20.1
+        │   └── pygments v2.17.2
+        ├── requests v2.31.0
+        │   ├── charset-normalizer v3.3.2
+        │   ├── idna v3.6
+        │   ├── urllib3 v2.2.1
+        │   └── certifi v2024.2.2
+        ├── requests-toolbelt v1.0.0
+        │   └── requests v2.31.0 (*)
+        ├── urllib3 v2.2.1 (*)
+        ├── importlib-metadata v7.1.0
+        │   └── zipp v3.18.1
+        ├── keyring v25.0.0
+        │   ├── jaraco-classes v3.3.1
+        │   │   └── more-itertools v10.2.0
+        │   ├── jaraco-functools v4.0.0
+        │   │   └── more-itertools v10.2.0 (*)
+        │   └── jaraco-context v4.3.0
+        ├── rfc3986 v2.0.0
+        └── rich v13.7.1
+            ├── markdown-it-py v3.0.0
+            │   └── mdurl v0.1.2
+            └── pygments v2.17.2 (*)
+    Note: (*) indicates the package has been `de-duplicated`.
+    The dependencies for the package have already been shown elsewhere in the graph, and so are not repeated.
 
     ----- stderr -----
     "###

--- a/crates/uv/tests/pip_tree.rs
+++ b/crates/uv/tests/pip_tree.rs
@@ -158,6 +158,106 @@ fn nested_dependencies() {
 }
 
 #[test]
+fn depth() {
+    let context = TestContext::new("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt
+        .write_str("scikit-learn==1.4.1.post1")
+        .unwrap();
+
+    uv_snapshot!(install_command(&context)
+        .arg("-r")
+        .arg("requirements.txt")
+        .arg("--strict"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
+    Installed 5 packages in [TIME]
+     + joblib==1.3.2
+     + numpy==1.26.4
+     + scikit-learn==1.4.1.post1
+     + scipy==1.12.0
+     + threadpoolctl==3.4.0
+    "###
+    );
+
+    uv_snapshot!(context.filters(), Command::new(get_bin())
+        .arg("pip")
+        .arg("tree")
+        .arg("--cache-dir")
+        .arg(context.cache_dir.path())
+        .arg("--depth")
+        .arg("0")
+        .env("VIRTUAL_ENV", context.venv.as_os_str())
+        .env("UV_NO_WRAP", "1")
+        .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    scikit-learn v1.4.1.post1
+
+    ----- stderr -----
+
+    "###
+    );
+
+    uv_snapshot!(context.filters(), Command::new(get_bin())
+        .arg("pip")
+        .arg("tree")
+        .arg("--cache-dir")
+        .arg(context.cache_dir.path())
+        .arg("--depth")
+        .arg("1")
+        .env("VIRTUAL_ENV", context.venv.as_os_str())
+        .env("UV_NO_WRAP", "1")
+        .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    scikit-learn v1.4.1.post1
+    ├── numpy v1.26.4
+    ├── scipy v1.12.0
+    ├── joblib v1.3.2
+    └── threadpoolctl v3.4.0
+
+    ----- stderr -----
+
+    "###
+    );
+
+    uv_snapshot!(context.filters(), Command::new(get_bin())
+        .arg("pip")
+        .arg("tree")
+        .arg("--cache-dir")
+        .arg(context.cache_dir.path())
+        .arg("--depth")
+        .arg("2")
+        .env("VIRTUAL_ENV", context.venv.as_os_str())
+        .env("UV_NO_WRAP", "1")
+        .current_dir(&context.temp_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    scikit-learn v1.4.1.post1
+    ├── numpy v1.26.4
+    ├── scipy v1.12.0
+    │   └── numpy v1.26.4 (*)
+    ├── joblib v1.3.2
+    └── threadpoolctl v3.4.0
+    (*) Package tree already displayed
+
+    ----- stderr -----
+
+    "###
+    );
+}
+
+#[test]
 #[cfg(target_os = "macos")]
 fn nested_dependencies_more_complex() {
     let context = TestContext::new("3.12");


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Resolves https://github.com/astral-sh/uv/issues/4439 partially.

Implements for `uv pip tree`:
- `--depth` flag, similar to `cargo tree --depth` .
- `--prune` flag, similar to `cargo tree --prune` .

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
The existing tests pass, added a test for:
- `--depth` varying the value of the `--depth` from `0` to `2`.
- `--prune` pruning a bunch of different packages in small / large nested dependency trees.
<!-- How was it tested? -->
