### PR TITLE
Show when we retried requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ dependencies = [
  "itertools 0.12.1",
  "memmap2 0.9.4",
  "reqwest",
- "reqwest-middleware",
+ "reqwest-middleware 0.3.2 (git+https://github.com/konstin/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3053,7 +3053,7 @@ dependencies = [
  "pypi-types",
  "regex",
  "reqwest",
- "reqwest-middleware",
+ "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
  "tempfile",
  "test-case",
  "thiserror",
@@ -3118,6 +3118,20 @@ dependencies = [
 [[package]]
 name = "reqwest-middleware"
 version = "0.3.2"
+source = "git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe#21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.3.2"
 source = "git+https://github.com/konstin/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe#21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe"
 dependencies = [
  "anyhow",
@@ -3132,7 +3146,7 @@ dependencies = [
 [[package]]
 name = "reqwest-retry"
 version = "0.7.0"
-source = "git+https://github.com/konstin/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe#21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe"
+source = "git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe#21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3143,7 +3157,7 @@ dependencies = [
  "hyper",
  "parking_lot 0.11.2",
  "reqwest",
- "reqwest-middleware",
+ "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
  "retry-policies",
  "thiserror",
  "tokio",
@@ -4507,7 +4521,7 @@ dependencies = [
  "once-map",
  "once_cell",
  "reqwest",
- "reqwest-middleware",
+ "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
  "rust-netrc",
  "tempfile",
  "test-log",
@@ -4621,7 +4635,7 @@ dependencies = [
  "platform-tags",
  "pypi-types",
  "reqwest",
- "reqwest-middleware",
+ "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
  "reqwest-retry",
  "rkyv",
  "rmp-serde",
@@ -4753,7 +4767,7 @@ dependencies = [
  "pypi-types",
  "regex",
  "reqwest",
- "reqwest-middleware",
+ "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
  "rmp-serde",
  "rustc-hash 2.0.0",
  "schemars",
@@ -4830,7 +4844,7 @@ dependencies = [
  "dashmap",
  "fs-err",
  "reqwest",
- "reqwest-middleware",
+ "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
  "thiserror",
  "tokio",
  "tracing",
@@ -5073,7 +5087,7 @@ dependencies = [
  "pypi-types",
  "regex",
  "reqwest",
- "reqwest-middleware",
+ "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
  "rmp-serde",
  "same-file",
  "schemars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,8 +3118,7 @@ dependencies = [
 [[package]]
 name = "reqwest-middleware"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39346a33ddfe6be00cbc17a34ce996818b97b230b87229f10114693becca1268"
+source = "git+https://github.com/konstin/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe#21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3132,9 +3131,8 @@ dependencies = [
 
 [[package]]
 name = "reqwest-retry"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2a94ba69ceb30c42079a137e2793d6d0f62e581a24c06cd4e9bb32e973c7da"
+version = "0.7.0"
+source = "git+https://github.com/konstin/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe#21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3147,6 +3145,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "retry-policies",
+ "thiserror",
  "tokio",
  "tracing",
  "wasm-timer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ dependencies = [
  "itertools 0.12.1",
  "memmap2 0.9.4",
  "reqwest",
- "reqwest-middleware 0.3.2 (git+https://github.com/konstin/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
+ "reqwest-middleware",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3053,7 +3053,7 @@ dependencies = [
  "pypi-types",
  "regex",
  "reqwest",
- "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
+ "reqwest-middleware",
  "tempfile",
  "test-case",
  "thiserror",
@@ -3130,20 +3130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-middleware"
-version = "0.3.2"
-source = "git+https://github.com/konstin/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe#21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe"
-dependencies = [
- "anyhow",
- "async-trait",
- "http",
- "reqwest",
- "serde",
- "thiserror",
- "tower-service",
-]
-
-[[package]]
 name = "reqwest-retry"
 version = "0.7.0"
 source = "git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe#21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe"
@@ -3157,7 +3143,7 @@ dependencies = [
  "hyper",
  "parking_lot 0.11.2",
  "reqwest",
- "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
+ "reqwest-middleware",
  "retry-policies",
  "thiserror",
  "tokio",
@@ -4521,7 +4507,7 @@ dependencies = [
  "once-map",
  "once_cell",
  "reqwest",
- "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
+ "reqwest-middleware",
  "rust-netrc",
  "tempfile",
  "test-log",
@@ -4635,7 +4621,7 @@ dependencies = [
  "platform-tags",
  "pypi-types",
  "reqwest",
- "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
+ "reqwest-middleware",
  "reqwest-retry",
  "rkyv",
  "rmp-serde",
@@ -4767,7 +4753,7 @@ dependencies = [
  "pypi-types",
  "regex",
  "reqwest",
- "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
+ "reqwest-middleware",
  "rmp-serde",
  "rustc-hash 2.0.0",
  "schemars",
@@ -4844,7 +4830,7 @@ dependencies = [
  "dashmap",
  "fs-err",
  "reqwest",
- "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
+ "reqwest-middleware",
  "thiserror",
  "tokio",
  "tracing",
@@ -5087,7 +5073,7 @@ dependencies = [
  "pypi-types",
  "regex",
  "reqwest",
- "reqwest-middleware 0.3.2 (git+https://github.com/astral-sh/reqwest-middleware?rev=21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe)",
+ "reqwest-middleware",
  "rmp-serde",
  "same-file",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ ignored = ["flate2"]
 # For pyproject-toml
 pep440_rs = { path = "crates/pep440-rs" }
 pep508_rs = { path = "crates/pep508-rs" }
-reqwest-middleware = { git = "https://github.com/konstin/reqwest-middleware", rev = "21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe" }
+reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe" }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,8 +113,8 @@ rayon = { version = "1.8.0" }
 reflink-copy = { version = "0.1.15" }
 regex = { version = "1.10.2" }
 reqwest = { version = "0.12.3", default-features = false, features = ["json", "gzip", "brotli", "stream", "rustls-tls", "rustls-tls-native-roots"] }
-reqwest-middleware = { version = "0.3.0" }
-reqwest-retry = { version = "0.6.0" }
+reqwest-middleware = { git = "https://github.com/konstin/reqwest-middleware", rev = "21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe" }
+reqwest-retry = { git = "https://github.com/konstin/reqwest-middleware", rev = "21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe" }
 rkyv = { version = "0.7.43", features = ["strict", "validation"] }
 rmp-serde = { version = "1.1.2" }
 rust-netrc = { version = "0.1.1" }
@@ -159,6 +159,7 @@ ignored = ["flate2"]
 # For pyproject-toml
 pep440_rs = { path = "crates/pep440-rs" }
 pep508_rs = { path = "crates/pep508-rs" }
+reqwest-middleware = { git = "https://github.com/konstin/reqwest-middleware", rev = "21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe" }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,8 +113,8 @@ rayon = { version = "1.8.0" }
 reflink-copy = { version = "0.1.15" }
 regex = { version = "1.10.2" }
 reqwest = { version = "0.12.3", default-features = false, features = ["json", "gzip", "brotli", "stream", "rustls-tls", "rustls-tls-native-roots"] }
-reqwest-middleware = { git = "https://github.com/konstin/reqwest-middleware", rev = "21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe" }
-reqwest-retry = { git = "https://github.com/konstin/reqwest-middleware", rev = "21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe" }
+reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe" }
+reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe" }
 rkyv = { version = "0.7.43", features = ["strict", "validation"] }
 rmp-serde = { version = "1.1.2" }
 rust-netrc = { version = "0.1.1" }

--- a/crates/uv-client/src/lib.rs
+++ b/crates/uv-client/src/lib.rs
@@ -1,6 +1,6 @@
 pub use base_client::{BaseClient, BaseClientBuilder};
 pub use cached_client::{CacheControl, CachedClient, CachedClientError, DataWithCachePolicy};
-pub use error::{BetterReqwestError, Error, ErrorKind};
+pub use error::{Error, ErrorKind, WrappedReqwestError};
 pub use flat_index::{FlatIndexClient, FlatIndexEntries, FlatIndexError};
 pub use linehaul::LineHaul;
 pub use registry_client::{

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -234,7 +234,7 @@ impl RegistryClient {
                     ErrorKind::Offline(_) => continue,
 
                     // The package could not be found in the remote index.
-                    ErrorKind::ReqwestError(err) => {
+                    ErrorKind::WrappedReqwestError(err) => {
                         if err.status() == Some(StatusCode::NOT_FOUND)
                             || err.status() == Some(StatusCode::UNAUTHORIZED)
                             || err.status() == Some(StatusCode::FORBIDDEN)

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -8,7 +8,7 @@ use crate::metadata::MetadataError;
 use distribution_filename::WheelFilenameError;
 use pep440_rs::Version;
 use pypi_types::HashDigest;
-use uv_client::BetterReqwestError;
+use uv_client::WrappedReqwestError;
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
 
@@ -31,7 +31,7 @@ pub enum Error {
     #[error(transparent)]
     Git(#[from] uv_git::GitResolverError),
     #[error(transparent)]
-    Reqwest(#[from] BetterReqwestError),
+    Reqwest(#[from] WrappedReqwestError),
     #[error(transparent)]
     Client(#[from] uv_client::Error),
 
@@ -130,7 +130,7 @@ pub enum Error {
 
 impl From<reqwest::Error> for Error {
     fn from(error: reqwest::Error) -> Self {
-        Self::Reqwest(BetterReqwestError::from(error))
+        Self::Reqwest(WrappedReqwestError::from(error))
     }
 }
 
@@ -139,7 +139,7 @@ impl From<reqwest_middleware::Error> for Error {
         match error {
             reqwest_middleware::Error::Middleware(error) => Self::ReqwestMiddlewareError(error),
             reqwest_middleware::Error::Reqwest(error) => {
-                Self::Reqwest(BetterReqwestError::from(error))
+                Self::Reqwest(WrappedReqwestError::from(error))
             }
         }
     }

--- a/crates/uv-toolchain/src/downloads.rs
+++ b/crates/uv-toolchain/src/downloads.rs
@@ -10,7 +10,7 @@ use crate::platform::{self, Arch, Libc, Os};
 use crate::toolchain::ToolchainKey;
 use crate::{Interpreter, PythonVersion, ToolchainRequest, VersionRequest};
 use thiserror::Error;
-use uv_client::BetterReqwestError;
+use uv_client::WrappedReqwestError;
 
 use futures::TryStreamExt;
 
@@ -30,7 +30,7 @@ pub enum Error {
     #[error("Invalid request key, too many parts: {0}")]
     TooManyParts(String),
     #[error("Download failed")]
-    NetworkError(#[from] BetterReqwestError),
+    NetworkError(#[from] WrappedReqwestError),
     #[error("Download failed")]
     NetworkMiddlewareError(#[source] anyhow::Error),
     #[error("Failed to extract archive: {0}")]
@@ -450,7 +450,7 @@ impl PythonDownload {
 
 impl From<reqwest::Error> for Error {
     fn from(error: reqwest::Error) -> Self {
-        Self::NetworkError(BetterReqwestError::from(error))
+        Self::NetworkError(WrappedReqwestError::from(error))
     }
 }
 
@@ -459,7 +459,7 @@ impl From<reqwest_middleware::Error> for Error {
         match error {
             reqwest_middleware::Error::Middleware(error) => Self::NetworkMiddlewareError(error),
             reqwest_middleware::Error::Reqwest(error) => {
-                Self::NetworkError(BetterReqwestError::from(error))
+                Self::NetworkError(WrappedReqwestError::from(error))
             }
         }
     }

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use axoupdater::{AxoUpdater, AxoupdateError};
 use owo_colors::OwoColorize;
 use tracing::debug;
-use uv_client::BetterReqwestError;
+use uv_client::WrappedReqwestError;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -103,7 +103,7 @@ pub(crate) async fn self_update(printer: Printer) -> Result<ExitStatus> {
         }
         Err(err) => {
             return Err(if let AxoupdateError::Reqwest(err) = err {
-                BetterReqwestError::from(err).into()
+                WrappedReqwestError::from(err).into()
             } else {
                 err.into()
             });


### PR DESCRIPTION
In #3514 and #2755, users had intermittent network errors, but it was not always clear whether we had already retried these requests or not. Building upon https://github.com/TrueLayer/reqwest-middleware/pull/159, this PR adds the number of retries to the error message, so we can see at first glance where we're missing retries and where we might need to change retry settings.

Example error trace:

```
Could not connect, are you offline?
  Caused by: Request failed after 3 retries
  Caused by: error sending request for url (https://pypi.org/simple/uv/)
  Caused by: client error (Connect)
  Caused by: dns error: failed to lookup address information: Name or service not known
  Caused by: failed to lookup address information: Name or service not known
```

This code is ugly since i'm missing a better pattern for attaching context to reqwest middleware errors in https://github.com/TrueLayer/reqwest-middleware/pull/159.