### PR TITLE
Search for all `python3.x` in PATH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5361,6 +5361,7 @@ checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
 dependencies = [
  "either",
  "home",
+ "regex",
  "rustix",
  "winsafe",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4942,6 +4942,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "rmp-serde",
+ "rustix",
  "same-file",
  "schemars",
  "serde",
@@ -4964,6 +4965,7 @@ dependencies = [
  "uv-warnings",
  "which",
  "winapi",
+ "winsafe 0.0.21",
 ]
 
 [[package]]
@@ -5363,7 +5365,7 @@ dependencies = [
  "home",
  "regex",
  "rustix",
- "winsafe",
+ "winsafe 0.0.19",
 ]
 
 [[package]]
@@ -5673,6 +5675,12 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "winsafe"
+version = "0.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c4afa7176f9fadc45817419f5fe481b9e8b90299c62af90e8c19486d0320274"
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ rkyv = { version = "0.7.43", features = ["strict", "validation"] }
 rmp-serde = { version = "1.1.2" }
 rust-netrc = { version = "0.1.1" }
 rustc-hash = { version = "2.0.0" }
+rustix = { version = "0.38.34", default-features = false, features = ["fs", "std"] }
 same-file = { version = "1.0.6" }
 schemars = { version = "0.8.16", features = ["url"] }
 seahash = { version = "4.1.0" }
@@ -154,6 +155,7 @@ walkdir = { version = "2.5.0" }
 which = { version = "6.0.0", features = ["regex"] }
 winapi = { version = "0.3.9", features = ["fileapi", "handleapi", "ioapiset", "winbase", "winioctl", "winnt"] }
 winreg = { version = "0.52.0" }
+winsafe = { version = "0.0.21", features = ["kernel"] }
 wiremock = { version = "0.6.0" }
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ unscanny = { version = "0.1.0" }
 url = { version = "2.5.0" }
 urlencoding = { version = "2.1.3" }
 walkdir = { version = "2.5.0" }
-which = { version = "6.0.0" }
+which = { version = "6.0.0", features = ["regex"] }
 winapi = { version = "0.3.9", features = ["fileapi", "handleapi", "ioapiset", "winbase", "winioctl", "winnt"] }
 winreg = { version = "0.52.0" }
 wiremock = { version = "0.6.0" }

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -38,7 +38,6 @@ regex = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
-rustix = { workspace = true }
 same-file = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
@@ -51,6 +50,9 @@ tokio-util = { workspace = true, features = ["compat"] }
 tracing = { workspace = true }
 url = { workspace = true }
 which = { workspace = true }
+
+[target.'cfg(any(unix, target_os = "wasi", target_os = "redox"))'.dependencies]
+rustix = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { workspace = true }

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -38,6 +38,7 @@ regex = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
+rustix = { workspace = true }
 same-file = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
@@ -53,6 +54,7 @@ which = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { workspace = true }
+winsafe = { workspace = true }
 
 [dev-dependencies]
 anyhow = { version = "1.0.80" }

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1,6 +1,5 @@
 use itertools::{Either, Itertools};
 use regex::Regex;
-use rustix::path::Arg;
 use same_file::is_same_file;
 use std::borrow::Cow;
 use std::env::consts::EXE_SUFFIX;
@@ -449,7 +448,7 @@ fn find_all_minor(
                     let Some(filename) = path.file_name() else {
                         return false;
                     };
-                    let Some(filename) = filename.as_str().ok() else {
+                    let Some(filename) = filename.to_str() else {
                         return false;
                     };
                     let Some(captures) = regex.captures(filename) else {

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -1753,6 +1753,32 @@ mod tests {
     }
 
     #[test]
+    fn find_python_all_minors() -> Result<()> {
+        let mut context = TestContext::new()?;
+        context.add_python_interpreters(&[
+            (true, ImplementationName::CPython, "python", "3.10.0"),
+            (true, ImplementationName::CPython, "python3", "3.10.0"),
+            (true, ImplementationName::CPython, "python3.12", "3.12.0"),
+        ])?;
+
+        let python = context.run(|| {
+            find_python_installation(
+                &PythonRequest::parse(">= 3.11"),
+                EnvironmentPreference::Any,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        })??;
+        assert_eq!(
+            python.interpreter().python_full_version().to_string(),
+            "3.12.0",
+            "We should find matching minor version even if they aren't called `python` or `python3`"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn find_python_pypy_prefers_executable_with_implementation_name() -> Result<()> {
         let mut context = TestContext::new()?;
 

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -33,6 +33,7 @@ mod python_version;
 mod target;
 mod version_files;
 mod virtualenv;
+mod which;
 
 #[cfg(not(test))]
 pub(crate) fn current_dir() -> Result<std::path::PathBuf, std::io::Error> {


### PR DESCRIPTION
Search for all `python3.x` minor versions in PATH, skipping those we already know we can use.

For example, let's say `python` and `python3` are Python 3.10. When a user requests `>= 3.11`, we still need to find a `python3.12` in PATH. We do so with a regex matcher.

Fixes #4709
