### PR TITLE
Fix implementation of `GitDatabase::contains`

### DIFF
--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -175,7 +175,7 @@ impl GitRepository {
         })
     }
 
-    /// Fetches the object ID of the given `refname`.
+    /// Parses the object ID of the given `refname`.
     fn rev_parse(&self, refname: &str) -> Result<GitOid> {
         let result = ProcessBuilder::new("git")
             .arg("rev-parse")
@@ -295,9 +295,9 @@ impl GitDatabase {
         Ok(result)
     }
 
-    /// Checks if the database contains the object of this `oid`.
+    /// Checks if `oid` resolves to a commit in this database.
     pub(crate) fn contains(&self, oid: GitOid) -> bool {
-        self.repo.rev_parse(oid.as_str()).is_ok()
+        self.repo.rev_parse(&format!("{oid}^0")).is_ok()
     }
 }
 

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1354,6 +1354,53 @@ fn install_git_public_https() {
     context.assert_installed("uv_public_pypackage", "0.1.0");
 }
 
+/// Install and update a package from a public GitHub repository
+#[test]
+#[cfg(feature = "git")]
+fn update_ref_git_public_https() {
+    let context = TestContext::new("3.8");
+
+    uv_snapshot!(
+        context
+        .pip_install()
+        .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979"),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
+    "###);
+
+    context.assert_installed("uv_public_pypackage", "0.1.0");
+
+    // Update to a newer commit.
+    uv_snapshot!(
+        context
+        .pip_install()
+        .arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389")
+        .arg("--refresh"),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
+     - uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
+     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
+    "###);
+
+    context.assert_installed("uv_public_pypackage", "0.1.0");
+}
+
 /// Install a package from a public GitHub repository at a ref that does not exist
 #[test]
 #[cfg(feature = "git")]


### PR DESCRIPTION
## Summary

`GitDatabase::contains` previously only parsed the commit to see if it was a valid hash and didn't verify if the commit existed in the object database. This led to the database never being updated.

Resolves https://github.com/astral-sh/uv/issues/4378.

## Test Plan

Added a test that fails without this change.