### PR TITLE
Use correct pyproject.toml path in warnings

### DIFF
--- a/crates/uv-distribution/src/workspace.rs
+++ b/crates/uv-distribution/src/workspace.rs
@@ -777,7 +777,7 @@ async fn find_workspace(
             // We require that a `project.toml` file either declares a workspace or a project.
             warn_user!(
                 "pyproject.toml does not contain `project` table: `{}`",
-                workspace_root.simplified_display()
+                pyproject_path.simplified_display()
             );
             Ok(None)
         };


### PR DESCRIPTION
One part of #5068. I think the other is not warning when the version is dynamic, but this fix is needed either way.