### PR TITLE
Remove useless `#[allow(clippy::too_many_arguments)]`

### DIFF
--- a/crates/install-wheel-rs/src/wheel.rs
+++ b/crates/install-wheel-rs/src/wheel.rs
@@ -513,7 +513,6 @@ fn install_script(
 }
 
 /// Move the files from the .data directory to the right location in the venv
-#[allow(clippy::too_many_arguments)]
 #[instrument(skip_all)]
 pub(crate) fn install_data(
     layout: &Layout,

--- a/crates/uv-requirements/src/lookahead.rs
+++ b/crates/uv-requirements/src/lookahead.rs
@@ -61,7 +61,6 @@ pub struct LookaheadResolver<'a, Context: BuildContext> {
 
 impl<'a, Context: BuildContext> LookaheadResolver<'a, Context> {
     /// Instantiate a new [`LookaheadResolver`] for a given set of requirements.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         requirements: &'a [Requirement],
         constraints: &'a Constraints,

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -59,7 +59,6 @@ impl FlatIndex {
         Self { index, offline }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn add_file(
         distributions: &mut FlatDistributions,
         file: File,

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -420,7 +420,6 @@ impl VersionMapLazy {
         simple.dist.get_or_init(get_or_init).as_ref()
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn source_dist_compatibility(
         &self,
         version: &Version,

--- a/crates/uv/src/commands/toolchain/find.rs
+++ b/crates/uv/src/commands/toolchain/find.rs
@@ -11,7 +11,6 @@ use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Find a toolchain.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn find(
     request: Option<String>,
     toolchain_preference: ToolchainPreference,

--- a/crates/uv/src/commands/toolchain/install.rs
+++ b/crates/uv/src/commands/toolchain/install.rs
@@ -15,7 +15,6 @@ use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Download and install a Python toolchain.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn install(
     targets: Vec<String>,
     force: bool,

--- a/crates/uv/src/commands/toolchain/list.rs
+++ b/crates/uv/src/commands/toolchain/list.rs
@@ -25,7 +25,6 @@ enum Kind {
 }
 
 /// List available toolchains.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn list(
     kinds: ToolchainListKinds,
     all_versions: bool,


### PR DESCRIPTION
I went through all `#[allow(clippy::too_many_arguments)]` and removed the useless ones.