### PR TITLE
Use cycle aware algorithm for propagating markers

### DIFF
--- a/crates/uv-resolver/src/resolution/display.rs
+++ b/crates/uv-resolver/src/resolution/display.rs
@@ -360,11 +360,13 @@ fn propagate_markers(mut graph: IntermediatePetGraph) -> IntermediatePetGraph {
     // TODO(charlie): The above reasoning could be incorrect. Consider using a graph algorithm that
     // can handle weight propagation with cycles.
     let edges = {
-        let fas = greedy_feedback_arc_set(&graph)
+        let mut fas = greedy_feedback_arc_set(&graph)
             .map(|edge| edge.id())
             .collect::<Vec<_>>();
         let mut edges = Vec::with_capacity(fas.len());
-        for edge_id in fas {
+        // remove edges in reverse order, only safe way to remove from Graph.
+        fas.sort_unstable();
+        for &edge_id in fas.iter().rev() {
             edges.push(graph.edge_endpoints(edge_id).unwrap());
             graph.remove_edge(edge_id);
         }


### PR DESCRIPTION
This is my attempt at this - I don't exactly have much prior experience with
Uv's codebase and w.r.t graph algorithms I'm pretty rusty.
Let's look at this critically and try to find out if it does the right thing.

The strongly connected components algorithm both finds all cyclic
subgraphs, and a topological order of them. This seems to be a good
way to replace Topo with something cycle-aware.

The new algorithm uses the fact that in a strongly connected component,
all vertices reach each other through some edge. That means we can
combine markers of all internal edges in a component.

As an optimization, only outgoing edges pointing out of the current
component are updated. I didn't look outside this function, so don't
know if that's a reasonable choice.

There are useful pictures in this article:
https://en.wikipedia.org/wiki/Strongly_connected_component

## Test Plan

Using existing tests