### PR TITLE
Allow the package spec to be passed positionally in `uv tool install`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1890,13 +1890,13 @@ pub struct ToolRunArgs {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct ToolInstallArgs {
-    /// The command to install.
-    pub name: String,
+    /// The package to install commands from.
+    pub package: String,
 
-    /// Use the given package to provide the command.
+    /// The package to install commands from.
     ///
-    /// By default, the package name is assumed to match the command name.
-    #[arg(long)]
+    /// This option is provided for parity with `uv tool run`, but is redundant with `package`.
+    #[arg(long, hide = true)]
     pub from: Option<String>,
 
     /// Include the following extra requirements.

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -811,9 +811,9 @@ async fn run() -> Result<ExitStatus> {
             let cache = cache.init()?.with_refresh(args.refresh);
 
             commands::tool_install(
-                args.name,
-                args.python,
+                args.package,
                 args.from,
+                args.python,
                 args.with,
                 args.force,
                 args.settings,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -235,7 +235,7 @@ impl ToolRunSettings {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct ToolInstallSettings {
-    pub(crate) name: String,
+    pub(crate) package: String,
     pub(crate) from: Option<String>,
     pub(crate) with: Vec<String>,
     pub(crate) python: Option<String>,
@@ -249,7 +249,7 @@ impl ToolInstallSettings {
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn resolve(args: ToolInstallArgs, filesystem: Option<FilesystemOptions>) -> Self {
         let ToolInstallArgs {
-            name,
+            package,
             from,
             with,
             installer,
@@ -260,7 +260,7 @@ impl ToolInstallSettings {
         } = args;
 
         Self {
-            name,
+            package,
             from,
             with,
             python,

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -27,7 +27,6 @@ fn tool_install() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Installed: black, blackd
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning.
@@ -40,6 +39,7 @@ fn tool_install() {
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
+    Installed: black, blackd
     "###);
 
     tool_dir.child("black").assert(predicate::path::is_dir());
@@ -98,7 +98,6 @@ fn tool_install() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Installed: flask
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning.
@@ -112,6 +111,7 @@ fn tool_install() {
      + jinja2==3.1.3
      + markupsafe==2.1.5
      + werkzeug==3.0.1
+    Installed: flask
     "###);
 
     tool_dir.child("flask").assert(predicate::path::is_dir());
@@ -158,6 +158,150 @@ fn tool_install() {
     });
 }
 
+/// Test installing a tool at a version
+#[test]
+fn tool_install_version() {
+    let context = TestContext::new("3.12");
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `black`
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("black==24.2.0")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv tool install` is experimental and may change without warning.
+    Resolved 6 packages in [TIME]
+    Prepared 6 packages in [TIME]
+    Installed 6 packages in [TIME]
+     + black==24.2.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
+    Installed: black, blackd
+    "###);
+
+    tool_dir.child("black").assert(predicate::path::is_dir());
+    tool_dir
+        .child("black")
+        .child("uv-receipt.toml")
+        .assert(predicate::path::exists());
+
+    let executable = bin_dir.child(format!("black{}", std::env::consts::EXE_SUFFIX));
+    assert!(executable.exists());
+
+    // On Windows, we can't snapshot an executable file.
+    #[cfg(not(windows))]
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        // Should run black in the virtual environment
+        assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
+        #![TEMP_DIR]/tools/black/bin/python
+        # -*- coding: utf-8 -*-
+        import re
+        import sys
+        from black import patched_main
+        if __name__ == "__main__":
+            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            sys.exit(patched_main())
+        "###);
+
+    });
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        // We should have a tool receipt
+        assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
+        [tool]
+        requirements = ["black==24.2.0"]
+        "###);
+    });
+
+    uv_snapshot!(context.filters(), Command::new("black").arg("--version").env("PATH", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    black, 24.2.0 (compiled: yes)
+    Python (CPython) 3.12.[X]
+
+    ----- stderr -----
+    "###);
+}
+
+/// Test installing a tool with `uv tool install --from`
+#[test]
+fn tool_install_from() {
+    let context = TestContext::new("3.12");
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `black` using `--from` to specify the version
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("black")
+        .arg("--from")
+        .arg("black==24.2.0")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv tool install` is experimental and may change without warning.
+    Resolved 6 packages in [TIME]
+    Prepared 6 packages in [TIME]
+    Installed 6 packages in [TIME]
+     + black==24.2.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
+    Installed: black, blackd
+    "###);
+
+    // Attempt to install `black` using `--from` with a different package name
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("black")
+        .arg("--from")
+        .arg("flask==24.2.0")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv tool install` is experimental and may change without warning.
+    error: Package name `flask` provided with `--from` does not match install request `black`
+    "###);
+
+    // Attempt to install `black` using `--from` with a different version
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("black==24.2.0")
+        .arg("--from")
+        .arg("black==24.3.0")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv tool install` is experimental and may change without warning.
+    error: Package requirement `black==24.3.0` provided with `--from` conflicts with install request `black==24.2.0`
+    "###);
+}
+
 /// Test installing and reinstalling an already installed tool
 #[test]
 fn tool_install_already_installed() {
@@ -180,7 +324,6 @@ fn tool_install_already_installed() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Installed: black, blackd
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning.
@@ -193,6 +336,7 @@ fn tool_install_already_installed() {
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
+    Installed: black, blackd
     "###);
 
     tool_dir.child("black").assert(predicate::path::is_dir());
@@ -272,7 +416,6 @@ fn tool_install_already_installed() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Installed: black, blackd
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning.
@@ -284,6 +427,7 @@ fn tool_install_already_installed() {
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
+    Installed: black, blackd
     "###);
 
     // Install `black` again with `--reinstall-package` for `black`
@@ -297,7 +441,6 @@ fn tool_install_already_installed() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Installed: black, blackd
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning.
@@ -306,6 +449,7 @@ fn tool_install_already_installed() {
     Installed 1 package in [TIME]
      - black==24.3.0
      + black==24.3.0
+    Installed: black, blackd
     "###);
 
     // Install `black` again with `--reinstall-package` for a dependency
@@ -462,7 +606,6 @@ fn tool_install_entry_point_exists() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Installed: black, blackd
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning.
@@ -474,6 +617,7 @@ fn tool_install_entry_point_exists() {
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
+    Installed: black, blackd
     "###);
 
     tool_dir.child("black").assert(predicate::path::is_dir());
@@ -542,7 +686,6 @@ fn tool_install_home() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Installed: black, blackd
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning.
@@ -555,6 +698,7 @@ fn tool_install_home() {
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
+    Installed: black, blackd
     "###);
 
     context
@@ -578,7 +722,6 @@ fn tool_install_xdg_data_home() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Installed: black, blackd
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning.
@@ -591,6 +734,7 @@ fn tool_install_xdg_data_home() {
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
+    Installed: black, blackd
     "###);
 
     context
@@ -614,7 +758,6 @@ fn tool_install_xdg_bin_home() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Installed: black, blackd
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning.
@@ -627,6 +770,7 @@ fn tool_install_xdg_bin_home() {
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
+    Installed: black, blackd
     "###);
 
     bin_dir


### PR DESCRIPTION
Moves `--from` to a hidden argument — we allow it still but we validate that it is compatible with whatever is passed to `uv tool install <package>`. The positional package can now be a full specification, allowing things like `uv tool install black==24.2.0`.