### PR TITLE
Support workspace to workspace path dependencies

### DIFF
--- a/crates/distribution-types/src/buildable.rs
+++ b/crates/distribution-types/src/buildable.rs
@@ -166,7 +166,8 @@ impl<'a> From<&'a PathSourceDist> for PathSourceUrl<'a> {
 #[derive(Debug, Clone)]
 pub struct DirectorySourceUrl<'a> {
     pub url: &'a Url,
-    pub path: Cow<'a, Path>,
+    pub install_path: Cow<'a, Path>,
+    pub lock_path: Cow<'a, Path>,
     pub editable: bool,
 }
 
@@ -180,7 +181,8 @@ impl<'a> From<&'a DirectorySourceDist> for DirectorySourceUrl<'a> {
     fn from(dist: &'a DirectorySourceDist) -> Self {
         Self {
             url: &dist.url,
-            path: Cow::Borrowed(&dist.install_path),
+            install_path: Cow::Borrowed(&dist.install_path),
+            lock_path: Cow::Borrowed(&dist.lock_path),
             editable: dist.editable,
         }
     }

--- a/crates/pep508-rs/src/verbatim_url.rs
+++ b/crates/pep508-rs/src/verbatim_url.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use thiserror::Error;
 use url::{ParseError, Url};
 
-use uv_fs::{normalize_path, normalize_url_path};
+use uv_fs::{normalize_absolute_path, normalize_url_path};
 
 use crate::Pep508Url;
 
