### PR TITLE
Use inline table for dependencies in lockfile

### DIFF
--- a/crates/uv/tests/branching_urls.rs
+++ b/crates/uv/tests/branching_urls.rs
@@ -327,18 +327,10 @@ fn branching_between_registry_and_direct_url() -> Result<()> {
     name = "a"
     version = "0.1.0"
     source = "editable+."
-
-    [[distribution.dependencies]]
-    name = "iniconfig"
-    version = "1.1.1"
-    source = "registry+https://pypi.org/simple"
-    marker = "python_version < '3.12'"
-
-    [[distribution.dependencies]]
-    name = "iniconfig"
-    version = "2.0.0"
-    source = "direct+https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl"
-    marker = "python_version >= '3.12'"
+    dependencies = [
+        { name = "iniconfig", version = "1.1.1", source = "registry+https://pypi.org/simple", marker = "python_version < '3.12'" },
+        { name = "iniconfig", version = "2.0.0", source = "direct+https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", marker = "python_version >= '3.12'" },
+    ]
 
     [[distribution]]
     name = "iniconfig"
@@ -397,18 +389,10 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     name = "a"
     version = "0.1.0"
     source = "editable+."
-
-    [[distribution.dependencies]]
-    name = "iniconfig"
-    version = "1.1.1"
-    source = "direct+https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl"
-    marker = "python_version < '3.12'"
-
-    [[distribution.dependencies]]
-    name = "iniconfig"
-    version = "2.0.0"
-    source = "git+https://github.com/pytest-dev/iniconfig?rev=93f5930e668c0d1ddf4597e38dd0dea4e2665e7a#93f5930e668c0d1ddf4597e38dd0dea4e2665e7a"
-    marker = "python_version >= '3.12'"
+    dependencies = [
+        { name = "iniconfig", version = "1.1.1", source = "direct+https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", marker = "python_version < '3.12'" },
+        { name = "iniconfig", version = "2.0.0", source = "git+https://github.com/pytest-dev/iniconfig?rev=93f5930e668c0d1ddf4597e38dd0dea4e2665e7a#93f5930e668c0d1ddf4597e38dd0dea4e2665e7a", marker = "python_version >= '3.12'" },
+    ]
 
     [[distribution]]
     name = "iniconfig"

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -74,13 +74,11 @@ fn add_registry() -> Result<()> {
         version = "3.7.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", hash = "sha256:eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0", size = 80873 }]
-
-        [[distribution.dependencies]]
-        name = "idna"
-
-        [[distribution.dependencies]]
-        name = "sniffio"
 
         [[distribution]]
         name = "idna"
@@ -93,9 +91,9 @@ fn add_registry() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "anyio"
+        dependencies = [
+            { name = "anyio" },
+        ]
 
         [[distribution]]
         name = "sniffio"
@@ -222,13 +220,11 @@ fn add_git() -> Result<()> {
         version = "3.7.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", hash = "sha256:eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0", size = 80873 }]
-
-        [[distribution.dependencies]]
-        name = "idna"
-
-        [[distribution.dependencies]]
-        name = "sniffio"
 
         [[distribution]]
         name = "idna"
@@ -241,12 +237,10 @@ fn add_git() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "anyio"
-
-        [[distribution.dependencies]]
-        name = "uv-public-pypackage"
+        dependencies = [
+            { name = "anyio" },
+            { name = "uv-public-pypackage" },
+        ]
 
         [[distribution]]
         name = "sniffio"
@@ -366,13 +360,11 @@ fn add_git_raw() -> Result<()> {
         version = "3.7.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", hash = "sha256:eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0", size = 80873 }]
-
-        [[distribution.dependencies]]
-        name = "idna"
-
-        [[distribution.dependencies]]
-        name = "sniffio"
 
         [[distribution]]
         name = "idna"
@@ -385,12 +377,10 @@ fn add_git_raw() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "anyio"
-
-        [[distribution.dependencies]]
-        name = "uv-public-pypackage"
+        dependencies = [
+            { name = "anyio" },
+            { name = "uv-public-pypackage" },
+        ]
 
         [[distribution]]
         name = "sniffio"
@@ -485,9 +475,9 @@ fn add_unnamed() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "uv-public-pypackage"
+        dependencies = [
+            { name = "uv-public-pypackage" },
+        ]
 
         [[distribution]]
         name = "uv-public-pypackage"
@@ -578,13 +568,11 @@ fn add_remove_dev() -> Result<()> {
         version = "3.7.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", hash = "sha256:eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0", size = 80873 }]
-
-        [[distribution.dependencies]]
-        name = "idna"
-
-        [[distribution.dependencies]]
-        name = "sniffio"
 
         [[distribution]]
         name = "idna"
@@ -599,9 +587,9 @@ fn add_remove_dev() -> Result<()> {
         source = "editable+."
 
         [distribution.dev-dependencies]
-
-        [[distribution.dev-dependencies.dev]]
-        name = "anyio"
+        dev = [
+            { name = "anyio" },
+        ]
 
         [[distribution]]
         name = "sniffio"
@@ -811,9 +799,9 @@ fn add_remove_workspace() -> Result<()> {
         name = "child1"
         version = "0.1.0"
         source = "editable+child1"
-
-        [[distribution.dependencies]]
-        name = "child2"
+        dependencies = [
+            { name = "child2" },
+        ]
 
         [[distribution]]
         name = "child2"
@@ -991,9 +979,9 @@ fn add_workspace_editable() -> Result<()> {
         name = "child1"
         version = "0.1.0"
         source = "editable+child1"
-
-        [[distribution.dependencies]]
-        name = "child2"
+        dependencies = [
+            { name = "child2" },
+        ]
 
         [[distribution]]
         name = "child2"
@@ -1302,20 +1290,11 @@ fn update() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "requests"
-        marker = "python_version > '3.7'"
-
-        [[distribution.dependencies]]
-        name = "requests"
-        extra = "socks"
-        marker = "python_version > '3.7'"
-
-        [[distribution.dependencies]]
-        name = "requests"
-        extra = "use-chardet-on-py3"
-        marker = "python_version > '3.7'"
+        dependencies = [
+            { name = "requests", marker = "python_version > '3.7'" },
+            { name = "requests", extra = "socks", marker = "python_version > '3.7'" },
+            { name = "requests", extra = "use-chardet-on-py3", marker = "python_version > '3.7'" },
+        ]
 
         [[distribution]]
         name = "pysocks"
@@ -1331,26 +1310,20 @@ fn update() -> Result<()> {
         name = "requests"
         version = "2.32.3"
         source = "git+https://github.com/psf/requests?tag=v2.32.3#0e322af87745eff34caffe4df68456ebc20d9068"
-
-        [[distribution.dependencies]]
-        name = "certifi"
-
-        [[distribution.dependencies]]
-        name = "charset-normalizer"
-
-        [[distribution.dependencies]]
-        name = "idna"
-
-        [[distribution.dependencies]]
-        name = "urllib3"
+        dependencies = [
+            { name = "certifi" },
+            { name = "charset-normalizer" },
+            { name = "idna" },
+            { name = "urllib3" },
+        ]
 
         [distribution.optional-dependencies]
-
-        [[distribution.optional-dependencies.socks]]
-        name = "pysocks"
-
-        [[distribution.optional-dependencies.use-chardet-on-py3]]
-        name = "chardet"
+        socks = [
+            { name = "pysocks" },
+        ]
+        use-chardet-on-py3 = [
+            { name = "chardet" },
+        ]
 
         [[distribution]]
         name = "urllib3"
@@ -1481,9 +1454,9 @@ fn add_no_clean() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "iniconfig"
+        dependencies = [
+            { name = "iniconfig" },
+        ]
         "###
         );
     });

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -50,13 +50,11 @@ fn lock_wheel_registry() -> Result<()> {
         version = "3.7.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", hash = "sha256:eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0", size = 80873 }]
