### PR TITLE
Drop the crate description from the `uv` help menu

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -49,7 +49,7 @@ fn extra_name_with_clap_error(arg: &str) -> Result<ExtraName> {
 }
 
 #[derive(Parser)]
-#[command(name = "uv", author, version = uv_version::version(), long_version = crate::version::version(), about)]
+#[command(name = "uv", author, version = uv_version::version(), long_version = crate::version::version())]
 #[command(propagate_version = true)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Cli {


### PR DESCRIPTION
Previously this displayed:

```
❯ cargo run -q -- --help
The command line interface for the uv binary.

Usage: uv [OPTIONS] <COMMAND>
```

This is.. weird. Here I remove it entirely. I could see adding `about_long` text being helpful in the future.