### PR TITLE
docs(settings): bunch of fixes and improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,9 +127,19 @@ To preview any changes to the documentation locally:
 
     # For contributors.
     uv pip install -r docs/requirements.txt
-   
+
     # Or, for members of the Astral org, which has access to MkDocs Insiders via sponsorship.
     uv pip install -r docs/requirements-insiders.txt
+    ```
+
+1. Activate the virtual environment with:
+
+    ```shell
+    # On macOS and Linux.
+    source .venv/bin/activate
+
+    # On Windows.
+    .venv\Scripts\activate
     ```
 
 1. Run the development server with:

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -194,8 +194,8 @@ pub struct ResolverOptions {
 pub struct ResolverInstallerOptions {
     /// The URL of the Python package index (by default: <https://pypi.org/simple>).
     ///
-    /// Accepts either a repository compliant with PEP 503 (the simple repository API), or a local
-    /// directory laid out in the same format.
+    /// Accepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/)
+    /// (the simple repository API), or a local directory laid out in the same format.
     ///
     /// The index provided by this setting is given lower priority than any indexes specified via
     /// [`extra_index_url`](#extra-index-url).
@@ -209,8 +209,8 @@ pub struct ResolverInstallerOptions {
     pub index_url: Option<IndexUrl>,
     /// Extra URLs of package indexes to use, in addition to `--index-url`.
     ///
-    /// Accepts either a repository compliant with PEP 503 (the simple repository API), or a local
-    /// directory laid out in the same format.
+    /// Accepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/)
+    /// (the simple repository API), or a local directory laid out in the same format.
     ///
     /// All indexes provided via this flag take priority over the index specified by
     /// [`index_url`](#index-url). When multiple indexes are provided, earlier values take priority.
@@ -305,7 +305,8 @@ pub struct ResolverInstallerOptions {
         possible_values = true
     )]
     pub prerelease: Option<PreReleaseMode>,
-    /// Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
+    /// Settings to pass to the [PEP 517](https://peps.python.org/pep-0517/) build backend,
+    /// specified as `KEY=VALUE` pairs.
     #[option(
         default = "{}",
         value_type = "dict",
@@ -316,8 +317,8 @@ pub struct ResolverInstallerOptions {
     pub config_settings: Option<ConfigSettings>,
     /// Limit candidate packages to those that were uploaded prior to the given date.
     ///
-    /// Accepts both RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`) and UTC dates in the same
-    /// format (e.g., `2006-12-02`).
+    /// Accepts both [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339.html) timestamps (e.g.,
+    /// `2006-12-02T02:07:43Z`) and UTC dates in the same format (e.g., `2006-12-02`).
     #[option(
         default = "None",
         value_type = "str",
@@ -527,8 +528,8 @@ pub struct PipOptions {
     pub prefix: Option<PathBuf>,
     /// The URL of the Python package index (by default: <https://pypi.org/simple>).
     ///
-    /// Accepts either a repository compliant with PEP 503 (the simple repository API), or a local
-    /// directory laid out in the same format.
+    /// Accepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/)
+    /// (the simple repository API), or a local directory laid out in the same format.
     ///
     /// The index provided by this setting is given lower priority than any indexes specified via
     /// [`extra_index_url`](#extra-index-url).
@@ -542,8 +543,8 @@ pub struct PipOptions {
     pub index_url: Option<IndexUrl>,
     /// Extra URLs of package indexes to use, in addition to `--index-url`.
     ///
-    /// Accepts either a repository compliant with PEP 503 (the simple repository API), or a local
-    /// directory laid out in the same format.
+    /// Accepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/)
+    /// (the simple repository API), or a local directory laid out in the same format.
     ///
     /// All indexes provided via this flag take priority over the index specified by
     /// [`index_url`](#index-url). When multiple indexes are provided, earlier values take priority.
@@ -659,7 +660,8 @@ pub struct PipOptions {
     pub only_binary: Option<Vec<PackageNameSpecifier>>,
     /// Disable isolation when building source distributions.
     ///
-    /// Assumes that build dependencies specified by PEP 518 are already installed.
+    /// Assumes that build dependencies specified by [PEP 518](https://peps.python.org/pep-0518/)
+    /// are already installed.
     #[option(
         default = "false",
         value_type = "bool",
@@ -833,7 +835,8 @@ pub struct PipOptions {
         "#
     )]
     pub legacy_setup_py: Option<bool>,
-    /// Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
+    /// Settings to pass to the [PEP 517](https://peps.python.org/pep-0517/) build backend,
+    /// specified as `KEY=VALUE` pairs.
     #[option(
         default = "{}",
         value_type = "dict",
@@ -885,8 +888,8 @@ pub struct PipOptions {
     pub universal: Option<bool>,
     /// Limit candidate packages to those that were uploaded prior to the given date.
     ///
-    /// Accepts both RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`) and UTC dates in the same
-    /// format (e.g., `2006-12-02`).
+    /// Accepts both [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339.html) timestamps (e.g.,
+    /// `2006-12-02T02:07:43Z`) and UTC dates in the same format (e.g., `2006-12-02`).
     #[option(
         default = "None",
         value_type = "str",

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -129,7 +129,7 @@ pub struct GlobalOptions {
         default = "\"automatic\"",
         value_type = "str",
         example = r#"
-            python-fetch = \"automatic\"
+            python-fetch = "manual"
         "#,
         possible_values = true
     )]
@@ -203,7 +203,7 @@ pub struct ResolverInstallerOptions {
         default = "\"https://pypi.org/simple\"",
         value_type = "str",
         example = r#"
-            index-url = "https://pypi.org/simple"
+            index-url = "https://test.pypi.org/simple"
         "#
     )]
     pub index_url: Option<IndexUrl>,
@@ -536,7 +536,7 @@ pub struct PipOptions {
         default = "\"https://pypi.org/simple\"",
         value_type = "str",
         example = r#"
-            index-url = "https://pypi.org/simple"
+            index-url = "https://test.pypi.org/simple"
         "#
     )]
     pub index_url: Option<IndexUrl>,
