### PR TITLE
Respect data scripts in `uv tool install`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5037,6 +5037,7 @@ dependencies = [
  "fs-err",
  "install-wheel-rs",
  "path-slash",
+ "pathdiff",
  "pep440_rs",
  "pep508_rs",
  "pypi-types",

--- a/crates/install-wheel-rs/src/lib.rs
+++ b/crates/install-wheel-rs/src/lib.rs
@@ -11,11 +11,10 @@ use zip::result::ZipError;
 use pep440_rs::Version;
 use platform_tags::{Arch, Os};
 use pypi_types::Scheme;
-pub use script::{scripts_from_ini, Script};
 pub use uninstall::{uninstall_egg, uninstall_legacy_editable, uninstall_wheel, Uninstall};
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
-pub use wheel::{parse_wheel_file, LibKind};
+pub use wheel::{parse_wheel_file, read_record_file, LibKind};
 
 pub mod linker;
 pub mod metadata;

--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -1,7 +1,7 @@
 //! Like `wheel.rs`, but for installing wheels that have already been unzipped, rather than
 //! reading from a zip file.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::str::FromStr;
 use std::time::SystemTime;
 
@@ -141,24 +141,6 @@ pub fn install_wheel(
     }
 
     Ok(())
-}
-
-/// Determine the absolute path to an entrypoint script.
-pub fn entrypoint_path(entrypoint: &Script, layout: &Layout) -> PathBuf {
-    if cfg!(windows) {
-        // On windows we actually build an .exe wrapper
-        let script_name = entrypoint
-            .name
-            // FIXME: What are the in-reality rules here for names?
-            .strip_suffix(".py")
-            .unwrap_or(&entrypoint.name)
-            .to_string()
-            + ".exe";
-
-        layout.scheme.scripts.join(script_name)
-    } else {
-        layout.scheme.scripts.join(&entrypoint.name)
-    }
 }
 
 /// Find the `dist-info` directory in an unzipped wheel.

--- a/crates/install-wheel-rs/src/record.rs
+++ b/crates/install-wheel-rs/src/record.rs
@@ -8,9 +8,9 @@ use serde::{Deserialize, Serialize};
 /// tqdm-4.62.3.dist-info/RECORD,,
 /// ```
 #[derive(Deserialize, Serialize, PartialOrd, PartialEq, Ord, Eq)]
-pub(crate) struct RecordEntry {
-    pub(crate) path: String,
-    pub(crate) hash: Option<String>,
+pub struct RecordEntry {
+    pub path: String,
+    pub hash: Option<String>,
     #[allow(dead_code)]
-    pub(crate) size: Option<u64>,
+    pub size: Option<u64>,
 }

--- a/crates/install-wheel-rs/src/script.rs
+++ b/crates/install-wheel-rs/src/script.rs
@@ -9,10 +9,10 @@ use crate::{wheel, Error};
 /// A script defining the name of the runnable entrypoint and the module and function that should be
 /// run.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-pub struct Script {
-    pub name: String,
-    pub module: String,
-    pub function: String,
+pub(crate) struct Script {
+    pub(crate) name: String,
+    pub(crate) module: String,
+    pub(crate) function: String,
 }
 
 impl Script {
@@ -64,7 +64,7 @@ impl Script {
     }
 }
 
-pub fn scripts_from_ini(
+pub(crate) fn scripts_from_ini(
     extras: Option<&[String]>,
     python_minor: u8,
     ini: String,

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -27,8 +27,9 @@ uv-warnings = { workspace = true }
 dirs-sys = { workspace = true }
 fs-err = { workspace = true }
 path-slash = { workspace = true }
+pathdiff = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-toml = { workspace = true } 
-toml_edit = { workspace = true } 
+toml = { workspace = true }
+toml_edit = { workspace = true }
 tracing = { workspace = true }

--- a/crates/uv/tests/tool_uninstall.rs
+++ b/crates/uv/tests/tool_uninstall.rs
@@ -8,7 +8,7 @@ mod common;
 
 #[test]
 fn tool_uninstall() {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -71,7 +71,7 @@ fn tool_uninstall() {
 
 #[test]
 fn tool_uninstall_not_installed() {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -90,7 +90,7 @@ fn tool_uninstall_not_installed() {
 
 #[test]
 fn tool_uninstall_missing_receipt() {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12").with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 


### PR DESCRIPTION
## Summary

Packages that provide scripts that _aren't_ Python entrypoints need to respected in `uv tool install`. For example, Ruff ships a script in `ruff-0.5.0.data/scripts`.

Unfortunately, the `.data` directory doesn't exist in the virtual environment at all (it's removed, per the spec, after install). So this PR changes the entry point detection to look at the `RECORD` file, which is the only evidence that the scripts were installed.

Closes https://github.com/astral-sh/uv/issues/4691.

## Test Plan

`cargo run uv tool install ruff` (snapshot tests to-come)
