### PR TITLE
Show default value of `python-fetch` and `python-preference` in doc

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -132,11 +132,11 @@ pub struct GlobalArgs {
     pub no_offline: bool,
 
     /// Whether to prefer using Python from uv or on the system.
-    #[arg(global = true, long)]
+    #[arg(global = true, long, value_enum, default_value = "installed")]
     pub python_preference: Option<PythonPreference>,
 
     /// Whether to automatically download Python when required.
-    #[arg(global = true, long)]
+    #[arg(global = true, long, value_enum, default_value = "automatic")]
     pub python_fetch: Option<PythonFetch>,
 
     /// Whether to enable experimental, preview features.


### PR DESCRIPTION
## Summary

It's unclear what the default behaviors of `--python-fetch` and `--python-preference` are. This would help clarify their usage.
