### PR TITLE
Add unowned settings variants

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -186,7 +186,7 @@ pub(crate) async fn add(
     let lock = project::lock::do_lock(
         project.workspace(),
         venv.interpreter(),
-        settings.clone().into(),
+        settings.as_ref().into(),
         preview,
         connectivity,
         concurrency,
@@ -209,7 +209,7 @@ pub(crate) async fn add(
         extras,
         dev,
         Modifications::Sufficient,
-        settings.into(),
+        settings.as_ref().into(),
         preview,
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -101,7 +101,7 @@ pub(crate) async fn remove(
     let lock = project::lock::do_lock(
         project.workspace(),
         venv.interpreter(),
-        settings,
+        settings.as_ref(),
         preview,
         connectivity,
         concurrency,
@@ -125,7 +125,7 @@ pub(crate) async fn remove(
         extras,
         dev,
         Modifications::Exact,
-        settings,
+        settings.as_ref(),
         preview,
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -78,7 +78,7 @@ pub(crate) async fn run(
         let lock = project::lock::do_lock(
             project.workspace(),
             venv.interpreter(),
-            settings.clone().into(),
+            settings.as_ref().into(),
             preview,
             connectivity,
             concurrency,
@@ -95,7 +95,7 @@ pub(crate) async fn run(
             extras,
             dev,
             Modifications::Sufficient,
-            settings.clone().into(),
+            settings.as_ref().into(),
             preview,
             connectivity,
             concurrency,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -19,7 +19,7 @@ use crate::commands::pip::operations::Modifications;
 use crate::commands::project::ProjectError;
 use crate::commands::{pip, project, ExitStatus};
 use crate::printer::Printer;
-use crate::settings::InstallerSettings;
+use crate::settings::{InstallerSettings, InstallerSettingsRef};
 
 /// Sync the project environment.
 #[allow(clippy::too_many_arguments)]
@@ -72,7 +72,7 @@ pub(crate) async fn sync(
         extras,
         dev,
         modifications,
-        settings,
+        settings.as_ref(),
         preview,
         connectivity,
         concurrency,
@@ -95,7 +95,7 @@ pub(super) async fn do_sync(
     extras: ExtrasSpecification,
     dev: bool,
     modifications: Modifications,
-    settings: InstallerSettings,
+    settings: InstallerSettingsRef<'_>,
     preview: PreviewMode,
     connectivity: Connectivity,
     concurrency: Concurrency,
@@ -104,7 +104,7 @@ pub(super) async fn do_sync(
     printer: Printer,
 ) -> Result<(), ProjectError> {
     // Extract the project settings.
-    let InstallerSettings {
+    let InstallerSettingsRef {
         index_locations,
         index_strategy,
         keyring_provider,
@@ -167,7 +167,7 @@ pub(super) async fn do_sync(
     let flat_index = {
         let client = FlatIndexClient::new(&client, cache);
         let entries = client.fetch(index_locations.flat_index()).await?;
-        FlatIndex::from_entries(entries, Some(tags), &hasher, &build_options)
+        FlatIndex::from_entries(entries, Some(tags), &hasher, build_options)
     };
 
     // Create a build dispatch.
@@ -175,17 +175,17 @@ pub(super) async fn do_sync(
         &client,
         cache,
         venv.interpreter(),
-        &index_locations,
+        index_locations,
         &flat_index,
         &index,
         &git,
         &in_flight,
         index_strategy,
         setup_py,
-        &config_setting,
+        config_setting,
         build_isolation,
         link_mode,
-        &build_options,
+        build_options,
         exclude_newer,
         concurrency,
         preview,
@@ -198,11 +198,11 @@ pub(super) async fn do_sync(
         &resolution,
         site_packages,
         modifications,
-        &reinstall,
-        &build_options,
+        reinstall,
+        build_options,
         link_mode,
         compile_bytecode,
-        &index_locations,
+        index_locations,
         &hasher,
         tags,
         &client,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1087,6 +1087,18 @@ pub(crate) struct InstallerSettings {
     pub(crate) build_options: BuildOptions,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct InstallerSettingsRef<'a> {
+    pub(crate) index_locations: &'a IndexLocations,
+    pub(crate) index_strategy: IndexStrategy,
+    pub(crate) keyring_provider: KeyringProviderType,
+    pub(crate) config_setting: &'a ConfigSettings,
+    pub(crate) link_mode: LinkMode,
+    pub(crate) compile_bytecode: bool,
+    pub(crate) reinstall: &'a Reinstall,
+    pub(crate) build_options: &'a BuildOptions,
+}
+
 impl InstallerSettings {
     /// Resolve the [`InstallerSettings`] from the CLI and filesystem configuration.
     pub(crate) fn combine(args: InstallerOptions, filesystem: Option<FilesystemOptions>) -> Self {
@@ -1164,6 +1176,19 @@ impl InstallerSettings {
             ),
         }
     }
+
+    pub(crate) fn as_ref(&self) -> InstallerSettingsRef {
+        InstallerSettingsRef {
+            index_locations: &self.index_locations,
+            index_strategy: self.index_strategy,
+            keyring_provider: self.keyring_provider,
+            config_setting: &self.config_setting,
+            link_mode: self.link_mode,
+            compile_bytecode: self.compile_bytecode,
+            reinstall: &self.reinstall,
+            build_options: &self.build_options,
+        }
+    }
 }
 
 /// The resolved settings to use for an invocation of the `uv` CLI when resolving dependencies.
@@ -1183,6 +1208,20 @@ pub(crate) struct ResolverSettings {
     pub(crate) link_mode: LinkMode,
     pub(crate) upgrade: Upgrade,
     pub(crate) build_options: BuildOptions,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResolverSettingsRef<'a> {
+    pub(crate) index_locations: &'a IndexLocations,
+    pub(crate) index_strategy: IndexStrategy,
+    pub(crate) keyring_provider: KeyringProviderType,
+    pub(crate) resolution: ResolutionMode,
+    pub(crate) prerelease: PreReleaseMode,
+    pub(crate) config_setting: &'a ConfigSettings,
+    pub(crate) exclude_newer: Option<ExcludeNewer>,
+    pub(crate) link_mode: LinkMode,
+    pub(crate) upgrade: &'a Upgrade,
+    pub(crate) build_options: &'a BuildOptions,
 }
 
 impl ResolverSettings {
@@ -1261,6 +1300,21 @@ impl ResolverSettings {
             ),
         }
     }
+
+    pub(crate) fn as_ref(&self) -> ResolverSettingsRef {
+        ResolverSettingsRef {
+            index_locations: &self.index_locations,
+            index_strategy: self.index_strategy,
+            keyring_provider: self.keyring_provider,
+            resolution: self.resolution,
+            prerelease: self.prerelease,
+            config_setting: &self.config_setting,
+            exclude_newer: self.exclude_newer,
+            link_mode: self.link_mode,
+            upgrade: &self.upgrade,
+            build_options: &self.build_options,
+        }
+    }
 }
 
 /// The resolved settings to use for an invocation of the `uv` CLI with both resolver and installer
@@ -1283,6 +1337,22 @@ pub(crate) struct ResolverInstallerSettings {
     pub(crate) upgrade: Upgrade,
     pub(crate) reinstall: Reinstall,
     pub(crate) build_options: BuildOptions,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResolverInstallerSettingsRef<'a> {
+    pub(crate) index_locations: &'a IndexLocations,
+    pub(crate) index_strategy: IndexStrategy,
+    pub(crate) keyring_provider: KeyringProviderType,
+    pub(crate) resolution: ResolutionMode,
+    pub(crate) prerelease: PreReleaseMode,
+    pub(crate) config_setting: &'a ConfigSettings,
+    pub(crate) exclude_newer: Option<ExcludeNewer>,
+    pub(crate) link_mode: LinkMode,
+    pub(crate) compile_bytecode: bool,
+    pub(crate) upgrade: &'a Upgrade,
+    pub(crate) reinstall: &'a Reinstall,
+    pub(crate) build_options: &'a BuildOptions,
 }
 
 impl ResolverInstallerSettings {
@@ -1372,6 +1442,23 @@ impl ResolverInstallerSettings {
                         .unwrap_or_default(),
                 ),
             ),
+        }
+    }
+
+    pub(crate) fn as_ref(&self) -> ResolverInstallerSettingsRef {
+        ResolverInstallerSettingsRef {
+            index_locations: &self.index_locations,
+            index_strategy: self.index_strategy,
+            keyring_provider: self.keyring_provider,
+            resolution: self.resolution,
+            prerelease: self.prerelease,
+            config_setting: &self.config_setting,
+            exclude_newer: self.exclude_newer,
+            link_mode: self.link_mode,
+            compile_bytecode: self.compile_bytecode,
+            upgrade: &self.upgrade,
+            reinstall: &self.reinstall,
+            build_options: &self.build_options,
         }
     }
 }
@@ -1681,8 +1768,8 @@ impl PipSettings {
     }
 }
 
-impl From<ResolverInstallerSettings> for ResolverSettings {
-    fn from(settings: ResolverInstallerSettings) -> Self {
+impl<'a> From<ResolverInstallerSettingsRef<'a>> for ResolverSettingsRef<'a> {
+    fn from(settings: ResolverInstallerSettingsRef<'a>) -> Self {
         Self {
             index_locations: settings.index_locations,
             index_strategy: settings.index_strategy,
@@ -1698,8 +1785,8 @@ impl From<ResolverInstallerSettings> for ResolverSettings {
     }
 }
 
-impl From<ResolverInstallerSettings> for InstallerSettings {
-    fn from(settings: ResolverInstallerSettings) -> Self {
+impl<'a> From<ResolverInstallerSettingsRef<'a>> for InstallerSettingsRef<'a> {
+    fn from(settings: ResolverInstallerSettingsRef<'a>) -> Self {
         Self {
             index_locations: settings.index_locations,
             index_strategy: settings.index_strategy,


### PR DESCRIPTION
## Summary

This PR adds unowned settings variants so that we can convert from `ResolverInstallerSettings` to `ResolverSettings` without allocating.
