### PR TITLE
Add GraalPy support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,7 +712,9 @@ jobs:
         run: chmod +x ./uv
 
       - name: Graalpy info
-        run: which graalpy
+        run: |
+          which graalpy
+          echo "GRAAL_PYTHONHOME=$(graalpy -c 'print(__graalpython__.home)')" >> $GITHUB_ENV
 
       - name: "Create a virtual environment"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -692,6 +692,135 @@ jobs:
         run: |
           .\uv.exe pip install anyio
 
+  integration-test-graalpy-linux:
+    needs: build-binary-linux
+    name: "integration test | graalpy on ubuntu"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "graalpy24.0"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-linux-${{ github.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: Graalpy info
+        run: which graalpy
+
+      - name: "Create a virtual environment"
+        run: |
+          ./uv venv -p $(which graalpy)
+
+      - name: "Check for executables"
+        run: |
+          check_in_bin() {
+              local executable_name=$1
+              local bin_path=".venv/bin"
+
+              if [[ -x "$bin_path/$executable_name" ]]; then
+                  return 0
+              else
+                  echo "Executable '$executable_name' not found in folder '$bin_path'."
+                  return 1
+              fi
+          }
+
+          executables=("graalpy" "python3" "python")
+
+          all_found=true
+          for executable_name in "${executables[@]}"; do
+              check_in_bin "$executable_name" "$folder_path"
+              result=$?
+
+              if [[ $result -ne 0 ]]; then
+                  all_found=false
+              fi
+          done
+
+          if ! $all_found; then
+            echo "One or more expected executables were not found."
+            exit 1
+          fi
+
+      - name: "Check version"
+        run: |
+          .venv/bin/graalpy --version
+          .venv/bin/python3 --version
+          .venv/bin/python --version
+
+      - name: "Check install"
+        run: |
+          ./uv pip install anyio
+
+  integration-test-graalpy-windows:
+    needs: build-binary-windows
+    name: "integration test | graalpy on windows"
+    runs-on: windows-latest
+
+    steps:
+      - uses: timfel/setup-python@fc9bcb4a04f5b1ea7d678c2ca7ea1c479a2468d7
+        with:
+          python-version: "graalpy24.0"
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-windows-${{ github.sha }}
+
+      - name: Graalpy info
+        run: Get-Command graalpy
+
+      - name: "Create a virtual environment"
+        run: |
+          $graalpy = (Get-Command graalpy).source
+          .\uv.exe venv -p $graalpy
+
+      - name: "Check for executables"
+        shell: python
+        run: |
+          import sys
+          from pathlib import Path
+
+          def binary_exist(binary):
+            binaries_path = Path(".venv\\Scripts")
+            if (binaries_path / binary).exists():
+              return True
+            print(f"Executable '{binary}' not found in folder '{binaries_path}'.")
+
+          all_found = True
+          expected_binaries = [
+              "graalpy.exe",
+              "python.exe",
+              "python3.exe",
+          ]
+          for binary in expected_binaries:
+            if not binary_exist(binary):
+              all_found = False
+
+          if not all_found:
+            print("One or more expected executables were not found.")
+            sys.exit(1)
+
+      - name: "Check version"
+        run: |
+          & .venv\Scripts\graalpy.exe --version
+          & .venv\Scripts\python3.exe --version
+          & .venv\Scripts\python.exe --version
+
+      - name: "Check install"
+        env:
+          # Avoid debug build stack overflows.
+          UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
+        run: |
+          .\uv.exe pip install anyio
+
   integration-test-github-actions:
     needs: build-binary-linux
     name: "integration test | github actions"

--- a/crates/platform-tags/src/tags.rs
+++ b/crates/platform-tags/src/tags.rs
@@ -298,6 +298,7 @@ impl std::fmt::Display for Tags {
 enum Implementation {
     CPython { gil_disabled: bool },
     PyPy,
+    GraalPy,
     Pyston,
 }
 
@@ -310,6 +311,8 @@ impl Implementation {
             Self::CPython { .. } => format!("cp{}{}", python_version.0, python_version.1),
             // Ex) `pp39`
             Self::PyPy => format!("pp{}{}", python_version.0, python_version.1),
+            // Ex) `graalpy310`
+            Self::GraalPy => format!("graalpy{}{}", python_version.0, python_version.1),
             // Ex) `pt38``
             Self::Pyston => format!("pt{}{}", python_version.0, python_version.1),
         }
@@ -342,6 +345,16 @@ impl Implementation {
                 implementation_version.0,
                 implementation_version.1
             ),
+            // Ex) `graalpy310_graalpy240_310_native
+            Self::GraalPy => format!(
+                "graalpy{}{}_graalpy{}{}_{}{}_native",
+                python_version.0,
+                python_version.1,
+                implementation_version.0,
+                implementation_version.1,
+                python_version.0,
+                python_version.1
+            ),
             // Ex) `pyston38-pyston_23`
             Self::Pyston => format!(
                 "pyston{}{}-pyston_{}{}",
@@ -361,6 +374,7 @@ impl Implementation {
             // Known and supported implementations.
             "cpython" => Ok(Self::CPython { gil_disabled }),
             "pypy" => Ok(Self::PyPy),
+            "graalpy" => Ok(Self::GraalPy),
             "pyston" => Ok(Self::Pyston),
             // Known but unsupported implementations.
             "python" => Err(TagsError::UnsupportedImplementation(name.to_string())),

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1641,6 +1641,14 @@ mod tests {
             PythonRequest::Implementation(ImplementationName::PyPy)
         );
         assert_eq!(
+            PythonRequest::parse("graalpy"),
+            PythonRequest::Implementation(ImplementationName::GraalPy)
+        );
+        assert_eq!(
+            PythonRequest::parse("gp"),
+            PythonRequest::Implementation(ImplementationName::GraalPy)
+        );
+        assert_eq!(
             PythonRequest::parse("cp"),
             PythonRequest::Implementation(ImplementationName::CPython)
         );
@@ -1655,6 +1663,20 @@ mod tests {
             PythonRequest::parse("pp310"),
             PythonRequest::ImplementationVersion(
                 ImplementationName::PyPy,
+                VersionRequest::from_str("3.10").unwrap()
+            )
+        );
+        assert_eq!(
+            PythonRequest::parse("graalpy3.10"),
+            PythonRequest::ImplementationVersion(
+                ImplementationName::GraalPy,
+                VersionRequest::from_str("3.10").unwrap()
+            )
+        );
+        assert_eq!(
+            PythonRequest::parse("gp310"),
+            PythonRequest::ImplementationVersion(
+                ImplementationName::GraalPy,
                 VersionRequest::from_str("3.10").unwrap()
             )
         );
@@ -1676,6 +1698,20 @@ mod tests {
             PythonRequest::parse("pypy310"),
             PythonRequest::ImplementationVersion(
                 ImplementationName::PyPy,
+                VersionRequest::from_str("3.10").unwrap()
+            )
+        );
+        assert_eq!(
+            PythonRequest::parse("graalpy@3.10"),
+            PythonRequest::ImplementationVersion(
+                ImplementationName::GraalPy,
+                VersionRequest::from_str("3.10").unwrap()
+            )
+        );
+        assert_eq!(
+            PythonRequest::parse("graalpy310"),
+            PythonRequest::ImplementationVersion(
+                ImplementationName::GraalPy,
                 VersionRequest::from_str("3.10").unwrap()
             )
         );
@@ -1748,6 +1784,18 @@ mod tests {
             )
             .to_canonical_string(),
             "pypy@3.10"
+        );
+        assert_eq!(
+            PythonRequest::Implementation(ImplementationName::GraalPy).to_canonical_string(),
+            "graalpy"
+        );
+        assert_eq!(
+            PythonRequest::ImplementationVersion(
+                ImplementationName::GraalPy,
+                VersionRequest::from_str("3.10").unwrap()
+            )
+            .to_canonical_string(),
+            "graalpy@3.10"
         );
 
         let tempdir = TempDir::new().unwrap();

--- a/crates/uv-python/src/implementation.rs
+++ b/crates/uv-python/src/implementation.rs
@@ -15,6 +15,7 @@ pub enum ImplementationName {
     #[default]
     CPython,
     PyPy,
+    GraalPy,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
@@ -25,13 +26,14 @@ pub enum LenientImplementationName {
 
 impl ImplementationName {
     pub(crate) fn possible_names() -> impl Iterator<Item = &'static str> {
-        ["cpython", "pypy", "cp", "pp"].into_iter()
+        ["cpython", "pypy", "graalpy", "cp", "pp", "gp"].into_iter()
     }
 
     pub fn pretty(self) -> &'static str {
         match self {
             Self::CPython => "CPython",
             Self::PyPy => "PyPy",
+            Self::GraalPy => "GraalPy",
         }
     }
 }
@@ -50,6 +52,7 @@ impl From<&ImplementationName> for &'static str {
         match v {
             ImplementationName::CPython => "cpython",
             ImplementationName::PyPy => "pypy",
+            ImplementationName::GraalPy => "graalpy",
         }
     }
 }
@@ -73,6 +76,7 @@ impl FromStr for ImplementationName {
         match s.to_ascii_lowercase().as_str() {
             "cpython" | "cp" => Ok(Self::CPython),
             "pypy" | "pp" => Ok(Self::PyPy),
+            "graalpy" | "gp" => Ok(Self::GraalPy),
             _ => Err(Error::UnknownImplementation(s.to_string())),
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Currently, `uv` refuses to install anything on GraalPy. This is currently blocking GraalPy testing with cibuildwheel, since manylinux includes both `uv` and `graalpy` (but doesn't test with `uv`), whereas cibuildwheel defaults to `uv`. See e.g. https://github.com/pypa/cibuildwheel/actions/runs/9956369360/job/27506182952?pr=1538 where it gives
```
      + python -m build /project/sample_proj --wheel --outdir=/tmp/cibuildwheel/built_wheel --installer=uv
  * Creating isolated environment: venv+uv...
  * Using external uv from /usr/local/bin/uv
  * Installing packages in isolated environment:
    - setuptools >= 40.8.0
  > /usr/local/bin/uv pip install "setuptools >= 40.8.0"
  < error: Unknown implementation: `graalpy`
```

## Test Plan

I simply based the GraalPy support on PyPy and added some small tests. I'm open to discussing how to test this. GraalPy is available for manylinux images and with setup-python, so we should be able to add tests against it to the CI. I locally confirmed by installing `uv` into a GraalPy venv and then trying things like `uv pip install Pillow` and testing those extensions.
