### PR TITLE
Make registry hashes optional in the lockfile

### DIFF
--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
@@ -36,7 +36,14 @@ Ok(
                         url: UrlString(
                             "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl",
                         ),
-                        hash: None,
+                        hash: Some(
+                            Hash(
+                                HashDigest {
+                                    algorithm: Sha256,
+                                    digest: "048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8",
+                                },
+                            ),
+                        ),
                         size: None,
                         filename: WheelFilename {
                             name: PackageName(

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_required_present.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_required_present.snap
@@ -2,15 +2,69 @@
 source: crates/uv-resolver/src/lock.rs
 expression: result
 ---
-Err(
-    Error {
-        inner: Error {
-            inner: TomlError {
-                message: "since the distribution `anyio==4.3.0 @ registry+https://pypi.org/simple` comes from a registry dependency, a hash was expected but one was not found for wheel",
-                raw: None,
-                keys: [],
-                span: None,
+Ok(
+    Lock {
+        version: 1,
+        distributions: [
+            Distribution {
+                id: DistributionId {
+                    name: PackageName(
+                        "anyio",
+                    ),
+                    version: "4.3.0",
+                    source: Path(
+                        "file:///foo/bar",
+                    ),
+                },
+                sdist: None,
+                wheels: [
+                    Wheel {
+                        url: UrlString(
+                            "file:///foo/bar/anyio-4.3.0-py3-none-any.whl",
+                        ),
+                        hash: Some(
+                            Hash(
+                                HashDigest {
+                                    algorithm: Sha256,
+                                    digest: "048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8",
+                                },
+                            ),
+                        ),
+                        size: None,
+                        filename: WheelFilename {
+                            name: PackageName(
+                                "anyio",
+                            ),
+                            version: "4.3.0",
+                            build_tag: None,
+                            python_tag: [
+                                "py3",
+                            ],
+                            abi_tag: [
+                                "none",
+                            ],
+                            platform_tag: [
+                                "any",
+                            ],
+                        },
+                    },
+                ],
+                dependencies: [],
+                optional_dependencies: {},
+                dev_dependencies: {},
             },
+        ],
+        requires_python: None,
+        by_id: {
+            DistributionId {
+                name: PackageName(
+                    "anyio",
+                ),
+                version: "4.3.0",
+                source: Path(
+                    "file:///foo/bar",
+                ),
+            }: 0,
         },
     },
 )

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
@@ -48,11 +48,13 @@ Ok(
                             fragment: None,
                         },
                         metadata: SourceDistMetadata {
-                            hash: Hash(
-                                HashDigest {
-                                    algorithm: Sha256,
-                                    digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
-                                },
+                            hash: Some(
+                                Hash(
+                                    HashDigest {
+                                        algorithm: Sha256,
+                                        digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                                    },
+                                ),
                             ),
                             size: Some(
                                 0,
@@ -107,11 +109,13 @@ Ok(
                             fragment: None,
                         },
                         metadata: SourceDistMetadata {
-                            hash: Hash(
-                                HashDigest {
-                                    algorithm: Sha256,
-                                    digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
-                                },
+                            hash: Some(
+                                Hash(
+                                    HashDigest {
+                                        algorithm: Sha256,
+                                        digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                                    },
+                                ),
                             ),
                             size: Some(
                                 0,

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
@@ -48,11 +48,13 @@ Ok(
                             fragment: None,
                         },
                         metadata: SourceDistMetadata {
-                            hash: Hash(
-                                HashDigest {
-                                    algorithm: Sha256,
-                                    digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
-                                },
+                            hash: Some(
+                                Hash(
+                                    HashDigest {
+                                        algorithm: Sha256,
+                                        digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                                    },
+                                ),
                             ),
                             size: Some(
                                 0,
@@ -107,11 +109,13 @@ Ok(
                             fragment: None,
                         },
                         metadata: SourceDistMetadata {
-                            hash: Hash(
-                                HashDigest {
-                                    algorithm: Sha256,
-                                    digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
-                                },
+                            hash: Some(
+                                Hash(
+                                    HashDigest {
+                                        algorithm: Sha256,
+                                        digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                                    },
+                                ),
                             ),
                             size: Some(
                                 0,

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
@@ -48,11 +48,13 @@ Ok(
                             fragment: None,
                         },
                         metadata: SourceDistMetadata {
-                            hash: Hash(
-                                HashDigest {
-                                    algorithm: Sha256,
-                                    digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
-                                },
+                            hash: Some(
+                                Hash(
+                                    HashDigest {
+                                        algorithm: Sha256,
+                                        digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                                    },
+                                ),
                             ),
                             size: Some(
                                 0,
@@ -107,11 +109,13 @@ Ok(
                             fragment: None,
                         },
                         metadata: SourceDistMetadata {
-                            hash: Hash(
-                                HashDigest {
-                                    algorithm: Sha256,
-                                    digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
-                                },
+                            hash: Some(
+                                Hash(
+                                    HashDigest {
+                                        algorithm: Sha256,
+                                        digest: "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                                    },
+                                ),
                             ),
                             size: Some(
                                 0,


### PR DESCRIPTION
## Summary

If a registry doesn't include hashes, then we won't include them in the lockfile either.

Part of: https://github.com/astral-sh/uv/issues/4924.

Closes: https://github.com/astral-sh/uv/issues/5120.
