### PR TITLE
Add `--no-progress` global option to hide all progress animations

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -157,7 +157,7 @@ pub struct GlobalArgs {
 
     /// Hides all progress outputs when set
     #[arg(global = true, long)]
-    pub no_progress_bar: bool,
+    pub no_progress: bool,
 }
 
 #[derive(Debug, Copy, Clone, clap::ValueEnum)]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -84,14 +84,14 @@ pub struct Cli {
 #[allow(clippy::struct_excessive_bools)]
 pub struct GlobalArgs {
     /// Do not print any output.
-    #[arg(global = true, long, short, conflicts_with = "verbose")]
+    #[arg(global = true, long, short, conflicts_with_all = ["verbose", "no_progress_bar"])]
     pub quiet: bool,
 
     /// Use verbose output.
     ///
     /// You can configure fine-grained logging using the `RUST_LOG` environment variable.
     /// (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
-    #[arg(global = true, action = clap::ArgAction::Count, long, short, conflicts_with = "quiet")]
+    #[arg(global = true, action = clap::ArgAction::Count, long, short, conflicts_with_all = ["quiet", "no_progress_bar"])]
     pub verbose: u8,
 
     /// Disable colors; provided for compatibility with `pip`.
@@ -154,6 +154,10 @@ pub struct GlobalArgs {
     /// Show the resolved settings for the current command.
     #[arg(global = true, long, hide = true)]
     pub show_settings: bool,
+
+    /// Hides all progress bars when set
+    #[arg(global = true, long, conflicts_with_all = ["quiet", "verbose"])]
+    pub no_progress_bar: bool,
 }
 
 #[derive(Debug, Copy, Clone, clap::ValueEnum)]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -84,14 +84,14 @@ pub struct Cli {
 #[allow(clippy::struct_excessive_bools)]
 pub struct GlobalArgs {
     /// Do not print any output.
-    #[arg(global = true, long, short, conflicts_with_all = ["verbose", "no_progress_bar"])]
+    #[arg(global = true, long, short, conflicts_with = "verbose")]
     pub quiet: bool,
 
     /// Use verbose output.
     ///
     /// You can configure fine-grained logging using the `RUST_LOG` environment variable.
     /// (<https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives>)
-    #[arg(global = true, action = clap::ArgAction::Count, long, short, conflicts_with_all = ["quiet", "no_progress_bar"])]
+    #[arg(global = true, action = clap::ArgAction::Count, long, short, conflicts_with = "quiet")]
     pub verbose: u8,
 
     /// Disable colors; provided for compatibility with `pip`.
@@ -155,8 +155,8 @@ pub struct GlobalArgs {
     #[arg(global = true, long, hide = true)]
     pub show_settings: bool,
 
-    /// Hides all progress bars when set
-    #[arg(global = true, long, conflicts_with_all = ["quiet", "verbose"])]
+    /// Hides all progress outputs when set
+    #[arg(global = true, long)]
     pub no_progress_bar: bool,
 }
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -109,6 +109,8 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         Printer::Quiet
     } else if globals.verbose > 0 {
         Printer::Verbose
+    } else if globals.no_progress_bar {
+        Printer::NoProgressBar
     } else {
         Printer::Default
     };

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -110,7 +110,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
     } else if globals.verbose > 0 {
         Printer::Verbose
     } else if globals.no_progress {
-        Printer::NoProgressBar
+        Printer::NoProgress
     } else {
         Printer::Default
     };

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -109,7 +109,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         Printer::Quiet
     } else if globals.verbose > 0 {
         Printer::Verbose
-    } else if globals.no_progress_bar {
+    } else if globals.no_progress {
         Printer::NoProgressBar
     } else {
         Printer::Default

--- a/crates/uv/src/printer.rs
+++ b/crates/uv/src/printer.rs
@@ -9,6 +9,8 @@ pub(crate) enum Printer {
     Quiet,
     /// A printer that prints all output, including debug messages.
     Verbose,
+    /// A printer that prints all output, excluding all progress bars
+    NoProgressBar,
 }
 
 impl Printer {
@@ -20,6 +22,7 @@ impl Printer {
             // Confusingly, hide the progress bar when in verbose mode.
             // Otherwise, it gets interleaved with debug messages.
             Self::Verbose => ProgressDrawTarget::hidden(),
+            Self::NoProgressBar => ProgressDrawTarget::hidden(),
         }
     }
 
@@ -29,6 +32,7 @@ impl Printer {
             Self::Default => Stdout::Enabled,
             Self::Quiet => Stdout::Disabled,
             Self::Verbose => Stdout::Enabled,
+            Self::NoProgressBar => Stdout::Enabled,
         }
     }
 
