### PR TITLE
uv-resolver: add TRACE dump of resolver output

### DIFF
--- a/crates/uv-normalize/src/package_name.rs
+++ b/crates/uv-normalize/src/package_name.rs
@@ -59,6 +59,11 @@ impl PackageName {
             Cow::Borrowed(self.0.as_str())
         }
     }
+
+    /// Returns the underlying package name.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 impl From<&Self> for PackageName {


### PR DESCRIPTION
Specifically, this shows the resolution produced by the
resolver *before* constructing a resolution graph.

Unlike most trace messages, this is a multi-line message
that needs to do some small amount of work to build
itself. So we do an explicit gating on the log level here
instead of just relying on the `trace!` macro itself.

I added this as part of debugging #5086, and it seemed
like a useful thing to keep around. It could be a little
noisy, which is why I put it under the TRACE level, but
its output should be about the same as, say, the output
of `uv pip compile`.
