### PR TITLE
Make `--universal` and `--python-platform` mutually exclusive

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -575,7 +575,11 @@ pub struct PipCompileArgs {
     /// In universal mode, the current Python version (or user-provided `--python-version`) will be
     /// treated as a lower bound. For example, `--universal --python-version 3.7` would produce a
     /// universal resolution for Python 3.7 and later.
-    #[arg(long, overrides_with("no_universal"))]
+    #[arg(
+        long,
+        overrides_with("no_universal"),
+        conflicts_with("python_platform")
+    )]
     pub universal: bool,
 
     #[arg(long, overrides_with("universal"), hide = true)]


### PR DESCRIPTION
## Summary

Open to just making this a warning but no strong opinion.

Closes https://github.com/astral-sh/uv/issues/4593.

## Test Plan

Failure:

```
❯ echo "pandas==2.2.2" | cargo run pip compile --universal -p 3.11 --no-header - --python-platform linux
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/uv pip compile --universal -p 3.11 --no-header - --python-platform linux`
error: the argument '--universal' cannot be used with '--python-platform <PYTHON_PLATFORM>'

Usage: uv pip compile --universal --python-version <PYTHON_VERSION> --no-header <SRC_FILE>...

For more information, try '--help'.
```
