### PR TITLE
Improve 'any' search message during `uv python install`

### DIFF
--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -26,6 +26,7 @@ pub(crate) async fn install(
     native_tls: bool,
     connectivity: Connectivity,
     preview: PreviewMode,
+    isolated: bool,
     _cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -41,7 +42,11 @@ pub(crate) async fn install(
 
     let targets = targets.into_iter().collect::<BTreeSet<_>>();
     let requests: Vec<_> = if targets.is_empty() {
-        if let Some(requests) = requests_from_version_file().await? {
+        // Read from the version file, unless `isolated` was requested
+        if let Some(requests) = match isolated {
+            false => requests_from_version_file().await?,
+            true => None,
+        } {
             requests
         } else {
             vec![PythonRequest::Any]

--- a/crates/uv/src/main.rs
+++ b/crates/uv/src/main.rs
@@ -776,6 +776,7 @@ async fn run() -> Result<ExitStatus> {
                 globals.native_tls,
                 globals.connectivity,
                 globals.preview,
+                globals.isolated,
                 &cache,
                 printer,
             )


### PR DESCRIPTION
Special cases the `Any` request in output

e.g.,

```
❯ cargo run -q -- python install --isolated
warning: `uv python install` is experimental and may change without warning.
Searching for Python installations
Found existing installation: cpython-3.12.3-macos-aarch64-none
Python is already available. Use `uv python install <request>` to install a specific version.
```

instead of 

```
❯ cargo run -q -- python install --isolated
warning: `uv python install` is experimental and may change without warning.
Searching for Python versions matching: any Python
Found existing installation for any Python: cpython-3.12.3-macos-aarch64-none
Python is already available. Use `uv python install <request>` to install a specific version.
```