### PR TITLE
Add context to unregistered task name to error context

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -36,8 +36,8 @@ pub enum ResolveError {
     #[error(transparent)]
     Join(#[from] tokio::task::JoinError),
 
-    #[error("Attempted to wait on an unregistered task")]
-    Unregistered,
+    #[error("Attempted to wait on an unregistered task: `{_0}`")]
+    UnregisteredTask(String),
 
     #[error("Package metadata name `{metadata}` does not match given name `{given}`")]
     NameMismatch {

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -74,7 +74,7 @@ impl BatchPrefetcher {
         let versions_response = index
             .packages()
             .wait_blocking(name)
-            .ok_or(ResolveError::Unregistered)?;
+            .ok_or_else(|| ResolveError::UnregisteredTask(name.to_string()))?;
 
         let VersionsResponse::Found(ref version_map) = *versions_response else {
             return Ok(());


### PR DESCRIPTION
I caused this error during development and having the name of the task on it is helpful for debugging.

Split out from #4435