### PR TITLE
Rework reformatting in PyProjectTomlMut to respect original indentation

### DIFF
--- a/crates/uv-distribution/src/pyproject_mut.rs
+++ b/crates/uv-distribution/src/pyproject_mut.rs
@@ -424,14 +424,38 @@ fn reformat_array_multiline(deps: &mut Array) {
             })
     }
 
+    let mut indentation_prefix = None;
+
     for item in deps.iter_mut() {
         let decor = item.decor_mut();
         let mut prefix = String::new();
+        // calculating the indentation prefix as the indentation of the first dependency entry
+        if indentation_prefix.is_none() {
+            let decor_prefix = decor
+                .prefix()
+                .and_then(|s| s.as_str())
+                .map(|s| s.split('#').next().unwrap_or("").to_string())
+                .unwrap_or(String::new())
+                .trim_start_matches("\n")
+                .to_string();
+
+            // if there is no indentation then apply a default one
+            indentation_prefix = Some(if decor_prefix.is_empty() {
+                "    ".to_string()
+            } else {
+                decor_prefix
+            });
+        }
+
+        let indentation_prefix_str = indentation_prefix.as_ref().unwrap();
+
         for comment in find_comments(decor.prefix()).chain(find_comments(decor.suffix())) {
-            prefix.push_str("\n    ");
+            prefix.push_str("\n");
+            prefix.push_str(indentation_prefix_str);
             prefix.push_str(comment);
         }
-        prefix.push_str("\n    ");
+        prefix.push_str("\n");
+        prefix.push_str(indentation_prefix_str);
         decor.set_prefix(prefix);
         decor.set_suffix("");
     }

--- a/crates/uv-distribution/src/pyproject_mut.rs
+++ b/crates/uv-distribution/src/pyproject_mut.rs
@@ -436,7 +436,7 @@ fn reformat_array_multiline(deps: &mut Array) {
                 .and_then(|s| s.as_str())
                 .map(|s| s.split('#').next().unwrap_or("").to_string())
                 .unwrap_or(String::new())
-                .trim_start_matches("\n")
+                .trim_start_matches('\n')
                 .to_string();
 
             // if there is no indentation then apply a default one
@@ -447,15 +447,13 @@ fn reformat_array_multiline(deps: &mut Array) {
             });
         }
 
-        let indentation_prefix_str = indentation_prefix.as_ref().unwrap();
+        let indentation_prefix_str = format!("\n{}", indentation_prefix.as_ref().unwrap());
 
         for comment in find_comments(decor.prefix()).chain(find_comments(decor.suffix())) {
-            prefix.push_str("\n");
-            prefix.push_str(indentation_prefix_str);
+            prefix.push_str(&indentation_prefix_str);
             prefix.push_str(comment);
         }
-        prefix.push_str("\n");
-        prefix.push_str(indentation_prefix_str);
+        prefix.push_str(&indentation_prefix_str);
         decor.set_prefix(prefix);
         decor.set_suffix("");
     }


### PR DESCRIPTION
## Summary

So this PR introduces change to how `Array` of dependencies representation is reformatted while `PyProjectTomlMut` is manipulated. These changes are here for it to respect the original indentation.
Closes https://github.com/astral-sh/uv/issues/5009

## Test Plan
Using `pyproject.toml` like
```
[project]
name = "project"
version = "0.1.0"
requires-python = ">=3.12"
dependencies = [
  "requests"
]
```
Executed 
```
$ uv add httpx
```
And expected in `pyproject.toml`
```
[project]
name = "project"
version = "0.1.0"
requires-python = ">=3.12"
dependencies = [
  "requests",
  "httpx",
]
```
Preserving original indentation