### PR TITLE
Remove confusing punctuation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ brew install uv
 To create a virtual environment:
 
 ```shell
-uv venv  # Create a virtual environment at .venv
+uv venv  # Create a virtual environment at `.venv`.
 ```
 
 To activate the virtual environment:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ brew install uv
 To create a virtual environment:
 
 ```shell
-uv venv  # Create a virtual environment at .venv.
+uv venv  # Create a virtual environment at .venv
 ```
 
 To activate the virtual environment:


### PR DESCRIPTION
admittedly, nitpick PR but i initially misread the trailing dot in

```
# Create a virtual environment at .venv.
```

as part of the directory name, i.e. that the env would be placed in `.venv.`