### PR TITLE
Use `requires-python` semantics for `--universal`

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -831,7 +831,7 @@ impl std::fmt::Display for PubGrubHint {
             } => {
                 write!(
                     f,
-                    "{}{} The `Requires-Python` requirement ({}) defined in your `pyproject.toml` includes Python versions that are not supported by your dependencies (e.g., {} only supports {}). Consider using a more restrictive `Requires-Python` requirement (like {}).",
+                    "{}{} The `Requires-Python` requirement ({}) includes Python versions that are not supported by your dependencies (e.g., {} only supports {}). Consider using a more restrictive `Requires-Python` requirement (like {}).",
                     "hint".bold().cyan(),
                     ":".bold(),
                     requires_python.bold(),

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -191,11 +191,6 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
         provider: Provider,
         installed_packages: InstalledPackages,
     ) -> Result<Self, ResolveError> {
-        let requires_python = if markers.is_some() {
-            None
-        } else {
-            Some(python_requirement.to_marker_tree())
-        };
         let state = ResolverState {
             index: index.clone(),
             git: git.clone(),
@@ -214,8 +209,12 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
             exclusions: manifest.exclusions,
             hasher: hasher.clone(),
             markers: markers.cloned(),
+            requires_python: if markers.is_some() {
+                None
+            } else {
+                python_requirement.to_marker_tree()
+            },
             python_requirement: python_requirement.clone(),
-            requires_python,
             reporter: None,
             installed_packages,
         };

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -1650,7 +1650,7 @@ fn lock_requires_python() -> Result<()> {
           And because project==0.1.0 depends on pygls>=1.1.0, we can conclude that project==0.1.0 cannot be used.
           And because only project==0.1.0 is available and you require project, we can conclude that the requirements are unsatisfiable.
 
-          hint: The `Requires-Python` requirement (>=3.7) defined in your `pyproject.toml` includes Python versions that are not supported by your dependencies (e.g., pygls>=1.1.0,<=1.2.1 only supports >=3.7.9, <4). Consider using a more restrictive `Requires-Python` requirement (like >=3.7.9, <4).
+          hint: The `Requires-Python` requirement (>=3.7) includes Python versions that are not supported by your dependencies (e.g., pygls>=1.1.0,<=1.2.1 only supports >=3.7.9, <4). Consider using a more restrictive `Requires-Python` requirement (like >=3.7.9, <4).
     "###);
 
     // Require >=3.7, and allow locking to a version of `pygls` that is compatible (==1.0.1).


### PR DESCRIPTION
## Summary

This doesn't actually change any behaviors, but it does make it a bit easier to solve #4669, because we don't have to support "version narrowing" for the non-`RequiresPython` variants in here. Right now, the semantics are kind of muddied, because the `target` variant is _sometimes_ interpreted as an exact version and sometimes as a lower bound.
