### PR TITLE
Document that `--universal` implies `--no-strip-markers`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -682,7 +682,7 @@ pub struct PipCompileArgs {
 
     /// Perform a universal resolution, attempting to generate a single `requirements.txt` output
     /// file that is compatible with all operating systems, architectures, and Python
-    /// implementations.
+    /// implementations. Implies `--no-strip-markers`.
     ///
     /// In universal mode, the current Python version (or user-provided `--python-version`) will be
     /// treated as a lower bound. For example, `--universal --python-version 3.7` would produce a

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -682,15 +682,18 @@ pub struct PipCompileArgs {
 
     /// Perform a universal resolution, attempting to generate a single `requirements.txt` output
     /// file that is compatible with all operating systems, architectures, and Python
-    /// implementations. Implies `--no-strip-markers`.
+    /// implementations.
     ///
     /// In universal mode, the current Python version (or user-provided `--python-version`) will be
     /// treated as a lower bound. For example, `--universal --python-version 3.7` would produce a
     /// universal resolution for Python 3.7 and later.
+    ///
+    /// Using this option implies `--no-strip-markers`.
     #[arg(
         long,
         overrides_with("no_universal"),
-        conflicts_with("python_platform")
+        conflicts_with("python_platform"),
+        conflicts_with("strip_markers")
     )]
     pub universal: bool,
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -688,7 +688,7 @@ pub struct PipCompileArgs {
     /// treated as a lower bound. For example, `--universal --python-version 3.7` would produce a
     /// universal resolution for Python 3.7 and later.
     ///
-    /// Using this option implies `--no-strip-markers`.
+    /// Implies `--no-strip-markers`.
     #[arg(
         long,
         overrides_with("no_universal"),


### PR DESCRIPTION
Prompted by https://github.com/python-trio/trio/pull/3032#discussion_r1679435422.

Should this go in the summary description or the extended description?