### PR TITLE
More precise locking with --prefix option

### DIFF
--- a/crates/uv-toolchain/src/environment.rs
+++ b/crates/uv-toolchain/src/environment.rs
@@ -160,6 +160,9 @@ impl PythonEnvironment {
         if let Some(target) = self.0.interpreter.target() {
             // If we're installing into a `--target`, use a target-specific lock file.
             LockedFile::acquire(target.root().join(".lock"), target.root().user_display())
+        } else if let Some(prefix) = self.0.interpreter.prefix() {
+            // Likewise, if we're installing into a `--prefix`, use a prefix-specific lock file.
+            LockedFile::acquire(prefix.root().join(".lock"), prefix.root().user_display())
         } else if self.0.interpreter.is_virtualenv() {
             // If the environment a virtualenv, use a virtualenv-specific lock file.
             LockedFile::acquire(self.0.root.join(".lock"), self.0.root.user_display())


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

In #4085, support was implemented for the `--prefix` option. When using this option, however, a lock is either acquired on the virtualenv or globally, preventing multiple installs to different `--prefix`s from the same interpreter.

In this change, acquire the lock on just the prefix in question.

## Test Plan

Ran a `uv pip install` with `--prefix` and `RUST_LOG=trace` and observed that the lock was acquired in the prefix.
