### PR TITLE
make `source` field in lock file more structured

### DIFF
--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -2376,4 +2376,60 @@ wheels = [{ url = "file:///foo/bar/anyio-4.3.0-py3-none-any.whl", hash = "sha256
         let result: Result<Lock, _> = toml::from_str(data);
         insta::assert_debug_snapshot!(result);
     }
+
+    #[test]
+    fn source_direct_no_subdir() {
+        let data = r#"
+version = 1
+
+[[distribution]]
+name = "anyio"
+version = "4.3.0"
+source = { url = "https://burntsushi.net" }
+"#;
+        let result: Result<Lock, _> = toml::from_str(data);
+        insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn source_direct_has_subdir() {
+        let data = r#"
+version = 1
+
+[[distribution]]
+name = "anyio"
+version = "4.3.0"
+source = { url = "https://burntsushi.net", subdirectory = "wat/foo/bar" }
+"#;
+        let result: Result<Lock, _> = toml::from_str(data);
+        insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn source_directory() {
+        let data = r#"
+version = 1
+
+[[distribution]]
+name = "anyio"
+version = "4.3.0"
+source = { directory = "path/to/dir" }
+"#;
+        let result: Result<Lock, _> = toml::from_str(data);
+        insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn source_editable() {
+        let data = r#"
+version = 1
+
+[[distribution]]
+name = "anyio"
+version = "4.3.0"
+source = { editable = "path/to/dir" }
+"#;
+        let result: Result<Lock, _> = toml::from_str(data);
+        insta::assert_debug_snapshot!(result);
+    }
 }

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
@@ -1,0 +1,77 @@
+---
+source: crates/uv-resolver/src/lock.rs
+expression: result
+---
+Ok(
+    Lock {
+        version: 1,
+        distributions: [
+            Distribution {
+                id: DistributionId {
+                    name: PackageName(
+                        "anyio",
+                    ),
+                    version: "4.3.0",
+                    source: Direct(
+                        Url {
+                            scheme: "https",
+                            cannot_be_a_base: false,
+                            username: "",
+                            password: None,
+                            host: Some(
+                                Domain(
+                                    "burntsushi.net",
+                                ),
+                            ),
+                            port: None,
+                            path: "/",
+                            query: None,
+                            fragment: None,
+                        },
+                        DirectSource {
+                            subdirectory: Some(
+                                "wat/foo/bar",
+                            ),
+                        },
+                    ),
+                },
+                sdist: None,
+                wheels: [],
+                dependencies: [],
+                optional_dependencies: {},
+                dev_dependencies: {},
+            },
+        ],
+        requires_python: None,
+        by_id: {
+            DistributionId {
+                name: PackageName(
+                    "anyio",
+                ),
+                version: "4.3.0",
+                source: Direct(
+                    Url {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "burntsushi.net",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                    DirectSource {
+                        subdirectory: Some(
+                            "wat/foo/bar",
+                        ),
+                    },
+                ),
+            }: 0,
+        },
+    },
+)

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
@@ -1,0 +1,73 @@
+---
+source: crates/uv-resolver/src/lock.rs
+expression: result
+---
+Ok(
+    Lock {
+        version: 1,
+        distributions: [
+            Distribution {
+                id: DistributionId {
+                    name: PackageName(
+                        "anyio",
+                    ),
+                    version: "4.3.0",
+                    source: Direct(
+                        Url {
+                            scheme: "https",
+                            cannot_be_a_base: false,
+                            username: "",
+                            password: None,
+                            host: Some(
+                                Domain(
+                                    "burntsushi.net",
+                                ),
+                            ),
+                            port: None,
+                            path: "/",
+                            query: None,
+                            fragment: None,
+                        },
+                        DirectSource {
+                            subdirectory: None,
+                        },
+                    ),
+                },
+                sdist: None,
+                wheels: [],
+                dependencies: [],
+                optional_dependencies: {},
+                dev_dependencies: {},
+            },
+        ],
+        requires_python: None,
+        by_id: {
+            DistributionId {
+                name: PackageName(
+                    "anyio",
+                ),
+                version: "4.3.0",
+                source: Direct(
+                    Url {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "burntsushi.net",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                    DirectSource {
+                        subdirectory: None,
+                    },
+                ),
+            }: 0,
+        },
+    },
+)

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_directory.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_directory.snap
@@ -1,0 +1,39 @@
+---
+source: crates/uv-resolver/src/lock.rs
+expression: result
+---
+Ok(
+    Lock {
+        version: 1,
+        distributions: [
+            Distribution {
+                id: DistributionId {
+                    name: PackageName(
+                        "anyio",
+                    ),
+                    version: "4.3.0",
+                    source: Directory(
+                        "path/to/dir",
+                    ),
+                },
+                sdist: None,
+                wheels: [],
+                dependencies: [],
+                optional_dependencies: {},
+                dev_dependencies: {},
+            },
+        ],
+        requires_python: None,
+        by_id: {
+            DistributionId {
+                name: PackageName(
+                    "anyio",
+                ),
+                version: "4.3.0",
+                source: Directory(
+                    "path/to/dir",
+                ),
+            }: 0,
+        },
+    },
+)

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_editable.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_editable.snap
@@ -1,0 +1,39 @@
+---
+source: crates/uv-resolver/src/lock.rs
+expression: result
+---
+Ok(
+    Lock {
+        version: 1,
+        distributions: [
+            Distribution {
+                id: DistributionId {
+                    name: PackageName(
+                        "anyio",
+                    ),
+                    version: "4.3.0",
+                    source: Editable(
+                        "path/to/dir",
+                    ),
+                },
+                sdist: None,
+                wheels: [],
+                dependencies: [],
+                optional_dependencies: {},
+                dev_dependencies: {},
+            },
+        ],
+        requires_python: None,
+        by_id: {
+            DistributionId {
+                name: PackageName(
+                    "anyio",
+                ),
+                version: "4.3.0",
+                source: Editable(
+                    "path/to/dir",
+                ),
+            }: 0,
+        },
+    },
+)

--- a/crates/uv/tests/branching_urls.rs
+++ b/crates/uv/tests/branching_urls.rs
@@ -326,16 +326,16 @@ fn branching_between_registry_and_direct_url() -> Result<()> {
     [[distribution]]
     name = "a"
     version = "0.1.0"
-    source = "editable+."
+    source = { editable = "." }
     dependencies = [
-        { name = "iniconfig", version = "1.1.1", source = "registry+https://pypi.org/simple", marker = "python_version < '3.12'" },
-        { name = "iniconfig", version = "2.0.0", source = "direct+https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", marker = "python_version >= '3.12'" },
+        { name = "iniconfig", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '3.12'" },
+        { name = "iniconfig", version = "2.0.0", source = { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" }, marker = "python_version >= '3.12'" },
     ]
 
     [[distribution]]
     name = "iniconfig"
     version = "1.1.1"
-    source = "registry+https://pypi.org/simple"
+    source = { registry = "https://pypi.org/simple" }
     sdist = { url = "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32", size = 8104 }
     wheels = [
         { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3", size = 4990 },
@@ -344,7 +344,7 @@ fn branching_between_registry_and_direct_url() -> Result<()> {
     [[distribution]]
     name = "iniconfig"
     version = "2.0.0"
-    source = "direct+https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl"
+    source = { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" }
     wheels = [
         { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" },
     ]
@@ -392,16 +392,16 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     [[distribution]]
     name = "a"
     version = "0.1.0"
-    source = "editable+."
+    source = { editable = "." }
     dependencies = [
-        { name = "iniconfig", version = "1.1.1", source = "direct+https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", marker = "python_version < '3.12'" },
-        { name = "iniconfig", version = "2.0.0", source = "git+https://github.com/pytest-dev/iniconfig?rev=93f5930e668c0d1ddf4597e38dd0dea4e2665e7a#93f5930e668c0d1ddf4597e38dd0dea4e2665e7a", marker = "python_version >= '3.12'" },
+        { name = "iniconfig", version = "1.1.1", source = { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl" }, marker = "python_version < '3.12'" },
+        { name = "iniconfig", version = "2.0.0", source = { git = "https://github.com/pytest-dev/iniconfig?rev=93f5930e668c0d1ddf4597e38dd0dea4e2665e7a#93f5930e668c0d1ddf4597e38dd0dea4e2665e7a" }, marker = "python_version >= '3.12'" },
     ]
 
     [[distribution]]
     name = "iniconfig"
     version = "1.1.1"
-    source = "direct+https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl"
+    source = { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl" }
     wheels = [
         { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3" },
     ]
@@ -409,7 +409,7 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     [[distribution]]
     name = "iniconfig"
     version = "2.0.0"
-    source = "git+https://github.com/pytest-dev/iniconfig?rev=93f5930e668c0d1ddf4597e38dd0dea4e2665e7a#93f5930e668c0d1ddf4597e38dd0dea4e2665e7a"
+    source = { git = "https://github.com/pytest-dev/iniconfig?rev=93f5930e668c0d1ddf4597e38dd0dea4e2665e7a#93f5930e668c0d1ddf4597e38dd0dea4e2665e7a" }
     "###);
 
     Ok(())

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -72,7 +72,7 @@ fn add_registry() -> Result<()> {
         [[distribution]]
         name = "anyio"
         version = "3.7.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
         dependencies = [
             { name = "idna" },
@@ -85,7 +85,7 @@ fn add_registry() -> Result<()> {
         [[distribution]]
         name = "idna"
         version = "3.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
@@ -94,7 +94,7 @@ fn add_registry() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "anyio" },
         ]
@@ -102,7 +102,7 @@ fn add_registry() -> Result<()> {
         [[distribution]]
         name = "sniffio"
         version = "1.3.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
@@ -224,7 +224,7 @@ fn add_git() -> Result<()> {
         [[distribution]]
         name = "anyio"
         version = "3.7.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
         dependencies = [
             { name = "idna" },
@@ -237,7 +237,7 @@ fn add_git() -> Result<()> {
         [[distribution]]
         name = "idna"
         version = "3.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
@@ -246,7 +246,7 @@ fn add_git() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "anyio" },
             { name = "uv-public-pypackage" },
@@ -255,7 +255,7 @@ fn add_git() -> Result<()> {
         [[distribution]]
         name = "sniffio"
         version = "1.3.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
@@ -264,7 +264,7 @@ fn add_git() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = "git+https://github.com/astral-test/uv-public-pypackage?tag=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979"
+        source = { git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
         "###
         );
     });
@@ -370,7 +370,7 @@ fn add_git_raw() -> Result<()> {
         [[distribution]]
         name = "anyio"
         version = "3.7.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
         dependencies = [
             { name = "idna" },
@@ -383,7 +383,7 @@ fn add_git_raw() -> Result<()> {
         [[distribution]]
         name = "idna"
         version = "3.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
@@ -392,7 +392,7 @@ fn add_git_raw() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "anyio" },
             { name = "uv-public-pypackage" },
@@ -401,7 +401,7 @@ fn add_git_raw() -> Result<()> {
         [[distribution]]
         name = "sniffio"
         version = "1.3.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
@@ -410,7 +410,7 @@ fn add_git_raw() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = "git+https://github.com/astral-test/uv-public-pypackage?rev=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979"
+        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
         "###
         );
     });
@@ -492,7 +492,7 @@ fn add_unnamed() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "uv-public-pypackage" },
         ]
@@ -500,7 +500,7 @@ fn add_unnamed() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = "git+https://github.com/astral-test/uv-public-pypackage?tag=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979"
+        source = { git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
         "###
         );
     });
@@ -584,7 +584,7 @@ fn add_remove_dev() -> Result<()> {
         [[distribution]]
         name = "anyio"
         version = "3.7.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
         dependencies = [
             { name = "idna" },
@@ -597,7 +597,7 @@ fn add_remove_dev() -> Result<()> {
         [[distribution]]
         name = "idna"
         version = "3.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
@@ -606,7 +606,7 @@ fn add_remove_dev() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
 
         [distribution.dev-dependencies]
         dev = [
@@ -616,7 +616,7 @@ fn add_remove_dev() -> Result<()> {
         [[distribution]]
         name = "sniffio"
         version = "1.3.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
@@ -699,7 +699,7 @@ fn add_remove_dev() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         "###
         );
     });
@@ -780,7 +780,7 @@ fn add_remove_optional() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         "###
         );
     });
@@ -856,7 +856,7 @@ fn add_remove_optional() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         "###
         );
     });
@@ -979,7 +979,7 @@ fn add_remove_workspace() -> Result<()> {
         [[distribution]]
         name = "child1"
         version = "0.1.0"
-        source = "editable+child1"
+        source = { editable = "child1" }
         dependencies = [
             { name = "child2" },
         ]
@@ -987,7 +987,7 @@ fn add_remove_workspace() -> Result<()> {
         [[distribution]]
         name = "child2"
         version = "0.1.0"
-        source = "editable+child2"
+        source = { editable = "child2" }
         "###
         );
     });
@@ -1051,12 +1051,12 @@ fn add_remove_workspace() -> Result<()> {
         [[distribution]]
         name = "child1"
         version = "0.1.0"
-        source = "editable+child1"
+        source = { editable = "child1" }
 
         [[distribution]]
         name = "child2"
         version = "0.1.0"
-        source = "editable+child2"
+        source = { editable = "child2" }
         "###
         );
     });
@@ -1159,7 +1159,7 @@ fn add_workspace_editable() -> Result<()> {
         [[distribution]]
         name = "child1"
         version = "0.1.0"
-        source = "editable+child1"
+        source = { editable = "child1" }
         dependencies = [
             { name = "child2" },
         ]
@@ -1167,7 +1167,7 @@ fn add_workspace_editable() -> Result<()> {
         [[distribution]]
         name = "child2"
         version = "0.1.0"
-        source = "editable+child2"
+        source = { editable = "child2" }
         "###
         );
     });
@@ -1352,7 +1352,7 @@ fn update() -> Result<()> {
         [[distribution]]
         name = "certifi"
         version = "2024.2.2"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/71/da/e94e26401b62acd6d91df2b52954aceb7f561743aa5ccc32152886c76c96/certifi-2024.2.2.tar.gz", hash = "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f", size = 164886 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl", hash = "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1", size = 163774 },
@@ -1361,7 +1361,7 @@ fn update() -> Result<()> {
         [[distribution]]
         name = "chardet"
         version = "5.2.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
@@ -1370,7 +1370,7 @@ fn update() -> Result<()> {
         [[distribution]]
         name = "charset-normalizer"
         version = "3.3.2"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5", size = 104809 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/2b/61/095a0aa1a84d1481998b534177c8566fdc50bb1233ea9a0478cd3cc075bd/charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3", size = 194219 },
@@ -1467,7 +1467,7 @@ fn update() -> Result<()> {
         [[distribution]]
         name = "idna"
         version = "3.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
@@ -1476,7 +1476,7 @@ fn update() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "requests", marker = "python_version > '3.7'" },
             { name = "requests", extra = "socks", marker = "python_version > '3.7'" },
@@ -1486,7 +1486,7 @@ fn update() -> Result<()> {
         [[distribution]]
         name = "pysocks"
         version = "1.7.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/a2/4b/52123768624ae28d84c97515dd96c9958888e8c2d8f122074e31e2be878c/PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299", size = 16726 },
@@ -1496,7 +1496,7 @@ fn update() -> Result<()> {
         [[distribution]]
         name = "requests"
         version = "2.32.3"
-        source = "git+https://github.com/psf/requests?tag=v2.32.3#0e322af87745eff34caffe4df68456ebc20d9068"
+        source = { git = "https://github.com/psf/requests?tag=v2.32.3#0e322af87745eff34caffe4df68456ebc20d9068" }
         dependencies = [
             { name = "certifi" },
             { name = "charset-normalizer" },
@@ -1515,7 +1515,7 @@ fn update() -> Result<()> {
         [[distribution]]
         name = "urllib3"
         version = "2.2.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/7a/50/7fd50a27caa0652cd4caf224aa87741ea41d3265ad13f010886167cfcc79/urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19", size = 291020 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d", size = 121067 },
@@ -1635,7 +1635,7 @@ fn add_no_clean() -> Result<()> {
         [[distribution]]
         name = "iniconfig"
         version = "2.0.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
@@ -1644,7 +1644,7 @@ fn add_no_clean() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "iniconfig" },
         ]
@@ -1766,7 +1766,7 @@ fn remove_registry() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         "###
         );
     });

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -48,7 +48,7 @@ fn lock_wheel_registry() -> Result<()> {
         [[distribution]]
         name = "anyio"
         version = "3.7.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
         dependencies = [
             { name = "idna" },
@@ -61,7 +61,7 @@ fn lock_wheel_registry() -> Result<()> {
         [[distribution]]
         name = "idna"
         version = "3.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
@@ -70,7 +70,7 @@ fn lock_wheel_registry() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "anyio" },
         ]
@@ -78,7 +78,7 @@ fn lock_wheel_registry() -> Result<()> {
         [[distribution]]
         name = "sniffio"
         version = "1.3.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
@@ -145,7 +145,7 @@ fn lock_sdist_registry() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "source-distribution" },
         ]
@@ -153,7 +153,7 @@ fn lock_sdist_registry() -> Result<()> {
         [[distribution]]
         name = "source-distribution"
         version = "0.0.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz", hash = "sha256:1f83ed7498336c7f2ab9b002cf22583d91115ebc624053dc4eb3a45694490106", size = 2157 }
         "###
         );
@@ -215,7 +215,7 @@ fn lock_sdist_git() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "uv-public-pypackage" },
         ]
@@ -223,7 +223,7 @@ fn lock_sdist_git() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = "git+https://github.com/astral-test/uv-public-pypackage?rev=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979"
+        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
         "###
         );
     });
@@ -284,7 +284,7 @@ fn lock_wheel_url() -> Result<()> {
         [[distribution]]
         name = "anyio"
         version = "4.3.0"
-        source = "direct+https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl"
+        source = { url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl" }
         dependencies = [
             { name = "idna" },
             { name = "sniffio" },
@@ -296,7 +296,7 @@ fn lock_wheel_url() -> Result<()> {
         [[distribution]]
         name = "idna"
         version = "3.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
@@ -305,7 +305,7 @@ fn lock_wheel_url() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "anyio" },
         ]
@@ -313,7 +313,7 @@ fn lock_wheel_url() -> Result<()> {
         [[distribution]]
         name = "sniffio"
         version = "1.3.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
@@ -380,7 +380,7 @@ fn lock_sdist_url() -> Result<()> {
         [[distribution]]
         name = "anyio"
         version = "4.3.0"
-        source = "direct+https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz"
+        source = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz" }
         sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6" }
         dependencies = [
             { name = "idna" },
@@ -390,7 +390,7 @@ fn lock_sdist_url() -> Result<()> {
         [[distribution]]
         name = "idna"
         version = "3.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
@@ -399,7 +399,7 @@ fn lock_sdist_url() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "anyio" },
         ]
@@ -407,7 +407,7 @@ fn lock_sdist_url() -> Result<()> {
         [[distribution]]
         name = "sniffio"
         version = "1.3.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
@@ -477,7 +477,7 @@ fn lock_project_extra() -> Result<()> {
         [[distribution]]
         name = "anyio"
         version = "3.7.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz", hash = "sha256:275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce", size = 142737 }
         dependencies = [
             { name = "idna" },
@@ -490,7 +490,7 @@ fn lock_project_extra() -> Result<()> {
         [[distribution]]
         name = "idna"
         version = "3.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
@@ -499,7 +499,7 @@ fn lock_project_extra() -> Result<()> {
         [[distribution]]
         name = "iniconfig"
         version = "2.0.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
@@ -508,7 +508,7 @@ fn lock_project_extra() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "anyio" },
         ]
@@ -521,7 +521,7 @@ fn lock_project_extra() -> Result<()> {
         [[distribution]]
         name = "sniffio"
         version = "1.3.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
@@ -651,7 +651,7 @@ fn lock_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "blinker"
         version = "1.7.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a1/13/6df5fc090ff4e5d246baf1f45fe9e5623aa8565757dfa5bd243f6a545f9e/blinker-1.7.0.tar.gz", hash = "sha256:e6820ff6fa4e4d1d8e2747c2283749c3f547e4fee112b98555cdcdae32996182", size = 28134 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/fa/2a/7f3714cbc6356a0efec525ce7a0613d581072ed6eb53eb7b9754f33db807/blinker-1.7.0-py3-none-any.whl", hash = "sha256:c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9", size = 13068 },
@@ -660,7 +660,7 @@ fn lock_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "click"
         version = "8.1.7"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
         dependencies = [
             { name = "colorama", marker = "platform_system == 'Windows'" },
@@ -672,7 +672,7 @@ fn lock_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "colorama"
         version = "0.4.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
@@ -681,7 +681,7 @@ fn lock_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "flask"
         version = "3.0.2"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/3f/e0/a89e8120faea1edbfca1a9b171cff7f2bf62ec860bbafcb2c2387c0317be/flask-3.0.2.tar.gz", hash = "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d", size = 675248 }
         dependencies = [
             { name = "blinker" },
@@ -702,7 +702,7 @@ fn lock_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "itsdangerous"
         version = "2.1.2"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/7f/a1/d3fb83e7a61fa0c0d3d08ad0a94ddbeff3731c05212617dff3a94e097f08/itsdangerous-2.1.2.tar.gz", hash = "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a", size = 56143 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl", hash = "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44", size = 15749 },
@@ -711,7 +711,7 @@ fn lock_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "jinja2"
         version = "3.1.3"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/b2/5e/3a21abf3cd467d7876045335e681d276ac32492febe6d98ad89562d1a7e1/Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90", size = 268261 }
         dependencies = [
             { name = "markupsafe" },
@@ -723,7 +723,7 @@ fn lock_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "markupsafe"
         version = "2.1.5"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b", size = 19384 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e4/54/ad5eb37bf9d51800010a74e4665425831a9db4e7c4e0fde4352e391e808e/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc", size = 18206 },
@@ -790,7 +790,7 @@ fn lock_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "flask" },
             { name = "flask", extra = "dotenv" },
@@ -799,7 +799,7 @@ fn lock_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "python-dotenv"
         version = "1.0.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
@@ -808,7 +808,7 @@ fn lock_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "werkzeug"
         version = "3.0.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/0d/cc/ff1904eb5eb4b455e442834dabf9427331ac0fa02853bf83db817a7dd53d/werkzeug-3.0.1.tar.gz", hash = "sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc", size = 801436 }
         dependencies = [
             { name = "markupsafe" },
@@ -884,7 +884,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "certifi"
         version = "2024.2.2"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/71/da/e94e26401b62acd6d91df2b52954aceb7f561743aa5ccc32152886c76c96/certifi-2024.2.2.tar.gz", hash = "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f", size = 164886 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl", hash = "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1", size = 163774 },
@@ -893,7 +893,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "charset-normalizer"
         version = "3.0.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/96/d7/1675d9089a1f4677df5eb29c3f8b064aa1e70c1251a0a8a127803158942d/charset-normalizer-3.0.1.tar.gz", hash = "sha256:ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f", size = 92842 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/b2/4c/9a4f30042bfee22d34d80daf75f51817cdd23180d718e0160aab235c4faf/charset_normalizer-3.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88600c72ef7587fe1708fd242b385b6ed4b8904976d5da0893e31df8b3480cb6", size = 201319 },
@@ -988,7 +988,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "idna"
         version = "3.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
@@ -997,7 +997,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "requests" },
             { name = "requests", extra = "socks", marker = "python_version < '3.10'" },
@@ -1006,7 +1006,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "pysocks"
         version = "1.7.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/a2/4b/52123768624ae28d84c97515dd96c9958888e8c2d8f122074e31e2be878c/PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299", size = 16726 },
@@ -1016,7 +1016,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "requests"
         version = "2.31.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1", size = 110794 }
         dependencies = [
             { name = "certifi" },
@@ -1036,7 +1036,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         [[distribution]]
         name = "urllib3"
         version = "2.0.7"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/af/47/b215df9f71b4fdba1025fc05a77db2ad243fa0926755a52c5e71659f4e3c/urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84", size = 282546 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/d2/b2/b157855192a68541a91ba7b2bbcb91f1b4faa51f8bae38d8005c034be524/urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e", size = 124213 },
@@ -1131,7 +1131,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         [[distribution]]
         name = "blinker"
         version = "1.7.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a1/13/6df5fc090ff4e5d246baf1f45fe9e5623aa8565757dfa5bd243f6a545f9e/blinker-1.7.0.tar.gz", hash = "sha256:e6820ff6fa4e4d1d8e2747c2283749c3f547e4fee112b98555cdcdae32996182", size = 28134 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/fa/2a/7f3714cbc6356a0efec525ce7a0613d581072ed6eb53eb7b9754f33db807/blinker-1.7.0-py3-none-any.whl", hash = "sha256:c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9", size = 13068 },
@@ -1140,7 +1140,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         [[distribution]]
         name = "click"
         version = "8.1.7"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
         dependencies = [
             { name = "colorama", marker = "platform_system == 'Windows'" },
@@ -1152,7 +1152,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         [[distribution]]
         name = "colorama"
         version = "0.4.6"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
@@ -1161,7 +1161,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         [[distribution]]
         name = "flask"
         version = "3.0.2"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/3f/e0/a89e8120faea1edbfca1a9b171cff7f2bf62ec860bbafcb2c2387c0317be/flask-3.0.2.tar.gz", hash = "sha256:822c03f4b799204250a7ee84b1eddc40665395333973dfb9deebfe425fefcb7d", size = 675248 }
         dependencies = [
             { name = "blinker" },
@@ -1177,7 +1177,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         [[distribution]]
         name = "itsdangerous"
         version = "2.1.2"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/7f/a1/d3fb83e7a61fa0c0d3d08ad0a94ddbeff3731c05212617dff3a94e097f08/itsdangerous-2.1.2.tar.gz", hash = "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a", size = 56143 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/68/5f/447e04e828f47465eeab35b5d408b7ebaaaee207f48b7136c5a7267a30ae/itsdangerous-2.1.2-py3-none-any.whl", hash = "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44", size = 15749 },
@@ -1186,7 +1186,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         [[distribution]]
         name = "jinja2"
         version = "3.1.3"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/b2/5e/3a21abf3cd467d7876045335e681d276ac32492febe6d98ad89562d1a7e1/Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90", size = 268261 }
         dependencies = [
             { name = "markupsafe" },
@@ -1198,7 +1198,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         [[distribution]]
         name = "markupsafe"
         version = "2.1.5"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b", size = 19384 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e4/54/ad5eb37bf9d51800010a74e4665425831a9db4e7c4e0fde4352e391e808e/MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc", size = 18206 },
@@ -1265,7 +1265,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "flask" },
         ]
@@ -1273,7 +1273,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         [[distribution]]
         name = "werkzeug"
         version = "3.0.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/0d/cc/ff1904eb5eb4b455e442834dabf9427331ac0fa02853bf83db817a7dd53d/werkzeug-3.0.1.tar.gz", hash = "sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc", size = 801436 }
         dependencies = [
             { name = "markupsafe" },
@@ -1347,7 +1347,7 @@ fn lock_preference() -> Result<()> {
         [[distribution]]
         name = "iniconfig"
         version = "1.1.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32", size = 8104 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3", size = 4990 },
@@ -1356,7 +1356,7 @@ fn lock_preference() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "iniconfig" },
         ]
@@ -1399,7 +1399,7 @@ fn lock_preference() -> Result<()> {
         [[distribution]]
         name = "iniconfig"
         version = "1.1.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32", size = 8104 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3", size = 4990 },
@@ -1408,7 +1408,7 @@ fn lock_preference() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "iniconfig" },
         ]
@@ -1440,7 +1440,7 @@ fn lock_preference() -> Result<()> {
         [[distribution]]
         name = "iniconfig"
         version = "2.0.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
@@ -1449,7 +1449,7 @@ fn lock_preference() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "iniconfig" },
         ]
@@ -1500,7 +1500,7 @@ fn lock_git_sha() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "uv-public-pypackage" },
         ]
