### PR TITLE
Add lockfile snapshots for branching URL tests

### DIFF
--- a/crates/uv/tests/branching_urls.rs
+++ b/crates/uv/tests/branching_urls.rs
@@ -228,6 +228,106 @@ fn root_package_splits_transitive_too() -> Result<()> {
     "###
     );
 
+    assert_snapshot!(fs_err::read_to_string(context.temp_dir.join("uv.lock"))?, @r###"
+    version = 1
+    requires-python = ">=3.11, <3.13"
+
+    [[distribution]]
+    name = "a"
+    version = "0.1.0"
+    source = { editable = "." }
+    dependencies = [
+        { name = "anyio", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '3.12'" },
+        { name = "anyio", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_version >= '3.12'" },
+        { name = "b" },
+    ]
+
+    [[distribution]]
+    name = "anyio"
+    version = "4.2.0"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/2d/b8/7333d87d5f03247215d86a86362fd3e324111788c6cdd8d2e6196a6ba833/anyio-4.2.0.tar.gz", hash = "sha256:e1875bb4b4e2de1669f4bc7869b6d3f54231cdced71605e6e64c9be77e3be50f", size = 158770 }
+    dependencies = [
+        { name = "idna" },
+        { name = "sniffio" },
+    ]
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/bf/cd/d6d9bb1dadf73e7af02d18225cbd2c93f8552e13130484f1c8dcfece292b/anyio-4.2.0-py3-none-any.whl", hash = "sha256:745843b39e829e108e518c489b31dc757de7d2131d53fac32bd8df268227bfee", size = 85481 },
+    ]
+
+    [[distribution]]
+    name = "anyio"
+    version = "4.3.0"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6", size = 159642 }
+    dependencies = [
+        { name = "idna" },
+        { name = "sniffio" },
+    ]
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", hash = "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8", size = 85584 },
+    ]
+
+    [[distribution]]
+    name = "b"
+    version = "0.1.0"
+    source = { directory = "b" }
+    dependencies = [
+        { name = "b1", marker = "python_version < '3.12'" },
+        { name = "b2", marker = "python_version >= '3.12'" },
+    ]
+
+    [[distribution]]
+    name = "b1"
+    version = "0.1.0"
+    source = { directory = "../b1" }
+    dependencies = [
+        { name = "iniconfig", version = "1.1.1", source = { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl" } },
+    ]
+
+    [[distribution]]
+    name = "b2"
+    version = "0.1.0"
+    source = { directory = "../b2" }
+    dependencies = [
+        { name = "iniconfig", version = "2.0.0", source = { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" } },
+    ]
+
+    [[distribution]]
+    name = "idna"
+    version = "3.6"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
+    ]
+
+    [[distribution]]
+    name = "iniconfig"
+    version = "1.1.1"
+    source = { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl" }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3" },
+    ]
+
+    [[distribution]]
+    name = "iniconfig"
+    version = "2.0.0"
+    source = { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374" },
+    ]
+
+    [[distribution]]
+    name = "sniffio"
+    version = "1.3.1"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+    ]
+    "###);
+
     Ok(())
 }
 
@@ -284,6 +384,100 @@ fn root_package_splits_other_dependencies_too() -> Result<()> {
     Resolved 9 packages in [TIME]
     "###
     );
+
+    assert_snapshot!(fs_err::read_to_string(context.temp_dir.join("uv.lock"))?, @r###"
+    version = 1
+    requires-python = ">=3.11, <3.13"
+
+    [[distribution]]
+    name = "a"
+    version = "0.1.0"
+    source = { editable = "." }
+    dependencies = [
+        { name = "anyio", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '3.12'" },
+        { name = "anyio", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_version >= '3.12'" },
+        { name = "b1", marker = "python_version < '3.12'" },
+        { name = "b2", marker = "python_version >= '3.12'" },
+    ]
+
+    [[distribution]]
+    name = "anyio"
+    version = "4.2.0"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/2d/b8/7333d87d5f03247215d86a86362fd3e324111788c6cdd8d2e6196a6ba833/anyio-4.2.0.tar.gz", hash = "sha256:e1875bb4b4e2de1669f4bc7869b6d3f54231cdced71605e6e64c9be77e3be50f", size = 158770 }
+    dependencies = [
+        { name = "idna" },
+        { name = "sniffio" },
+    ]
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/bf/cd/d6d9bb1dadf73e7af02d18225cbd2c93f8552e13130484f1c8dcfece292b/anyio-4.2.0-py3-none-any.whl", hash = "sha256:745843b39e829e108e518c489b31dc757de7d2131d53fac32bd8df268227bfee", size = 85481 },
+    ]
+
+    [[distribution]]
+    name = "anyio"
+    version = "4.3.0"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6", size = 159642 }
+    dependencies = [
+        { name = "idna" },
+        { name = "sniffio" },
+    ]
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", hash = "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8", size = 85584 },
+    ]
+
+    [[distribution]]
+    name = "b1"
+    version = "0.1.0"
+    source = { directory = "b1" }
+    dependencies = [
+        { name = "iniconfig", version = "1.1.1", source = { registry = "https://pypi.org/simple" } },
+    ]
+
+    [[distribution]]
+    name = "b2"
+    version = "0.1.0"
+    source = { directory = "b2" }
+    dependencies = [
+        { name = "iniconfig", version = "2.0.0", source = { registry = "https://pypi.org/simple" } },
+    ]
+
+    [[distribution]]
+    name = "idna"
+    version = "3.6"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
+    ]
+
+    [[distribution]]
+    name = "iniconfig"
+    version = "1.1.1"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32", size = 8104 }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3", size = 4990 },
+    ]
+
+    [[distribution]]
+    name = "iniconfig"
+    version = "2.0.0"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+    ]
+
+    [[distribution]]
+    name = "sniffio"
+    version = "1.3.1"
+    source = { registry = "https://pypi.org/simple" }
+    sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+    wheels = [
+        { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+    ]
+    "###);
 
     Ok(())
 }
@@ -454,7 +648,7 @@ fn branching_urls_of_different_sources_conflict() -> Result<()> {
 
 /// Ensure that we don't pre-visit package with URLs.
 #[test]
-fn dont_previsit_url_packages() -> Result<()> {
+fn dont_pre_visit_url_packages() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let deps = indoc! {r#"
@@ -492,6 +686,33 @@ fn dont_previsit_url_packages() -> Result<()> {
     Resolved 3 packages in [TIME]
     "###
     );
+
+    assert_snapshot!(fs_err::read_to_string(context.temp_dir.join("uv.lock"))?, @r###"
+    version = 1
+    requires-python = ">=3.11, <3.13"
+
+    [[distribution]]
+    name = "a"
+    version = "0.1.0"
+    source = { editable = "." }
+    dependencies = [
+        { name = "b" },
+        { name = "c" },
+    ]
+
+    [[distribution]]
+    name = "b"
+    version = "0.1.0"
+    source = { directory = "b" }
+    dependencies = [
+        { name = "c" },
+    ]
+
+    [[distribution]]
+    name = "c"
+    version = "0.1.0"
+    source = { directory = "../c" }
+    "###);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

These are changing in one of my branches but I can't tell _what's_ changing. Some tests include the lock, but others don't. This PR adds it for all successful resolves in the suite.
