### PR TITLE
Avoid resetting dispatch and in-flight state with reinstalls

### DIFF
--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -291,8 +291,8 @@ pub(crate) async fn pip_install(
     // Track in-flight downloads, builds, etc., across resolutions.
     let in_flight = InFlight::default();
 
-    // Create a build dispatch for resolution.
-    let resolve_dispatch = BuildDispatch::new(
+    // Create a build dispatch.
+    let build_dispatch = BuildDispatch::new(
         &client,
         &cache,
         interpreter,
@@ -340,7 +340,7 @@ pub(crate) async fn pip_install(
         &client,
         &flat_index,
         &index,
-        &resolve_dispatch,
+        &build_dispatch,
         concurrency,
         options,
         printer,
@@ -358,35 +358,6 @@ pub(crate) async fn pip_install(
         Err(err) => return Err(err.into()),
     };
 
-    // Re-initialize the in-flight map.
-    let in_flight = InFlight::default();
-
-    // If we're running with `--reinstall`, initialize a separate `BuildDispatch`, since we may
-    // end up removing some distributions from the environment.
-    let install_dispatch = if reinstall.is_none() {
-        resolve_dispatch
-    } else {
-        BuildDispatch::new(
-            &client,
-            &cache,
-            interpreter,
-            &index_locations,
-            &flat_index,
-            &index,
-            &git,
-            &in_flight,
-            index_strategy,
-            setup_py,
-            config_settings,
-            build_isolation,
-            link_mode,
-            &build_options,
-            exclude_newer,
-            concurrency,
-            preview,
-        )
-    };
-
     // Sync the environment.
     operations::install(
         &resolution,
@@ -402,7 +373,7 @@ pub(crate) async fn pip_install(
         &client,
         &in_flight,
         concurrency,
-        &install_dispatch,
+        &build_dispatch,
         &cache,
         &environment,
         dry_run,

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -244,8 +244,8 @@ pub(crate) async fn pip_sync(
     // Ignore development dependencies.
     let dev = Vec::default();
 
-    // Create a build dispatch for resolution.
-    let resolve_dispatch = BuildDispatch::new(
+    // Create a build dispatch.
+    let build_dispatch = BuildDispatch::new(
         &client,
         &cache,
         interpreter,
@@ -295,7 +295,7 @@ pub(crate) async fn pip_sync(
         &client,
         &flat_index,
         &index,
-        &resolve_dispatch,
+        &build_dispatch,
         concurrency,
         options,
         printer,
@@ -313,35 +313,6 @@ pub(crate) async fn pip_sync(
         Err(err) => return Err(err.into()),
     };
 
-    // Re-initialize the in-flight map.
-    let in_flight = InFlight::default();
-
-    // If we're running with `--reinstall`, initialize a separate `BuildDispatch`, since we may
-    // end up removing some distributions from the environment.
-    let install_dispatch = if reinstall.is_none() {
-        resolve_dispatch
-    } else {
-        BuildDispatch::new(
-            &client,
-            &cache,
-            interpreter,
-            &index_locations,
-            &flat_index,
-            &index,
-            &git,
-            &in_flight,
-            index_strategy,
-            setup_py,
-            config_settings,
-            build_isolation,
-            link_mode,
-            &build_options,
-            exclude_newer,
-            concurrency,
-            preview,
-        )
-    };
-
     // Sync the environment.
     operations::install(
         &resolution,
@@ -357,7 +328,7 @@ pub(crate) async fn pip_sync(
         &client,
         &in_flight,
         concurrency,
-        &install_dispatch,
+        &build_dispatch,
         &cache,
         &environment,
         dry_run,

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -471,7 +471,7 @@ pub(crate) async fn update_environment(
     };
 
     // Create a build dispatch.
-    let resolve_dispatch = BuildDispatch::new(
+    let build_dispatch = BuildDispatch::new(
         &client,
         cache,
         interpreter,
@@ -511,7 +511,7 @@ pub(crate) async fn update_environment(
         &client,
         &flat_index,
         &state.index,
-        &resolve_dispatch,
+        &build_dispatch,
         concurrency,
         options,
         printer,
@@ -521,35 +521,6 @@ pub(crate) async fn update_environment(
     {
         Ok(resolution) => Resolution::from(resolution),
         Err(err) => return Err(err.into()),
-    };
-
-    // Re-initialize the in-flight map.
-    let in_flight = InFlight::default();
-
-    // If we're running with `--reinstall`, initialize a separate `BuildDispatch`, since we may
-    // end up removing some distributions from the environment.
-    let install_dispatch = if reinstall.is_none() {
-        resolve_dispatch
-    } else {
-        BuildDispatch::new(
-            &client,
-            cache,
-            interpreter,
-            index_locations,
-            &flat_index,
-            &state.index,
-            &state.git,
-            &in_flight,
-            *index_strategy,
-            setup_py,
-            config_setting,
-            build_isolation,
-            *link_mode,
-            build_options,
-            *exclude_newer,
-            concurrency,
-            preview,
-        )
     };
 
     // Sync the environment.
@@ -567,7 +538,7 @@ pub(crate) async fn update_environment(
         &client,
         &in_flight,
         concurrency,
-        &install_dispatch,
+        &build_dispatch,
         cache,
         &venv,
         dry_run,


### PR DESCRIPTION
## Summary

This used to be necessary because we purged the cache in the `InstallPlan` if the user passed `--reinstall`. _However_, we later changed the cache to be append-only.

## Test Plan

I ran through the test plan in https://github.com/astral-sh/uv/pull/933, which includes an integration test and running `uv pip install --reinstall` with:

```text
setuptools
devpi @ https://files.pythonhosted.org/packages/e4/f3/e334eb4dc930ccb677363e1305a3730003d203efbb023329e4b610e4515b/devpi-2.2.0.tar.gz
```