@@ -42,7 +42,7 @@ impl VerbatimUrl {
         let path = path.as_ref();
 
         // Normalize the path.
-        let path = normalize_path(path)
+        let path = normalize_absolute_path(path)
             .map_err(|err| VerbatimUrlError::Normalization(path.to_path_buf(), err))?;
 
         // Extract the fragment, if it exists.
@@ -83,7 +83,7 @@ impl VerbatimUrl {
         };
 
         // Normalize the path.
-        let path = normalize_path(&path)
+        let path = normalize_absolute_path(&path)
             .map_err(|err| VerbatimUrlError::Normalization(path.clone(), err))?;
 
         // Extract the fragment, if it exists.
@@ -113,7 +113,7 @@ impl VerbatimUrl {
         };
 
         // Normalize the path.
-        let Ok(path) = normalize_path(&path) else {
+        let Ok(path) = normalize_absolute_path(&path) else {
             return Err(VerbatimUrlError::WorkingDirectory(path));
         };
 

--- a/crates/uv-distribution/src/metadata/mod.rs
+++ b/crates/uv-distribution/src/metadata/mod.rs
@@ -57,7 +57,8 @@ impl Metadata {
     /// dependencies.
     pub async fn from_workspace(
         metadata: Metadata23,
-        project_root: &Path,
+        install_path: &Path,
+        lock_path: &Path,
         preview_mode: PreviewMode,
     ) -> Result<Self, MetadataError> {
         // Lower the requirements.
@@ -66,13 +67,14 @@ impl Metadata {
             requires_dist,
             provides_extras,
             dev_dependencies,
-        } = RequiresDist::from_workspace(
+        } = RequiresDist::from_project_maybe_workspace(
             pypi_types::RequiresDist {
                 name: metadata.name,
                 requires_dist: metadata.requires_dist,
                 provides_extras: metadata.provides_extras,
             },
-            project_root,
+            install_path,
+            lock_path,
             preview_mode,
         )
         .await?;

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -427,8 +427,13 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     /// Return the [`RequiresDist`] from a `pyproject.toml`, if it can be statically extracted.
     pub(crate) async fn requires_dist(&self, project_root: &Path) -> Result<RequiresDist, Error> {
         let requires_dist = read_requires_dist(project_root).await?;
-        let requires_dist =
-            RequiresDist::from_workspace(requires_dist, project_root, self.preview_mode).await?;
+        let requires_dist = RequiresDist::from_project_maybe_workspace(
+            requires_dist,
+            project_root,
+            project_root,
+            self.preview_mode,
+        )
+        .await?;
         Ok(requires_dist)
     }
 
@@ -920,7 +925,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .map(|reporter| reporter.on_build_start(source));
 
         let (disk_filename, filename, metadata) = self
-            .build_distribution(source, &resource.path, None, &cache_shard)
+            .build_distribution(source, &resource.install_path, None, &cache_shard)
             .await?;
 
         if let Some(task) = task {
@@ -982,14 +987,19 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         if let Some(metadata) = read_cached_metadata(&metadata_entry).await? {
             debug!("Using cached metadata for: {source}");
             return Ok(ArchiveMetadata::from(
-                Metadata::from_workspace(metadata, resource.path.as_ref(), self.preview_mode)
-                    .await?,
+                Metadata::from_workspace(
+                    metadata,
+                    resource.install_path.as_ref(),
+                    resource.lock_path.as_ref(),
+                    self.preview_mode,
+                )
+                .await?,
             ));
         }
 
         // If the backend supports `prepare_metadata_for_build_wheel`, use it.
         if let Some(metadata) = self
-            .build_metadata(source, &resource.path, None)
+            .build_metadata(source, &resource.install_path, None)
             .boxed_local()
             .await?
         {
@@ -1002,8 +1012,13 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 .map_err(Error::CacheWrite)?;
 
             return Ok(ArchiveMetadata::from(
-                Metadata::from_workspace(metadata, resource.path.as_ref(), self.preview_mode)
-                    .await?,
+                Metadata::from_workspace(
+                    metadata,
+                    resource.install_path.as_ref(),
+                    resource.lock_path.as_ref(),
+                    self.preview_mode,
+                )
+                .await?,
             ));
         }
 
@@ -1014,7 +1029,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .map(|reporter| reporter.on_build_start(source));
 
         let (_disk_filename, _filename, metadata) = self
-            .build_distribution(source, &resource.path, None, &cache_shard)
+            .build_distribution(source, &resource.install_path, None, &cache_shard)
             .await?;
 
         if let Some(task) = task {
@@ -1029,7 +1044,13 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .map_err(Error::CacheWrite)?;
 
         Ok(ArchiveMetadata::from(
-            Metadata::from_workspace(metadata, resource.path.as_ref(), self.preview_mode).await?,
+            Metadata::from_workspace(
+                metadata,
+                resource.install_path.as_ref(),
+                resource.lock_path.as_ref(),
+                self.preview_mode,
+            )
+            .await?,
         ))
     }
 
@@ -1040,15 +1061,17 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         cache_shard: &CacheShard,
     ) -> Result<Revision, Error> {
         // Verify that the source tree exists.
-        if !resource.path.is_dir() {
+        if !resource.install_path.is_dir() {
             return Err(Error::NotFound(resource.url.clone()));
         }
 
         // Determine the last-modified time of the source distribution.
         let Some(modified) =
-            ArchiveTimestamp::from_source_tree(&resource.path).map_err(Error::CacheRead)?
+            ArchiveTimestamp::from_source_tree(&resource.install_path).map_err(Error::CacheRead)?
         else {
-            return Err(Error::DirWithoutEntrypoint(resource.path.to_path_buf()));
+            return Err(Error::DirWithoutEntrypoint(
+                resource.install_path.to_path_buf(),
+            ));
         };
 
         // Read the existing metadata from the cache. We treat source trees as if `--refresh` is
@@ -1229,7 +1252,13 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             if let Some(metadata) = read_cached_metadata(&metadata_entry).await? {
                 debug!("Using cached metadata for: {source}");
                 return Ok(ArchiveMetadata::from(
-                    Metadata::from_workspace(metadata, fetch.path(), self.preview_mode).await?,
+                    Metadata::from_workspace(
+                        metadata,
+                        fetch.path(),
+                        fetch.path(),
+                        self.preview_mode,
+                    )
+                    .await?,
                 ));
             }
         }
@@ -1249,7 +1278,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 .map_err(Error::CacheWrite)?;
 
             return Ok(ArchiveMetadata::from(
-                Metadata::from_workspace(metadata, fetch.path(), self.preview_mode).await?,
+                Metadata::from_workspace(metadata, fetch.path(), fetch.path(), self.preview_mode)
+                    .await?,
             ));
         }
 
@@ -1275,7 +1305,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             .map_err(Error::CacheWrite)?;
 
         Ok(ArchiveMetadata::from(
-            Metadata::from_workspace(metadata, fetch.path(), self.preview_mode).await?,
+            Metadata::from_workspace(metadata, fetch.path(), fetch.path(), self.preview_mode)
+                .await?,
         ))
     }
 

--- a/crates/uv-distribution/src/workspace.rs
+++ b/crates/uv-distribution/src/workspace.rs
@@ -960,8 +960,8 @@ impl VirtualProject {
     /// Similar to calling [`ProjectWorkspace::discover`] with a fallback to [`Workspace::discover`],
     /// but avoids rereading the `pyproject.toml` (and relying on error-handling as control flow).
     ///
-    /// This method always uses absolute path, i.e. this method only supports discovering the main
-    /// workspace.
+    /// This method requires an absolute path and panics otherwise, i.e. this method only supports
+    /// discovering the main workspace.
     pub async fn discover(
         path: &Path,
         stop_discovery_at: Option<&Path>,

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -172,7 +172,8 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
         };
         let source = SourceUrl::Directory(DirectorySourceUrl {
             url: &url,
-            path: Cow::Borrowed(source_tree),
+            install_path: Cow::Borrowed(source_tree),
+            lock_path: Cow::Borrowed(source_tree),
             editable: false,
         });
 

--- a/crates/uv-requirements/src/unnamed.rs
+++ b/crates/uv-requirements/src/unnamed.rs
@@ -235,7 +235,8 @@ impl<'a, Context: BuildContext> NamedRequirementsResolver<'a, Context> {
 
                 SourceUrl::Directory(DirectorySourceUrl {
                     url: &requirement.url.verbatim,
-                    path: Cow::Borrowed(&parsed_directory_url.install_path),
+                    install_path: Cow::Borrowed(&parsed_directory_url.install_path),
+                    lock_path: Cow::Borrowed(&parsed_directory_url.lock_path),
                     editable: parsed_directory_url.editable,
                 })
             }

--- a/crates/uv/tests/branching_urls.rs
+++ b/crates/uv/tests/branching_urls.rs
@@ -1,35 +1,12 @@
 use std::env;
-use std::path::Path;
 
 use anyhow::Result;
-use indoc::{formatdoc, indoc};
+use indoc::indoc;
 use insta::assert_snapshot;
 
-use crate::common::{uv_snapshot, TestContext};
+use crate::common::{make_project, uv_snapshot, TestContext};
 
 mod common;
-
-/// Create a stub package `name` in `dir` with the given `pyproject.toml` body.
-fn make_project(dir: &Path, name: &str, body: &str) -> Result<()> {
-    let pyproject_toml = formatdoc! {r#"
-        [project]
-        name = "{name}"
-        version = "0.1.0"
-        description = "Test package for direct URLs in branches"
-        requires-python = ">=3.11,<3.13"
-        {body}
-
-        [build-system]
-        requires = ["flit_core>=3.8,<4"]
-        build-backend = "flit_core.buildapi"
-        "#
-    };
-    fs_err::create_dir_all(dir)?;
-    fs_err::write(dir.join("pyproject.toml"), pyproject_toml)?;
-    fs_err::create_dir(dir.join(name))?;
-    fs_err::write(dir.join(name).join("__init__.py"), "")?;
-    Ok(())
-}
 
 /// The root package has diverging URLs for disjoint markers:
 /// ```toml

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -12,6 +12,7 @@ use std::str::FromStr;
 use assert_cmd::assert::{Assert, OutputAssertExt};
 use assert_fs::assert::PathAssert;
 use assert_fs::fixture::{ChildPath, PathChild, PathCreateDir, SymlinkToFile};
+use indoc::formatdoc;
 use predicates::prelude::predicate;
 use regex::Regex;
 
@@ -859,6 +860,28 @@ pub fn copy_dir_ignore(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> anyhow::
             fs_err::copy(entry.path(), dst.as_ref().join(relative))?;
         }
     }
+    Ok(())
+}
+
+/// Create a stub package `name` in `dir` with the given `pyproject.toml` body.
+pub fn make_project(dir: &Path, name: &str, body: &str) -> anyhow::Result<()> {
+    let pyproject_toml = formatdoc! {r#"
+        [project]
+        name = "{name}"
+        version = "0.1.0"
+        description = "Test package for direct URLs in branches"
+        requires-python = ">=3.11,<3.13"
+        {body}
+
+        [build-system]
+        requires = ["flit_core>=3.8,<4"]
+        build-backend = "flit_core.buildapi"
+        "#
+    };
+    fs_err::create_dir_all(dir)?;
+    fs_err::write(dir.join("pyproject.toml"), pyproject_toml)?;
+    fs_err::create_dir(dir.join(name))?;
+    fs_err::write(dir.join(name).join("__init__.py"), "")?;
     Ok(())
 }
 


### PR DESCRIPTION
Add support for path dependencies from a package in one workspace to a package in another workspace, which it self has workspace dependencies.

Say we have a main workspace with packages `a` and `b`, and a second workspace with `c` and `d`. We have `a -> b`, `b -> c`, `c -> d`. This would previously lead to a mangled path for `d`, which is now fixed.

Like distribution paths, we split workspace paths into an absolute install path and a relative (or absolute, if the user provided an absolute path) lock path.

Part of https://github.com/astral-sh/uv/issues/3943