@@ -1508,7 +1508,7 @@ fn lock_git_sha() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = "git+https://github.com/astral-test/uv-public-pypackage?rev=0dacfd662c64cb4ceb16e6cf65a157a8b715b979#0dacfd662c64cb4ceb16e6cf65a157a8b715b979"
+        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=0dacfd662c64cb4ceb16e6cf65a157a8b715b979#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
         "###
         );
     });
@@ -1554,7 +1554,7 @@ fn lock_git_sha() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "uv-public-pypackage" },
         ]
@@ -1562,7 +1562,7 @@ fn lock_git_sha() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = "git+https://github.com/astral-test/uv-public-pypackage?rev=main#0dacfd662c64cb4ceb16e6cf65a157a8b715b979"
+        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=main#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
         "###
         );
     });
@@ -1593,7 +1593,7 @@ fn lock_git_sha() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "uv-public-pypackage" },
         ]
@@ -1601,7 +1601,7 @@ fn lock_git_sha() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = "git+https://github.com/astral-test/uv-public-pypackage?rev=main#b270df1a2fb5d012294e9aaf05e7e0bab1e6a389"
+        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=main#b270df1a2fb5d012294e9aaf05e7e0bab1e6a389" }
         "###
         );
     });
@@ -1687,7 +1687,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "attrs"
         version = "23.2.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30", size = 780820 }
         dependencies = [
             { name = "importlib-metadata", marker = "python_version < '3.8'" },
@@ -1699,7 +1699,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "cattrs"
         version = "23.1.2"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/68/d4/27f9fd840e74d51b6d6a024d39ff495b56ffde71d28eb82758b7b85d0617/cattrs-23.1.2.tar.gz", hash = "sha256:db1c821b8c537382b2c7c66678c3790091ca0275ac486c76f3c8f3920e83c657", size = 39998 }
         dependencies = [
             { name = "attrs" },
@@ -1713,7 +1713,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "exceptiongroup"
         version = "1.2.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/8e/1c/beef724eaf5b01bb44b6338c8c3494eff7cab376fab4904cfbbc3585dc79/exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68", size = 26264 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/b8/9a/5028fd52db10e600f1c4674441b968cf2ea4959085bfb5b99fb1250e5f68/exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14", size = 16210 },
@@ -1722,7 +1722,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "importlib-metadata"
         version = "6.7.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a3/82/f6e29c8d5c098b6be61460371c2c5591f4a335923639edec43b3830650a4/importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4", size = 53569 }
         dependencies = [
             { name = "typing-extensions", marker = "python_version < '3.8'" },
@@ -1735,7 +1735,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "lsprotocol"
         version = "2023.0.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/9d/f6/6e80484ec078d0b50699ceb1833597b792a6c695f90c645fbaf54b947e6f/lsprotocol-2023.0.1.tar.gz", hash = "sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d", size = 69434 }
         dependencies = [
             { name = "attrs" },
@@ -1748,7 +1748,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "pygls" },
         ]
