### PR TITLE
Fix `CONTRIBUTING.md` instructions to install multiple Python versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ If tests fail due to a mismatch in the JSON Schema, run: `cargo dev generate-jso
 Testing uv requires multiple specific Python versions; they can be installed with:
 
 ```shell
-cargo run toolchain install
+cargo run python install
 ```
 
 The storage directory can be configured with `UV_PYTHON_INSTALL_DIR`.


### PR DESCRIPTION
## Summary

I noticed the command to install multiple Python versions was wrong as it was failing cause `toolchain` is not a known command. 

I looked in the `ci.yml` workflow to see which command is used there and updated the instructions accordingly.

## Test Plan

I just ran the command locally. :)