### PR TITLE
Fix Fedora system test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,8 +637,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Install Python"
-        run: |
-          dnf install python3.9 which -y && python3 -m ensurepip
+        run: dnf install python3 which -y && python3 -m ensurepip
 
       - name: "Download binary"
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,7 +637,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Install Python"
-        run: dnf install which -y && python3 -m ensurepip
+        run: |
+          dnf install python3.9 which -y && python3 -m ensurepip
 
       - name: "Download binary"
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Seems like the latest [`fedora:41`](https://hub.docker.com/layers/library/fedora/rawhide/images/sha256-c037a87094660ceda037ee319b17f59559241d2a3580d1d0f414e72b0a8f3827?context=explore) (pushed at Jul 12, 2024 at 22:05 UTC) docker image has removed the `python3` package, causing our current [CI failure](https://github.com/astral-sh/uv/actions/runs/9917708846/job/27401528178).