@@ -1756,7 +1756,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "pygls"
         version = "1.0.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/8e/27/58ff0f76b379fc11a1d03e8d4b4e96fd0abb463d27709a7fb4193bcdbbc4/pygls-1.0.1.tar.gz", hash = "sha256:f3ee98ddbb4690eb5c755bc32ba7e129607f14cbd313575f33d0cea443b78cb2", size = 674546 }
         dependencies = [
             { name = "lsprotocol" },
@@ -1769,7 +1769,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "typeguard"
         version = "2.13.3"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/3a/38/c61bfcf62a7b572b5e9363a802ff92559cb427ee963048e1442e3aef7490/typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4", size = 40604 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/9a/bb/d43e5c75054e53efce310e79d63df0ac3f25e34c926be5dffb7d283fb2a8/typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1", size = 17605 },
@@ -1778,7 +1778,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "typing-extensions"
         version = "4.7.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/3c/8b/0111dd7d6c1478bf83baa1cab85c686426c7a6274119aceb2bd9d35395ad/typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2", size = 72876 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36", size = 33232 },
@@ -1787,7 +1787,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "zipp"
         version = "3.15.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b", size = 18454 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556", size = 6758 },
@@ -1833,7 +1833,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "attrs"
         version = "23.2.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30", size = 780820 }
         dependencies = [
             { name = "importlib-metadata", marker = "python_version < '3.8'" },
@@ -1845,7 +1845,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "cattrs"
         version = "23.1.2"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/68/d4/27f9fd840e74d51b6d6a024d39ff495b56ffde71d28eb82758b7b85d0617/cattrs-23.1.2.tar.gz", hash = "sha256:db1c821b8c537382b2c7c66678c3790091ca0275ac486c76f3c8f3920e83c657", size = 39998 }
         dependencies = [
             { name = "attrs" },
@@ -1859,7 +1859,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "exceptiongroup"
         version = "1.2.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/8e/1c/beef724eaf5b01bb44b6338c8c3494eff7cab376fab4904cfbbc3585dc79/exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68", size = 26264 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/b8/9a/5028fd52db10e600f1c4674441b968cf2ea4959085bfb5b99fb1250e5f68/exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14", size = 16210 },
@@ -1868,7 +1868,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "importlib-metadata"
         version = "6.7.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/a3/82/f6e29c8d5c098b6be61460371c2c5591f4a335923639edec43b3830650a4/importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4", size = 53569 }
         dependencies = [
             { name = "typing-extensions", marker = "python_version < '3.8'" },
@@ -1881,7 +1881,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "lsprotocol"
         version = "2023.0.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/3e/fe/f7671a4fb28606ff1663bba60aff6af21b1e43a977c74c33db13cb83680f/lsprotocol-2023.0.0.tar.gz", hash = "sha256:c9d92e12a3f4ed9317d3068226592860aab5357d93cf5b2451dc244eee8f35f2", size = 69399 }
         dependencies = [
             { name = "attrs" },
@@ -1894,7 +1894,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "pygls" },
         ]
