### PR TITLE
Add `pypy` executables when calling `uv venv`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,13 +571,13 @@ jobs:
               fi
           }
 
-          executables=("python")
+          executables=("pypy" "pypy3.9" "python")
 
           all_found=true
           for executable_name in "${executables[@]}"; do
               check_in_bin "$executable_name" "$folder_path"
               result=$?
-            
+
               if [[ $result -ne 0 ]]; then
                   all_found=false
               fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,7 +571,7 @@ jobs:
               fi
           }
 
-          executables=("pypy" "pypy3.9" "python")
+          executables=("pypy" "pypy3" "python")
 
           all_found=true
           for executable_name in "${executables[@]}"; do

--- a/crates/uv-virtualenv/src/bare.rs
+++ b/crates/uv-virtualenv/src/bare.rs
@@ -353,6 +353,8 @@ impl WindowsExecutable {
         match self {
             WindowsExecutable::Python => "venvlauncher.exe",
             WindowsExecutable::Pythonw => "venvwlauncher.exe",
+            // From 3.13 on these should replace the `python.exe` and `pythonw.exe` shims.
+            // These are not relevant as of now for PyPy as it doesn't yet support Python 3.13.
             WindowsExecutable::PyPy => "venvlauncher.exe",
             WindowsExecutable::PyPyw => "venvwlauncher.exe",
         }

--- a/crates/uv-virtualenv/src/bare.rs
+++ b/crates/uv-virtualenv/src/bare.rs
@@ -170,6 +170,14 @@ pub fn create_bare_venv(
                 interpreter.python_minor(),
             )),
         )?;
+
+        if interpreter.markers().implementation_name() == "pypy" {
+            uv_fs::replace_symlink(
+                "python",
+                scripts.join(format!("pypy{}", interpreter.python_major())),
+            )?;
+            uv_fs::replace_symlink("python", scripts.join("pypy"))?;
+        }
     }
 
     // No symlinking on Windows, at least not on a regular non-dev non-admin Windows install.

