### PR TITLE
Remove special casing from no solution error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2700,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "pubgrub"
 version = "0.2.1"
-source = "git+https://github.com/astral-sh/pubgrub?rev=b4435e2f3af10dab2336a0345b35dcd622699d06#b4435e2f3af10dab2336a0345b35dcd622699d06"
+source = "git+https://github.com/astral-sh/pubgrub?rev=3f0ba760951ab0deeac874b98bb18fc90103fcf7#3f0ba760951ab0deeac874b98bb18fc90103fcf7"
 dependencies = [
  "indexmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 petgraph = { version = "0.6.4" }
 platform-info = { version = "2.0.2" }
-pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "b4435e2f3af10dab2336a0345b35dcd622699d06" }
+pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "3f0ba760951ab0deeac874b98bb18fc90103fcf7" }
 pyo3 = { version = "0.21.0" }
 pyo3-log = { version = "0.10.0" }
 quote = { version = "1.0.36" }

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -2,10 +2,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use dashmap::DashMap;
 use pubgrub::range::Range;
 use pubgrub::report::{DefaultStringReporter, DerivationTree, External, Reporter};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 use distribution_types::{BuiltDist, IndexLocations, InstalledDist, SourceDist};
 use pep440_rs::Version;
@@ -19,9 +18,7 @@ use crate::pubgrub::{
     PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter, PubGrubSpecifierError,
 };
 use crate::python_requirement::PythonRequirement;
-use crate::resolver::{
-    FxOnceMap, IncompletePackage, UnavailablePackage, UnavailableReason, VersionsResponse,
-};
+use crate::resolver::{IncompletePackage, UnavailablePackage, UnavailableReason};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ResolveError {
@@ -117,107 +114,88 @@ impl<T> From<tokio::sync::mpsc::error::SendError<T>> for ResolveError {
     }
 }
 
