### PR TITLE
Add `tool dir` and `toolchain dir` commands

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1877,6 +1877,8 @@ pub enum ToolCommand {
     List(ToolListArgs),
     /// Uninstall a tool.
     Uninstall(ToolUninstallArgs),
+    /// Show the tools directory.
+    Dir,
 }
 
 #[derive(Args)]
@@ -2001,6 +2003,9 @@ pub enum ToolchainCommand {
     /// Search for a toolchain
     #[command(disable_version_flag = true)]
     Find(ToolchainFindArgs),
+
+    /// Show the toolchains directory.
+    Dir,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/cache_dir.rs
+++ b/crates/uv/src/commands/cache_dir.rs
@@ -4,5 +4,5 @@ use uv_fs::Simplified;
 
 /// Show the cache directory.
 pub(crate) fn cache_dir(cache: &Cache) {
-    anstream::println!("{}", cache.root().user_display().cyan());
+    anstream::println!("{}", cache.root().simplified_display().cyan());
 }

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub(crate) use project::run::run;
 pub(crate) use project::sync::sync;
 #[cfg(feature = "self-update")]
 pub(crate) use self_update::self_update;
+pub(crate) use tool::dir::dir as tool_dir;
 pub(crate) use tool::install::install as tool_install;
 pub(crate) use tool::list::list as tool_list;
 pub(crate) use tool::run::run as tool_run;

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use tool::install::install as tool_install;
 pub(crate) use tool::list::list as tool_list;
 pub(crate) use tool::run::run as tool_run;
 pub(crate) use tool::uninstall::uninstall as tool_uninstall;
+pub(crate) use toolchain::dir::dir as toolchain_dir;
 pub(crate) use toolchain::find::find as toolchain_find;
 pub(crate) use toolchain::install::install as toolchain_install;
 pub(crate) use toolchain::list::list as toolchain_list;

--- a/crates/uv/src/commands/tool/dir.rs
+++ b/crates/uv/src/commands/tool/dir.rs
@@ -1,0 +1,17 @@
+use anyhow::Context;
+use owo_colors::OwoColorize;
+use uv_configuration::PreviewMode;
+use uv_fs::Simplified;
+use uv_tool::InstalledTools;
+use uv_warnings::warn_user_once;
+
+/// Show the tool directory.
+pub(crate) fn dir(preview: PreviewMode) -> anyhow::Result<()> {
+    if preview.is_disabled() {
+        warn_user_once!("`uv tool dir` is experimental and may change without warning.");
+    }
+    let installed_tools =
+        InstalledTools::from_settings().context("Failed to initialize tools settings")?;
+    anstream::println!("{}", installed_tools.root().user_display().cyan());
+    Ok(())
+}

--- a/crates/uv/src/commands/tool/dir.rs
+++ b/crates/uv/src/commands/tool/dir.rs
@@ -12,6 +12,6 @@ pub(crate) fn dir(preview: PreviewMode) -> anyhow::Result<()> {
     }
     let installed_tools =
         InstalledTools::from_settings().context("Failed to initialize tools settings")?;
-    anstream::println!("{}", installed_tools.root().user_display().cyan());
+    anstream::println!("{}", installed_tools.root().simplified_display().cyan());
     Ok(())
 }

--- a/crates/uv/src/commands/tool/mod.rs
+++ b/crates/uv/src/commands/tool/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod dir;
 pub(crate) mod install;
 pub(crate) mod list;
 pub(crate) mod run;

--- a/crates/uv/src/commands/toolchain/dir.rs
+++ b/crates/uv/src/commands/toolchain/dir.rs
@@ -12,6 +12,9 @@ pub(crate) fn dir(preview: PreviewMode) -> anyhow::Result<()> {
     }
     let installed_toolchains =
         InstalledToolchains::from_settings().context("Failed to initialize toolchain settings")?;
-    anstream::println!("{}", installed_toolchains.root().user_display().cyan());
+    anstream::println!(
+        "{}",
+        installed_toolchains.root().simplified_display().cyan()
+    );
     Ok(())
 }

--- a/crates/uv/src/commands/toolchain/dir.rs
+++ b/crates/uv/src/commands/toolchain/dir.rs
@@ -1,0 +1,17 @@
+use anyhow::Context;
+use owo_colors::OwoColorize;
+use uv_configuration::PreviewMode;
+use uv_fs::Simplified;
+use uv_toolchain::managed::InstalledToolchains;
+use uv_warnings::warn_user_once;
+
+/// Show the toolchain directory.
+pub(crate) fn dir(preview: PreviewMode) -> anyhow::Result<()> {
+    if preview.is_disabled() {
+        warn_user_once!("`uv toolchain dir` is experimental and may change without warning.");
+    }
+    let installed_toolchains =
+        InstalledToolchains::from_settings().context("Failed to initialize toolchain settings")?;
+    anstream::println!("{}", installed_toolchains.root().user_display().cyan());
+    Ok(())
+}

