### PR TITLE
Add entrypoints to tool list

### DIFF
--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -27,8 +27,19 @@ pub(crate) async fn list(preview: PreviewMode, printer: Printer) -> Result<ExitS
     }
 
     // TODO(zanieb): Track and display additional metadata, like entry points
-    for (name, _tool) in tools {
+    for (name, tool) in tools {
+        // Output tool name
         writeln!(printer.stdout(), "{name}")?;
+
+        // Output tool entrypoints
+        for entrypoint in tool
+            .entrypoints()
+            .iter()
+            .map(|entry| entry.name.clone())
+            .collect::<Vec<String>>()
+        {
+            writeln!(printer.stdout(), "  {entrypoint}")?;
+        }
     }
 
     Ok(ExitStatus::Success)

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -38,7 +38,7 @@ pub(crate) async fn list(preview: PreviewMode, printer: Printer) -> Result<ExitS
             .map(|entry| entry.name.clone())
             .collect::<Vec<String>>()
         {
-            writeln!(printer.stdout(), "  {entrypoint}")?;
+            writeln!(printer.stdout(), "\t{entrypoint}")?;
         }
     }
 

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -38,7 +38,7 @@ pub(crate) async fn list(preview: PreviewMode, printer: Printer) -> Result<ExitS
             .map(|entry| entry.name.clone())
             .collect::<Vec<String>>()
         {
-            writeln!(printer.stdout(), "\t{entrypoint}")?;
+            writeln!(printer.stdout(), "    {entrypoint}")?;
         }
     }
 

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -32,13 +32,8 @@ pub(crate) async fn list(preview: PreviewMode, printer: Printer) -> Result<ExitS
         writeln!(printer.stdout(), "{name}")?;
 
         // Output tool entrypoints
-        for entrypoint in tool
-            .entrypoints()
-            .iter()
-            .map(|entry| entry.name.clone())
-            .collect::<Vec<String>>()
-        {
-            writeln!(printer.stdout(), "    {entrypoint}")?;
+        for entrypoint in tool.entrypoints() {
+            writeln!(printer.stdout(), "    {}", &entrypoint.name)?;
         }
     }
 

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -26,7 +26,6 @@ pub(crate) async fn list(preview: PreviewMode, printer: Printer) -> Result<ExitS
         return Ok(ExitStatus::Success);
     }
 
-    // TODO(zanieb): Track and display additional metadata, like entry points
     for (name, tool) in tools {
         // Output tool name
         writeln!(printer.stdout(), "{name}")?;

--- a/crates/uv/tests/tool_list.rs
+++ b/crates/uv/tests/tool_list.rs
@@ -30,6 +30,7 @@ fn tool_list() {
     black
         black
         blackd
+    
     ----- stderr -----
     warning: `uv tool list` is experimental and may change without warning.
     "###);

--- a/crates/uv/tests/tool_list.rs
+++ b/crates/uv/tests/tool_list.rs
@@ -28,7 +28,8 @@ fn tool_list() {
     exit_code: 0
     ----- stdout -----
     black
-
+        black
+        blackd
     ----- stderr -----
     warning: `uv tool list` is experimental and may change without warning.
     "###);

--- a/crates/uv/tests/tool_list.rs
+++ b/crates/uv/tests/tool_list.rs
@@ -8,7 +8,7 @@ mod common;
 
 #[test]
 fn tool_list() {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -38,7 +38,7 @@ fn tool_list() {
 
 #[test]
 fn tool_list_empty() {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -57,7 +57,7 @@ fn tool_list_empty() {
 
 #[test]
 fn tool_list_missing_receipt() {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Closes #4654 
## Summary

The purpose of this is to show the entrypoints of each tool when running `uv tool list` as below:

```
$ uv tool list
black
    black
    blackd

```

I used the proposed formatting as it was written in #4653 by @blueraft.
I had to use spaces instead of tabs in order to make the test successful. Indeed in the test we are using a raw string and I did not manage to make the test pass when escaping the tab in the list.rs file so I used spaces everywhere.

I had a deeper look into #4653 as well but it is more difficult as we need to get the version of the tool in the Tool object, I will continue on this next one later. 

Please tell me if anything else is needed I tried to follow the contribution guidelines but I might have forgotten something. 
Have a great day!


## Test Plan

`cargo clippy`

then by using the local version of uv as described in the Readme.md. 


```
my-computer :~/mypath/uv$ cargo run -- tool list
   Compiling uv-cli v0.0.1 (/mypath/uv/crates/uv-cli)
   Compiling uv v0.2.18 (/mypath/uv/crates/uv)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.69s
     Running `target/debug/uv tool list`
warning: `uv tool list` is experimental and may change without warning.
black
  black
  blackd
isort
  isort
  isort-identify-imports

```

and 

`cargo test tool_list`