-/// Given a [`DerivationTree`], collapse any [`External::FromDependencyOf`] incompatibilities
-/// wrap an [`PubGrubPackageInner::Extra`] package.
-fn collapse_proxies(
-    derivation_tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
-) {
-    match derivation_tree {
-        DerivationTree::External(_) => {}
-        DerivationTree::Derived(derived) => {
-            match (
-                Arc::make_mut(&mut derived.cause1),
-                Arc::make_mut(&mut derived.cause2),
-            ) {
-                (
-                    DerivationTree::External(External::FromDependencyOf(package, ..)),
-                    ref mut cause,
-                ) if matches!(
-                    &**package,
-                    PubGrubPackageInner::Extra { .. }
-                        | PubGrubPackageInner::Marker { .. }
-                        | PubGrubPackageInner::Dev { .. }
-                ) =>
-                {
-                    collapse_proxies(cause);
-                    *derivation_tree = cause.clone();
-                }
-                (
-                    ref mut cause,
-                    DerivationTree::External(External::FromDependencyOf(package, ..)),
-                ) if matches!(
-                    &**package,
-                    PubGrubPackageInner::Extra { .. }
-                        | PubGrubPackageInner::Marker { .. }
-                        | PubGrubPackageInner::Dev { .. }
-                ) =>
-                {
-                    collapse_proxies(cause);
-                    *derivation_tree = cause.clone();
-                }
-                _ => {
-                    collapse_proxies(Arc::make_mut(&mut derived.cause1));
-                    collapse_proxies(Arc::make_mut(&mut derived.cause2));
-                }
-            }
-        }
-    }
-}
-
-impl ResolveError {
-    /// Convert an error from PubGrub to a resolver error.
-    ///
-    /// [`ForkUrls`] breaks the usual pattern used here since it's part of one the [`SolveState`],
-    /// not of the [`ResolverState`], so we have to take it from the fork that errored instead of
-    /// being able to add it later.
-    pub(crate) fn from_pubgrub_error(
-        value: pubgrub::error::PubGrubError<UvDependencyProvider>,
-        fork_urls: ForkUrls,
-    ) -> Self {
-        match value {
-            // These are all never type variant that can never match, but never is experimental
-            pubgrub::error::PubGrubError::ErrorChoosingPackageVersion(_)
-            | pubgrub::error::PubGrubError::ErrorInShouldCancel(_)
-            | pubgrub::error::PubGrubError::ErrorRetrievingDependencies { .. } => {
-                unreachable!()
-            }
-            pubgrub::error::PubGrubError::Failure(inner) => Self::Failure(inner),
-            pubgrub::error::PubGrubError::NoSolution(mut derivation_tree) => {
-                collapse_proxies(&mut derivation_tree);
-
-                Self::NoSolution(NoSolutionError {
-                    derivation_tree,
-                    // The following should be populated before display for the best error messages
-                    available_versions: FxHashMap::default(),
-                    selector: None,
-                    python_requirement: None,
-                    index_locations: None,
-                    unavailable_packages: FxHashMap::default(),
-                    incomplete_packages: FxHashMap::default(),
-                    fork_urls,
-                })
-            }
-            pubgrub::error::PubGrubError::SelfDependency { package, version } => {
-                Self::SelfDependency {
-                    package: Box::new(package),
-                    version: Box::new(version),
-                }
-            }
-        }
-    }
-}
-
-/// A wrapper around [`pubgrub::error::PubGrubError::NoSolution`] that displays a resolution failure report.
+/// A wrapper around [`pubgrub::error::NoSolutionError`] that displays a resolution failure report.
 #[derive(Debug)]
 pub struct NoSolutionError {
-    derivation_tree: DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+    error: pubgrub::error::NoSolutionError<UvDependencyProvider>,
     available_versions: FxHashMap<PubGrubPackage, BTreeSet<Version>>,
-    selector: Option<CandidateSelector>,
-    python_requirement: Option<PythonRequirement>,
-    index_locations: Option<IndexLocations>,
+    selector: CandidateSelector,
+    python_requirement: PythonRequirement,
+    index_locations: IndexLocations,
     unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
     incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, IncompletePackage>>,
     fork_urls: ForkUrls,
+}
+
+impl NoSolutionError {
+    pub(crate) fn new(
+        error: pubgrub::error::NoSolutionError<UvDependencyProvider>,
+        available_versions: FxHashMap<PubGrubPackage, BTreeSet<Version>>,
+        selector: CandidateSelector,
+        python_requirement: PythonRequirement,
+        index_locations: IndexLocations,
+        unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
+        incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, IncompletePackage>>,
+        fork_urls: ForkUrls,
+    ) -> Self {
+        Self {
+            error,
+            available_versions,
+            selector,
+            python_requirement,
+            index_locations,
+            unavailable_packages,
+            incomplete_packages,
+            fork_urls,
+        }
+    }
+
+    /// Given a [`DerivationTree`], collapse any [`External::FromDependencyOf`] incompatibilities
+    /// wrap an [`PubGrubPackageInner::Extra`] package.
+    pub(crate) fn collapse_proxies(
+        derivation_tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+    ) {
+        match derivation_tree {
+            DerivationTree::External(_) => {}
+            DerivationTree::Derived(derived) => {
+                match (
+                    Arc::make_mut(&mut derived.cause1),
+                    Arc::make_mut(&mut derived.cause2),
+                ) {
+                    (
+                        DerivationTree::External(External::FromDependencyOf(package, ..)),
+                        ref mut cause,
+                    ) if matches!(
+                        &**package,
+                        PubGrubPackageInner::Extra { .. }
+                            | PubGrubPackageInner::Marker { .. }
+                            | PubGrubPackageInner::Dev { .. }
+                    ) =>
+                    {
+                        Self::collapse_proxies(cause);
+                        *derivation_tree = cause.clone();
+                    }
+                    (
+                        ref mut cause,
+                        DerivationTree::External(External::FromDependencyOf(package, ..)),
+                    ) if matches!(
+                        &**package,
+                        PubGrubPackageInner::Extra { .. }
+                            | PubGrubPackageInner::Marker { .. }
+                            | PubGrubPackageInner::Dev { .. }
+                    ) =>
+                    {
+                        Self::collapse_proxies(cause);
+                        *derivation_tree = cause.clone();
+                    }
+                    _ => {
+                        Self::collapse_proxies(Arc::make_mut(&mut derived.cause1));
+                        Self::collapse_proxies(Arc::make_mut(&mut derived.cause2));
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl std::error::Error for NoSolutionError {}
@@ -227,15 +205,14 @@ impl std::fmt::Display for NoSolutionError {
         // Write the derivation report.
         let formatter = PubGrubReportFormatter {
             available_versions: &self.available_versions,
-            python_requirement: self.python_requirement.as_ref(),
+            python_requirement: &self.python_requirement,
         };
-        let report =
-            DefaultStringReporter::report_with_formatter(&self.derivation_tree, &formatter);
+        let report = DefaultStringReporter::report_with_formatter(&self.error, &formatter);
         write!(f, "{report}")?;
 
         // Include any additional hints.
         for hint in formatter.hints(
-            &self.derivation_tree,
+            &self.error,
             &self.selector,
             &self.index_locations,
             &self.unavailable_packages,
@@ -246,115 +223,5 @@ impl std::fmt::Display for NoSolutionError {
         }
 
         Ok(())
-    }
-}
-
-impl NoSolutionError {
-    /// Update the available versions attached to the error using the given package version index.
-    ///
-    /// Only packages used in the error's derivation tree will be retrieved.
-    #[must_use]
-    pub(crate) fn with_available_versions(
-        mut self,
-        visited: &FxHashSet<PackageName>,
-        package_versions: &FxOnceMap<PackageName, Arc<VersionsResponse>>,
-    ) -> Self {
-        let mut available_versions = FxHashMap::default();
-        for package in self.derivation_tree.packages() {
-            match &**package {
-                PubGrubPackageInner::Root { .. } => {}
-                PubGrubPackageInner::Python { .. } => {}
-                PubGrubPackageInner::Marker { .. } => {}
-                PubGrubPackageInner::Extra { .. } => {}
-                PubGrubPackageInner::Dev { .. } => {}
-                PubGrubPackageInner::Package { name, .. } => {
-                    // Avoid including available versions for packages that exist in the derivation
-                    // tree, but were never visited during resolution. We _may_ have metadata for
-                    // these packages, but it's non-deterministic, and omitting them ensures that
-                    // we represent the state of the resolver at the time of failure.
-                    if visited.contains(name) {
-                        if let Some(response) = package_versions.get(name) {
-                            if let VersionsResponse::Found(ref version_maps) = *response {
-                                for version_map in version_maps {
-                                    available_versions
-                                        .entry(package.clone())
-                                        .or_insert_with(BTreeSet::new)
-                                        .extend(
-                                            version_map.iter().map(|(version, _)| version.clone()),
-                                        );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        self.available_versions = available_versions;
-        self
-    }
-
-    /// Update the candidate selector attached to the error.
-    #[must_use]
-    pub(crate) fn with_selector(mut self, selector: CandidateSelector) -> Self {
-        self.selector = Some(selector);
-        self
-    }
-
-    /// Update the index locations attached to the error.
-    #[must_use]
-    pub(crate) fn with_index_locations(mut self, index_locations: &IndexLocations) -> Self {
-        self.index_locations = Some(index_locations.clone());
-        self
-    }
-
-    /// Update the unavailable packages attached to the error.
-    #[must_use]
-    pub(crate) fn with_unavailable_packages(
-        mut self,
-        unavailable_packages: &DashMap<PackageName, UnavailablePackage>,
-    ) -> Self {
-        let mut new = FxHashMap::default();
-        for package in self.derivation_tree.packages() {
-            if let PubGrubPackageInner::Package { name, .. } = &**package {
-                if let Some(reason) = unavailable_packages.get(name) {
-                    new.insert(name.clone(), reason.clone());
-                }
-            }
-        }
-        self.unavailable_packages = new;
-        self
-    }
-
-    /// Update the incomplete packages attached to the error.
-    #[must_use]
-    pub(crate) fn with_incomplete_packages(
-        mut self,
-        incomplete_packages: &DashMap<PackageName, DashMap<Version, IncompletePackage>>,
-    ) -> Self {
-        let mut new = FxHashMap::default();
-        for package in self.derivation_tree.packages() {
-            if let PubGrubPackageInner::Package { name, .. } = &**package {
-                if let Some(versions) = incomplete_packages.get(name) {
-                    for entry in versions.iter() {
-                        let (version, reason) = entry.pair();
-                        new.entry(name.clone())
-                            .or_insert_with(BTreeMap::default)
-                            .insert(version.clone(), reason.clone());
-                    }
-                }
-            }
-        }
-        self.incomplete_packages = new;
-        self
-    }
-
-    /// Update the Python requirements attached to the error.
-    #[must_use]
-    pub(crate) fn with_python_requirement(
-        mut self,
-        python_requirement: &PythonRequirement,
-    ) -> Self {
-        self.python_requirement = Some(python_requirement.clone());
-        self
     }
 }


### PR DESCRIPTION
The only pubgrub error that can occur is a `NoSolutionError`, and the only place it can occur is `unit_propagation`, all other variants if `PubGrubError` are unreachable. By changing the return type on pubgrub's side (https://github.com/astral-sh/pubgrub/pull/28), we can remove the pattern matching and the `unreachable!()` asserts on `PubGrubError`.

Our pubgrub error wrapper used to have a two phased initialization, first mostly stubs in `solve[_tracked]()` and then adding the actual context in `resolve()`. When constructing the error in `solve` we already have all this context, so we can unify this to a regular constructor and remove the special casing in `resolve()` and `hints()`.
