### PR TITLE
Fill Python requests with platform information during automatic fetches

### DIFF
--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -88,7 +88,7 @@ impl PythonInstallation {
         // Perform a fetch aggressively if managed Python is preferred
         if matches!(preference, PythonPreference::Managed) && python_fetch.is_automatic() {
             if let Some(request) = PythonDownloadRequest::try_from_request(&request) {
-                return Self::fetch(request, client_builder, cache).await;
+                return Self::fetch(request.fill(), client_builder, cache).await;
             }
         }
 

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -103,7 +103,7 @@ impl PythonInstallation {
             {
                 if let Some(request) = PythonDownloadRequest::try_from_request(&request) {
                     debug!("Requested Python not found, checking for available download...");
-                    Self::fetch(request, client_builder, cache).await
+                    Self::fetch(request.fill(), client_builder, cache).await
                 } else {
                     err
                 }


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/4800

We do this during `install` — it's an important step to ensure the request has the platform information in it.