### PR TITLE
Use max rather than min to sort managed Pythons

### DIFF
--- a/crates/uv-python/src/implementation.rs
+++ b/crates/uv-python/src/implementation.rs
@@ -12,16 +12,16 @@ pub enum Error {
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Default, PartialOrd, Ord, Hash)]
 pub enum ImplementationName {
+    GraalPy,
+    PyPy,
     #[default]
     CPython,
-    PyPy,
-    GraalPy,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Ord, PartialOrd, Hash)]
 pub enum LenientImplementationName {
-    Known(ImplementationName),
     Unknown(String),
+    Known(ImplementationName),
 }
 
 impl ImplementationName {

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use fs_err as fs;
 use itertools::Itertools;
+use std::cmp::Reverse;
 use std::ffi::OsStr;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -150,14 +151,14 @@ impl ManagedPythonInstallations {
                         },
                         Err(err) => Some(Err(err)),
                     })
-                    .collect::<Result<_, std::io::Error>>()
+                    .collect::<Result<_, io::Error>>()
                     .map_err(|err| Error::ReadError {
                         dir: self.root.clone(),
                         err,
                     })?;
                 directories
             }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => vec![],
+            Err(err) if err.kind() == io::ErrorKind::NotFound => vec![],
             Err(err) => {
                 return Err(Error::ReadError {
                     dir: self.root.clone(),
@@ -174,7 +175,7 @@ impl ManagedPythonInstallations {
                     })
                     .ok()
             })
-            .sorted_unstable_by_key(|installation| installation.key().clone()))
+            .sorted_unstable_by_key(|installation| Reverse(installation.key().clone())))
     }
 
     /// Iterate over Python installations that support the current platform.


### PR DESCRIPTION
## Summary

See: https://github.com/astral-sh/uv/issues/5139 and https://github.com/astral-sh/uv/pull/5201#discussion_r1683636935.

## Test Plan

Verified that 3.12 was chosen above 3.8 in:

- `cargo run -- python uninstall --all`
- `cargo run -- python install 3.8 3.12`
- `cargo run -- tool run -v httpx`
