### PR TITLE
Move `Requires-Python` incompatibilities out of version map

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -23,9 +23,9 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, enabled, instrument, trace, warn, Level};
 
 use distribution_types::{
-    BuiltDist, Dist, DistributionMetadata, IncompatibleDist, IncompatibleSource, IncompatibleWheel,
-    InstalledDist, PythonRequirementKind, RemoteSource, ResolvedDist, ResolvedDistRef, SourceDist,
-    VersionOrUrlRef,
+    BuiltDist, CompatibleDist, Dist, DistributionMetadata, IncompatibleDist, IncompatibleSource,
+    IncompatibleWheel, InstalledDist, PythonRequirementKind, RemoteSource, ResolvedDist,
+    ResolvedDistRef, SourceDist, VersionOrUrlRef,
 };
 pub(crate) use locals::Locals;
 use pep440_rs::{Version, MIN_VERSION};
@@ -155,7 +155,6 @@ impl<'a, Context: BuildContext, InstalledPackages: InstalledPackagesProvider>
             database,
             flat_index,
             tags,
-            python_requirement.clone(),
             AllowedYanks::from_manifest(&manifest, markers, options.dependency_mode),
             hasher,
             options.exclude_newer,
@@ -921,6 +920,77 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 )));
             }
         };
+
+        let incompatibility = match dist {
+            CompatibleDist::InstalledDist(_) => None,
+            CompatibleDist::SourceDist { sdist, .. }
+            | CompatibleDist::IncompatibleWheel { sdist, .. } => {
+                // Source distributions must meet both the _target_ Python version and the
+                // _installed_ Python version (to build successfully).
+                sdist
+                    .file
+                    .requires_python
+                    .as_ref()
+                    .and_then(|requires_python| {
+                        if let Some(target) = self.python_requirement.target() {
+                            if !target.is_compatible_with(requires_python) {
+                                return Some(IncompatibleDist::Source(
+                                    IncompatibleSource::RequiresPython(
+                                        requires_python.clone(),
+                                        PythonRequirementKind::Target,
+                                    ),
+                                ));
+                            }
+                        }
+                        if !requires_python.contains(self.python_requirement.installed()) {
+                            return Some(IncompatibleDist::Source(
+                                IncompatibleSource::RequiresPython(
+                                    requires_python.clone(),
+                                    PythonRequirementKind::Installed,
+                                ),
+                            ));
+                        }
+                        None
+                    })
+            }
+            CompatibleDist::CompatibleWheel { wheel, .. } => {
+                // Wheels must meet the _target_ Python version.
+                wheel
+                    .file
+                    .requires_python
+                    .as_ref()
+                    .and_then(|requires_python| {
+                        if let Some(target) = self.python_requirement.target() {
+                            if !target.is_compatible_with(requires_python) {
+                                return Some(IncompatibleDist::Wheel(
+                                    IncompatibleWheel::RequiresPython(
+                                        requires_python.clone(),
+                                        PythonRequirementKind::Installed,
+                                    ),
+                                ));
+                            }
+                        } else {
+                            if !requires_python.contains(self.python_requirement.installed()) {
+                                return Some(IncompatibleDist::Wheel(
+                                    IncompatibleWheel::RequiresPython(
+                                        requires_python.clone(),
+                                        PythonRequirementKind::Target,
+                                    ),
+                                ));
+                            }
+                        }
+                        None
+                    })
+            }
+        };
+
+        // The version is incompatible due to its Python requirement.
+        if let Some(incompatibility) = incompatibility {
+            return Ok(Some(ResolverVersion::Unavailable(
+                candidate.version().clone(),
+                UnavailableVersion::IncompatibleDist(incompatibility),
+            )));
+        }
 
         let filename = match dist.for_installation() {
             ResolvedDistRef::InstallableRegistrySourceDist { sdist, .. } => sdist

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -8,7 +8,6 @@ use uv_normalize::PackageName;
 use uv_types::{BuildContext, HashStrategy};
 
 use crate::flat_index::FlatIndex;
-use crate::python_requirement::PythonRequirement;
 use crate::version_map::VersionMap;
 use crate::yanks::AllowedYanks;
 use crate::ExcludeNewer;
@@ -77,7 +76,6 @@ pub struct DefaultResolverProvider<'a, Context: BuildContext> {
     /// These are the entries from `--find-links` that act as overrides for index responses.
     flat_index: FlatIndex,
     tags: Option<Tags>,
-    python_requirement: PythonRequirement,
     allowed_yanks: AllowedYanks,
     hasher: HashStrategy,
     exclude_newer: Option<ExcludeNewer>,
@@ -90,7 +88,6 @@ impl<'a, Context: BuildContext> DefaultResolverProvider<'a, Context> {
         fetcher: DistributionDatabase<'a, Context>,
         flat_index: &'a FlatIndex,
         tags: Option<&'a Tags>,
-        python_requirement: PythonRequirement,
         allowed_yanks: AllowedYanks,
         hasher: &'a HashStrategy,
         exclude_newer: Option<ExcludeNewer>,
@@ -100,7 +97,6 @@ impl<'a, Context: BuildContext> DefaultResolverProvider<'a, Context> {
             fetcher,
             flat_index: flat_index.clone(),
             tags: tags.cloned(),
-            python_requirement,
             allowed_yanks,
             hasher: hasher.clone(),
             exclude_newer,
@@ -131,7 +127,6 @@ impl<'a, Context: BuildContext> ResolverProvider for DefaultResolverProvider<'a,
                             package_name,
                             &index,
                             self.tags.as_ref(),
-                            &self.python_requirement,
                             &self.allowed_yanks,
                             &self.hasher,
                             self.exclude_newer.as_ref(),


### PR DESCRIPTION
## Summary

This is required to solve https://github.com/astral-sh/uv/issues/4669, because the `Requires-Python` version can now vary across a resolution. For example, within certain forks, we might have a more narrow range, which would allow us to use distributions that would not be allowed for the global resolution.
