### PR TITLE
Normalize fork markers

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -43,6 +43,7 @@ use crate::dependency_provider::UvDependencyProvider;
 use crate::error::ResolveError;
 use crate::fork_urls::ForkUrls;
 use crate::manifest::Manifest;
+use crate::marker::normalize;
 use crate::pins::FilePins;
 use crate::preferences::Preferences;
 use crate::pubgrub::{
@@ -548,6 +549,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                     cur_state = Some(forked_state.clone());
                                 }
                                 forked_state.markers.and(fork.markers);
+                                forked_state.markers = normalize(forked_state.markers)
+                                    .unwrap_or(MarkerTree::And(Vec::new()));
 
                                 forked_state.add_package_version_dependencies(
                                     for_package.as_deref(),
@@ -1719,14 +1722,7 @@ impl SolveState {
             }
 
             if let Some(for_package) = for_package {
-                if self.markers == MarkerTree::And(Vec::new()) {
-                    debug!("Adding transitive dependency for {for_package}: {package}{version}",);
-                } else {
-                    debug!(
-                        "Adding transitive dependency for {for_package}{{{}}}: {package}{version}",
-                        self.markers
-                    );
-                }
+                debug!("Adding transitive dependency for {for_package}: {package}{version}");
             } else {
                 // A dependency from the root package or requirements.txt.
                 debug!("Adding direct dependency: {package}{version}");


### PR DESCRIPTION
Looks much better than #4618:

```
DEBUG Pre-fork split universal took 0.644s
DEBUG Split python_version >= '3.12' and platform_machine == 'aarch64' and platform_system == 'Darwin' and platform_system == 'Linux' took 0.659s
DEBUG Split python_version == '3.9' and platform_machine == 'arm64' and platform_system == 'Darwin' took 0.291s
```