### PR TITLE
Ignore `compile_invalid_pyc_invalidation_mode` on all platforms

### DIFF
--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -3168,7 +3168,7 @@ fn compile() -> Result<()> {
 
 /// Test that the `PYC_INVALIDATION_MODE` option is recognized and that the error handling works.
 #[test]
-#[cfg_attr(target_os = "macos", ignore = "Fails spuriously on macOS")]
+#[ignore = "This test fails spuriously a lot"]
 fn compile_invalid_pyc_invalidation_mode() -> Result<()> {
     let context = TestContext::new("3.12");
 


### PR DESCRIPTION
This test is failing most times for me when running nextest locally, failing the overall test run, so i'm deactivating it for now. I'm still not sure what the root cause here is. It seems to have something to do with python stdin not being ready immediately after we spawn the process and us being too fast.
