### PR TITLE
Add standard filters for virtual environment bin directories and python executables

### DIFF
--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -124,6 +124,32 @@ impl TestContext {
         self
     }
 
+    /// Add extra standard filtering for Python executable names.
+    #[must_use]
+    pub fn with_filtered_python_names(mut self) -> Self {
+        if cfg!(windows) {
+            self.filters
+                .push(("python.exe".to_string(), "python".to_string()));
+        } else {
+            self.filters
+                .push((r"python\d".to_string(), "python".to_string()));
+            self.filters
+                .push((r"python\d.\d\d".to_string(), "python".to_string()));
+        }
+        self
+    }
+
+    /// Add extra standard filtering for venv executable directories on the current platform e.g.
+    /// `Scripts` on Windows and `bin` on Unix.
+    #[must_use]
+    pub fn with_filtered_virtualenv_bin(mut self) -> Self {
+        self.filters.push((
+            format!(r"[\\/]{}", venv_bin_path(PathBuf::new()).to_string_lossy()),
+            "/[BIN]".to_string(),
+        ));
+        self
+    }
+
     /// Create a new test context with multiple Python versions.
     ///
     /// Does not create a virtual environment by default, but the first Python version

--- a/crates/uv/tests/tool_list.rs
+++ b/crates/uv/tests/tool_list.rs
@@ -91,7 +91,10 @@ fn tool_list_missing_receipt() {
 
 #[test]
 fn tool_list_bad_environment() -> Result<()> {
-    let context = TestContext::new("3.12").with_filtered_exe_suffix();
+    let context = TestContext::new("3.12")
+        .with_filtered_python_names()
+        .with_filtered_virtualenv_bin()
+        .with_filtered_exe_suffix();
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
@@ -117,11 +120,8 @@ fn tool_list_bad_environment() -> Result<()> {
     // Remove the python interpreter for black
     fs::remove_dir_all(venv_path.clone())?;
 
-    let mut filters = context.filters().clone();
-    filters.push((r"/black/.*", "/black/[VENV_PATH]`"));
-
     uv_snapshot!(
-        filters,
+        context.filters(),
         context
             .tool_list()
             .env("UV_TOOL_DIR", tool_dir.as_os_str())
@@ -135,7 +135,7 @@ fn tool_list_bad_environment() -> Result<()> {
 
     ----- stderr -----
     warning: `uv tool list` is experimental and may change without warning.
-    Python interpreter not found at `[TEMP_DIR]/tools/black/[VENV_PATH]`
+    Python interpreter not found at `[TEMP_DIR]/tools/black/[BIN]/python`
     "###
     );
 


### PR DESCRIPTION
Needed over in https://github.com/astral-sh/uv/pull/4674

These filters are relatively aggressive and may have a high false positive rate, we don't need them for most tests so we leave them as opt-in for now.