### PR TITLE
Skip submodule update for fresh clones

### DIFF
--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -278,7 +278,6 @@ impl GitDatabase {
             Some(co) => co,
             None => GitCheckout::clone_into(destination, self, rev)?,
         };
-        checkout.update_submodules()?;
         Ok(checkout)
     }
 
@@ -414,12 +413,7 @@ impl GitCheckout {
             .cwd(&self.repo.path)
             .exec_with_output()?;
 
-        paths::create(ok_file)?;
-        Ok(())
-    }
-
-    /// Runs `git submodule update --recursive` on this git checkout.
-    fn update_submodules(&self) -> Result<()> {
+        // Update submodules (`git submodule update --recursive`).
         ProcessBuilder::new("git")
             .arg("submodule")
             .arg("update")
@@ -427,7 +421,10 @@ impl GitCheckout {
             .arg("--init")
             .cwd(&self.repo.path)
             .exec_with_output()
-            .map(drop)
+            .map(drop)?;
+
+        paths::create(ok_file)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

We unconditionally update the submodules in our Git code, but AFAICT it shouldn't be necessary if we already have a complete, up-to-date fetch available.