@@ -1902,7 +1902,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "pygls"
         version = "1.2.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/e6/94/534c11ba5475df09542e48d751a66e0448d52bbbb92cbef5541deef7760d/pygls-1.2.1.tar.gz", hash = "sha256:04f9b9c115b622dcc346fb390289066565343d60245a424eca77cb429b911ed8", size = 45274 }
         dependencies = [
             { name = "lsprotocol" },
@@ -1914,7 +1914,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "typing-extensions"
         version = "4.7.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/3c/8b/0111dd7d6c1478bf83baa1cab85c686426c7a6274119aceb2bd9d35395ad/typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2", size = 72876 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36", size = 33232 },
@@ -1923,7 +1923,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "zipp"
         version = "3.15.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz", hash = "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b", size = 18454 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl", hash = "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556", size = 6758 },
@@ -1969,7 +1969,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "attrs"
         version = "23.2.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30", size = 780820 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1", size = 60752 },
@@ -1978,7 +1978,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "cattrs"
         version = "23.2.3"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/1e/57/c6ccd22658c4bcb3beb3f1c262e1f170cf136e913b122763d0ddd328d284/cattrs-23.2.3.tar.gz", hash = "sha256:a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f", size = 610215 }
         dependencies = [
             { name = "attrs" },
@@ -1990,7 +1990,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "lsprotocol"
         version = "2023.0.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/9d/f6/6e80484ec078d0b50699ceb1833597b792a6c695f90c645fbaf54b947e6f/lsprotocol-2023.0.1.tar.gz", hash = "sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d", size = 69434 }
         dependencies = [
             { name = "attrs" },
@@ -2003,7 +2003,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "pygls" },
         ]
