### PR TITLE
Rename `python install --force` parameter to `--reinstall`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2205,8 +2205,8 @@ pub struct PythonInstallArgs {
     /// installed any Python versions. If not, it will install the latest stable version of Python.
     pub targets: Vec<String>,
 
-    /// Reinstall the requested Python version.
-    #[arg(long, short)]
+    /// Reinstall the requested Python version, if it's already installed.
+    #[arg(long, short, alias = "force")]
     pub reinstall: bool,
 }
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2205,7 +2205,7 @@ pub struct PythonInstallArgs {
     /// installed any Python versions. If not, it will install the latest stable version of Python.
     pub targets: Vec<String>,
 
-    /// Force the installation of the requested Python, even if it is already installed.
+    /// Reinstall the requested Python version.
     #[arg(long, short)]
     pub reinstall: bool,
 }

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2207,7 +2207,7 @@ pub struct PythonInstallArgs {
 
     /// Force the installation of the requested Python, even if it is already installed.
     #[arg(long, short)]
-    pub force: bool,
+    pub reinstall: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -26,7 +26,7 @@ use crate::printer::Printer;
 /// Download and install Python versions.
 pub(crate) async fn install(
     targets: Vec<String>,
-    force: bool,
+    reinstall: bool,
     native_tls: bool,
     connectivity: Connectivity,
     preview: PreviewMode,
@@ -96,7 +96,7 @@ pub(crate) async fn install(
                     installation.key().green(),
                 )?;
             }
-            if force {
+            if reinstall {
                 writeln!(
                     printer.stderr(),
                     "Uninstalling {}",

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -712,7 +712,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
 
             commands::python_install(
                 args.targets,
-                args.force,
+                args.reinstall,
                 globals.native_tls,
                 globals.connectivity,
                 globals.preview,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -359,16 +359,16 @@ impl PythonListSettings {
 #[derive(Debug, Clone)]
 pub(crate) struct PythonInstallSettings {
     pub(crate) targets: Vec<String>,
-    pub(crate) force: bool,
+    pub(crate) reinstall: bool,
 }
 
 impl PythonInstallSettings {
     /// Resolve the [`PythonInstallSettings`] from the CLI and filesystem configuration.
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn resolve(args: PythonInstallArgs, _filesystem: Option<FilesystemOptions>) -> Self {
-        let PythonInstallArgs { targets, force } = args;
+        let PythonInstallArgs { targets, reinstall } = args;
 
-        Self { targets, force }
+        Self { targets, reinstall }
     }
 }
 

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -301,8 +301,8 @@ fn help_subsubcommand() {
               any Python versions. If not, it will install the latest stable version of Python.
 
     Options:
-      -f, --force
-              Force the installation of the requested Python, even if it is already installed
+      -r, --reinstall
+              Reinstall the requested Python version
 
       -q, --quiet
               Do not print any output
@@ -462,8 +462,8 @@ fn help_flag_subsubcommand() {
       [TARGETS]...  The Python version(s) to install
 
     Options:
-      -f, --force
-              Force the installation of the requested Python, even if it is already installed
+      -r, --reinstall
+              Reinstall the requested Python version
       -q, --quiet
               Do not print any output
       -v, --verbose...

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -302,7 +302,7 @@ fn help_subsubcommand() {
 
     Options:
       -r, --reinstall
-              Reinstall the requested Python version
+              Reinstall the requested Python version, if it's already installed
 
       -q, --quiet
               Do not print any output
@@ -463,7 +463,7 @@ fn help_flag_subsubcommand() {
 
     Options:
       -r, --reinstall
-              Reinstall the requested Python version
+              Reinstall the requested Python version, if it's already installed
       -q, --quiet
               Do not print any output
       -v, --verbose...


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->
Closes #4961

## Summary
Rename the `--force` parameter of `uv python install` to `--reinstall`

