### PR TITLE
Add `--no-pager` option in `help` command

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -241,6 +241,10 @@ pub enum Commands {
 
 #[derive(Args, Debug)]
 pub struct HelpArgs {
+    /// Disable pager when printing help
+    #[arg(long)]
+    pub no_pager: bool,
+
     pub command: Option<Vec<String>>,
 }
 

--- a/crates/uv/src/commands/help.rs
+++ b/crates/uv/src/commands/help.rs
@@ -67,11 +67,12 @@ pub(crate) fn help(query: &[String], printer: Printer, no_pager: bool) -> Result
     };
 
     let is_terminal = std::io::stdout().is_terminal();
-    if !no_pager && !is_root && is_terminal && which("less").is_ok() {
+    let should_page = !no_pager && !is_root && is_terminal;
+    if should_page && which("less").is_ok() {
         // When using less, we use the command name as the file name and can support colors
         let prompt = format!("help: uv {}", query.join(" "));
         spawn_pager("less", &["-R", "-P", &prompt], &help_ansi)?;
-    } else if !no_pager && !is_root && is_terminal && which("more").is_ok() {
+    } else if should_page && which("more").is_ok() {
         // When using more, we skip the ANSI color codes
         spawn_pager("more", &[], &help)?;
     } else {

--- a/crates/uv/src/commands/help.rs
+++ b/crates/uv/src/commands/help.rs
@@ -11,7 +11,7 @@ use super::ExitStatus;
 use crate::printer::Printer;
 use uv_cli::Cli;
 
-pub(crate) fn help(query: &[String], printer: Printer) -> Result<ExitStatus> {
+pub(crate) fn help(query: &[String], printer: Printer, no_pager: bool) -> Result<ExitStatus> {
     let mut uv = Cli::command();
 
     // It is very important to build the command before beginning inspection or subcommands
@@ -67,11 +67,11 @@ pub(crate) fn help(query: &[String], printer: Printer) -> Result<ExitStatus> {
     };
 
     let is_terminal = std::io::stdout().is_terminal();
-    if !is_root && is_terminal && which("less").is_ok() {
+    if !no_pager && !is_root && is_terminal && which("less").is_ok() {
         // When using less, we use the command name as the file name and can support colors
         let prompt = format!("help: uv {}", query.join(" "));
         spawn_pager("less", &["-R", "-P", &prompt], &help_ansi)?;
-    } else if !is_root && is_terminal && which("more").is_ok() {
+    } else if !no_pager && !is_root && is_terminal && which("more").is_ok() {
         // When using more, we skip the ANSI color codes
         spawn_pager("more", &[], &help)?;
     } else {

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -157,9 +157,11 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
     let cache = Cache::from_settings(cache_settings.no_cache, cache_settings.cache_dir)?;
 
     match *cli.command {
-        Commands::Help(args) => {
-            commands::help(args.command.unwrap_or_default().as_slice(), printer)
-        }
+        Commands::Help(args) => commands::help(
+            args.command.unwrap_or_default().as_slice(),
+            printer,
+            args.no_pager,
+        ),
         Commands::Pip(PipNamespace {
             command: PipCommand::Compile(args),
         }) => {

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -705,6 +705,9 @@ fn test_with_no_pager() {
           --python-fetch <PYTHON_FETCH>
               Whether to automatically download Python when required [possible values: automatic,
               manual]
+          --isolated
+              Avoid discovering a `pyproject.toml` or `uv.toml` file in the current directory or any
+              parent directories
       -n, --no-cache
               Avoid reading from or writing to the cache [env: UV_NO_CACHE=]
           --cache-dir [CACHE_DIR]

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -668,6 +668,8 @@ fn help_with_version() {
 fn test_with_no_pager() {
     let context = TestContext::new_with_versions(&[]);
 
+    // We can't really test wether the --no-pager option works with a snapshot test.
+    // It's still nice to have a test for the option to confirm the option exists.
     uv_snapshot!(context.filters(), context.help().arg("--no-pager"), @r###"
     success: true
     exit_code: 0

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -668,7 +668,7 @@ fn help_with_version() {
 fn test_with_no_pager() {
     let context = TestContext::new_with_versions(&[]);
 
-    // We can't really test wether the --no-pager option works with a snapshot test.
+    // We can't really test whether the --no-pager option works with a snapshot test.
     // It's still nice to have a test for the option to confirm the option exists.
     uv_snapshot!(context.filters(), context.help().arg("--no-pager"), @r###"
     success: true

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -663,3 +663,60 @@ fn help_with_version() {
     ----- stderr -----
     "###);
 }
+
+#[test]
+fn test_with_no_pager() {
+    let context = TestContext::new_with_versions(&[]);
+
+    uv_snapshot!(context.filters(), context.help().arg("--no-pager"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    An extremely fast Python package manager.
+
+    Usage: uv [OPTIONS] <COMMAND>
+
+    Commands:
+      pip      Resolve and install Python packages
+      tool     Run and manage executable Python packages
+      python   Manage Python installations
+      venv     Create a virtual environment
+      cache    Manage the cache
+      version  Display uv's version
+      help     Display documentation for a command
+
+    Options:
+      -q, --quiet
+              Do not print any output
+      -v, --verbose...
+              Use verbose output
+          --color <COLOR_CHOICE>
+              Control colors in output [default: auto] [possible values: auto, always, never]
+          --native-tls
+              Whether to load TLS certificates from the platform's native certificate store [env:
+              UV_NATIVE_TLS=]
+          --offline
+              Disable network access, relying only on locally cached data and locally available files
+          --python-preference <PYTHON_PREFERENCE>
+              Whether to prefer using Python from uv or on the system [possible values: only-managed,
+              installed, managed, system, only-system]
+          --python-fetch <PYTHON_FETCH>
+              Whether to automatically download Python when required [possible values: automatic,
+              manual]
+      -n, --no-cache
+              Avoid reading from or writing to the cache [env: UV_NO_CACHE=]
+          --cache-dir [CACHE_DIR]
+              Path to the cache directory [env: UV_CACHE_DIR=]
+          --config-file <CONFIG_FILE>
+              The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
+      -h, --help
+              Print help
+      -V, --version
+              Print version
+
+    Use `uv help <command>` for more information on a specific command.
+
+
+    ----- stderr -----
+    "###);
+}


### PR DESCRIPTION
## Summary

Fixes #4941.

This PR adds a `--no-pager` option in `help` command to explicitly disable the pager.

I noted that the template used for the text printed when calling `help` with no argument or option doesn't show any option. It made sense before this PR since `help` didn't have any available option. Though I'm unsure if it makes sense to update the template as it would make it extremely verbose as all the global options would be shown too.

I leave the decision to you.

## Test Plan

I ran `cargo run -- help` to verify `--isolated` was visible and it.
I ran clippy with `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` as CI does.

I also ran tests locally with:
```
cargo nextest run \
            --features python-patch \
            --workspace \
            --status-level skip --failure-output immediate-final --no-fail-fast -j 12 --final-status-level slow
```
