### PR TITLE
docs: update dev dependencies

### DIFF
--- a/docs/preview/dependencies.md
+++ b/docs/preview/dependencies.md
@@ -157,21 +157,6 @@ dev-dependencies = [
 ]
 ```
 
-You can also put development dependencies into groups and install them individually:
-
-```toml
-[tool.uv.dev-dependencies]
-test = [
-  "pytest >=8.1.1,<9"
-]
-lint = [
-  "mypy >=1,<2"
-]
-
-[tool.uv]
-default-dev-dependencies = ["test"]
-```
-
 ## PEP 508
 
 The [PEP 508](https://peps.python.org/pep-0508/) syntax allows you to specify, in order:

--- a/docs/preview/dependencies.md
+++ b/docs/preview/dependencies.md
@@ -146,8 +146,6 @@ excel = [
 
 ## Development dependencies
 
-_N.B. This feature is not yet implemented._
-
 Unlike optional dependencies, development dependencies are local-only and will _not_ be published
 to PyPI or other indexes. As such, development dependencies are included under `[tool.uv]` instead
 of `[project]`. `tool.uv.sources` applies to them equally.


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

While playing out with `uv` preview features, I've noticed 2 issues with the development dependencies documentation:
- it is mentioned that the feature is not implemented, but it looks like it actually is
- despite what is said, it doesn't seem that it's possible to use a map for development dependencies yet:
  ```toml
  [tool.uv.dev-dependencies]
  test = [
      "pytest >=8.1.1,<9"
  ]
  lint = [
      "mypy >=1,<2"
  ]

  [tool.uv]
  default-dev-dependencies = ["test"]
  ```

  ```console
  $ uv sync --preview
  error: Failed to parse: `pyproject.toml`
    Caused by: TOML parse error at line 32, column 1
     |
  32 | [tool.uv.dev-dependencies]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^
  invalid type: map, expected a sequence
  ```