### PR TITLE
Include environment preferences in the toolchain not found errors

### DIFF
--- a/crates/uv-toolchain/src/lib.rs
+++ b/crates/uv-toolchain/src/lib.rs
@@ -792,7 +792,7 @@ mod tests {
             matches!(
                 result,
                 Err(ToolchainNotFound::NoMatchingVersion(
-                    _,
+                    ..,
                     VersionRequest::MajorMinor(3, 9)
                 ))
             ),
@@ -819,7 +819,7 @@ mod tests {
             matches!(
                 result,
                 Err(ToolchainNotFound::NoMatchingVersion(
-                    _,
+                    ..,
                     VersionRequest::MajorMinorPatch(3, 11, 9)
                 ))
             ),
@@ -1301,8 +1301,8 @@ mod tests {
             matches!(
                 result,
                 Err(ToolchainNotFound::NoPythonInstallation(
-                    // TODO(zanieb): We need the environment preference in the error
                     ToolchainPreference::OnlySystem,
+                    _,
                     None
                 ))
             ),
@@ -1326,6 +1326,7 @@ mod tests {
                 result,
                 Err(ToolchainNotFound::NoMatchingVersion(
                     ToolchainPreference::OnlySystem,
+                    _,
                     VersionRequest::MajorMinorPatch(3, 12, 3)
                 ))
             ),
@@ -1569,7 +1570,7 @@ mod tests {
         assert_eq!(
             toolchain.interpreter().python_full_version().to_string(),
             "3.10.0",
-            "We should prefer the requested directory over the system and active virtul toolchains"
+            "We should prefer the requested directory over the system and active virtual environments"
         );
 
         Ok(())

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -66,7 +66,7 @@ fn missing_venv() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: No Python interpreters found in system toolchains
+    error: No Python interpreters found in virtual environments or system toolchains
     "###);
 
     assert!(predicates::path::missing().eval(&context.venv));


### PR DESCRIPTION
This regressed as part of #4416 

```
❯ uv --version
uv 0.2.13 (fa6ed3410 2024-06-18)
❯ uv pip sync requirements.txt
error: No Python interpreters found in virtual environments
❯ uv self update
info: Checking for updates...
success: Upgraded `uv` to v0.2.17! https://github.com/astral-sh/uv/releases/tag/0.2.17
❯ uv pip sync requirements.txt
error: No Python interpreters found in system toolchains
```

Now we'll say

```
error: No Python interpreters found in virtual environments or system toolchains
```

I'm going to follow-up with special cases for `PythonEnvironment::find`
