### PR TITLE
Disable Clippy's `too-many-arguments` rule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ module_name_repetitions = "allow"
 must_use_candidate = "allow"
 similar_names = "allow"
 too_many_lines = "allow"
+too_many_arguments = "allow"
 # Disallowed restriction lints
 print_stdout = "warn"
 print_stderr = "warn"

--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -681,7 +681,6 @@ impl MarkerEnvironment {
         python_version,
         sys_platform
     ))]
-    #[allow(clippy::too_many_arguments)]
     fn py_new(
         implementation_name: &str,
         implementation_version: &str,

--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -398,7 +398,6 @@ impl SourceBuild {
     /// contents from an archive if necessary.
     ///
     /// `source_dist` is for error reporting only.
-    #[allow(clippy::too_many_arguments)]
     pub async fn setup(
         source: &Path,
         subdirectory: Option<&Path>,
@@ -901,7 +900,6 @@ fn escape_path_for_python(path: &Path) -> String {
 }
 
 /// Not a method because we call it before the builder is completely initialized
-#[allow(clippy::too_many_arguments)]
 async fn create_pep517_build_environment(
     runner: &PythonRunner,
     source_tree: &Path,

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -54,7 +54,6 @@ pub struct BuildDispatch<'a> {
 }
 
 impl<'a> BuildDispatch<'a> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         client: &'a RegistryClient,
         cache: &'a Cache,

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -433,7 +433,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     }
 
     /// Build a source distribution from a remote URL.
-    #[allow(clippy::too_many_arguments)]
     async fn url<'data>(
         &self,
         source: &BuildableSource<'data>,
@@ -505,7 +504,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     ///
     /// If the build backend supports `prepare_metadata_for_build_wheel`, this method will avoid
     /// building the wheel.
-    #[allow(clippy::too_many_arguments)]
     async fn url_metadata<'data>(
         &self,
         source: &BuildableSource<'data>,

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -50,7 +50,6 @@ impl<'a> Planner<'a> {
     /// The install plan will also respect the required hashes, such that it will never return a
     /// cached distribution that does not match the required hash. Like pip, though, it _will_
     /// return an _installed_ distribution that does not match the required hash.
-    #[allow(clippy::too_many_arguments)]
     pub fn build(
         self,
         mut site_packages: SitePackages,

--- a/crates/uv-resolver/src/manifest.rs
+++ b/crates/uv-resolver/src/manifest.rs
@@ -50,7 +50,6 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         requirements: Vec<Requirement>,
         constraints: Constraints,

--- a/crates/uv-resolver/src/resolution/display.rs
+++ b/crates/uv-resolver/src/resolution/display.rs
@@ -64,7 +64,7 @@ impl<'a> From<&'a ResolutionGraph> for DisplayResolutionGraph<'a> {
 
 impl<'a> DisplayResolutionGraph<'a> {
     /// Create a new [`DisplayResolutionGraph`] for the given graph.
-    #[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
+    #[allow(clippy::fn_params_excessive_bools)]
     pub fn new(
         underlying: &'a ResolutionGraph,
         marker_env: Option<&'a MarkerEnvironment>,

--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -52,7 +52,6 @@ pub(crate) enum ResolutionGraphNode {
 
 impl ResolutionGraph {
     /// Create a new graph from the resolved PubGrub state.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_state(
         requirements: &[Requirement],
         constraints: &Constraints,

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -137,7 +137,6 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
     /// When a marker environment is provided, the resolver is in
     /// "non-universal" mode, which corresponds to standard `pip` behavior that
     /// works only for a specific marker environment.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         manifest: Manifest,
         options: Options,
@@ -180,7 +179,6 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
     Resolver<Provider, InstalledPackages>
 {
     /// Initialize a new resolver using a user provided backend.
-    #[allow(clippy::too_many_arguments)]
     pub fn new_custom_io(
         manifest: Manifest,
         options: Options,

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -86,7 +86,6 @@ pub struct DefaultResolverProvider<'a, Context: BuildContext> {
 
 impl<'a, Context: BuildContext> DefaultResolverProvider<'a, Context> {
     /// Reads the flat index entries and builds the provider.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         fetcher: DistributionDatabase<'a, Context>,
         flat_index: &'a FlatIndex,

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -40,7 +40,6 @@ impl VersionMap {
     ///
     /// PEP 592: <https://peps.python.org/pep-0592/#warehouse-pypi-implementation-notes>
     #[instrument(skip_all, fields(package_name))]
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn from_metadata(
         simple_metadata: OwnedArchive<SimpleMetadata>,
         package_name: &PackageName,
@@ -489,7 +488,6 @@ impl VersionMapLazy {
         SourceDistCompatibility::Compatible(hash)
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn wheel_compatibility(
         &self,
         filename: &WheelFilename,

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -73,7 +73,6 @@ pub(crate) async fn read_requirements(
 }
 
 /// Resolve a set of requirements, similar to running `pip compile`.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
     requirements: Vec<UnresolvedRequirementSpecification>,
     constraints: Vec<Requirement>,
@@ -278,7 +277,6 @@ pub(crate) enum Modifications {
 }
 
 /// Install a set of requirements into the current environment.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn install(
     resolution: &Resolution,
     site_packages: SitePackages,

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -18,7 +18,6 @@ use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Display the installed packages in the current environment as a dependency tree.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn pip_tree(
     depth: u8,
     prune: Vec<PackageName>,

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -22,7 +22,6 @@ use crate::commands::{elapsed, ExitStatus};
 use crate::printer::Printer;
 
 /// Uninstall packages from the current environment.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn pip_uninstall(
     sources: &[RequirementsSource],
     python: Option<String>,

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -23,7 +23,6 @@ use crate::printer::Printer;
 use crate::settings::{ResolverSettings, ResolverSettingsRef};
 
 /// Resolve the project requirements into a lockfile.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn lock(
     python: Option<String>,
     settings: ResolverSettings,
@@ -82,7 +81,6 @@ pub(crate) async fn lock(
 }
 
 /// Lock the project requirements into a lockfile.
-#[allow(clippy::too_many_arguments)]
 pub(super) async fn do_lock(
     workspace: &Workspace,
     interpreter: &Interpreter,

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -278,7 +278,6 @@ pub(crate) async fn init_environment(
 }
 
 /// Update a [`PythonEnvironment`] to satisfy a set of [`RequirementsSource`]s.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn update_environment(
     venv: PythonEnvironment,
     requirements: &[RequirementsSource],

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -16,7 +16,6 @@ use crate::printer::Printer;
 use crate::settings::{InstallerSettings, ResolverSettings};
 
 /// Remove one or more packages from the project requirements.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn remove(
     requirements: Vec<PackageName>,
     dependency_type: DependencyType,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -25,7 +25,6 @@ use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 
 /// Run a command.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run(
     extras: ExtrasSpecification,
     dev: bool,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -19,7 +19,6 @@ use crate::printer::Printer;
 use crate::settings::{InstallerSettings, InstallerSettingsRef};
 
 /// Sync the project environment.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn sync(
     extras: ExtrasSpecification,
     dev: bool,
@@ -82,7 +81,6 @@ pub(crate) async fn sync(
 }
 
 /// Sync a lockfile with an environment.
-#[allow(clippy::too_many_arguments)]
 pub(super) async fn do_sync(
     project: &VirtualProject,
     venv: &PythonEnvironment,

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -28,7 +28,6 @@ use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 
 /// Install a tool.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn install(
     package: String,
     from: Option<String>,

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -10,7 +10,6 @@ use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// List installed tools.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn list(preview: PreviewMode, printer: Printer) -> Result<ExitStatus> {
     if preview.is_disabled() {
         warn_user_once!("`uv tool list` is experimental and may change without warning.");

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -25,7 +25,6 @@ use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 
 /// Run a command.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run(
     command: ExternalCommand,
     python: Option<String>,

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -13,7 +13,6 @@ use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Uninstall a tool.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn uninstall(
     name: String,
     preview: PreviewMode,


### PR DESCRIPTION
## Summary

We allow this constantly, I think it's just too pedantic for us.
