### PR TITLE
Sort `ManagedPythonInstallation` by version

### DIFF
--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -345,8 +345,14 @@ impl PartialOrd for PythonInstallationKey {
         Some(self.cmp(other))
     }
 }
+
 impl Ord for PythonInstallationKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.to_string().cmp(&other.to_string())
+        self.implementation
+            .cmp(&other.implementation)
+            .then_with(|| other.version().cmp(&self.version()))
+            .then_with(|| self.os.to_string().cmp(&other.os.to_string()))
+            .then_with(|| self.arch.to_string().cmp(&other.arch.to_string()))
+            .then_with(|| self.libc.to_string().cmp(&other.libc.to_string()))
     }
 }


### PR DESCRIPTION
## Summary
Resolves #5139

`PythonInstallationKey` was sorted as a string, which caused `3.8` to appear before `3.11`. This update changes the sorting of `PythonInstallationKey` to be a descending order by version.

## Test Plan
```sh
$ cargo run -- python install 3.8 3.12
$ cargo run -- tool run -v python -V
DEBUG uv 0.2.25
warning: `uv tool run` is experimental and may change without warning.
DEBUG Searching for Python interpreter in managed installations, system path, or `py` launcher
DEBUG Searching for managed installations at `C:\Users\xx\AppData\Roaming\uv\data\python`
DEBUG Found managed Python `cpython-3.12.3-windows-x86_64-none`
DEBUG Found cpython 3.12.3 at `C:\Users\xx\AppData\Roaming\uv\data\python\cpython-3.12.3-windows-x86_64-none\install\python.exe` (managed installations)
DEBUG Using request timeout of 30s
DEBUG Using request timeout of 30s
DEBUG Acquired lock for `C:\Users\nigel\AppData\Roaming\uv\data\tools`
DEBUG Using existing environment for tool `httpx`: C:\Users\xx\AppData\Roaming\uv\data\tools\httpx
DEBUG Using existing tool `httpx`
DEBUG Running `httpx -v`
```
