### PR TITLE
Fix construction of Python path in test context

### DIFF
--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -511,7 +511,10 @@ fn windows_shims() -> Result<()> {
     fs_err::create_dir(&shim_path)?;
     fs_err::write(
         shim_path.child("python.bat"),
-        format!("@echo off\r\n{}/python.exe %*", py38.1.display()),
+        format!(
+            "@echo off\r\n{}/python.exe %*",
+            py38.1.parent().unwrap().display()
+        ),
     )?;
 
     // Create a virtual environment at `.venv` with the shim


### PR DESCRIPTION
When executables were not named `python3` e.g. `python3.11` we would construct a Python path that would only work for _some_ requests in tests since we don't search for those names unless a specific version is requested. To solve, we construct a test context with constant Python executable names. For example, if a test context was created with `3.11` and `3.12` we could end up with the search path `/usr/local/python-3.11/bin:/usr/local/python-3.12/bin` where the executables are named `python3.11` and `python3` respectively. A test invocation of uv requesting any Python toolchain version would then locate the `3.12` executable since the `3.11` executable doesn't have the generic name, but we want `3.11` to come first.

On Windows, we just leave things as-is because executables are always called `python.exe`.

Closes https://github.com/astral-sh/uv/issues/4376