### PR TITLE
Defer finding uv binary to shutil

### DIFF
--- a/python/uv/__init__.py
+++ b/python/uv/__init__.py
@@ -1,39 +1,16 @@
 from __future__ import annotations
 
-import os
-import sys
-import sysconfig
+import shutil
 
 
 def find_uv_bin() -> str:
     """Return the uv binary path."""
-
-    uv_exe = "uv" + sysconfig.get_config_var("EXE")
-
-    path = os.path.join(sysconfig.get_path("scripts"), uv_exe)
-    if os.path.isfile(path):
+    
+    path = shutil.which("uv")
+    if path:
         return path
 
-    if sys.version_info >= (3, 10):
-        user_scheme = sysconfig.get_preferred_scheme("user")
-    elif os.name == "nt":
-        user_scheme = "nt_user"
-    elif sys.platform == "darwin" and sys._framework:
-        user_scheme = "osx_framework_user"
-    else:
-        user_scheme = "posix_user"
-
-    path = os.path.join(sysconfig.get_path("scripts", scheme=user_scheme), uv_exe)
-    if os.path.isfile(path):
-        return path
-
-    # Search in `bin` adjacent to package root (as created by `pip install --target`).
-    pkg_root = os.path.dirname(os.path.dirname(__file__))
-    target_path = os.path.join(pkg_root, "bin", uv_exe)
-    if os.path.isfile(target_path):
-        return target_path
-
-    raise FileNotFoundError(path)
+    raise FileNotFoundError("uv")
 
 
 __all__ = [

--- a/python/uv/__init__.py
+++ b/python/uv/__init__.py
@@ -5,7 +5,7 @@ import shutil
 
 def find_uv_bin() -> str:
     """Return the uv binary path."""
-    
+
     path = shutil.which("uv")
     if path:
         return path


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Currently the `find_uv_binary` function searches some amount of pre-defined locations. Finding the binary itself can be achieved in a simpler way by deferring the logic to `shutil.which`, which does the following for us for free:
- handle `exe` extension logic in Windows
- search user/system-installed paths
- search virtualenv paths

In addition, leaving the location logic to `PATH` and `shutil.which` has the additional advantage of being compatible with tools that expose binaries via `PATH` (ie Nix), and any other package managers that work in ways we don't expect

## Test Plan

No new functions -- previously written tests should cover correctness. Marked as Draft until all tests pass
