### PR TITLE
Enforce hashes in lockfile install

### DIFF
--- a/crates/distribution-types/src/resolution.rs
+++ b/crates/distribution-types/src/resolution.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use pypi_types::{Requirement, RequirementSource};
+use pypi_types::{HashDigest, Requirement, RequirementSource};
 use uv_normalize::{ExtraName, GroupName, PackageName};
 
 use crate::{BuiltDist, Diagnostic, Dist, Name, ResolvedDist, SourceDist};
@@ -9,6 +9,7 @@ use crate::{BuiltDist, Diagnostic, Dist, Name, ResolvedDist, SourceDist};
 #[derive(Debug, Default, Clone)]
 pub struct Resolution {
     packages: BTreeMap<PackageName, ResolvedDist>,
+    hashes: BTreeMap<PackageName, Vec<HashDigest>>,
     diagnostics: Vec<ResolutionDiagnostic>,
 }
 
@@ -16,10 +17,12 @@ impl Resolution {
     /// Create a new resolution from the given pinned packages.
     pub fn new(
         packages: BTreeMap<PackageName, ResolvedDist>,
+        hashes: BTreeMap<PackageName, Vec<HashDigest>>,
         diagnostics: Vec<ResolutionDiagnostic>,
     ) -> Self {
         Self {
             packages,
+            hashes,
             diagnostics,
         }
     }
@@ -30,6 +33,11 @@ impl Resolution {
             ResolvedDist::Installable(dist) => Some(dist),
             ResolvedDist::Installed(_) => None,
         }
+    }
+
+    /// Return the hashes for the given package name, if they exist.
+    pub fn get_hashes(&self, package_name: &PackageName) -> &[HashDigest] {
+        self.hashes.get(package_name).map_or(&[], Vec::as_slice)
     }
 
     /// Iterate over the [`PackageName`] entities in this resolution.

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -382,6 +382,7 @@ impl Lock {
         }
 
         let mut map = BTreeMap::default();
+        let mut hashes = BTreeMap::default();
         while let Some((dist, extra)) = queue.pop_front() {
             let deps =
                 if let Some(extra) = extra {
@@ -406,13 +407,14 @@ impl Lock {
                     }
                 }
             }
-            let name = dist.id.name.clone();
-            let resolved_dist =
-                ResolvedDist::Installable(dist.to_dist(project.workspace().install_path(), tags)?);
-            map.insert(name, resolved_dist);
+            map.insert(
+                dist.id.name.clone(),
+                ResolvedDist::Installable(dist.to_dist(project.workspace().install_path(), tags)?),
+            );
+            hashes.insert(dist.id.name.clone(), dist.hashes());
         }
         let diagnostics = vec![];
-        Ok(Resolution::new(map, diagnostics))
+        Ok(Resolution::new(map, hashes, diagnostics))
     }
 
     /// Returns the TOML representation of this lock file.

--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -489,6 +489,10 @@ impl From<ResolutionGraph> for distribution_types::Resolution {
                 .dists()
                 .map(|node| (node.name().clone(), node.dist.clone()))
                 .collect(),
+            graph
+                .dists()
+                .map(|node| (node.name().clone(), node.hashes.clone()))
+                .collect(),
             graph.diagnostics,
         )
     }

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -64,6 +64,9 @@ pub(crate) enum ProjectError {
     Virtualenv(#[from] uv_virtualenv::Error),
 
     #[error(transparent)]
+    HashStrategy(#[from] uv_types::HashStrategyError),
+
+    #[error(transparent)]
     Tags(#[from] platform_tags::TagsError),
 
     #[error(transparent)]

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
-use uv_configuration::{Concurrency, ExtrasSpecification, PreviewMode, SetupPyStrategy};
+use uv_configuration::{
+    Concurrency, ExtrasSpecification, HashCheckingMode, PreviewMode, SetupPyStrategy,
+};
 use uv_dispatch::BuildDispatch;
 use uv_distribution::{VirtualProject, DEV_DEPENDENCIES};
 use uv_installer::SitePackages;
@@ -230,8 +232,10 @@ pub(super) async fn do_sync(
     // optional on the downstream APIs.
     let build_isolation = BuildIsolation::default();
     let dry_run = false;
-    let hasher = HashStrategy::default();
     let setup_py = SetupPyStrategy::default();
+
+    // Extract the hashes from the lockfile.
+    let hasher = HashStrategy::from_resolution(&resolution, HashCheckingMode::Verify)?;
 
     // Resolve the flat indexes from `--find-links`.
     let flat_index = {


### PR DESCRIPTION
## Summary

Hashes will be validated if present, but aren't required (since, e.g., some registries will omit them, as will Git dependencies and such).

Closes https://github.com/astral-sh/uv/issues/5168.
