### PR TITLE
Process completed Python installs and uninstalls as a stream

### DIFF
--- a/crates/pep508-rs/src/marker.rs
+++ b/crates/pep508-rs/src/marker.rs
@@ -1631,7 +1631,7 @@ impl Display for MarkerExpression {
                 {
                     return write!(f, "{key} {op} '{version}.*'");
                 }
-                write!(f, "{key} {op} '{version}'",)
+                write!(f, "{key} {op} '{version}'")
             }
             MarkerExpression::VersionInverted {
                 version,

--- a/crates/platform-tags/src/tags.rs
+++ b/crates/platform-tags/src/tags.rs
@@ -327,7 +327,7 @@ impl Implementation {
                 } else if gil_disabled {
                     // https://peps.python.org/pep-0703/#build-configuration-changes
                     // Python 3.13+ only, but it makes more sense to just rely on the sysconfig var.
-                    format!("cp{}{}t", python_version.0, python_version.1,)
+                    format!("cp{}{}t", python_version.0, python_version.1)
                 } else {
                     format!(
                         "cp{}{}{}",

--- a/crates/uv-resolver/src/resolution/requirements_txt.rs
+++ b/crates/uv-resolver/src/resolution/requirements_txt.rs
@@ -99,7 +99,7 @@ impl RequirementsTxtDist {
 
         if self.extras.is_empty() || !include_extras {
             if let Some(markers) = self.markers.as_ref().filter(|_| include_markers) {
-                Cow::Owned(format!("{} ; {}", self.dist.verbatim(), markers,))
+                Cow::Owned(format!("{} ; {}", self.dist.verbatim(), markers))
             } else {
                 self.dist.verbatim()
             }


### PR DESCRIPTION
## Summary

This ensures that we process Python installs and uninstalls as soon as they complete, rather than waiting for them all to complete, then processing them sequentially. In practice, it shouldn't be much of a difference (since the processing is code is fairly light), but it strikes me as more correct.
