### PR TITLE
`uv cache prune` removes all cached environments

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -388,12 +388,20 @@ impl Cache {
             }
         }
 
-        for entry in fs::read_dir(self.bucket(CacheBucket::Archive))? {
-            let entry = entry?;
-            let path = entry.path().canonicalize()?;
-            if !references.contains(&path) {
-                debug!("Removing dangling cache entry: {}", path.display());
-                summary += rm_rf(path)?;
+        for bucket in [CacheBucket::Archive, CacheBucket::Environments]
+            .iter()
+            .copied()
+        {
+            let bucket = self.bucket(bucket);
+            if bucket.is_dir() {
+                for entry in fs::read_dir(bucket)? {
+                    let entry = entry?;
+                    let path = entry.path().canonicalize()?;
+                    if !references.contains(&path) {
+                        debug!("Removing dangling cache entry: {}", path.display());
+                        summary += rm_rf(path)?;
+                    }
+                }
             }
         }
 

--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -120,7 +120,6 @@ fn prune_cached_env() {
                 r"\[CACHE_DIR\](\\|\/)(.+)(\\|\/).*",
                 "[CACHE_DIR]/$2/[ENTRY]",
             ),
-            (r"\d+ files", "[N] files"),
         ])
         .collect();
 

--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -83,6 +83,59 @@ fn prune_stale_directory() -> Result<()> {
     Ok(())
 }
 
+/// `cache prune` should remove all cached environments from the cache.
+#[test]
+fn prune_cached_env() {
+    let context = TestContext::new("3.12").with_filtered_counts();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("pytest@8.0.0")
+        .arg("--version")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    pytest 8.0.0
+
+    ----- stderr -----
+    warning: `uv tool run` is experimental and may change without warning.
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + iniconfig==2.0.0
+     + packaging==24.0
+     + pluggy==1.4.0
+     + pytest==8.0.0
+    "###);
+
+    let filters: Vec<_> = context
+        .filters()
+        .into_iter()
+        .chain([
+            // The cache entry does not have a stable key, so we filter it out
+            (
+                r"\[CACHE_DIR\](\\|\/)(.+)(\\|\/).*",
+                "[CACHE_DIR]/$2/[ENTRY]",
+            ),
+        ])
+        .collect();
+
+    uv_snapshot!(filters, prune_command(&context).arg("--verbose"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    DEBUG uv [VERSION] ([COMMIT] DATE)
+    Pruning cache at: [CACHE_DIR]/
+    DEBUG Removing dangling cache entry: [CACHE_DIR]/environments-v1/[ENTRY]
+    Removed 235 files ([SIZE])
+    "###);
+}
+
 /// `cache prune` should remove any stale symlink from the cache.
 #[test]
 fn prune_stale_symlink() -> Result<()> {

--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -120,6 +120,7 @@ fn prune_cached_env() {
                 r"\[CACHE_DIR\](\\|\/)(.+)(\\|\/).*",
                 "[CACHE_DIR]/$2/[ENTRY]",
             ),
+            (r"\d+ files", "[N] files"),
         ])
         .collect();
 
@@ -132,7 +133,7 @@ fn prune_cached_env() {
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
     DEBUG Removing dangling cache entry: [CACHE_DIR]/environments-v1/[ENTRY]
-    Removed 235 files ([SIZE])
+    Removed [N] files ([SIZE])
     "###);
 }
 

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -108,8 +108,10 @@ impl TestContext {
                 format!("{verb} [N] packages"),
             ));
         }
-        self.filters
-            .push((format!("Removed \\d+ files?"), format!("Removed [N] files")));
+        self.filters.push((
+            "Removed \\d+ files?".to_string(),
+            "Removed [N] files".to_string(),
+        ));
         self
     }
 

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -108,6 +108,8 @@ impl TestContext {
                 format!("{verb} [N] packages"),
             ));
         }
+        self.filters
+            .push((format!("Removed \\d+ files?"), format!("Removed [N] files")));
         self
     }
 


### PR DESCRIPTION
## Summary

Resolves #4802

## Test Plan
- `cargo test`
```sh
❯ cargo run -- cache prune -v
Pruning cache at: /Users/ahmedilyas/Library/Caches/uv
No unused entries found
❯ cargo run -- tool run cowsay
warning: `uv tool run` is experimental and may change without warning.
Resolved 1 package in 182ms
Installed 1 package in 20ms
 + cowsay==6.1
usage: Cowsay [-h] [-c CHARACTER] -t TEXT [-v]
Cowsay: error: the following arguments are required: -t/--text
❯ cargo run -- cache prune -v
Pruning cache at: /Users/ahmedilyas/Library/Caches/uv
    0.793440s DEBUG uv_cache Removing dangling cache entry: /Users/ahmedilyas/Library/Caches/uv/environments-v1/095cd7c4c298a0d8
Removed 41 files (143.5KiB)
```