### PR TITLE
Use the strongest hash in the lockfile

### DIFF
--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -1736,7 +1736,7 @@ impl SourceDist {
             .to_url()
             .map_err(LockErrorKind::InvalidFileUrl)
             .map_err(LockError::from)?;
-        let hash = reg_dist.file.hashes.first().cloned().map(Hash::from);
+        let hash = reg_dist.file.hashes.iter().max().cloned().map(Hash::from);
         let size = reg_dist.file.size;
         Ok(SourceDist::Url {
             url,
@@ -1749,7 +1749,7 @@ impl SourceDist {
         direct_dist: &DirectUrlSourceDist,
         hashes: &[HashDigest],
     ) -> Result<SourceDist, LockError> {
-        let Some(hash) = hashes.first().cloned().map(Hash::from) else {
+        let Some(hash) = hashes.iter().max().cloned().map(Hash::from) else {
             let kind = LockErrorKind::Hash {
                 id: id.clone(),
                 artifact_type: "direct URL source distribution",
@@ -1920,7 +1920,7 @@ impl Wheel {
             .to_url_string()
             .map_err(LockErrorKind::InvalidFileUrl)
             .map_err(LockError::from)?;
-        let hash = wheel.file.hashes.first().cloned().map(Hash::from);
+        let hash = wheel.file.hashes.iter().max().cloned().map(Hash::from);
         let size = wheel.file.size;
         Ok(Wheel {
             url,
@@ -1933,7 +1933,7 @@ impl Wheel {
     fn from_direct_dist(direct_dist: &DirectUrlBuiltDist, hashes: &[HashDigest]) -> Wheel {
         Wheel {
             url: direct_dist.url.to_url().into(),
-            hash: hashes.first().cloned().map(Hash::from),
+            hash: hashes.iter().max().cloned().map(Hash::from),
             size: None,
             filename: direct_dist.filename.clone(),
         }
@@ -1942,7 +1942,7 @@ impl Wheel {
     fn from_path_dist(path_dist: &PathBuiltDist, hashes: &[HashDigest]) -> Wheel {
         Wheel {
             url: path_dist.url.to_url().into(),
-            hash: hashes.first().cloned().map(Hash::from),
+            hash: hashes.iter().max().cloned().map(Hash::from),
             size: None,
             filename: path_dist.filename.clone(),
         }


### PR DESCRIPTION
## Summary

We only need to store one hash -- it should be the "strongest" hash. In practice, most registries (like PyPI) only serve one, and we only compute a SHA256 hash for direct URLs.

Part of: https://github.com/astral-sh/uv/issues/4924

## Test Plan

I verified that changing:

```diff
diff --git a/crates/distribution-types/src/hash.rs b/crates/distribution-types/src/hash.rs
index 553a74f55..d36c62286 100644
--- a/crates/distribution-types/src/hash.rs
+++ b/crates/distribution-types/src/hash.rs
@@ -31,7 +31,7 @@ impl<'a> HashPolicy<'a> {
     pub fn algorithms(&self) -> Vec<HashAlgorithm> {
         match self {
             Self::None => vec![],
-            Self::Generate => vec![HashAlgorithm::Sha256],
+            Self::Generate => vec![HashAlgorithm::Sha256, HashAlgorithm::Sha512],
             Self::Validate(hashes) => {
                 let mut algorithms = hashes.iter().map(HashDigest::algorithm).collect::<Vec<_>>();
                 algorithms.sort();
```

Then running `uv lock` with a URL gave me:

```toml
[[distribution]]
name = "iniconfig"
version = "2.0.0"
source = { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" }
wheels = [
    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha512:44cc53a6c8dd7cf4d6d52bded308bcc4b4f85fff2ed081f60f7d4beaa86a7cde6d099e3976331232d4cbd472ad5d1781064725b0999c7cd3a2a4d42df687ee81" },
]
```