@@ -38,6 +42,7 @@ impl Printer {
             Self::Default => Stderr::Enabled,
             Self::Quiet => Stderr::Disabled,
             Self::Verbose => Stderr::Enabled,
+            Self::NoProgressBar => Stderr::Enabled,
         }
     }
 }

--- a/crates/uv/src/printer.rs
+++ b/crates/uv/src/printer.rs
@@ -9,8 +9,8 @@ pub(crate) enum Printer {
     Quiet,
     /// A printer that prints all output, including debug messages.
     Verbose,
-    /// A printer that prints all output, excluding all progress bars
-    NoProgressBar,
+    /// A printer that prints to standard streams, excluding all progress outputs
+    NoProgress,
 }
 
 impl Printer {
@@ -22,7 +22,7 @@ impl Printer {
             // Confusingly, hide the progress bar when in verbose mode.
             // Otherwise, it gets interleaved with debug messages.
             Self::Verbose => ProgressDrawTarget::hidden(),
-            Self::NoProgressBar => ProgressDrawTarget::hidden(),
+            Self::NoProgress => ProgressDrawTarget::hidden(),
         }
     }
 
@@ -32,7 +32,7 @@ impl Printer {
             Self::Default => Stdout::Enabled,
             Self::Quiet => Stdout::Disabled,
             Self::Verbose => Stdout::Enabled,
-            Self::NoProgressBar => Stdout::Enabled,
+            Self::NoProgress => Stdout::Enabled,
         }
     }
 
