### PR TITLE
Separate the TOC from the navigation bar

### DIFF
--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -9,7 +9,6 @@ theme:
     - navigation.expand
     - navigation.tracking
     - content.code.annotate
-    - toc.integrate
     - toc.follow
     - navigation.path
     - navigation.top


### PR DESCRIPTION
Starting a discussion.

I find the navigation bar too long and verbose, it's overwhelming. I think we either need to either:

- Limit the depth of the navigation bar (i.e. via `toc_depth: 2`)
- Move the table of contents out of the navigation bar over to the right side

I prefer the second, though I think we ought to do some styling to improve the aesthetics.