@@ -826,7 +826,7 @@ pub struct PipOptions {
     /// Use legacy `setuptools` behavior when building source distributions without a
     /// `pyproject.toml`.
     #[option(
-        default = "None",
+        default = "false",
         value_type = "bool",
         example = r#"
             legacy-setup-py = true
@@ -876,7 +876,7 @@ pub struct PipOptions {
     /// treated as a lower bound. For example, `--universal --python-version 3.7` would produce a
     /// universal resolution for Python 3.7 and later.
     #[option(
-        default = "None",
+        default = "false",
         value_type = "bool",
         example = r#"
             universal = true
@@ -928,7 +928,7 @@ pub struct PipOptions {
         default = "false",
         value_type = "bool",
         example = r#"
-            emit-binary = true
+            emit-build-options = true
         "#
     )]
     pub emit_build_options: Option<bool>,

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -63,7 +63,8 @@ ignore errors.
 
 #### [`config-settings`](#config-settings) {: #config-settings }
 
-Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
+Settings to pass to the [PEP 517](https://peps.python.org/pep-0517/) build backend,
+specified as `KEY=VALUE` pairs.
 
 **Default value**: `{}`
 
@@ -90,8 +91,8 @@ Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
 
 Limit candidate packages to those that were uploaded prior to the given date.
 
-Accepts both RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`) and UTC dates in the same
-format (e.g., `2006-12-02`).
+Accepts both [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339.html) timestamps (e.g.,
+`2006-12-02T02:07:43Z`) and UTC dates in the same format (e.g., `2006-12-02`).
 
 **Default value**: `None`
 
@@ -118,8 +119,8 @@ format (e.g., `2006-12-02`).
 
 Extra URLs of package indexes to use, in addition to `--index-url`.
 
-Accepts either a repository compliant with PEP 503 (the simple repository API), or a local
-directory laid out in the same format.
+Accepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/)
+(the simple repository API), or a local directory laid out in the same format.
 
 All indexes provided via this flag take priority over the index specified by
 [`index_url`](#index-url). When multiple indexes are provided, earlier values take priority.
@@ -218,8 +219,8 @@ same name to a secondary.
 
 The URL of the Python package index (by default: <https://pypi.org/simple>).
 
-Accepts either a repository compliant with PEP 503 (the simple repository API), or a local
-directory laid out in the same format.
+Accepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/)
+(the simple repository API), or a local directory laid out in the same format.
 
 The index provided by this setting is given lower priority than any indexes specified via
 [`extra_index_url`](#extra-index-url).
@@ -234,13 +235,13 @@ The index provided by this setting is given lower priority than any indexes spec
 
     ```toml
     [tool.uv]
-    index-url = "https://pypi.org/simple"
+    index-url = "https://test.pypi.org/simple"
     ```
 === "uv.toml"
 
     ```toml
     
-    index-url = "https://pypi.org/simple"
+    index-url = "https://test.pypi.org/simple"
     ```
 
 ---
@@ -625,13 +626,13 @@ Whether to automatically download Python when required.
 
     ```toml
     [tool.uv]
-    python-fetch = \"automatic\"
+    python-fetch = "manual"
     ```
 === "uv.toml"
 
     ```toml
     
-    python-fetch = \"automatic\"
+    python-fetch = "manual"
     ```
 
 ---
@@ -1048,7 +1049,8 @@ Defaults to the number of available CPU cores.
 #### [`config-settings`](#pip_config-settings) {: #pip_config-settings }
 <span id="config-settings"></span>
 
-Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.
+Settings to pass to the [PEP 517](https://peps.python.org/pep-0517/) build backend,
+specified as `KEY=VALUE` pairs.
 
 **Default value**: `{}`
 
@@ -1114,13 +1116,13 @@ Include `--no-binary` and `--only-binary` entries in the output file generated b
 
     ```toml
     [tool.uv.pip]
-    emit-binary = true
+    emit-build-options = true
     ```
 === "uv.toml"
 
     ```toml
     [pip]
-    emit-binary = true
+    emit-build-options = true
     ```
 
 ---
@@ -1240,8 +1242,8 @@ be correct.
 
 Limit candidate packages to those that were uploaded prior to the given date.
 
-Accepts both RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`) and UTC dates in the same
-format (e.g., `2006-12-02`).
+Accepts both [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339.html) timestamps (e.g.,
+`2006-12-02T02:07:43Z`) and UTC dates in the same format (e.g., `2006-12-02`).
 
 **Default value**: `None`
 
@@ -1297,8 +1299,8 @@ Only applies to `pyproject.toml`, `setup.py`, and `setup.cfg` sources.
 
 Extra URLs of package indexes to use, in addition to `--index-url`.
 
-Accepts either a repository compliant with PEP 503 (the simple repository API), or a local
-directory laid out in the same format.
+Accepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/)
+(the simple repository API), or a local directory laid out in the same format.
 
 All indexes provided via this flag take priority over the index specified by
 [`index_url`](#index-url). When multiple indexes are provided, earlier values take priority.
@@ -1426,8 +1428,8 @@ same name to a secondary.
 
 The URL of the Python package index (by default: <https://pypi.org/simple>).
 
-Accepts either a repository compliant with PEP 503 (the simple repository API), or a local
-directory laid out in the same format.
+Accepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/)
+(the simple repository API), or a local directory laid out in the same format.
 
 The index provided by this setting is given lower priority than any indexes specified via
 [`extra_index_url`](#extra-index-url).
@@ -1442,13 +1444,13 @@ The index provided by this setting is given lower priority than any indexes spec
 
     ```toml
     [tool.uv.pip]
-    index-url = "https://pypi.org/simple"
+    index-url = "https://test.pypi.org/simple"
     ```
 === "uv.toml"
 
     ```toml
     [pip]
-    index-url = "https://pypi.org/simple"
+    index-url = "https://test.pypi.org/simple"
     ```
 
 ---
@@ -1488,7 +1490,7 @@ use the `keyring` CLI to handle authentication.
 Use legacy `setuptools` behavior when building source distributions without a
 `pyproject.toml`.
 
-**Default value**: `None`
+**Default value**: `false`
 
 **Type**: `bool`
 
@@ -1638,7 +1640,8 @@ Alias for `--only-binary :all:`.
 
 Disable isolation when building source distributions.
 
-Assumes that build dependencies specified by PEP 518 are already installed.
+Assumes that build dependencies specified by [PEP 518](https://peps.python.org/pep-0518/)
+are already installed.
 
 **Default value**: `false`
 
@@ -2274,7 +2277,7 @@ In universal mode, the current Python version (or user-provided `--python-versio
 treated as a lower bound. For example, `--universal --python-version 3.7` would produce a
 universal resolution for Python 3.7 and later.
 
-**Default value**: `None`
+**Default value**: `false`
 
 **Type**: `bool`
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -19,7 +19,7 @@
       ]
     },
     "config-settings": {
-      "description": "Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.",
+      "description": "Settings to pass to the [PEP 517](https://peps.python.org/pep-0517/) build backend, specified as `KEY=VALUE` pairs.",
       "anyOf": [
         {
           "$ref": "#/definitions/ConfigSettings"
@@ -40,7 +40,7 @@
       }
     },
     "exclude-newer": {
-      "description": "Limit candidate packages to those that were uploaded prior to the given date.\n\nAccepts both RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`) and UTC dates in the same format (e.g., `2006-12-02`).",
+      "description": "Limit candidate packages to those that were uploaded prior to the given date.\n\nAccepts both [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339.html) timestamps (e.g., `2006-12-02T02:07:43Z`) and UTC dates in the same format (e.g., `2006-12-02`).",
       "anyOf": [
         {
           "$ref": "#/definitions/ExcludeNewer"
@@ -51,7 +51,7 @@
       ]
     },
     "extra-index-url": {
-      "description": "Extra URLs of package indexes to use, in addition to `--index-url`.\n\nAccepts either a repository compliant with PEP 503 (the simple repository API), or a local directory laid out in the same format.\n\nAll indexes provided via this flag take priority over the index specified by [`index_url`](#index-url). When multiple indexes are provided, earlier values take priority.\n\nTo control uv's resolution strategy when multiple indexes are present, see [`index_strategy`](#index-strategy).",
+      "description": "Extra URLs of package indexes to use, in addition to `--index-url`.\n\nAccepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/) (the simple repository API), or a local directory laid out in the same format.\n\nAll indexes provided via this flag take priority over the index specified by [`index_url`](#index-url). When multiple indexes are provided, earlier values take priority.\n\nTo control uv's resolution strategy when multiple indexes are present, see [`index_strategy`](#index-strategy).",
       "type": [
         "array",
         "null"
@@ -82,7 +82,7 @@
       ]
     },
     "index-url": {
-      "description": "The URL of the Python package index (by default: <https://pypi.org/simple>).\n\nAccepts either a repository compliant with PEP 503 (the simple repository API), or a local directory laid out in the same format.\n\nThe index provided by this setting is given lower priority than any indexes specified via [`extra_index_url`](#extra-index-url).",
+      "description": "The URL of the Python package index (by default: <https://pypi.org/simple>).\n\nAccepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/) (the simple repository API), or a local directory laid out in the same format.\n\nThe index provided by this setting is given lower priority than any indexes specified via [`extra_index_url`](#extra-index-url).",
       "anyOf": [
         {
           "$ref": "#/definitions/IndexUrl"
@@ -537,7 +537,7 @@
           "minimum": 1.0
         },
         "config-settings": {
-          "description": "Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs.",
+          "description": "Settings to pass to the [PEP 517](https://peps.python.org/pep-0517/) build backend, specified as `KEY=VALUE` pairs.",
           "anyOf": [
             {
               "$ref": "#/definitions/ConfigSettings"
@@ -590,7 +590,7 @@
           ]
         },
         "exclude-newer": {
-          "description": "Limit candidate packages to those that were uploaded prior to the given date.\n\nAccepts both RFC 3339 timestamps (e.g., `2006-12-02T02:07:43Z`) and UTC dates in the same format (e.g., `2006-12-02`).",
+          "description": "Limit candidate packages to those that were uploaded prior to the given date.\n\nAccepts both [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339.html) timestamps (e.g., `2006-12-02T02:07:43Z`) and UTC dates in the same format (e.g., `2006-12-02`).",
           "anyOf": [
             {
               "$ref": "#/definitions/ExcludeNewer"
@@ -611,7 +611,7 @@
           }
         },
         "extra-index-url": {
-          "description": "Extra URLs of package indexes to use, in addition to `--index-url`.\n\nAccepts either a repository compliant with PEP 503 (the simple repository API), or a local directory laid out in the same format.\n\nAll indexes provided via this flag take priority over the index specified by [`index_url`](#index-url). When multiple indexes are provided, earlier values take priority.\n\nTo control uv's resolution strategy when multiple indexes are present, see [`index_strategy`](#index-strategy).",
+          "description": "Extra URLs of package indexes to use, in addition to `--index-url`.\n\nAccepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/) (the simple repository API), or a local directory laid out in the same format.\n\nAll indexes provided via this flag take priority over the index specified by [`index_url`](#index-url). When multiple indexes are provided, earlier values take priority.\n\nTo control uv's resolution strategy when multiple indexes are present, see [`index_strategy`](#index-strategy).",
           "type": [
             "array",
             "null"
@@ -649,7 +649,7 @@
           ]
         },
         "index-url": {
-          "description": "The URL of the Python package index (by default: <https://pypi.org/simple>).\n\nAccepts either a repository compliant with PEP 503 (the simple repository API), or a local directory laid out in the same format.\n\nThe index provided by this setting is given lower priority than any indexes specified via [`extra_index_url`](#extra-index-url).",
+          "description": "The URL of the Python package index (by default: <https://pypi.org/simple>).\n\nAccepts either a repository compliant with [PEP 503](https://peps.python.org/pep-0503/) (the simple repository API), or a local directory laid out in the same format.\n\nThe index provided by this setting is given lower priority than any indexes specified via [`extra_index_url`](#extra-index-url).",
           "anyOf": [
             {
               "$ref": "#/definitions/IndexUrl"
@@ -713,7 +713,7 @@
           ]
         },
         "no-build-isolation": {
-          "description": "Disable isolation when building source distributions.\n\nAssumes that build dependencies specified by PEP 518 are already installed.",
+          "description": "Disable isolation when building source distributions.\n\nAssumes that build dependencies specified by [PEP 518](https://peps.python.org/pep-0518/) are already installed.",
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
## Summary

Spotted some issues in the settings documentation, and room for small improvements by linking to PEPs/RFCs.

Also updating contribution documentation to mention that it's necessary to enable the virtual environment before running `mkdocs serve`.

## Test Plan

Running documentation locally.