@@ -2011,7 +2011,7 @@ fn lock_requires_python() -> Result<()> {
         [[distribution]]
         name = "pygls"
         version = "1.3.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/e9/8d/31b50ac0879464049d744a1ddf00dc6474433eb55d40fa0c8e8510591ad2/pygls-1.3.0.tar.gz", hash = "sha256:1b44ace89c9382437a717534f490eadc6fda7c0c6c16ac1eaaf5568e345e4fb8", size = 45539 }
         dependencies = [
             { name = "cattrs" },
@@ -2096,7 +2096,7 @@ fn lock_requires_python_star() -> Result<()> {
         [[distribution]]
         name = "attrs"
         version = "23.2.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30", size = 780820 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1", size = 60752 },
@@ -2105,7 +2105,7 @@ fn lock_requires_python_star() -> Result<()> {
         [[distribution]]
         name = "cattrs"
         version = "23.2.3"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/1e/57/c6ccd22658c4bcb3beb3f1c262e1f170cf136e913b122763d0ddd328d284/cattrs-23.2.3.tar.gz", hash = "sha256:a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f", size = 610215 }
         dependencies = [
             { name = "attrs" },
@@ -2117,7 +2117,7 @@ fn lock_requires_python_star() -> Result<()> {
         [[distribution]]
         name = "linehaul"
         version = "1.0.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/f8/e7/74d1bd36ed26ac43bfe22e97129edaa7066f7af4bf76084b9493cd581d58/linehaul-1.0.1.tar.gz", hash = "sha256:09d71b1f6a9ab92dd8c763b3d099e4ae05c2845ee783a02d5fe731e6e2a6a997", size = 19410 }
         dependencies = [
             { name = "cattrs" },
@@ -2131,7 +2131,7 @@ fn lock_requires_python_star() -> Result<()> {
         [[distribution]]
         name = "packaging"
         version = "24.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/ee/b5/b43a27ac7472e1818c4bafd44430e69605baefe1f34440593e0332ec8b4d/packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9", size = 147882 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5", size = 53488 },
@@ -2140,7 +2140,7 @@ fn lock_requires_python_star() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "linehaul" },
         ]
@@ -2148,7 +2148,7 @@ fn lock_requires_python_star() -> Result<()> {
         [[distribution]]
         name = "pyparsing"
         version = "3.1.2"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/46/3a/31fd28064d016a2182584d579e033ec95b809d8e220e74c4af6f0f2e8842/pyparsing-3.1.2.tar.gz", hash = "sha256:a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad", size = 889571 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl", hash = "sha256:f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742", size = 103245 },
@@ -2203,7 +2203,7 @@ fn lock_requires_python_pre() -> Result<()> {
         [[distribution]]
         name = "attrs"
         version = "23.2.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30", size = 780820 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1", size = 60752 },
@@ -2212,7 +2212,7 @@ fn lock_requires_python_pre() -> Result<()> {
         [[distribution]]
         name = "cattrs"
         version = "23.2.3"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/1e/57/c6ccd22658c4bcb3beb3f1c262e1f170cf136e913b122763d0ddd328d284/cattrs-23.2.3.tar.gz", hash = "sha256:a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f", size = 610215 }
         dependencies = [
             { name = "attrs" },
@@ -2224,7 +2224,7 @@ fn lock_requires_python_pre() -> Result<()> {
         [[distribution]]
         name = "linehaul"
         version = "1.0.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/f8/e7/74d1bd36ed26ac43bfe22e97129edaa7066f7af4bf76084b9493cd581d58/linehaul-1.0.1.tar.gz", hash = "sha256:09d71b1f6a9ab92dd8c763b3d099e4ae05c2845ee783a02d5fe731e6e2a6a997", size = 19410 }
         dependencies = [
             { name = "cattrs" },
@@ -2238,7 +2238,7 @@ fn lock_requires_python_pre() -> Result<()> {
         [[distribution]]
         name = "packaging"
         version = "24.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/ee/b5/b43a27ac7472e1818c4bafd44430e69605baefe1f34440593e0332ec8b4d/packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9", size = 147882 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5", size = 53488 },
@@ -2247,7 +2247,7 @@ fn lock_requires_python_pre() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "linehaul" },
         ]
@@ -2255,7 +2255,7 @@ fn lock_requires_python_pre() -> Result<()> {
         [[distribution]]
         name = "pyparsing"
         version = "3.1.2"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/46/3a/31fd28064d016a2182584d579e033ec95b809d8e220e74c4af6f0f2e8842/pyparsing-3.1.2.tar.gz", hash = "sha256:a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad", size = 889571 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl", hash = "sha256:f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742", size = 103245 },
@@ -2309,7 +2309,7 @@ fn lock_requires_python_unbounded() -> Result<()> {
         [[distribution]]
         name = "iniconfig"
         version = "1.1.1"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32", size = 8104 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3", size = 4990 },
@@ -2318,7 +2318,7 @@ fn lock_requires_python_unbounded() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "iniconfig" },
         ]
@@ -2371,7 +2371,7 @@ fn lock_dev() -> Result<()> {
         [[distribution]]
         name = "iniconfig"
         version = "2.0.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
@@ -2380,7 +2380,7 @@ fn lock_dev() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "iniconfig" },
         ]
@@ -2393,7 +2393,7 @@ fn lock_dev() -> Result<()> {
         [[distribution]]
         name = "typing-extensions"
         version = "4.12.2"
-        source = "direct+https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"
+        source = { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl" }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d" },
         ]
@@ -2469,7 +2469,7 @@ fn lock_conditional_unconditional() -> Result<()> {
         [[distribution]]
         name = "iniconfig"
         version = "2.0.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
@@ -2478,7 +2478,7 @@ fn lock_conditional_unconditional() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "iniconfig" },
         ]
@@ -2528,7 +2528,7 @@ fn lock_multiple_markers() -> Result<()> {
         [[distribution]]
         name = "iniconfig"
         version = "2.0.0"
-        source = "registry+https://pypi.org/simple"
+        source = { registry = "https://pypi.org/simple" }
         sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
         wheels = [
             { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
@@ -2537,7 +2537,7 @@ fn lock_multiple_markers() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "iniconfig", marker = "implementation_name == 'cpython'" },
         ]
@@ -2627,7 +2627,7 @@ fn relative_and_absolute_paths() -> Result<()> {
         [[distribution]]
         name = "a"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "b" },
             { name = "c" },
@@ -2636,12 +2636,12 @@ fn relative_and_absolute_paths() -> Result<()> {
         [[distribution]]
         name = "b"
         version = "0.1.0"
-        source = "directory+b"
+        source = { directory = "b" }
 
         [[distribution]]
         name = "c"
         version = "0.1.0"
-        source = "directory+[TEMP_DIR]/c"
+        source = { directory = "[TEMP_DIR]/c" }
         "###
         );
     });

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -87,7 +87,7 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_allows_non_conflicting_non_overlapping_dependencies_a-1.0.0.tar.gz#sha256=dd40a6bd59fbeefbf9f4936aec3df6fb6017e57d334f85f482ae5dd03ae353b9", hash = "sha256:dd40a6bd59fbeefbf9f4936aec3df6fb6017e57d334f85f482ae5dd03ae353b9" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_allows_non_conflicting_non_overlapping_dependencies_a-1.0.0-py3-none-any.whl#sha256=37c13aa13cca009990929df08bed3d9de26e1d405a5ebd16ec0c3baef6899b23", hash = "sha256:37c13aa13cca009990929df08bed3d9de26e1d405a5ebd16ec0c3baef6899b23" },
@@ -96,7 +96,7 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_allows_non_conflicting_non_overlapping_dependencies_a-2.0.0.tar.gz#sha256=0b4ca63d060f4daa2269c08b7083f594e096b94e1bcbde53d212c65b52378358", hash = "sha256:0b4ca63d060f4daa2269c08b7083f594e096b94e1bcbde53d212c65b52378358" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_allows_non_conflicting_non_overlapping_dependencies_a-2.0.0-py3-none-any.whl#sha256=35168196ad80d0f2822191a47e3a805b4ad527280c8b84e7eed77b7fee505497", hash = "sha256:35168196ad80d0f2822191a47e3a805b4ad527280c8b84e7eed77b7fee505497" },
@@ -105,10 +105,10 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -193,7 +193,7 @@ fn fork_allows_non_conflicting_repeated_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_allows_non_conflicting_repeated_dependencies_a-1.0.0.tar.gz#sha256=45ca30f1f66eaf6790198fad279b6448719092f2128f23b99f2ede0d6dde613b", hash = "sha256:45ca30f1f66eaf6790198fad279b6448719092f2128f23b99f2ede0d6dde613b" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_allows_non_conflicting_repeated_dependencies_a-1.0.0-py3-none-any.whl#sha256=b08be7896afa7402a2650dd9ebf38e32cf65d5bf86956dc23cf793c5f1f21af2", hash = "sha256:b08be7896afa7402a2650dd9ebf38e32cf65d5bf86956dc23cf793c5f1f21af2" },
@@ -202,7 +202,7 @@ fn fork_allows_non_conflicting_repeated_dependencies() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "package-a" },
         ]