-
-        [[distribution.dependencies]]
-        name = "idna"
-
-        [[distribution.dependencies]]
-        name = "sniffio"
 
         [[distribution]]
         name = "idna"
@@ -69,9 +67,9 @@ fn lock_wheel_registry() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "anyio"
+        dependencies = [
+            { name = "anyio" },
+        ]
 
         [[distribution]]
         name = "sniffio"
@@ -142,9 +140,9 @@ fn lock_sdist_registry() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "source-distribution"
+        dependencies = [
+            { name = "source-distribution" },
+        ]
 
         [[distribution]]
         name = "source-distribution"
@@ -212,9 +210,9 @@ fn lock_sdist_git() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "uv-public-pypackage"
+        dependencies = [
+            { name = "uv-public-pypackage" },
+        ]
 
         [[distribution]]
         name = "uv-public-pypackage"
@@ -281,13 +279,11 @@ fn lock_wheel_url() -> Result<()> {
         name = "anyio"
         version = "4.3.0"
         source = "direct+https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl"
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", hash = "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8" }]
-
-        [[distribution.dependencies]]
-        name = "idna"
-
-        [[distribution.dependencies]]
-        name = "sniffio"
 
         [[distribution]]
         name = "idna"
@@ -300,9 +296,9 @@ fn lock_wheel_url() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "anyio"
+        dependencies = [
+            { name = "anyio" },
+        ]
 
         [[distribution]]
         name = "sniffio"
@@ -374,12 +370,10 @@ fn lock_sdist_url() -> Result<()> {
         version = "4.3.0"
         source = "direct+https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz"
         sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6" }
-
-        [[distribution.dependencies]]
-        name = "idna"
-
-        [[distribution.dependencies]]
-        name = "sniffio"
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
 
         [[distribution]]
         name = "idna"
@@ -392,9 +386,9 @@ fn lock_sdist_url() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "anyio"
+        dependencies = [
+            { name = "anyio" },
+        ]
 
         [[distribution]]
         name = "sniffio"
@@ -469,13 +463,11 @@ fn lock_project_extra() -> Result<()> {
         version = "3.7.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/68/fe/7ce1926952c8a403b35029e194555558514b365ad77d75125f521a2bec62/anyio-3.7.0-py3-none-any.whl", hash = "sha256:eddca883c4175f14df8aedce21054bfca3adb70ffe76a9f607aef9d7fa2ea7f0", size = 80873 }]
-
-        [[distribution.dependencies]]
-        name = "idna"
-
-        [[distribution.dependencies]]
-        name = "sniffio"
 
         [[distribution]]
         name = "idna"
@@ -495,14 +487,14 @@ fn lock_project_extra() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "anyio"
+        dependencies = [
+            { name = "anyio" },
+        ]
 
         [distribution.optional-dependencies]
-
-        [[distribution.optional-dependencies.test]]
-        name = "iniconfig"
+        test = [
+            { name = "iniconfig" },
+        ]
 
         [[distribution]]
         name = "sniffio"
@@ -644,11 +636,10 @@ fn lock_dependency_extra() -> Result<()> {
         version = "8.1.7"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
+        dependencies = [
+            { name = "colorama", marker = "platform_system == 'Windows'" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941 }]
-
-        [[distribution.dependencies]]
-        name = "colorama"
-        marker = "platform_system == 'Windows'"
 
         [[distribution]]
         name = "colorama"
@@ -662,27 +653,19 @@ fn lock_dependency_extra() -> Result<()> {
         version = "3.0.2"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/3f/e0/a89e8120faea1edbfca1a9b171cff7f2bf62ec860bbafcb2c2387c0317be/flask-3.0.2.tar.gz", hash = "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d", size = 675248 }
+        dependencies = [
+            { name = "blinker" },
+            { name = "click" },
+            { name = "itsdangerous" },
+            { name = "jinja2" },
+            { name = "werkzeug" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/93/a6/aa98bfe0eb9b8b15d36cdfd03c8ca86a03968a87f27ce224fb4f766acb23/flask-3.0.2-py3-none-any.whl", hash = "sha256:3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e", size = 101300 }]
 
-        [[distribution.dependencies]]
-        name = "blinker"
-
-        [[distribution.dependencies]]
-        name = "click"
-
-        [[distribution.dependencies]]
-        name = "itsdangerous"
-
-        [[distribution.dependencies]]
-        name = "jinja2"
-
-        [[distribution.dependencies]]
-        name = "werkzeug"
-
         [distribution.optional-dependencies]
-
-        [[distribution.optional-dependencies.dotenv]]
-        name = "python-dotenv"
+        dotenv = [
+            { name = "python-dotenv" },
+        ]
 
         [[distribution]]
         name = "itsdangerous"
@@ -696,10 +679,10 @@ fn lock_dependency_extra() -> Result<()> {
         version = "3.1.3"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/b2/5e/3a21abf3cd467d7876045335e681d276ac32492febe6d98ad89562d1a7e1/Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90", size = 268261 }
+        dependencies = [
+            { name = "markupsafe" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa", size = 133236 }]
-
-        [[distribution.dependencies]]
-        name = "markupsafe"
 
         [[distribution]]
         name = "markupsafe"
@@ -772,13 +755,10 @@ fn lock_dependency_extra() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "flask"
-
-        [[distribution.dependencies]]
-        name = "flask"
-        extra = "dotenv"
+        dependencies = [
+            { name = "flask" },
+            { name = "flask", extra = "dotenv" },
+        ]
 
         [[distribution]]
         name = "python-dotenv"
@@ -792,10 +772,10 @@ fn lock_dependency_extra() -> Result<()> {
         version = "3.0.1"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/0d/cc/ff1904eb5eb4b455e442834dabf9427331ac0fa02853bf83db817a7dd53d/werkzeug-3.0.1.tar.gz", hash = "sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc", size = 801436 }
+        dependencies = [
+            { name = "markupsafe" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/c3/fc/254c3e9b5feb89ff5b9076a23218dafbc99c96ac5941e900b71206e6313b/werkzeug-3.0.1-py3-none-any.whl", hash = "sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10", size = 226669 }]
-
-        [[distribution.dependencies]]
-        name = "markupsafe"
         "###
         );
     });
@@ -974,14 +954,10 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "requests"
-
-        [[distribution.dependencies]]
-        name = "requests"
-        extra = "socks"
-        marker = "python_version < '3.10'"
+        dependencies = [
+            { name = "requests" },
+            { name = "requests", extra = "socks", marker = "python_version < '3.10'" },
+        ]
 
         [[distribution]]
         name = "pysocks"
@@ -998,24 +974,18 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         version = "2.31.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1", size = 110794 }
+        dependencies = [
+            { name = "certifi" },
+            { name = "charset-normalizer" },
+            { name = "idna" },
+            { name = "urllib3" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f", size = 62574 }]
 
-        [[distribution.dependencies]]
-        name = "certifi"
-
-        [[distribution.dependencies]]
-        name = "charset-normalizer"
-
-        [[distribution.dependencies]]
-        name = "idna"
-
-        [[distribution.dependencies]]
-        name = "urllib3"
-
         [distribution.optional-dependencies]
-
-        [[distribution.optional-dependencies.socks]]
-        name = "pysocks"
+        socks = [
+            { name = "pysocks" },
+        ]
 
         [[distribution]]
         name = "urllib3"
@@ -1122,11 +1092,10 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         version = "8.1.7"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
+        dependencies = [
+            { name = "colorama", marker = "platform_system == 'Windows'" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941 }]
-
-        [[distribution.dependencies]]
-        name = "colorama"
-        marker = "platform_system == 'Windows'"
 
         [[distribution]]
         name = "colorama"
@@ -1140,22 +1109,14 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         version = "3.0.2"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/3f/e0/a89e8120faea1edbfca1a9b171cff7f2bf62ec860bbafcb2c2387c0317be/flask-3.0.2.tar.gz", hash = "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d", size = 675248 }
+        dependencies = [
+            { name = "blinker" },
+            { name = "click" },
+            { name = "itsdangerous" },
+            { name = "jinja2" },
+            { name = "werkzeug" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/93/a6/aa98bfe0eb9b8b15d36cdfd03c8ca86a03968a87f27ce224fb4f766acb23/flask-3.0.2-py3-none-any.whl", hash = "sha256:3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e", size = 101300 }]
-
-        [[distribution.dependencies]]
-        name = "blinker"
-
-        [[distribution.dependencies]]
-        name = "click"
-
-        [[distribution.dependencies]]
-        name = "itsdangerous"
-
-        [[distribution.dependencies]]
-        name = "jinja2"
-
-        [[distribution.dependencies]]
-        name = "werkzeug"
 
         [[distribution]]
         name = "itsdangerous"
@@ -1169,10 +1130,10 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         version = "3.1.3"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/b2/5e/3a21abf3cd467d7876045335e681d276ac32492febe6d98ad89562d1a7e1/Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90", size = 268261 }
+        dependencies = [
+            { name = "markupsafe" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/30/6d/6de6be2d02603ab56e72997708809e8a5b0fbfee080735109b40a3564843/Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa", size = 133236 }]
-
-        [[distribution.dependencies]]
-        name = "markupsafe"
 
         [[distribution]]
         name = "markupsafe"
@@ -1245,19 +1206,19 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "flask"
+        dependencies = [
+            { name = "flask" },
+        ]
 
         [[distribution]]
         name = "werkzeug"
         version = "3.0.1"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/0d/cc/ff1904eb5eb4b455e442834dabf9427331ac0fa02853bf83db817a7dd53d/werkzeug-3.0.1.tar.gz", hash = "sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc", size = 801436 }
+        dependencies = [
+            { name = "markupsafe" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/c3/fc/254c3e9b5feb89ff5b9076a23218dafbc99c96ac5941e900b71206e6313b/werkzeug-3.0.1-py3-none-any.whl", hash = "sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10", size = 226669 }]
-
-        [[distribution.dependencies]]
-        name = "markupsafe"
         "###
         );
     });
@@ -1332,9 +1293,9 @@ fn lock_preference() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "iniconfig"
+        dependencies = [
+            { name = "iniconfig" },
+        ]
         "###
         );
     });
@@ -1382,9 +1343,9 @@ fn lock_preference() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "iniconfig"
+        dependencies = [
+            { name = "iniconfig" },
+        ]
         "###
         );
     });
@@ -1421,9 +1382,9 @@ fn lock_preference() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "iniconfig"
+        dependencies = [
+            { name = "iniconfig" },
+        ]
         "###
         );
     });
@@ -1472,9 +1433,9 @@ fn lock_git_sha() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "uv-public-pypackage"
+        dependencies = [
+            { name = "uv-public-pypackage" },
+        ]
 
         [[distribution]]
         name = "uv-public-pypackage"
@@ -1526,9 +1487,9 @@ fn lock_git_sha() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "uv-public-pypackage"
+        dependencies = [
+            { name = "uv-public-pypackage" },
+        ]
 
         [[distribution]]
         name = "uv-public-pypackage"
@@ -1565,9 +1526,9 @@ fn lock_git_sha() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "uv-public-pypackage"
+        dependencies = [
+            { name = "uv-public-pypackage" },
+        ]
 
         [[distribution]]
         name = "uv-public-pypackage"
@@ -1660,29 +1621,22 @@ fn lock_requires_python() -> Result<()> {
         version = "23.2.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30", size = 780820 }
+        dependencies = [
+            { name = "importlib-metadata", marker = "python_version < '3.8'" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1", size = 60752 }]
-
-        [[distribution.dependencies]]
-        name = "importlib-metadata"
-        marker = "python_version < '3.8'"
 
         [[distribution]]
         name = "cattrs"
         version = "23.1.2"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/68/d4/27f9fd840e74d51b6d6a024d39ff495b56ffde71d28eb82758b7b85d0617/cattrs-23.1.2.tar.gz", hash = "sha256:db1c821b8c537382b2c7c66678c3790091ca0275ac486c76f3c8f3920e83c657", size = 39998 }
+        dependencies = [
+            { name = "attrs" },
+            { name = "exceptiongroup", marker = "python_version < '3.11'" },
+            { name = "typing-extensions", marker = "python_version < '3.11'" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/3a/ba/05df14efaa0624fac6b1510e87f5ce446208d2f6ce50270a89b6268aebfe/cattrs-23.1.2-py3-none-any.whl", hash = "sha256:b2bb14311ac17bed0d58785e5a60f022e5431aca3932e3fc5cc8ed8639de50a4", size = 50845 }]
-
-        [[distribution.dependencies]]
-        name = "attrs"
-
-        [[distribution.dependencies]]
-        name = "exceptiongroup"
-        marker = "python_version < '3.11'"
-
-        [[distribution.dependencies]]
-        name = "typing-extensions"
-        marker = "python_version < '3.11'"
 
         [[distribution]]
         name = "exceptiongroup"
@@ -1696,48 +1650,41 @@ fn lock_requires_python() -> Result<()> {
         version = "6.7.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/a3/82/f6e29c8d5c098b6be61460371c2c5591f4a335923639edec43b3830650a4/importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4", size = 53569 }
+        dependencies = [
+            { name = "typing-extensions", marker = "python_version < '3.8'" },
+            { name = "zipp" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/ff/94/64287b38c7de4c90683630338cf28f129decbba0a44f0c6db35a873c73c4/importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5", size = 22934 }]
-
-        [[distribution.dependencies]]
-        name = "typing-extensions"
-        marker = "python_version < '3.8'"
-
-        [[distribution.dependencies]]
-        name = "zipp"
 
         [[distribution]]
         name = "lsprotocol"
         version = "2023.0.1"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/9d/f6/6e80484ec078d0b50699ceb1833597b792a6c695f90c645fbaf54b947e6f/lsprotocol-2023.0.1.tar.gz", hash = "sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d", size = 69434 }
+        dependencies = [
+            { name = "attrs" },
+            { name = "cattrs" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/8d/37/2351e48cb3309673492d3a8c59d407b75fb6630e560eb27ecd4da03adc9a/lsprotocol-2023.0.1-py3-none-any.whl", hash = "sha256:c75223c9e4af2f24272b14c6375787438279369236cd568f596d4951052a60f2", size = 70826 }]
-
-        [[distribution.dependencies]]
-        name = "attrs"
-
-        [[distribution.dependencies]]
-        name = "cattrs"
 
         [[distribution]]
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "pygls"
+        dependencies = [
+            { name = "pygls" },
+        ]
 
         [[distribution]]
         name = "pygls"
         version = "1.0.1"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/8e/27/58ff0f76b379fc11a1d03e8d4b4e96fd0abb463d27709a7fb4193bcdbbc4/pygls-1.0.1.tar.gz", hash = "sha256:f3ee98ddbb4690eb5c755bc32ba7e129607f14cbd313575f33d0cea443b78cb2", size = 674546 }
+        dependencies = [
+            { name = "lsprotocol" },
+            { name = "typeguard" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/da/9b/4fd77a060068f2f3f46f97ed6ba8762c5a73f11ef0c196cfd34f3a9be878/pygls-1.0.1-py3-none-any.whl", hash = "sha256:adacc96da77598c70f46acfdfd1481d3da90cd54f639f7eee52eb6e4dbd57b55", size = 40367 }]
-
-        [[distribution.dependencies]]
-        name = "lsprotocol"
-
-        [[distribution.dependencies]]
-        name = "typeguard"
 
         [[distribution]]
         name = "typeguard"
@@ -1802,29 +1749,22 @@ fn lock_requires_python() -> Result<()> {
         version = "23.2.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30", size = 780820 }
+        dependencies = [
+            { name = "importlib-metadata", marker = "python_version < '3.8'" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1", size = 60752 }]
-
-        [[distribution.dependencies]]
-        name = "importlib-metadata"
-        marker = "python_version < '3.8'"
 
         [[distribution]]
         name = "cattrs"
         version = "23.1.2"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/68/d4/27f9fd840e74d51b6d6a024d39ff495b56ffde71d28eb82758b7b85d0617/cattrs-23.1.2.tar.gz", hash = "sha256:db1c821b8c537382b2c7c66678c3790091ca0275ac486c76f3c8f3920e83c657", size = 39998 }
+        dependencies = [
+            { name = "attrs" },
+            { name = "exceptiongroup", marker = "python_version < '3.11'" },
+            { name = "typing-extensions", marker = "python_version < '3.11'" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/3a/ba/05df14efaa0624fac6b1510e87f5ce446208d2f6ce50270a89b6268aebfe/cattrs-23.1.2-py3-none-any.whl", hash = "sha256:b2bb14311ac17bed0d58785e5a60f022e5431aca3932e3fc5cc8ed8639de50a4", size = 50845 }]
-
-        [[distribution.dependencies]]
-        name = "attrs"
-
-        [[distribution.dependencies]]
-        name = "exceptiongroup"
-        marker = "python_version < '3.11'"
-
-        [[distribution.dependencies]]
-        name = "typing-extensions"
-        marker = "python_version < '3.11'"
 
         [[distribution]]
         name = "exceptiongroup"
@@ -1838,45 +1778,40 @@ fn lock_requires_python() -> Result<()> {
         version = "6.7.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/a3/82/f6e29c8d5c098b6be61460371c2c5591f4a335923639edec43b3830650a4/importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4", size = 53569 }
+        dependencies = [
+            { name = "typing-extensions", marker = "python_version < '3.8'" },
+            { name = "zipp" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/ff/94/64287b38c7de4c90683630338cf28f129decbba0a44f0c6db35a873c73c4/importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5", size = 22934 }]
-
-        [[distribution.dependencies]]
-        name = "typing-extensions"
-        marker = "python_version < '3.8'"
-
-        [[distribution.dependencies]]
-        name = "zipp"
 
         [[distribution]]
         name = "lsprotocol"
         version = "2023.0.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/3e/fe/f7671a4fb28606ff1663bba60aff6af21b1e43a977c74c33db13cb83680f/lsprotocol-2023.0.0.tar.gz", hash = "sha256:c9d92e12a3f4ed9317d3068226592860aab5357d93cf5b2451dc244eee8f35f2", size = 69399 }
+        dependencies = [
+            { name = "attrs" },
+            { name = "cattrs" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/2d/5b/f18eb1823a4cee9bed70cdcc25eed5a75845367c42e63a79010a7c34f8a7/lsprotocol-2023.0.0-py3-none-any.whl", hash = "sha256:e85fc87ee26c816adca9eb497bb3db1a7c79c477a11563626e712eaccf926a05", size = 70789 }]
-
-        [[distribution.dependencies]]
-        name = "attrs"
-
-        [[distribution.dependencies]]
-        name = "cattrs"
 
         [[distribution]]
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "pygls"
+        dependencies = [
+            { name = "pygls" },
+        ]
 
         [[distribution]]
         name = "pygls"
         version = "1.2.1"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/e6/94/534c11ba5475df09542e48d751a66e0448d52bbbb92cbef5541deef7760d/pygls-1.2.1.tar.gz", hash = "sha256:04f9b9c115b622dcc346fb390289066565343d60245a424eca77cb429b911ed8", size = 45274 }
+        dependencies = [
+            { name = "lsprotocol" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/36/31/3799444d3f072ffca1a35eb02a48f964384cc13f001125e87d9f0748687b/pygls-1.2.1-py3-none-any.whl", hash = "sha256:7dcfcf12b6f15beb606afa46de2ed348b65a279c340ef2242a9a35c22eeafe94", size = 55983 }]
-
-        [[distribution.dependencies]]
-        name = "lsprotocol"
 
         [[distribution]]
         name = "typing-extensions"
@@ -1941,44 +1876,40 @@ fn lock_requires_python() -> Result<()> {
         version = "23.2.3"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/1e/57/c6ccd22658c4bcb3beb3f1c262e1f170cf136e913b122763d0ddd328d284/cattrs-23.2.3.tar.gz", hash = "sha256:a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f", size = 610215 }
+        dependencies = [
+            { name = "attrs" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/b3/0d/cd4a4071c7f38385dc5ba91286723b4d1090b87815db48216212c6c6c30e/cattrs-23.2.3-py3-none-any.whl", hash = "sha256:0341994d94971052e9ee70662542699a3162ea1e0c62f7ce1b4a57f563685108", size = 57474 }]
-
-        [[distribution.dependencies]]
-        name = "attrs"
 
         [[distribution]]
         name = "lsprotocol"
         version = "2023.0.1"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/9d/f6/6e80484ec078d0b50699ceb1833597b792a6c695f90c645fbaf54b947e6f/lsprotocol-2023.0.1.tar.gz", hash = "sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d", size = 69434 }
+        dependencies = [
+            { name = "attrs" },
+            { name = "cattrs" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/8d/37/2351e48cb3309673492d3a8c59d407b75fb6630e560eb27ecd4da03adc9a/lsprotocol-2023.0.1-py3-none-any.whl", hash = "sha256:c75223c9e4af2f24272b14c6375787438279369236cd568f596d4951052a60f2", size = 70826 }]
-
-        [[distribution.dependencies]]
-        name = "attrs"
-
-        [[distribution.dependencies]]
-        name = "cattrs"
 
         [[distribution]]
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "pygls"
+        dependencies = [
+            { name = "pygls" },
+        ]
 
         [[distribution]]
         name = "pygls"
         version = "1.3.0"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/e9/8d/31b50ac0879464049d744a1ddf00dc6474433eb55d40fa0c8e8510591ad2/pygls-1.3.0.tar.gz", hash = "sha256:1b44ace89c9382437a717534f490eadc6fda7c0c6c16ac1eaaf5568e345e4fb8", size = 45539 }
+        dependencies = [
+            { name = "cattrs" },
+            { name = "lsprotocol" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/4e/1e/643070d8f5c851958662e7e5df16d9c3a068a598a7ee7bb2eb8d95b4e5d7/pygls-1.3.0-py3-none-any.whl", hash = "sha256:d4a01414b6ed4e34e7e8fd29b77d3e88c29615df7d0bbff49bf019e15ec04b8f", size = 56031 }]
-
-        [[distribution.dependencies]]
-        name = "cattrs"
-
-        [[distribution.dependencies]]
-        name = "lsprotocol"
         "###
         );
     });
@@ -2062,26 +1993,22 @@ fn lock_requires_python_star() -> Result<()> {
         version = "23.2.3"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/1e/57/c6ccd22658c4bcb3beb3f1c262e1f170cf136e913b122763d0ddd328d284/cattrs-23.2.3.tar.gz", hash = "sha256:a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f", size = 610215 }
+        dependencies = [
+            { name = "attrs" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/b3/0d/cd4a4071c7f38385dc5ba91286723b4d1090b87815db48216212c6c6c30e/cattrs-23.2.3-py3-none-any.whl", hash = "sha256:0341994d94971052e9ee70662542699a3162ea1e0c62f7ce1b4a57f563685108", size = 57474 }]
-
-        [[distribution.dependencies]]
-        name = "attrs"
 
         [[distribution]]
         name = "linehaul"
         version = "1.0.1"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/f8/e7/74d1bd36ed26ac43bfe22e97129edaa7066f7af4bf76084b9493cd581d58/linehaul-1.0.1.tar.gz", hash = "sha256:09d71b1f6a9ab92dd8c763b3d099e4ae05c2845ee783a02d5fe731e6e2a6a997", size = 19410 }
+        dependencies = [
+            { name = "cattrs" },
+            { name = "packaging" },
+            { name = "pyparsing" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/03/73/c73588052198be06462d1a7c4653b602a109a0df0208c59e58075dc3bc73/linehaul-1.0.1-py3-none-any.whl", hash = "sha256:d19ca669008dad910868dfae7f904dfc5362583729bda344799cf7ea2ad5ef12", size = 27848 }]
-
-        [[distribution.dependencies]]
-        name = "cattrs"
-
-        [[distribution.dependencies]]
-        name = "packaging"
-
-        [[distribution.dependencies]]
-        name = "pyparsing"
 
         [[distribution]]
         name = "packaging"
@@ -2094,9 +2021,9 @@ fn lock_requires_python_star() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "linehaul"
+        dependencies = [
+            { name = "linehaul" },
+        ]
 
         [[distribution]]
         name = "pyparsing"
@@ -2163,26 +2090,22 @@ fn lock_requires_python_pre() -> Result<()> {
         version = "23.2.3"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/1e/57/c6ccd22658c4bcb3beb3f1c262e1f170cf136e913b122763d0ddd328d284/cattrs-23.2.3.tar.gz", hash = "sha256:a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f", size = 610215 }
+        dependencies = [
+            { name = "attrs" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/b3/0d/cd4a4071c7f38385dc5ba91286723b4d1090b87815db48216212c6c6c30e/cattrs-23.2.3-py3-none-any.whl", hash = "sha256:0341994d94971052e9ee70662542699a3162ea1e0c62f7ce1b4a57f563685108", size = 57474 }]
-
-        [[distribution.dependencies]]
-        name = "attrs"
 
         [[distribution]]
         name = "linehaul"
         version = "1.0.1"
         source = "registry+https://pypi.org/simple"
         sdist = { url = "https://files.pythonhosted.org/packages/f8/e7/74d1bd36ed26ac43bfe22e97129edaa7066f7af4bf76084b9493cd581d58/linehaul-1.0.1.tar.gz", hash = "sha256:09d71b1f6a9ab92dd8c763b3d099e4ae05c2845ee783a02d5fe731e6e2a6a997", size = 19410 }
+        dependencies = [
+            { name = "cattrs" },
+            { name = "packaging" },
+            { name = "pyparsing" },
+        ]
         wheels = [{ url = "https://files.pythonhosted.org/packages/03/73/c73588052198be06462d1a7c4653b602a109a0df0208c59e58075dc3bc73/linehaul-1.0.1-py3-none-any.whl", hash = "sha256:d19ca669008dad910868dfae7f904dfc5362583729bda344799cf7ea2ad5ef12", size = 27848 }]
-
-        [[distribution.dependencies]]
-        name = "cattrs"
-
-        [[distribution.dependencies]]
-        name = "packaging"
-
-        [[distribution.dependencies]]
-        name = "pyparsing"
 
         [[distribution]]
         name = "packaging"
@@ -2195,9 +2118,9 @@ fn lock_requires_python_pre() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "linehaul"
+        dependencies = [
+            { name = "linehaul" },
+        ]
 
         [[distribution]]
         name = "pyparsing"
@@ -2262,9 +2185,9 @@ fn lock_requires_python_unbounded() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "iniconfig"
+        dependencies = [
+            { name = "iniconfig" },
+        ]
         "###
         );
     });
@@ -2322,14 +2245,14 @@ fn lock_dev() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "iniconfig"
+        dependencies = [
+            { name = "iniconfig" },
+        ]
 
         [distribution.dev-dependencies]
-
-        [[distribution.dev-dependencies.dev]]
-        name = "typing-extensions"
+        dev = [
+            { name = "typing-extensions" },
+        ]
 
         [[distribution]]
         name = "typing-extensions"
@@ -2416,9 +2339,9 @@ fn lock_conditional_unconditional() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "iniconfig"
+        dependencies = [
+            { name = "iniconfig" },
+        ]
         "###
         );
     });
@@ -2473,10 +2396,9 @@ fn lock_multiple_markers() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "iniconfig"
-        marker = "implementation_name == 'cpython'"
+        dependencies = [
+            { name = "iniconfig", marker = "implementation_name == 'cpython'" },
+        ]
         "###
         );
     });
@@ -2564,12 +2486,10 @@ fn relative_and_absolute_paths() -> Result<()> {
         name = "a"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "b"
-
-        [[distribution.dependencies]]
-        name = "c"
+        dependencies = [
+            { name = "b" },
+            { name = "c" },
+        ]
 
         [[distribution]]
         name = "b"

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -102,18 +102,10 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
+        dependencies = [
+            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+        ]
         "###
         );
     });
@@ -205,9 +197,9 @@ fn fork_allows_non_conflicting_repeated_dependencies() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
+        dependencies = [
+            { name = "package-a" },
+        ]
         "###
         );
     });
@@ -295,18 +287,10 @@ fn fork_basic() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
+        dependencies = [
+            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+        ]
         "###
         );
     });
@@ -482,24 +466,20 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_b-1.0.0.tar.gz#sha256=af3f861d6df9a2bbad55bae02acf17384ea2efa1abbf19206ac56cb021814613", hash = "sha256:af3f861d6df9a2bbad55bae02acf17384ea2efa1abbf19206ac56cb021814613" }
+        dependencies = [
+            { name = "package-d", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_b-1.0.0-py3-none-any.whl#sha256=229e8570b5bec521c62fa46ffc242ecdf49e095d043f7761a8390213a63f8d7f", hash = "sha256:229e8570b5bec521c62fa46ffc242ecdf49e095d043f7761a8390213a63f8d7f" }]
-
-        [[distribution.dependencies]]
-        name = "package-d"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
 
         [[distribution]]
         name = "package-c"
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_c-1.0.0.tar.gz#sha256=c03742ca6e81c2a5d7d8cb72d1214bf03b2925e63858a19097f17d3e1a750192", hash = "sha256:c03742ca6e81c2a5d7d8cb72d1214bf03b2925e63858a19097f17d3e1a750192" }
+        dependencies = [
+            { name = "package-d", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_c-1.0.0-py3-none-any.whl#sha256=28b4728d6ef73637bd296038f8b1895de6fffab1a0f5a2673b7408ac6941e401", hash = "sha256:28b4728d6ef73637bd296038f8b1895de6fffab1a0f5a2673b7408ac6941e401" }]
-
-        [[distribution.dependencies]]
-        name = "package-d"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
 
         [[distribution]]
         name = "package-d"
@@ -519,26 +499,12 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "4.3.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "4.4.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        marker = "sys_platform == 'linux'"
-
-        [[distribution.dependencies]]
-        name = "package-c"
-        marker = "sys_platform == 'darwin'"
+        dependencies = [
+            { name = "package-a", version = "4.3.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "4.4.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-b", marker = "sys_platform == 'linux'" },
+            { name = "package-c", marker = "sys_platform == 'darwin'" },
+        ]
         "###
         );
     });
@@ -623,22 +589,20 @@ fn fork_marker_accrue() -> Result<()> {
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_a-1.0.0.tar.gz#sha256=c791e6062a510c63bff857ca6f7a921a7795bfbc588f21a51124e091fb0343d6", hash = "sha256:c791e6062a510c63bff857ca6f7a921a7795bfbc588f21a51124e091fb0343d6" }
+        dependencies = [
+            { name = "package-c", marker = "sys_platform == 'linux'" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_a-1.0.0-py3-none-any.whl#sha256=c1b40f368e7be6c16c1d537481421bf6cd1e18a09a83f42ed35029633d4b3249", hash = "sha256:c1b40f368e7be6c16c1d537481421bf6cd1e18a09a83f42ed35029633d4b3249" }]
-
-        [[distribution.dependencies]]
-        name = "package-c"
-        marker = "sys_platform == 'linux'"
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_b-1.0.0.tar.gz#sha256=32e7ea1022061783857c3f6fec5051b4b320630fe8a5aec6523cd565db350387", hash = "sha256:32e7ea1022061783857c3f6fec5051b4b320630fe8a5aec6523cd565db350387" }
+        dependencies = [
+            { name = "package-c", marker = "sys_platform == 'darwin'" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_b-1.0.0-py3-none-any.whl#sha256=2df49decd1b188800d1cbf5265806d32388e4c792da3074b6f9be2e7b72185f5", hash = "sha256:2df49decd1b188800d1cbf5265806d32388e4c792da3074b6f9be2e7b72185f5" }]
-
-        [[distribution.dependencies]]
-        name = "package-c"
-        marker = "sys_platform == 'darwin'"
 
         [[distribution]]
         name = "package-c"
@@ -651,14 +615,10 @@ fn fork_marker_accrue() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        marker = "implementation_name == 'cpython'"
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        marker = "implementation_name == 'pypy'"
+        dependencies = [
+            { name = "package-a", marker = "implementation_name == 'cpython'" },
+            { name = "package-b", marker = "implementation_name == 'pypy'" },
+        ]
         "###
         );
     });
@@ -812,19 +772,11 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_a-1.0.0.tar.gz#sha256=c7232306e8597d46c3fe53a3b1472f99b8ff36b3169f335ba0a5b625e193f7d4", hash = "sha256:c7232306e8597d46c3fe53a3b1472f99b8ff36b3169f335ba0a5b625e193f7d4" }
+        dependencies = [
+            { name = "package-b", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'pypy'" },
+            { name = "package-b", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'cpython'" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_a-1.0.0-py3-none-any.whl#sha256=609b50f1a9fdbea0cc5d77f3eaf5143900159d809c56db5839de138c3123d980", hash = "sha256:609b50f1a9fdbea0cc5d77f3eaf5143900159d809c56db5839de138c3123d980" }]
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "implementation_name == 'pypy'"
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "implementation_name == 'cpython'"
 
         [[distribution]]
         name = "package-a"
@@ -838,11 +790,10 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_b-1.0.0.tar.gz#sha256=d6bd196a0a152c1b32e09f08e554d22ae6a6b3b916e39ad4552572afae5f5492", hash = "sha256:d6bd196a0a152c1b32e09f08e554d22ae6a6b3b916e39ad4552572afae5f5492" }
+        dependencies = [
+            { name = "package-c", marker = "implementation_name == 'pypy' or sys_platform == 'linux'" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_b-1.0.0-py3-none-any.whl#sha256=7935455a6f9a9448dd7ee33978bb4d463b16ef9cd021c24462c7b51e8c4ebc86", hash = "sha256:7935455a6f9a9448dd7ee33978bb4d463b16ef9cd021c24462c7b51e8c4ebc86" }]
-
-        [[distribution.dependencies]]
-        name = "package-c"
-        marker = "implementation_name == 'pypy' or sys_platform == 'linux'"
 
         [[distribution]]
         name = "package-b"
@@ -862,18 +813,10 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
+        dependencies = [
+            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+        ]
         "###
         );
     });
@@ -963,19 +906,11 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_a-1.0.0.tar.gz#sha256=92081d91570582f3a94ed156f203de53baca5b3fdc350aa1c831c7c42723e798", hash = "sha256:92081d91570582f3a94ed156f203de53baca5b3fdc350aa1c831c7c42723e798" }
+        dependencies = [
+            { name = "package-b", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'pypy'" },
+            { name = "package-b", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'cpython'" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_a-1.0.0-py3-none-any.whl#sha256=5a3da0f8036be92c72212ff734672805ed8b799a1bc46d3bde56f8486180e1cf", hash = "sha256:5a3da0f8036be92c72212ff734672805ed8b799a1bc46d3bde56f8486180e1cf" }]
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "implementation_name == 'pypy'"
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "implementation_name == 'cpython'"
 
         [[distribution]]
         name = "package-a"
@@ -1002,18 +937,10 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
+        dependencies = [
+            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+        ]
         "###
         );
     });
@@ -1104,19 +1031,11 @@ fn fork_marker_inherit_combined() -> Result<()> {
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_a-1.0.0.tar.gz#sha256=2ec4c9dbb7078227d996c344b9e0c1b365ed0000de9527b2ba5b616233636f07", hash = "sha256:2ec4c9dbb7078227d996c344b9e0c1b365ed0000de9527b2ba5b616233636f07" }
+        dependencies = [
+            { name = "package-b", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'pypy'" },
+            { name = "package-b", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'cpython'" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_a-1.0.0-py3-none-any.whl#sha256=b24ba06cf3717872f4155240294a11d5cbe8c6b4a5b00963d056b491886b4efe", hash = "sha256:b24ba06cf3717872f4155240294a11d5cbe8c6b4a5b00963d056b491886b4efe" }]
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "implementation_name == 'pypy'"
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "implementation_name == 'cpython'"
 
         [[distribution]]
         name = "package-a"
@@ -1143,18 +1062,10 @@ fn fork_marker_inherit_combined() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
+        dependencies = [
+            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+        ]
         "###
         );
     });
@@ -1246,11 +1157,10 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         version = "2.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_a-2.0.0.tar.gz#sha256=bc4567da4349a9c09b7fb4733f0b9f6476249240192291cf051c2b1d28b829fd", hash = "sha256:bc4567da4349a9c09b7fb4733f0b9f6476249240192291cf051c2b1d28b829fd" }
+        dependencies = [
+            { name = "package-b", marker = "sys_platform == 'linux'" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_a-2.0.0-py3-none-any.whl#sha256=dc624746ae061d80e0bb3e25d0427177983f1edd0b519095f7a3f22b13bc54bd", hash = "sha256:dc624746ae061d80e0bb3e25d0427177983f1edd0b519095f7a3f22b13bc54bd" }]
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        marker = "sys_platform == 'linux'"
 
         [[distribution]]
         name = "package-b"
@@ -1263,18 +1173,10 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
+        dependencies = [
+            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+        ]
         "###
         );
     });
@@ -1364,10 +1266,10 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_a-1.0.0.tar.gz#sha256=8bcab85231487b9350471da0c4c22dc3d69dfe4a1198d16b5f81b0235d7112ce", hash = "sha256:8bcab85231487b9350471da0c4c22dc3d69dfe4a1198d16b5f81b0235d7112ce" }
+        dependencies = [
+            { name = "package-b" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_a-1.0.0-py3-none-any.whl#sha256=6904ed373d504f278de986c440e39b6105be4680654e38dbe37c5d539a67fd3d", hash = "sha256:6904ed373d504f278de986c440e39b6105be4680654e38dbe37c5d539a67fd3d" }]
-
-        [[distribution.dependencies]]
-        name = "package-b"
 
         [[distribution]]
         name = "package-a"
@@ -1381,10 +1283,10 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_b-1.0.0.tar.gz#sha256=03b4b0e323c36bd4a1e51a65e1489715da231d44d26e12b54544e3bf9a9f6129", hash = "sha256:03b4b0e323c36bd4a1e51a65e1489715da231d44d26e12b54544e3bf9a9f6129" }
+        dependencies = [
+            { name = "package-c" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_b-1.0.0-py3-none-any.whl#sha256=f3975f31f7e3dee42abb1b44f6e7fea0048bd1f204debc2f1decf16b3d597c9f", hash = "sha256:f3975f31f7e3dee42abb1b44f6e7fea0048bd1f204debc2f1decf16b3d597c9f" }]
-
-        [[distribution.dependencies]]
-        name = "package-c"
 
         [[distribution]]
         name = "package-c"
@@ -1397,18 +1299,10 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
+        dependencies = [
+            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+        ]
         "###
         );
     });
@@ -1506,18 +1400,10 @@ fn fork_marker_inherit() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
+        dependencies = [
+            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+        ]
         "###
         );
     });
@@ -1621,11 +1507,10 @@ fn fork_marker_limited_inherit() -> Result<()> {
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_b-1.0.0.tar.gz#sha256=4c04e090df03e308ecd38a9b8db9813a09fb20a747a89f86c497702c3e5a9001", hash = "sha256:4c04e090df03e308ecd38a9b8db9813a09fb20a747a89f86c497702c3e5a9001" }
+        dependencies = [
+            { name = "package-c", marker = "sys_platform == 'linux'" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_b-1.0.0-py3-none-any.whl#sha256=ee96eb6ec4c7fa40a60feaa557df01550ecbfe1f5e49ec3a9282f243f76a5113", hash = "sha256:ee96eb6ec4c7fa40a60feaa557df01550ecbfe1f5e49ec3a9282f243f76a5113" }]
-
-        [[distribution.dependencies]]
-        name = "package-c"
-        marker = "sys_platform == 'linux'"
 
         [[distribution]]
         name = "package-c"
@@ -1638,21 +1523,11 @@ fn fork_marker_limited_inherit() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
-
-        [[distribution.dependencies]]
-        name = "package-b"
+        dependencies = [
+            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-b" },
+        ]
         "###
         );
     });
@@ -1746,12 +1621,10 @@ fn fork_marker_selection() -> Result<()> {
         version = "0.2.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_a-0.2.0.tar.gz#sha256=42abfb3ce2c13ae008e498d27c80ae39ab19e30fd56e175719b67b1c778ea632", hash = "sha256:42abfb3ce2c13ae008e498d27c80ae39ab19e30fd56e175719b67b1c778ea632" }
+        dependencies = [
+            { name = "package-b", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_a-0.2.0-py3-none-any.whl#sha256=65ff1ce26de8218278abb1ae190fe70d031de79833d85231112208672566b9c4", hash = "sha256:65ff1ce26de8218278abb1ae190fe70d031de79833d85231112208672566b9c4" }]
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
 
         [[distribution]]
         name = "package-b"
@@ -1771,28 +1644,12 @@ fn fork_marker_selection() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "0.1.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "0.2.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
+        dependencies = [
+            { name = "package-a", version = "0.1.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+            { name = "package-a", version = "0.2.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+            { name = "package-b", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-b", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+        ]
         "###
         );
     });
@@ -1890,23 +1747,20 @@ fn fork_marker_track() -> Result<()> {
         version = "1.3.1"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_a-1.3.1.tar.gz#sha256=ffc490c887058825e96a0cc4a270cf56b72f7f28b927c450086603317bb8c120", hash = "sha256:ffc490c887058825e96a0cc4a270cf56b72f7f28b927c450086603317bb8c120" }
+        dependencies = [
+            { name = "package-c", marker = "implementation_name == 'iron'" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_a-1.3.1-py3-none-any.whl#sha256=79e82592fe6644839cdb6dc73d3d54fc543f0e0f28cce26e221a6c1e30072104", hash = "sha256:79e82592fe6644839cdb6dc73d3d54fc543f0e0f28cce26e221a6c1e30072104" }]
-
-        [[distribution.dependencies]]
-        name = "package-c"
-        marker = "implementation_name == 'iron'"
 
         [[distribution]]
         name = "package-a"
         version = "4.3.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_a-4.3.0.tar.gz#sha256=ce810c2e0922cff256d3050167c0d2a041955d389d21280fd684ab986dfdb1f5", hash = "sha256:ce810c2e0922cff256d3050167c0d2a041955d389d21280fd684ab986dfdb1f5" }
+        dependencies = [
+            { name = "package-b", version = "2.8", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_a-4.3.0-py3-none-any.whl#sha256=fb90bca8d00206119df736f59a9c4e18e104a9321b8ea91f19400a119b77ef99", hash = "sha256:fb90bca8d00206119df736f59a9c4e18e104a9321b8ea91f19400a119b77ef99" }]
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "2.8"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
 
         [[distribution]]
         name = "package-b"
@@ -1933,28 +1787,12 @@ fn fork_marker_track() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "1.3.1"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        version = "4.3.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "2.7"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'darwin'"
-
-        [[distribution.dependencies]]
-        name = "package-b"
-        version = "2.8"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
-        marker = "sys_platform == 'linux'"
+        dependencies = [
+            { name = "package-a", version = "1.3.1", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+            { name = "package-a", version = "4.3.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+            { name = "package-b", version = "2.7", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
+            { name = "package-b", version = "2.8", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+        ]
         "###
         );
     });
@@ -2038,22 +1876,20 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_a-1.0.0.tar.gz#sha256=68cff02c9f4a0b3014fdce524982a3cbf3a2ecaf0291c32c824cadb19f1e7cd0", hash = "sha256:68cff02c9f4a0b3014fdce524982a3cbf3a2ecaf0291c32c824cadb19f1e7cd0" }
+        dependencies = [
+            { name = "package-c", marker = "sys_platform == 'linux'" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_a-1.0.0-py3-none-any.whl#sha256=589fb29588410fe1685650a1151e0f33131c9b295506af6babe16e98dad9da59", hash = "sha256:589fb29588410fe1685650a1151e0f33131c9b295506af6babe16e98dad9da59" }]
-
-        [[distribution.dependencies]]
-        name = "package-c"
-        marker = "sys_platform == 'linux'"
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
         source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_b-1.0.0.tar.gz#sha256=ae7abe9cde79b810f91dff7329b63788a8253250053fe4e82563f0b2d0877182", hash = "sha256:ae7abe9cde79b810f91dff7329b63788a8253250053fe4e82563f0b2d0877182" }
+        dependencies = [
+            { name = "package-c", marker = "sys_platform == 'darwin'" },
+        ]
         wheels = [{ url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_b-1.0.0-py3-none-any.whl#sha256=545bea70509188de241037b506a1c38dbabb4e52042bb88ca836c04d8103fc48", hash = "sha256:545bea70509188de241037b506a1c38dbabb4e52042bb88ca836c04d8103fc48" }]
-
-        [[distribution.dependencies]]
-        name = "package-c"
-        marker = "sys_platform == 'darwin'"
 
         [[distribution]]
         name = "package-c"
@@ -2066,12 +1902,10 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-
-        [[distribution.dependencies]]
-        name = "package-b"
+        dependencies = [
+            { name = "package-a" },
+            { name = "package-b" },
+        ]
         "###
         );
     });
@@ -2445,10 +2279,9 @@ fn fork_requires_python_patch_overlap() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = "editable+."
-
-        [[distribution.dependencies]]
-        name = "package-a"
-        marker = "python_version == '3.10'"
+        dependencies = [
+            { name = "package-a", marker = "python_version == '3.10'" },
+        ]
         "###
         );
     });


### PR DESCRIPTION
Use indented inline tables for `distribution.dependencies`, `distribution.optional-dependencies` and `distribution.dev-dependencies`.

The new style is more concise (see examples below) and it makes the association between a distribution and its dependencies clearer (previously, they were both individual `[[...]]` blocks separated by newlines). The style is optimized for small, meaningful diffs by placing each dependency on a single line with a final trailing comma. Whenever a dependency is added, removed or changed, there should be a one line diff in `distribution.dependencies`. The final trailing comma ensures that adding a dependency doesn't change the line ahead.

Part of #3611

## Examples

### Simple workspace package

Before:
```toml
[[distribution]]
name = "bird-feeder"
version = "1.0.0"
source = "editable+packages/bird-feeder"

[[distribution.dependencies]]
name = "anyio"

[[distribution.dependencies]]
name = "seeds"
```

After:
```toml
[[distribution]]
name = "bird-feeder"
version = "1.0.0"
source = "editable+packages/bird-feeder"
dependencies = [
    { name = "anyio" },
    { name = "seeds" },
]
```

### Flask

Before:
```toml
[[distribution]]
name = "flask"
version = "3.0.2"
source = "registry+https://pypi.org/simple"
sdist = { url = "https://files.pythonhosted.org/packages/3f/e0/a89e8120faea1edbfca1a9b171cff7f2bf62ec860bbafcb2c2387c0317be/flask-3.0.2.tar.gz", hash = "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d", size = 675248 }
wheels = [{ url = "https://files.pythonhosted.org/packages/93/a6/aa98bfe0eb9b8b15d36cdfd03c8ca86a03968a87f27ce224fb4f766acb23/flask-3.0.2-py3-none-any.whl", hash = "sha256:3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e", size = 101300 }]

[[distribution.dependencies]]
name = "blinker"

[[distribution.dependencies]]
name = "click"

[[distribution.dependencies]]
name = "itsdangerous"

[[distribution.dependencies]]
name = "jinja2"

[[distribution.dependencies]]
name = "werkzeug"

[distribution.optional-dependencies]

[[distribution.optional-dependencies.dotenv]]
name = "python-dotenv"
```

After:
```toml
[[distribution]]
name = "flask"
version = "3.0.2"
source = "registry+https://pypi.org/simple"
sdist = { url = "https://files.pythonhosted.org/packages/3f/e0/a89e8120faea1edbfca1a9b171cff7f2bf62ec860bbafcb2c2387c0317be/flask-3.0.2.tar.gz", hash = "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d", size = 675248 }
dependencies = [
    { name = "blinker" },
    { name = "click" },
    { name = "itsdangerous" },
    { name = "jinja2" },
    { name = "werkzeug" },
]
wheels = [{ url = "https://files.pythonhosted.org/packages/93/a6/aa98bfe0eb9b8b15d36cdfd03c8ca86a03968a87f27ce224fb4f766acb23/flask-3.0.2-py3-none-any.whl", hash = "sha256:3232e0e9c850d781933cf0207523d1ece087eb8d87b23777ae38456e2fbe7c6e", size = 101300 }]

[distribution.optional-dependencies]
dotenv = [
    { name = "python-dotenv" },
]
```

### Forking

Before:
```toml
[[distribution]]
name = "project"
version = "0.1.0"
source = "editable+."

[[distribution.dependencies]]
name = "package-a"
version = "4.3.0"
source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
marker = "sys_platform == 'darwin'"

[[distribution.dependencies]]
name = "package-a"
version = "4.4.0"
source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
marker = "sys_platform == 'linux'"

[[distribution.dependencies]]
name = "package-b"
marker = "sys_platform == 'linux'"

[[distribution.dependencies]]
name = "package-c"
marker = "sys_platform == 'darwin'"
```

After:
```toml
[[distribution]]
name = "project"
version = "0.1.0"
source = "editable+."
dependencies = [
    { name = "package-a", version = "4.3.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
    { name = "package-a", version = "4.4.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
    { name = "package-b", marker = "sys_platform == 'linux'" },
    { name = "package-c", marker = "sys_platform == 'darwin'" },
]
```