### PR TITLE
uv: fix doc test

### DIFF
--- a/crates/uv/src/shell.rs
+++ b/crates/uv/src/shell.rs
@@ -60,7 +60,7 @@ impl Shell {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// use crate::shells::Shell;
     ///
     /// assert_eq!(Shell::from_shell_path("/bin/bash"), Some(Shell::Bash));


### PR DESCRIPTION
[Doc tests can't use crate internal APIs unfortunately.][internal-doc]
I really want them to be able to, but for now, mark such tests as
`ignore`.

I was motivated to do this because it otherwise breaks `cargo t --all`
for me.

[internal-doc]: https://github.com/rust-lang/rust/issues/50784
