### PR TITLE
Use aws-lc-rs instead of ring for TLS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
     steps:
       - name: Create Dev Drive using ReFS
         run: |
-          $Volume = New-VHD -Path C:/uv_dev_drive.vhdx -SizeBytes 12GB |
+          $Volume = New-VHD -Path C:/uv_dev_drive.vhdx -SizeBytes 14GB |
                     Mount-VHD -Passthru |
                     Initialize-Disk -Passthru |
                     New-Partition -AssignDriveLetter -UseMaximumSize |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,7 @@ jobs:
     steps:
       - name: Create Dev Drive using ReFS
         run: |
-          $Volume = New-VHD -Path C:/uv_dev_drive.vhdx -SizeBytes 10GB |
+          $Volume = New-VHD -Path C:/uv_dev_drive.vhdx -SizeBytes 12GB |
                     Mount-VHD -Passthru |
                     Initialize-Disk -Passthru |
                     New-Partition -AssignDriveLetter -UseMaximumSize |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
     name: "cargo clippy | windows"
     steps:
       - uses: actions/checkout@v4
+      - name: "Install nasm"
+        uses: ilammy/setup-nasm@v1
       - name: "Install Rust toolchain"
         run: rustup target add x86_64-pc-windows-msvc
       - name: Load xwin cache
@@ -215,6 +217,9 @@ jobs:
       - name: Copy Git Repo to Dev Drive
         run: |
           Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.DEV_DRIVE }}/uv" -Recurse
+
+      - name: "Install nasm"
+        uses: ilammy/setup-nasm@v1
 
       - name: "Install Rust toolchain"
         working-directory: ${{ env.DEV_DRIVE }}/uv
@@ -428,6 +433,9 @@ jobs:
           Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.DEV_DRIVE }}/uv" -Recurse
 
       - uses: rui314/setup-mold@v1
