### PR TITLE
add `dependencies` to --format JSON

### DIFF
--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -143,6 +143,7 @@ pub(crate) fn pip_list(
 struct Entry {
     name: String,
     version: String,
+    dependencies: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     editable_project_location: Option<String>,
 }
@@ -155,6 +156,13 @@ impl From<&InstalledDist> for Entry {
             editable_project_location: dist
                 .as_editable()
                 .map(|url| url.to_file_path().unwrap().simplified_display().to_string()),
+            dependencies: dist
+                .metadata()
+                .unwrap()
+                .requires_dist
+                .into_iter()
+                .map(|r| r.name.to_string())
+                .collect(),
         }
     }
 }

--- a/crates/uv/tests/pip_list.rs
+++ b/crates/uv/tests/pip_list.rs
@@ -350,7 +350,7 @@ fn list_format_json() {
     success: true
     exit_code: 0
     ----- stdout -----
-    [{"name":"poetry-editable","version":"0.1.0","editable_project_location":"[WORKSPACE]/scripts/packages/poetry_editable"}]
+    [{"name":"poetry-editable","version":"0.1.0","dependencies":["anyio"],"editable_project_location":"[WORKSPACE]/scripts/packages/poetry_editable"}]
 
     ----- stderr -----
     "###
@@ -362,7 +362,7 @@ fn list_format_json() {
     success: true
     exit_code: 0
     ----- stdout -----
-    [{"name":"anyio","version":"4.3.0"},{"name":"idna","version":"3.6"},{"name":"sniffio","version":"1.3.1"}]
+    [{"name":"anyio","version":"4.3.0","dependencies":["idna","sniffio","exceptiongroup","typing-extensions","packaging","sphinx","sphinx-rtd-theme","sphinx-autodoc-typehints","anyio","coverage","exceptiongroup","hypothesis","psutil","pytest","pytest-mock","trustme","uvloop","trio"]},{"name":"idna","version":"3.6","dependencies":[]},{"name":"sniffio","version":"1.3.1","dependencies":[]}]
 
     ----- stderr -----
     "###

--- a/crates/uv/tests/pip_list.rs
+++ b/crates/uv/tests/pip_list.rs
@@ -338,7 +338,7 @@ fn list_format_json() {
     success: true
     exit_code: 0
     ----- stdout -----
-    [{"name":"anyio","version":"4.3.0"},{"name":"idna","version":"3.6"},{"name":"poetry-editable","version":"0.1.0","editable_project_location":"[WORKSPACE]/scripts/packages/poetry_editable"},{"name":"sniffio","version":"1.3.1"}]
+    [{"name":"anyio","version":"4.3.0","dependencies":["idna","sniffio","exceptiongroup","typing-extensions","packaging","sphinx","sphinx-rtd-theme","sphinx-autodoc-typehints","anyio","coverage","exceptiongroup","hypothesis","psutil","pytest","pytest-mock","trustme","uvloop","trio"]},{"name":"idna","version":"3.6","dependencies":[]},{"name":"poetry-editable","version":"0.1.0","dependencies":["anyio"],"editable_project_location":"[WORKSPACE]/scripts/packages/poetry_editable"},{"name":"sniffio","version":"1.3.1","dependencies":[]}]
 
     ----- stderr -----
     "###


### PR DESCRIPTION
## Summary
_maybe_ resolves https://github.com/astral-sh/uv/issues/4711?

wasn't sure if this is the preferred place to tack the `dependency` field on, but seemed like the least amount of code / work involved (also wasn't sure if this should be gated behind a flag).

## Test Plan
modified the existing test to include `"dependencies"` field.
