### PR TITLE
Drop `prefer` prefix from `toolchain-preference` values

### DIFF
--- a/crates/uv-toolchain/src/toolchain.rs
+++ b/crates/uv-toolchain/src/toolchain.rs
@@ -88,9 +88,7 @@ impl Toolchain {
         let request = request.unwrap_or_default();
 
         // Perform a fetch aggressively if managed toolchains are preferred
-        if matches!(preference, ToolchainPreference::PreferManaged)
-            && toolchain_fetch.is_automatic()
-        {
+        if matches!(preference, ToolchainPreference::Managed) && toolchain_fetch.is_automatic() {
             if let Some(request) = PythonDownloadRequest::try_from_request(&request) {
                 return Self::fetch(request, client_builder, cache).await;
             }

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -711,7 +711,7 @@ pub fn python_toolchains_for_versions(
             if let Ok(toolchain) = Toolchain::find(
                 &ToolchainRequest::parse(python_version),
                 EnvironmentPreference::OnlySystem,
-                ToolchainPreference::PreferManaged,
+                ToolchainPreference::Managed,
                 &cache,
             ) {
                 toolchain.into_interpreter().sys_executable().to_owned()

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1218,35 +1218,35 @@
     "ToolchainPreference": {
       "oneOf": [
         {
-          "description": "Only use managed toolchains, never use system toolchains.",
+          "description": "Only use managed toolchains; never use system toolchains.",
           "type": "string",
           "enum": [
             "only-managed"
           ]
         },
         {
-          "description": "Prefer installed toolchains, only download managed toolchains if no system toolchain is found.",
+          "description": "Prefer installed toolchains, only download managed toolchains if no system toolchain is found.\n\nInstalled managed toolchains are still preferred over system toolchains.",
           "type": "string",
           "enum": [
             "installed"
           ]
         },
         {
-          "description": "Prefer managed toolchains over system toolchains, even if one needs to be downloaded.",
+          "description": "Prefer managed toolchains over system toolchains, even if fetching is required.",
           "type": "string",
           "enum": [
-            "prefer-managed"
+            "managed"
           ]
         },
         {
-          "description": "Prefer system toolchains, only use managed toolchains if no system toolchain is found.",
+          "description": "Prefer system toolchains over managed toolchains.\n\nIf a system toolchain cannot be found, a managed toolchain can be used.",
           "type": "string",
           "enum": [
-            "prefer-system"
+            "system"
           ]
         },
         {
-          "description": "Only use system toolchains, never use managed toolchains.",
+          "description": "Only use system toolchains; never use managed toolchains.",
           "type": "string",
           "enum": [
             "only-system"


### PR DESCRIPTION
I think `--toolchain-preference system` is sufficiently clear and `--toolchain-preference prefer-system` is excessively verbose. This was discussed in the original pull request at https://github.com/astral-sh/uv/pull/4424 but because we had a case for preferring "installed managed" toolchains I was hesitant to change it. Now that I've dropped that in #4601, I think we can drop the prefix.