@@ -42,7 +42,7 @@ impl Printer {
             Self::Default => Stderr::Enabled,
             Self::Quiet => Stderr::Disabled,
             Self::Verbose => Stderr::Enabled,
-            Self::NoProgressBar => Stderr::Enabled,
+            Self::NoProgress => Stderr::Enabled,
         }
     }
 }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -48,6 +48,7 @@ pub(crate) struct GlobalSettings {
     pub(crate) preview: PreviewMode,
     pub(crate) python_preference: PythonPreference,
     pub(crate) python_fetch: PythonFetch,
+    pub(crate) no_progress_bar: bool,
 }
 
 impl GlobalSettings {
@@ -118,6 +119,7 @@ impl GlobalSettings {
                 .python_fetch
                 .combine(workspace.and_then(|workspace| workspace.globals.python_fetch))
                 .unwrap_or_default(),
+            no_progress_bar: args.no_progress_bar,
         }
     }
 }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -48,7 +48,7 @@ pub(crate) struct GlobalSettings {
     pub(crate) preview: PreviewMode,
     pub(crate) python_preference: PythonPreference,
     pub(crate) python_fetch: PythonFetch,
-    pub(crate) no_progress_bar: bool,
+    pub(crate) no_progress: bool,
 }
 
 impl GlobalSettings {
@@ -119,7 +119,7 @@ impl GlobalSettings {
                 .python_fetch
                 .combine(workspace.and_then(|workspace| workspace.globals.python_fetch))
                 .unwrap_or_default(),
-            no_progress_bar: args.no_progress_bar,
+            no_progress: args.no_progress,
         }
     }
 }

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -45,6 +45,8 @@ fn help() {
           --isolated
               Avoid discovering a `pyproject.toml` or `uv.toml` file in the current directory or any
               parent directories
+          --no-progress
+              Hides all progress outputs when set
       -n, --no-cache
               Avoid reading from or writing to the cache [env: UV_NO_CACHE=]
           --cache-dir [CACHE_DIR]
@@ -104,6 +106,8 @@ fn help_flag() {
           --isolated
               Avoid discovering a `pyproject.toml` or `uv.toml` file in the current directory or any
               parent directories
+          --no-progress
+              Hides all progress outputs when set
       -n, --no-cache
               Avoid reading from or writing to the cache [env: UV_NO_CACHE=]
           --cache-dir [CACHE_DIR]
@@ -162,6 +166,8 @@ fn help_short_flag() {
           --isolated
               Avoid discovering a `pyproject.toml` or `uv.toml` file in the current directory or any
               parent directories
+          --no-progress
+              Hides all progress outputs when set
       -n, --no-cache
               Avoid reading from or writing to the cache [env: UV_NO_CACHE=]
           --cache-dir [CACHE_DIR]
@@ -261,6 +267,9 @@ fn help_subcommand() {
           --isolated
               Avoid discovering a `pyproject.toml` or `uv.toml` file in the current directory or any
               parent directories
+
+          --no-progress
+              Hides all progress outputs when set
 
       -n, --no-cache
               Avoid reading from or writing to the cache
@@ -379,6 +388,9 @@ fn help_subsubcommand() {
               Avoid discovering a `pyproject.toml` or `uv.toml` file in the current directory or any
               parent directories
 
+          --no-progress
+              Hides all progress outputs when set
+
       -n, --no-cache
               Avoid reading from or writing to the cache
               
@@ -449,6 +461,8 @@ fn help_flag_subcommand() {
           --isolated
               Avoid discovering a `pyproject.toml` or `uv.toml` file in the current directory or any
               parent directories
+          --no-progress
+              Hides all progress outputs when set
       -n, --no-cache
               Avoid reading from or writing to the cache [env: UV_NO_CACHE=]
           --cache-dir [CACHE_DIR]
@@ -504,6 +518,8 @@ fn help_flag_subsubcommand() {
           --isolated
               Avoid discovering a `pyproject.toml` or `uv.toml` file in the current directory or any
               parent directories
+          --no-progress
+              Hides all progress outputs when set
       -n, --no-cache
               Avoid reading from or writing to the cache [env: UV_NO_CACHE=]
           --cache-dir [CACHE_DIR]
@@ -616,6 +632,8 @@ fn help_with_global_option() {
           --isolated
               Avoid discovering a `pyproject.toml` or `uv.toml` file in the current directory or any
               parent directories
+          --no-progress
+              Hides all progress outputs when set
       -n, --no-cache
               Avoid reading from or writing to the cache [env: UV_NO_CACHE=]
           --cache-dir [CACHE_DIR]
@@ -708,6 +726,8 @@ fn test_with_no_pager() {
           --isolated
               Avoid discovering a `pyproject.toml` or `uv.toml` file in the current directory or any
               parent directories
+          --no-progress
+              Hides all progress outputs when set
       -n, --no-cache
               Avoid reading from or writing to the cache [env: UV_NO_CACHE=]
           --cache-dir [CACHE_DIR]

--- a/crates/uv/tests/show_settings.rs
+++ b/crates/uv/tests/show_settings.rs
@@ -59,6 +59,7 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -191,6 +192,7 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -324,6 +326,7 @@ fn resolve_uv_toml() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -489,6 +492,7 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -623,6 +627,7 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -743,6 +748,7 @@ fn resolve_pyproject_toml() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -900,6 +906,7 @@ fn resolve_index_url() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -1057,6 +1064,7 @@ fn resolve_index_url() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -1259,6 +1267,7 @@ fn resolve_find_links() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -1415,6 +1424,7 @@ fn resolve_top_level() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -1541,6 +1551,7 @@ fn resolve_top_level() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -1695,6 +1706,7 @@ fn resolve_top_level() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -1873,6 +1885,7 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -1989,6 +2002,7 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -2105,6 +2119,7 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -2223,6 +2238,7 @@ fn resolve_user_configuration() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -2366,6 +2382,7 @@ fn resolve_poetry_toml() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,
@@ -2510,6 +2527,7 @@ fn resolve_both() -> anyhow::Result<()> {
         preview: Disabled,
         python_preference: OnlySystem,
         python_fetch: Automatic,
+        no_progress: false,
     }
     CacheSettings {
         no_cache: false,


### PR DESCRIPTION
## Summary

Fixes #5082.

Adds a new `Printer::NoProgress` that is identical to `Printer::Default` but doesn't draw any progress bar.

## Test Plan

It seems to me that as of now it's not possible to use `insta-cmd` to get any progress bar in the comparable output of command.

Best way to test this would be to run any command that usually shows progress indicators like `uv pip install` with and without `--no-progress` options.