### PR TITLE
Handle universal vs. fork markers with `ResolverMarkers`

### DIFF
--- a/crates/bench/benches/uv.rs
+++ b/crates/bench/benches/uv.rs
@@ -90,7 +90,7 @@ mod resolver {
     use uv_python::PythonEnvironment;
     use uv_resolver::{
         FlatIndex, InMemoryIndex, Manifest, OptionsBuilder, PythonRequirement, ResolutionGraph,
-        Resolver,
+        Resolver, ResolverMarkers,
     };
     use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
 
@@ -175,7 +175,7 @@ mod resolver {
             manifest,
             options,
             &python_requirement,
-            Some(&MARKERS),
+            ResolverMarkers::SpecificEnvironment(MARKERS.clone()),
             Some(&TAGS),
             &flat_index,
             &index,

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -26,6 +26,7 @@ use uv_installer::{Installer, Plan, Planner, Preparer, SitePackages};
 use uv_python::{Interpreter, PythonEnvironment};
 use uv_resolver::{
     ExcludeNewer, FlatIndex, InMemoryIndex, Manifest, OptionsBuilder, PythonRequirement, Resolver,
+    ResolverMarkers,
 };
 use uv_types::{BuildContext, BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
 
@@ -146,7 +147,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
                 .index_strategy(self.index_strategy)
                 .build(),
             &python_requirement,
-            Some(markers),
+            ResolverMarkers::SpecificEnvironment(markers.clone()),
             Some(tags),
             self.flat_index,
             self.index,

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -18,7 +18,7 @@ use crate::pubgrub::{
     PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter, PubGrubSpecifierError,
 };
 use crate::python_requirement::PythonRequirement;
-use crate::resolver::{IncompletePackage, UnavailablePackage, UnavailableReason};
+use crate::resolver::{IncompletePackage, ResolverMarkers, UnavailablePackage, UnavailableReason};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ResolveError {
@@ -50,10 +50,10 @@ pub enum ResolveError {
     ConflictingOverrideUrls(PackageName, String, String),
 
     #[error("Requirements contain conflicting URLs for package `{0}`:\n- {}", _1.join("\n- "))]
-    ConflictingUrls(PackageName, Vec<String>),
+    ConflictingUrlsUniversal(PackageName, Vec<String>),
 
     #[error("Requirements contain conflicting URLs for package `{package_name}` in split `{fork_markers}`:\n- {}", urls.join("\n- "))]
-    ConflictingUrlsInFork {
+    ConflictingUrlsFork {
         package_name: PackageName,
         urls: Vec<String>,
         fork_markers: MarkerTree,
@@ -125,15 +125,18 @@ pub struct NoSolutionError {
     unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
     incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, IncompletePackage>>,
     fork_urls: ForkUrls,
-    markers: Option<MarkerTree>,
+    markers: ResolverMarkers,
 }
 
 impl NoSolutionError {
     pub fn header(&self) -> String {
-        if let Some(markers) = &self.markers {
-            format!("No solution found when resolving dependencies for split ({markers}):")
-        } else {
-            "No solution found when resolving dependencies:".to_string()
+        match &self.markers {
+            ResolverMarkers::Universal => {
+                "No solution found when resolving dependencies:".to_string()
+            }
+            ResolverMarkers::Fork(markers) => {
+                format!("No solution found when resolving dependencies for split ({markers}):")
+            }
         }
     }
 
@@ -146,7 +149,7 @@ impl NoSolutionError {
         unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
         incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, IncompletePackage>>,
         fork_urls: ForkUrls,
-        markers: Option<MarkerTree>,
+        markers: ResolverMarkers,
     ) -> Self {
         Self {
             error,

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -131,7 +131,7 @@ pub struct NoSolutionError {
 impl NoSolutionError {
     pub fn header(&self) -> String {
         match &self.markers {
-            ResolverMarkers::Universal => {
+            ResolverMarkers::Universal | ResolverMarkers::SpecificEnvironment(_) => {
                 "No solution found when resolving dependencies:".to_string()
             }
             ResolverMarkers::Fork(markers) => {

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -125,9 +125,18 @@ pub struct NoSolutionError {
     unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
     incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, IncompletePackage>>,
     fork_urls: ForkUrls,
+    markers: Option<MarkerTree>,
 }
 
 impl NoSolutionError {
+    pub fn header(&self) -> String {
+        if let Some(markers) = &self.markers {
+            format!("No solution found when resolving dependencies for split ({markers}):")
+        } else {
+            "No solution found when resolving dependencies:".to_string()
+        }
+    }
+
     pub(crate) fn new(
         error: pubgrub::error::NoSolutionError<UvDependencyProvider>,
         available_versions: FxHashMap<PubGrubPackage, BTreeSet<Version>>,
@@ -137,6 +146,7 @@ impl NoSolutionError {
         unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
         incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, IncompletePackage>>,
         fork_urls: ForkUrls,
+        markers: Option<MarkerTree>,
     ) -> Self {
         Self {
             error,
@@ -147,6 +157,7 @@ impl NoSolutionError {
             unavailable_packages,
             incomplete_packages,
             fork_urls,
+            markers,
         }
     }
 

--- a/crates/uv-resolver/src/fork_urls.rs
+++ b/crates/uv-resolver/src/fork_urls.rs
@@ -29,7 +29,7 @@ impl ForkUrls {
         &mut self,
         package_name: &PackageName,
         url: &VerbatimParsedUrl,
-        fork_markers: &MarkerTree,
+        fork_markers: Option<&MarkerTree>,
     ) -> Result<(), ResolveError> {
         match self.0.entry(package_name.clone()) {
             Entry::Occupied(previous) => {
@@ -39,17 +39,17 @@ impl ForkUrls {
                         url.verbatim.verbatim().to_string(),
                     ];
                     conflicting_url.sort();
-                    return if fork_markers.is_universal() {
-                        Err(ResolveError::ConflictingUrls(
-                            package_name.clone(),
-                            conflicting_url,
-                        ))
-                    } else {
+                    return if let Some(fork_markers) = fork_markers {
                         Err(ResolveError::ConflictingUrlsInFork {
                             package_name: package_name.clone(),
                             urls: conflicting_url,
                             fork_markers: fork_markers.clone(),
                         })
+                    } else {
+                        Err(ResolveError::ConflictingUrls(
+                            package_name.clone(),
+                            conflicting_url,
+                        ))
                     };
                 }
             }

--- a/crates/uv-resolver/src/fork_urls.rs
+++ b/crates/uv-resolver/src/fork_urls.rs
@@ -40,10 +40,12 @@ impl ForkUrls {
                     ];
                     conflicting_url.sort();
                     return match fork_markers {
-                        ResolverMarkers::Universal => Err(ResolveError::ConflictingUrlsUniversal(
-                            package_name.clone(),
-                            conflicting_url,
-                        )),
+                        ResolverMarkers::Universal | ResolverMarkers::SpecificEnvironment(_) => {
+                            Err(ResolveError::ConflictingUrlsUniversal(
+                                package_name.clone(),
+                                conflicting_url,
+                            ))
+                        }
                         ResolverMarkers::Fork(fork_markers) => {
                             Err(ResolveError::ConflictingUrlsFork {
                                 package_name: package_name.clone(),

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -15,7 +15,7 @@ pub use resolution::{AnnotationStyle, DisplayResolutionGraph, ResolutionGraph};
 pub use resolution_mode::ResolutionMode;
 pub use resolver::{
     BuildId, DefaultResolverProvider, InMemoryIndex, MetadataResponse, PackageVersionsResult,
-    Reporter as ResolverReporter, Resolver, ResolverProvider, VersionsResponse,
+    Reporter as ResolverReporter, Resolver, ResolverMarkers, ResolverProvider, VersionsResponse,
     WheelMetadataResult,
 };
 pub use version_map::VersionMap;

--- a/crates/uv-resolver/src/resolver/resolver_markers.rs
+++ b/crates/uv-resolver/src/resolver/resolver_markers.rs
@@ -1,0 +1,50 @@
+use pep508_rs::{MarkerEnvironment, MarkerTree};
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone)]
+/// Whether we're solving for a specific environment, universally or for a specific fork.
+pub enum ResolverMarkers {
+    /// We're solving for this specific environment only.
+    SpecificEnvironment(MarkerEnvironment),
+    /// We're doing a universal resolution for all environments (a python version
+    /// constraint is expressed separately).
+    Universal,
+    /// We're in a fork of the universal resolution solving only for specific markers.
+    Fork(MarkerTree),
+}
+
+impl ResolverMarkers {
+    /// Add the markers of an initial or subsequent fork to the current markers.
+    pub(crate) fn and(self, other: MarkerTree) -> MarkerTree {
+        match self {
+            ResolverMarkers::Universal => other,
+            ResolverMarkers::Fork(mut current) => {
+                current.and(other);
+                current
+            }
+            ResolverMarkers::SpecificEnvironment(_) => {
+                unreachable!("Specific environment mode must not fork")
+            }
+        }
+    }
+
+    /// If solving for a specific environment, return this environment
+    pub fn marker_environment(&self) -> Option<&MarkerEnvironment> {
+        match self {
+            ResolverMarkers::Universal | ResolverMarkers::Fork(_) => None,
+            ResolverMarkers::SpecificEnvironment(env) => Some(env),
+        }
+    }
+}
+
+impl Display for ResolverMarkers {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolverMarkers::Universal => f.write_str("universal"),
+            ResolverMarkers::SpecificEnvironment(_) => f.write_str("specific environment"),
+            ResolverMarkers::Fork(markers) => {
+                write!(f, "({markers})")
+            }
+        }
+    }
+}

--- a/crates/uv-resolver/src/resolver/urls.rs
+++ b/crates/uv-resolver/src/resolver/urls.rs
@@ -174,7 +174,7 @@ impl Urls {
                 .chain(iter::once(verbatim_url.verbatim().to_string()))
                 .collect();
             conflicting_urls.sort();
-            return Err(ResolveError::ConflictingUrls(
+            return Err(ResolveError::ConflictingUrlsUniversal(
                 package_name.clone(),
                 conflicting_urls,
             ));

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -351,8 +351,7 @@ pub(crate) async fn pip_compile(
     {
         Ok(resolution) => resolution,
         Err(operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(err))) => {
-            let report = miette::Report::msg(format!("{err}"))
-                .context("No solution found when resolving dependencies:");
+            let report = miette::Report::msg(format!("{err}")).context(err.header());
             eprint!("{report:?}");
             return Ok(ExitStatus::Failure);
         }

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -33,7 +33,7 @@ use uv_requirements::{
 use uv_resolver::{
     AnnotationStyle, DependencyMode, DisplayResolutionGraph, ExcludeNewer, FlatIndex,
     InMemoryIndex, OptionsBuilder, PreReleaseMode, PythonRequirement, RequiresPython,
-    ResolutionMode,
+    ResolutionMode, ResolverMarkers,
 };
 use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
 use uv_warnings::warn_user;
@@ -230,11 +230,14 @@ pub(crate) async fn pip_compile(
 
     // Determine the environment for the resolution.
     let (tags, markers) = if universal {
-        (None, None)
+        (None, ResolverMarkers::Universal)
     } else {
         let (tags, markers) =
             resolution_environment(python_version, python_platform, &interpreter)?;
-        (Some(tags), Some(markers))
+        (
+            Some(tags),
+            ResolverMarkers::SpecificEnvironment((*markers).clone()),
+        )
     };
 
     // Generate, but don't enforce hashes for the requirements.
@@ -335,7 +338,7 @@ pub(crate) async fn pip_compile(
         &Reinstall::None,
         &upgrade,
         tags.as_deref(),
-        markers.as_deref(),
+        markers.clone(),
         python_requirement,
         &client,
         &flat_index,
@@ -383,7 +386,7 @@ pub(crate) async fn pip_compile(
     }
 
     if include_marker_expression {
-        if let Some(markers) = markers.as_deref() {
+        if let ResolverMarkers::SpecificEnvironment(markers) = &markers {
             let relevant_markers = resolution.marker_tree(&top_level_index, markers)?;
             writeln!(
                 writer,
@@ -456,7 +459,7 @@ pub(crate) async fn pip_compile(
         "{}",
         DisplayResolutionGraph::new(
             &resolution,
-            markers.as_deref(),
+            &markers,
             &no_emit_packages,
             generate_hashes,
             include_extras,

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -25,7 +25,7 @@ use uv_python::{
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_resolver::{
     DependencyMode, ExcludeNewer, FlatIndex, OptionsBuilder, PreReleaseMode, PythonRequirement,
-    ResolutionMode,
+    ResolutionMode, ResolverMarkers,
 };
 use uv_types::{BuildIsolation, HashStrategy};
 
@@ -326,7 +326,7 @@ pub(crate) async fn pip_install(
         &reinstall,
         &upgrade,
         Some(&tags),
-        Some(&markers),
+        ResolverMarkers::SpecificEnvironment((*markers).clone()),
         python_requirement,
         &client,
         &flat_index,

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -342,8 +342,7 @@ pub(crate) async fn pip_install(
     {
         Ok(resolution) => Resolution::from(resolution),
         Err(operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(err))) => {
-            let report = miette::Report::msg(format!("{err}"))
-                .context("No solution found when resolving dependencies:");
+            let report = miette::Report::msg(format!("{err}")).context(err.header());
             eprint!("{report:?}");
             return Ok(ExitStatus::Failure);
         }

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -297,8 +297,7 @@ pub(crate) async fn pip_sync(
     {
         Ok(resolution) => Resolution::from(resolution),
         Err(operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(err))) => {
-            let report = miette::Report::msg(format!("{err}"))
-                .context("No solution found when resolving dependencies:");
+            let report = miette::Report::msg(format!("{err}")).context(err.header());
             eprint!("{report:?}");
             return Ok(ExitStatus::Failure);
         }

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -24,7 +24,7 @@ use uv_python::{
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_resolver::{
     DependencyMode, ExcludeNewer, FlatIndex, OptionsBuilder, PreReleaseMode, PythonRequirement,
-    ResolutionMode,
+    ResolutionMode, ResolverMarkers,
 };
 use uv_types::{BuildIsolation, HashStrategy};
 
@@ -281,7 +281,7 @@ pub(crate) async fn pip_sync(
         &reinstall,
         &upgrade,
         Some(&tags),
-        Some(&markers),
+        ResolverMarkers::SpecificEnvironment((*markers).clone()),
         python_requirement,
         &client,
         &flat_index,

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -83,8 +83,7 @@ pub(crate) async fn lock(
         Err(ProjectError::Operation(pip::operations::Error::Resolve(
             uv_resolver::ResolveError::NoSolution(err),
         ))) => {
-            let report = miette::Report::msg(format!("{err}"))
-                .context("No solution found when resolving dependencies:");
+            let report = miette::Report::msg(format!("{err}")).context(err.header());
             eprint!("{report:?}");
             Ok(ExitStatus::Failure)
         }

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -12,7 +12,9 @@ use uv_distribution::{Workspace, DEV_DEPENDENCIES};
 use uv_git::ResolvedRepositoryReference;
 use uv_python::{Interpreter, PythonFetch, PythonPreference, PythonRequest};
 use uv_requirements::upgrade::{read_lock_requirements, LockedRequirements};
-use uv_resolver::{FlatIndex, Lock, OptionsBuilder, PythonRequirement, RequiresPython};
+use uv_resolver::{
+    FlatIndex, Lock, OptionsBuilder, PythonRequirement, RequiresPython, ResolverMarkers,
+};
 use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
 use uv_warnings::{warn_user, warn_user_once};
 
@@ -268,7 +270,7 @@ pub(super) async fn do_lock(
                 &Reinstall::default(),
                 upgrade,
                 None,
-                None,
+                ResolverMarkers::Universal,
                 python_requirement.clone(),
                 &client,
                 &flat_index,
@@ -344,7 +346,7 @@ pub(super) async fn do_lock(
                 &Reinstall::default(),
                 upgrade,
                 None,
-                None,
+                ResolverMarkers::Universal,
                 python_requirement,
                 &client,
                 &flat_index,

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -21,7 +21,9 @@ use uv_python::{
     PythonInstallation, PythonPreference, PythonRequest, VersionRequest,
 };
 use uv_requirements::{NamedRequirementsResolver, RequirementsSpecification};
-use uv_resolver::{FlatIndex, OptionsBuilder, PythonRequirement, RequiresPython, ResolutionGraph};
+use uv_resolver::{
+    FlatIndex, OptionsBuilder, PythonRequirement, RequiresPython, ResolutionGraph, ResolverMarkers,
+};
 use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
 use uv_warnings::warn_user;
 
@@ -485,7 +487,7 @@ pub(crate) async fn resolve_environment<'a>(
         &reinstall,
         &upgrade,
         Some(tags),
-        Some(markers),
+        ResolverMarkers::SpecificEnvironment(markers.clone()),
         python_requirement,
         &client,
         &flat_index,
@@ -737,7 +739,7 @@ pub(crate) async fn update_environment(
         reinstall,
         upgrade,
         Some(tags),
-        Some(markers),
+        ResolverMarkers::SpecificEnvironment(markers.clone()),
         python_requirement,
         &client,
         &flat_index,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -92,8 +92,7 @@ pub(crate) async fn sync(
             Err(ProjectError::Operation(pip::operations::Error::Resolve(
                 uv_resolver::ResolveError::NoSolution(err),
             ))) => {
-                let report = miette::Report::msg(format!("{err}"))
-                    .context("No solution found when resolving dependencies:");
+                let report = miette::Report::msg(format!("{err}")).context(err.header());
                 anstream::eprint!("{report:?}");
                 return Ok(ExitStatus::Failure);
             }
@@ -133,8 +132,7 @@ pub(crate) async fn sync(
             Err(ProjectError::Operation(pip::operations::Error::Resolve(
                 uv_resolver::ResolveError::NoSolution(err),
             ))) => {
-                let report = miette::Report::msg(format!("{err}"))
-                    .context("No solution found when resolving dependencies:");
+                let report = miette::Report::msg(format!("{err}")).context(err.header());
                 anstream::eprint!("{report:?}");
                 return Ok(ExitStatus::Failure);
             }

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -362,7 +362,7 @@ fn conflict_in_fork() -> Result<()> {
 
     ----- stderr -----
     warning: `uv lock` is experimental and may change without warning.
-      × No solution found when resolving dependencies:
+      × No solution found when resolving dependencies for split (sys_platform == 'darwin'):
       ╰─▶ Because only package-b==1.0.0 is available and package-b==1.0.0 depends on package-d==1, we can conclude that all versions of package-b depend on package-d==1.
           And because package-c==1.0.0 depends on package-d==2 and only package-c==1.0.0 is available, we can conclude that all versions of package-b and all versions of package-c are incompatible.
           And because package-a{sys_platform == 'darwin'}==1.0.0 depends on package-b and package-c, we can conclude that package-a{sys_platform == 'darwin'}==1.0.0 cannot be used.

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -6872,7 +6872,7 @@ fn universal_requires_python() -> Result<()> {
 
     ----- stderr -----
     warning: The requested Python version 3.8 is not available; 3.12.[X] will be used to build dependencies instead.
-      × No solution found when resolving dependencies:
+      × No solution found when resolving dependencies for split (python_version >= '3.9'):
       ╰─▶ Because only the following versions of numpy{python_version >= '3.9'} are available:
               numpy{python_version >= '3.9'}<=1.26.0
               numpy{python_version >= '3.9'}==1.26.1


### PR DESCRIPTION
* Use a dedicated `ResolverMarkers` check in the fork state. This is better than the `MarkerTree::And(Vec::new())` check.
* Report the timing correct naming universal resolution instead of two spaces around an empty string when there are no markers.
* On resolution error, show the split that we're in. I'm not sure how to word this, since we're doing a universal resolution until we fork, so the trace may contain information from requirements that are not part of this fork.