### PR TITLE
Improve error message when package has no installation candidates

### DIFF
--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -2242,7 +2242,7 @@ enum LockErrorKind {
     },
     /// An error that occurs when a distribution is included with neither wheels nor a source
     /// distribution.
-    #[error("distribution {id} can't be installed because it has neither a source distribution nor a wheel for the current platform")]
+    #[error("distribution {id} can't be installed because it doesn't have a source distribution or wheel for the current platform")]
     NeitherSourceDistNorWheel {
         /// The ID of the distribution that has a missing base.
         id: DistributionId,

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -2242,7 +2242,7 @@ enum LockErrorKind {
     },
     /// An error that occurs when a distribution is included with neither wheels nor a source
     /// distribution.
-    #[error("found distribution {id} with neither wheels nor source distribution")]
+    #[error("distribution {id} can't be installed because it has neither a source distribution nor a wheel for the current platform")]
     NeitherSourceDistNorWheel {
         /// The ID of the distribution that has a missing base.
         id: DistributionId,


### PR DESCRIPTION
Currently, with
```toml
[project]
name = "transformers"
version = "4.39.0.dev0"
requires-python = ">=3.10"
dependencies = [
  "torch==1.10.0"
]
```
i get
```
$ uv sync --preview
Resolved 3 packages in 7ms
error: found distribution torch==1.10.0 @ registry+https://pypi.org/simple with neither wheels nor source distribution
```
This error message is wrong, there are wheels, they are just not compatible. I initially got this error message during `uv lock` (in a build), so i also added that this is about installation, not about locking.

We should reject this version immediately because with the current requires python, it can never be installed, but even then we need to change the error message because you can be on the correct python version, but an unsupported platform.
