### PR TITLE
Replace `PubGrubDependencies` by `PubGrubDependency`

### DIFF
--- a/crates/uv-resolver/src/pubgrub/mod.rs
+++ b/crates/uv-resolver/src/pubgrub/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) use crate::pubgrub::dependencies::PubGrubDependencies;
+pub(crate) use crate::pubgrub::dependencies::PubGrubDependency;
 pub(crate) use crate::pubgrub::distribution::PubGrubDistribution;
 pub(crate) use crate::pubgrub::package::{PubGrubPackage, PubGrubPackageInner, PubGrubPython};
 pub(crate) use crate::pubgrub::priority::{PubGrubPriorities, PubGrubPriority};


### PR DESCRIPTION
In the last PR (#4430), we flatten the requirements. In the next PR (#4435), we want to pass `Url` around next to `PubGrubPackage` and `Range<Version>` to keep track of which `Requirement`s added a url across forking. This PR is a refactoring split out from #4435 that rolls the dependency conversion into a single iterator and introduces a new `PubGrubDependency` struct as abstraction over `(PubGrubPackage, Range<Version>)` (or `(PubGrubPackage, Range<Version>, VerbatimParsedUrl)` in the next PR), and it removes the now unnecessary `PubGrubDependencies` abstraction.
