### PR TITLE
Sync all packages when syncing workspaces

### DIFF
--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -24,6 +24,7 @@ use pep508_rs::{MarkerEnvironment, MarkerTree, VerbatimUrl, VerbatimUrlError};
 use platform_tags::{TagCompatibility, TagPriority, Tags};
 use pypi_types::{HashDigest, ParsedArchiveUrl, ParsedGitUrl};
 use uv_configuration::ExtrasSpecification;
+use uv_distribution::Workspace;
 use uv_git::{GitReference, GitSha, RepositoryReference, ResolvedRepositoryReference};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 
@@ -317,35 +318,36 @@ impl Lock {
     /// Convert the [`Lock`] to a [`Resolution`] using the given marker environment, tags, and root.
     pub fn to_resolution(
         &self,
-        workspace_root: &Path,
+        workspace: &Workspace,
         marker_env: &MarkerEnvironment,
         tags: &Tags,
-        root_name: &PackageName,
         extras: &ExtrasSpecification,
         dev: &[GroupName],
     ) -> Result<Resolution, LockError> {
         let mut queue: VecDeque<(&Distribution, Option<&ExtraName>)> = VecDeque::new();
 
-        // Add the root distribution to the queue.
-        let root = self
-            .find_by_name(root_name)
-            .expect("found too many distributions matching root")
-            .expect("could not find root");
+        // Add the workspace packages to the queue.
+        for root_name in workspace.packages().keys() {
+            let root = self
+                .find_by_name(root_name)
+                .expect("found too many distributions matching root")
+                .expect("could not find root");
 
-        // Add the base package.
-        queue.push_back((root, None));
+            // Add the base package.
+            queue.push_back((root, None));
 
-        // Add any extras.
-        match extras {
-            ExtrasSpecification::None => {}
-            ExtrasSpecification::All => {
-                for extra in root.optional_dependencies.keys() {
-                    queue.push_back((root, Some(extra)));
+            // Add any extras.
+            match extras {
+                ExtrasSpecification::None => {}
+                ExtrasSpecification::All => {
+                    for extra in root.optional_dependencies.keys() {
+                        queue.push_back((root, Some(extra)));
+                    }
                 }
-            }
-            ExtrasSpecification::Some(extras) => {
-                for extra in extras {
-                    queue.push_back((root, Some(extra)));
+                ExtrasSpecification::Some(extras) => {
+                    for extra in extras {
+                        queue.push_back((root, Some(extra)));
+                    }
                 }
             }
         }
@@ -375,7 +377,7 @@ impl Lock {
                 }
             }
             let name = dist.id.name.clone();
-            let resolved_dist = ResolvedDist::Installable(dist.to_dist(workspace_root, tags)?);
+            let resolved_dist = ResolvedDist::Installable(dist.to_dist(workspace.root(), tags)?);
             map.insert(name, resolved_dist);
         }
         let diagnostics = vec![];

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -202,8 +202,7 @@ pub(crate) async fn add(
     let dev = true;
 
     project::sync::do_sync(
-        project.project_name(),
-        project.workspace().root(),
+        project.workspace(),
         &venv,
         &lock,
         extras,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -118,8 +118,7 @@ pub(crate) async fn remove(
     let dev = true;
 
     project::sync::do_sync(
-        project.project_name(),
-        project.workspace().root(),
+        project.workspace(),
         &venv,
         &lock,
         extras,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -100,8 +100,7 @@ pub(crate) async fn run(
             )
             .await?;
             project::sync::do_sync(
-                project.project_name(),
-                project.workspace().root(),
+                project.workspace(),
                 &venv,
                 &lock,
                 extras,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -1,15 +1,12 @@
-use std::path::Path;
-
 use anyhow::Result;
 
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{Concurrency, ExtrasSpecification, PreviewMode, SetupPyStrategy};
 use uv_dispatch::BuildDispatch;
-use uv_distribution::{ProjectWorkspace, DEV_DEPENDENCIES};
+use uv_distribution::{ProjectWorkspace, Workspace, DEV_DEPENDENCIES};
 use uv_git::GitResolver;
 use uv_installer::SitePackages;
-use uv_normalize::PackageName;
 use uv_resolver::{FlatIndex, InMemoryIndex, Lock};
 use uv_toolchain::{PythonEnvironment, ToolchainPreference, ToolchainRequest};
 use uv_types::{BuildIsolation, HashStrategy, InFlight};
@@ -65,8 +62,7 @@ pub(crate) async fn sync(
 
     // Perform the sync operation.
     do_sync(
-        project.project_name(),
-        project.workspace().root(),
+        project.workspace(),
         &venv,
         &lock,
         extras,
@@ -88,8 +84,7 @@ pub(crate) async fn sync(
 /// Sync a lockfile with an environment.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn do_sync(
-    project_name: &PackageName,
-    workspace_root: &Path,
+    workspace: &Workspace,
     venv: &PythonEnvironment,
     lock: &Lock,
     extras: ExtrasSpecification,
@@ -136,8 +131,7 @@ pub(super) async fn do_sync(
     let tags = venv.interpreter().tags()?;
 
     // Read the lockfile.
-    let resolution =
-        lock.to_resolution(workspace_root, markers, tags, project_name, &extras, &dev)?;
+    let resolution = lock.to_resolution(workspace, markers, tags, &extras, &dev)?;
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -824,11 +824,10 @@ fn add_remove_workspace() -> Result<()> {
     warning: `uv remove` is experimental and may change without warning.
     Resolved 2 packages in [TIME]
     Prepared 1 package in [TIME]
-    Uninstalled 2 packages in [TIME]
+    Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - child1==0.1.0 (from file://[TEMP_DIR]/child1)
      + child1==0.1.0 (from file://[TEMP_DIR]/child1)
-     - child2==0.1.0 (from file://[TEMP_DIR]/child2)
     "###);
 
     let pyproject_toml = fs_err::read_to_string(child1.join("pyproject.toml"))?;
@@ -880,7 +879,7 @@ fn add_remove_workspace() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Audited 1 package in [TIME]
+    Audited 2 packages in [TIME]
     "###);
 
     Ok(())

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -357,23 +357,25 @@ fn test_uv_run_with_package_virtual_workspace() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON]
     Creating virtualenv at: .venv
     Resolved 8 packages in [TIME]
-    Prepared 5 packages in [TIME]
-    Installed 5 packages in [TIME]
+    Prepared 7 packages in [TIME]
+    Installed 7 packages in [TIME]
+     + albatross==0.1.0 (from file://[TEMP_DIR]/albatross-virtual-workspace/packages/albatross)
      + anyio==4.3.0
      + bird-feeder==1.0.0 (from file://[TEMP_DIR]/albatross-virtual-workspace/packages/bird-feeder)
      + idna==3.6
      + seeds==1.0.0 (from file://[TEMP_DIR]/albatross-virtual-workspace/packages/seeds)
      + sniffio==1.3.1
+     + tqdm==4.66.2
     "###
     );
 
     uv_snapshot!(context.filters(), universal_windows_filters=true, context
         .run()
         .arg("--preview")
-            .arg("--package")
-            .arg("albatross")
-            .arg("packages/albatross/check_installed_albatross.py")
-            .current_dir(&work_dir), @r###"
+        .arg("--package")
+        .arg("albatross")
+        .arg("packages/albatross/check_installed_albatross.py")
+        .current_dir(&work_dir), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -381,10 +383,7 @@ fn test_uv_run_with_package_virtual_workspace() -> Result<()> {
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Prepared 2 packages in [TIME]
-    Installed 2 packages in [TIME]
-     + albatross==0.1.0 (from file://[TEMP_DIR]/albatross-virtual-workspace/packages/albatross)
-     + tqdm==4.66.2
+    Audited 7 packages in [TIME]
     "###
     );
 
@@ -421,23 +420,25 @@ fn test_uv_run_with_package_root_workspace() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON]
     Creating virtualenv at: .venv
     Resolved 8 packages in [TIME]
-    Prepared 5 packages in [TIME]
-    Installed 5 packages in [TIME]
+    Prepared 7 packages in [TIME]
+    Installed 7 packages in [TIME]
+     + albatross==0.1.0 (from file://[TEMP_DIR]/albatross-root-workspace)
      + anyio==4.3.0
      + bird-feeder==1.0.0 (from file://[TEMP_DIR]/albatross-root-workspace/packages/bird-feeder)
      + idna==3.6
      + seeds==1.0.0 (from file://[TEMP_DIR]/albatross-root-workspace/packages/seeds)
      + sniffio==1.3.1
+     + tqdm==4.66.2
     "###
     );
 
     uv_snapshot!(context.filters(), universal_windows_filters=true, context
         .run()
         .arg("--preview")
-            .arg("--package")
-            .arg("albatross")
-            .arg("check_installed_albatross.py")
-            .current_dir(&work_dir), @r###"
+        .arg("--package")
+        .arg("albatross")
+        .arg("check_installed_albatross.py")
+        .current_dir(&work_dir), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -445,10 +446,7 @@ fn test_uv_run_with_package_root_workspace() -> Result<()> {
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Prepared 2 packages in [TIME]
-    Installed 2 packages in [TIME]
-     + albatross==0.1.0 (from file://[TEMP_DIR]/albatross-root-workspace)
-     + tqdm==4.66.2
+    Audited 7 packages in [TIME]
     "###
     );
 

--- a/scripts/workspaces/albatross-in-example/examples/bird-feeder/check_installed_bird_feeder.py
+++ b/scripts/workspaces/albatross-in-example/examples/bird-feeder/check_installed_bird_feeder.py
@@ -1,10 +1,3 @@
 from bird_feeder import use
 
-try:
-    from albatross import fly
-
-    raise RuntimeError("albatross installed")
-except ModuleNotFoundError:
-    pass
-
 print("Success")

--- a/scripts/workspaces/albatross-project-in-excluded/excluded/bird-feeder/check_installed_bird_feeder.py
+++ b/scripts/workspaces/albatross-project-in-excluded/excluded/bird-feeder/check_installed_bird_feeder.py
@@ -1,10 +1,3 @@
 from bird_feeder import use
 
-try:
-    from albatross import fly
-
-    raise RuntimeError("albatross installed")
-except ModuleNotFoundError:
-    pass
-
 print("Success")

--- a/scripts/workspaces/albatross-root-workspace/packages/bird-feeder/check_installed_bird_feeder.py
+++ b/scripts/workspaces/albatross-root-workspace/packages/bird-feeder/check_installed_bird_feeder.py
@@ -1,10 +1,3 @@
 from bird_feeder import use
 
-try:
-    from albatross import fly
-
-    raise RuntimeError("albatross installed")
-except ModuleNotFoundError:
-    pass
-
 print("Success")

--- a/scripts/workspaces/albatross-virtual-workspace/packages/bird-feeder/check_installed_bird_feeder.py
+++ b/scripts/workspaces/albatross-virtual-workspace/packages/bird-feeder/check_installed_bird_feeder.py
@@ -1,10 +1,3 @@
 from bird_feeder import use
 
-try:
-    from albatross import fly
-
-    raise RuntimeError("albatross installed")
-except ModuleNotFoundError:
-    pass
-
 print("Success")


### PR DESCRIPTION
## Summary

For consistency, syncing a workspace should involve syncing all members. Perhaps we revisit this in the future -- it may be possible to skip work here when you're operating on a single package.

## Test Plan

Run `cargo run sync` from `./scripts/workspaces/albatross-root-workspace/packages/seeds`. Verify that all packages are installed, rather than just `seeds`.
