### PR TITLE
Respect `XDG_DATA_HOME` on macOS if set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5070,6 +5070,7 @@ name = "uv-state"
 version = "0.0.1"
 dependencies = [
  "directories",
+ "dirs-sys",
  "fs-err",
  "tempfile",
 ]

--- a/crates/uv-state/Cargo.toml
+++ b/crates/uv-state/Cargo.toml
@@ -16,3 +16,4 @@ workspace = true
 directories = { workspace = true }
 tempfile = { workspace = true }
 fs-err = { workspace = true }
+dirs-sys = { workspace = true }


### PR DESCRIPTION
Rather than using `Application Support` for state storage, we use `XDG_DATA_HOME` _if_ it is set. This feels like a reasonable compromise respecting the OS defaults while allowing users to opt-in to XDG.

Closes #4411 

e.g. 

```
❯ export XDG_DATA_HOME="$HOME/.local/share"
❯ cargo run -- python install
Looking for installation Python 3.12.1 (any-3.12.1-any-any-any)
Looking for installation Python 3.11.7 (any-3.11.7-any-any-any)
Looking for installation Python 3.10.13 (any-3.10.13-any-any-any)
Looking for installation Python 3.9.18 (any-3.9.18-any-any-any)
Looking for installation Python 3.8.18 (any-3.8.18-any-any-any)
Looking for installation Python 3.8.12 (any-3.8.12-any-any-any)
Found 6/6 installations requiring installation
Downloading cpython-3.12.1-macos-aarch64-none
Downloading cpython-3.11.7-macos-aarch64-none
Downloading cpython-3.10.13-macos-aarch64-none
Downloading cpython-3.9.18-macos-aarch64-none
Installed Python 3.12.1 to /Users/zb/.local/share/uv/python/cpython-3.12.1-macos-aarch64-none
Installed Python 3.11.7 to /Users/zb/.local/share/uv/python/cpython-3.11.7-macos-aarch64-none
Installed Python 3.10.13 to /Users/zb/.local/share/uv/python/cpython-3.10.13-macos-aarch64-none
Installed Python 3.9.18 to /Users/zb/.local/share/uv/python/cpython-3.9.18-macos-aarch64-none
Downloading cpython-3.8.18-macos-aarch64-none
Downloading cpython-3.8.12-macos-aarch64-none
Installed Python 3.8.18 to /Users/zb/.local/share/uv/python/cpython-3.8.18-macos-aarch64-none
Installed Python 3.8.12 to /Users/zb/.local/share/uv/python/cpython-3.8.12-macos-aarch64-none
Installed 6 installations in 8s
```