### PR TITLE
Explicitly mention use of seed packages during `uv venv --seed`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1499,7 +1499,7 @@ pub struct VenvArgs {
 
     /// Install seed packages (one or more of: `pip`, `setuptools`, and `wheel`) into the virtual environment.
     ///
-    /// Installing `setuptools` and `wheel` is disabled on Python 3.12+ environments.
+    /// Note `setuptools` and `wheel` are not included in Python 3.12+ environments.
     #[arg(long)]
     pub seed: bool,
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1497,7 +1497,9 @@ pub struct VenvArgs {
     #[arg(long, overrides_with("system"), hide = true)]
     pub no_system: bool,
 
-    /// Install seed packages (`pip`, `setuptools`, and `wheel`) into the virtual environment.
+    /// Install seed packages (one or more of: `pip`, `setuptools`, and `wheel`) into the virtual environment.
+    ///
+    /// Installing `setuptools` and `wheel` is disabled on Python 3.12+ environments.
     #[arg(long)]
     pub seed: bool,
 
@@ -1545,7 +1547,7 @@ pub struct VenvArgs {
     /// The strategy to use when resolving against multiple index URLs.
     ///
     /// By default, `uv` will stop at the first index on which a given package is available, and
-    /// limit resolutions to those present on that first index (`first-match`. This prevents
+    /// limit resolutions to those present on that first index (`first-match`). This prevents
     /// "dependency confusion" attacks, whereby an attack can upload a malicious package under the
     /// same name to a secondary
     #[arg(long, value_enum, env = "UV_INDEX_STRATEGY")]

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -163,7 +163,8 @@ async fn venv_impl(
 
     writeln!(
         printer.stderr(),
-        "Creating virtualenv at: {}",
+        "Creating virtualenv {}at: {}",
+        if seed { "with seed packages " } else { "" },
         path.user_display().cyan()
     )
     .into_diagnostic()?;

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -210,7 +210,7 @@ fn seed() {
 
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    Creating virtualenv at: .venv
+    Creating virtualenv with seed packages at: .venv
      + pip==24.0
     Activate with: source .venv/bin/activate
     "###
@@ -221,19 +221,19 @@ fn seed() {
 
 #[test]
 fn seed_older_python_version() {
-    let context = TestContext::new_with_versions(&["3.10"]);
+    let context = TestContext::new_with_versions(&["3.11"]);
     uv_snapshot!(context.filters(), context.venv()
         .arg(context.venv.as_os_str())
         .arg("--seed")
         .arg("--python")
-        .arg("3.10"), @r###"
+        .arg("3.11"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    Using Python 3.10.[X] interpreter at: [PYTHON-3.10]
-    Creating virtualenv at: .venv
+    Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
+    Creating virtualenv with seed packages at: .venv
      + pip==24.0
      + setuptools==69.2.0
      + wheel==0.43.0


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

Closes #1329.

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Mentions use of seed packages during `uv venv --seed`, and clarifies the divergence in behavior when using Python 3.12+.

## Test Plan

<!-- How was it tested? -->

`cargo nextest run --test venv`
