### PR TITLE
Revert `uninstall` deduplication changes from #4841

### DIFF
--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -228,8 +228,8 @@ static EXTERNALLY_MANAGED: &str = "[externally-managed]
 Error=This Python installation is managed by uv and should not be modified.
 ";
 
-/// A uv-managed Python installation on the current system..
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+/// A uv-managed Python installation on the current system.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ManagedPythonInstallation {
     /// The path to the top-level directory of the installed Python.
     path: PathBuf,

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -84,7 +84,7 @@ pub(crate) async fn uninstall(
         return Ok(ExitStatus::Failure);
     }
 
-    let tasks = futures::stream::iter(matching_installations.iter().unique())
+    let tasks = futures::stream::iter(matching_installations.iter())
         .map(|installation| async {
             (
                 installation.key(),


### PR DESCRIPTION
`matching_installations` is BTreeSet already, no need to deduplicate it.

https://github.com/astral-sh/uv/pull/4841#discussion_r1667241722