### PR TITLE
Reinstall and recreate environments when interpreter is removed

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -23,6 +23,7 @@ use uv_python::{
 use uv_requirements::{NamedRequirementsResolver, RequirementsSpecification};
 use uv_resolver::{FlatIndex, OptionsBuilder, PythonRequirement, RequiresPython, ResolutionGraph};
 use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
+use uv_warnings::warn_user;
 
 use crate::commands::pip::operations::Modifications;
 use crate::commands::reporters::{PythonDownloadReporter, ResolverReporter};
@@ -174,6 +175,12 @@ impl FoundInterpreter {
                 }
             }
             Err(uv_python::Error::MissingEnvironment(_)) => {}
+            Err(uv_python::Error::Query(uv_python::InterpreterError::NotFound(path))) => {
+                warn_user!(
+                    "Ignoring existing virtual environment linked to non-existent Python interpreter: {}",
+                    path.user_display().cyan()
+                );
+            }
             Err(err) => return Err(err.into()),
         };
 

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -166,9 +166,8 @@ pub(crate) async fn install(
                     } else {
                         let _ = writeln!(
                             printer.stderr(),
-                            "Existing environment for `{}` does not satisfy the requested Python interpreter (`{}`)",
+                            "Existing environment for `{}` does not satisfy the requested Python interpreter",
                             from.name,
-                            python_request
                         );
                         false
                     }

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -1393,7 +1393,7 @@ fn tool_install_python_request() {
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning.
-    Existing environment for `black` does not satisfy the requested Python interpreter (`Python 3.11`)
+    Existing environment for `black` does not satisfy the requested Python interpreter
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]


### PR DESCRIPTION
## Summary

We now recreate the environment in `uv sync`, `uv tool install`, and `uv tool run` if the underlying interpreter has been removed.

Closes https://github.com/astral-sh/uv/issues/4933.
