### PR TITLE
Respect the libc of the execution environment with `uv python list`

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -233,6 +233,11 @@ impl PythonDownloadRequest {
                 return false;
             }
         }
+        if let Some(libc) = &self.libc {
+            if key.libc != *libc {
+                return false;
+            }
+        }
         if let Some(implementation) = &self.implementation {
             if key.implementation != LenientImplementationName::from(*implementation) {
                 return false;

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -120,7 +120,8 @@ pub(crate) async fn list(
                 }
             }
             if let [major, minor, patch] = version.release() {
-                if !seen_patch.insert((os.clone(), *major, *minor, *patch, *key.arch(), key.libc())) {
+                if !seen_patch.insert((os.clone(), *major, *minor, *patch, *key.arch(), key.libc()))
+                {
                     if matches!(kind, Kind::Download) {
                         continue;
                     }

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -113,14 +113,14 @@ pub(crate) async fn list(
         // Only show the latest patch version for each download unless all were requested
         if !matches!(kind, Kind::System) {
             if let [major, minor, ..] = version.release() {
-                if !seen_minor.insert((os.clone(), *major, *minor)) {
+                if !seen_minor.insert((os.clone(), *major, *minor, *key.arch(), *key.libc())) {
                     if matches!(kind, Kind::Download) && !all_versions {
                         continue;
                     }
                 }
             }
             if let [major, minor, patch] = version.release() {
-                if !seen_patch.insert((os.clone(), *major, *minor, *patch)) {
+                if !seen_patch.insert((os.clone(), *major, *minor, *patch, *key.arch(), key.libc())) {
                     if matches!(kind, Kind::Download) {
                         continue;
                     }


### PR DESCRIPTION
Fix #4988

## Summary

Running `uv python list` on glibc-based Linux will list musl pythons.

```bash
$ uv version
uv 0.2.24
$ uv python list
warning: `uv python list` is experimental and may change without warning.
cpython-3.12.3-linux-x86_64-musl     <download available>
cpython-3.12.3-linux-x86_64-gnu      /usr/bin/python3
cpython-3.12.3-linux-x86_64-gnu      /bin/python3
cpython-3.11.9-linux-x86_64-musl     <download available>
cpython-3.10.14-linux-x86_64-musl    <download available>
cpython-3.9.19-linux-x86_64-musl     <download available>
cpython-3.8.19-linux-x86_64-musl     <download available>
cpython-3.7.9-linux-x86_64-musl      <download available>
```

Change it to show Python matching the environment's libc as follows.

```bash
$ uv python list
warning: `uv python list` is experimental and may change without warning.
cpython-3.12.3-linux-x86_64-gnu     /usr/bin/python3
cpython-3.12.3-linux-x86_64-gnu     /bin/python3
cpython-3.12.3-linux-x86_64-gnu     <download available>
cpython-3.11.9-linux-x86_64-gnu     <download available>
cpython-3.10.14-linux-x86_64-gnu    <download available>
cpython-3.9.19-linux-x86_64-gnu     <download available>
cpython-3.8.19-linux-x86_64-gnu     <download available>
cpython-3.7.9-linux-x86_64-gnu      <download available>
```

Also, if --all-platforms is specified, change to list Python for all architectures and libc.

```bash
$ uv python list --all-platforms
warning: `uv python list` is experimental and may change without warning.
cpython-3.12.3-windows-x86_64-none       <download available>
cpython-3.12.3-windows-x86-none          <download available>
cpython-3.12.3-macos-x86_64-none         <download available>
cpython-3.12.3-macos-aarch64-none        <download available>
cpython-3.12.3-linux-x86_64-musl         <download available>
cpython-3.12.3-linux-x86_64-gnu          /usr/bin/python3
cpython-3.12.3-linux-x86_64-gnu          /bin/python3
cpython-3.12.3-linux-x86_64-gnu          <download available>
cpython-3.12.3-linux-s390x-gnu           <download available>
cpython-3.12.3-linux-powerpc64le-gnu     <download available>
cpython-3.12.3-linux-armv7-gnueabihf     <download available>
cpython-3.12.3-linux-armv7-gnueabi       <download available>
cpython-3.12.3-linux-aarch64-gnu         <download available>
...
```

## Test Plan

The following commands were executed on the command line to confirm the results in Ubuntu 24.04.
- `cargo run python list`
- `cargo run python list --all-platforms`