--- a/crates/uv-virtualenv/src/bare.rs
+++ b/crates/uv-virtualenv/src/bare.rs
@@ -199,6 +199,20 @@ pub fn create_bare_venv(
 
         if interpreter.markers().implementation_name() == "pypy" {
             copy_launcher_windows(
+                WindowsExecutable::PythonMajor,
+                interpreter,
+                &base_python,
+                &scripts,
+                python_home,
+            )?;
+            copy_launcher_windows(
+                WindowsExecutable::PythonMajorMinor,
+                interpreter,
+                &base_python,
+                &scripts,
+                python_home,
+            )?;
+            copy_launcher_windows(
                 WindowsExecutable::PyPy,
                 interpreter,
                 &base_python,
@@ -350,6 +364,10 @@ pub fn create_bare_venv(
 enum WindowsExecutable {
     /// The `python.exe` executable (or `venvlauncher.exe` launcher shim).
     Python,
+    /// The `python3.exe` executable (or `venvlauncher.exe` launcher shim).
+    PythonMajor,
+    /// The `python3.<minor>.exe` executable (or `venvlauncher.exe` launcher shim).
+    PythonMajorMinor,
     /// The `pythonw.exe` executable (or `venvwlauncher.exe` launcher shim).
     Pythonw,
     // The `pypy.exe` executable
@@ -369,6 +387,16 @@ impl WindowsExecutable {
     fn exe(self, interpreter: &Interpreter) -> String {
         match self {
             WindowsExecutable::Python => String::from("python.exe"),
+            WindowsExecutable::PythonMajor => {
+                format!("python{}.exe", interpreter.python_major())
+            }
+            WindowsExecutable::PythonMajorMinor => {
+                format!(
+                    "python{}.{}.exe",
+                    interpreter.python_major(),
+                    interpreter.python_minor()
+                )
+            }
             WindowsExecutable::Pythonw => String::from("pythonw.exe"),
             WindowsExecutable::PyPy => String::from("pypy.exe"),
             WindowsExecutable::PyPyMajor => {
@@ -396,6 +424,8 @@ impl WindowsExecutable {
     fn launcher(self) -> &'static str {
         match self {
             WindowsExecutable::Python => "venvlauncher.exe",
+            WindowsExecutable::PythonMajor => "venvlauncher.exe",
+            WindowsExecutable::PythonMajorMinor => "venvlauncher.exe",
             WindowsExecutable::Pythonw => "venvwlauncher.exe",
             // From 3.13 on these should replace the `python.exe` and `pythonw.exe` shims.
             // These are not relevant as of now for PyPy as it doesn't yet support Python 3.13.

--- a/crates/uv-virtualenv/src/bare.rs
+++ b/crates/uv-virtualenv/src/bare.rs
@@ -196,6 +196,23 @@ pub fn create_bare_venv(
             &scripts,
             python_home,
         )?;
+
+        if interpreter.markers().implementation_name() == "pypy" {
+            copy_launcher_windows(
+                WindowsExecutable::PyPy,
+                interpreter,
+                &base_python,
+                &scripts,
+                python_home,
+            )?;
+            copy_launcher_windows(
+                WindowsExecutable::PyPyw,
+                interpreter,
+                &base_python,
+                &scripts,
+                python_home,
+            )?;
+        }
     }
 
     #[cfg(not(any(unix, windows)))]
@@ -314,6 +331,10 @@ enum WindowsExecutable {
     Python,
     /// The `pythonw.exe` executable (or `venvwlauncher.exe` launcher shim).
     Pythonw,
+    // The `pypy.exe` executable
+    PyPy,
+    // The `pypyw.exe` executable
+    PyPyw,
 }
 
 impl WindowsExecutable {
@@ -322,6 +343,8 @@ impl WindowsExecutable {
         match self {
             WindowsExecutable::Python => "python.exe",
             WindowsExecutable::Pythonw => "pythonw.exe",
+            WindowsExecutable::PyPy => "pypy.exe",
+            WindowsExecutable::PyPyw => "pypyw.exe",
         }
     }
 
@@ -330,6 +353,8 @@ impl WindowsExecutable {
         match self {
             WindowsExecutable::Python => "venvlauncher.exe",
             WindowsExecutable::Pythonw => "venvwlauncher.exe",
+            WindowsExecutable::PyPy => "venvlauncher.exe",
+            WindowsExecutable::PyPyw => "venvwlauncher.exe",
         }
     }
 }


### PR DESCRIPTION
## Summary

Should fix #2092.

This PR changes `uv venv` so it also creates symlinks to `pypy` on Unix and copies executables on Windows when creating a new environment using PyPy.

I found a bit of discrepancy between creation of a venv using `python` and `uv`, as using `python` brings all the executables with it. While `uv` brings only those without any version number, at least on Windows. The behaviour is different on Unix as we take the versioned symlinks too.

Some examples below.

`python -m venv` generates the following `Scripts` folder.
```
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         7/14/2024     15:41           2031 activate
-a----         7/14/2024     15:41           1029 activate.bat
-a----         7/14/2024     15:41           9033 Activate.ps1
-a----         7/14/2024     15:41            393 deactivate.bat
-a----         7/14/2024     15:40          27648 libffi-8.dll
-a----         7/14/2024     15:41       44290560 libpypy3.10-c.dll
-a----         7/14/2024     15:41         108424 pip.exe
-a----         7/14/2024     15:41         108424 pip3.10.exe
-a----         7/14/2024     15:41         108424 pip3.exe
-a----         7/14/2024     15:41          79360 pypy.exe
-a----         7/14/2024     15:41          79360 pypy3.10.exe
-a----         7/14/2024     15:41          79360 pypy3.10w.exe
-a----         7/14/2024     15:41          79360 pypy3.exe
-a----         7/14/2024     15:41          79360 pypyw.exe
-a----         7/14/2024     15:41          79360 python.exe
-a----         7/14/2024     15:41          79360 python3.10.exe
-a----         7/14/2024     15:41          79360 python3.exe
-a----         7/14/2024     15:41          79360 pythonw.exe
```

`uv venv` instead generates this. 
```
-a----         7/14/2024     16:27           3360 activate
-a----         7/14/2024     16:27           2251 activate.bat
-a----         7/14/2024     16:27           2627 activate.csh
-a----         7/14/2024     16:27           4191 activate.fish
-a----         7/14/2024     16:27           3875 activate.nu
-a----         7/14/2024     16:27           2766 activate.ps1
-a----         7/14/2024     16:27           2378 activate_this.py
-a----         7/14/2024     16:27           1728 deactivate.bat
-a----         7/13/2024     19:19          27648 libffi-8.dll
-a----         7/13/2024     19:19       44290560 libpypy3.10-c.dll
-a----         7/14/2024     16:27           1215 pydoc.bat
-a----         7/13/2024     19:19          79360 pypy.exe
-a----         7/13/2024     19:19          79360 pypyw.exe
-a----         7/13/2024     19:19          79360 python.exe
-a----         7/13/2024     19:19          79360 pythonw.exe
```

## Test Plan

To verify the correct behaviour:

1. Download and install PyPy from [official website](https://www.pypy.org/download.html)
2. Call `uv venv -p <path_to_pypy_>`
3. Run `.\.venv\Scripts\activate` on Windows or `./.venv/Scripts/activate` on Unix
4. Run `pypy`

I thought of writing some automated tests but I couldn't rely on `uv python install` command to install PyPy as it's not in the list of installable Python builds.
