### PR TITLE
Use cached environments in PEP 723 execution

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -177,7 +177,7 @@ pub enum Commands {
     Python(PythonNamespace),
     /// Manage Python projects.
     #[command(flatten)]
-    Project(ProjectCommand),
+    Project(Box<ProjectCommand>),
     /// Create a virtual environment.
     #[command(alias = "virtualenv", alias = "v")]
     Venv(VenvArgs),

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -126,4 +126,9 @@ impl CachedEnvironment {
 
         Ok(Self(venv))
     }
+
+    /// Convert the [`EphemeralEnvironment`] into an [`Interpreter`].
+    pub(crate) fn into_interpreter(self) -> Interpreter {
+        self.0.into_interpreter()
+    }
 }

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -223,6 +223,7 @@ fn run_script() -> Result<()> {
        "#
     })?;
 
+    // Running the script should install the requirements.
     uv_snapshot!(context.filters(), context.run().arg("--preview").arg("main.py"), @r###"
         success: true
         exit_code: 0
@@ -234,6 +235,16 @@ fn run_script() -> Result<()> {
         Installed 1 package in [TIME]
          + iniconfig==2.0.0
         "###);
+
+    // Running again should use the existing environment.
+    uv_snapshot!(context.filters(), context.run().arg("--preview").arg("main.py"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    "###);
 
     // Otherwise, the script requirements should _not_ be available, but the project requirements
     // should.


### PR DESCRIPTION
## Summary

This seems like another good candidate for environment caching. If you run a script repeatedly, we can just use the existing cached environment.
