### PR TITLE
Copy tool entrypoints on Windows instead of using a symbolic link

### DIFF
--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -829,6 +829,7 @@ pub fn python_toolchains_for_versions(
 
 #[derive(Debug, Copy, Clone)]
 pub enum WindowsFilters {
+    CachedPlatform,
     Platform,
     Universal,
 }
@@ -908,6 +909,10 @@ pub fn run_and_format<T: AsRef<str>>(
                     for verb in match windows_filters {
                         WindowsFilters::Platform => {
                             ["Resolved", "Prepared", "Installed", "Uninstalled"].iter()
+                        }
+                        // When cached, "Prepared" should not change.
+                        WindowsFilters::CachedPlatform => {
+                            ["Resolved", "Installed", "Uninstalled"].iter()
                         }
                         WindowsFilters::Universal => {
                             ["Prepared", "Installed", "Uninstalled"].iter()
@@ -999,6 +1004,12 @@ macro_rules! uv_snapshot {
     ($filters:expr, universal_windows_filters=true, $spawnable:expr, @$snapshot:literal) => {{
         // Take a reference for backwards compatibility with the vec-expecting insta filters.
         let (snapshot, output) = $crate::common::run_and_format($spawnable, &$filters, function_name!(), Some($crate::common::WindowsFilters::Universal));
+        ::insta::assert_snapshot!(snapshot, @$snapshot);
+        output
+    }};
+    ($filters:expr, cached_windows_filters=true, $spawnable:expr, @$snapshot:literal) => {{
+        // Take a reference for backwards compatibility with the vec-expecting insta filters.
+        let (snapshot, output) = $crate::common::run_and_format($spawnable, &$filters, function_name!(), Some($crate::common::WindowsFilters::CachedPlatform));
         ::insta::assert_snapshot!(snapshot, @$snapshot);
         output
     }};


### PR DESCRIPTION
This matches [pipx's behavior](https://github.com/pypa/pipx/blob/4d8c05884317f7b646a66ffd4e933f4d1df471b7/src/pipx/commands/common.py#L69-L70). Includes test changes to get past some blockers on Windows.

Resolves failures on #4509
