### PR TITLE
pip compile: change order of check to handle exact argument first

### DIFF
--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -528,15 +528,16 @@ fn cmd(
 
             // Skip any `--find-links` URLs, unless requested.
             if !include_find_links {
-                if arg.starts_with("--find-links=") || arg.starts_with("-f") {
-                    // Reset state; skip this iteration.
-                    *skip_next = None;
+                // Always skip the `--find-links` and mark the next item to be skipped
+                if arg == "--find-links" || arg == "-f" {
+                    *skip_next = Some(true);
                     return Some(None);
                 }
 
-                // Mark the next item as (to be) skipped.
-                if arg == "--find-links" || arg == "-f" {
-                    *skip_next = Some(true);
+                // Skip only this argument if option and value are together
+                if arg.starts_with("--find-links=") || arg.starts_with("-f") {
+                    // Reset state; skip this iteration.
+                    *skip_next = None;
                     return Some(None);
                 }
             }
@@ -547,16 +548,16 @@ fn cmd(
                 return Some(None);
             }
 
-            // Always skip the `--upgrade-package` flag
-            if arg.starts_with("--upgrade-package=") || arg.starts_with("-P") {
-                // Reset state; skip this iteration.
-                *skip_next = None;
+            // Always skip the `--upgrade-package` and mark the next item to be skipped
+            if arg == "--upgrade-package" || arg == "-P" {
+                *skip_next = Some(true);
                 return Some(None);
             }
 
-            // Mark the next item as (to be) skipped.
-            if arg == "--upgrade-package" || arg == "-P" {
-                *skip_next = Some(true);
+            // Skip only this argument if option and value are together
+            if arg.starts_with("--upgrade-package=") || arg.starts_with("-P") {
+                // Reset state; skip this iteration.
+                *skip_next = None;
                 return Some(None);
             }
 

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -4807,7 +4807,7 @@ fn upgrade_constraint() -> Result<()> {
             .arg("requirements.in")
             .arg("--output-file")
             .arg("requirements.txt")
-            .arg("--upgrade-package")
+            .arg("-P")
             .arg("iniconfig"), @r###"
     success: true
     exit_code: 0


### PR DESCRIPTION
I messed up the order of checks in #5033, due to which it failed to exclude the case of `-P package`, as `arg.startswith("-P")` check came first and skipped only the first argument.

That means that, in the following command:
```console
uv pip compile --output-file pip_compile_uv_header.txt unpinned_uv.in -P attrs==18.1.0
```

The generated header would exclude `-P`, but keep `attrs==18.1.0`.

```plaintext
# This file was autogenerated by uv via the following command:
#    uv pip compile --output-file pip_compile_uv_header.txt unpinned_uv.in attrs==18.1.0
```

But we want to check for an exact match first and then only check for the case when option and value are together.

This also affected `--find-links` short option of style `-f <uri>`.


Hopefully, third times going to be a charm. 😳 


<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

I tested locally, and also changed one snapshot test to use `-P` for variation. I don't think it's worth an extra test, but can do that for sure.

