### PR TITLE
Track tool entry points in receipts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5025,6 +5025,7 @@ dependencies = [
  "serde",
  "thiserror",
  "toml",
+ "toml_edit",
  "tracing",
  "uv-cache",
  "uv-fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5019,6 +5019,7 @@ dependencies = [
  "dirs-sys",
  "fs-err",
  "install-wheel-rs",
+ "path-slash",
  "pep440_rs",
  "pep508_rs",
  "pypi-types",

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -13,21 +13,22 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-uv-fs = { workspace = true }
-uv-state = { workspace = true }
-pep508_rs = { workspace = true }
-pypi-types = { workspace = true }
-uv-virtualenv = { workspace = true }
-uv-toolchain = { workspace = true }
 install-wheel-rs = { workspace = true }
 pep440_rs = { workspace = true }
-uv-warnings = { workspace = true }
+pep508_rs = { workspace = true }
+pypi-types = { workspace = true }
 uv-cache = { workspace = true }
+uv-fs = { workspace = true }
+uv-state = { workspace = true }
+uv-toolchain = { workspace = true }
+uv-virtualenv = { workspace = true }
+uv-warnings = { workspace = true }
 
-thiserror = { workspace = true }
-tracing = { workspace = true }
+dirs-sys = { workspace = true }
 fs-err = { workspace = true }
+path-slash = { workspace = true }
 serde = { workspace = true }
+thiserror = { workspace = true }
 toml = { workspace = true } 
 toml_edit = { workspace = true } 
-dirs-sys = { workspace = true }
+tracing = { workspace = true }

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -29,4 +29,5 @@ tracing = { workspace = true }
 fs-err = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true } 
+toml_edit = { workspace = true } 
 dirs-sys = { workspace = true }

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -135,10 +135,9 @@ impl InstalledTools {
             path.user_display()
         );
 
-        let doc = toml::to_string(&tool_receipt)
-            .map_err(|err| Error::ReceiptWrite(path.clone(), Box::new(err)))?;
+        let doc = tool_receipt.to_toml();
 
-        // Save the modified `tools.toml`.
+        // Save the modified `uv-receipt.toml`.
         fs_err::write(&path, doc)?;
 
         Ok(())

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -14,7 +14,7 @@ use uv_toolchain::{Interpreter, PythonEnvironment};
 use uv_warnings::warn_user_once;
 
 pub use receipt::ToolReceipt;
-pub use tool::Tool;
+pub use tool::{Tool, ToolEntrypoint};
 
 use uv_state::{StateBucket, StateStore};
 mod receipt;

--- a/crates/uv-tool/src/receipt.rs
+++ b/crates/uv-tool/src/receipt.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::Tool;
 
 /// A `uv-receipt.toml` file tracking the installation of a tool.
 #[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ToolReceipt {
     pub(crate) tool: Tool,
 
@@ -29,6 +29,16 @@ impl ToolReceipt {
                 .map_err(|err| crate::Error::ReceiptRead(path.to_owned(), Box::new(err)))?),
             Err(err) => Err(err.into()),
         }
+    }
+
+    /// Returns the TOML representation of this receipt.
+    pub(crate) fn to_toml(&self) -> String {
+        // We construct a TOML document manually instead of going through Serde to enable
+        // the use of inline tables.
+        let mut doc = toml_edit::DocumentMut::new();
+        doc.insert("tool", toml_edit::Item::Table(self.tool.to_toml()));
+
+        doc.to_string()
     }
 }
 

--- a/crates/uv-tool/src/tool.rs
+++ b/crates/uv-tool/src/tool.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use pypi_types::VerbatimParsedUrl;
 use serde::{Deserialize, Serialize};
 
@@ -7,8 +9,18 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Tool {
+    // The requirements requested by the user during installation.
     requirements: Vec<pep508_rs::Requirement<VerbatimParsedUrl>>,
+    /// The Python requested by the user during installation.
     python: Option<String>,
+    // A mapping of entry point names to their metadata.
+    entrypoints: Vec<ToolEntrypoint>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct ToolEntrypoint {
+    name: String,
+    install_path: PathBuf,
 }
 
 impl Tool {
@@ -16,10 +28,21 @@ impl Tool {
     pub fn new(
         requirements: Vec<pep508_rs::Requirement<VerbatimParsedUrl>>,
         python: Option<String>,
+        entrypoints: impl Iterator<Item = ToolEntrypoint>,
     ) -> Self {
+        let mut entrypoints: Vec<_> = entrypoints.collect();
+        entrypoints.sort();
         Self {
             requirements,
             python,
+            entrypoints,
         }
+    }
+}
+
+impl ToolEntrypoint {
+    /// Create a new [`ToolEntrypoint`].
+    pub fn new(name: String, install_path: PathBuf) -> Self {
+        Self { name, install_path }
     }
 }

--- a/crates/uv-tool/src/tool.rs
+++ b/crates/uv-tool/src/tool.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use path_slash::PathBufExt;
 use pypi_types::VerbatimParsedUrl;
 use serde::Deserialize;
 use toml_edit::value;
@@ -118,7 +119,8 @@ impl ToolEntrypoint {
         table.insert("name", value(&self.name));
         table.insert(
             "install-path",
-            value(self.install_path.to_string_lossy().to_string()),
+            // Use cross-platform slashes so the toml string type does not change
+            value(self.install_path.to_slash_lossy().to_string()),
         );
         table
     }

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -77,14 +77,10 @@ fn tool_install() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 
@@ -162,10 +158,9 @@ fn tool_install() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("flask").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["flask"]
-
-        [[tool.entrypoints]]
-        name = "flask"
-        install_path = "[TEMP_DIR]/bin/flask"
+        entrypoints = [
+            { name = "flask", install-path = "[TEMP_DIR]/bin/flask" },
+        ]
         "###);
     });
 }
