### PR TITLE
Cache downloaded wheel when range requests aren't supported

### DIFF
--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -208,6 +208,31 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         hashes: archive.hashes,
                         filename: wheel.filename.clone(),
                     }),
+                    Err(Error::Client(err)) if err.is_http_streaming_unsupported() => {
+                        warn!(
+                            "Streaming unsupported for {dist}; downloading wheel to disk ({err})"
+                        );
+
+                        // If the request failed because streaming is unsupported, download the
+                        // wheel directly.
+                        let archive = self
+                            .download_wheel(
+                                url,
+                                &wheel.filename,
+                                wheel.file.size,
+                                &wheel_entry,
+                                dist,
+                                hashes,
+                            )
+                            .await?;
+
+                        Ok(LocalWheel {
+                            dist: Dist::Built(dist.clone()),
+                            archive: self.build_context.cache().archive(&archive.id),
+                            hashes: archive.hashes,
+                            filename: wheel.filename.clone(),
+                        })
+                    }
                     Err(Error::Extract(err)) => {
                         if err.is_http_streaming_unsupported() {
                             warn!(
@@ -273,6 +298,36 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         warn!(
                             "Streaming unsupported for {dist}; downloading wheel to disk ({err})"
                         );
+
+                        // If the request failed because streaming is unsupported, download the
+                        // wheel directly.
+                        let archive = self
+                            .download_wheel(
+                                wheel.url.raw().clone(),
+                                &wheel.filename,
+                                None,
+                                &wheel_entry,
+                                dist,
+                                hashes,
+                            )
+                            .await?;
+                        Ok(LocalWheel {
+                            dist: Dist::Built(dist.clone()),
+                            archive: self.build_context.cache().archive(&archive.id),
+                            hashes: archive.hashes,
+                            filename: wheel.filename.clone(),
+                        })
+                    }
+                    Err(Error::Extract(err)) => {
+                        if err.is_http_streaming_unsupported() {
+                            warn!(
+                                "Streaming unsupported for {dist}; downloading wheel to disk ({err})"
+                            );
+                        } else if err.is_http_streaming_failed() {
+                            warn!("Streaming failed for {dist}; downloading wheel to disk ({err})");
+                        } else {
+                            return Err(Error::Extract(err));
+                        }
 
                         // If the request failed because streaming is unsupported, download the
                         // wheel directly.
@@ -390,11 +445,11 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
 
         match result {
             Ok(metadata) => Ok(ArchiveMetadata::from_metadata23(metadata)),
-            Err(err) if err.is_http_streaming_unsupported() => {
-                warn!("Streaming unsupported when fetching metadata for {dist}; downloading wheel directly ({err})");
+            Err(err) if err.is_http_range_requests_unsupported() => {
+                warn!("Range requests unsupported when fetching metadata for {dist}; downloading wheel directly ({err})");
 
-                // If the request failed due to an error that could be resolved by
-                // downloading the wheel directly, try that.
+                // If the request failed due to an error that could be resolved by downloading the
+                // wheel directly, try that.
                 let wheel = self.get_wheel(dist, hashes).await?;
                 let metadata = wheel.metadata()?;
                 let hashes = wheel.hashes;

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -3227,7 +3227,6 @@ fn no_stream() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + hashb-foxglove-protocolbuffers-python==25.3.0.1.20240226043130+465630478360
     "###


### PR DESCRIPTION
## Summary

When range requests aren't supported, we fall back to streaming the wheel, stopping as soon as we hit a `METADATA` file. This is a small optimization, but the downside is that we don't get to cache the resulting wheel...

We don't know whether `METADATA` will be at the beginning or end of the wheel, but it _seems_ like a better tradeoff to download and cache the entire wheel?

Closes: https://github.com/astral-sh/uv/issues/5088.

Sort of a revert of: https://github.com/astral-sh/uv/pull/1792.
