### PR TITLE
Always use exact semantics in `update_environment`

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -361,7 +361,6 @@ pub(crate) async fn resolve_names(
 pub(crate) async fn update_environment(
     venv: PythonEnvironment,
     spec: RequirementsSpecification,
-    modifications: Modifications,
     settings: &ResolverInstallerSettings,
     state: &SharedState,
     preview: PreviewMode,
@@ -509,7 +508,7 @@ pub(crate) async fn update_environment(
     pip::operations::install(
         &resolution,
         site_packages,
-        modifications,
+        Modifications::Exact,
         reinstall,
         build_options,
         *link_mode,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -110,7 +110,6 @@ pub(crate) async fn run(
             let environment = project::update_environment(
                 venv,
                 spec,
-                Modifications::Sufficient,
                 &settings,
                 &state,
                 preview,
@@ -300,7 +299,6 @@ pub(crate) async fn run(
             project::update_environment(
                 venv,
                 spec,
-                Modifications::Sufficient,
                 &settings,
                 &state,
                 preview,

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -24,7 +24,6 @@ use uv_requirements::RequirementsSpecification;
 use uv_tool::{entrypoint_paths, find_executable_directory, InstalledTools, Tool, ToolEntrypoint};
 use uv_warnings::warn_user_once;
 
-use crate::commands::pip::operations::Modifications;
 use crate::commands::project::update_environment;
 use crate::commands::tool::common::resolve_requirements;
 use crate::commands::{ExitStatus, SharedState};
@@ -211,7 +210,6 @@ pub(crate) async fn install(
     let environment = update_environment(
         environment,
         spec,
-        Modifications::Exact,
         &settings,
         &state,
         preview,

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -25,7 +25,6 @@ use uv_requirements::RequirementsSpecification;
 use uv_tool::InstalledTools;
 use uv_warnings::warn_user_once;
 
-use crate::commands::pip::operations::Modifications;
 use crate::commands::project::update_environment;
 use crate::commands::tool::common::resolve_requirements;
 use crate::commands::{ExitStatus, SharedState};
@@ -286,7 +285,6 @@ async fn get_or_create_environment(
     let ephemeral_env = update_environment(
         venv,
         spec,
-        Modifications::Exact,
         settings,
         &state,
         preview,


### PR DESCRIPTION
## Summary

We don't need to expose this -- these are always environments that we want to be perfectly synced.