### PR TITLE
Upgrade to Rust 1.79

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         with:
           tool: cargo-xwin
       - name: Install xwin dependencies
-        run: sudo apt-get install --no-install-recommends -y llvm clang cmake ninja-build
+        run: sudo apt-get install --no-install-recommends -y lld llvm clang cmake ninja-build
       - name: "Clippy"
         run: cargo xwin clippy --target x86_64-pc-windows-msvc --workspace --all-targets --all-features --locked --profile fast-build -- -D warnings
         env:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.78"
+channel = "1.79"


### PR DESCRIPTION
## Summary

Updates default toolchain to [1.79](https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html).
There didn't seem to be any breaking changes besides xwin now requiring lld llvm linker.

## Test Plan

Existing tests.