### PR TITLE
Avoid serializing if lockfile does not change

### DIFF
--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -38,7 +38,7 @@ use crate::{RequiresPython, ResolutionGraph};
 /// The current version of the lock file format.
 const VERSION: u32 = 1;
 
-#[derive(Clone, Debug, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
 #[serde(try_from = "LockWire")]
 pub struct Lock {
     version: u32,
@@ -514,7 +514,7 @@ impl TryFrom<LockWire> for Lock {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Distribution {
     pub(crate) id: DistributionId,
     sdist: Option<SourceDist>,
@@ -1321,12 +1321,15 @@ enum SourceWire {
         subdirectory: Option<String>,
     },
     Path {
+        #[serde(deserialize_with = "deserialize_path_with_dot")]
         path: PathBuf,
     },
     Directory {
+        #[serde(deserialize_with = "deserialize_path_with_dot")]
         directory: PathBuf,
     },
     Editable {
+        #[serde(deserialize_with = "deserialize_path_with_dot")]
         editable: PathBuf,
     },
 }
@@ -1430,7 +1433,7 @@ enum GitSourceKind {
 }
 
 /// Inspired by: <https://discuss.python.org/t/lock-files-again-but-this-time-w-sdists/46593>
-#[derive(Clone, Debug, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
 struct SourceDistMetadata {
     /// A hash of the source distribution.
     hash: Hash,
@@ -1444,7 +1447,7 @@ struct SourceDistMetadata {
 /// locked against was found. The location does not need to exist in the
 /// future, so this should be treated as only a hint to where to look
 /// and/or recording where the source dist file originally came from.
-#[derive(Clone, Debug, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 enum SourceDist {
     Url {
@@ -1695,7 +1698,7 @@ fn locked_git_url(git_dist: &GitSourceDist) -> Url {
 }
 
 /// Inspired by: <https://discuss.python.org/t/lock-files-again-but-this-time-w-sdists/46593>
-#[derive(Clone, Debug, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
 #[serde(try_from = "WheelWire")]
 struct Wheel {
     /// A URL or file path (via `file://`) where the wheel that was locked
@@ -2047,7 +2050,7 @@ impl From<Dependency> for DependencyWire {
 ///
 /// A hash is encoded as a single TOML string in the format
 /// `{algorithm}:{digest}`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct Hash(HashDigest);
 
 impl From<HashDigest> for Hash {

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -8,7 +8,7 @@ use uv_dispatch::BuildDispatch;
 use uv_distribution::{Workspace, DEV_DEPENDENCIES};
 use uv_git::ResolvedRepositoryReference;
 use uv_python::{Interpreter, PythonFetch, PythonPreference, PythonRequest};
-use uv_requirements::upgrade::{read_lockfile, LockedRequirements};
+use uv_requirements::upgrade::{read_lock_requirements, read_lockfile, LockedRequirements};
 use uv_resolver::{FlatIndex, Lock, OptionsBuilder, PythonRequirement, RequiresPython};
 use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
 use uv_warnings::{warn_user, warn_user_once};
@@ -175,7 +175,11 @@ pub(super) async fn do_lock(
     };
 
     // If an existing lockfile exists, build up a set of preferences.
-    let LockedRequirements { preferences, git } = read_lockfile(workspace, upgrade).await?;
+    let lock = read_lockfile(workspace, upgrade).await?;
+    let LockedRequirements { preferences, git } = lock
+        .as_ref()
+        .map(|lock| read_lock_requirements(lock, upgrade))
+        .unwrap_or_default();
 
     // Populate the Git resolver.
     for ResolvedRepositoryReference { reference, sha } in git {
@@ -234,10 +238,15 @@ pub(super) async fn do_lock(
     // Notify the user of any resolution diagnostics.
     pip::operations::diagnose_resolution(resolution.diagnostics(), printer)?;
 
+    // Avoid serializing and writing to disk if the lock hasn't changed.
+    let new_lock = Lock::from_resolution_graph(&resolution)?;
+    if lock.is_some_and(|lock| lock == new_lock) {
+        return Ok(new_lock);
+    }
+
     // Write the lockfile to disk.
-    let lock = Lock::from_resolution_graph(&resolution)?;
-    let encoded = lock.to_toml()?;
+    let encoded = new_lock.to_toml()?;
     fs_err::tokio::write(workspace.install_path().join("uv.lock"), encoded.as_bytes()).await?;
 
-    Ok(lock)
+    Ok(new_lock)
 }


### PR DESCRIPTION
## Summary

Avoid serializing and writing the lockfile if a cheap comparison shows that the contents have not changed.

## Test Plan

Shaves ~10ms off of https://github.com/astral-sh/uv/issues/4860 for me.

```
➜  transformers hyperfine "../../uv/target/profiling/uv lock" "../../uv/target/profiling/baseline lock" --warmup 3
Benchmark 1: ../../uv/target/profiling/uv lock
  Time (mean ± σ):     130.5 ms ±   2.5 ms    [User: 130.3 ms, System: 85.0 ms]
  Range (min … max):   126.8 ms … 136.9 ms    23 runs
 
Benchmark 2: ../../uv/target/profiling/baseline lock
  Time (mean ± σ):     140.5 ms ±   5.0 ms    [User: 142.8 ms, System: 85.5 ms]
  Range (min … max):   133.2 ms … 153.3 ms    21 runs
 
Summary
  ../../uv/target/profiling/uv lock ran
    1.08 ± 0.04 times faster than ../../uv/target/profiling/baseline lock
```