### PR TITLE
DRY up some project interpreter validation and discovery

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -60,7 +60,7 @@ pub(crate) async fn add(
     };
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(
+    let venv = project::get_or_init_environment(
         project.workspace(),
         python.as_deref().map(ToolchainRequest::parse),
         toolchain_preference,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -81,7 +81,7 @@ pub(crate) async fn remove(
     )?;
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(
+    let venv = project::get_or_init_environment(
         project.workspace(),
         python.as_deref().map(ToolchainRequest::parse),
         toolchain_preference,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -160,7 +160,7 @@ pub(crate) async fn run(
                 );
             }
 
-            let venv = project::init_environment(
+            let venv = project::get_or_init_environment(
                 project.workspace(),
                 python.as_deref().map(ToolchainRequest::parse),
                 toolchain_preference,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -41,7 +41,7 @@ pub(crate) async fn sync(
     let project = VirtualProject::discover(&std::env::current_dir()?, None).await?;
 
     // Discover or create the virtual environment.
-    let venv = project::init_environment(
+    let venv = project::get_or_init_environment(
         project.workspace(),
         python.as_deref().map(ToolchainRequest::parse),
         toolchain_preference,
@@ -111,7 +111,7 @@ pub(super) async fn do_sync(
     // Validate that the Python version is supported by the lockfile.
     if let Some(requires_python) = lock.requires_python() {
         if !requires_python.contains(venv.interpreter().python_version()) {
-            return Err(ProjectError::PythonIncompatibility(
+            return Err(ProjectError::LockedPythonIncompatibility(
                 venv.interpreter().python_version().clone(),
                 requires_python.clone(),
             ));

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -2047,7 +2047,6 @@ fn lock_requires_python() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning.
-    Removing virtual environment at: .venv
     error: No interpreter found for Python >=3.12 in system path
     "###);
 


### PR DESCRIPTION
## Summary

I noticed that `init_environment` and `find_interpreter` were both calling `find_environment`, which seemed like a code smell to me. Instead, `find_interpreter` now returns either a compatible environment or an interpreter (if no compatible environment was found).

Additionally, `interpreter_meets_requirements` now no longer validates `requires-python` if `--python` or `.python-version` is set. Instead, we warn, which matches the behavior we get when creating a new environment at the bottom of `find_interpreter`.

In total, I think this makes the data flow in project interpreter discovery less repetitive and easier to reason about.
