### PR TITLE
Private locks

### DIFF
--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -370,6 +370,19 @@ pub struct ToolUvWorkspace {
         "#
     )]
     pub members: Option<Vec<SerdePattern>>,
+    /// Packages to include as workspace private members.
+    ///
+    /// Supports both globs and explicit paths.
+    ///
+    /// For more information on the glob syntax, refer to the [`glob` documentation](https://docs.rs/glob/latest/glob/struct.Pattern.html).
+    #[option(
+        default = r#"[]"#,
+        value_type = "list[str]",
+        example = r#"
+            private-members = ["project1", "path/to/project2", "projects/*"]
+        "#
+    )]
+    pub private_members: Option<Vec<SerdePattern>>,
     /// Packages to exclude as workspace members. If a package matches both `members` and
     /// `exclude`, it will be excluded.
     ///

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -207,7 +207,7 @@ pub(crate) async fn add(
 
         // Discover or create the virtual environment.
         let venv = project::get_or_init_environment(
-            project.workspace(),
+            &project,
             python.as_deref().map(PythonRequest::parse),
             python_preference,
             python_downloads,
@@ -636,7 +636,7 @@ async fn lock_and_sync(
     let mut lock = project::lock::do_safe_lock(
         locked,
         frozen,
-        project.workspace(),
+        &project,
         venv.interpreter(),
         settings.into(),
         Box::new(DefaultResolveLogger),
@@ -735,7 +735,7 @@ async fn lock_and_sync(
             lock = project::lock::do_safe_lock(
                 locked,
                 frozen,
-                project.workspace(),
+                &project,
                 venv.interpreter(),
                 settings.into(),
                 Box::new(SummaryResolveLogger),

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -69,13 +69,13 @@ pub(crate) async fn export(
         VirtualProject::discover(project_dir, &DiscoveryOptions::default()).await?
     };
 
-    let VirtualProject::Project(project) = project else {
+    let VirtualProject::Project(_) = project else {
         return Err(anyhow::anyhow!("Legacy non-project roots are not supported in `uv export`; add a `[project]` table to your `pyproject.toml` to enable exports"));
     };
 
     // Find an interpreter for the project
     let interpreter = ProjectInterpreter::discover(
-        project.workspace(),
+        &project,
         python.as_deref().map(PythonRequest::parse),
         python_preference,
         python_downloads,
@@ -91,7 +91,7 @@ pub(crate) async fn export(
     let lock = match do_safe_lock(
         locked,
         frozen,
-        project.workspace(),
+        &project,
         &interpreter,
         settings.as_ref(),
         Box::new(DefaultResolveLogger),
@@ -140,7 +140,7 @@ pub(crate) async fn export(
         ExportFormat::RequirementsTxt => {
             let export = RequirementsTxtExport::from_lock(
                 &lock,
-                project.project_name(),
+                project.project_name().unwrap(),
                 &extras,
                 dev,
                 editable,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -155,7 +155,7 @@ pub(crate) async fn remove(
 
     // Discover or create the virtual environment.
     let venv = project::get_or_init_environment(
-        project.workspace(),
+        &project,
         python.as_deref().map(PythonRequest::parse),
         python_preference,
         python_downloads,
@@ -170,7 +170,7 @@ pub(crate) async fn remove(
     let lock = project::lock::do_safe_lock(
         locked,
         frozen,
-        project.workspace(),
+        &project,
         venv.interpreter(),
         settings.as_ref().into(),
         Box::new(DefaultResolveLogger),

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -470,7 +470,7 @@ pub(crate) async fn run(
                 // If we're not isolating the environment, reuse the base environment for the
                 // project.
                 project::get_or_init_environment(
-                    project.workspace(),
+                    &project,
                     python.as_deref().map(PythonRequest::parse),
                     python_preference,
                     python_downloads,
@@ -488,16 +488,13 @@ pub(crate) async fn run(
                 // If we're not syncing, we should still attempt to respect the locked preferences
                 // in any `--with` requirements.
                 if !isolated && !requirements.is_empty() {
-                    lock = project::lock::read(project.workspace())
-                        .await
-                        .ok()
-                        .flatten();
+                    lock = project::lock::read(&project).await.ok().flatten();
                 }
             } else {
                 let result = match project::lock::do_safe_lock(
                     locked,
                     frozen,
-                    project.workspace(),
+                    &project,
                     venv.interpreter(),
                     settings.as_ref().into(),
                     if show_resolution {

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -92,7 +92,7 @@ pub(crate) async fn sync(
 
     // Discover or create the virtual environment.
     let venv = project::get_or_init_environment(
-        target.workspace(),
+        &project,
         python.as_deref().map(PythonRequest::parse),
         python_preference,
         python_downloads,
@@ -106,7 +106,7 @@ pub(crate) async fn sync(
     let lock = match do_safe_lock(
         locked,
         frozen,
-        target.workspace(),
+        &project,
         venv.interpreter(),
         settings.as_ref().into(),
         Box::new(DefaultResolveLogger),

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -8,7 +8,7 @@ use uv_configuration::{Concurrency, TargetTriple};
 use uv_pep508::PackageName;
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest, PythonVersion};
 use uv_resolver::TreeDisplay;
-use uv_workspace::{DiscoveryOptions, Workspace};
+use uv_workspace::{DiscoveryOptions, VirtualProject};
 
 use crate::commands::pip::loggers::DefaultResolveLogger;
 use crate::commands::pip::resolution_markers;
@@ -42,11 +42,11 @@ pub(crate) async fn tree(
     printer: Printer,
 ) -> Result<ExitStatus> {
     // Find the project requirements.
-    let workspace = Workspace::discover(project_dir, &DiscoveryOptions::default()).await?;
+    let project = VirtualProject::discover(project_dir, &DiscoveryOptions::default()).await?;
 
     // Find an interpreter for the project
     let interpreter = ProjectInterpreter::discover(
-        &workspace,
+        &project,
         python.as_deref().map(PythonRequest::parse),
         python_preference,
         python_downloads,
@@ -62,7 +62,7 @@ pub(crate) async fn tree(
     let lock = project::lock::do_safe_lock(
         locked,
         frozen,
-        &workspace,
+        &project,
         &interpreter,
         settings.as_ref(),
         Box::new(DefaultResolveLogger),

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -172,8 +172,7 @@ async fn venv_impl(
                 // Only use the project environment path if we're invoked from the root
                 // This isn't strictly necessary and we may want to change it later, but this
                 // avoids a breaking change when adding project environment support to `uv venv`.
-                (project.workspace().install_path() == project_dir)
-                    .then(|| project.workspace().venv())
+                (project.workspace().install_path() == project_dir).then(|| project.venv())
             })
             .unwrap_or(PathBuf::from(".venv")),
     );

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -1724,3 +1724,67 @@ fn test_path_hopping() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_shared_libraries() {
+    let context = TestContext::new("3.12").with_filtered_counts();
+    let work_dir = context.temp_dir.join("shared-lib-ws");
+    copy_dir_ignore(workspaces_dir().join("shared-libs"), &work_dir)
+        .expect("Could not copy to temp dir");
+
+    uv_snapshot!(context.filters(), context.sync().env_remove("UV_EXCLUDE_NEWER")
+        .current_dir(&work_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+        Creating virtual environment at: .venv
+        Resolved [N] packages in [TIME]
+        Prepared [N] packages in [TIME]
+        Installed [N] packages in [TIME]
+         + shared-corelib==1.0.0 (from file://[TEMP_DIR]/shared-lib-ws/shared_corelib)
+         + shared-lib==1.0.0 (from file://[TEMP_DIR]/shared-lib-ws/shared_lib)
+         + six==1.16.0
+         + tqdm==4.66.2
+         "###);
+
+    for (app_name, numpy_version) in [("app1", "2.0.0"), ("app2", "1.26.4")] {
+        let app_dir = work_dir.join(app_name);
+
+        let mut filters = context.filters();
+
+        filters.push((app_name, "[app_name]"));
+        filters.push((numpy_version, "[numpy_version]"));
+
+        insta::allow_duplicates! {
+                uv_snapshot!(filters, context.run().env_remove("UV_EXCLUDE_NEWER")
+        .arg(format!("{app_name}/app.py"))
+        .current_dir(&app_dir), @r###"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+        shared-lib is loaded from [TEMP_DIR]/shared-lib-ws/shared_lib/shared_lib/__init__.py
+        six 1.16.0
+        shared-corelib is loaded from [TEMP_DIR]/shared-lib-ws/shared_corelib/shared_corelib/__init__.py
+        tqdm 4.66.2
+        numpy [numpy_version]
+
+        ----- stderr -----
+        warning: `VIRTUAL_ENV=[VENV]/` does not match the project environment path `.venv` and will be ignored
+        Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
+        Creating virtual environment at: .venv
+        Resolved [N] packages in [TIME]
+        Prepared [N] packages in [TIME]
+        Installed [N] packages in [TIME]
+         + [app_name]==1.0.0 (from file://[TEMP_DIR]/shared-lib-ws/[app_name])
+         + numpy==[numpy_version]
+         + shared-corelib==1.0.0 (from file://[TEMP_DIR]/shared-lib-ws/shared_corelib)
+         + shared-lib==1.0.0 (from file://[TEMP_DIR]/shared-lib-ws/shared_lib)
+         + six==1.16.0
+         + tqdm==4.66.2
+         "###);
+        }
+    }
+}

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -200,6 +200,28 @@ members = ["member1", "path/to/member2", "libs/*"]
 
 ---
 
+#### [`private-members`](#workspace_private-members) {: #workspace_private-members }
+<span id="private-members"></span>
+
+Packages to include as workspace private members.
+
+Supports both globs and explicit paths.
+
+For more information on the glob syntax, refer to the [`glob` documentation](https://docs.rs/glob/latest/glob/struct.Pattern.html).
+
+**Default value**: `[]`
+
+**Type**: `list[str]`
+
+**Example usage**:
+
+```toml title="pyproject.toml"
+[tool.uv.workspace]
+private-members = ["project1", "path/to/project2", "projects/*"]
+```
+
+---
+
 ## Configuration
 ### [`allow-insecure-host`](#allow-insecure-host) {: #allow-insecure-host }
 

--- a/scripts/workspaces/shared-libs/README.md
+++ b/scripts/workspaces/shared-libs/README.md
@@ -1,0 +1,15 @@
+This is a simple workspace with 2 applications `app1` and `app2` and 2 libraries.
+
+The applications have conflicting dependencies:
+
+- `app1` depends on `numpy == 2.0.0`
+- `app2` depends on `numpy == 1.26.4`
+
+Both `app1` and `app2` depend on another workspace member `shared_lib`, which in turn depends on
+`shared_corelib`.
+
+The workspace will create 3 `uv.lock` and `.venv`:
+
+- in the root, containing `shared_lib` and `shared_corelib`
+- in `app1`, with `app1`, `shared_lib`, `shared_corelib`
+- in `app2`, with `app2`, `shared_lib`, `shared_corelib`

--- a/scripts/workspaces/shared-libs/app1/app1/app.py
+++ b/scripts/workspaces/shared-libs/app1/app1/app.py
@@ -1,0 +1,9 @@
+from shared_lib import hello_shared
+import numpy as np
+
+def main():
+    hello_shared()
+    print(f"numpy {np.__version__}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/workspaces/shared-libs/app1/pyproject.toml
+++ b/scripts/workspaces/shared-libs/app1/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "app1"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies=[
+    "shared_lib",
+    "numpy == 2.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["app1"]
+
+[tool.uv.sources]
+shared_lib = { workspace = true }

--- a/scripts/workspaces/shared-libs/app2/app2/app.py
+++ b/scripts/workspaces/shared-libs/app2/app2/app.py
@@ -1,0 +1,9 @@
+from shared_lib import hello_shared
+import numpy as np
+
+def main():
+    hello_shared()
+    print(f"numpy {np.__version__}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/workspaces/shared-libs/app2/pyproject.toml
+++ b/scripts/workspaces/shared-libs/app2/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "app2"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies=[
+    "shared_lib",
+    "numpy == 1.26.4",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["app1"]
+
+[tool.uv.sources]
+shared_lib = { workspace = true }

--- a/scripts/workspaces/shared-libs/pyproject.toml
+++ b/scripts/workspaces/shared-libs/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.uv.workspace]
+members = ["shared_*"]
+private-members = ["app*"]

--- a/scripts/workspaces/shared-libs/shared_corelib/pyproject.toml
+++ b/scripts/workspaces/shared-libs/shared_corelib/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "shared_corelib"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies = ["tqdm == 4.66.2"]
+
+[build-system]
+requires = ["hatchling==1.24.2"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["shared_corelib"]
+

--- a/scripts/workspaces/shared-libs/shared_corelib/shared_corelib/__init__.py
+++ b/scripts/workspaces/shared-libs/shared_corelib/shared_corelib/__init__.py
@@ -1,0 +1,5 @@
+import tqdm
+
+def hello_shared_core():
+    print(f"shared-corelib is loaded from {__file__}")
+    print(f"tqdm {tqdm.__version__}")

--- a/scripts/workspaces/shared-libs/shared_lib/pyproject.toml
+++ b/scripts/workspaces/shared-libs/shared_lib/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "shared_lib"
+version = "1.0.0"
+requires-python = ">=3.12"
+dependencies=[
+    "six == 1.16.0",
+    "shared_corelib",
+]
+
+[build-system]
+requires = ["hatchling==1.24.2"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["shared_lib"]
+
+[tool.uv.sources]
+shared_corelib = { workspace = true }

--- a/scripts/workspaces/shared-libs/shared_lib/shared_lib/__init__.py
+++ b/scripts/workspaces/shared-libs/shared_lib/shared_lib/__init__.py
@@ -1,0 +1,7 @@
+import six
+from shared_corelib import hello_shared_core
+
+def hello_shared():
+    print(f"shared-lib is loaded from {__file__}")
+    print(f"six {six.__version__}")
+    hello_shared_core()

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1568,6 +1568,16 @@
           "items": {
             "$ref": "#/definitions/String"
           }
+        },
+        "private-members": {
+          "description": "Packages to include as workspace private members.\n\nSupports both globs and explicit paths.\n\nFor more information on the glob syntax, refer to the [`glob` documentation](https://docs.rs/glob/latest/glob/struct.Pattern.html).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/String"
+          }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

A basic implementation for #4574.

This introduces `private-members` to `[tool.uv.workspace]`.
Private members are not included in the workspace `uv.lock` and `.venv`, but have their own instead.

The code could use some polish, and we'd need to make sure pip commands and workspace commands work consistently.

Otherwise I think it's good enough to review.

The basic implementation is in [workspace.rs](https://github.com/idlsoft/uv/blob/private_locks/crates/uv-workspace/src/workspace.rs).
There is a new `private_lock` field in `WorkspaceMember`.
The following functions moved from `Workspace` to `VirtualProject` and depend on `private_lock`:
```rust
pub fn venv(&self) -> PathBuf
pub fn lockfile(&self) -> PathBuf
pub fn members_as_requirements(&self) -> Vec<Requirement>
pub fn constraints(&self) -> Vec<Requirement>
pub fn overrides(&self) -> Vec<Requirement>
```
The rest is some refactoring to make the calls possible.
These include changing the `Workspace` argument to `VirtualProject` for the following functions in [mod.rs](https://github.com/idlsoft/uv/blob/private_locks/crates/uv/src/commands/project/mod.rs):
- `find_environment`
- `FoundInterpreter::discover`
- `get_or_init_environment`

I split it in a few commits to make following the changes easier.


## Test Plan

A sample workspace and unittest.
