### PR TITLE
Exit with zero when `uv tool install` request is already satisfied

### DIFF
--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -190,7 +190,7 @@ pub(crate) async fn install(
                 if !force && settings.reinstall.is_none() && settings.upgrade.is_none() {
                     // We're done.
                     writeln!(printer.stderr(), "`{from}` is already installed")?;
-                    return Ok(ExitStatus::Failure);
+                    return Ok(ExitStatus::Success);
                 }
             }
         }

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -403,8 +403,8 @@ fn tool_install_already_installed() {
         .env("UV_TOOL_DIR", tool_dir.as_os_str())
         .env("XDG_BIN_HOME", bin_dir.as_os_str())
         .env("PATH", bin_dir.as_os_str()), @r###"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
@@ -676,8 +676,8 @@ fn tool_install_entry_point_exists() {
         .env("UV_TOOL_DIR", tool_dir.as_os_str())
         .env("XDG_BIN_HOME", bin_dir.as_os_str())
         .env("PATH", bin_dir.as_os_str()), @r###"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
@@ -1407,8 +1407,8 @@ fn tool_install_python_request() {
         .env("UV_TOOL_DIR", tool_dir.as_os_str())
         .env("XDG_BIN_HOME", bin_dir.as_os_str())
         .env("PATH", bin_dir.as_os_str()), @r###"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
@@ -1501,8 +1501,8 @@ fn tool_install_preserve_environment() {
         .env("UV_TOOL_DIR", tool_dir.as_os_str())
         .env("XDG_BIN_HOME", bin_dir.as_os_str())
         .env("PATH", bin_dir.as_os_str()), @r###"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

`uv tool install X` fails for tools already installed and exits with code 1. Allow already installed tools to exit with code 0.

## Test Plan

<!-- How was it tested? -->
