### PR TITLE
Add some text decoration to toolchain CLI

### DIFF
--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -78,7 +78,7 @@ pub(crate) async fn list(
     .collect::<Result<Vec<Result<PythonInstallation, PythonNotFound>>, DiscoveryError>>()?
     .into_iter()
     // Drop any "missing" installations
-    .filter_map(std::result::Result::ok);
+    .filter_map(Result::ok);
 
     let mut output = BTreeSet::new();
     for installation in installed {


### PR DESCRIPTION
## Summary

Attempts to make the CLI output a little more consistent with the `pip` interface. I opted to make the Python versions, requests, and filenames blue, and the keys green, but open to opinions on that. (We use blue for filenames elsewhere.)

Closes #4813.
Closes https://github.com/astral-sh/uv/issues/4814.

![Screenshot 2024-07-07 at 9 18 48 PM](https://github.com/astral-sh/uv/assets/1309177/8518b559-196b-4cd0-bc16-8e79e66460bb)
