### PR TITLE
uv lock to use overrides from tool.uv (#4108)

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use pypi_types::Requirement;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_dispatch::BuildDispatch;
 use uv_distribution::pyproject::{Source, SourceError};
@@ -25,6 +26,7 @@ use crate::settings::ResolverInstallerSettings;
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) async fn add(
     requirements: Vec<RequirementsSource>,
+    overrides: Vec<Requirement>,
     workspace: bool,
     dev: bool,
     editable: Option<bool>,
@@ -194,6 +196,7 @@ pub(crate) async fn add(
         settings.prerelease,
         &settings.config_setting,
         settings.exclude_newer,
+        overrides,
         settings.link_mode,
         &settings.build_options,
         preview,

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -4,6 +4,7 @@ use anstream::eprint;
 
 use distribution_types::{IndexLocations, UnresolvedRequirementSpecification};
 use install_wheel_rs::linker::LinkMode;
+use pypi_types::Requirement;
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
@@ -32,6 +33,7 @@ use crate::settings::ResolverSettings;
 pub(crate) async fn lock(
     python: Option<String>,
     settings: ResolverSettings,
+    overrides: Vec<Requirement>,
     preview: PreviewMode,
     toolchain_preference: ToolchainPreference,
     connectivity: Connectivity,
@@ -71,6 +73,7 @@ pub(crate) async fn lock(
         settings.prerelease,
         &settings.config_setting,
         settings.exclude_newer,
+        overrides,
         settings.link_mode,
         &settings.build_options,
         preview,
@@ -108,6 +111,7 @@ pub(super) async fn do_lock(
     prerelease: PreReleaseMode,
     config_setting: &ConfigSettings,
     exclude_newer: Option<ExcludeNewer>,
+    overrides: Vec<Requirement>,
     link_mode: LinkMode,
     build_options: &BuildOptions,
     preview: PreviewMode,
@@ -124,7 +128,10 @@ pub(super) async fn do_lock(
         .map(UnresolvedRequirementSpecification::from)
         .collect();
     let constraints = vec![];
-    let overrides = vec![];
+    let overrides = overrides
+        .into_iter()
+        .map(UnresolvedRequirementSpecification::from)
+        .collect();
     let dev = vec![DEV_DEPENDENCIES.clone()];
 
     let source_trees = vec![];

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
 use pep508_rs::PackageName;
+use pypi_types::Requirement;
 use uv_cache::Cache;
 use uv_client::Connectivity;
 use uv_configuration::{Concurrency, ExtrasSpecification, PreviewMode};
@@ -18,6 +19,7 @@ use crate::settings::{InstallerSettings, ResolverSettings};
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn remove(
     requirements: Vec<PackageName>,
+    overrides: Vec<Requirement>,
     dev: bool,
     python: Option<String>,
     toolchain_preference: ToolchainPreference,
@@ -109,6 +111,7 @@ pub(crate) async fn remove(
         settings.prerelease,
         &settings.config_setting,
         settings.exclude_newer,
+        overrides,
         settings.link_mode,
         &settings.build_options,
         preview,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use itertools::Itertools;
+use pypi_types::Requirement;
 use tokio::process::Command;
 use tracing::debug;
 
@@ -30,6 +31,7 @@ pub(crate) async fn run(
     dev: bool,
     command: ExternalCommand,
     requirements: Vec<RequirementsSource>,
+    overrides: Vec<Requirement>,
     python: Option<String>,
     package: Option<PackageName>,
     settings: ResolverInstallerSettings,
@@ -86,6 +88,7 @@ pub(crate) async fn run(
             settings.prerelease,
             &settings.config_setting,
             settings.exclude_newer,
+            overrides,
             settings.link_mode,
             &settings.build_options,
             preview,

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -647,6 +647,7 @@ async fn run() -> Result<ExitStatus> {
                 args.dev,
                 args.command,
                 requirements,
+                args.overrides_from_workspace,
                 args.python,
                 args.package,
                 args.settings,
@@ -696,6 +697,7 @@ async fn run() -> Result<ExitStatus> {
             commands::lock(
                 args.python,
                 args.settings,
+                args.overrides_from_workspace,
                 globals.preview,
                 globals.toolchain_preference,
                 globals.connectivity,
@@ -716,6 +718,7 @@ async fn run() -> Result<ExitStatus> {
 
             commands::add(
                 args.requirements,
+                args.overrides_from_workspace,
                 args.workspace,
                 args.dev,
                 args.editable,
@@ -745,6 +748,7 @@ async fn run() -> Result<ExitStatus> {
 
             commands::remove(
                 args.requirements,
+                args.overrides_from_workspace,
                 args.dev,
                 args.python,
                 globals.toolchain_preference,


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This will make `uv lock` read `override-dependencies` from  the `[tool.uv]` section of `pyproject.toml`.
Resolves #4108

Alternative to https://github.com/astral-sh/uv/pull/4369, an implementation more consistent with `pip compile` and `pip install`. 

## Test Plan

Unit test