### PR TITLE
Use cross-platform paths in tool receipt entry point paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5019,6 +5019,7 @@ dependencies = [
  "dirs-sys",
  "fs-err",
  "install-wheel-rs",
+ "path-slash",
  "pep440_rs",
  "pep508_rs",
  "pypi-types",

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -13,20 +13,21 @@ license = { workspace = true }
 workspace = true
 
 [dependencies]
-uv-fs = { workspace = true }
-uv-state = { workspace = true }
-pep508_rs = { workspace = true }
-pypi-types = { workspace = true }
-uv-virtualenv = { workspace = true }
-uv-toolchain = { workspace = true }
 install-wheel-rs = { workspace = true }
 pep440_rs = { workspace = true }
+pep508_rs = { workspace = true }
+pypi-types = { workspace = true }
 uv-cache = { workspace = true }
+uv-fs = { workspace = true }
+uv-state = { workspace = true }
+uv-toolchain = { workspace = true }
+uv-virtualenv = { workspace = true }
 
-thiserror = { workspace = true }
-tracing = { workspace = true }
+dirs-sys = { workspace = true }
 fs-err = { workspace = true }
+path-slash = { workspace = true }
 serde = { workspace = true }
+thiserror = { workspace = true }
 toml = { workspace = true } 
 toml_edit = { workspace = true } 
-dirs-sys = { workspace = true }
+tracing = { workspace = true }

--- a/crates/uv-tool/src/tool.rs
+++ b/crates/uv-tool/src/tool.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use path_slash::PathBufExt;
 use pypi_types::VerbatimParsedUrl;
 use serde::Deserialize;
 use toml_edit::value;
@@ -118,7 +119,8 @@ impl ToolEntrypoint {
         table.insert("name", value(&self.name));
         table.insert(
             "install-path",
-            value(self.install_path.to_string_lossy().to_string()),
+            // Use cross-platform slashes so the toml string type does not change
+            value(self.install_path.to_slash_lossy().to_string()),
         );
         table
     }

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -15,7 +15,9 @@ mod common;
 /// Test installing a tool with `uv tool install`
 #[test]
 fn tool_install() {
-    let context = TestContext::new("3.12").with_filtered_counts();
+    let context = TestContext::new("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -316,7 +318,9 @@ fn tool_install_from() {
 /// Test installing and reinstalling an already installed tool
 #[test]
 fn tool_install_already_installed() {
-    let context = TestContext::new("3.12").with_filtered_counts();
+    let context = TestContext::new("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 


### PR DESCRIPTION
As https://github.com/astral-sh/uv/pull/4324 did for lock files, updates the tool receipts to use portable paths. This resolves CI failures on Windows in #4634 where the toml string literal type changes depending on the platform.