### PR TITLE
Bold durations in CLI messages

### DIFF
--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -146,9 +146,9 @@ pub(super) async fn compile_bytecode(
         printer.stderr(),
         "{}",
         format!(
-            "Bytecode compiled {} in {}",
+            "Bytecode compiled {} {}",
             format!("{files} file{s}").bold(),
-            elapsed(start.elapsed())
+            format!("in {}", elapsed(start.elapsed())).dimmed()
         )
         .dimmed()
     )?;

--- a/crates/uv/src/commands/pip/check.rs
+++ b/crates/uv/src/commands/pip/check.rs
@@ -47,9 +47,9 @@ pub(crate) fn pip_check(
         printer.stderr(),
         "{}",
         format!(
-            "Checked {} in {}",
+            "Checked {} {}",
             format!("{} package{}", packages.len(), s).bold(),
-            elapsed(start.elapsed())
+            format!("in {}", elapsed(start.elapsed())).dimmed()
         )
         .dimmed()
     )?;

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -198,9 +198,9 @@ pub(crate) async fn pip_install(
                     printer.stderr(),
                     "{}",
                     format!(
-                        "Audited {} in {}",
+                        "Audited {} {}",
                         format!("{num_requirements} package{s}").bold(),
-                        elapsed(start.elapsed())
+                        format!("in {}", elapsed(start.elapsed())).dimmed()
                     )
                     .dimmed()
                 )?;

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -251,9 +251,9 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
         printer.stderr(),
         "{}",
         format!(
-            "Resolved {} in {}",
+            "Resolved {} {}",
             format!("{} package{}", resolution.len(), s).bold(),
-            elapsed(start.elapsed())
+            format!("in {}", elapsed(start.elapsed())).dimmed()
         )
         .dimmed()
     )?;
@@ -342,9 +342,9 @@ pub(crate) async fn install(
             printer.stderr(),
             "{}",
             format!(
-                "Audited {} in {}",
+                "Audited {} {}",
                 format!("{} package{}", resolution.len(), s).bold(),
-                elapsed(start.elapsed())
+                format!("in {}", elapsed(start.elapsed())).dimmed()
             )
             .dimmed()
         )?;
@@ -386,9 +386,9 @@ pub(crate) async fn install(
             printer.stderr(),
             "{}",
             format!(
-                "Prepared {} in {}",
+                "Prepared {} {}",
                 format!("{} package{}", wheels.len(), s).bold(),
-                elapsed(start.elapsed())
+                format!("in {}", elapsed(start.elapsed())).dimmed()
             )
             .dimmed()
         )?;
@@ -433,9 +433,9 @@ pub(crate) async fn install(
             printer.stderr(),
             "{}",
             format!(
-                "Uninstalled {} in {}",
+                "Uninstalled {} {}",
                 format!("{} package{}", extraneous.len() + reinstalls.len(), s).bold(),
-                elapsed(start.elapsed())
+                format!("in {}", elapsed(start.elapsed())).dimmed()
             )
             .dimmed()
         )?;
@@ -455,9 +455,9 @@ pub(crate) async fn install(
             printer.stderr(),
             "{}",
             format!(
-                "Installed {} in {}",
+                "Installed {} {}",
                 format!("{} package{}", wheels.len(), s).bold(),
-                elapsed(start.elapsed())
+                format!("in {}", elapsed(start.elapsed())).dimmed()
             )
             .dimmed()
         )?;
@@ -501,9 +501,9 @@ fn report_dry_run(
             printer.stderr(),
             "{}",
             format!(
-                "Audited {} in {}",
+                "Audited {} {}",
                 format!("{} package{}", resolution.len(), s).bold(),
-                elapsed(start.elapsed())
+                format!("in {}", elapsed(start.elapsed())).dimmed()
             )
             .dimmed()
         )?;

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -206,14 +206,14 @@ pub(crate) async fn pip_uninstall(
         printer.stderr(),
         "{}",
         format!(
-            "Uninstalled {} in {}",
+            "Uninstalled {} {}",
             format!(
                 "{} package{}",
                 distributions.len(),
                 if distributions.len() == 1 { "" } else { "s" }
             )
             .bold(),
-            elapsed(start.elapsed())
+            format!("in {}", elapsed(start.elapsed())).dimmed()
         )
         .dimmed()
     )?;


### PR DESCRIPTION
I guess the `.bold()` on the preceding text causes the `.dimmed()` to... stop?

But you can compare before and after:

![Screenshot 2024-07-04 at 2 06 41 PM](https://github.com/astral-sh/uv/assets/1309177/b8298cce-5c7f-4a65-8279-93f1c777344c)

Closes #4817.