### PR TITLE
pip compile: exclude --upgrade-package when option and value are passed as a single argument

### DIFF
--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -547,7 +547,14 @@ fn cmd(
                 return Some(None);
             }
 
-            // Always skip the `--upgrade-package` flag, and mark the next item as skipped
+            // Always skip the `--upgrade-package` flag
+            if arg.starts_with("--upgrade-package=") || arg.starts_with("-P") {
+                // Reset state; skip this iteration.
+                *skip_next = None;
+                return Some(None);
+            }
+
+            // Mark the next item as (to be) skipped.
             if arg == "--upgrade-package" || arg == "-P" {
                 *skip_next = Some(true);
                 return Some(None);

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -528,7 +528,7 @@ fn cmd(
 
             // Skip any `--find-links` URLs, unless requested.
             if !include_find_links {
-                if arg.starts_with("--find-links=") || arg.starts_with("-f=") {
+                if arg.starts_with("--find-links=") || arg.starts_with("-f") {
                     // Reset state; skip this iteration.
                     *skip_next = None;
                     return Some(None);


### PR DESCRIPTION
This excludes `--upgrade-package` from `compile_command` when value and option are passed as a single argument. Eg:

```console
--upgrade-package=package
-P=package
-Ppackage
```

I missed this on #5032.
Fixes #5031.

## Test Plan

Tested locally