### PR TITLE
Read persistent configuration from non-workspace `pyproject.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4999,6 +4999,7 @@ dependencies = [
  "uv-normalize",
  "uv-resolver",
  "uv-toolchain",
+ "uv-warnings",
 ]
 
 [[package]]

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -19,10 +19,11 @@ pep508_rs = { workspace = true }
 pypi-types = { workspace = true }
 uv-configuration = { workspace = true, features = ["schemars"] }
 uv-fs = { workspace = true }
+uv-macros = { workspace = true }
 uv-normalize = { workspace = true, features = ["schemars"] }
 uv-resolver = { workspace = true, features = ["schemars"] }
 uv-toolchain = { workspace = true, features = ["schemars"] }
-uv-macros = { workspace = true }
+uv-warnings = { workspace = true }
 
 dirs-sys = { workspace = true }
 fs-err = { workspace = true }

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -3204,6 +3204,7 @@ fn override_dependency_from_workspace_invalid_syntax() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    warning: Failed to parse `pyproject.toml` during settings discovery; skipping...
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 9, column 29
       |

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -143,6 +143,7 @@ fn invalid_pyproject_toml_syntax() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    warning: Failed to parse `pyproject.toml` during settings discovery; skipping...
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 1, column 5
       |


### PR DESCRIPTION
## Summary

If the user puts their configuration in a `pyproject.toml` that _isn't_ a valid workspace root (e.g., it's a Poetry file), we won't discover it, because we only look in `uv.toml` files in that case. I think this is somewhat debatable... We could choose to _require_ `uv.toml` there, but as a user I'd probably expect it to work?

Closes https://github.com/astral-sh/uv/issues/4521.
