### PR TITLE
Retry on spurious failures when caching built wheels

### DIFF
--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -30,7 +30,7 @@ use pep440_rs::Version;
 use pep508_rs::PackageName;
 use pypi_types::{Requirement, VerbatimParsedUrl};
 use uv_configuration::{BuildKind, ConfigSettings, SetupPyStrategy};
-use uv_fs::{PythonExt, Simplified};
+use uv_fs::{rename_with_retry, PythonExt, Simplified};
 use uv_toolchain::{Interpreter, PythonEnvironment};
 use uv_types::{BuildContext, BuildIsolation, SourceBuildTrait};
 
@@ -757,7 +757,7 @@ impl SourceBuild {
 
             let from = tmp_dir.path().join(&filename);
             let to = wheel_dir.join(&filename);
-            fs_err::rename(from, to)?;
+            rename_with_retry(from, to).await?;
             Ok(filename)
         } else {
             if self.build_kind != BuildKind::Wheel {


### PR DESCRIPTION
https://github.com/astral-sh/uv/pull/2419 appears to have only applied this retry to wheels that were already downloaded (though I would have to look more carefully to be certain). In https://github.com/astral-sh/uv/issues/1491, we've gotten continued reports of spurious failures on Windows and tracing reveals that we are not applying our retry logic during the rename. I believe we're in this code path — switching to our backoff retry should resolve the failures.