### PR TITLE
Use +- install output for Python versions

### DIFF
--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -350,7 +350,7 @@ impl Ord for PythonInstallationKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.implementation
             .cmp(&other.implementation)
-            .then_with(|| other.version().cmp(&self.version()))
+            .then_with(|| self.version().cmp(&other.version()))
             .then_with(|| self.os.to_string().cmp(&other.os.to_string()))
             .then_with(|| self.arch.to_string().cmp(&other.arch.to_string()))
             .then_with(|| self.libc.to_string().cmp(&other.libc.to_string()))

--- a/crates/uv/src/commands/python/mod.rs
+++ b/crates/uv/src/commands/python/mod.rs
@@ -4,3 +4,17 @@ pub(crate) mod install;
 pub(crate) mod list;
 pub(crate) mod pin;
 pub(crate) mod uninstall;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub(super) enum ChangeEventKind {
+    /// The Python version was uninstalled.
+    Removed,
+    /// The Python version was installed.
+    Added,
+}
+
+#[derive(Debug)]
+pub(super) struct ChangeEvent {
+    key: uv_python::PythonInstallationKey,
+    kind: ChangeEventKind,
+}


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/astral-sh/uv/pull/4939. Uses a format that's closer to `uv pip install`, with some special-casing for single Pythons.

## Test Plan

A few examples:

![Screenshot 2024-07-18 at 8 39 35 PM](https://github.com/user-attachments/assets/868d4c87-d8f4-4e5f-a52c-1f7a3e8d6a16)
![Screenshot 2024-07-18 at 8 39 46 PM](https://github.com/user-attachments/assets/3a12461e-9d9b-4c33-a685-55ca7256ff52)
![Screenshot 2024-07-18 at 8 39 27 PM](https://github.com/user-attachments/assets/1059e6d6-a445-4531-8496-59bc51d01663)
![Screenshot 2024-07-18 at 8 39 54 PM](https://github.com/user-attachments/assets/dcb69e86-8702-402b-a0cd-6f827b04a6ab)
