### PR TITLE
Fall back to streaming wheel when `Content-Length` header is absent

### DIFF
--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -61,6 +61,14 @@ impl Error {
                 return true;
             }
 
+            // The server doesn't support rage requests (it doesn't return the necessary headers).
+            ErrorKind::AsyncHttpRangeReader(
+                AsyncHttpRangeReaderError::ContentLengthMissing
+                | AsyncHttpRangeReaderError::ContentRangeMissing,
+            ) => {
+                return true;
+            }
+
             // The server returned a "Method Not Allowed" error, indicating it doesn't support
             // HEAD requests, so we can't check for range requests.
             ErrorKind::WrappedReqwestError(err) => {


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/4993
