### PR TITLE
Remove installed python for force installation

### DIFF
--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write;
 
 use anyhow::Result;
+use fs_err as fs;
 use futures::StreamExt;
 
 use uv_cache::Cache;
@@ -70,6 +71,12 @@ pub(crate) async fn install(
                 installation.key()
             )?;
             if force {
+                writeln!(
+                    printer.stderr(),
+                    "Removing installed installation `{}`",
+                    installation.key()
+                )?;
+                fs::remove_dir_all(installation.path())?;
                 unfilled_requests.push(download_request);
             }
         } else {


### PR DESCRIPTION
## Summary

Currently `uv python install` does not respect `--force` reinstallation, the downloading process is just skipped if the installation existed.

```
$ uv python install 3.12

Looking for installation Python 3.12 (any-3.12-any-any-any)
Downloading cpython-3.12.3-windows-x86_64-none
Installed Python 3.12.3 to C:\Users\jo\AppData\Roaming\uv\data\python\cpython-3.12.3-windows-x86_64-none
Installed 1 installation in 6s

$ uv python install --force 3.12

Looking for installation Python 3.12 (any-3.12-any-any-any)
Found installed installation `cpython-3.12.3-windows-x86_64-none` that satisfies Python 3.12
Downloading cpython-3.12.3-windows-x86_64-none
Installed 1 installation in 0s
```

## Test Plan


```
$ uv python install 3.12

Looking for installation Python 3.12 (any-3.12-any-any-any)
Downloading cpython-3.12.3-windows-x86_64-none
Installed Python 3.12.3 to C:\Users\jo\AppData\Roaming\uv\data\python\cpython-3.12.3-windows-x86_64-none
Installed 1 installation in 6s

$ uv python install --force 3.12

Looking for installation Python 3.12 (any-3.12-any-any-any)
Found installed installation `cpython-3.12.3-windows-x86_64-none` that satisfies Python 3.12
Removing installed installation `cpython-3.12.3-windows-x86_64-none`
Downloading cpython-3.12.3-windows-x86_64-none
Installed Python 3.12.3 to C:\Users\jo\AppData\Roaming\uv\data\python\cpython-3.12.3-windows-x86_64-none
Installed 1 installation in 7s
```