### PR TITLE
Remove dangling environments in `tool uninstall`

### DIFF
--- a/crates/uv/tests/tool_uninstall.rs
+++ b/crates/uv/tests/tool_uninstall.rs
@@ -108,12 +108,12 @@ fn tool_uninstall_missing_receipt() {
     uv_snapshot!(context.filters(), context.tool_uninstall().arg("black")
         .env("UV_TOOL_DIR", tool_dir.as_os_str())
         .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
     warning: `uv tool uninstall` is experimental and may change without warning.
-    error: Tool `black` is not installed
+    Removed dangling environment for tool: `black` (missing receipt)
     "###);
 }


### PR DESCRIPTION
## Summary

It seems useful that `tool uninstall` guarantees the tool is gone (e.g., if the receipt and environment get out-of-sync somehow).
