### PR TITLE
`Box::pin(run())` and 2MB test stack

### DIFF
--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -975,11 +975,12 @@ async fn run_project(
 }
 
 fn main() -> ExitCode {
+    // Windows has a default stack size of 1MB, which is lower than the linux and mac default.
+    // https://learn.microsoft.com/en-us/cpp/build/reference/stack-stack-allocations?view=msvc-170
+    // We support increasing the stack size to avoid stack overflows in debug mode on Windows. In
+    // addition, we box types and futures in various places. This includes the `Box::pin(run())`
+    // here, which prevents the large (non-send) main future alone from overflowing the stack.
     let result = if let Ok(stack_size) = env::var("UV_STACK_SIZE") {
-        // Artificially limit or increase the stack size to test without stack overflows in debug
-        // mode. Windows has a default stack size of 1MB, which is lower than the linux and mac
-        // default.
-        // https://learn.microsoft.com/en-us/cpp/build/reference/stack-stack-allocations?view=msvc-170
         let stack_size = stack_size.parse().expect("Invalid stack size");
         let tokio_main = move || {
             let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -987,6 +988,7 @@ fn main() -> ExitCode {
                 .thread_stack_size(stack_size)
                 .build()
                 .expect("Failed building the Runtime");
+            // Box the large main future to avoid stack overflows.
             let result = runtime.block_on(Box::pin(run()));
             // Avoid waiting for pending tasks to complete.
             //
@@ -1007,6 +1009,7 @@ fn main() -> ExitCode {
             .enable_all()
             .build()
             .expect("Failed building the Runtime");
+        // Box the large main future to avoid stack overflows.
         let result = runtime.block_on(Box::pin(run()));
         runtime.shutdown_background();
         result

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -987,7 +987,7 @@ fn main() -> ExitCode {
                 .thread_stack_size(stack_size)
                 .build()
                 .expect("Failed building the Runtime");
-            let result = runtime.block_on(run());
+            let result = runtime.block_on(Box::pin(run()));
             // Avoid waiting for pending tasks to complete.
             //
             // The resolver may have kicked off HTTP requests during resolution that
@@ -1007,7 +1007,7 @@ fn main() -> ExitCode {
             .enable_all()
             .build()
             .expect("Failed building the Runtime");
-        let result = runtime.block_on(run());
+        let result = runtime.block_on(Box::pin(run()));
         runtime.shutdown_background();
         result
     };

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -306,7 +306,7 @@ impl TestContext {
         if cfg!(all(windows, debug_assertions)) {
             // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
             // default windows stack of 1MB
-            command.env("UV_STACK_SIZE", (8 * 1024 * 1024).to_string());
+            command.env("UV_STACK_SIZE", (2 * 1024 * 1024).to_string());
         }
     }
 


### PR DESCRIPTION
By using `Box::pin(run())` we can reduce the artificial stack size for running tests on windows in debug mode from 8MB to 2MB. I've checked and 1MB/no custom stack size still fail tests, e.g. `add_workspace_editable`.