### PR TITLE
Added a way to inspect installation scripts on Powershell(Windows)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,6 +24,10 @@ uv is installed to `~/.cargo/bin`.
     curl -LsSf https://astral.sh/uv/install.sh | less
     ```
 
+    On Windows
+    ```powershell
+    powershell -c "irm https://astral.sh/uv/install.ps1 | more"
+    ```
     Alternatively, the installer or binaries can be downloaded directly from [GitHub](#github-releases).
 
 A specific release can be requested by including the version in the URL:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,13 +21,13 @@ uv is installed to `~/.cargo/bin`.
     The installation script may be inspected with:
 
     ```bash
+    # On macOS and Linux.
     curl -LsSf https://astral.sh/uv/install.sh | less
-    ```
 
-    On Windows
-    ```powershell
+    # On Windows.
     powershell -c "irm https://astral.sh/uv/install.ps1 | more"
     ```
+
     Alternatively, the installer or binaries can be downloaded directly from [GitHub](#github-releases).
 
 A specific release can be requested by including the version in the URL:


### PR DESCRIPTION
## Summary
### command
 ```powershell
    powershell -c "irm https://astral.sh/uv/install.ps1 | more"
 ```
Add a method to inspect installation script files that works on Windows, it may not work on other platforms supported by PowerShell. <br>
Other platforms information:
[PowerShell differences on non-Windows platforms / General Unix interoperability changes](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/unix-support?view=powershell-7.4#general-unix-interoperability-changes)
[Differences between Windows PowerShell 5.1 and PowerShell 7.x / Removal of the more function](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/differences-from-windows-powershell?view=powershell-7.4#removal-of-the-more-function)
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
**terminal**
* Powershell Version: 5.1.22621.3880 (Windows)
![image](https://github.com/user-attachments/assets/418c10a4-f672-4c79-9d3b-7c58822316dd)
* Powershell Version: 7.4.3 (Windows)
![image](https://github.com/user-attachments/assets/9ee73310-a244-4320-a092-df8c6f0745c5)

## Result (Website)
![image](https://github.com/user-attachments/assets/3faede7d-4004-4e2c-b35a-80147532019b)

