### PR TITLE
Replace all uses of `fs_err::tokio::rename` with `uv_fs::rename_with_retry`

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -30,7 +30,7 @@ use uv_client::{
 };
 use uv_configuration::{BuildKind, PreviewMode};
 use uv_extract::hash::Hasher;
-use uv_fs::{write_atomic, LockedFile};
+use uv_fs::{rename_with_retry, write_atomic, LockedFile};
 use uv_types::{BuildContext, SourceBuildTrait};
 
 use crate::distribution_database::ManagedClient;
@@ -1375,7 +1375,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         fs_err::tokio::create_dir_all(target.parent().expect("Cache entry to have parent"))
             .await
             .map_err(Error::CacheWrite)?;
-        fs_err::tokio::rename(extracted, &target)
+        rename_with_retry(extracted, &target)
             .await
             .map_err(Error::CacheWrite)?;
 

--- a/crates/uv-toolchain/src/downloads.rs
+++ b/crates/uv-toolchain/src/downloads.rs
@@ -17,7 +17,7 @@ use futures::TryStreamExt;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tracing::{debug, instrument};
 use url::Url;
-use uv_fs::Simplified;
+use uv_fs::{rename_with_retry, Simplified};
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -427,7 +427,7 @@ impl PythonDownload {
 
         // Persist it to the target
         debug!("Moving {} to {}", extracted.display(), path.user_display());
-        fs_err::tokio::rename(extracted, &path)
+        rename_with_retry(extracted, &path)
             .await
             .map_err(|err| Error::CopyError {
                 to: path.clone(),


### PR DESCRIPTION
Same as #4605 but includes persistence of extracted archives and toolchain downloads.