### PR TITLE
add split to cover marker universe when existing splits are incomplete

### DIFF
--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -2515,6 +2515,12 @@ mod test {
             neg("os_name == 'bar' or os_name == 'foo'"),
             "os_name != 'bar' and os_name != 'foo'"
         );
+
+        // Always true negates to always false!
+        assert_eq!(
+            neg("python_version >= '3.6' or python_version < '3.6'"),
+            "python_version < '3.6' and python_version >= '3.6'"
+        );
     }
 
     #[test]

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2467,6 +2467,13 @@ impl Dependencies {
             };
             assert!(fork_groups.forks.len() >= 2, "expected definitive fork");
             let mut new_forks: Vec<Fork> = vec![];
+            if let Some(markers) = fork_groups.remaining_universe() {
+                debug!("Adding split to cover possibly incomplete markers: {markers}");
+                new_forks.push(Fork {
+                    dependencies: vec![],
+                    markers,
+                });
+            }
             for group in fork_groups.forks {
                 let mut new_forks_for_group = forks.clone();
                 for (index, _) in group.packages {
@@ -2721,6 +2728,22 @@ impl<'a> PossibleForkGroups<'a> {
             .iter_mut()
             .find(|fork| fork.is_overlapping(marker))
     }
+
+    /// Returns a marker tree corresponding to the set of marker expressions
+    /// outside of this fork group.
+    ///
+    /// In many cases, it can be easily known that the set of marker
+    /// expressions referred to by this marker tree is empty. In this case,
+    /// `None` is returned. But note that if a marker tree is returned, it is
+    /// still possible for it to describe exactly zero marker environments.
+    fn remaining_universe(&self) -> Option<MarkerTree> {
+        let have = MarkerTree::Or(self.forks.iter().map(PossibleFork::union).collect());
+        let missing = have.negate();
+        if crate::marker::is_definitively_empty_set(&missing) {
+            return None;
+        }
+        Some(missing)
+    }
 }
 
 /// Intermediate state representing a single possible fork.
@@ -2755,6 +2778,19 @@ impl<'a> PossibleFork<'a> {
             }
         }
         false
+    }
+
+    /// Returns the union of all the marker expressions in this possible fork.
+    ///
+    /// Each marker expression in the union returned is guaranteed to be overlapping
+    /// with at least one other expression in the same union.
+    fn union(&self) -> MarkerTree {
+        MarkerTree::Or(
+            self.packages
+                .iter()
+                .map(|&(_, tree)| (*tree).clone())
+                .collect(),
+        )
     }
 }
 

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -28,7 +28,7 @@ static EXCLUDE_NEWER: &str = "2024-03-25T00:00:00Z";
 /// Using a find links url allows using `--index-url` instead of `--extra-index-url` in tests
 /// to prevent dependency confusion attacks against our test suite.
 pub const BUILD_VENDOR_LINKS_URL: &str =
-    "https://raw.githubusercontent.com/astral-sh/packse/0.3.29/vendor/links.html";
+    "https://raw.githubusercontent.com/astral-sh/packse/0.3.30/vendor/links.html";
 
 #[doc(hidden)] // Macro and test context only, don't use directly.
 pub const INSTA_FILTERS: &[(&str, &str)] = &[

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -664,7 +664,7 @@ fn fork_incomplete_markers() -> Result<()> {
 
     ----- stderr -----
     warning: `uv lock` is experimental and may change without warning.
-    Resolved 4 packages in [TIME]
+    Resolved 5 packages in [TIME]
     "###
     );
 
@@ -699,9 +699,21 @@ fn fork_incomplete_markers() -> Result<()> {
         name = "package-b"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        dependencies = [
+            { name = "package-c", marker = "python_version == '3.10'" },
+        ]
         sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_incomplete_markers_b-1.0.0.tar.gz#sha256=c4deba44768923473d077bdc0e177033fcb6e6fd406d56830d7ee6f4ffad68c1", hash = "sha256:c4deba44768923473d077bdc0e177033fcb6e6fd406d56830d7ee6f4ffad68c1" }
         wheels = [
             { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_incomplete_markers_b-1.0.0-py3-none-any.whl#sha256=5c2a5f446580787ed7b3673431b112474237ddeaf1c81325bb30b86e7ee76adb", hash = "sha256:5c2a5f446580787ed7b3673431b112474237ddeaf1c81325bb30b86e7ee76adb" },
+        ]
+
+        [[distribution]]
+        name = "package-c"
+        version = "1.0.0"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_incomplete_markers_c-1.0.0.tar.gz#sha256=ecc02ea1cc8d3b561c8dcb9d2ba1abcdae2dd32de608bf8e8ed2878118426022", hash = "sha256:ecc02ea1cc8d3b561c8dcb9d2ba1abcdae2dd32de608bf8e8ed2878118426022" }
+        wheels = [
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_incomplete_markers_c-1.0.0-py3-none-any.whl#sha256=03fa287aa4cb78457211cb3df7459b99ba1ee2259aae24bc745eaab45e7eaaee", hash = "sha256:03fa287aa4cb78457211cb3df7459b99ba1ee2259aae24bc745eaab45e7eaaee" },
         ]
 
         [[distribution]]

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -1,7 +1,7 @@
 //! DO NOT EDIT
 //!
 //! Generated with `./scripts/sync_scenarios.sh`
-//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.29/scenarios>
+//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.30/scenarios>
 //!
 #![cfg(all(feature = "python", feature = "pypi"))]
 #![allow(clippy::needless_raw_string_hashes)]
@@ -16,6 +16,10 @@ mod common;
 
 /// This test ensures that multiple non-conflicting but also non-overlapping
 /// dependency specifications with the same package name are allowed and supported.
+/// At time of writing, this provokes a fork in the resolver, but it arguably
+/// shouldn't since the requirements themselves do not conflict with one another.
+/// However, this does impact resolution. Namely, it leaves the `a>=1` fork free to
+/// choose `a==2.0.0` since it behaves as if the `a<2` constraint doesn't exist.
 ///
 /// ```text
 /// fork-allows-non-conflicting-non-overlapping-dependencies
@@ -59,7 +63,7 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -83,10 +87,10 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_allows_non_conflicting_non_overlapping_dependencies_a-1.0.0.tar.gz#sha256=dd40a6bd59fbeefbf9f4936aec3df6fb6017e57d334f85f482ae5dd03ae353b9", hash = "sha256:dd40a6bd59fbeefbf9f4936aec3df6fb6017e57d334f85f482ae5dd03ae353b9" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_allows_non_conflicting_non_overlapping_dependencies_a-1.0.0.tar.gz#sha256=dd40a6bd59fbeefbf9f4936aec3df6fb6017e57d334f85f482ae5dd03ae353b9", hash = "sha256:dd40a6bd59fbeefbf9f4936aec3df6fb6017e57d334f85f482ae5dd03ae353b9" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_allows_non_conflicting_non_overlapping_dependencies_a-1.0.0-py3-none-any.whl#sha256=37c13aa13cca009990929df08bed3d9de26e1d405a5ebd16ec0c3baef6899b23", hash = "sha256:37c13aa13cca009990929df08bed3d9de26e1d405a5ebd16ec0c3baef6899b23" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_allows_non_conflicting_non_overlapping_dependencies_a-1.0.0-py3-none-any.whl#sha256=8111e996c2a4e04c7a7cf91cf6f8338f5195c22ecf2303d899c4ef4e718a8175", hash = "sha256:8111e996c2a4e04c7a7cf91cf6f8338f5195c22ecf2303d899c4ef4e718a8175" },
         ]
 
         [[distribution]]
@@ -155,7 +159,7 @@ fn fork_allows_non_conflicting_repeated_dependencies() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -179,10 +183,10 @@ fn fork_allows_non_conflicting_repeated_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_allows_non_conflicting_repeated_dependencies_a-1.0.0.tar.gz#sha256=45ca30f1f66eaf6790198fad279b6448719092f2128f23b99f2ede0d6dde613b", hash = "sha256:45ca30f1f66eaf6790198fad279b6448719092f2128f23b99f2ede0d6dde613b" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_allows_non_conflicting_repeated_dependencies_a-1.0.0.tar.gz#sha256=45ca30f1f66eaf6790198fad279b6448719092f2128f23b99f2ede0d6dde613b", hash = "sha256:45ca30f1f66eaf6790198fad279b6448719092f2128f23b99f2ede0d6dde613b" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_allows_non_conflicting_repeated_dependencies_a-1.0.0-py3-none-any.whl#sha256=b08be7896afa7402a2650dd9ebf38e32cf65d5bf86956dc23cf793c5f1f21af2", hash = "sha256:b08be7896afa7402a2650dd9ebf38e32cf65d5bf86956dc23cf793c5f1f21af2" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_allows_non_conflicting_repeated_dependencies_a-1.0.0-py3-none-any.whl#sha256=fc3f6d2fab10d1bb4f52bd9a7de69dc97ed1792506706ca78bdc9e95d6641a6b", hash = "sha256:fc3f6d2fab10d1bb4f52bd9a7de69dc97ed1792506706ca78bdc9e95d6641a6b" },
         ]
 
         [[distribution]]
@@ -240,7 +244,7 @@ fn fork_basic() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -264,19 +268,19 @@ fn fork_basic() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_basic_a-1.0.0.tar.gz#sha256=9bd6d9d74d8928854f79ea3ed4cd0d8a4906eeaa40f5f3d63460a1c2d5f6d773", hash = "sha256:9bd6d9d74d8928854f79ea3ed4cd0d8a4906eeaa40f5f3d63460a1c2d5f6d773" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_basic_a-1.0.0.tar.gz#sha256=9bd6d9d74d8928854f79ea3ed4cd0d8a4906eeaa40f5f3d63460a1c2d5f6d773", hash = "sha256:9bd6d9d74d8928854f79ea3ed4cd0d8a4906eeaa40f5f3d63460a1c2d5f6d773" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_basic_a-1.0.0-py3-none-any.whl#sha256=1a28e30240634de42f24d34ff9bdac181208ef57215def75baac0de205685d27", hash = "sha256:1a28e30240634de42f24d34ff9bdac181208ef57215def75baac0de205685d27" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_basic_a-1.0.0-py3-none-any.whl#sha256=9d3af617bb44ae1c8daf19f6d4d118ee8aac7eaf0cc5368d0f405137411291a1", hash = "sha256:9d3af617bb44ae1c8daf19f6d4d118ee8aac7eaf0cc5368d0f405137411291a1" },
         ]
 
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_basic_a-2.0.0.tar.gz#sha256=c0ce6dfb6d712eb42a4bbe9402a1f823627b9d3773f31d259c49478fc7d8d082", hash = "sha256:c0ce6dfb6d712eb42a4bbe9402a1f823627b9d3773f31d259c49478fc7d8d082" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_basic_a-2.0.0.tar.gz#sha256=c0ce6dfb6d712eb42a4bbe9402a1f823627b9d3773f31d259c49478fc7d8d082", hash = "sha256:c0ce6dfb6d712eb42a4bbe9402a1f823627b9d3773f31d259c49478fc7d8d082" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_basic_a-2.0.0-py3-none-any.whl#sha256=c830122b1b31a6229208e04ced83ae4d1cef8be28b857b56af054bb4bd868a30", hash = "sha256:c830122b1b31a6229208e04ced83ae4d1cef8be28b857b56af054bb4bd868a30" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_basic_a-2.0.0-py3-none-any.whl#sha256=3876778dc6e5178b0e456b0d988cb8c2542cb943a45497aff3e198cbec3dfcc9", hash = "sha256:3876778dc6e5178b0e456b0d988cb8c2542cb943a45497aff3e198cbec3dfcc9" },
         ]
 
         [[distribution]]
