### PR TITLE
Rename `Workspace.root` to `Workspace.install_path`

### DIFF
--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -170,7 +170,7 @@ pub(crate) fn lower_requirement(
             path_source(
                 path,
                 project_dir,
-                workspace.root(),
+                workspace.install_path(),
                 editable.unwrap_or(false),
             )?
         }
@@ -207,8 +207,8 @@ pub(crate) fn lower_requirement(
                 .ok_or(LoweringError::UndeclaredWorkspacePackage)?
                 .clone();
             // The lockfile is relative to the workspace root.
-            let relative_to_workspace =
-                relative_to(path.root(), workspace.root()).map_err(LoweringError::RelativeTo)?;
+            let relative_to_workspace = relative_to(path.root(), workspace.install_path())
+                .map_err(LoweringError::RelativeTo)?;
             let url = VerbatimUrl::parse_absolute_path(path.root())?
                 .with_given(relative_to_workspace.to_string_lossy());
             RequirementSource::Directory {

--- a/crates/uv-distribution/src/workspace.rs
+++ b/crates/uv-distribution/src/workspace.rs
@@ -48,7 +48,7 @@ pub enum WorkspaceError {
 pub struct Workspace {
     /// The path to the workspace root, the directory containing the top level `pyproject.toml` with
     /// the `uv.tool.workspace`, or the `pyproject.toml` in an implicit single workspace project.
-    root: PathBuf,
+    install_path: PathBuf,
     /// The members of the workspace.
     packages: BTreeMap<PackageName, WorkspaceMember>,
     /// The sources table from the workspace `pyproject.toml`. It is overridden by the project
@@ -198,7 +198,7 @@ impl Workspace {
                         install_path: member.root.clone(),
                         lock_path: member
                             .root
-                            .strip_prefix(&self.root)
+                            .strip_prefix(&self.install_path)
                             .expect("Project must be below workspace root")
                             .to_path_buf(),
                         editable: true,
@@ -215,7 +215,7 @@ impl Workspace {
         let Some(workspace_package) = self
             .packages
             .values()
-            .find(|workspace_package| workspace_package.root() == self.root())
+            .find(|workspace_package| workspace_package.root() == self.install_path())
         else {
             return vec![];
         };
@@ -244,13 +244,13 @@ impl Workspace {
 
     /// The path to the workspace root, the directory containing the top level `pyproject.toml` with
     /// the `uv.tool.workspace`, or the `pyproject.toml` in an implicit single workspace project.
-    pub fn root(&self) -> &PathBuf {
-        &self.root
+    pub fn install_path(&self) -> &PathBuf {
+        &self.install_path
     }
 
     /// The path to the workspace virtual environment.
     pub fn venv(&self) -> PathBuf {
-        self.root.join(".venv")
+        self.install_path.join(".venv")
     }
 
     /// The members of the workspace.
@@ -386,7 +386,7 @@ impl Workspace {
         check_nested_workspaces(&workspace_root, stop_discovery_at);
 
         Ok(Workspace {
-            root: workspace_root,
+            install_path: workspace_root,
             packages: workspace_members,
             sources: workspace_sources,
         })
@@ -668,7 +668,7 @@ impl ProjectWorkspace {
                 project_root: project_path.clone(),
                 project_name: project.name.clone(),
                 workspace: Workspace {
-                    root: project_path.clone(),
+                    install_path: project_path.clone(),
                     packages: current_project_as_members,
                     // There may be package sources, but we don't need to duplicate them into the
                     // workspace sources.
@@ -1031,7 +1031,7 @@ mod tests {
           "project_root": "[ROOT]/albatross-in-example/examples/bird-feeder",
           "project_name": "bird-feeder",
           "workspace": {
-            "root": "[ROOT]/albatross-in-example/examples/bird-feeder",
+            "install_path": "[ROOT]/albatross-in-example/examples/bird-feeder",
             "packages": {
               "bird-feeder": {
                 "root": "[ROOT]/albatross-in-example/examples/bird-feeder",
@@ -1066,7 +1066,7 @@ mod tests {
               "project_root": "[ROOT]/albatross-project-in-excluded/excluded/bird-feeder",
               "project_name": "bird-feeder",
               "workspace": {
-                "root": "[ROOT]/albatross-project-in-excluded/excluded/bird-feeder",
+                "install_path": "[ROOT]/albatross-project-in-excluded/excluded/bird-feeder",
                 "packages": {
                   "bird-feeder": {
                     "root": "[ROOT]/albatross-project-in-excluded/excluded/bird-feeder",
@@ -1100,7 +1100,7 @@ mod tests {
               "project_root": "[ROOT]/albatross-root-workspace",
               "project_name": "albatross",
               "workspace": {
-                "root": "[ROOT]/albatross-root-workspace",
+                "install_path": "[ROOT]/albatross-root-workspace",
                 "packages": {
                   "albatross": {
                     "root": "[ROOT]/albatross-root-workspace",
@@ -1158,7 +1158,7 @@ mod tests {
               "project_root": "[ROOT]/albatross-virtual-workspace/packages/albatross",
               "project_name": "albatross",
               "workspace": {
-                "root": "[ROOT]/albatross-virtual-workspace",
+                "install_path": "[ROOT]/albatross-virtual-workspace",
                 "packages": {
                   "albatross": {
                     "root": "[ROOT]/albatross-virtual-workspace/packages/albatross",
@@ -1210,7 +1210,7 @@ mod tests {
               "project_root": "[ROOT]/albatross-just-project",
               "project_name": "albatross",
               "workspace": {
-                "root": "[ROOT]/albatross-just-project",
+                "install_path": "[ROOT]/albatross-just-project",
                 "packages": {
                   "albatross": {
                     "root": "[ROOT]/albatross-just-project",

--- a/crates/uv-requirements/src/upgrade.rs
+++ b/crates/uv-requirements/src/upgrade.rs
@@ -71,7 +71,7 @@ pub async fn read_lockfile(workspace: &Workspace, upgrade: &Upgrade) -> Result<L
     }
 
     // If an existing lockfile exists, build up a set of preferences.
-    let lockfile = workspace.root().join("uv.lock");
+    let lockfile = workspace.install_path().join("uv.lock");
     let lock = match fs_err::tokio::read_to_string(&lockfile).await {
         Ok(encoded) => match toml::from_str::<Lock>(&encoded) {
             Ok(lock) => lock,

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -394,7 +394,7 @@ impl Lock {
             }
             let name = dist.id.name.clone();
             let resolved_dist =
-                ResolvedDist::Installable(dist.to_dist(project.workspace().root(), tags)?);
+                ResolvedDist::Installable(dist.to_dist(project.workspace().install_path(), tags)?);
             map.insert(name, resolved_dist);
         }
         let diagnostics = vec![];

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -237,7 +237,7 @@ pub(super) async fn do_lock(
     // Write the lockfile to disk.
     let lock = Lock::from_resolution_graph(&resolution)?;
     let encoded = lock.to_toml()?;
-    fs_err::tokio::write(workspace.root().join("uv.lock"), encoded.as_bytes()).await?;
+    fs_err::tokio::write(workspace.install_path().join("uv.lock"), encoded.as_bytes()).await?;
 
     Ok(lock)
 }

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -145,12 +145,12 @@ pub(crate) async fn run(
             if let Some(project_name) = project.project_name() {
                 debug!(
                     "Discovered project `{project_name}` at: {}",
-                    project.workspace().root().display()
+                    project.workspace().install_path().display()
                 );
             } else {
                 debug!(
                     "Discovered virtual workspace at: {}",
-                    project.workspace().root().display()
+                    project.workspace().install_path().display()
                 );
             }
 

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -56,7 +56,8 @@ pub(crate) async fn sync(
     // Read the lockfile.
     let lock: Lock = {
         let encoded =
-            fs_err::tokio::read_to_string(project.workspace().root().join("uv.lock")).await?;
+            fs_err::tokio::read_to_string(project.workspace().install_path().join("uv.lock"))
+                .await?;
         toml::from_str(&encoded)?
     };
 

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -136,7 +136,7 @@ async fn run() -> Result<ExitStatus> {
     } else if cli.global_args.isolated {
         None
     } else if let Ok(project) = Workspace::discover(&env::current_dir()?, None).await {
-        let project = uv_settings::FilesystemOptions::from_directory(project.root())?;
+        let project = uv_settings::FilesystemOptions::from_directory(project.install_path())?;
         let user = uv_settings::FilesystemOptions::user()?;
         project.combine(user)
     } else {


### PR DESCRIPTION
Renaming in preparation of #4833, which adds a `Workspace.lock_path`. No functional changes.
