### PR TITLE
Allow workspace members from sibling directories

### DIFF
--- a/scripts/workspaces/shared-lib/app1/app1/app.py
+++ b/scripts/workspaces/shared-lib/app1/app1/app.py
@@ -1,0 +1,9 @@
+from shared_lib import hello_shared
+import numpy as np
+
+def main():
+    hello_shared()
+    print(f"numpy {np.__version__}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/workspaces/shared-lib/app1/pyproject.toml
+++ b/scripts/workspaces/shared-lib/app1/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "app1"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies=[
+    "shared_lib",
+    "numpy == 2.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["app1"]
+
+[tool.uv.workspace]
+members = ["../shared_*"]
+
+[tool.uv.sources]
+shared_lib = { workspace = true }

--- a/scripts/workspaces/shared-lib/app2/app2/app.py
+++ b/scripts/workspaces/shared-lib/app2/app2/app.py
@@ -1,0 +1,9 @@
+from shared_lib import hello_shared
+import numpy as np
+
+def main():
+    hello_shared()
+    print(f"numpy {np.__version__}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/workspaces/shared-lib/app2/pyproject.toml
+++ b/scripts/workspaces/shared-lib/app2/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "app2"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies=[
+    "shared_lib",
+    "numpy == 1.26.4",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["app1"]
+
+[tool.uv.workspace]
+members = ["../shared_*"]
+
+[tool.uv.sources]
+shared_lib = { workspace = true }

--- a/scripts/workspaces/shared-lib/pyproject.toml
+++ b/scripts/workspaces/shared-lib/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.uv.workspace]
+members = ["shared_*"]
+exclude = ["app*"]

--- a/scripts/workspaces/shared-lib/shared_corelib/pyproject.toml
+++ b/scripts/workspaces/shared-lib/shared_corelib/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "shared_corelib"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies = ["tqdm == 4.66.2"]
+
+[build-system]
+requires = ["hatchling==1.24.2"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["shared_corelib"]
+

--- a/scripts/workspaces/shared-lib/shared_corelib/shared_corelib/__init__.py
+++ b/scripts/workspaces/shared-lib/shared_corelib/shared_corelib/__init__.py
@@ -1,0 +1,5 @@
+import tqdm
+
+def hello_shared_core():
+    print(f"shared-corelib is loaded from {__file__}")
+    print(f"tqdm {tqdm.__version__}")

--- a/scripts/workspaces/shared-lib/shared_lib/pyproject.toml
+++ b/scripts/workspaces/shared-lib/shared_lib/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "shared_lib"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies=[
+    "six == 1.16.0",
+    "shared_corelib",
+]
+
+[build-system]
+requires = ["hatchling==1.24.2"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["shared_lib"]
+
+[tool.uv.sources]
+shared_corelib = { workspace = true }

--- a/scripts/workspaces/shared-lib/shared_lib/shared_lib/__init__.py
+++ b/scripts/workspaces/shared-lib/shared_lib/shared_lib/__init__.py
@@ -1,0 +1,7 @@
+import six
+from shared_corelib import hello_shared_core
+
+def hello_shared():
+    print(f"shared-lib is loaded from {__file__}")
+    print(f"six {six.__version__}")
+    hello_shared_core()


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary
Shared libraries for independent projects. 

Let's say I have the following layout:
```
src_root
├── app1
├── app2
├── shared_lib
└── shared_corelib
```

`app1` and `app2` never have to coexist in the same virtualenv, their dependencies are independent
and allowed to conflict with each other. `shared_lib` and `shared_corelib`, being libraries, have to play nice with both of them.

I want to use worskpaces to define the following direct dependencies:
 - `app1->shared_lib`
 - `app2->shared_lib`
 -  `shared_lib->shared_corelib`

But if I simply create a workspace in `src_root` it'll try to create a shared lock and shared virtualenv for all four projects.
And if I create a workspace in either `app1` or `app2`, they won't let me include `shared_lib` because it's in a sibling directory, and workspaces require a single root.

At my previous job I've implemented a build, that assumed this kind of scenario, and the workspace part was only responsible for locating members, and storing shared settings like default dependency versions, constraints, etc. This has the downside of having many virtualenvs so may not be for everyone, but I think it's a valid case.

I don't know if there are any future plans to support this in `uv`, perhaps by introducing the notion of a "leaf" member?

In the meantime, the scenario could be supported if workspaces were allowed to include sibling directories.
This is what this PR does.

## Test Plan

<!-- How was it tested? -->
Unit test