@@ -284,12 +288,91 @@ fn fork_basic() -> Result<()> {
         version = "0.1.0"
         source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
     });
+
+    Ok(())
+}
+
+/// We have a conflict after forking. This scenario exists to test the error
+/// message.
+///
+/// ```text
+/// conflict-in-fork
+/// ├── environment
+/// │   └── python3.8
+/// ├── root
+/// │   ├── requires a>=2; sys_platform == "linux"
+/// │   │   └── satisfied by a-2.0.0
+/// │   └── requires a<2; sys_platform == "darwin"
+/// │       └── satisfied by a-1.0.0
+/// ├── a
+/// │   ├── a-1.0.0
+/// │   │   ├── requires b
+/// │   │   │   └── satisfied by b-1.0.0
+/// │   │   └── requires c
+/// │   │       └── satisfied by c-1.0.0
+/// │   └── a-2.0.0
+/// ├── b
+/// │   └── b-1.0.0
+/// │       └── requires d==1
+/// │           └── satisfied by d-1.0.0
+/// ├── c
+/// │   └── c-1.0.0
+/// │       └── requires d==2
+/// │           └── satisfied by d-2.0.0
+/// └── d
+///     ├── d-1.0.0
+///     └── d-2.0.0
+/// ```
+#[test]
+fn conflict_in_fork() -> Result<()> {
+    let context = TestContext::new("3.8");
+
+    // In addition to the standard filters, swap out package names for shorter messages
+    let mut filters = context.filters();
+    filters.push((r"conflict-in-fork-", "package-"));
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''conflict-in-fork-a>=2; sys_platform == "linux"''',
+          '''conflict-in-fork-a<2; sys_platform == "darwin"''',
+        ]
+        requires-python = ">=3.8"
+        "###,
+    )?;
+
+    let mut cmd = context.lock();
+    cmd.env_remove("UV_EXCLUDE_NEWER");
+    cmd.arg("--index-url")
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
+    uv_snapshot!(filters, cmd, @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv lock` is experimental and may change without warning.
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only package-b==1.0.0 is available and package-b==1.0.0 depends on package-d==1, we can conclude that all versions of package-b depend on package-d==1.
+          And because package-c==1.0.0 depends on package-d==2 and only package-c==1.0.0 is available, we can conclude that all versions of package-b and all versions of package-c are incompatible.
+          And because package-a{sys_platform == 'darwin'}==1.0.0 depends on package-b and package-c, we can conclude that package-a{sys_platform == 'darwin'}==1.0.0 cannot be used.
+          And because only the following versions of package-a{sys_platform == 'darwin'} are available:
+              package-a{sys_platform == 'darwin'}==1.0.0
+              package-a{sys_platform == 'darwin'}>=2
+          and project==0.1.0 depends on package-a{sys_platform == 'darwin'}<2, we can conclude that project==0.1.0 cannot be used.
+          And because only project==0.1.0 is available and you require project, we can conclude that the requirements are unsatisfiable.
+    "###
+    );
 
     Ok(())
 }
@@ -340,7 +423,7 @@ fn fork_conflict_unsatisfiable() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: false
     exit_code: 1
@@ -422,7 +505,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -446,61 +529,61 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "4.3.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_a-4.3.0.tar.gz#sha256=5389f0927f61393ba8bd940622329299d769e79b725233604a6bdac0fd088c49", hash = "sha256:5389f0927f61393ba8bd940622329299d769e79b725233604a6bdac0fd088c49" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_a-4.3.0.tar.gz#sha256=5389f0927f61393ba8bd940622329299d769e79b725233604a6bdac0fd088c49", hash = "sha256:5389f0927f61393ba8bd940622329299d769e79b725233604a6bdac0fd088c49" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_a-4.3.0-py3-none-any.whl#sha256=dabbae1b6f06cf5e94660f5f7d7b15984480ad0c8506fb0e89d86693fadf604a", hash = "sha256:dabbae1b6f06cf5e94660f5f7d7b15984480ad0c8506fb0e89d86693fadf604a" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_a-4.3.0-py3-none-any.whl#sha256=932c128393cd499617d1a5b457b11887d51039284b18e06add4c384ab661148c", hash = "sha256:932c128393cd499617d1a5b457b11887d51039284b18e06add4c384ab661148c" },
         ]
 
         [[distribution]]
         name = "package-a"
         version = "4.4.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_a-4.4.0.tar.gz#sha256=7dbb8575aec8f87063954917b6ee628191cd53ca233ec810f6d926b4954e578b", hash = "sha256:7dbb8575aec8f87063954917b6ee628191cd53ca233ec810f6d926b4954e578b" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_a-4.4.0.tar.gz#sha256=7dbb8575aec8f87063954917b6ee628191cd53ca233ec810f6d926b4954e578b", hash = "sha256:7dbb8575aec8f87063954917b6ee628191cd53ca233ec810f6d926b4954e578b" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_a-4.4.0-py3-none-any.whl#sha256=7fb31ea56cb4bbe1d7035b93d39bdb9f37148e1ced83607b69a8f7279546e5a0", hash = "sha256:7fb31ea56cb4bbe1d7035b93d39bdb9f37148e1ced83607b69a8f7279546e5a0" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_a-4.4.0-py3-none-any.whl#sha256=26989734e8fa720896dbbf900adc64551bf3f0026fb62c3c22b47dc23edd4a4c", hash = "sha256:26989734e8fa720896dbbf900adc64551bf3f0026fb62c3c22b47dc23edd4a4c" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
-            { name = "package-d", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" } },
+            { name = "package-d", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" } },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_b-1.0.0.tar.gz#sha256=af3f861d6df9a2bbad55bae02acf17384ea2efa1abbf19206ac56cb021814613", hash = "sha256:af3f861d6df9a2bbad55bae02acf17384ea2efa1abbf19206ac56cb021814613" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_b-1.0.0.tar.gz#sha256=af3f861d6df9a2bbad55bae02acf17384ea2efa1abbf19206ac56cb021814613", hash = "sha256:af3f861d6df9a2bbad55bae02acf17384ea2efa1abbf19206ac56cb021814613" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_b-1.0.0-py3-none-any.whl#sha256=229e8570b5bec521c62fa46ffc242ecdf49e095d043f7761a8390213a63f8d7f", hash = "sha256:229e8570b5bec521c62fa46ffc242ecdf49e095d043f7761a8390213a63f8d7f" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_b-1.0.0-py3-none-any.whl#sha256=bc72ef97f57a77fc7be9dc400be26ae5c344aabddbe39407c05a62e07554cdbf", hash = "sha256:bc72ef97f57a77fc7be9dc400be26ae5c344aabddbe39407c05a62e07554cdbf" },
         ]
 
         [[distribution]]
         name = "package-c"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
-            { name = "package-d", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" } },
+            { name = "package-d", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" } },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_c-1.0.0.tar.gz#sha256=c03742ca6e81c2a5d7d8cb72d1214bf03b2925e63858a19097f17d3e1a750192", hash = "sha256:c03742ca6e81c2a5d7d8cb72d1214bf03b2925e63858a19097f17d3e1a750192" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_c-1.0.0.tar.gz#sha256=c03742ca6e81c2a5d7d8cb72d1214bf03b2925e63858a19097f17d3e1a750192", hash = "sha256:c03742ca6e81c2a5d7d8cb72d1214bf03b2925e63858a19097f17d3e1a750192" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_c-1.0.0-py3-none-any.whl#sha256=28b4728d6ef73637bd296038f8b1895de6fffab1a0f5a2673b7408ac6941e401", hash = "sha256:28b4728d6ef73637bd296038f8b1895de6fffab1a0f5a2673b7408ac6941e401" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_c-1.0.0-py3-none-any.whl#sha256=71fc9aec5527839358209ccb927186dd0529e9814a725d86aa17e7a033c59cd4", hash = "sha256:71fc9aec5527839358209ccb927186dd0529e9814a725d86aa17e7a033c59cd4" },
         ]
 
         [[distribution]]
         name = "package-d"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_d-1.0.0.tar.gz#sha256=cc1af60e53faf957fd0542349441ea79a909cd5feb30fb8933c39dc33404e4b2", hash = "sha256:cc1af60e53faf957fd0542349441ea79a909cd5feb30fb8933c39dc33404e4b2" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_d-1.0.0.tar.gz#sha256=cc1af60e53faf957fd0542349441ea79a909cd5feb30fb8933c39dc33404e4b2", hash = "sha256:cc1af60e53faf957fd0542349441ea79a909cd5feb30fb8933c39dc33404e4b2" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_d-1.0.0-py3-none-any.whl#sha256=aae484d9359b53d95f5ae5e6413317c15cc0f715e5053251394fb748d3de992f", hash = "sha256:aae484d9359b53d95f5ae5e6413317c15cc0f715e5053251394fb748d3de992f" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_d-1.0.0-py3-none-any.whl#sha256=de669ada03e9f8625e3ac4af637c88de04066a72675c16c3d1757e0e9d5db7a8", hash = "sha256:de669ada03e9f8625e3ac4af637c88de04066a72675c16c3d1757e0e9d5db7a8" },
         ]
 
         [[distribution]]
         name = "package-d"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_d-2.0.0.tar.gz#sha256=68e380efdea5206363f5397e4cd560a64f5f4927396dc0b6f6f36dd3f026281f", hash = "sha256:68e380efdea5206363f5397e4cd560a64f5f4927396dc0b6f6f36dd3f026281f" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_d-2.0.0.tar.gz#sha256=68e380efdea5206363f5397e4cd560a64f5f4927396dc0b6f6f36dd3f026281f", hash = "sha256:68e380efdea5206363f5397e4cd560a64f5f4927396dc0b6f6f36dd3f026281f" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_filter_sibling_dependencies_d-2.0.0-py3-none-any.whl#sha256=d1c58c45df69e10aaf278190025c77d9bb989518f9d5bc2fe57643434f3de1d2", hash = "sha256:d1c58c45df69e10aaf278190025c77d9bb989518f9d5bc2fe57643434f3de1d2" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_filter_sibling_dependencies_d-2.0.0-py3-none-any.whl#sha256=87c133dcc987137d62c011a41af31e8372ca971393d93f808dffc32e136363c7", hash = "sha256:87c133dcc987137d62c011a41af31e8372ca971393d93f808dffc32e136363c7" },
         ]
 
         [[distribution]]
@@ -508,10 +591,127 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         version = "0.1.0"
         source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "4.3.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "4.4.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "4.3.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "4.4.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'linux'" },
             { name = "package-b", marker = "sys_platform == 'linux'" },
             { name = "package-c", marker = "sys_platform == 'darwin'" },
+        ]
+        "###
+        );
+    });
+
+    Ok(())
+}
+
+/// The root cause the resolver to fork over `a`, but the markers on the variant of
+/// `a` don't cover the entire marker space, they are missing Python 3.10. Later, we
+/// have a dependency this very hole, which we still need to select, instead of
+/// having two forks around but without Python 3.10 and omitting `c` from the
+/// solution.
+///
+/// ```text
+/// fork-incomplete-markers
+/// ├── environment
+/// │   └── python3.8
+/// ├── root
+/// │   ├── requires a==1; python_version < "3.10"
+/// │   │   └── satisfied by a-1.0.0
+/// │   ├── requires a==2; python_version >= "3.11"
+/// │   │   └── satisfied by a-2.0.0
+/// │   └── requires b
+/// │       └── satisfied by b-1.0.0
+/// ├── a
+/// │   ├── a-1.0.0
+/// │   └── a-2.0.0
+/// ├── b
+/// │   └── b-1.0.0
+/// │       └── requires c; python_version == "3.10"
+/// │           └── satisfied by c-1.0.0
+/// └── c
+///     └── c-1.0.0
+/// ```
+#[test]
+fn fork_incomplete_markers() -> Result<()> {
+    let context = TestContext::new("3.8");
+
+    // In addition to the standard filters, swap out package names for shorter messages
+    let mut filters = context.filters();
+    filters.push((r"fork-incomplete-markers-", "package-"));
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        dependencies = [
+          '''fork-incomplete-markers-a==1; python_version < "3.10"''',
+          '''fork-incomplete-markers-a==2; python_version >= "3.11"''',
+          '''fork-incomplete-markers-b''',
+        ]
+        requires-python = ">=3.8"
+        "###,
+    )?;
+
+    let mut cmd = context.lock();
+    cmd.env_remove("UV_EXCLUDE_NEWER");
+    cmd.arg("--index-url")
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
+    uv_snapshot!(filters, cmd, @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv lock` is experimental and may change without warning.
+    Resolved 4 packages in [TIME]
+    "###
+    );
+
+    let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock"))?;
+    insta::with_settings!({
+        filters => filters,
+    }, {
+        assert_snapshot!(
+            lock, @r###"
+        version = 1
+        requires-python = ">=3.8"
+
+        [[distribution]]
+        name = "package-a"
+        version = "1.0.0"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_incomplete_markers_a-1.0.0.tar.gz#sha256=dd56de2e560b3f95c529c44cbdae55d9b1ada826ddd3e19d3ea45438224ad603", hash = "sha256:dd56de2e560b3f95c529c44cbdae55d9b1ada826ddd3e19d3ea45438224ad603" }
+        wheels = [
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_incomplete_markers_a-1.0.0-py3-none-any.whl#sha256=779bb805058fc59858e8b9260cd1a40f13f1640631fdea89d9d243691a4f39ca", hash = "sha256:779bb805058fc59858e8b9260cd1a40f13f1640631fdea89d9d243691a4f39ca" },
+        ]
+
+        [[distribution]]
+        name = "package-a"
+        version = "2.0.0"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_incomplete_markers_a-2.0.0.tar.gz#sha256=580f1454a172036c89f5cfbefe52f175b011806a61f243eb476526bcc186e0be", hash = "sha256:580f1454a172036c89f5cfbefe52f175b011806a61f243eb476526bcc186e0be" }
+        wheels = [
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_incomplete_markers_a-2.0.0-py3-none-any.whl#sha256=58a4b7dcf929aabf1ed434d9ff8d715929dc3dec02b92cf2b364d5a2206f1f6a", hash = "sha256:58a4b7dcf929aabf1ed434d9ff8d715929dc3dec02b92cf2b364d5a2206f1f6a" },
+        ]
+
+        [[distribution]]
+        name = "package-b"
+        version = "1.0.0"
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_incomplete_markers_b-1.0.0.tar.gz#sha256=c4deba44768923473d077bdc0e177033fcb6e6fd406d56830d7ee6f4ffad68c1", hash = "sha256:c4deba44768923473d077bdc0e177033fcb6e6fd406d56830d7ee6f4ffad68c1" }
+        wheels = [
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_incomplete_markers_b-1.0.0-py3-none-any.whl#sha256=5c2a5f446580787ed7b3673431b112474237ddeaf1c81325bb30b86e7ee76adb", hash = "sha256:5c2a5f446580787ed7b3673431b112474237ddeaf1c81325bb30b86e7ee76adb" },
+        ]
+
+        [[distribution]]
+        name = "project"
+        version = "0.1.0"
+        source = { editable = "." }
+        dependencies = [
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "python_version < '3.10'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "python_version >= '3.11'" },
+            { name = "package-b" },
         ]
         "###
         );
@@ -571,7 +771,7 @@ fn fork_marker_accrue() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -595,34 +795,34 @@ fn fork_marker_accrue() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
             { name = "package-c", marker = "sys_platform == 'linux'" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_a-1.0.0.tar.gz#sha256=c791e6062a510c63bff857ca6f7a921a7795bfbc588f21a51124e091fb0343d6", hash = "sha256:c791e6062a510c63bff857ca6f7a921a7795bfbc588f21a51124e091fb0343d6" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_accrue_a-1.0.0.tar.gz#sha256=c791e6062a510c63bff857ca6f7a921a7795bfbc588f21a51124e091fb0343d6", hash = "sha256:c791e6062a510c63bff857ca6f7a921a7795bfbc588f21a51124e091fb0343d6" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_a-1.0.0-py3-none-any.whl#sha256=c1b40f368e7be6c16c1d537481421bf6cd1e18a09a83f42ed35029633d4b3249", hash = "sha256:c1b40f368e7be6c16c1d537481421bf6cd1e18a09a83f42ed35029633d4b3249" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_accrue_a-1.0.0-py3-none-any.whl#sha256=cba9cb55cca41833a15c9f8eb75045236cf80cad5d663f7fb7ecae18dad79538", hash = "sha256:cba9cb55cca41833a15c9f8eb75045236cf80cad5d663f7fb7ecae18dad79538" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
             { name = "package-c", marker = "sys_platform == 'darwin'" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_b-1.0.0.tar.gz#sha256=32e7ea1022061783857c3f6fec5051b4b320630fe8a5aec6523cd565db350387", hash = "sha256:32e7ea1022061783857c3f6fec5051b4b320630fe8a5aec6523cd565db350387" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_accrue_b-1.0.0.tar.gz#sha256=32e7ea1022061783857c3f6fec5051b4b320630fe8a5aec6523cd565db350387", hash = "sha256:32e7ea1022061783857c3f6fec5051b4b320630fe8a5aec6523cd565db350387" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_b-1.0.0-py3-none-any.whl#sha256=2df49decd1b188800d1cbf5265806d32388e4c792da3074b6f9be2e7b72185f5", hash = "sha256:2df49decd1b188800d1cbf5265806d32388e4c792da3074b6f9be2e7b72185f5" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_accrue_b-1.0.0-py3-none-any.whl#sha256=c5202800c26be15ecaf5560e09ad1df710778bb9debd3c267be1c76f44fbc0c9", hash = "sha256:c5202800c26be15ecaf5560e09ad1df710778bb9debd3c267be1c76f44fbc0c9" },
         ]
 
         [[distribution]]
         name = "package-c"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_c-1.0.0.tar.gz#sha256=a3e09ac3dc8e787a08ebe8d5d6072e09720c76cbbcb76a6645d6f59652742015", hash = "sha256:a3e09ac3dc8e787a08ebe8d5d6072e09720c76cbbcb76a6645d6f59652742015" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_accrue_c-1.0.0.tar.gz#sha256=a3e09ac3dc8e787a08ebe8d5d6072e09720c76cbbcb76a6645d6f59652742015", hash = "sha256:a3e09ac3dc8e787a08ebe8d5d6072e09720c76cbbcb76a6645d6f59652742015" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_accrue_c-1.0.0-py3-none-any.whl#sha256=01993b60f134b3b80585fe95e3511b9a6194c2387c0215d962dbf65abd5a5fe1", hash = "sha256:01993b60f134b3b80585fe95e3511b9a6194c2387c0215d962dbf65abd5a5fe1" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_accrue_c-1.0.0-py3-none-any.whl#sha256=b0c8719d38c91b2a8548bd065b1d2153fbe031b37775ed244e76fe5bdfbb502e", hash = "sha256:b0c8719d38c91b2a8548bd065b1d2153fbe031b37775ed244e76fe5bdfbb502e" },
         ]
 
         [[distribution]]
@@ -688,7 +888,7 @@ fn fork_marker_disjoint() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: false
     exit_code: 1
@@ -760,7 +960,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -784,53 +984,53 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
-            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'pypy'" },
-            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'cpython'" },
+            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "implementation_name == 'pypy'" },
+            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "implementation_name == 'cpython'" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_a-1.0.0.tar.gz#sha256=c7232306e8597d46c3fe53a3b1472f99b8ff36b3169f335ba0a5b625e193f7d4", hash = "sha256:c7232306e8597d46c3fe53a3b1472f99b8ff36b3169f335ba0a5b625e193f7d4" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_allowed_a-1.0.0.tar.gz#sha256=c7232306e8597d46c3fe53a3b1472f99b8ff36b3169f335ba0a5b625e193f7d4", hash = "sha256:c7232306e8597d46c3fe53a3b1472f99b8ff36b3169f335ba0a5b625e193f7d4" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_a-1.0.0-py3-none-any.whl#sha256=609b50f1a9fdbea0cc5d77f3eaf5143900159d809c56db5839de138c3123d980", hash = "sha256:609b50f1a9fdbea0cc5d77f3eaf5143900159d809c56db5839de138c3123d980" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_allowed_a-1.0.0-py3-none-any.whl#sha256=198ae54c02a59734dc009bfcee1148d40f56c605b62f9f1a00467e09ebf2ff07", hash = "sha256:198ae54c02a59734dc009bfcee1148d40f56c605b62f9f1a00467e09ebf2ff07" },
         ]
 
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_a-2.0.0.tar.gz#sha256=0dcb58c8276afbe439e1c94708fb71954fb8869cc65c230ce8f462c911992ceb", hash = "sha256:0dcb58c8276afbe439e1c94708fb71954fb8869cc65c230ce8f462c911992ceb" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_allowed_a-2.0.0.tar.gz#sha256=0dcb58c8276afbe439e1c94708fb71954fb8869cc65c230ce8f462c911992ceb", hash = "sha256:0dcb58c8276afbe439e1c94708fb71954fb8869cc65c230ce8f462c911992ceb" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_a-2.0.0-py3-none-any.whl#sha256=ed8912f08993ddc9131dcc268b28385ddd84635f4a3c6a3fd83f680838353f1f", hash = "sha256:ed8912f08993ddc9131dcc268b28385ddd84635f4a3c6a3fd83f680838353f1f" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_allowed_a-2.0.0-py3-none-any.whl#sha256=61b7d273468584342de4c0185beed5b128797ce95ec9ec4a670fe30f73351cf7", hash = "sha256:61b7d273468584342de4c0185beed5b128797ce95ec9ec4a670fe30f73351cf7" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
             { name = "package-c", marker = "implementation_name == 'pypy' or sys_platform == 'linux'" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_b-1.0.0.tar.gz#sha256=d6bd196a0a152c1b32e09f08e554d22ae6a6b3b916e39ad4552572afae5f5492", hash = "sha256:d6bd196a0a152c1b32e09f08e554d22ae6a6b3b916e39ad4552572afae5f5492" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_allowed_b-1.0.0.tar.gz#sha256=d6bd196a0a152c1b32e09f08e554d22ae6a6b3b916e39ad4552572afae5f5492", hash = "sha256:d6bd196a0a152c1b32e09f08e554d22ae6a6b3b916e39ad4552572afae5f5492" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_b-1.0.0-py3-none-any.whl#sha256=7935455a6f9a9448dd7ee33978bb4d463b16ef9cd021c24462c7b51e8c4ebc86", hash = "sha256:7935455a6f9a9448dd7ee33978bb4d463b16ef9cd021c24462c7b51e8c4ebc86" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_allowed_b-1.0.0-py3-none-any.whl#sha256=e1deba885509945ef087e4f31c7dba3ee436fc8284b360fe207a3c42f2f9e22f", hash = "sha256:e1deba885509945ef087e4f31c7dba3ee436fc8284b360fe207a3c42f2f9e22f" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_b-2.0.0.tar.gz#sha256=4533845ba671575a25ceb32f10f0bc6836949bef37b7da6e7dd37d9be389871c", hash = "sha256:4533845ba671575a25ceb32f10f0bc6836949bef37b7da6e7dd37d9be389871c" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_allowed_b-2.0.0.tar.gz#sha256=4533845ba671575a25ceb32f10f0bc6836949bef37b7da6e7dd37d9be389871c", hash = "sha256:4533845ba671575a25ceb32f10f0bc6836949bef37b7da6e7dd37d9be389871c" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_b-2.0.0-py3-none-any.whl#sha256=6ec5a8c2241bafcf537c695257cd0cd66f392607bac2fc523ee1ad91fbbf623f", hash = "sha256:6ec5a8c2241bafcf537c695257cd0cd66f392607bac2fc523ee1ad91fbbf623f" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_allowed_b-2.0.0-py3-none-any.whl#sha256=736d1b59cb46a0b889614bc7557c293de245fe8954e3200e786500ae8e42504b", hash = "sha256:736d1b59cb46a0b889614bc7557c293de245fe8954e3200e786500ae8e42504b" },
         ]
 
         [[distribution]]
         name = "package-c"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_c-1.0.0.tar.gz#sha256=7ce8efca029cfa952e64f55c2d47fe33975c7f77ec689384bda11cbc3b7ef1db", hash = "sha256:7ce8efca029cfa952e64f55c2d47fe33975c7f77ec689384bda11cbc3b7ef1db" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_allowed_c-1.0.0.tar.gz#sha256=7ce8efca029cfa952e64f55c2d47fe33975c7f77ec689384bda11cbc3b7ef1db", hash = "sha256:7ce8efca029cfa952e64f55c2d47fe33975c7f77ec689384bda11cbc3b7ef1db" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_allowed_c-1.0.0-py3-none-any.whl#sha256=8513f5ac195dbb03aa5cec408fed74ad6ab7ace4822dbc6a8effec7f5a1bf47b", hash = "sha256:8513f5ac195dbb03aa5cec408fed74ad6ab7ace4822dbc6a8effec7f5a1bf47b" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_allowed_c-1.0.0-py3-none-any.whl#sha256=6a6b776dedabceb6a6c4f54a5d932076fa3fed1380310491999ca2d31e13b41c", hash = "sha256:6a6b776dedabceb6a6c4f54a5d932076fa3fed1380310491999ca2d31e13b41c" },
         ]
 
         [[distribution]]
@@ -838,8 +1038,8 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         version = "0.1.0"
         source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -904,7 +1104,7 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -928,41 +1128,41 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
-            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'pypy'" },
-            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'cpython'" },
+            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "implementation_name == 'pypy'" },
+            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "implementation_name == 'cpython'" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_a-1.0.0.tar.gz#sha256=92081d91570582f3a94ed156f203de53baca5b3fdc350aa1c831c7c42723e798", hash = "sha256:92081d91570582f3a94ed156f203de53baca5b3fdc350aa1c831c7c42723e798" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_disallowed_a-1.0.0.tar.gz#sha256=92081d91570582f3a94ed156f203de53baca5b3fdc350aa1c831c7c42723e798", hash = "sha256:92081d91570582f3a94ed156f203de53baca5b3fdc350aa1c831c7c42723e798" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_a-1.0.0-py3-none-any.whl#sha256=5a3da0f8036be92c72212ff734672805ed8b799a1bc46d3bde56f8486180e1cf", hash = "sha256:5a3da0f8036be92c72212ff734672805ed8b799a1bc46d3bde56f8486180e1cf" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_disallowed_a-1.0.0-py3-none-any.whl#sha256=ee2dc68d5b33c0318183431cebf99ccca63d98601b936e5d3eae804c73f2b154", hash = "sha256:ee2dc68d5b33c0318183431cebf99ccca63d98601b936e5d3eae804c73f2b154" },
         ]
 
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_a-2.0.0.tar.gz#sha256=9d48383b0699f575af15871f6f7a928b835cd5ad4e13f91a675ee5aba722dabc", hash = "sha256:9d48383b0699f575af15871f6f7a928b835cd5ad4e13f91a675ee5aba722dabc" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_disallowed_a-2.0.0.tar.gz#sha256=9d48383b0699f575af15871f6f7a928b835cd5ad4e13f91a675ee5aba722dabc", hash = "sha256:9d48383b0699f575af15871f6f7a928b835cd5ad4e13f91a675ee5aba722dabc" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_a-2.0.0-py3-none-any.whl#sha256=16091f91bfb46e9db76d7e513d521e15baf7cf1ceae86c09e71e31b6734a7834", hash = "sha256:16091f91bfb46e9db76d7e513d521e15baf7cf1ceae86c09e71e31b6734a7834" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_disallowed_a-2.0.0-py3-none-any.whl#sha256=099db8d3af6c9dfc10589ab0f1e2e6a74276a167afb39322ddaf657791247456", hash = "sha256:099db8d3af6c9dfc10589ab0f1e2e6a74276a167afb39322ddaf657791247456" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_b-1.0.0.tar.gz#sha256=d44b87bd8d39240bca55eaae84a245e74197ed0b7897c27af9f168c713cc63bd", hash = "sha256:d44b87bd8d39240bca55eaae84a245e74197ed0b7897c27af9f168c713cc63bd" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_disallowed_b-1.0.0.tar.gz#sha256=d44b87bd8d39240bca55eaae84a245e74197ed0b7897c27af9f168c713cc63bd", hash = "sha256:d44b87bd8d39240bca55eaae84a245e74197ed0b7897c27af9f168c713cc63bd" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_b-1.0.0-py3-none-any.whl#sha256=382d45c91771c962d7d12328bc58248fe0908d258307474beae1c868d9005631", hash = "sha256:382d45c91771c962d7d12328bc58248fe0908d258307474beae1c868d9005631" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_disallowed_b-1.0.0-py3-none-any.whl#sha256=999b3d0029ea0131272257e2b04c0e673defa6c25be6efc411e04936bce72ef6", hash = "sha256:999b3d0029ea0131272257e2b04c0e673defa6c25be6efc411e04936bce72ef6" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_b-2.0.0.tar.gz#sha256=75a48bf2d44a0a0be6ca33820f5076665765be7b43dabf5f94f7fd5247071097", hash = "sha256:75a48bf2d44a0a0be6ca33820f5076665765be7b43dabf5f94f7fd5247071097" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_disallowed_b-2.0.0.tar.gz#sha256=75a48bf2d44a0a0be6ca33820f5076665765be7b43dabf5f94f7fd5247071097", hash = "sha256:75a48bf2d44a0a0be6ca33820f5076665765be7b43dabf5f94f7fd5247071097" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_disallowed_b-2.0.0-py3-none-any.whl#sha256=cf730e495e15e6eed66857ce2c044f6dd16fe9ba24354f56ac1c6abfeb9cd976", hash = "sha256:cf730e495e15e6eed66857ce2c044f6dd16fe9ba24354f56ac1c6abfeb9cd976" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_disallowed_b-2.0.0-py3-none-any.whl#sha256=2c6aedd257d0ed21bb96f6e0baba8314c001d4078d09413cda147fb6badb39a2", hash = "sha256:2c6aedd257d0ed21bb96f6e0baba8314c001d4078d09413cda147fb6badb39a2" },
         ]
 
         [[distribution]]
@@ -970,8 +1170,8 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         version = "0.1.0"
         source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1037,7 +1237,7 @@ fn fork_marker_inherit_combined() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -1061,41 +1261,41 @@ fn fork_marker_inherit_combined() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
-            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'pypy'" },
-            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "implementation_name == 'cpython'" },
+            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "implementation_name == 'pypy'" },
+            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "implementation_name == 'cpython'" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_a-1.0.0.tar.gz#sha256=2ec4c9dbb7078227d996c344b9e0c1b365ed0000de9527b2ba5b616233636f07", hash = "sha256:2ec4c9dbb7078227d996c344b9e0c1b365ed0000de9527b2ba5b616233636f07" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_a-1.0.0.tar.gz#sha256=2ec4c9dbb7078227d996c344b9e0c1b365ed0000de9527b2ba5b616233636f07", hash = "sha256:2ec4c9dbb7078227d996c344b9e0c1b365ed0000de9527b2ba5b616233636f07" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_a-1.0.0-py3-none-any.whl#sha256=b24ba06cf3717872f4155240294a11d5cbe8c6b4a5b00963d056b491886b4efe", hash = "sha256:b24ba06cf3717872f4155240294a11d5cbe8c6b4a5b00963d056b491886b4efe" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_a-1.0.0-py3-none-any.whl#sha256=1150f6d977824bc0260cfb5fcf34816424ed4602d5df316c291b8df3f723c888", hash = "sha256:1150f6d977824bc0260cfb5fcf34816424ed4602d5df316c291b8df3f723c888" },
         ]
 
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_a-2.0.0.tar.gz#sha256=47958d1659220ee7722b0f26e8c1fe41217a2816881ffa929f0ba794a87ceebf", hash = "sha256:47958d1659220ee7722b0f26e8c1fe41217a2816881ffa929f0ba794a87ceebf" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_a-2.0.0.tar.gz#sha256=47958d1659220ee7722b0f26e8c1fe41217a2816881ffa929f0ba794a87ceebf", hash = "sha256:47958d1659220ee7722b0f26e8c1fe41217a2816881ffa929f0ba794a87ceebf" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_a-2.0.0-py3-none-any.whl#sha256=e2c1eb831475f344a019e6e5b90e1f95f51553d45a4dc9d6f8e23593b8e5c8a1", hash = "sha256:e2c1eb831475f344a019e6e5b90e1f95f51553d45a4dc9d6f8e23593b8e5c8a1" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_a-2.0.0-py3-none-any.whl#sha256=67e142d749674a27c872db714d50fda083010789da51291e3c30b4daf0e96b3b", hash = "sha256:67e142d749674a27c872db714d50fda083010789da51291e3c30b4daf0e96b3b" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_b-1.0.0.tar.gz#sha256=6992d194cb5a0f0eed9ed6617d3212af4e3ff09274bf7622c8a1008b072128da", hash = "sha256:6992d194cb5a0f0eed9ed6617d3212af4e3ff09274bf7622c8a1008b072128da" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_b-1.0.0.tar.gz#sha256=6992d194cb5a0f0eed9ed6617d3212af4e3ff09274bf7622c8a1008b072128da", hash = "sha256:6992d194cb5a0f0eed9ed6617d3212af4e3ff09274bf7622c8a1008b072128da" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_b-1.0.0-py3-none-any.whl#sha256=a3a0071d27faf67fb6d4766b8e557d4642c4f2baa043c4ef430311b177bc126c", hash = "sha256:a3a0071d27faf67fb6d4766b8e557d4642c4f2baa043c4ef430311b177bc126c" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_b-1.0.0-py3-none-any.whl#sha256=d9b50d8a0968d65af338e27d6b2a58eea59c514e47b820752a2c068b5a8333a7", hash = "sha256:d9b50d8a0968d65af338e27d6b2a58eea59c514e47b820752a2c068b5a8333a7" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_b-2.0.0.tar.gz#sha256=e340061505d621a340d10ec1dbaf02dfce0c66358ee8190f61f78018f9999989", hash = "sha256:e340061505d621a340d10ec1dbaf02dfce0c66358ee8190f61f78018f9999989" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_b-2.0.0.tar.gz#sha256=e340061505d621a340d10ec1dbaf02dfce0c66358ee8190f61f78018f9999989", hash = "sha256:e340061505d621a340d10ec1dbaf02dfce0c66358ee8190f61f78018f9999989" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_combined_b-2.0.0-py3-none-any.whl#sha256=1723c70dd56b62995764ce0d616052caa9183fcac252a130eeb34fe3f2e9656f", hash = "sha256:1723c70dd56b62995764ce0d616052caa9183fcac252a130eeb34fe3f2e9656f" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_combined_b-2.0.0-py3-none-any.whl#sha256=ff364fd590d05651579d8bea621b069934470106b9a82ab960fb93dfd88ea038", hash = "sha256:ff364fd590d05651579d8bea621b069934470106b9a82ab960fb93dfd88ea038" },
         ]
 
         [[distribution]]
@@ -1103,8 +1303,8 @@ fn fork_marker_inherit_combined() -> Result<()> {
         version = "0.1.0"
         source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1164,7 +1364,7 @@ fn fork_marker_inherit_isolated() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -1188,31 +1388,31 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_a-1.0.0.tar.gz#sha256=724ffc24debfa2bc6b5c2457df777c523638ec3586cc953f8509dad581aa6887", hash = "sha256:724ffc24debfa2bc6b5c2457df777c523638ec3586cc953f8509dad581aa6887" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_isolated_a-1.0.0.tar.gz#sha256=724ffc24debfa2bc6b5c2457df777c523638ec3586cc953f8509dad581aa6887", hash = "sha256:724ffc24debfa2bc6b5c2457df777c523638ec3586cc953f8509dad581aa6887" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_a-1.0.0-py3-none-any.whl#sha256=0d66a59f2f0afc2d077594603239bf616eabe9ffd203fe9d41621782c7fef33a", hash = "sha256:0d66a59f2f0afc2d077594603239bf616eabe9ffd203fe9d41621782c7fef33a" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_isolated_a-1.0.0-py3-none-any.whl#sha256=6823b88bf6debf2ec6195d82943c2812235a642438f007c0a3c95d745a5b95ba", hash = "sha256:6823b88bf6debf2ec6195d82943c2812235a642438f007c0a3c95d745a5b95ba" },
         ]
 
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
             { name = "package-b", marker = "sys_platform == 'linux'" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_a-2.0.0.tar.gz#sha256=bc4567da4349a9c09b7fb4733f0b9f6476249240192291cf051c2b1d28b829fd", hash = "sha256:bc4567da4349a9c09b7fb4733f0b9f6476249240192291cf051c2b1d28b829fd" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_isolated_a-2.0.0.tar.gz#sha256=bc4567da4349a9c09b7fb4733f0b9f6476249240192291cf051c2b1d28b829fd", hash = "sha256:bc4567da4349a9c09b7fb4733f0b9f6476249240192291cf051c2b1d28b829fd" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_a-2.0.0-py3-none-any.whl#sha256=dc624746ae061d80e0bb3e25d0427177983f1edd0b519095f7a3f22b13bc54bd", hash = "sha256:dc624746ae061d80e0bb3e25d0427177983f1edd0b519095f7a3f22b13bc54bd" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_isolated_a-2.0.0-py3-none-any.whl#sha256=16986b43ef61e3f639b61fc9c22ede133864606d3d72716161a59acd64793c02", hash = "sha256:16986b43ef61e3f639b61fc9c22ede133864606d3d72716161a59acd64793c02" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_b-1.0.0.tar.gz#sha256=96f8c3cabc5795e08a064c89ec76a4bfba8afe3c13d647161b4a1568b4584ced", hash = "sha256:96f8c3cabc5795e08a064c89ec76a4bfba8afe3c13d647161b4a1568b4584ced" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_isolated_b-1.0.0.tar.gz#sha256=96f8c3cabc5795e08a064c89ec76a4bfba8afe3c13d647161b4a1568b4584ced", hash = "sha256:96f8c3cabc5795e08a064c89ec76a4bfba8afe3c13d647161b4a1568b4584ced" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_isolated_b-1.0.0-py3-none-any.whl#sha256=79e3a8219a49a5d72db2468c856a65212345e9a7e028abf8c179320f49d85be5", hash = "sha256:79e3a8219a49a5d72db2468c856a65212345e9a7e028abf8c179320f49d85be5" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_isolated_b-1.0.0-py3-none-any.whl#sha256=c8affc2f13f9bcd08b3d1601a21a1781ea14d52a8cddc708b29428c9c3d53ea5", hash = "sha256:c8affc2f13f9bcd08b3d1601a21a1781ea14d52a8cddc708b29428c9c3d53ea5" },
         ]
 
         [[distribution]]
@@ -1220,8 +1420,8 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         version = "0.1.0"
         source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1286,7 +1486,7 @@ fn fork_marker_inherit_transitive() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -1310,43 +1510,43 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
             { name = "package-b" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_a-1.0.0.tar.gz#sha256=8bcab85231487b9350471da0c4c22dc3d69dfe4a1198d16b5f81b0235d7112ce", hash = "sha256:8bcab85231487b9350471da0c4c22dc3d69dfe4a1198d16b5f81b0235d7112ce" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_transitive_a-1.0.0.tar.gz#sha256=8bcab85231487b9350471da0c4c22dc3d69dfe4a1198d16b5f81b0235d7112ce", hash = "sha256:8bcab85231487b9350471da0c4c22dc3d69dfe4a1198d16b5f81b0235d7112ce" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_a-1.0.0-py3-none-any.whl#sha256=6904ed373d504f278de986c440e39b6105be4680654e38dbe37c5d539a67fd3d", hash = "sha256:6904ed373d504f278de986c440e39b6105be4680654e38dbe37c5d539a67fd3d" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_transitive_a-1.0.0-py3-none-any.whl#sha256=84d650ff1a909198ba82cbe0f697e836d8a570fb71faa6ad4a30c4df332dfde6", hash = "sha256:84d650ff1a909198ba82cbe0f697e836d8a570fb71faa6ad4a30c4df332dfde6" },
         ]
 
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_a-2.0.0.tar.gz#sha256=4437ac14c340fec0b451cbc9486f5b8e106568634264ecad339a8de565a93be6", hash = "sha256:4437ac14c340fec0b451cbc9486f5b8e106568634264ecad339a8de565a93be6" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_transitive_a-2.0.0.tar.gz#sha256=4437ac14c340fec0b451cbc9486f5b8e106568634264ecad339a8de565a93be6", hash = "sha256:4437ac14c340fec0b451cbc9486f5b8e106568634264ecad339a8de565a93be6" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_a-2.0.0-py3-none-any.whl#sha256=2965412b82b12d0b0ab081c7e05133cb64209241a4f2836359c76a5ed8d7fb99", hash = "sha256:2965412b82b12d0b0ab081c7e05133cb64209241a4f2836359c76a5ed8d7fb99" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_transitive_a-2.0.0-py3-none-any.whl#sha256=420c4c6b02d22c33f7f8ae9f290acc5b4c372fc2e49c881d259237a31c76dc0b", hash = "sha256:420c4c6b02d22c33f7f8ae9f290acc5b4c372fc2e49c881d259237a31c76dc0b" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
             { name = "package-c" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_b-1.0.0.tar.gz#sha256=03b4b0e323c36bd4a1e51a65e1489715da231d44d26e12b54544e3bf9a9f6129", hash = "sha256:03b4b0e323c36bd4a1e51a65e1489715da231d44d26e12b54544e3bf9a9f6129" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_transitive_b-1.0.0.tar.gz#sha256=03b4b0e323c36bd4a1e51a65e1489715da231d44d26e12b54544e3bf9a9f6129", hash = "sha256:03b4b0e323c36bd4a1e51a65e1489715da231d44d26e12b54544e3bf9a9f6129" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_b-1.0.0-py3-none-any.whl#sha256=f3975f31f7e3dee42abb1b44f6e7fea0048bd1f204debc2f1decf16b3d597c9f", hash = "sha256:f3975f31f7e3dee42abb1b44f6e7fea0048bd1f204debc2f1decf16b3d597c9f" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_transitive_b-1.0.0-py3-none-any.whl#sha256=c9738afccc13d7d5bd7be85abf5dc77f88c43c577fb2f90dfa2abf1ffa0c8db6", hash = "sha256:c9738afccc13d7d5bd7be85abf5dc77f88c43c577fb2f90dfa2abf1ffa0c8db6" },
         ]
 
         [[distribution]]
         name = "package-c"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_c-1.0.0.tar.gz#sha256=58bb788896b2297f2948f51a27fc48cfe44057c687a3c0c4d686b107975f7f32", hash = "sha256:58bb788896b2297f2948f51a27fc48cfe44057c687a3c0c4d686b107975f7f32" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_transitive_c-1.0.0.tar.gz#sha256=58bb788896b2297f2948f51a27fc48cfe44057c687a3c0c4d686b107975f7f32", hash = "sha256:58bb788896b2297f2948f51a27fc48cfe44057c687a3c0c4d686b107975f7f32" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_transitive_c-1.0.0-py3-none-any.whl#sha256=a827909e237ab405b250b4cc534dc51e502a7e583a11205b6db8af51058b38c5", hash = "sha256:a827909e237ab405b250b4cc534dc51e502a7e583a11205b6db8af51058b38c5" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_transitive_c-1.0.0-py3-none-any.whl#sha256=ad2cbb0582ec6f4dc9549d1726d2aae66cd1fdf0e355acc70cd720cf65ae4d86", hash = "sha256:ad2cbb0582ec6f4dc9549d1726d2aae66cd1fdf0e355acc70cd720cf65ae4d86" },
         ]
 
         [[distribution]]
@@ -1354,8 +1554,8 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         version = "0.1.0"
         source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1367,11 +1567,11 @@ fn fork_marker_inherit_transitive() -> Result<()> {
 /// This tests that markers which provoked a fork in the universal resolver are used
 /// to ignore dependencies which cannot possibly be installed by a resolution
 /// produced by that fork.  In this example, the `a<2` dependency is only active on
-/// Darwin platforms. But the `a==1.0.0` distribution has a dependency on on `b`
-/// that is only active on Linux, where as `a==2.0.0` does not. Therefore, when the
-/// fork provoked by the `a<2` dependency considers `b`, it should ignore it because
-/// it isn't possible for `sys_platform == 'linux'` and `sys_platform == 'darwin'`
-/// to be simultaneously true.
+/// Darwin platforms. But the `a==1.0.0` distribution has a dependency on `b` that
+/// is only active on Linux, where as `a==2.0.0` does not. Therefore, when the fork
+/// provoked by the `a<2` dependency considers `b`, it should ignore it because it
+/// isn't possible for `sys_platform == 'linux'` and `sys_platform == 'darwin'` to
+/// be simultaneously true.
 ///
 /// ```text
 /// fork-marker-inherit
@@ -1415,7 +1615,7 @@ fn fork_marker_inherit() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -1439,19 +1639,19 @@ fn fork_marker_inherit() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_a-1.0.0.tar.gz#sha256=177511ec69a2f04de39867d43f167a33194ae983e8f86a1cc9b51f59fc379d4b", hash = "sha256:177511ec69a2f04de39867d43f167a33194ae983e8f86a1cc9b51f59fc379d4b" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_a-1.0.0.tar.gz#sha256=177511ec69a2f04de39867d43f167a33194ae983e8f86a1cc9b51f59fc379d4b", hash = "sha256:177511ec69a2f04de39867d43f167a33194ae983e8f86a1cc9b51f59fc379d4b" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_a-1.0.0-py3-none-any.whl#sha256=a7b95b768a7181d9713510b22bb69c5c4f634950e50d13ae44126d800e76abd9", hash = "sha256:a7b95b768a7181d9713510b22bb69c5c4f634950e50d13ae44126d800e76abd9" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_a-1.0.0-py3-none-any.whl#sha256=16447932477c5feaa874b4e7510023c6f732578cec07158bc0e872af887a77d6", hash = "sha256:16447932477c5feaa874b4e7510023c6f732578cec07158bc0e872af887a77d6" },
         ]
 
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_a-2.0.0.tar.gz#sha256=43e24ce6fcbfbbff1db5eb20b583c20c2aa0888138bfafeab205c4ccc6e7e0a4", hash = "sha256:43e24ce6fcbfbbff1db5eb20b583c20c2aa0888138bfafeab205c4ccc6e7e0a4" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_a-2.0.0.tar.gz#sha256=43e24ce6fcbfbbff1db5eb20b583c20c2aa0888138bfafeab205c4ccc6e7e0a4", hash = "sha256:43e24ce6fcbfbbff1db5eb20b583c20c2aa0888138bfafeab205c4ccc6e7e0a4" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_inherit_a-2.0.0-py3-none-any.whl#sha256=d11786be689f457db5be1729abbb80861259050dbb54e3bb8cfe2b89562db6ec", hash = "sha256:d11786be689f457db5be1729abbb80861259050dbb54e3bb8cfe2b89562db6ec" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_inherit_a-2.0.0-py3-none-any.whl#sha256=d650b6acf8f68d85e210ceb3e7802fbe84aad2b918b06a72dee534fe5474852b", hash = "sha256:d650b6acf8f68d85e210ceb3e7802fbe84aad2b918b06a72dee534fe5474852b" },
         ]
 
         [[distribution]]
@@ -1459,8 +1659,8 @@ fn fork_marker_inherit() -> Result<()> {
         version = "0.1.0"
         source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1525,7 +1725,7 @@ fn fork_marker_limited_inherit() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -1549,40 +1749,40 @@ fn fork_marker_limited_inherit() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_a-1.0.0.tar.gz#sha256=ab1fde8d0acb9a2fe99b7a005939962b1c26c6d876e4a55e81fb9d1a1e5e9f76", hash = "sha256:ab1fde8d0acb9a2fe99b7a005939962b1c26c6d876e4a55e81fb9d1a1e5e9f76" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_limited_inherit_a-1.0.0.tar.gz#sha256=ab1fde8d0acb9a2fe99b7a005939962b1c26c6d876e4a55e81fb9d1a1e5e9f76", hash = "sha256:ab1fde8d0acb9a2fe99b7a005939962b1c26c6d876e4a55e81fb9d1a1e5e9f76" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_a-1.0.0-py3-none-any.whl#sha256=cb79be6fc2fe9c69f19d5452b711d838facf916caddd24dd40b78d34da3930de", hash = "sha256:cb79be6fc2fe9c69f19d5452b711d838facf916caddd24dd40b78d34da3930de" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_limited_inherit_a-1.0.0-py3-none-any.whl#sha256=0dcb9659eeb891701535005a2afd7c579f566d3908e96137db74129924ae6a7e", hash = "sha256:0dcb9659eeb891701535005a2afd7c579f566d3908e96137db74129924ae6a7e" },
         ]
 
         [[distribution]]
         name = "package-a"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_a-2.0.0.tar.gz#sha256=009fdb8872cf52324c1bcdebef31feaba3c262fd76d150a753152aeee3d55b10", hash = "sha256:009fdb8872cf52324c1bcdebef31feaba3c262fd76d150a753152aeee3d55b10" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_limited_inherit_a-2.0.0.tar.gz#sha256=009fdb8872cf52324c1bcdebef31feaba3c262fd76d150a753152aeee3d55b10", hash = "sha256:009fdb8872cf52324c1bcdebef31feaba3c262fd76d150a753152aeee3d55b10" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_a-2.0.0-py3-none-any.whl#sha256=222092e35ef8ac65f5974f3ea38056ff85a5ce981d84ede5a799a04b5ae50661", hash = "sha256:222092e35ef8ac65f5974f3ea38056ff85a5ce981d84ede5a799a04b5ae50661" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_limited_inherit_a-2.0.0-py3-none-any.whl#sha256=10957fddbd5611e0db154744a01d588c7105e26fd5f6a8150956ca9542d844c5", hash = "sha256:10957fddbd5611e0db154744a01d588c7105e26fd5f6a8150956ca9542d844c5" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
             { name = "package-c", marker = "sys_platform == 'linux'" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_b-1.0.0.tar.gz#sha256=4c04e090df03e308ecd38a9b8db9813a09fb20a747a89f86c497702c3e5a9001", hash = "sha256:4c04e090df03e308ecd38a9b8db9813a09fb20a747a89f86c497702c3e5a9001" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_limited_inherit_b-1.0.0.tar.gz#sha256=4c04e090df03e308ecd38a9b8db9813a09fb20a747a89f86c497702c3e5a9001", hash = "sha256:4c04e090df03e308ecd38a9b8db9813a09fb20a747a89f86c497702c3e5a9001" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_b-1.0.0-py3-none-any.whl#sha256=ee96eb6ec4c7fa40a60feaa557df01550ecbfe1f5e49ec3a9282f243f76a5113", hash = "sha256:ee96eb6ec4c7fa40a60feaa557df01550ecbfe1f5e49ec3a9282f243f76a5113" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_limited_inherit_b-1.0.0-py3-none-any.whl#sha256=17365faaf25dba08be579867f219f914a0ff3298441f8d7b6201625a253333ec", hash = "sha256:17365faaf25dba08be579867f219f914a0ff3298441f8d7b6201625a253333ec" },
         ]
 
         [[distribution]]
         name = "package-c"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_c-1.0.0.tar.gz#sha256=8dcb05f5dff09fec52ab507b215ff367fe815848319a17929db997ad3afe88ae", hash = "sha256:8dcb05f5dff09fec52ab507b215ff367fe815848319a17929db997ad3afe88ae" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_limited_inherit_c-1.0.0.tar.gz#sha256=8dcb05f5dff09fec52ab507b215ff367fe815848319a17929db997ad3afe88ae", hash = "sha256:8dcb05f5dff09fec52ab507b215ff367fe815848319a17929db997ad3afe88ae" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_limited_inherit_c-1.0.0-py3-none-any.whl#sha256=6870cf7f8eec58dc27a701f9dc0669151e914c013d3e7910953fdfeb387a5e6b", hash = "sha256:6870cf7f8eec58dc27a701f9dc0669151e914c013d3e7910953fdfeb387a5e6b" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_limited_inherit_c-1.0.0-py3-none-any.whl#sha256=877a87a4987ad795ddaded3e7266ed7defdd3cfbe07a29500cb6047637db4065", hash = "sha256:877a87a4987ad795ddaded3e7266ed7defdd3cfbe07a29500cb6047637db4065" },
         ]
 
         [[distribution]]
@@ -1590,8 +1790,8 @@ fn fork_marker_limited_inherit() -> Result<()> {
         version = "0.1.0"
         source = { editable = "." }
         dependencies = [
-            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
-            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
+            { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'linux'" },
             { name = "package-b" },
         ]
         "###
@@ -1654,7 +1854,7 @@ fn fork_marker_selection() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -1678,28 +1878,28 @@ fn fork_marker_selection() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "0.1.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_a-0.1.0.tar.gz#sha256=ece83ba864a62d5d747439f79a0bf36aa4c18d15bca96aab855ffc2e94a8eef7", hash = "sha256:ece83ba864a62d5d747439f79a0bf36aa4c18d15bca96aab855ffc2e94a8eef7" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_selection_a-0.1.0.tar.gz#sha256=ece83ba864a62d5d747439f79a0bf36aa4c18d15bca96aab855ffc2e94a8eef7", hash = "sha256:ece83ba864a62d5d747439f79a0bf36aa4c18d15bca96aab855ffc2e94a8eef7" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_a-0.1.0-py3-none-any.whl#sha256=8aecc639cc090aa80aa263fb3a9644a7cec9da215133299b8fb381cb7a6bcbb7", hash = "sha256:8aecc639cc090aa80aa263fb3a9644a7cec9da215133299b8fb381cb7a6bcbb7" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_selection_a-0.1.0-py3-none-any.whl#sha256=a3b9d6e46cc226d20994cc60653fd59d81d96527749f971a6f59ef8cbcbc7c01", hash = "sha256:a3b9d6e46cc226d20994cc60653fd59d81d96527749f971a6f59ef8cbcbc7c01" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_b-1.0.0.tar.gz#sha256=6f5ea28cadb8b5dfa15d32c9e38818f8f7150fc4f9a58e49aec4e10b23342be4", hash = "sha256:6f5ea28cadb8b5dfa15d32c9e38818f8f7150fc4f9a58e49aec4e10b23342be4" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_selection_b-1.0.0.tar.gz#sha256=6f5ea28cadb8b5dfa15d32c9e38818f8f7150fc4f9a58e49aec4e10b23342be4", hash = "sha256:6f5ea28cadb8b5dfa15d32c9e38818f8f7150fc4f9a58e49aec4e10b23342be4" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_b-1.0.0-py3-none-any.whl#sha256=d86ba6d371e152071be1e5bc902a5a54010e94592c8c7e7908870b96ad04d851", hash = "sha256:d86ba6d371e152071be1e5bc902a5a54010e94592c8c7e7908870b96ad04d851" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_selection_b-1.0.0-py3-none-any.whl#sha256=5eb8c7fc25dfe94c8a3b71bc09eadb8cd4c7e55b974cee851b848c3856d6a4f9", hash = "sha256:5eb8c7fc25dfe94c8a3b71bc09eadb8cd4c7e55b974cee851b848c3856d6a4f9" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_b-2.0.0.tar.gz#sha256=d32033ecdf37d605e4b3b3e88df6562bb7ca01c6ed3fb9a55ec078eccc1df9d1", hash = "sha256:d32033ecdf37d605e4b3b3e88df6562bb7ca01c6ed3fb9a55ec078eccc1df9d1" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_selection_b-2.0.0.tar.gz#sha256=d32033ecdf37d605e4b3b3e88df6562bb7ca01c6ed3fb9a55ec078eccc1df9d1", hash = "sha256:d32033ecdf37d605e4b3b3e88df6562bb7ca01c6ed3fb9a55ec078eccc1df9d1" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_selection_b-2.0.0-py3-none-any.whl#sha256=535c038dec0bb33c867ee979fe8863734dd6fb913a94603dcbff42c62790f98b", hash = "sha256:535c038dec0bb33c867ee979fe8863734dd6fb913a94603dcbff42c62790f98b" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_selection_b-2.0.0-py3-none-any.whl#sha256=163fbcd238a66243064d41bd383657a63e45155f63bf92668c23af5245307380", hash = "sha256:163fbcd238a66243064d41bd383657a63e45155f63bf92668c23af5245307380" },
         ]
 
         [[distribution]]
@@ -1708,8 +1908,8 @@ fn fork_marker_selection() -> Result<()> {
         source = { editable = "." }
         dependencies = [
             { name = "package-a" },
-            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
-            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
+            { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-b", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1782,7 +1982,7 @@ fn fork_marker_track() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -1806,40 +2006,40 @@ fn fork_marker_track() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.3.1"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
             { name = "package-c", marker = "implementation_name == 'iron'" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_a-1.3.1.tar.gz#sha256=ffc490c887058825e96a0cc4a270cf56b72f7f28b927c450086603317bb8c120", hash = "sha256:ffc490c887058825e96a0cc4a270cf56b72f7f28b927c450086603317bb8c120" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_track_a-1.3.1.tar.gz#sha256=ffc490c887058825e96a0cc4a270cf56b72f7f28b927c450086603317bb8c120", hash = "sha256:ffc490c887058825e96a0cc4a270cf56b72f7f28b927c450086603317bb8c120" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_a-1.3.1-py3-none-any.whl#sha256=79e82592fe6644839cdb6dc73d3d54fc543f0e0f28cce26e221a6c1e30072104", hash = "sha256:79e82592fe6644839cdb6dc73d3d54fc543f0e0f28cce26e221a6c1e30072104" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_track_a-1.3.1-py3-none-any.whl#sha256=d9dc6a64400a041199df2d37182582ff7cc986bac486da273d814627e9b86648", hash = "sha256:d9dc6a64400a041199df2d37182582ff7cc986bac486da273d814627e9b86648" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "2.7"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_b-2.7.tar.gz#sha256=855bf45837a4ba669a5850b14b0253cb138925fdd2b06a2f15c6582b8fabb8a0", hash = "sha256:855bf45837a4ba669a5850b14b0253cb138925fdd2b06a2f15c6582b8fabb8a0" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_track_b-2.7.tar.gz#sha256=855bf45837a4ba669a5850b14b0253cb138925fdd2b06a2f15c6582b8fabb8a0", hash = "sha256:855bf45837a4ba669a5850b14b0253cb138925fdd2b06a2f15c6582b8fabb8a0" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_b-2.7-py3-none-any.whl#sha256=106d0c1c60d67fcf1711029f58f34b770007fed24d087f2fb9cee91226dbdbba", hash = "sha256:106d0c1c60d67fcf1711029f58f34b770007fed24d087f2fb9cee91226dbdbba" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_track_b-2.7-py3-none-any.whl#sha256=544eb2b567d2293c47da724af91fec59c2d3e06675617d29068864ec3a4e390f", hash = "sha256:544eb2b567d2293c47da724af91fec59c2d3e06675617d29068864ec3a4e390f" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "2.8"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_b-2.8.tar.gz#sha256=2e14b0ff1fb7f5cf491bd31d876218adee1d6a208ff197dc30363cdf25262e80", hash = "sha256:2e14b0ff1fb7f5cf491bd31d876218adee1d6a208ff197dc30363cdf25262e80" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_track_b-2.8.tar.gz#sha256=2e14b0ff1fb7f5cf491bd31d876218adee1d6a208ff197dc30363cdf25262e80", hash = "sha256:2e14b0ff1fb7f5cf491bd31d876218adee1d6a208ff197dc30363cdf25262e80" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_b-2.8-py3-none-any.whl#sha256=7e2ea2b4f530fa04bec90cf131289ac7eaca1ae38267150587d418d42c814b7c", hash = "sha256:7e2ea2b4f530fa04bec90cf131289ac7eaca1ae38267150587d418d42c814b7c" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_track_b-2.8-py3-none-any.whl#sha256=5aba691ce804ee39b2464c7757f8680786a1468e152ee845ff841c37f8112e21", hash = "sha256:5aba691ce804ee39b2464c7757f8680786a1468e152ee845ff841c37f8112e21" },
         ]
 
         [[distribution]]
         name = "package-c"
         version = "1.10"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_c-1.10.tar.gz#sha256=c89006d893254790b0fcdd1b33520241c8ff66ab950c6752b745e006bdeff144", hash = "sha256:c89006d893254790b0fcdd1b33520241c8ff66ab950c6752b745e006bdeff144" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_track_c-1.10.tar.gz#sha256=c89006d893254790b0fcdd1b33520241c8ff66ab950c6752b745e006bdeff144", hash = "sha256:c89006d893254790b0fcdd1b33520241c8ff66ab950c6752b745e006bdeff144" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_marker_track_c-1.10-py3-none-any.whl#sha256=6894f06e085884d812ec5e929ed42e7e01a1c7c95fd5ab30781541e4cd94b58d", hash = "sha256:6894f06e085884d812ec5e929ed42e7e01a1c7c95fd5ab30781541e4cd94b58d" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_marker_track_c-1.10-py3-none-any.whl#sha256=cedcb8fbcdd9fbde4eea76612e57536c8b56507a9d7f7a92e483cb56b18c57a3", hash = "sha256:cedcb8fbcdd9fbde4eea76612e57536c8b56507a9d7f7a92e483cb56b18c57a3" },
         ]
 
         [[distribution]]
@@ -1848,8 +2048,8 @@ fn fork_marker_track() -> Result<()> {
         source = { editable = "." }
         dependencies = [
             { name = "package-a" },
-            { name = "package-b", version = "2.7", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'darwin'" },
-            { name = "package-b", version = "2.8", source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }, marker = "sys_platform == 'linux'" },
+            { name = "package-b", version = "2.7", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'darwin'" },
+            { name = "package-b", version = "2.8", source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }, marker = "sys_platform == 'linux'" },
         ]
         "###
         );
@@ -1908,7 +2108,7 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -1932,34 +2132,34 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
             { name = "package-c", marker = "sys_platform == 'linux'" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_a-1.0.0.tar.gz#sha256=68cff02c9f4a0b3014fdce524982a3cbf3a2ecaf0291c32c824cadb19f1e7cd0", hash = "sha256:68cff02c9f4a0b3014fdce524982a3cbf3a2ecaf0291c32c824cadb19f1e7cd0" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_non_fork_marker_transitive_a-1.0.0.tar.gz#sha256=68cff02c9f4a0b3014fdce524982a3cbf3a2ecaf0291c32c824cadb19f1e7cd0", hash = "sha256:68cff02c9f4a0b3014fdce524982a3cbf3a2ecaf0291c32c824cadb19f1e7cd0" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_a-1.0.0-py3-none-any.whl#sha256=589fb29588410fe1685650a1151e0f33131c9b295506af6babe16e98dad9da59", hash = "sha256:589fb29588410fe1685650a1151e0f33131c9b295506af6babe16e98dad9da59" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_non_fork_marker_transitive_a-1.0.0-py3-none-any.whl#sha256=6c49aef823d3544d795c05497ca2dbd5c419cad4454e4d41b8f4860be45bd4bf", hash = "sha256:6c49aef823d3544d795c05497ca2dbd5c419cad4454e4d41b8f4860be45bd4bf" },
         ]
 
         [[distribution]]
         name = "package-b"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
         dependencies = [
             { name = "package-c", marker = "sys_platform == 'darwin'" },
         ]
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_b-1.0.0.tar.gz#sha256=ae7abe9cde79b810f91dff7329b63788a8253250053fe4e82563f0b2d0877182", hash = "sha256:ae7abe9cde79b810f91dff7329b63788a8253250053fe4e82563f0b2d0877182" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_non_fork_marker_transitive_b-1.0.0.tar.gz#sha256=ae7abe9cde79b810f91dff7329b63788a8253250053fe4e82563f0b2d0877182", hash = "sha256:ae7abe9cde79b810f91dff7329b63788a8253250053fe4e82563f0b2d0877182" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_b-1.0.0-py3-none-any.whl#sha256=545bea70509188de241037b506a1c38dbabb4e52042bb88ca836c04d8103fc48", hash = "sha256:545bea70509188de241037b506a1c38dbabb4e52042bb88ca836c04d8103fc48" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_non_fork_marker_transitive_b-1.0.0-py3-none-any.whl#sha256=6f301799cb51d920c7bef0120d5914f8315758ddc9f856b88783efae706dac16", hash = "sha256:6f301799cb51d920c7bef0120d5914f8315758ddc9f856b88783efae706dac16" },
         ]
 
         [[distribution]]
         name = "package-c"
         version = "2.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_c-2.0.0.tar.gz#sha256=ffab9124854f64c8b5059ccaed481547f54abac868ba98aa6a454c0163cdb1c7", hash = "sha256:ffab9124854f64c8b5059ccaed481547f54abac868ba98aa6a454c0163cdb1c7" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_non_fork_marker_transitive_c-2.0.0.tar.gz#sha256=ffab9124854f64c8b5059ccaed481547f54abac868ba98aa6a454c0163cdb1c7", hash = "sha256:ffab9124854f64c8b5059ccaed481547f54abac868ba98aa6a454c0163cdb1c7" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_non_fork_marker_transitive_c-2.0.0-py3-none-any.whl#sha256=80495d1a9075682f6e9dc8d474afd98a3324d32c57c65769b573f281105f3d08", hash = "sha256:80495d1a9075682f6e9dc8d474afd98a3324d32c57c65769b573f281105f3d08" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_non_fork_marker_transitive_c-2.0.0-py3-none-any.whl#sha256=2b72d6af81967e1c55f30d920d6a7b913fce6ad0a0658ec79972a3d1a054e85f", hash = "sha256:2b72d6af81967e1c55f30d920d6a7b913fce6ad0a0658ec79972a3d1a054e85f" },
         ]
 
         [[distribution]]
@@ -2028,7 +2228,7 @@ fn fork_non_local_fork_marker_direct() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: false
     exit_code: 1
@@ -2103,7 +2303,7 @@ fn fork_non_local_fork_marker_transitive() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: false
     exit_code: 1
@@ -2164,7 +2364,7 @@ fn fork_requires_python_full_prerelease() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -2236,7 +2436,7 @@ fn fork_requires_python_full() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -2311,7 +2511,7 @@ fn fork_requires_python_patch_overlap() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0
@@ -2335,10 +2535,10 @@ fn fork_requires_python_patch_overlap() -> Result<()> {
         [[distribution]]
         name = "package-a"
         version = "1.0.0"
-        source = { registry = "https://astral-sh.github.io/packse/0.3.29/simple-html/" }
-        sdist = { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_requires_python_patch_overlap_a-1.0.0.tar.gz#sha256=ac2820ee4808788674295192d79a709e3259aa4eef5b155e77f719ad4eaa324d", hash = "sha256:ac2820ee4808788674295192d79a709e3259aa4eef5b155e77f719ad4eaa324d" }
+        source = { registry = "https://astral-sh.github.io/packse/0.3.30/simple-html/" }
+        sdist = { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_requires_python_patch_overlap_a-1.0.0.tar.gz#sha256=ac2820ee4808788674295192d79a709e3259aa4eef5b155e77f719ad4eaa324d", hash = "sha256:ac2820ee4808788674295192d79a709e3259aa4eef5b155e77f719ad4eaa324d" }
         wheels = [
-            { url = "https://astral-sh.github.io/packse/0.3.29/files/fork_requires_python_patch_overlap_a-1.0.0-py3-none-any.whl#sha256=9c8e127993ded58b011f08453d4103f71f12aa2e8fb61e755061fb56128214e2", hash = "sha256:9c8e127993ded58b011f08453d4103f71f12aa2e8fb61e755061fb56128214e2" },
+            { url = "https://astral-sh.github.io/packse/0.3.30/files/fork_requires_python_patch_overlap_a-1.0.0-py3-none-any.whl#sha256=43a750ba4eaab749d608d70e94d3d51e083cc21f5a52ac99b5967b26486d5ef1", hash = "sha256:43a750ba4eaab749d608d70e94d3d51e083cc21f5a52ac99b5967b26486d5ef1" },
         ]
 
         [[distribution]]
@@ -2393,7 +2593,7 @@ fn fork_requires_python() -> Result<()> {
     let mut cmd = context.lock();
     cmd.env_remove("UV_EXCLUDE_NEWER");
     cmd.arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/");
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/");
     uv_snapshot!(filters, cmd, @r###"
     success: true
     exit_code: 0

--- a/crates/uv/tests/pip_compile_scenarios.rs
+++ b/crates/uv/tests/pip_compile_scenarios.rs
@@ -1,7 +1,7 @@
 //! DO NOT EDIT
 //!
 //! Generated with `./scripts/sync_scenarios.sh`
-//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.29/scenarios>
+//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.30/scenarios>
 //!
 #![cfg(all(feature = "python", feature = "pypi", unix))]
 
@@ -27,9 +27,9 @@ fn command(context: &TestContext, python_versions: &[&str]) -> Command {
         .arg("compile")
         .arg("requirements.in")
         .arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/")
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.29/vendor/links.html");
+        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.30/vendor/links.html");
     context.add_shared_args(&mut command);
     command.env_remove("UV_EXCLUDE_NEWER");
     command.env("UV_TEST_PYTHON_PATH", python_path);

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -1,7 +1,7 @@
 //! DO NOT EDIT
 //!
 //! Generated with `./scripts/sync_scenarios.sh`
-//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.29/scenarios>
+//! Scenarios from <https://github.com/astral-sh/packse/tree/0.3.30/scenarios>
 //!
 #![cfg(all(feature = "python", feature = "pypi", unix))]
 
@@ -46,9 +46,9 @@ fn command(context: &TestContext) -> Command {
         .arg("pip")
         .arg("install")
         .arg("--index-url")
-        .arg("https://astral-sh.github.io/packse/0.3.29/simple-html/")
+        .arg("https://astral-sh.github.io/packse/0.3.30/simple-html/")
         .arg("--find-links")
-        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.29/vendor/links.html");
+        .arg("https://raw.githubusercontent.com/astral-sh/packse/0.3.30/vendor/links.html");
     context.add_shared_args(&mut command);
     command.env_remove("UV_EXCLUDE_NEWER");
     command

--- a/scripts/scenarios/requirements.in
+++ b/scripts/scenarios/requirements.in
@@ -1,2 +1,2 @@
 chevron-blue
-packse>=0.3.29
+packse>=0.3.30

--- a/scripts/scenarios/requirements.txt
+++ b/scripts/scenarios/requirements.txt
@@ -46,7 +46,7 @@ nh3==0.2.17
     # via readme-renderer
 packaging==24.0
     # via hatchling
-packse==0.3.29
+packse==0.3.30
     # via -r scripts/scenarios/requirements.in
 pathspec==0.12.1
     # via hatchling


### PR DESCRIPTION
In some cases, it's possible for the marker expressions on conflicting
dependency specification to be disjoint but *incomplete*. That is, if
one unions the disjoint markers, the result is not the complete set
of marker environments possible. There may be some "gap" of marker
environments not covered by the markers.

This is a problem in practice because, before this commit, we only
created forks in the resolver for specific marker expressions. So if a
dependency happened to fall in a "gap," our resolver would never see
it.

This commit fixes this by adding a new split covering the negation of
the union of all marker expressions in a set of forks for a specific
package.

Originally, I had planned on only creating this split when it was
known that the gap actually existed. That is, when the negation of the
marker expressions did *not* correspond to the empty set. After a lot
of thought, unfortunately, this (I believe) effectively boils down to
3SAT, which is NP-complete.

Instead, what we do here is *always* create an extra split unless we
can definitively tell that it is empty. We look for a few cases, but
otherwise throw our hands up and potentially do wasted work.

This also updates the lock scenario tests to reflect the actual bug fix
here.

Ref #4732, Fixes #4687