### PR TITLE
`python pin` now finds workspace root folder when called in subfolder

### DIFF
--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -14,8 +14,9 @@ pub use crate::prefix::Prefix;
 pub use crate::python_version::PythonVersion;
 pub use crate::target::Target;
 pub use crate::version_files::{
-    request_from_version_file, requests_from_version_file, version_file_exists,
-    versions_file_exists, PYTHON_VERSIONS_FILENAME, PYTHON_VERSION_FILENAME,
+    request_from_version_file, request_from_version_file_in, requests_from_version_file,
+    requests_from_version_file_in, version_file_exists, versions_file_exists,
+    PYTHON_VERSIONS_FILENAME, PYTHON_VERSION_FILENAME,
 };
 pub use crate::virtualenv::{Error as VirtualEnvError, PyVenvConfiguration, VirtualEnvironment};
 mod discovery;

--- a/crates/uv-python/src/version_files.rs
+++ b/crates/uv-python/src/version_files.rs
@@ -13,7 +13,77 @@ pub static PYTHON_VERSIONS_FILENAME: &str = ".python-versions";
 /// Read [`PythonRequest`]s from a version file, if present.
 ///
 /// Prefers `.python-versions` then `.python-version`.
-/// If only one Python version is desired, use [`request_from_version_files`] which prefers the `.python-version` file.
+/// If only one Python version is desired, use [`request_from_version_file_in`] which prefers the `.python-version` file.
+pub async fn requests_from_version_file_in(
+    root: &PathBuf,
+) -> Result<Option<Vec<PythonRequest>>, io::Error> {
+    if let Some(versions) = read_versions_file_in(root).await? {
+        Ok(Some(
+            versions
+                .into_iter()
+                .map(|version| PythonRequest::parse(&version))
+                .collect(),
+        ))
+    } else if let Some(version) = read_version_file_in(root).await? {
+        Ok(Some(vec![PythonRequest::parse(&version)]))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Read a [`PythonRequest`] from a version file, if present.
+///
+/// Prefers `.python-version` then the first entry of `.python-versions`.
+/// If multiple Python versions are desired, use [`requests_from_version_file_in`] instead.
+pub async fn request_from_version_file_in(
+    root: &PathBuf,
+) -> Result<Option<PythonRequest>, io::Error> {
+    if let Some(version) = read_version_file_in(root).await? {
+        Ok(Some(PythonRequest::parse(&version)))
+    } else if let Some(versions) = read_versions_file_in(root).await? {
+        Ok(versions
+            .into_iter()
+            .next()
+            .inspect(|_| debug!("Using the first version from `.python-versions`"))
+            .map(|version| PythonRequest::parse(&version)))
+    } else {
+        Ok(None)
+    }
+}
+
+async fn read_versions_file_in(root: &PathBuf) -> Result<Option<Vec<String>>, io::Error> {
+    let mut version_file = PathBuf::from(root);
+    version_file.push(PYTHON_VERSIONS_FILENAME);
+    if !version_file.try_exists()? {
+        return Ok(None);
+    }
+    debug!("Reading requests from `{}`", version_file.display());
+    let lines: Vec<String> = fs::tokio::read_to_string(version_file)
+        .await?
+        .lines()
+        .map(ToString::to_string)
+        .collect();
+    Ok(Some(lines))
+}
+
+async fn read_version_file_in(root: &PathBuf) -> Result<Option<String>, io::Error> {
+    let mut version_file = PathBuf::from(root);
+    version_file.push(PYTHON_VERSION_FILENAME);
+    if !version_file.try_exists()? {
+        return Ok(None);
+    }
+    debug!("Reading requests from `{}`", version_file.display());
+    Ok(fs::tokio::read_to_string(version_file)
+        .await?
+        .lines()
+        .next()
+        .map(ToString::to_string))
+}
+
+/// Read [`PythonRequest`]s from a version file, if present.
+///
+/// Prefers `.python-versions` then `.python-version`.
+/// If only one Python version is desired, use [`request_from_version_file`] which prefers the `.python-version` file.
 pub async fn requests_from_version_file() -> Result<Option<Vec<PythonRequest>>, io::Error> {
     if let Some(versions) = read_versions_file().await? {
         Ok(Some(
@@ -32,7 +102,7 @@ pub async fn requests_from_version_file() -> Result<Option<Vec<PythonRequest>>, 
 /// Read a [`PythonRequest`] from a version file, if present.
 ///
 /// Prefers `.python-version` then the first entry of `.python-versions`.
-/// If multiple Python versions are desired, use [`requests_from_version_files`] instead.
+/// If multiple Python versions are desired, use [`requests_from_version_file`] instead.
 pub async fn request_from_version_file() -> Result<Option<PythonRequest>, io::Error> {
     if let Some(version) = read_version_file().await? {
         Ok(Some(PythonRequest::parse(&version)))

--- a/crates/uv-python/src/version_files.rs
+++ b/crates/uv-python/src/version_files.rs
@@ -1,5 +1,5 @@
 use fs_err as fs;
-use std::{io, path::PathBuf};
+use std::{io, path::Path, path::PathBuf};
 use tracing::debug;
 
 use crate::PythonRequest;
@@ -51,9 +51,9 @@ pub async fn request_from_version_file_in(
     }
 }
 
-async fn read_versions_file_in(root: &PathBuf) -> Result<Option<Vec<String>>, io::Error> {
-    let mut version_file = PathBuf::from(root);
-    version_file.push(PYTHON_VERSIONS_FILENAME);
+/// Read a `.python-versions` file in `root` folder if present.
+async fn read_versions_file_in(root: impl AsRef<Path>) -> Result<Option<Vec<String>>, io::Error> {
+    let version_file = root.as_ref().join(PYTHON_VERSIONS_FILENAME);
     if !version_file.try_exists()? {
         return Ok(None);
     }
@@ -66,9 +66,9 @@ async fn read_versions_file_in(root: &PathBuf) -> Result<Option<Vec<String>>, io
     Ok(Some(lines))
 }
 
-async fn read_version_file_in(root: &PathBuf) -> Result<Option<String>, io::Error> {
-    let mut version_file = PathBuf::from(root);
-    version_file.push(PYTHON_VERSION_FILENAME);
+/// Read a `.python-version` file in `root` folder if present.
+async fn read_version_file_in(root: impl AsRef<Path>) -> Result<Option<String>, io::Error> {
+    let version_file = root.as_ref().join(PYTHON_VERSION_FILENAME);
     if !version_file.try_exists()? {
         return Ok(None);
     }

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -29,7 +29,7 @@ pub(crate) async fn pin(
         warn_user_once!("`uv python pin` is experimental and may change without warning.");
     }
 
-    let working_dir =
+    let target_dir =
         if let Ok(workspace) = Workspace::discover(&std::env::current_dir()?, None).await {
             workspace.install_path().to_owned()
         } else {
@@ -38,7 +38,7 @@ pub(crate) async fn pin(
 
     let Some(request) = request else {
         // Display the current pinned Python version
-        if let Some(pins) = requests_from_version_file_in(&working_dir).await? {
+        if let Some(pins) = requests_from_version_file_in(&target_dir).await? {
             for pin in pins {
                 writeln!(printer.stdout(), "{}", pin.to_canonical_string())?;
             }
@@ -76,7 +76,7 @@ pub(crate) async fn pin(
     };
 
     debug!("Using pin `{}`", output);
-    let version_file = working_dir.join(PYTHON_VERSION_FILENAME);
+    let version_file = target_dir.join(PYTHON_VERSION_FILENAME);
     let exists = version_file.exists();
 
     debug!("Writing pin to {}", version_file.user_display());

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -22,6 +22,7 @@ pub(crate) async fn pin(
     resolved: bool,
     python_preference: PythonPreference,
     preview: PreviewMode,
+    isolated: bool,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -29,12 +30,13 @@ pub(crate) async fn pin(
         warn_user_once!("`uv python pin` is experimental and may change without warning.");
     }
 
-    let target_dir =
-        if let Ok(workspace) = Workspace::discover(&std::env::current_dir()?, None).await {
-            workspace.install_path().to_owned()
-        } else {
-            std::env::current_dir()?
-        };
+    let target_dir = if isolated {
+        std::env::current_dir()?
+    } else if let Ok(workspace) = Workspace::discover(&std::env::current_dir()?, None).await {
+        workspace.install_path().to_owned()
+    } else {
+        std::env::current_dir()?
+    };
 
     let Some(request) = request else {
         // Display the current pinned Python version

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -92,7 +92,7 @@ pub(crate) async fn pin(
     if target_dir != std::env::current_dir()? {
         // Print the version file use to pin only
         // if it's not in the current working directory
-        message = format!("{message} in `{}`", version_file.display())
+        message = format!("{message} in `{}`", version_file.display());
     };
 
     writeln!(printer.stdout(), "{message}")?;

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -81,11 +81,19 @@ pub(crate) async fn pin(
 
     debug!("Writing pin to {}", version_file.user_display());
     fs_err::write(&version_file, format!("{output}\n"))?;
-    if exists {
-        writeln!(printer.stdout(), "Replaced existing pin with `{output}`")?;
+    let mut message = if exists {
+        format!("Replaced existing pin with `{output}`")
     } else {
-        writeln!(printer.stdout(), "Pinned to `{output}`")?;
-    }
+        format!("Pinned to `{output}`")
+    };
+
+    if target_dir != std::env::current_dir()? {
+        // Print the version file use to pin only
+        // if it's not in the current working directory
+        message = format!("{message} in `{}`", version_file.display())
+    };
+
+    writeln!(printer.stdout(), "{message}")?;
 
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -777,6 +777,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.resolved,
                 globals.python_preference,
                 globals.preview,
+                globals.isolated,
                 &cache,
                 printer,
             )

--- a/crates/uv/tests/python_pin.rs
+++ b/crates/uv/tests/python_pin.rs
@@ -239,7 +239,7 @@ fn python_pin_in_workspace_subfolder() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Pinned to `3.11`
+    Pinned to `3.11` in `[TEMP_DIR]/.python-version`
 
     ----- stderr -----
     "###);


### PR DESCRIPTION
## Summary

Fixes #4971.

This PR changes `python pin` behaviour when called in a workspace subfolder. Previously it would only read or create a `.python-version` file in the current working directory, now instead it will first search for the workspace root folder and read or create the `.python-version` file in that folder. 

We assume the root folder contains a valid `pyproject.toml` file.

If we're not in a workspace use the previous behaviour and creates or reads `.python-version` in the current working directory.

## Test Plan

I added a new test to verify this new behaviour, and run all tests locally.
