### PR TITLE
Add conversion from lockfile `Distribution` to `Metadata`

### DIFF
--- a/crates/pypi-types/src/requirement.rs
+++ b/crates/pypi-types/src/requirement.rs
@@ -253,6 +253,12 @@ impl RequirementSource {
         }
     }
 
+    /// Construct a [`RequirementSource`] for a URL source, given a URL parsed into components.
+    pub fn from_verbatim_parsed_url(parsed_url: ParsedUrl) -> Self {
+        let verbatim_url = VerbatimUrl::from_url(Url::from(parsed_url.clone()));
+        RequirementSource::from_parsed_url(parsed_url, verbatim_url)
+    }
+
     /// Convert the source to a [`VerbatimParsedUrl`], if it's a URL source.
     pub fn to_verbatim_parsed_url(&self) -> Option<VerbatimParsedUrl> {
         match &self {


### PR DESCRIPTION
## Summary

Splitting this out from https://github.com/astral-sh/uv/pull/4495 because it's also useful to reuse the `uv pip tree` code for `uv tree`.