--- a/crates/uv/src/commands/toolchain/mod.rs
+++ b/crates/uv/src/commands/toolchain/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod dir;
 pub(crate) mod find;
 pub(crate) mod install;
 pub(crate) mod list;

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -848,6 +848,12 @@ async fn run() -> Result<ExitStatus> {
 
             commands::tool_uninstall(args.name, globals.preview, printer).await
         }
+        Commands::Tool(ToolNamespace {
+            command: ToolCommand::Dir,
+        }) => {
+            commands::tool_dir(globals.preview)?;
+            Ok(ExitStatus::Success)
+        }
         Commands::Toolchain(ToolchainNamespace {
             command: ToolchainCommand::List(args),
         }) => {

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -914,6 +914,12 @@ async fn run() -> Result<ExitStatus> {
             )
             .await
         }
+        Commands::Toolchain(ToolchainNamespace {
+            command: ToolchainCommand::Dir,
+        }) => {
+            commands::toolchain_dir(globals.preview)?;
+            Ok(ExitStatus::Success)
+        }
     }
 }
 

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -420,6 +420,14 @@ impl TestContext {
         command
     }
 
+    /// Create a `uv tool dir` command with options shared across scenarios.
+    pub fn tool_dir(&self) -> Command {
+        let mut command = Command::new(get_bin());
+        command.arg("tool").arg("dir");
+        self.add_shared_args(&mut command);
+        command
+    }
+
     /// Create a `uv tool uninstall` command with options shared across scenarios.
     pub fn tool_uninstall(&self) -> std::process::Command {
         let mut command = std::process::Command::new(get_bin());

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -376,6 +376,14 @@ impl TestContext {
         command
     }
 
+    /// Create a `uv toolchain dir` command with options shared across scenarios.
+    pub fn toolchain_dir(&self) -> Command {
+        let mut command = Command::new(get_bin());
+        command.arg("toolchain").arg("dir");
+        self.add_shared_args(&mut command);
+        command
+    }
+
     /// Create a `uv run` command with options shared across scenarios.
     pub fn run(&self) -> Command {
         let mut command = Command::new(get_bin());

--- a/crates/uv/tests/tool_dir.rs
+++ b/crates/uv/tests/tool_dir.rs
@@ -1,0 +1,25 @@
+#![cfg(all(feature = "python", feature = "pypi"))]
+
+use assert_fs::fixture::PathChild;
+use common::{uv_snapshot, TestContext};
+
+mod common;
+
+#[test]
+fn tool_dir() {
+    let context = TestContext::new("3.12");
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context.tool_dir()
+    .env("UV_TOOL_DIR", tool_dir.as_os_str())
+    .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_DIR]/tools
+
+    ----- stderr -----
+    warning: `uv tool dir` is experimental and may change without warning.
+    "###);
+}

--- a/crates/uv/tests/toolchain_dir.rs
+++ b/crates/uv/tests/toolchain_dir.rs
@@ -1,0 +1,23 @@
+#![cfg(all(feature = "python", feature = "pypi"))]
+
+use assert_fs::fixture::PathChild;
+use common::{uv_snapshot, TestContext};
+
+mod common;
+
+#[test]
+fn toolchain_dir() {
+    let context = TestContext::new("3.12");
+
+    let toolchain_dir = context.temp_dir.child("toolchains");
+    uv_snapshot!(context.filters(), context.toolchain_dir()
+    .env("UV_TOOLCHAIN_DIR", toolchain_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [TEMP_DIR]/toolchains
+
+    ----- stderr -----
+    warning: `uv toolchain dir` is experimental and may change without warning.
+    "###);
+}


### PR DESCRIPTION
## Summary

Resolves #4483 
Resolves #4484 

## Test Plan

`cargo test`

```sh
❯ cargo run -- toolchain dir
warning: `uv toolchain dir` is experimental and may change without warning.
/Users/ahmedilyas/Library/Application Support/uv/toolchains

❯ cargo run -- tool dir
warning: `uv tool dir` is experimental and may change without warning.
/Users/ahmedilyas/Library/Application Support/uv/tools
```