### PR TITLE
Deduplicate when install or uninstall python

### DIFF
--- a/crates/uv-python/src/implementation.rs
+++ b/crates/uv-python/src/implementation.rs
@@ -10,14 +10,14 @@ pub enum Error {
     UnknownImplementation(String),
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Default, PartialOrd, Ord)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Default, PartialOrd, Ord, Hash)]
 pub enum ImplementationName {
     #[default]
     CPython,
     PyPy,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd)]
+#[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
 pub enum LenientImplementationName {
     Known(ImplementationName),
     Unknown(String),

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -208,7 +208,7 @@ pub enum PythonInstallationKeyError {
     ParseError(String, String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PythonInstallationKey {
     pub(crate) implementation: LenientImplementationName,
     pub(crate) major: u8,

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -229,7 +229,7 @@ Error=This Python installation is managed by uv and should not be modified.
 ";
 
 /// A uv-managed Python installation on the current system..
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ManagedPythonInstallation {
     /// The path to the top-level directory of the installed Python.
     path: PathBuf,

--- a/crates/uv-python/src/platform.rs
+++ b/crates/uv-python/src/platform.rs
@@ -13,13 +13,13 @@ pub enum Error {
     UnknownLibc(String),
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub struct Arch(pub(crate) target_lexicon::Architecture);
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub struct Os(pub(crate) target_lexicon::OperatingSystem);
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub enum Libc {
     Some(target_lexicon::Environment),
     None,

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use anyhow::Result;
 use fs_err as fs;
 use futures::StreamExt;
-
+use itertools::Itertools;
 use uv_cache::Cache;
 use uv_client::Connectivity;
 use uv_configuration::PreviewMode;
@@ -45,6 +45,7 @@ pub(crate) async fn install(
     } else {
         targets
             .iter()
+            .dedup()
             .map(|target| PythonRequest::parse(target.as_str()))
             .collect()
     };

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -116,13 +116,11 @@ pub(crate) async fn install(
         .unique_by(|download| download.key())
         .collect::<Vec<_>>();
 
-    if downloads.len() > 0 {
-        writeln!(
-            printer.stderr(),
-            "Found {} versions requiring installation",
-            downloads.len()
-        )?;
-    }
+    writeln!(
+        printer.stderr(),
+        "Found {} versions requiring installation",
+        downloads.len()
+    )?;
 
     // Construct a client
     let client = uv_client::BaseClientBuilder::new()

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -29,6 +29,7 @@ pub(crate) async fn uninstall(
 
     let requests = targets
         .iter()
+        .dedup()
         .map(|target| PythonRequest::parse(target.as_str()))
         .collect::<Vec<_>>();
 

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -27,9 +27,9 @@ pub(crate) async fn uninstall(
     let installations = ManagedPythonInstallations::from_settings()?.init()?;
     let _lock = installations.acquire_lock()?;
 
+    let targets = targets.into_iter().collect::<BTreeSet<_>>();
     let requests = targets
         .iter()
-        .dedup()
         .map(|target| PythonRequest::parse(target.as_str()))
         .collect::<Vec<_>>();
 
@@ -84,7 +84,7 @@ pub(crate) async fn uninstall(
         return Ok(ExitStatus::Failure);
     }
 
-    let tasks = futures::stream::iter(matching_installations.iter())
+    let tasks = futures::stream::iter(matching_installations.iter().unique())
         .map(|installation| async {
             (
                 installation.key(),


### PR DESCRIPTION
When specifying the same argument multiple times, the same version will be downloaded multiple times:

```sh

$ cargo run -- python install --preview --force 3.12.3 cpython-3.12 3.12.3 3.12
Looking for installation Python 3.12.3 (any-3.12.3-any-any-any)
Looking for installation cpython-3.12-any-any-any (cpython-3.12-any-any-any)
Looking for installation Python 3.12.3 (any-3.12.3-any-any-any)
Looking for installation Python 3.12 (any-3.12-any-any-any)
Found 4/4 versions requiring installation
Downloading cpython-3.12.3-windows-x86_64-none
Downloading cpython-3.12.3-windows-x86_64-none
Downloading cpython-3.12.3-windows-x86_64-none
Downloading cpython-3.12.3-windows-x86_64-none
```

This PR deduplicates the `ManagedPythonDownload` before `install` or `uninstall`:

```sh
$ cargo run -q -- python install --preview --force 3.12.3 cpython-3.12 3.12.3 3.12
Looking for installation Python 3.12 (any-3.12-any-any-any)
Looking for installation Python 3.12.3 (any-3.12.3-any-any-any)
Looking for installation cpython-3.12-any-any-any (cpython-3.12-any-any-any)
Downloading cpython-3.12.3-windows-x86_64-none
Installed Python 3.12.3 to C:\Users\nigel\AppData\Roaming\uv\data\python\cpython-3.12.3-windows-x86_64-none
Installed 1 version in 6s

$ cargo run -q -- python uninstall --preview  3.12.3 cpython-3.12 3.12.3 3.12
Looking for Python installations matching Python 3.12 (any-3.12-any-any-any)
Found installation `cpython-3.12.3-windows-x86_64-none` that matches Python 3.12
Looking for Python installations matching Python 3.12.3 (any-3.12.3-any-any-any)
Looking for Python installations matching cpython-3.12-any-any-any (cpython-3.12-any-any-any)
Uninstalled `cpython-3.12.3-windows-x86_64-none`
Removed 1 Python installation
```