### PR TITLE
Bump version to 0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.2.15
+
+### Enhancements
+
+- Add `--emit-build-options` flag to `uv pip compile` interface ([#4463](https://github.com/astral-sh/uv/pull/4463))
+- Add `pythonw` support for gui scripts on Windows ([#4409](https://github.com/astral-sh/uv/pull/4409))
+- Add `uv pip tree` ([#3859](https://github.com/astral-sh/uv/pull/3859))
+
+### CLI
+
+- Adjust the docs for the pip CLI commands ([#4445](https://github.com/astral-sh/uv/pull/4445))
+- Fix casing of `--no-compile` alias ([#4453](https://github.com/astral-sh/uv/pull/4453))
+
+### Bug fixes
+
+- Fix ordering of prefer-system toolchain preference ([#4441](https://github.com/astral-sh/uv/pull/4441))
+- Respect index strategy in source distribution builds ([#4468](https://github.com/astral-sh/uv/pull/4468))
+
+### Documentation
+
+- Add documentation for using uv in a Docker image ([#4433](https://github.com/astral-sh/uv/pull/4433))
+
 ## 0.2.14
 
 ### Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,7 +4427,7 @@ checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "uv"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anstream",
  "anyhow",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "uv-version"
-version = "0.2.14"
+version = "0.2.15"
 
 [[package]]
 name = "uv-virtualenv"

--- a/PREVIEW-CHANGELOG.md
+++ b/PREVIEW-CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.15
+
+<!-- No changes -->
+
 ## 0.2.14
 
 ### Preview features
@@ -136,6 +140,7 @@
 
 <!-- No changes -->
 
+
 ## 0.2.3
 
 ### Preview features
@@ -145,6 +150,7 @@
 ## 0.2.2
 
 <!-- No changes -->
+
 
 ## 0.2.1
 
@@ -182,6 +188,7 @@
 
 <!-- No changes -->
 
+
 ## 0.1.43
 
 ### Preview features
@@ -202,6 +209,7 @@
 ## 0.1.41
 
 <!-- No changes -->
+
 
 ## 0.1.40
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 
 # For a specific version.
-curl -LsSf https://astral.sh/uv/0.2.14/install.sh | sh
-powershell -c "irm https://astral.sh/uv/0.2.14/install.ps1 | iex"
+curl -LsSf https://astral.sh/uv/0.2.15/install.sh | sh
+powershell -c "irm https://astral.sh/uv/0.2.15/install.ps1 | iex"
 
 # With pip.
 pip install uv

--- a/crates/uv-version/Cargo.toml
+++ b/crates/uv-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-version"
-version = "0.2.14"
+version = "0.2.15"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv"
-version = "0.2.14"
+version = "0.2.15"
 edition = { workspace = true }
 rust-version = { workspace = true }
 homepage = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "uv"
-version = "0.2.14"
+version = "0.2.15"
 description = "An extremely fast Python package installer and resolver, written in Rust."
 authors = [{ name = "Astral Software Inc.", email = "hey@astral.sh" }]
 requires-python = ">=3.8"
@@ -66,6 +66,5 @@ changelog_contributors = false
 version_files = [
   "README.md",
   "crates/uv/Cargo.toml",
-  "crates/uv-cli/Cargo.toml",
   "crates/uv-version/Cargo.toml",
 ]


### PR DESCRIPTION
Releasing 0.2.15 with a few additions over 0.2.14. Motivated by the incorrect tagging of 0.2.14 (#4474).

Generated the changelog with a small patch to Rooster allowing me to force the previous commit to be correct.

```diff
diff --git a/src/rooster/_cli.py b/src/rooster/_cli.py
index 2a4f61b..4ec1299 100644
--- a/src/rooster/_cli.py
+++ b/src/rooster/_cli.py
@@ -38,6 +38,7 @@ def release(
     without_sections: list[str] = typer.Option(
         [], help="Sections to exclude from the changelog"
     ),
+    previous_commit: str = None,
 ):
     """
     Create a new release.
@@ -58,7 +59,11 @@ def release(
         typer.echo("It looks like there are no version tags for this project.")
 
     # Get the commits since the last release
-    changes = list(get_commits_between(config, repo, last_version))
+    changes = list(
+        get_commits_between(
+            config, repo, last_version, force_first_commit=previous_commit
+        )
+    )
     since = "since last release" if last_version else "in the project"
     typer.echo(f"Found {len(changes)} commits {since}.")
 
diff --git a/src/rooster/_git.py b/src/rooster/_git.py
index 597bb88..66bc54e 100644
--- a/src/rooster/_git.py
+++ b/src/rooster/_git.py
@@ -29,12 +29,13 @@ def get_commits_between(
     target: Path,
     first_version: Version | None = None,
     second_version: Version | None = None,
+    force_first_commit: str | None = None,
 ) -> Generator[git.Commit, None, None]:
     """
     Yield all commits between two tags
     """
     repo = git.repository.Repository(target.absolute())
-    first_commit = (
+    first_commit = force_first_commit or (
         repo.lookup_reference(
             TAG_PREFIX + config.version_tag_prefix + str(first_version)
         )
```