@@ -235,14 +230,10 @@ fn tool_install_version() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black==24.2.0"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 
@@ -387,14 +378,10 @@ fn tool_install_already_installed() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 
@@ -424,14 +411,10 @@ fn tool_install_already_installed() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 
@@ -649,14 +632,10 @@ fn tool_install_entry_point_exists() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 
@@ -686,14 +665,10 @@ fn tool_install_entry_point_exists() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -77,6 +77,14 @@ fn tool_install() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
+
+        [[tool.entrypoints]]
+        name = "black"
+        install_path = "[TEMP_DIR]/bin/black"
+
+        [[tool.entrypoints]]
+        name = "blackd"
+        install_path = "[TEMP_DIR]/bin/blackd"
         "###);
     });
 
@@ -154,6 +162,10 @@ fn tool_install() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("flask").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["flask"]
+
+        [[tool.entrypoints]]
+        name = "flask"
+        install_path = "[TEMP_DIR]/bin/flask"
         "###);
     });
 }
@@ -161,7 +173,7 @@ fn tool_install() {
 /// Test installing a tool at a version
 #[test]
 fn tool_install_version() {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -223,6 +235,14 @@ fn tool_install_version() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black==24.2.0"]
+
+        [[tool.entrypoints]]
+        name = "black"
+        install_path = "[TEMP_DIR]/bin/black"
+
+        [[tool.entrypoints]]
+        name = "blackd"
+        install_path = "[TEMP_DIR]/bin/blackd"
         "###);
     });
 
@@ -240,7 +260,7 @@ fn tool_install_version() {
 /// Test installing a tool with `uv tool install --from`
 #[test]
 fn tool_install_from() {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -367,6 +387,14 @@ fn tool_install_already_installed() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
+
+        [[tool.entrypoints]]
+        name = "black"
+        install_path = "[TEMP_DIR]/bin/black"
+
+        [[tool.entrypoints]]
+        name = "blackd"
+        install_path = "[TEMP_DIR]/bin/blackd"
         "###);
     });
 
@@ -396,6 +424,14 @@ fn tool_install_already_installed() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
+
+        [[tool.entrypoints]]
+        name = "black"
+        install_path = "[TEMP_DIR]/bin/black"
+
+        [[tool.entrypoints]]
+        name = "blackd"
+        install_path = "[TEMP_DIR]/bin/blackd"
         "###);
     });
 
@@ -613,6 +649,14 @@ fn tool_install_entry_point_exists() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
+
+        [[tool.entrypoints]]
+        name = "black"
+        install_path = "[TEMP_DIR]/bin/black"
+
+        [[tool.entrypoints]]
+        name = "blackd"
+        install_path = "[TEMP_DIR]/bin/blackd"
         "###);
     });
 
@@ -642,6 +686,14 @@ fn tool_install_entry_point_exists() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
+
+        [[tool.entrypoints]]
+        name = "black"
+        install_path = "[TEMP_DIR]/bin/black"
+
+        [[tool.entrypoints]]
+        name = "blackd"
+        install_path = "[TEMP_DIR]/bin/blackd"
         "###);
     });
 
@@ -662,7 +714,7 @@ fn tool_install_entry_point_exists() {
 #[cfg(unix)]
 #[test]
 fn tool_install_home() {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
 
     // Install `black`
@@ -694,7 +746,7 @@ fn tool_install_home() {
 /// Test `uv tool install` when the bin directory is inferred from `$XDG_DATA_HOME`
 #[test]
 fn tool_install_xdg_data_home() {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let data_home = context.temp_dir.child("data/home");
 
@@ -730,7 +782,7 @@ fn tool_install_xdg_data_home() {
 /// Test `uv tool install` when the bin directory is set by `$XDG_BIN_HOME`
 #[test]
 fn tool_install_xdg_bin_home() {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -15,7 +15,9 @@ mod common;
 /// Test installing a tool with `uv tool install`
 #[test]
 fn tool_install() {
-    let context = TestContext::new("3.12").with_filtered_counts();
+    let context = TestContext::new("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -316,7 +318,9 @@ fn tool_install_from() {
 /// Test installing and reinstalling an already installed tool
 #[test]
 fn tool_install_already_installed() {
-    let context = TestContext::new("3.12").with_filtered_counts();
+    let context = TestContext::new("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 


### PR DESCRIPTION
We need this to power uninstallations! 

The latter two commits were reviewed in:

- #4637 
- #4638 

Note this is a breaking change for existing tool installations, but it's in preview and very new. In the future, we'll need a clear upgrade path for tool receipt changes.