### PR TITLE
Shared Git and in-memory index across operations

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -18,6 +18,7 @@ use uv_warnings::warn_user_once;
 
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::resolution_environment;
+use crate::commands::project::SharedState;
 use crate::commands::reporters::ResolverReporter;
 use crate::commands::{project, ExitStatus};
 use crate::printer::Printer;
@@ -205,11 +206,15 @@ pub(crate) async fn add(
         pyproject.to_string(),
     )?;
 
+    // Initialize any shared state.
+    let state = SharedState::default();
+
     // Lock and sync the environment.
     let lock = project::lock::do_lock(
         project.workspace(),
         venv.interpreter(),
         settings.as_ref().into(),
+        &state,
         preview,
         connectivity,
         concurrency,
@@ -232,6 +237,7 @@ pub(crate) async fn add(
         dev,
         Modifications::Sufficient,
         settings.as_ref().into(),
+        &state,
         preview,
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -11,6 +11,7 @@ use uv_toolchain::{ToolchainPreference, ToolchainRequest};
 use uv_warnings::{warn_user, warn_user_once};
 
 use crate::commands::pip::operations::Modifications;
+use crate::commands::project::SharedState;
 use crate::commands::{project, ExitStatus};
 use crate::printer::Printer;
 use crate::settings::{InstallerSettings, ResolverSettings};
@@ -95,11 +96,15 @@ pub(crate) async fn remove(
     // Use the default settings.
     let settings = ResolverSettings::default();
 
+    // Initialize any shared state.
+    let state = SharedState::default();
+
     // Lock and sync the environment.
     let lock = project::lock::do_lock(
         project.workspace(),
         venv.interpreter(),
         settings.as_ref(),
+        &state,
         preview,
         connectivity,
         concurrency,
@@ -123,6 +128,7 @@ pub(crate) async fn remove(
         dev,
         Modifications::Exact,
         settings.as_ref(),
+        &state,
         preview,
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -21,6 +21,7 @@ use uv_toolchain::{
 use uv_warnings::warn_user_once;
 
 use crate::commands::pip::operations::Modifications;
+use crate::commands::project::SharedState;
 use crate::commands::{project, ExitStatus};
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
@@ -49,6 +50,9 @@ pub(crate) async fn run(
 
     // Parse the input command.
     let command = RunCommand::from(command);
+
+    // Initialize any shared state.
+    let state = SharedState::default();
 
     // Determine whether the command to execute is a PEP 723 script.
     let temp_dir;
@@ -106,6 +110,7 @@ pub(crate) async fn run(
                 venv,
                 spec,
                 &settings,
+                &state,
                 preview,
                 connectivity,
                 concurrency,
@@ -177,6 +182,7 @@ pub(crate) async fn run(
                 project.workspace(),
                 venv.interpreter(),
                 settings.as_ref().into(),
+                &state,
                 preview,
                 connectivity,
                 concurrency,
@@ -193,6 +199,7 @@ pub(crate) async fn run(
                 dev,
                 Modifications::Sufficient,
                 settings.as_ref().into(),
+                &state,
                 preview,
                 connectivity,
                 concurrency,
@@ -289,6 +296,7 @@ pub(crate) async fn run(
                 venv,
                 spec,
                 &settings,
+                &state,
                 preview,
                 connectivity,
                 concurrency,

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -21,7 +21,7 @@ use uv_tool::{entrypoint_paths, find_executable_directory, InstalledTools, Tool,
 use uv_toolchain::{EnvironmentPreference, Toolchain, ToolchainPreference, ToolchainRequest};
 use uv_warnings::warn_user_once;
 
-use crate::commands::project::update_environment;
+use crate::commands::project::{update_environment, SharedState};
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
@@ -146,6 +146,7 @@ pub(crate) async fn install(
         environment,
         spec,
         &settings,
+        &SharedState::default(),
         preview,
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -19,7 +19,7 @@ use uv_toolchain::{
 };
 use uv_warnings::warn_user_once;
 
-use crate::commands::project::update_environment;
+use crate::commands::project::{update_environment, SharedState};
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
@@ -102,6 +102,7 @@ pub(crate) async fn run(
             venv,
             spec,
             &settings,
+            &SharedState::default(),
             preview,
             connectivity,
             concurrency,


### PR DESCRIPTION
## Summary

I ended up needing this for https://github.com/astral-sh/uv/issues/4664 but I think it's a good change more broadly. We should be able to share this cached information across operations within a given invocation.