+
+      - name: "Install nasm"
+        uses: ilammy/setup-nasm@v1
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ See the [Python](#python) section for instructions on installing the Python vers
 
 You can install CMake from the [installers](https://cmake.org/download/) or with `pipx install cmake`.
 
+Only on Windows, you also need to install the [Netwide Assembler (NASM)](https://nasm.us/) and add its installation directory to your PATH:
+
+```
+set PATH="C:\Program Files\NASM;%PATH%"
+```
+
 ## Testing
 
 For running tests, we recommend [nextest](https://nexte.st/).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a47f2fb521b70c11ce7369a6c5fa4bd6af7e5d62ec06303875bafe7c6ba245"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2927c7af777b460b7ccd95f8b67acd7b4c04ec8896bf0c8e80ba30523cffc057"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "axoasset"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +438,29 @@ dependencies = [
  "uv-resolver",
  "uv-toolchain",
  "uv-types",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.5.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.68",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -619,6 +669,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +739,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1319,6 +1389,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1979,10 +2055,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libloading"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "libmimalloc-sys"
@@ -2161,6 +2253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,6 +2287,12 @@ checksum = "359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044"
 dependencies = [
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "nanoid"
@@ -2222,6 +2326,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2655,6 +2769,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.68",
+]
+
+[[package]]
 name = "priority-queue"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,7 +2840,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset 0.9.1",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -3328,6 +3452,8 @@ version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3371,6 +3497,7 @@ version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3570,6 +3697,12 @@ name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4625,6 +4758,7 @@ dependencies = [
  "reqwest-retry",
  "rkyv",
  "rmp-serde",
+ "rustls",
  "serde",
  "serde_json",
  "sys-info",
@@ -5095,7 +5229,7 @@ dependencies = [
  "uv-fs",
  "uv-state",
  "uv-warnings",
- "which",
+ "which 6.0.1",
  "winapi",
 ]
 
@@ -5313,6 +5447,18 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
 
 [[package]]
 name = "which"
@@ -5698,6 +5844,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,12 +112,13 @@ quote = { version = "1.0.36" }
 rayon = { version = "1.8.0" }
 reflink-copy = { version = "0.1.15" }
 regex = { version = "1.10.2" }
-reqwest = { version = "0.12.3", default-features = false, features = ["json", "gzip", "brotli", "stream", "rustls-tls", "rustls-tls-native-roots"] }
+reqwest = { version = "0.12.5", default-features = false, features = ["json", "gzip", "brotli", "stream", "rustls-tls", "rustls-tls-native-roots"] }
 reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe" }
 reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "21ceec9a5fd2e8d6f71c3ea2999078fecbd13cbe" }
 rkyv = { version = "0.7.43", features = ["strict", "validation"] }
 rmp-serde = { version = "1.1.2" }
 rust-netrc = { version = "0.1.1" }
+rustls = { version = "0.23.10", features = ["aws_lc_rs"] }
 rustc-hash = { version = "2.0.0" }
 same-file = { version = "1.0.6" }
 schemars = { version = "0.8.16", features = ["url"] }

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -36,6 +36,7 @@ itertools = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }
+rustls = { workspace = true }
 rkyv = { workspace = true }
 rmp-serde = { workspace = true }
 serde = { workspace = true }

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -137,12 +137,11 @@ impl<'a> BaseClientBuilder<'a> {
 
         // Initialize the base client.
         let client = self.client.clone().unwrap_or_else(|| {
-            match CryptoProvider::get_default() {
+            if let None = CryptoProvider::get_default() {
                 // Use aws_lc_rs as the default TLS provider to support more SSL cert algorithms
-                None => aws_lc_rs::default_provider()
+                aws_lc_rs::default_provider()
                     .install_default()
-                    .expect("failed to install aws_lc_rs as default TLS provider"),
-                _ => (),
+                    .expect("failed to install aws_lc_rs as default TLS provider")
             };
 
             // Check for the presence of an `SSL_CERT_FILE`.

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -139,9 +139,9 @@ impl<'a> BaseClientBuilder<'a> {
         let client = self.client.clone().unwrap_or_else(|| {
             if CryptoProvider::get_default().is_none() {
                 // Use aws_lc_rs as the default TLS provider to support more SSL cert algorithms
-                aws_lc_rs::default_provider()
-                    .install_default()
-                    .expect("failed to install aws_lc_rs as default TLS provider");
+                if aws_lc_rs::default_provider().install_default().is_err() {
+                    warn_user_once!("Failed to install aws_lc_rs as the default TLS provider.");
+                }
             };
 
             // Check for the presence of an `SSL_CERT_FILE`.

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -137,11 +137,11 @@ impl<'a> BaseClientBuilder<'a> {
 
         // Initialize the base client.
         let client = self.client.clone().unwrap_or_else(|| {
-            if let None = CryptoProvider::get_default() {
+            if CryptoProvider::get_default().is_none() {
                 // Use aws_lc_rs as the default TLS provider to support more SSL cert algorithms
                 aws_lc_rs::default_provider()
                     .install_default()
-                    .expect("failed to install aws_lc_rs as default TLS provider")
+                    .expect("failed to install aws_lc_rs as default TLS provider");
             };
 
             // Check for the presence of an `SSL_CERT_FILE`.

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -11,6 +11,7 @@ use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::{
     DefaultRetryableStrategy, RetryTransientMiddleware, Retryable, RetryableStrategy,
 };
+use rustls::crypto::aws_lc_rs;
 use tracing::debug;
 
 use pep508_rs::MarkerEnvironment;
@@ -136,6 +137,11 @@ impl<'a> BaseClientBuilder<'a> {
 
         // Initialize the base client.
         let client = self.client.clone().unwrap_or_else(|| {
+            // Use aws_lc_rs as the default TLS provider to support more SSL cert algorithms
+            aws_lc_rs::default_provider()
+                .install_default()
+                .expect("failed to install aws_lc_rs as default TLS provider");
+
             // Check for the presence of an `SSL_CERT_FILE`.
             let ssl_cert_file_exists = env::var_os("SSL_CERT_FILE").is_some_and(|path| {
                 let path_exists = Path::new(&path).exists();


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This PR switches the TLS backend used by `reqwest` from `ring` to `aws-lc` to support more SSL certificate signature algorithms (especially P521 algorithms which aren't yet supported by `ring`: https://github.com/briansmith/ring/pull/1631).

Fixes #4534 

## Test Plan

I used `uv pip install` to try installing a package from a private PyPI server whose SSL certificate was signed using the ECDSA SHA-512 certificate signature algorithm and, using the Rust debugger, observed that `uv` did not fail to install the package due to not supporting the ECDSA SHA-512 certificate signature algorithm.


