### PR TITLE
Box clap commands to avoid windows debug clap stack overflow

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -54,13 +54,13 @@ fn extra_name_with_clap_error(arg: &str) -> Result<ExtraName> {
 #[allow(clippy::struct_excessive_bools)]
 pub struct Cli {
     #[command(subcommand)]
-    pub command: Commands,
+    pub command: Box<Commands>,
 
     #[command(flatten)]
-    pub global_args: GlobalArgs,
+    pub global_args: Box<GlobalArgs>,
 
     #[command(flatten)]
-    pub cache_args: CacheArgs,
+    pub cache_args: Box<CacheArgs>,
 
     /// The path to a `uv.toml` file to use for configuration.
     #[arg(global = true, long, env = "UV_CONFIG_FILE")]

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -148,7 +148,7 @@ async fn run() -> Result<ExitStatus> {
     let globals = GlobalSettings::resolve(&cli.command, &cli.global_args, filesystem.as_ref());
 
     // Resolve the cache settings.
-    let cache_settings = CacheSettings::resolve(cli.cache_args, filesystem.as_ref());
+    let cache_settings = CacheSettings::resolve(*cli.cache_args, filesystem.as_ref());
 
     // Configure the `tracing` crate, which controls internal logging.
     #[cfg(feature = "tracing-durations-export")]
@@ -215,7 +215,7 @@ async fn run() -> Result<ExitStatus> {
     // Configure the cache.
     let cache = Cache::from_settings(cache_settings.no_cache, cache_settings.cache_dir)?;
 
-    match cli.command {
+    match *cli.command {
         Commands::Pip(PipNamespace {
             command: PipCommand::Compile(args),
         }) => {
@@ -945,8 +945,9 @@ async fn run() -> Result<ExitStatus> {
 
 fn main() -> ExitCode {
     let result = if let Ok(stack_size) = env::var("UV_STACK_SIZE") {
-        // Artificially limit the stack size to test for stack overflows. Windows has a default stack size of 1MB,
-        // which is lower than the linux and mac default.
+        // Artificially limit or increase the stack size to test without stack overflows in debug
+        // mode. Windows has a default stack size of 1MB, which is lower than the linux and mac
+        // default.
         // https://learn.microsoft.com/en-us/cpp/build/reference/stack-stack-allocations?view=msvc-170
         let stack_size = stack_size.parse().expect("Invalid stack size");
         let tokio_main = move || {


### PR DESCRIPTION
The changes in https://github.com/astral-sh/uv/pull/4708 caused an overflow in debug mode only of the 1MB default stack size in windows during clap. This means that even trivial wrong argument tests would fail without increasing the stack size. As remedy, we box the clap types.