### PR TITLE
Automatically detect workspace packages in `uv add`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1749,10 +1749,6 @@ pub struct AddArgs {
     #[arg(long)]
     pub dev: bool,
 
-    /// Add the requirements as workspace dependencies.
-    #[arg(long)]
-    pub workspace: bool,
-
     /// Add the requirements as editables.
     #[arg(long, default_missing_value = "true", num_args(0..=1))]
     pub editable: Option<bool>,

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -26,7 +26,6 @@ use crate::settings::ResolverInstallerSettings;
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) async fn add(
     requirements: Vec<RequirementsSource>,
-    workspace: bool,
     dev: bool,
     editable: Option<bool>,
     raw: bool,
@@ -154,7 +153,9 @@ pub(crate) async fn add(
             (pep508_rs::Requirement::from(req), None)
         } else {
             // Otherwise, try to construct the source.
+            let workspace = project.workspace().packages().contains_key(&req.name);
             let result = Source::from_requirement(
+                &req.name,
                 req.source.clone(),
                 workspace,
                 editable,

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -719,7 +719,6 @@ async fn run() -> Result<ExitStatus> {
 
             commands::add(
                 args.requirements,
-                args.workspace,
                 args.dev,
                 args.editable,
                 args.raw,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -432,7 +432,6 @@ impl LockSettings {
 pub(crate) struct AddSettings {
     pub(crate) requirements: Vec<RequirementsSource>,
     pub(crate) dev: bool,
-    pub(crate) workspace: bool,
     pub(crate) editable: Option<bool>,
     pub(crate) raw: bool,
     pub(crate) rev: Option<String>,
@@ -451,7 +450,6 @@ impl AddSettings {
         let AddArgs {
             requirements,
             dev,
-            workspace,
             editable,
             raw,
             rev,
@@ -471,7 +469,6 @@ impl AddSettings {
 
         Self {
             requirements,
-            workspace,
             dev,
             editable,
             raw,

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -735,11 +735,29 @@ fn add_remove_workspace() -> Result<()> {
         dependencies = []
     "#})?;
 
+    // Adding a workspace package with a mismatched source should error.
+    let mut add_cmd =
+        context.add(&["child2 @ git+https://github.com/astral-test/uv-public-pypackage"]);
+    add_cmd
+        .arg("--preview")
+        .arg("--package")
+        .arg("child1")
+        .current_dir(&context.temp_dir);
+
+    uv_snapshot!(context.filters(), add_cmd, @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Workspace dependency `child2` must refer to local directory, not a Git repository
+    "###);
+
+    // Workspace packages should be detected automatically.
     let child1 = context.temp_dir.join("child1");
     let mut add_cmd = context.add(&["child2"]);
     add_cmd
         .arg("--preview")
-        .arg("--workspace")
         .arg("--package")
         .arg("child1")
         .current_dir(&context.temp_dir);
@@ -921,7 +939,6 @@ fn add_workspace_editable() -> Result<()> {
     let mut add_cmd = context.add(&["child2"]);
     add_cmd
         .arg("--editable")
-        .arg("--workspace")
         .arg("--preview")
         .current_dir(&child1);
 


### PR DESCRIPTION
## Summary

If the package _isn't_ marked as `workspace = true`, locking will fail given:

```rust
let workspace_package_declared =
    // We require that when you use a package that's part of the workspace, ...
    !workspace.packages().contains_key(&requirement.name)
    // ... it must be declared as a workspace dependency (`workspace = true`), ...
    || matches!(
        source,
        Some(Source::Workspace {
            // By using toml, we technically support `workspace = false`.
            workspace: true,
            ..
        })
    )
    // ... except for recursive self-inclusion (extras that activate other extras), e.g.
    // `framework[machine_learning]` depends on `framework[cuda]`.
    || &requirement.name == project_name;
if !workspace_package_declared {
    return Err(LoweringError::UndeclaredWorkspacePackage);
}
```

Closes https://github.com/astral-sh/uv/issues/4552.
