### PR TITLE
uv/tests: fix tool_install_home test

### DIFF
--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -770,7 +770,14 @@ fn tool_install_home() {
     let tool_dir = context.temp_dir.child("tools");
 
     // Install `black`
-    uv_snapshot!(context.filters(), context.tool_install().arg("black").env("UV_TOOL_DIR", tool_dir.as_os_str()), @r###"
+    let mut cmd = context.tool_install();
+    cmd.arg("black")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env(
+            "XDG_DATA_HOME",
+            context.home_dir.child(".local").child("share").as_os_str(),
+        );
+    uv_snapshot!(context.filters(), cmd, @r###"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
This test was, I believe, relying on the XDG_DATA_HOME environment
variable not being set. When it is set, as is the case in my
environment, `uv tool run` will respect it and install `black` for this
particular test into my actual XDG_DATA_HOME directory. We fix this by
setting `XDG_DATA_HOME` explicitly.
