### PR TITLE
Use `toml_edit` for pretty tool receipt formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5025,6 +5025,7 @@ dependencies = [
  "serde",
  "thiserror",
  "toml",
+ "toml_edit",
  "tracing",
  "uv-cache",
  "uv-fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5019,6 +5019,7 @@ dependencies = [
  "dirs-sys",
  "fs-err",
  "install-wheel-rs",
+ "path-slash",
  "pep440_rs",
  "pep508_rs",
  "pypi-types",

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -13,20 +13,21 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-uv-fs = { workspace = true }
-uv-state = { workspace = true }
-pep508_rs = { workspace = true }
-pypi-types = { workspace = true }
-uv-virtualenv = { workspace = true }
-uv-toolchain = { workspace = true }
 install-wheel-rs = { workspace = true }
 pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
+pypi-types = { workspace = true }
 uv-cache = { workspace = true }
+uv-fs = { workspace = true }
+uv-state = { workspace = true }
+uv-toolchain = { workspace = true }
+uv-virtualenv = { workspace = true }
 
-thiserror = { workspace = true }
-tracing = { workspace = true }
+dirs-sys = { workspace = true }
 fs-err = { workspace = true }
+path-slash = { workspace = true }
 serde = { workspace = true }
+thiserror = { workspace = true }
 toml = { workspace = true } 
 toml_edit = { workspace = true } 
-dirs-sys = { workspace = true }
+tracing = { workspace = true }

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -28,4 +28,5 @@ tracing = { workspace = true }
 fs-err = { workspace = true }
 serde = { workspace = true }
 toml = { workspace = true } 
+toml_edit = { workspace = true } 
 dirs-sys = { workspace = true }

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -134,10 +134,9 @@ impl InstalledTools {
             path.user_display()
         );
 
-        let doc = toml::to_string(&tool_receipt)
-            .map_err(|err| Error::ReceiptWrite(path.clone(), Box::new(err)))?;
+        let doc = tool_receipt.to_toml();
 
-        // Save the modified `tools.toml`.
+        // Save the modified `uv-receipt.toml`.
         fs_err::write(&path, doc)?;
 
         Ok(())

--- a/crates/uv-tool/src/receipt.rs
+++ b/crates/uv-tool/src/receipt.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::Tool;
 
 /// A `uv-receipt.toml` file tracking the installation of a tool.
 #[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ToolReceipt {
     pub(crate) tool: Tool,
 
@@ -29,6 +29,16 @@ impl ToolReceipt {
                 .map_err(|err| crate::Error::ReceiptRead(path.to_owned(), Box::new(err)))?),
             Err(err) => Err(err.into()),
         }
+    }
+
+    /// Returns the TOML representation of this receipt.
+    pub(crate) fn to_toml(&self) -> String {
+        // We construct a TOML document manually instead of going through Serde to enable
+        // the use of inline tables.
+        let mut doc = toml_edit::DocumentMut::new();
+        doc.insert("tool", toml_edit::Item::Table(self.tool.to_toml()));
+
+        doc.to_string()
     }
 }
 

--- a/crates/uv-tool/src/tool.rs
+++ b/crates/uv-tool/src/tool.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use path_slash::PathBufExt;
 use pypi_types::VerbatimParsedUrl;
 use serde::Deserialize;
 use toml_edit::value;
@@ -118,7 +119,8 @@ impl ToolEntrypoint {
         table.insert("name", value(&self.name));
         table.insert(
             "install-path",
-            value(self.install_path.to_string_lossy().to_string()),
+            // Use cross-platform slashes so the toml string type does not change
+            value(self.install_path.to_slash_lossy().to_string()),
         );
         table
     }

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -77,14 +77,10 @@ fn tool_install() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 
@@ -162,10 +158,9 @@ fn tool_install() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("flask").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["flask"]
-
-        [[tool.entrypoints]]
-        name = "flask"
-        install_path = "[TEMP_DIR]/bin/flask"
+        entrypoints = [
+            { name = "flask", install-path = "[TEMP_DIR]/bin/flask" },
+        ]
         "###);
     });
 }
@@ -235,14 +230,10 @@ fn tool_install_version() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black==24.2.0"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 
@@ -387,14 +378,10 @@ fn tool_install_already_installed() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 
@@ -424,14 +411,10 @@ fn tool_install_already_installed() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 
@@ -649,14 +632,10 @@ fn tool_install_entry_point_exists() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 
@@ -686,14 +665,10 @@ fn tool_install_entry_point_exists() {
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
         requirements = ["black"]
-
-        [[tool.entrypoints]]
-        name = "black"
-        install_path = "[TEMP_DIR]/bin/black"
-
-        [[tool.entrypoints]]
-        name = "blackd"
-        install_path = "[TEMP_DIR]/bin/blackd"
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
+        ]
         "###);
     });
 

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -15,7 +15,9 @@ mod common;
 /// Test installing a tool with `uv tool install`
 #[test]
 fn tool_install() {
-    let context = TestContext::new("3.12").with_filtered_counts();
+    let context = TestContext::new("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -316,7 +318,9 @@ fn tool_install_from() {
 /// Test installing and reinstalling an already installed tool
 #[test]
 fn tool_install_already_installed() {
-    let context = TestContext::new("3.12").with_filtered_counts();
+    let context = TestContext::new("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 


### PR DESCRIPTION
I started doing this because I wanted more control over the document but this ends up being useful for https://github.com/astral-sh/uv/pull/4638

I worry about the complexity of this implementation for a largely internal document (unlike the lock file which is very user facing). I think https://github.com/astral-sh/uv/pull/4638 might be better implemented by wrapping `PathBuf`. Then, in the future document could change to JSON with little effort. However, I think that we want tool definitions to be user-facing _eventually_ so I'm unsure this is wasted effort or complexity.