### PR TITLE
uv-resolver: make source=git more structured

### DIFF
--- a/crates/uv/tests/branching_urls.rs
+++ b/crates/uv/tests/branching_urls.rs
@@ -589,7 +589,7 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     source = { editable = "." }
     dependencies = [
         { name = "iniconfig", version = "1.1.1", source = { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl" }, marker = "python_version < '3.12'" },
-        { name = "iniconfig", version = "2.0.0", source = { git = "https://github.com/pytest-dev/iniconfig?rev=93f5930e668c0d1ddf4597e38dd0dea4e2665e7a#93f5930e668c0d1ddf4597e38dd0dea4e2665e7a" }, marker = "python_version >= '3.12'" },
+        { name = "iniconfig", version = "2.0.0", source = { git = "https://github.com/pytest-dev/iniconfig", commit = "93f5930e668c0d1ddf4597e38dd0dea4e2665e7a", revision = "93f5930e668c0d1ddf4597e38dd0dea4e2665e7a" }, marker = "python_version >= '3.12'" },
     ]
 
     [[distribution]]
@@ -603,7 +603,7 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     [[distribution]]
     name = "iniconfig"
     version = "2.0.0"
-    source = { git = "https://github.com/pytest-dev/iniconfig?rev=93f5930e668c0d1ddf4597e38dd0dea4e2665e7a#93f5930e668c0d1ddf4597e38dd0dea4e2665e7a" }
+    source = { git = "https://github.com/pytest-dev/iniconfig", commit = "93f5930e668c0d1ddf4597e38dd0dea4e2665e7a", revision = "93f5930e668c0d1ddf4597e38dd0dea4e2665e7a" }
     "###);
 
     Ok(())

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -186,7 +186,7 @@ fn add_git() -> Result<()> {
     Installed 2 packages in [TIME]
      - project==0.1.0 (from file://[TEMP_DIR]/)
      + project==0.1.0 (from file://[TEMP_DIR]/)
-     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979?tag=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
+     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
     "###);
 
     let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
@@ -264,7 +264,7 @@ fn add_git() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = { git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
+        source = { git = "https://github.com/astral-test/uv-public-pypackage", commit = "0dacfd662c64cb4ceb16e6cf65a157a8b715b979", tag = "0.0.1" }
         "###
         );
     });
@@ -335,7 +335,7 @@ fn add_git_raw() -> Result<()> {
     Installed 2 packages in [TIME]
      - project==0.1.0 (from file://[TEMP_DIR]/)
      + project==0.1.0 (from file://[TEMP_DIR]/)
-     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979?rev=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
+     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
     "###);
 
     let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
@@ -410,7 +410,7 @@ fn add_git_raw() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
+        source = { git = "https://github.com/astral-test/uv-public-pypackage", commit = "0dacfd662c64cb4ceb16e6cf65a157a8b715b979", revision = "0.0.1" }
         "###
         );
     });
@@ -454,7 +454,7 @@ fn add_unnamed() -> Result<()> {
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
-     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979?tag=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
+     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
     "###);
 
     let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
@@ -500,7 +500,7 @@ fn add_unnamed() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = { git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
+        source = { git = "https://github.com/astral-test/uv-public-pypackage", commit = "0dacfd662c64cb4ceb16e6cf65a157a8b715b979", tag = "0.0.1" }
         "###
         );
     });
@@ -1315,7 +1315,7 @@ fn update() -> Result<()> {
      - project==0.1.0 (from file://[TEMP_DIR]/)
      + project==0.1.0 (from file://[TEMP_DIR]/)
      - requests==2.31.0
-     + requests==2.32.3 (from git+https://github.com/psf/requests@0e322af87745eff34caffe4df68456ebc20d9068?tag=v2.32.3#0e322af87745eff34caffe4df68456ebc20d9068)
+     + requests==2.32.3 (from git+https://github.com/psf/requests@0e322af87745eff34caffe4df68456ebc20d9068)
     "###);
 
     let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
@@ -1422,7 +1422,7 @@ fn update() -> Result<()> {
         [[distribution]]
         name = "requests"
         version = "2.32.3"
-        source = { git = "https://github.com/psf/requests?tag=v2.32.3#0e322af87745eff34caffe4df68456ebc20d9068" }
+        source = { git = "https://github.com/psf/requests", commit = "0e322af87745eff34caffe4df68456ebc20d9068", tag = "v2.32.3" }
         dependencies = [
             { name = "certifi" },
             { name = "charset-normalizer" },

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -223,7 +223,7 @@ fn lock_sdist_git() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
+        source = { git = "https://github.com/astral-test/uv-public-pypackage", commit = "0dacfd662c64cb4ceb16e6cf65a157a8b715b979", revision = "0.0.1" }
         "###
         );
     });
@@ -1411,7 +1411,7 @@ fn lock_git_sha() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=0dacfd662c64cb4ceb16e6cf65a157a8b715b979#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
+        source = { git = "https://github.com/astral-test/uv-public-pypackage", commit = "0dacfd662c64cb4ceb16e6cf65a157a8b715b979", revision = "0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
         "###
         );
     });
@@ -1465,7 +1465,7 @@ fn lock_git_sha() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=main#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
+        source = { git = "https://github.com/astral-test/uv-public-pypackage", commit = "b270df1a2fb5d012294e9aaf05e7e0bab1e6a389", revision = "main" }
         "###
         );
     });
@@ -1504,7 +1504,7 @@ fn lock_git_sha() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=main#b270df1a2fb5d012294e9aaf05e7e0bab1e6a389" }
+        source = { git = "https://github.com/astral-test/uv-public-pypackage", commit = "b270df1a2fb5d012294e9aaf05e7e0bab1e6a389", revision = "main" }
         "###
         );
     });


### PR DESCRIPTION
This splits out the git fields into an inline table instead of smushing
them into a single URL.

I'm unsure about this change, because it seems like we are using the git
URLs in other user facing ways. For example, some of the snapshot diffs
look like this:

         Installed 2 packages in [TIME]
          - project==0.1.0 (from file://[TEMP_DIR]/)
          + project==0.1.0 (from file://[TEMP_DIR]/)
    -     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979?rev=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
    +     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979)

which seems non-ideal. It should be possible to make the lock file use
structured fields while keeping the URL for terser output as above, but
I'm not sure that it's worth it.

This builds on top of #4627