@@ -278,7 +278,7 @@ fn fork_basic() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_basic_a-1.0.0.tar.gz#sha256=9bd6d9d74d8928854f79ea3ed4cd0d8a4906eeaa40f5f3d63460a1c2d5f6d773", hash = "sha256:9bd6d9d74d8928854f79ea3ed4cd0d8a4906eeaa40f5f3d63460a1c2d5f6d773" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_basic_a-1.0.0-py3-none-any.whl#sha256=1a28e30240634de42f24d34ff9bdac181208ef57215def75baac0de205685d27", hash = "sha256:1a28e30240634de42f24d34ff9bdac181208ef57215def75baac0de205685d27" },
@@ -287,7 +287,7 @@ fn fork_basic() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_basic_a-2.0.0.tar.gz#sha256=c0ce6dfb6d712eb42a4bbe9402a1f823627b9d3773f31d259c49478fc7d8d082", hash = "sha256:c0ce6dfb6d712eb42a4bbe9402a1f823627b9d3773f31d259c49478fc7d8d082" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_basic_a-2.0.0-py3-none-any.whl#sha256=c830122b1b31a6229208e04ced83ae4d1cef8be28b857b56af054bb4bd868a30", hash = "sha256:c830122b1b31a6229208e04ced83ae4d1cef8be28b857b56af054bb4bd868a30" },
@@ -296,10 +296,10 @@ fn fork_basic() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -460,7 +460,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "4.3.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_a-4.3.0.tar.gz#sha256=5389f0927f61393ba8bd940622329299d769e79b725233604a6bdac0fd088c49", hash = "sha256:5389f0927f61393ba8bd940622329299d769e79b725233604a6bdac0fd088c49" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_a-4.3.0-py3-none-any.whl#sha256=dabbae1b6f06cf5e94660f5f7d7b15984480ad0c8506fb0e89d86693fadf604a", hash = "sha256:dabbae1b6f06cf5e94660f5f7d7b15984480ad0c8506fb0e89d86693fadf604a" },
@@ -469,7 +469,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "4.4.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_a-4.4.0.tar.gz#sha256=7dbb8575aec8f87063954917b6ee628191cd53ca233ec810f6d926b4954e578b", hash = "sha256:7dbb8575aec8f87063954917b6ee628191cd53ca233ec810f6d926b4954e578b" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_a-4.4.0-py3-none-any.whl#sha256=7fb31ea56cb4bbe1d7035b93d39bdb9f37148e1ced83607b69a8f7279546e5a0", hash = "sha256:7fb31ea56cb4bbe1d7035b93d39bdb9f37148e1ced83607b69a8f7279546e5a0" },
@@ -478,10 +478,10 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_b-1.0.0.tar.gz#sha256=af3f861d6df9a2bbad55bae02acf17384ea2efa1abbf19206ac56cb021814613", hash = "sha256:af3f861d6df9a2bbad55bae02acf17384ea2efa1abbf19206ac56cb021814613" }
         dependencies = [
-            { name = "package-d", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+            { name = "package-d", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" } },
         ]
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_b-1.0.0-py3-none-any.whl#sha256=229e8570b5bec521c62fa46ffc242ecdf49e095d043f7761a8390213a63f8d7f", hash = "sha256:229e8570b5bec521c62fa46ffc242ecdf49e095d043f7761a8390213a63f8d7f" },
@@ -490,10 +490,10 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-c"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_c-1.0.0.tar.gz#sha256=c03742ca6e81c2a5d7d8cb72d1214bf03b2925e63858a19097f17d3e1a750192", hash = "sha256:c03742ca6e81c2a5d7d8cb72d1214bf03b2925e63858a19097f17d3e1a750192" }
         dependencies = [
-            { name = "package-d", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+            { name = "package-d", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" } },
         ]
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_c-1.0.0-py3-none-any.whl#sha256=28b4728d6ef73637bd296038f8b1895de6fffab1a0f5a2673b7408ac6941e401", hash = "sha256:28b4728d6ef73637bd296038f8b1895de6fffab1a0f5a2673b7408ac6941e401" },
@@ -502,7 +502,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-d"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_d-1.0.0.tar.gz#sha256=cc1af60e53faf957fd0542349441ea79a909cd5feb30fb8933c39dc33404e4b2", hash = "sha256:cc1af60e53faf957fd0542349441ea79a909cd5feb30fb8933c39dc33404e4b2" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_d-1.0.0-py3-none-any.whl#sha256=aae484d9359b53d95f5ae5e6413317c15cc0f715e5053251394fb748d3de992f", hash = "sha256:aae484d9359b53d95f5ae5e6413317c15cc0f715e5053251394fb748d3de992f" },
@@ -511,7 +511,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-d"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_d-2.0.0.tar.gz#sha256=68e380efdea5206363f5397e4cd560a64f5f4927396dc0b6f6f36dd3f026281f", hash = "sha256:68e380efdea5206363f5397e4cd560a64f5f4927396dc0b6f6f36dd3f026281f" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_d-2.0.0-py3-none-any.whl#sha256=d1c58c45df69e10aaf278190025c77d9bb989518f9d5bc2fe57643434f3de1d2", hash = "sha256:d1c58c45df69e10aaf278190025c77d9bb989518f9d5bc2fe57643434f3de1d2" },
@@ -520,10 +520,10 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "4.3.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "4.4.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "4.3.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "4.4.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
             { name = "package-b", marker = "sys_platform == 'linux'" },
             { name = "package-c", marker = "sys_platform == 'darwin'" },
         ]
@@ -609,7 +609,7 @@ fn fork_marker_accrue() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_a-1.0.0.tar.gz#sha256=c791e6062a510c63bff857ca6f7a921a7795bfbc588f21a51124e091fb0343d6", hash = "sha256:c791e6062a510c63bff857ca6f7a921a7795bfbc588f21a51124e091fb0343d6" }
         dependencies = [
             { name = "package-c", marker = "sys_platform == 'linux'" },
@@ -621,7 +621,7 @@ fn fork_marker_accrue() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_b-1.0.0.tar.gz#sha256=32e7ea1022061783857c3f6fec5051b4b320630fe8a5aec6523cd565db350387", hash = "sha256:32e7ea1022061783857c3f6fec5051b4b320630fe8a5aec6523cd565db350387" }
         dependencies = [
             { name = "package-c", marker = "sys_platform == 'darwin'" },
@@ -633,7 +633,7 @@ fn fork_marker_accrue() -> Result<()> {
         [[distribution]]
         name = "package-c"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_c-1.0.0.tar.gz#sha256=a3e09ac3dc8e787a08ebe8d5d6072e09720c76cbbcb76a6645d6f59652742015", hash = "sha256:a3e09ac3dc8e787a08ebe8d5d6072e09720c76cbbcb76a6645d6f59652742015" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_c-1.0.0-py3-none-any.whl#sha256=01993b60f134b3b80585fe95e3511b9a6194c2387c0215d962dbf65abd5a5fe1", hash = "sha256:01993b60f134b3b80585fe95e3511b9a6194c2387c0215d962dbf65abd5a5fe1" },
@@ -642,7 +642,7 @@ fn fork_marker_accrue() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "package-a", marker = "implementation_name == 'cpython'" },
             { name = "package-b", marker = "implementation_name == 'pypy'" },
@@ -798,11 +798,11 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_a-1.0.0.tar.gz#sha256=c7232306e8597d46c3fe53a3b1472f99b8ff36b3169f335ba0a5b625e193f7d4", hash = "sha256:c7232306e8597d46c3fe53a3b1472f99b8ff36b3169f335ba0a5b625e193f7d4" }
         dependencies = [
-            { name = "package-b", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'pypy'" },
-            { name = "package-b", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'cpython'" },
+            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'pypy'" },
+            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'cpython'" },
         ]
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_a-1.0.0-py3-none-any.whl#sha256=609b50f1a9fdbea0cc5d77f3eaf5143900159d809c56db5839de138c3123d980", hash = "sha256:609b50f1a9fdbea0cc5d77f3eaf5143900159d809c56db5839de138c3123d980" },
@@ -811,7 +811,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_a-2.0.0.tar.gz#sha256=0dcb58c8276afbe439e1c94708fb71954fb8869cc65c230ce8f462c911992ceb", hash = "sha256:0dcb58c8276afbe439e1c94708fb71954fb8869cc65c230ce8f462c911992ceb" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_a-2.0.0-py3-none-any.whl#sha256=ed8912f08993ddc9131dcc268b28385ddd84635f4a3c6a3fd83f680838353f1f", hash = "sha256:ed8912f08993ddc9131dcc268b28385ddd84635f4a3c6a3fd83f680838353f1f" },
@@ -820,7 +820,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_b-1.0.0.tar.gz#sha256=d6bd196a0a152c1b32e09f08e554d22ae6a6b3b916e39ad4552572afae5f5492", hash = "sha256:d6bd196a0a152c1b32e09f08e554d22ae6a6b3b916e39ad4552572afae5f5492" }
         dependencies = [
             { name = "package-c", marker = "implementation_name == 'pypy' or sys_platform == 'linux'" },
@@ -832,7 +832,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_b-2.0.0.tar.gz#sha256=4533845ba671575a25ceb32f10f0bc6836949bef37b7da6e7dd37d9be389871c", hash = "sha256:4533845ba671575a25ceb32f10f0bc6836949bef37b7da6e7dd37d9be389871c" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_b-2.0.0-py3-none-any.whl#sha256=6ec5a8c2241bafcf537c695257cd0cd66f392607bac2fc523ee1ad91fbbf623f", hash = "sha256:6ec5a8c2241bafcf537c695257cd0cd66f392607bac2fc523ee1ad91fbbf623f" },
@@ -841,7 +841,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         [[distribution]]
         name = "package-c"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_c-1.0.0.tar.gz#sha256=7ce8efca029cfa952e64f55c2d47fe33975c7f77ec689384bda11cbc3b7ef1db", hash = "sha256:7ce8efca029cfa952e64f55c2d47fe33975c7f77ec689384bda11cbc3b7ef1db" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_c-1.0.0-py3-none-any.whl#sha256=8513f5ac195dbb03aa5cec408fed74ad6ab7ace4822dbc6a8effec7f5a1bf47b", hash = "sha256:8513f5ac195dbb03aa5cec408fed74ad6ab7ace4822dbc6a8effec7f5a1bf47b" },
@@ -850,10 +850,10 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -942,11 +942,11 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_a-1.0.0.tar.gz#sha256=92081d91570582f3a94ed156f203de53baca5b3fdc350aa1c831c7c42723e798", hash = "sha256:92081d91570582f3a94ed156f203de53baca5b3fdc350aa1c831c7c42723e798" }
         dependencies = [
-            { name = "package-b", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'pypy'" },
-            { name = "package-b", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'cpython'" },
+            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'pypy'" },
+            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'cpython'" },
         ]
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_a-1.0.0-py3-none-any.whl#sha256=5a3da0f8036be92c72212ff734672805ed8b799a1bc46d3bde56f8486180e1cf", hash = "sha256:5a3da0f8036be92c72212ff734672805ed8b799a1bc46d3bde56f8486180e1cf" },
@@ -955,7 +955,7 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_a-2.0.0.tar.gz#sha256=9d48383b0699f575af15871f6f7a928b835cd5ad4e13f91a675ee5aba722dabc", hash = "sha256:9d48383b0699f575af15871f6f7a928b835cd5ad4e13f91a675ee5aba722dabc" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_a-2.0.0-py3-none-any.whl#sha256=16091f91bfb46e9db76d7e513d521e15baf7cf1ceae86c09e71e31b6734a7834", hash = "sha256:16091f91bfb46e9db76d7e513d521e15baf7cf1ceae86c09e71e31b6734a7834" },
@@ -964,7 +964,7 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_b-1.0.0.tar.gz#sha256=d44b87bd8d39240bca55eaae84a245e74197ed0b7897c27af9f168c713cc63bd", hash = "sha256:d44b87bd8d39240bca55eaae84a245e74197ed0b7897c27af9f168c713cc63bd" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_b-1.0.0-py3-none-any.whl#sha256=382d45c91771c962d7d12328bc58248fe0908d258307474beae1c868d9005631", hash = "sha256:382d45c91771c962d7d12328bc58248fe0908d258307474beae1c868d9005631" },
@@ -973,7 +973,7 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_b-2.0.0.tar.gz#sha256=75a48bf2d44a0a0be6ca33820f5076665765be7b43dabf5f94f7fd5247071097", hash = "sha256:75a48bf2d44a0a0be6ca33820f5076665765be7b43dabf5f94f7fd5247071097" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_b-2.0.0-py3-none-any.whl#sha256=cf730e495e15e6eed66857ce2c044f6dd16fe9ba24354f56ac1c6abfeb9cd976", hash = "sha256:cf730e495e15e6eed66857ce2c044f6dd16fe9ba24354f56ac1c6abfeb9cd976" },
@@ -982,10 +982,10 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1075,11 +1075,11 @@ fn fork_marker_inherit_combined() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_a-1.0.0.tar.gz#sha256=2ec4c9dbb7078227d996c344b9e0c1b365ed0000de9527b2ba5b616233636f07", hash = "sha256:2ec4c9dbb7078227d996c344b9e0c1b365ed0000de9527b2ba5b616233636f07" }
         dependencies = [
-            { name = "package-b", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'pypy'" },
-            { name = "package-b", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "implementation_name == 'cpython'" },
+            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'pypy'" },
+            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'cpython'" },
         ]
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_a-1.0.0-py3-none-any.whl#sha256=b24ba06cf3717872f4155240294a11d5cbe8c6b4a5b00963d056b491886b4efe", hash = "sha256:b24ba06cf3717872f4155240294a11d5cbe8c6b4a5b00963d056b491886b4efe" },
@@ -1088,7 +1088,7 @@ fn fork_marker_inherit_combined() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_a-2.0.0.tar.gz#sha256=47958d1659220ee7722b0f26e8c1fe41217a2816881ffa929f0ba794a87ceebf", hash = "sha256:47958d1659220ee7722b0f26e8c1fe41217a2816881ffa929f0ba794a87ceebf" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_a-2.0.0-py3-none-any.whl#sha256=e2c1eb831475f344a019e6e5b90e1f95f51553d45a4dc9d6f8e23593b8e5c8a1", hash = "sha256:e2c1eb831475f344a019e6e5b90e1f95f51553d45a4dc9d6f8e23593b8e5c8a1" },
@@ -1097,7 +1097,7 @@ fn fork_marker_inherit_combined() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_b-1.0.0.tar.gz#sha256=6992d194cb5a0f0eed9ed6617d3212af4e3ff09274bf7622c8a1008b072128da", hash = "sha256:6992d194cb5a0f0eed9ed6617d3212af4e3ff09274bf7622c8a1008b072128da" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_b-1.0.0-py3-none-any.whl#sha256=a3a0071d27faf67fb6d4766b8e557d4642c4f2baa043c4ef430311b177bc126c", hash = "sha256:a3a0071d27faf67fb6d4766b8e557d4642c4f2baa043c4ef430311b177bc126c" },
@@ -1106,7 +1106,7 @@ fn fork_marker_inherit_combined() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_b-2.0.0.tar.gz#sha256=e340061505d621a340d10ec1dbaf02dfce0c66358ee8190f61f78018f9999989", hash = "sha256:e340061505d621a340d10ec1dbaf02dfce0c66358ee8190f61f78018f9999989" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_b-2.0.0-py3-none-any.whl#sha256=1723c70dd56b62995764ce0d616052caa9183fcac252a130eeb34fe3f2e9656f", hash = "sha256:1723c70dd56b62995764ce0d616052caa9183fcac252a130eeb34fe3f2e9656f" },
@@ -1115,10 +1115,10 @@ fn fork_marker_inherit_combined() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1202,7 +1202,7 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_a-1.0.0.tar.gz#sha256=724ffc24debfa2bc6b5c2457df777c523638ec3586cc953f8509dad581aa6887", hash = "sha256:724ffc24debfa2bc6b5c2457df777c523638ec3586cc953f8509dad581aa6887" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_a-1.0.0-py3-none-any.whl#sha256=0d66a59f2f0afc2d077594603239bf616eabe9ffd203fe9d41621782c7fef33a", hash = "sha256:0d66a59f2f0afc2d077594603239bf616eabe9ffd203fe9d41621782c7fef33a" },
@@ -1211,7 +1211,7 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_a-2.0.0.tar.gz#sha256=bc4567da4349a9c09b7fb4733f0b9f6476249240192291cf051c2b1d28b829fd", hash = "sha256:bc4567da4349a9c09b7fb4733f0b9f6476249240192291cf051c2b1d28b829fd" }
         dependencies = [
             { name = "package-b", marker = "sys_platform == 'linux'" },
@@ -1223,7 +1223,7 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_b-1.0.0.tar.gz#sha256=96f8c3cabc5795e08a064c89ec76a4bfba8afe3c13d647161b4a1568b4584ced", hash = "sha256:96f8c3cabc5795e08a064c89ec76a4bfba8afe3c13d647161b4a1568b4584ced" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_b-1.0.0-py3-none-any.whl#sha256=79e3a8219a49a5d72db2468c856a65212345e9a7e028abf8c179320f49d85be5", hash = "sha256:79e3a8219a49a5d72db2468c856a65212345e9a7e028abf8c179320f49d85be5" },
@@ -1232,10 +1232,10 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1324,7 +1324,7 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_a-1.0.0.tar.gz#sha256=8bcab85231487b9350471da0c4c22dc3d69dfe4a1198d16b5f81b0235d7112ce", hash = "sha256:8bcab85231487b9350471da0c4c22dc3d69dfe4a1198d16b5f81b0235d7112ce" }
         dependencies = [
             { name = "package-b" },
@@ -1336,7 +1336,7 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_a-2.0.0.tar.gz#sha256=4437ac14c340fec0b451cbc9486f5b8e106568634264ecad339a8de565a93be6", hash = "sha256:4437ac14c340fec0b451cbc9486f5b8e106568634264ecad339a8de565a93be6" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_a-2.0.0-py3-none-any.whl#sha256=2965412b82b12d0b0ab081c7e05133cb64209241a4f2836359c76a5ed8d7fb99", hash = "sha256:2965412b82b12d0b0ab081c7e05133cb64209241a4f2836359c76a5ed8d7fb99" },
@@ -1345,7 +1345,7 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_b-1.0.0.tar.gz#sha256=03b4b0e323c36bd4a1e51a65e1489715da231d44d26e12b54544e3bf9a9f6129", hash = "sha256:03b4b0e323c36bd4a1e51a65e1489715da231d44d26e12b54544e3bf9a9f6129" }
         dependencies = [
             { name = "package-c" },
@@ -1357,7 +1357,7 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         [[distribution]]
         name = "package-c"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_c-1.0.0.tar.gz#sha256=58bb788896b2297f2948f51a27fc48cfe44057c687a3c0c4d686b107975f7f32", hash = "sha256:58bb788896b2297f2948f51a27fc48cfe44057c687a3c0c4d686b107975f7f32" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_c-1.0.0-py3-none-any.whl#sha256=a827909e237ab405b250b4cc534dc51e502a7e583a11205b6db8af51058b38c5", hash = "sha256:a827909e237ab405b250b4cc534dc51e502a7e583a11205b6db8af51058b38c5" },
@@ -1366,10 +1366,10 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1453,7 +1453,7 @@ fn fork_marker_inherit() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_a-1.0.0.tar.gz#sha256=177511ec69a2f04de39867d43f167a33194ae983e8f86a1cc9b51f59fc379d4b", hash = "sha256:177511ec69a2f04de39867d43f167a33194ae983e8f86a1cc9b51f59fc379d4b" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_a-1.0.0-py3-none-any.whl#sha256=a7b95b768a7181d9713510b22bb69c5c4f634950e50d13ae44126d800e76abd9", hash = "sha256:a7b95b768a7181d9713510b22bb69c5c4f634950e50d13ae44126d800e76abd9" },
@@ -1462,7 +1462,7 @@ fn fork_marker_inherit() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_a-2.0.0.tar.gz#sha256=43e24ce6fcbfbbff1db5eb20b583c20c2aa0888138bfafeab205c4ccc6e7e0a4", hash = "sha256:43e24ce6fcbfbbff1db5eb20b583c20c2aa0888138bfafeab205c4ccc6e7e0a4" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_a-2.0.0-py3-none-any.whl#sha256=d11786be689f457db5be1729abbb80861259050dbb54e3bb8cfe2b89562db6ec", hash = "sha256:d11786be689f457db5be1729abbb80861259050dbb54e3bb8cfe2b89562db6ec" },
@@ -1471,10 +1471,10 @@ fn fork_marker_inherit() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1563,7 +1563,7 @@ fn fork_marker_limited_inherit() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_a-1.0.0.tar.gz#sha256=ab1fde8d0acb9a2fe99b7a005939962b1c26c6d876e4a55e81fb9d1a1e5e9f76", hash = "sha256:ab1fde8d0acb9a2fe99b7a005939962b1c26c6d876e4a55e81fb9d1a1e5e9f76" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_a-1.0.0-py3-none-any.whl#sha256=cb79be6fc2fe9c69f19d5452b711d838facf916caddd24dd40b78d34da3930de", hash = "sha256:cb79be6fc2fe9c69f19d5452b711d838facf916caddd24dd40b78d34da3930de" },
@@ -1572,7 +1572,7 @@ fn fork_marker_limited_inherit() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_a-2.0.0.tar.gz#sha256=009fdb8872cf52324c1bcdebef31feaba3c262fd76d150a753152aeee3d55b10", hash = "sha256:009fdb8872cf52324c1bcdebef31feaba3c262fd76d150a753152aeee3d55b10" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_a-2.0.0-py3-none-any.whl#sha256=222092e35ef8ac65f5974f3ea38056ff85a5ce981d84ede5a799a04b5ae50661", hash = "sha256:222092e35ef8ac65f5974f3ea38056ff85a5ce981d84ede5a799a04b5ae50661" },
@@ -1581,7 +1581,7 @@ fn fork_marker_limited_inherit() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_b-1.0.0.tar.gz#sha256=4c04e090df03e308ecd38a9b8db9813a09fb20a747a89f86c497702c3e5a9001", hash = "sha256:4c04e090df03e308ecd38a9b8db9813a09fb20a747a89f86c497702c3e5a9001" }
         dependencies = [
             { name = "package-c", marker = "sys_platform == 'linux'" },
@@ -1593,7 +1593,7 @@ fn fork_marker_limited_inherit() -> Result<()> {
         [[distribution]]
         name = "package-c"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_c-1.0.0.tar.gz#sha256=8dcb05f5dff09fec52ab507b215ff367fe815848319a17929db997ad3afe88ae", hash = "sha256:8dcb05f5dff09fec52ab507b215ff367fe815848319a17929db997ad3afe88ae" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_c-1.0.0-py3-none-any.whl#sha256=6870cf7f8eec58dc27a701f9dc0669151e914c013d3e7910953fdfeb387a5e6b", hash = "sha256:6870cf7f8eec58dc27a701f9dc0669151e914c013d3e7910953fdfeb387a5e6b" },
@@ -1602,10 +1602,10 @@ fn fork_marker_limited_inherit() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
             { name = "package-b" },
         ]
         "###
@@ -1692,7 +1692,7 @@ fn fork_marker_selection() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "0.1.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_a-0.1.0.tar.gz#sha256=ece83ba864a62d5d747439f79a0bf36aa4c18d15bca96aab855ffc2e94a8eef7", hash = "sha256:ece83ba864a62d5d747439f79a0bf36aa4c18d15bca96aab855ffc2e94a8eef7" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_a-0.1.0-py3-none-any.whl#sha256=8aecc639cc090aa80aa263fb3a9644a7cec9da215133299b8fb381cb7a6bcbb7", hash = "sha256:8aecc639cc090aa80aa263fb3a9644a7cec9da215133299b8fb381cb7a6bcbb7" },
@@ -1701,10 +1701,10 @@ fn fork_marker_selection() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "0.2.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_a-0.2.0.tar.gz#sha256=42abfb3ce2c13ae008e498d27c80ae39ab19e30fd56e175719b67b1c778ea632", hash = "sha256:42abfb3ce2c13ae008e498d27c80ae39ab19e30fd56e175719b67b1c778ea632" }
         dependencies = [
-            { name = "package-b", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" } },
         ]
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_a-0.2.0-py3-none-any.whl#sha256=65ff1ce26de8218278abb1ae190fe70d031de79833d85231112208672566b9c4", hash = "sha256:65ff1ce26de8218278abb1ae190fe70d031de79833d85231112208672566b9c4" },
@@ -1713,7 +1713,7 @@ fn fork_marker_selection() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_b-1.0.0.tar.gz#sha256=6f5ea28cadb8b5dfa15d32c9e38818f8f7150fc4f9a58e49aec4e10b23342be4", hash = "sha256:6f5ea28cadb8b5dfa15d32c9e38818f8f7150fc4f9a58e49aec4e10b23342be4" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_b-1.0.0-py3-none-any.whl#sha256=d86ba6d371e152071be1e5bc902a5a54010e94592c8c7e7908870b96ad04d851", hash = "sha256:d86ba6d371e152071be1e5bc902a5a54010e94592c8c7e7908870b96ad04d851" },
@@ -1722,7 +1722,7 @@ fn fork_marker_selection() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_b-2.0.0.tar.gz#sha256=d32033ecdf37d605e4b3b3e88df6562bb7ca01c6ed3fb9a55ec078eccc1df9d1", hash = "sha256:d32033ecdf37d605e4b3b3e88df6562bb7ca01c6ed3fb9a55ec078eccc1df9d1" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_b-2.0.0-py3-none-any.whl#sha256=535c038dec0bb33c867ee979fe8863734dd6fb913a94603dcbff42c62790f98b", hash = "sha256:535c038dec0bb33c867ee979fe8863734dd6fb913a94603dcbff42c62790f98b" },
@@ -1731,12 +1731,12 @@ fn fork_marker_selection() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "0.1.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
-            { name = "package-a", version = "0.2.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
-            { name = "package-b", version = "1.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-b", version = "2.0.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "0.1.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" } },
+            { name = "package-a", version = "0.2.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" } },
+            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1833,7 +1833,7 @@ fn fork_marker_track() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.3.1"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_a-1.3.1.tar.gz#sha256=ffc490c887058825e96a0cc4a270cf56b72f7f28b927c450086603317bb8c120", hash = "sha256:ffc490c887058825e96a0cc4a270cf56b72f7f28b927c450086603317bb8c120" }
         dependencies = [
             { name = "package-c", marker = "implementation_name == 'iron'" },
@@ -1845,10 +1845,10 @@ fn fork_marker_track() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "4.3.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_a-4.3.0.tar.gz#sha256=ce810c2e0922cff256d3050167c0d2a041955d389d21280fd684ab986dfdb1f5", hash = "sha256:ce810c2e0922cff256d3050167c0d2a041955d389d21280fd684ab986dfdb1f5" }
         dependencies = [
-            { name = "package-b", version = "2.8", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
+            { name = "package-b", version = "2.8", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" } },
         ]
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_a-4.3.0-py3-none-any.whl#sha256=fb90bca8d00206119df736f59a9c4e18e104a9321b8ea91f19400a119b77ef99", hash = "sha256:fb90bca8d00206119df736f59a9c4e18e104a9321b8ea91f19400a119b77ef99" },
@@ -1857,7 +1857,7 @@ fn fork_marker_track() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "2.7"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_b-2.7.tar.gz#sha256=855bf45837a4ba669a5850b14b0253cb138925fdd2b06a2f15c6582b8fabb8a0", hash = "sha256:855bf45837a4ba669a5850b14b0253cb138925fdd2b06a2f15c6582b8fabb8a0" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_b-2.7-py3-none-any.whl#sha256=106d0c1c60d67fcf1711029f58f34b770007fed24d087f2fb9cee91226dbdbba", hash = "sha256:106d0c1c60d67fcf1711029f58f34b770007fed24d087f2fb9cee91226dbdbba" },
@@ -1866,7 +1866,7 @@ fn fork_marker_track() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "2.8"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_b-2.8.tar.gz#sha256=2e14b0ff1fb7f5cf491bd31d876218adee1d6a208ff197dc30363cdf25262e80", hash = "sha256:2e14b0ff1fb7f5cf491bd31d876218adee1d6a208ff197dc30363cdf25262e80" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_b-2.8-py3-none-any.whl#sha256=7e2ea2b4f530fa04bec90cf131289ac7eaca1ae38267150587d418d42c814b7c", hash = "sha256:7e2ea2b4f530fa04bec90cf131289ac7eaca1ae38267150587d418d42c814b7c" },
@@ -1875,7 +1875,7 @@ fn fork_marker_track() -> Result<()> {
         [[distribution]]
         name = "package-c"
         version = "1.10"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_c-1.10.tar.gz#sha256=c89006d893254790b0fcdd1b33520241c8ff66ab950c6752b745e006bdeff144", hash = "sha256:c89006d893254790b0fcdd1b33520241c8ff66ab950c6752b745e006bdeff144" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_c-1.10-py3-none-any.whl#sha256=6894f06e085884d812ec5e929ed42e7e01a1c7c95fd5ab30781541e4cd94b58d", hash = "sha256:6894f06e085884d812ec5e929ed42e7e01a1c7c95fd5ab30781541e4cd94b58d" },
@@ -1884,12 +1884,12 @@ fn fork_marker_track() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.3.1", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
-            { name = "package-a", version = "4.3.0", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/" },
-            { name = "package-b", version = "2.7", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'darwin'" },
-            { name = "package-b", version = "2.8", source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/", marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.3.1", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" } },
+            { name = "package-a", version = "4.3.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" } },
+            { name = "package-b", version = "2.7", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-b", version = "2.8", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1972,7 +1972,7 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_a-1.0.0.tar.gz#sha256=68cff02c9f4a0b3014fdce524982a3cbf3a2ecaf0291c32c824cadb19f1e7cd0", hash = "sha256:68cff02c9f4a0b3014fdce524982a3cbf3a2ecaf0291c32c824cadb19f1e7cd0" }
         dependencies = [
             { name = "package-c", marker = "sys_platform == 'linux'" },
@@ -1984,7 +1984,7 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_b-1.0.0.tar.gz#sha256=ae7abe9cde79b810f91dff7329b63788a8253250053fe4e82563f0b2d0877182", hash = "sha256:ae7abe9cde79b810f91dff7329b63788a8253250053fe4e82563f0b2d0877182" }
         dependencies = [
             { name = "package-c", marker = "sys_platform == 'darwin'" },
@@ -1996,7 +1996,7 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
         [[distribution]]
         name = "package-c"
         version = "2.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_c-2.0.0.tar.gz#sha256=ffab9124854f64c8b5059ccaed481547f54abac868ba98aa6a454c0163cdb1c7", hash = "sha256:ffab9124854f64c8b5059ccaed481547f54abac868ba98aa6a454c0163cdb1c7" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_c-2.0.0-py3-none-any.whl#sha256=80495d1a9075682f6e9dc8d474afd98a3324d32c57c65769b573f281105f3d08", hash = "sha256:80495d1a9075682f6e9dc8d474afd98a3324d32c57c65769b573f281105f3d08" },
@@ -2005,7 +2005,7 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "package-a" },
             { name = "package-b" },
@@ -2228,7 +2228,7 @@ fn fork_requires_python_full_prerelease() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         "###
         );
     });
@@ -2300,7 +2300,7 @@ fn fork_requires_python_full() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         "###
         );
     });
@@ -2375,7 +2375,7 @@ fn fork_requires_python_patch_overlap() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = "registry+https://astral-sh.github.io/packse/0.3.29/simple-html/"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
         sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_requires_python_patch_overlap_a-1.0.0.tar.gz#sha256=ac2820ee4808788674295192d79a709e3259aa4eef5b155e77f719ad4eaa324d", hash = "sha256:ac2820ee4808788674295192d79a709e3259aa4eef5b155e77f719ad4eaa324d" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_requires_python_patch_overlap_a-1.0.0-py3-none-any.whl#sha256=9c8e127993ded58b011f08453d4103f71f12aa2e8fb61e755061fb56128214e2", hash = "sha256:9c8e127993ded58b011f08453d4103f71f12aa2e8fb61e755061fb56128214e2" },
@@ -2384,7 +2384,7 @@ fn fork_requires_python_patch_overlap() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         dependencies = [
             { name = "package-a", marker = "python_version == '3.10'" },
         ]
@@ -2457,7 +2457,7 @@ fn fork_requires_python() -> Result<()> {
         [[distribution]]
         name = "project"
         version = "0.1.0"
-        source = "editable+."
+        source = { editable = "." }
         "###
         );
     });


### PR DESCRIPTION
The essence of this change is from this:

```toml
source = "editable+."
```

to this:

```toml
source = { editable = "." }
```

And similarly for other source types. For example, instead of `registry+https://...`, we now have:

```toml
source = { registry = "https://..." }
```

Note though that we retain URLs for git sources. For example:

```toml
source = { git = "https://github.com/pytest-dev/iniconfig?rev=93f5930e668c0d1ddf4597e38dd0dea4e2665e7a#93f5930e668c0d1ddf4597e38dd0dea4e2665e7a" }
```

I don't have a super compelling reason for this, but felt like it was
nice to keep the git info in a compact format. But if folks want to see
the git data more structured, I'd be happy to make that change.
