### PR TITLE
Skip invalid tools in `uv tool list`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5139,7 +5139,6 @@ dependencies = [
  "uv-python",
  "uv-state",
  "uv-virtualenv",
- "uv-warnings",
 ]
 
 [[package]]

--- a/crates/uv-tool/Cargo.toml
+++ b/crates/uv-tool/Cargo.toml
@@ -22,7 +22,6 @@ uv-fs = { workspace = true }
 uv-state = { workspace = true }
 uv-python = { workspace = true }
 uv-virtualenv = { workspace = true }
-uv-warnings = { workspace = true }
 uv-installer = { workspace = true }
 
 dirs-sys = { workspace = true }

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -7,7 +7,7 @@ use uv_cache::Cache;
 use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_tool::InstalledTools;
-use uv_warnings::warn_user_once;
+use uv_warnings::{warn_user, warn_user_once};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -42,6 +42,15 @@ pub(crate) async fn list(
     }
 
     for (name, tool) in tools {
+        // Skip invalid tools
+        let Ok(tool) = tool else {
+            warn_user!(
+                "Ignoring malformed tool `{name}` (run `{}` to remove)",
+                format!("uv tool uninstall {name}").green()
+            );
+            continue;
+        };
+
         // Output tool name and version
         let version = match installed_tools.version(&name, cache) {
             Ok(version) => version,

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -61,6 +61,25 @@ pub(crate) async fn uninstall(
     } else {
         let mut entrypoints = vec![];
         for (name, receipt) in installed_tools.tools()? {
+            let Ok(receipt) = receipt else {
+                // If the tool is not installed properly, attempt to remove the environment anyway.
+                match installed_tools.remove_environment(&name) {
+                    Ok(()) => {
+                        writeln!(
+                            printer.stderr(),
+                            "Removed dangling environment for `{name}`"
+                        )?;
+                        continue;
+                    }
+                    Err(uv_tool::Error::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => {
+                        bail!("`{name}` is not installed");
+                    }
+                    Err(err) => {
+                        return Err(err.into());
+                    }
+                }
+            };
+
             entrypoints.extend(uninstall_tool(&name, &receipt, &installed_tools).await?);
         }
         entrypoints

--- a/crates/uv/tests/tool_list.rs
+++ b/crates/uv/tests/tool_list.rs
@@ -114,8 +114,7 @@ fn tool_list_missing_receipt() {
 
     ----- stderr -----
     warning: `uv tool list` is experimental and may change without warning.
-    warning: Ignoring malformed tool `black`: missing receipt
-    No tools installed
+    warning: Ignoring malformed tool `black` (run `uv tool uninstall black` to remove)
     "###);
 }
 


### PR DESCRIPTION
## Summary

Makes the `tools()` return value include per-tool errors. This makes it easy to skip (rather than failing) in `uv tool list`, _and_ improves `uv tool uninstall` to remove those invalid tools, rather than leaving them around. (We already had that behavior for `uv tool uninstall ruff` with an invalid `ruff`, but `uv tool uninstall --all` just left them.)

Closes https://github.com/astral-sh/uv/issues/5151.
