### PR TITLE
Remove trailing period from user-facing messages

### DIFF
--- a/crates/distribution-types/src/resolution.rs
+++ b/crates/distribution-types/src/resolution.rs
@@ -99,16 +99,16 @@ impl Diagnostic for ResolutionDiagnostic {
     fn message(&self) -> String {
         match self {
             Self::MissingExtra { dist, extra } => {
-                format!("The package `{dist}` does not have an extra named `{extra}`.")
+                format!("The package `{dist}` does not have an extra named `{extra}`")
             }
             Self::MissingDev { dist, dev } => {
-                format!("The package `{dist}` does not have a development dependency group named `{dev}`.")
+                format!("The package `{dist}` does not have a development dependency group named `{dev}`")
             }
             Self::YankedVersion { dist, reason } => {
                 if let Some(reason) = reason {
-                    format!("`{dist}` is yanked (reason: \"{reason}\").")
+                    format!("`{dist}` is yanked (reason: \"{reason}\")")
                 } else {
-                    format!("`{dist}` is yanked.")
+                    format!("`{dist}` is yanked")
                 }
             }
         }

--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -167,10 +167,10 @@ impl Credentials {
         let mut buf = String::new();
         decoder
             .read_to_string(&mut buf)
-            .expect("HTTP Basic Authentication should be base64 encoded.");
+            .expect("HTTP Basic Authentication should be base64 encoded");
         let (username, password) = buf
             .split_once(':')
-            .expect("HTTP Basic Authentication should include a `:` separator.");
+            .expect("HTTP Basic Authentication should include a `:` separator");
         let username = if username.is_empty() {
             None
         } else {

--- a/crates/uv-cli/src/compat.rs
+++ b/crates/uv-cli/src/compat.rs
@@ -73,36 +73,34 @@ impl CompatArgs for PipCompileCompatArgs {
     fn validate(&self) -> Result<()> {
         if self.allow_unsafe {
             warn_user!(
-                "pip-compile's `--allow-unsafe` has no effect (uv can safely pin `pip` and other packages)."
+                "pip-compile's `--allow-unsafe` has no effect (uv can safely pin `pip` and other packages)"
             );
         }
 
         if self.no_allow_unsafe {
-            warn_user!("pip-compile's `--no-allow-unsafe` has no effect (uv can safely pin `pip` and other packages).");
+            warn_user!("pip-compile's `--no-allow-unsafe` has no effect (uv can safely pin `pip` and other packages)");
         }
 
         if self.reuse_hashes {
             return Err(anyhow!(
-                "pip-compile's `--reuse-hashes` is unsupported (uv doesn't reuse hashes)."
+                "pip-compile's `--reuse-hashes` is unsupported (uv doesn't reuse hashes)"
             ));
         }
 
         if self.no_reuse_hashes {
-            warn_user!(
-                "pip-compile's `--no-reuse-hashes` has no effect (uv doesn't reuse hashes)."
-            );
+            warn_user!("pip-compile's `--no-reuse-hashes` has no effect (uv doesn't reuse hashes)");
         }
 
         if let Some(resolver) = self.resolver {
             match resolver {
                 Resolver::Backtracking => {
                     warn_user!(
-                        "pip-compile's `--resolver=backtracking` has no effect (uv always backtracks)."
+                        "pip-compile's `--resolver=backtracking` has no effect (uv always backtracks)"
                     );
                 }
                 Resolver::Legacy => {
                     return Err(anyhow!(
-                        "pip-compile's `--resolver=legacy` is unsupported (uv always backtracks)."
+                        "pip-compile's `--resolver=legacy` is unsupported (uv always backtracks)"
                     ));
                 }
             }
@@ -110,59 +108,59 @@ impl CompatArgs for PipCompileCompatArgs {
 
         if self.max_rounds.is_some() {
             return Err(anyhow!(
-                "pip-compile's `--max-rounds` is unsupported (uv always resolves until convergence)."
+                "pip-compile's `--max-rounds` is unsupported (uv always resolves until convergence)"
             ));
         }
 
         if self.client_cert.is_some() {
             return Err(anyhow!(
-                "pip-compile's `--client-cert` is unsupported (uv doesn't support dedicated client certificates)."
+                "pip-compile's `--client-cert` is unsupported (uv doesn't support dedicated client certificates)"
             ));
         }
 
         if self.trusted_host.is_some() {
             return Err(anyhow!(
-                "pip-compile's `--trusted-host` is unsupported (uv always requires HTTPS)."
+                "pip-compile's `--trusted-host` is unsupported (uv always requires HTTPS)"
             ));
         }
 
         if self.emit_trusted_host {
             return Err(anyhow!(
-                "pip-compile's `--emit-trusted-host` is unsupported (uv always requires HTTPS)."
+                "pip-compile's `--emit-trusted-host` is unsupported (uv always requires HTTPS)"
             ));
         }
 
         if self.no_emit_trusted_host {
             warn_user!(
-                "pip-compile's `--no-emit-trusted-host` has no effect (uv never emits trusted hosts)."
+                "pip-compile's `--no-emit-trusted-host` has no effect (uv never emits trusted hosts)"
             );
         }
 
         if self.config.is_some() {
             return Err(anyhow!(
-                "pip-compile's `--config` is unsupported (uv does not use a configuration file)."
+                "pip-compile's `--config` is unsupported (uv does not use a configuration file)"
             ));
         }
 
         if self.no_config {
             warn_user!(
-                "pip-compile's `--no-config` has no effect (uv does not use a configuration file)."
+                "pip-compile's `--no-config` has no effect (uv does not use a configuration file)"
             );
         }
 
         if self.emit_options {
             return Err(anyhow!(
-                "pip-compile's `--emit-options` is unsupported (uv never emits options)."
+                "pip-compile's `--emit-options` is unsupported (uv never emits options)"
             ));
         }
 
         if self.no_emit_options {
-            warn_user!("pip-compile's `--no-emit-options` has no effect (uv never emits options).");
+            warn_user!("pip-compile's `--no-emit-options` has no effect (uv never emits options)");
         }
 
         if self.pip_args.is_some() {
             return Err(anyhow!(
-                "pip-compile's `--pip-args` is unsupported (try passing arguments to uv directly)."
+                "pip-compile's `--pip-args` is unsupported (try passing arguments to uv directly)"
             ));
         }
 
@@ -191,11 +189,11 @@ impl CompatArgs for PipListCompatArgs {
     /// `--outdated`), this method will return an error.
     fn validate(&self) -> Result<()> {
         if self.disable_pip_version_check {
-            warn_user!("pip's `--disable-pip-version-check` has no effect.");
+            warn_user!("pip's `--disable-pip-version-check` has no effect");
         }
 
         if self.outdated {
-            return Err(anyhow!("pip's `--outdated` is unsupported."));
+            return Err(anyhow!("pip's `--outdated` is unsupported"));
         }
 
         Ok(())
@@ -245,49 +243,49 @@ impl CompatArgs for PipSyncCompatArgs {
     fn validate(&self) -> Result<()> {
         if self.ask {
             return Err(anyhow!(
-                "pip-sync's `--ask` is unsupported (uv never asks for confirmation)."
+                "pip-sync's `--ask` is unsupported (uv never asks for confirmation)"
             ));
         }
 
         if self.python_executable.is_some() {
             return Err(anyhow!(
-                "pip-sync's `--python-executable` is unsupported (to install into a separate Python environment, try setting `VIRTUAL_ENV` instead)."
+                "pip-sync's `--python-executable` is unsupported (to install into a separate Python environment, try setting `VIRTUAL_ENV` instead)"
             ));
         }
 
         if self.user {
             return Err(anyhow!(
-                "pip-sync's `--user` is unsupported (use a virtual environment instead)."
+                "pip-sync's `--user` is unsupported (use a virtual environment instead)"
             ));
         }
 
         if self.client_cert.is_some() {
             return Err(anyhow!(
-                "pip-sync's `--client-cert` is unsupported (uv doesn't support dedicated client certificates)."
+                "pip-sync's `--client-cert` is unsupported (uv doesn't support dedicated client certificates)"
             ));
         }
 
         if self.trusted_host.is_some() {
             return Err(anyhow!(
-                "pip-sync's `--trusted-host` is unsupported (uv always requires HTTPS)."
+                "pip-sync's `--trusted-host` is unsupported (uv always requires HTTPS)"
             ));
         }
 
         if self.config.is_some() {
             return Err(anyhow!(
-                "pip-sync's `--config` is unsupported (uv does not use a configuration file)."
+                "pip-sync's `--config` is unsupported (uv does not use a configuration file)"
             ));
         }
 
         if self.no_config {
             warn_user!(
-                "pip-sync's `--no-config` has no effect (uv does not use a configuration file)."
+                "pip-sync's `--no-config` has no effect (uv does not use a configuration file)"
             );
         }
 
         if self.pip_args.is_some() {
             return Err(anyhow!(
-                "pip-sync's `--pip-args` is unsupported (try passing arguments to uv directly)."
+                "pip-sync's `--pip-args` is unsupported (try passing arguments to uv directly)"
             ));
         }
 
@@ -332,28 +330,28 @@ impl CompatArgs for VenvCompatArgs {
     fn validate(&self) -> Result<()> {
         if self.clear {
             warn_user!(
-                "virtualenv's `--clear` has no effect (uv always clears the virtual environment)."
+                "virtualenv's `--clear` has no effect (uv always clears the virtual environment)"
             );
         }
 
         if self.no_seed {
             warn_user!(
-                "virtualenv's `--no-seed` has no effect (uv omits seed packages by default)."
+                "virtualenv's `--no-seed` has no effect (uv omits seed packages by default)"
             );
         }
 
         if self.no_pip {
-            warn_user!("virtualenv's `--no-pip` has no effect (uv omits `pip` by default).");
+            warn_user!("virtualenv's `--no-pip` has no effect (uv omits `pip` by default)");
         }
 
         if self.no_setuptools {
             warn_user!(
-                "virtualenv's `--no-setuptools` has no effect (uv omits `setuptools` by default)."
+                "virtualenv's `--no-setuptools` has no effect (uv omits `setuptools` by default)"
             );
         }
 
         if self.no_wheel {
-            warn_user!("virtualenv's `--no-wheel` has no effect (uv omits `wheel` by default).");
+            warn_user!("virtualenv's `--no-wheel` has no effect (uv omits `wheel` by default)");
         }
 
         Ok(())
@@ -381,12 +379,12 @@ impl CompatArgs for PipInstallCompatArgs {
     /// return an error.
     fn validate(&self) -> Result<()> {
         if self.disable_pip_version_check {
-            warn_user!("pip's `--disable-pip-version-check` has no effect.");
+            warn_user!("pip's `--disable-pip-version-check` has no effect");
         }
 
         if self.user {
             return Err(anyhow!(
-                "pip's `--user` is unsupported (use a virtual environment instead)."
+                "pip's `--user` is unsupported (use a virtual environment instead)"
             ));
         }
 
@@ -412,7 +410,7 @@ impl CompatArgs for PipGlobalCompatArgs {
     /// return an error.
     fn validate(&self) -> Result<()> {
         if self.disable_pip_version_check {
-            warn_user!("pip's `--disable-pip-version-check` has no effect.");
+            warn_user!("pip's `--disable-pip-version-check` has no effect");
         }
 
         Ok(())

--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -127,7 +127,7 @@ impl<'a> BaseClientBuilder<'a> {
                 value.parse::<u64>()
                     .or_else(|_| {
                         // On parse error, warn and use the default timeout
-                        warn_user_once!("Ignoring invalid value from environment for UV_HTTP_TIMEOUT. Expected integer number of seconds, got \"{value}\".");
+                        warn_user_once!("Ignoring invalid value from environment for `UV_HTTP_TIMEOUT`. Expected an integer number of seconds, got \"{value}\".");
                         Ok(default_timeout)
                     })
             })
@@ -175,7 +175,7 @@ impl<'a> BaseClientBuilder<'a> {
                 client_core
             };
 
-            client_core.build().expect("Failed to build HTTP client.")
+            client_core.build().expect("Failed to build HTTP client")
         });
 
         // Wrap in any relevant middleware.

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -151,18 +151,18 @@ pub enum ErrorKind {
     #[error(transparent)]
     DistInfo(#[from] install_wheel_rs::Error),
 
-    #[error("{0} isn't available locally, but making network requests to registries was banned.")]
+    #[error("{0} isn't available locally, but making network requests to registries was banned")]
     NoIndex(String),
 
     /// The package was not found in the registry.
     ///
     /// Make sure the package name is spelled correctly and that you've
     /// configured the right registry to fetch it from.
-    #[error("Package `{0}` was not found in the registry.")]
+    #[error("Package `{0}` was not found in the registry")]
     PackageNotFound(String),
 
     /// The package was not found in the local (file-based) index.
-    #[error("Package `{0}` was not found in the local index.")]
+    #[error("Package `{0}` was not found in the local index")]
     FileNotFound(String),
 
     /// The metadata file could not be parsed.

--- a/crates/uv-client/tests/user_agent_version.rs
+++ b/crates/uv-client/tests/user_agent_version.rs
@@ -167,7 +167,7 @@ async fn test_user_agent_has_linehaul() -> Result<()> {
     // Unpack User-Agent with linehaul
     let (uv_version, uv_linehaul) = body
         .split_once(' ')
-        .expect("Failed to split User-Agent header.");
+        .expect("Failed to split User-Agent header");
 
     // Deserializing Linehaul
     let linehaul: LineHaul = serde_json::from_str(uv_linehaul)?;

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -93,7 +93,7 @@ pub(crate) fn lower_requirement(
     };
 
     if preview.is_disabled() {
-        warn_user_once!("`uv.sources` is experimental and may change without warning.");
+        warn_user_once!("`uv.sources` is experimental and may change without warning");
     }
 
     let source = match source {

--- a/crates/uv-distribution/src/pyproject_mut.rs
+++ b/crates/uv-distribution/src/pyproject_mut.rs
@@ -26,7 +26,7 @@ pub enum Error {
     MalformedDependencies,
     #[error("Sources in `pyproject.toml` are malformed")]
     MalformedSources,
-    #[error("Cannot perform ambiguous update; multiple entries with matching package names.")]
+    #[error("Cannot perform ambiguous update; found multiple entries with matching package names")]
     Ambiguous,
 }
 

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -428,26 +428,26 @@ impl Diagnostic for SitePackagesDiagnostic {
                 version,
                 requires_python,
             } => format!(
-                "The package `{package}` requires Python {requires_python}, but `{version}` is installed."
+                "The package `{package}` requires Python {requires_python}, but `{version}` is installed"
             ),
             Self::MissingDependency {
                 package,
                 requirement,
             } => {
-                format!("The package `{package}` requires `{requirement}`, but it's not installed.")
+                format!("The package `{package}` requires `{requirement}`, but it's not installed")
             }
             Self::IncompatibleDependency {
                 package,
                 version,
                 requirement,
             } => format!(
-                "The package `{package}` requires `{requirement}`, but `{version}` is installed."
+                "The package `{package}` requires `{requirement}`, but `{version}` is installed"
             ),
             Self::DuplicatePackage { package, paths } => {
                 let mut paths = paths.clone();
                 paths.sort();
                 format!(
-                    "The package `{package}` has multiple installed distributions:{}",
+                    "The package `{package}` has multiple installed distributions: {}",
                     paths.iter().fold(String::new(), |acc, path| acc + &format!("\n  - {}", path.display()))
                 )
             }

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -898,7 +898,7 @@ fn warn_on_unsupported_python(interpreter: &Interpreter) {
     // Warn on usage with an unsupported Python version
     if interpreter.python_tuple() < (3, 8) {
         warn_user_once!(
-            "uv is only compatible with Python 3.8+, found Python {}.",
+            "uv is only compatible with Python >=3.8, found Python {}",
             interpreter.python_version()
         );
     }

--- a/crates/uv-python/src/py_launcher.rs
+++ b/crates/uv-python/src/py_launcher.rs
@@ -24,9 +24,9 @@ pub enum Error {
         stdout: String,
         stderr: String,
     },
-    #[error("Failed to run `py --list-paths` to find Python installations.")]
+    #[error("Failed to run `py --list-paths` to find Python installations")]
     Io(#[source] io::Error),
-    #[error("The `py` launcher could not be found.")]
+    #[error("The `py` launcher could not be found")]
     NotFound,
 }
 

--- a/crates/uv-resolver/src/preferences.rs
+++ b/crates/uv-resolver/src/preferences.rs
@@ -35,17 +35,17 @@ impl Preference {
 
         let Some(VersionOrUrl::VersionSpecifier(specifier)) = requirement.version_or_url.as_ref()
         else {
-            trace!("Excluding {requirement} from preferences due to non-version specifier.");
+            trace!("Excluding {requirement} from preferences due to non-version specifier");
             return Ok(None);
         };
 
         let [specifier] = specifier.as_ref() else {
-            trace!("Excluding {requirement} from preferences due to multiple version specifiers.");
+            trace!("Excluding {requirement} from preferences due to multiple version specifiers");
             return Ok(None);
         };
 
         if *specifier.operator() != Operator::Equal {
-            trace!("Excluding {requirement} from preferences due to inexact version specifier.");
+            trace!("Excluding {requirement} from preferences due to inexact version specifier");
             return Ok(None);
         }
 
@@ -128,7 +128,7 @@ impl Preferences {
                         },
                     ))
                 } else {
-                    trace!("Excluding {preference} from preferences due to unmatched markers.");
+                    trace!("Excluding {preference} from preferences due to unmatched markers");
                     None
                 }
             })

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -406,7 +406,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     .pubgrub
                     .partial_solution
                     .term_intersection_for_package(&state.next)
-                    .expect("a package was chosen but we don't have a term.");
+                    .expect("a package was chosen but we don't have a term");
                 let decision = self.choose_version(
                     &state.next,
                     term_intersection.unwrap_positive(),
@@ -427,7 +427,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             .pubgrub
                             .partial_solution
                             .term_intersection_for_package(&state.next)
-                            .expect("a package was chosen but we don't have a term.");
+                            .expect("a package was chosen but we don't have a term");
 
                         // Check if the decision was due to the package being unavailable
                         if let PubGrubPackageInner::Package { ref name, .. } = &*state.next {

--- a/crates/uv-trampoline/src/bounce.rs
+++ b/crates/uv-trampoline/src/bounce.rs
@@ -75,7 +75,7 @@ fn make_child_cmdline() -> CString {
     // );
 
     CString::from_vec_with_nul(child_cmdline).unwrap_or_else(|_| {
-        eprintln!("Child command line is not correctly null terminated.");
+        eprintln!("Child command line is not correctly null terminated");
         exit_with_status(1)
     })
 }
@@ -128,7 +128,7 @@ fn executable_filename() -> CString {
     }
 
     CString::from_vec_with_nul(buffer).unwrap_or_else(|_| {
-        eprintln!("Executable name is not correctly null terminated.");
+        eprintln!("Executable name is not correctly null terminated");
         exit_with_status(1)
     })
 }
@@ -191,13 +191,13 @@ fn find_python_exe(executable_name: &CStr) -> CString {
         }
         .is_err()
         {
-            print_last_error_and_exit("Failed to set the file pointer to the end of the file.");
+            print_last_error_and_exit("Failed to set the file pointer to the end of the file");
         }
 
         let mut read_bytes = bytes_to_read;
         if unsafe { ReadFile(file_handle, Some(&mut buffer), Some(&mut read_bytes), None) }.is_err()
         {
-            print_last_error_and_exit("Failed to read the executable file.");
+            print_last_error_and_exit("Failed to read the executable file");
         }
 
         // Truncate the buffer to the actual number of bytes read.
@@ -240,7 +240,7 @@ fn find_python_exe(executable_name: &CStr) -> CString {
             buffer.push(b'\0');
 
             break CString::from_vec_with_nul(buffer).unwrap_or_else(|_| {
-                eprintln!("Python executable path is not correctly null terminated.");
+                eprintln!("Python executable path is not correctly null terminated");
                 exit_with_status(1)
             });
         } else {
@@ -249,14 +249,14 @@ fn find_python_exe(executable_name: &CStr) -> CString {
             bytes_to_read = (path_len + MAGIC_NUMBER.len() + PATH_LEN_SIZE) as u32;
 
             if i64::from(bytes_to_read) > file_size {
-                eprintln!("The length of the python executable path exceeds the file size. Verify that the path length is appended to the end of the launcher script as a u32 in little endian.");
+                eprintln!("The length of the python executable path exceeds the file size. Verify that the path length is appended to the end of the launcher script as a u32 in little endian");
                 exit_with_status(1);
             }
         }
     };
 
     if unsafe { CloseHandle(file_handle) }.is_err() {
-        print_last_error_and_exit("Failed to close file handle.");
+        print_last_error_and_exit("Failed to close file handle");
     }
 
     if is_absolute(&path) {
@@ -269,13 +269,13 @@ fn find_python_exe(executable_name: &CStr) -> CString {
         {
             Some(parent_dir) => parent_dir,
             None => {
-                eprintln!("Script path has unknown separator characters.");
+                eprintln!("Script path has unknown separator characters");
                 exit_with_status(1)
             }
         };
         let final_path = [parent_dir, b"\\", path.as_bytes()].concat();
         CString::new(final_path).unwrap_or_else(|_| {
-            eprintln!("Could not construct the absolute path to the Python executable.");
+            eprintln!("Could not construct the absolute path to the Python executable");
             exit_with_status(1)
         })
     }
@@ -334,7 +334,7 @@ fn skip_one_argument(arguments: &[u8]) -> &[u8] {
 
 fn make_job_object() -> HANDLE {
     let job = unsafe { CreateJobObjectW(None, None) }
-        .unwrap_or_else(|_| print_last_error_and_exit("Job creation failed."));
+        .unwrap_or_else(|_| print_last_error_and_exit("Job creation failed"));
     let mut job_info = MaybeUninit::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>::uninit();
     let mut retlen = 0u32;
     if unsafe {
@@ -348,7 +348,7 @@ fn make_job_object() -> HANDLE {
     }
     .is_err()
     {
-        print_last_error_and_exit("Job information querying failed.");
+        print_last_error_and_exit("Job information querying failed");
     }
     let mut job_info = unsafe { job_info.assume_init() };
     job_info.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
@@ -363,7 +363,7 @@ fn make_job_object() -> HANDLE {
     }
     .is_err()
     {
-        print_last_error_and_exit("Job information setting failed.");
+        print_last_error_and_exit("Job information setting failed");
     }
     job
 }
@@ -373,11 +373,11 @@ fn spawn_child(si: &STARTUPINFOA, child_cmdline: CString) -> HANDLE {
     if (si.dwFlags & STARTF_USESTDHANDLES).0 != 0 {
         // ignore errors, if the handles are not inheritable/valid, then nothing we can do
         unsafe { SetHandleInformation(si.hStdInput, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT) }
-            .unwrap_or_else(|_| eprintln!("Making stdin inheritable failed."));
+            .unwrap_or_else(|_| eprintln!("Making stdin inheritable failed"));
         unsafe { SetHandleInformation(si.hStdOutput, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT) }
-            .unwrap_or_else(|_| eprintln!("Making stdout inheritable failed."));
+            .unwrap_or_else(|_| eprintln!("Making stdout inheritable failed"));
         unsafe { SetHandleInformation(si.hStdError, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT) }
-            .unwrap_or_else(|_| eprintln!("Making stderr inheritable failed."));
+            .unwrap_or_else(|_| eprintln!("Making stderr inheritable failed"));
     }
     let mut child_process_info = MaybeUninit::<PROCESS_INFORMATION>::uninit();
     unsafe {
@@ -397,11 +397,11 @@ fn spawn_child(si: &STARTUPINFOA, child_cmdline: CString) -> HANDLE {
         )
     }
     .unwrap_or_else(|_| {
-        print_last_error_and_exit("Failed to spawn the python child process.");
+        print_last_error_and_exit("Failed to spawn the python child process");
     });
     let child_process_info = unsafe { child_process_info.assume_init() };
     unsafe { CloseHandle(child_process_info.hThread) }.unwrap_or_else(|_| {
-        print_last_error_and_exit("Failed to close handle to python child process main thread.");
+        print_last_error_and_exit("Failed to close handle to python child process main thread");
     });
     // Return handle to child process.
     child_process_info.hProcess
@@ -464,14 +464,14 @@ fn clear_app_starting_state(child_handle: HANDLE) {
     unsafe {
         // End the launcher's "app starting" cursor state.
         PostMessageA(None, 0, None, None).unwrap_or_else(|_| {
-            eprintln!("Failed to post a message to specified window.");
+            eprintln!("Failed to post a message to specified window");
         });
         if GetMessageA(msg.as_mut_ptr(), None, 0, 0) != TRUE {
-            eprintln!("Failed to retrieve posted window message.");
+            eprintln!("Failed to retrieve posted window message");
         }
         // Proxy the child's input idle event.
         if WaitForInputIdle(child_handle, INFINITE) != 0 {
-            eprintln!("Failed to wait for input from window.");
+            eprintln!("Failed to wait for input from window");
         }
         // Signal the process input idle event by creating a window and pumping
         // sent messages. The window class isn't important, so just use the
@@ -493,7 +493,7 @@ fn clear_app_starting_state(child_handle: HANDLE) {
         // Process all sent messages and signal input idle.
         _ = PeekMessageA(msg.as_mut_ptr(), hwnd, 0, 0, PEEK_MESSAGE_REMOVE_TYPE(0));
         DestroyWindow(hwnd).unwrap_or_else(|_| {
-            print_last_error_and_exit("Failed to destroy temporary window.");
+            print_last_error_and_exit("Failed to destroy temporary window");
         });
     }
 }
@@ -509,7 +509,7 @@ pub fn bounce(is_gui: bool) -> ! {
     let job = make_job_object();
 
     if unsafe { AssignProcessToJobObject(job, child_handle) }.is_err() {
-        print_last_error_and_exit("Failed to assign child process to the job.")
+        print_last_error_and_exit("Failed to assign child process to the job")
     }
 
     // (best effort) Close all the handles that we can
@@ -518,7 +518,7 @@ pub fn bounce(is_gui: bool) -> ! {
     // (best effort) Switch to some innocuous directory, so we don't hold the original cwd open.
     // See distlib/PC/launcher.c::switch_working_directory
     if std::env::set_current_dir(std::env::temp_dir()).is_err() {
-        eprintln!("Failed to set cwd to temp dir.");
+        eprintln!("Failed to set cwd to temp dir");
     }
 
     // We want to ignore control-C/control-Break/logout/etc.; the same event will
@@ -528,7 +528,7 @@ pub fn bounce(is_gui: bool) -> ! {
     }
     // See distlib/PC/launcher.c::control_key_handler
     unsafe { SetConsoleCtrlHandler(Some(control_key_handler), true) }.unwrap_or_else(|_| {
-        print_last_error_and_exit("Control handler setting failed.");
+        print_last_error_and_exit("Control handler setting failed");
     });
 
     if is_gui {
@@ -538,7 +538,7 @@ pub fn bounce(is_gui: bool) -> ! {
     _ = unsafe { WaitForSingleObject(child_handle, INFINITE) };
     let mut exit_code = 0u32;
     if unsafe { GetExitCodeProcess(child_handle, &mut exit_code) }.is_err() {
-        print_last_error_and_exit("Failed to get exit code of child process.");
+        print_last_error_and_exit("Failed to get exit code of child process");
     }
     exit_with_status(exit_code);
 }

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -145,7 +145,7 @@ pub(crate) async fn pip_uninstall(
             if installed.is_empty() {
                 writeln!(
                     printer.stderr(),
-                    "{}{} Skipping {} as it is not installed.",
+                    "{}{} Skipping {} as it is not installed",
                     "warning".yellow().bold(),
                     ":".bold(),
                     package.as_ref().bold()
@@ -161,7 +161,7 @@ pub(crate) async fn pip_uninstall(
             if installed.is_empty() {
                 writeln!(
                     printer.stderr(),
-                    "{}{} Skipping {} as it is not installed.",
+                    "{}{} Skipping {} as it is not installed",
                     "warning".yellow().bold(),
                     ":".bold(),
                     url.as_ref().bold()
@@ -180,7 +180,7 @@ pub(crate) async fn pip_uninstall(
     if distributions.is_empty() {
         writeln!(
             printer.stderr(),
-            "{}{} No packages to uninstall.",
+            "{}{} No packages to uninstall",
             "warning".yellow().bold(),
             ":".bold(),
         )?;

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -49,7 +49,7 @@ pub(crate) async fn add(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv add` is experimental and may change without warning.");
+        warn_user_once!("`uv add` is experimental and may change without warning");
     }
 
     // Find the project in the workspace.

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -44,7 +44,7 @@ pub(crate) async fn lock(
     printer: Printer,
 ) -> anyhow::Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv lock` is experimental and may change without warning.");
+        warn_user_once!("`uv lock` is experimental and may change without warning");
     }
 
     // Find the project requirements.
@@ -384,7 +384,7 @@ pub(super) async fn do_lock(
         // The lockfile did not contain enough information to obtain a resolution, fallback
         // to a fresh resolve.
         None => {
-            debug!("Starting clean resolution.");
+            debug!("Starting clean resolution");
 
             // Create a build dispatch.
             let build_dispatch = BuildDispatch::new(

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -34,7 +34,7 @@ pub(crate) async fn remove(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv remove` is experimental and may change without warning.");
+        warn_user_once!("`uv remove` is experimental and may change without warning");
     }
 
     // Find the project in the workspace.

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -57,7 +57,7 @@ pub(crate) async fn run(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv run` is experimental and may change without warning.");
+        warn_user_once!("`uv run` is experimental and may change without warning");
     }
 
     // Parse the input command.

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -41,7 +41,7 @@ pub(crate) async fn sync(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv sync` is experimental and may change without warning.");
+        warn_user_once!("`uv sync` is experimental and may change without warning");
     }
 
     // Identify the project

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -43,7 +43,7 @@ pub(crate) async fn tree(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv tree` is experimental and may change without warning.");
+        warn_user_once!("`uv tree` is experimental and may change without warning");
     }
 
     // Find the project requirements.

--- a/crates/uv/src/commands/python/dir.rs
+++ b/crates/uv/src/commands/python/dir.rs
@@ -10,7 +10,7 @@ use uv_warnings::warn_user_once;
 /// Show the toolchain directory.
 pub(crate) fn dir(preview: PreviewMode) -> anyhow::Result<()> {
     if preview.is_disabled() {
-        warn_user_once!("`uv python dir` is experimental and may change without warning.");
+        warn_user_once!("`uv python dir` is experimental and may change without warning");
     }
     let installed_toolchains = ManagedPythonInstallations::from_settings()
         .context("Failed to initialize toolchain settings")?;

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -20,7 +20,7 @@ pub(crate) async fn find(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv python find` is experimental and may change without warning.");
+        warn_user_once!("`uv python find` is experimental and may change without warning");
     }
 
     let request = match request {

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -35,7 +35,7 @@ pub(crate) async fn install(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv python install` is experimental and may change without warning.");
+        warn_user_once!("`uv python install` is experimental and may change without warning");
     }
 
     let start = std::time::Instant::now();

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -38,7 +38,7 @@ pub(crate) async fn list(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv python list` is experimental and may change without warning.");
+        warn_user_once!("`uv python list` is experimental and may change without warning");
     }
 
     let download_request = match kinds {

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -26,7 +26,7 @@ pub(crate) async fn pin(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv python pin` is experimental and may change without warning.");
+        warn_user_once!("`uv python pin` is experimental and may change without warning");
     }
 
     let Some(request) = request else {
@@ -37,7 +37,7 @@ pub(crate) async fn pin(
             }
             return Ok(ExitStatus::Success);
         }
-        bail!("No pinned Python version found.")
+        bail!("No pinned Python version found")
     };
     let request = PythonRequest::parse(&request);
 

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -25,7 +25,7 @@ pub(crate) async fn uninstall(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv python uninstall` is experimental and may change without warning.");
+        warn_user_once!("`uv python uninstall` is experimental and may change without warning");
     }
 
     let start = std::time::Instant::now();

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -95,7 +95,7 @@ pub(crate) async fn self_update(printer: Printer) -> Result<ExitStatus> {
                 printer.stderr(),
                 "{}",
                 format_args!(
-                    "{}{} You're on the latest version of uv ({}).",
+                    "{}{} You're on the latest version of uv ({})",
                     "success".green().bold(),
                     ":".bold(),
                     format!("v{}", env!("CARGO_PKG_VERSION")).bold().white()

--- a/crates/uv/src/commands/tool/dir.rs
+++ b/crates/uv/src/commands/tool/dir.rs
@@ -10,7 +10,7 @@ use uv_warnings::warn_user_once;
 /// Show the tool directory.
 pub(crate) fn dir(bin: bool, preview: PreviewMode) -> anyhow::Result<()> {
     if preview.is_disabled() {
-        warn_user_once!("`uv tool dir` is experimental and may change without warning.");
+        warn_user_once!("`uv tool dir` is experimental and may change without warning");
     }
 
     if bin {

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -55,7 +55,7 @@ pub(crate) async fn install(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv tool install` is experimental and may change without warning.");
+        warn_user_once!("`uv tool install` is experimental and may change without warning");
     }
 
     let client_builder = BaseClientBuilder::new()

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -20,7 +20,7 @@ pub(crate) async fn list(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv tool list` is experimental and may change without warning.");
+        warn_user_once!("`uv tool list` is experimental and may change without warning");
     }
 
     let installed_tools = InstalledTools::from_settings()?;

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -69,7 +69,7 @@ pub(crate) async fn run(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`{invocation_source}` is experimental and may change without warning.");
+        warn_user_once!("`{invocation_source}` is experimental and may change without warning");
     }
 
     let (target, args) = command.split();

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -21,7 +21,7 @@ pub(crate) async fn uninstall(
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv tool uninstall` is experimental and may change without warning.");
+        warn_user_once!("`uv tool uninstall` is experimental and may change without warning");
     }
 
     let installed_tools = InstalledTools::from_settings()?.init()?;

--- a/crates/uv/src/commands/tool/update_shell.rs
+++ b/crates/uv/src/commands/tool/update_shell.rs
@@ -19,7 +19,7 @@ use crate::printer::Printer;
 /// Ensure that the executable directory is in PATH.
 pub(crate) async fn update_shell(preview: PreviewMode, printer: Printer) -> Result<ExitStatus> {
     if preview.is_disabled() {
-        warn_user_once!("`uv tool update-shell` is experimental and may change without warning.");
+        warn_user_once!("`uv tool update-shell` is experimental and may change without warning");
     }
 
     let executable_directory = find_executable_directory()?;
@@ -36,7 +36,7 @@ pub(crate) async fn update_shell(preview: PreviewMode, printer: Printer) -> Resu
                 "Updated PATH to include executable directory {}",
                 executable_directory.simplified_display().cyan()
             )?;
-            writeln!(printer.stderr(), "Restart your shell to apply changes.")?;
+            writeln!(printer.stderr(), "Restart your shell to apply changes")?;
         } else {
             writeln!(
                 printer.stderr(),
@@ -58,18 +58,18 @@ pub(crate) async fn update_shell(preview: PreviewMode, printer: Printer) -> Resu
     } else {
         // Determine the current shell.
         let Some(shell) = Shell::from_env() else {
-            return Err(anyhow::anyhow!("The executable directory {} is not in PATH, but the current shell could not be determined.", executable_directory.simplified_display().cyan()));
+            return Err(anyhow::anyhow!("The executable directory {} is not in PATH, but the current shell could not be determined", executable_directory.simplified_display().cyan()));
         };
 
         // Look up the configuration files (e.g., `.bashrc`, `.zshrc`) for the shell.
         let files = shell.configuration_files();
         if files.is_empty() {
-            return Err(anyhow::anyhow!("The executable directory {} is not in PATH, but updating {shell} is currently unsupported.", executable_directory.simplified_display().cyan()));
+            return Err(anyhow::anyhow!("The executable directory {} is not in PATH, but updating {shell} is currently unsupported", executable_directory.simplified_display().cyan()));
         }
 
         // Prepare the command (e.g., `export PATH="$HOME/.cargo/bin:$PATH"`).
         let Some(command) = shell.prepend_path(&executable_directory) else {
-            return Err(anyhow::anyhow!("The executable directory {} is not in PATH, but the necessary command to update {shell} could not be determined.", executable_directory.simplified_display().cyan()));
+            return Err(anyhow::anyhow!("The executable directory {} is not in PATH, but the necessary command to update {shell} could not be determined", executable_directory.simplified_display().cyan()));
         };
 
         // Update each file, as necessary.
@@ -133,10 +133,10 @@ pub(crate) async fn update_shell(preview: PreviewMode, printer: Printer) -> Resu
         }
 
         if updated {
-            writeln!(printer.stderr(), "Restart your shell to apply changes.")?;
+            writeln!(printer.stderr(), "Restart your shell to apply changes")?;
             Ok(ExitStatus::Success)
         } else {
-            Err(anyhow::anyhow!("The executable directory {} is not in PATH, but the {shell} configuration files are already up-to-date.", executable_directory.simplified_display().cyan()))
+            Err(anyhow::anyhow!("The executable directory {} is not in PATH, but the {shell} configuration files are already up-to-date", executable_directory.simplified_display().cyan()))
         }
     }
 }

--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -101,7 +101,7 @@ fn prune_cached_env() {
     pytest 8.0.0
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -30,7 +30,7 @@ fn add_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning.
+    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -118,7 +118,7 @@ fn add_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 4 packages in [TIME]
     "###);
 
@@ -145,7 +145,7 @@ fn add_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -155,7 +155,7 @@ fn add_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -276,7 +276,7 @@ fn add_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 5 packages in [TIME]
     "###);
 
@@ -303,7 +303,7 @@ fn add_git_raw() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -313,7 +313,7 @@ fn add_git_raw() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -422,7 +422,7 @@ fn add_git_raw() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 5 packages in [TIME]
     "###);
 
@@ -512,7 +512,7 @@ fn add_unnamed() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 2 packages in [TIME]
     "###);
 
@@ -539,7 +539,7 @@ fn add_remove_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning.
+    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -632,7 +632,7 @@ fn add_remove_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 4 packages in [TIME]
     "###);
 
@@ -643,7 +643,7 @@ fn add_remove_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning.
+    warning: `uv remove` is experimental and may change without warning
     warning: `anyio` is a development dependency; try calling `uv remove --dev`
     error: The dependency `anyio` could not be found in `dependencies`
     "###);
@@ -655,7 +655,7 @@ fn add_remove_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning.
+    warning: `uv remove` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 4 packages in [TIME]
@@ -711,7 +711,7 @@ fn add_remove_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 1 package in [TIME]
     "###);
 
@@ -738,7 +738,7 @@ fn add_remove_optional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning.
+    warning: `uv add` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -792,7 +792,7 @@ fn add_remove_optional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 1 package in [TIME]
     "###);
 
@@ -803,7 +803,7 @@ fn add_remove_optional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning.
+    warning: `uv remove` is experimental and may change without warning
     warning: `anyio` is an optional dependency; try calling `uv remove --optional io`
     error: The dependency `anyio` could not be found in `dependencies`
     "###);
@@ -815,7 +815,7 @@ fn add_remove_optional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning.
+    warning: `uv remove` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -868,7 +868,7 @@ fn add_remove_optional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 1 package in [TIME]
     "###);
 
@@ -999,7 +999,7 @@ fn add_remove_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 2 packages in [TIME]
     "###);
 
@@ -1010,7 +1010,7 @@ fn add_remove_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning.
+    warning: `uv remove` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 2 packages in [TIME]
@@ -1068,7 +1068,7 @@ fn add_remove_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 1 package in [TIME]
     "###);
 
@@ -1179,7 +1179,7 @@ fn add_workspace_editable() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 2 packages in [TIME]
     "###);
 
@@ -1208,7 +1208,7 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###);
 
@@ -1218,7 +1218,7 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + certifi==2024.2.2
@@ -1236,7 +1236,7 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning.
+    warning: `uv add` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -1270,7 +1270,7 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning.
+    warning: `uv add` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 3 packages in [TIME]
     Uninstalled 1 package in [TIME]
@@ -1306,8 +1306,8 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning.
-    warning: `uv.sources` is experimental and may change without warning.
+    warning: `uv add` is experimental and may change without warning
+    warning: `uv.sources` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 2 packages in [TIME]
     Uninstalled 2 packages in [TIME]
@@ -1455,7 +1455,7 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 8 packages in [TIME]
     "###);
 
@@ -1484,7 +1484,7 @@ fn add_no_clean() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -1494,7 +1494,7 @@ fn add_no_clean() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -1518,7 +1518,7 @@ fn add_no_clean() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning.
+    warning: `uv add` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Uninstalled 1 package in [TIME]
@@ -1583,7 +1583,7 @@ fn add_no_clean() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 2 packages in [TIME]
     "###);
 
@@ -1594,7 +1594,7 @@ fn add_no_clean() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Uninstalled 3 packages in [TIME]
      - anyio==3.7.0
      - idna==3.6
@@ -1624,7 +1624,7 @@ fn remove_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -1634,7 +1634,7 @@ fn remove_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -1649,7 +1649,7 @@ fn remove_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning.
+    warning: `uv remove` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 4 packages in [TIME]
@@ -1702,7 +1702,7 @@ fn remove_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Audited 1 package in [TIME]
     "###);
 
@@ -1731,7 +1731,7 @@ fn add_preserves_indentation_in_pyproject_toml() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning.
+    warning: `uv add` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
@@ -1787,7 +1787,7 @@ fn add_puts_default_indentation_in_pyproject_toml_if_not_observed() -> Result<()
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning.
+    warning: `uv add` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
@@ -1844,7 +1844,7 @@ fn add_frozen() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning.
+    warning: `uv add` is experimental and may change without warning
     "###);
 
     let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -52,7 +52,7 @@ fn lock_wheel_registry() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 4 packages in [TIME]
         "###);
 
@@ -116,7 +116,7 @@ fn lock_wheel_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -151,7 +151,7 @@ fn lock_sdist_registry() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 2 packages in [TIME]
         "###);
 
@@ -190,7 +190,7 @@ fn lock_sdist_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
@@ -223,7 +223,7 @@ fn lock_sdist_git() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 2 packages in [TIME]
         "###);
 
@@ -261,7 +261,7 @@ fn lock_sdist_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
@@ -294,7 +294,7 @@ fn lock_wheel_url() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 4 packages in [TIME]
         "###);
 
@@ -357,7 +357,7 @@ fn lock_wheel_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 3 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0 (from https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl)
@@ -392,7 +392,7 @@ fn lock_sdist_url() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 4 packages in [TIME]
         "###);
 
@@ -453,7 +453,7 @@ fn lock_sdist_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0 (from https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz)
@@ -491,7 +491,7 @@ fn lock_project_extra() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 5 packages in [TIME]
         "###);
 
@@ -569,7 +569,7 @@ fn lock_project_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -585,7 +585,7 @@ fn lock_project_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
@@ -618,7 +618,7 @@ fn lock_project_with_overrides() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 9 packages in [TIME]
     "###);
 
@@ -629,7 +629,7 @@ fn lock_project_with_overrides() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
      + blinker==1.7.0
@@ -667,7 +667,7 @@ fn lock_dependency_extra() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 10 packages in [TIME]
         "###);
 
@@ -811,7 +811,7 @@ fn lock_dependency_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 9 packages in [TIME]
     Installed 9 packages in [TIME]
      + blinker==1.7.0
@@ -853,7 +853,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 7 packages in [TIME]
         "###);
 
@@ -1040,7 +1040,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + certifi==2024.2.2
@@ -1064,7 +1064,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + certifi==2024.2.2
@@ -1102,9 +1102,9 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 9 packages in [TIME]
-        warning: The package `flask==3.0.2` does not have an extra named `foo`.
+        warning: The package `flask==3.0.2` does not have an extra named `foo`
         "###);
 
         let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
@@ -1233,7 +1233,7 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
      + blinker==1.7.0
@@ -1272,7 +1272,7 @@ fn lock_upgrade_log() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 9 packages in [TIME]
         "###);
 
@@ -1402,7 +1402,7 @@ fn lock_upgrade_log() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 9 packages in [TIME]
     "###);
 
@@ -1424,7 +1424,7 @@ fn lock_upgrade_log() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 9 packages in [TIME]
     Updating flask v2.3.3 -> v3.0.2
     "###);
@@ -1574,7 +1574,7 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 10 packages in [TIME]
         "###);
 
@@ -1721,7 +1721,7 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 10 packages in [TIME]
     "###);
 
@@ -1743,7 +1743,7 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 9 packages in [TIME]
     Updating flask v2.3.3, 3.0.0 -> v3.0.2
     "###);
@@ -1892,7 +1892,7 @@ fn lock_preference() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 2 packages in [TIME]
         "###);
 
@@ -1947,7 +1947,7 @@ fn lock_preference() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -1993,7 +1993,7 @@ fn lock_preference() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 2 packages in [TIME]
         "###);
 
@@ -2056,7 +2056,7 @@ fn lock_git_sha() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 2 packages in [TIME]
         "###);
 
@@ -2109,7 +2109,7 @@ fn lock_git_sha() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -2149,7 +2149,7 @@ fn lock_git_sha() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 2 packages in [TIME]
         "###);
 
@@ -2211,7 +2211,7 @@ fn lock_requires_python() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
           × No solution found when resolving dependencies:
           ╰─▶ Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and the requested Python version (>=3.7) does not satisfy Python>=3.7.9,<3.8, we can conclude that Python>=3.7.9 is incompatible.
               And because pygls>=1.1.0,<=1.2.1 depends on Python>=3.7.9,<4 and only pygls<=1.3.0 is available, we can conclude that any of:
@@ -2249,7 +2249,7 @@ fn lock_requires_python() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 10 packages in [TIME]
         "###);
 
@@ -2397,7 +2397,7 @@ fn lock_requires_python() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 9 packages in [TIME]
         "###);
 
@@ -2535,7 +2535,7 @@ fn lock_requires_python() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 5 packages in [TIME]
         "###);
 
@@ -2630,7 +2630,7 @@ fn lock_requires_python() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     error: No interpreter found for Python >=3.12 in system path
     "###);
 
@@ -2663,7 +2663,7 @@ fn lock_requires_python_wheels() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
         Resolved 2 packages in [TIME]
         "###);
@@ -2732,7 +2732,7 @@ fn lock_requires_python_wheels() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
         Resolved 2 packages in [TIME]
         "###);
@@ -2812,7 +2812,7 @@ fn lock_requires_python_star() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 6 packages in [TIME]
         "###);
 
@@ -2921,7 +2921,7 @@ fn lock_requires_python_pre() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 6 packages in [TIME]
         "###);
 
@@ -3028,7 +3028,7 @@ fn lock_requires_python_unbounded() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         warning: The workspace `requires-python` field does not contain a lower bound: `<=3.12`. Set a lower bound to indicate the minimum compatible Python version (e.g., `>=3.11`).
         Resolved 2 packages in [TIME]
         "###);
@@ -3105,7 +3105,7 @@ fn lock_python_version_marker_complement() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 4 packages in [TIME]
         "###);
 
@@ -3189,7 +3189,7 @@ fn lock_dev() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 3 packages in [TIME]
         "###);
 
@@ -3244,7 +3244,7 @@ fn lock_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + iniconfig==2.0.0
@@ -3258,7 +3258,7 @@ fn lock_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Installed 1 package in [TIME]
      + typing-extensions==4.12.2 (from https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl)
     "###);
@@ -3289,7 +3289,7 @@ fn lock_conditional_unconditional() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 2 packages in [TIME]
         "###);
 
@@ -3350,7 +3350,7 @@ fn lock_multiple_markers() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 2 packages in [TIME]
         "###);
 
@@ -3514,7 +3514,7 @@ fn lock_cycles() -> Result<()> {
         ----- stdout -----
 
         ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning.
+        warning: `uv lock` is experimental and may change without warning
         Resolved 11 packages in [TIME]
         "###);
 
@@ -3660,7 +3660,7 @@ fn lock_cycles() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 11 packages in [TIME]
     Installed 11 packages in [TIME]
      + argparse==1.4.0
@@ -3989,7 +3989,7 @@ fn lock_invalid_hash() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     error: Failed to prepare distributions
       Caused by: Failed to fetch wheel: idna==3.6
       Caused by: Hash mismatch for `idna==3.6`

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -70,7 +70,7 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###
     );
@@ -166,7 +166,7 @@ fn fork_allows_non_conflicting_repeated_dependencies() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###
     );
@@ -251,7 +251,7 @@ fn fork_basic() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###
     );
@@ -361,7 +361,7 @@ fn conflict_in_fork() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies for split (sys_platform == 'darwin'):
       ╰─▶ Because only package-b==1.0.0 is available and package-b==1.0.0 depends on package-d==1, we can conclude that all versions of package-b depend on package-d==1.
           And because package-c==1.0.0 depends on package-d==2 and only package-c==1.0.0 is available, we can conclude that all versions of package-b and all versions of package-c are incompatible.
@@ -430,7 +430,7 @@ fn fork_conflict_unsatisfiable() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because project==0.1.0 depends on package-a>=2 and package-a<2, we can conclude that project==0.1.0 cannot be used.
           And because only project==0.1.0 is available and you require project, we can conclude that the requirements are unsatisfiable.
@@ -512,7 +512,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 7 packages in [TIME]
     "###
     );
@@ -663,7 +663,7 @@ fn fork_incomplete_markers() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -790,7 +790,7 @@ fn fork_marker_accrue() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###
     );
@@ -907,7 +907,7 @@ fn fork_marker_disjoint() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because project==0.1.0 depends on package-a{sys_platform == 'linux'}>=2 and package-a{sys_platform == 'linux'}<2, we can conclude that project==0.1.0 cannot be used.
           And because only project==0.1.0 is available and you require project, we can conclude that the requirements are unsatisfiable.
@@ -979,7 +979,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###
     );
@@ -1123,7 +1123,7 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -1256,7 +1256,7 @@ fn fork_marker_inherit_combined() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -1383,7 +1383,7 @@ fn fork_marker_inherit_isolated() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###
     );
@@ -1505,7 +1505,7 @@ fn fork_marker_inherit_transitive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -1634,7 +1634,7 @@ fn fork_marker_inherit() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###
     );
@@ -1744,7 +1744,7 @@ fn fork_marker_limited_inherit() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -1873,7 +1873,7 @@ fn fork_marker_selection() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###
     );
@@ -2001,7 +2001,7 @@ fn fork_marker_track() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -2127,7 +2127,7 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###
     );
@@ -2247,7 +2247,7 @@ fn fork_non_local_fork_marker_direct() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because package-b{sys_platform == 'darwin'}==1.0.0 depends on package-c>=2.0.0 and package-a{sys_platform == 'linux'}==1.0.0 depends on package-c<2.0.0, we can conclude that package-a{sys_platform == 'linux'}==1.0.0 and package-b{sys_platform == 'darwin'}==1.0.0 are incompatible.
           And because project==0.1.0 depends on package-a{sys_platform == 'linux'}==1.0.0 and package-b{sys_platform == 'darwin'}==1.0.0, we can conclude that project==0.1.0 cannot be used.
@@ -2322,7 +2322,7 @@ fn fork_non_local_fork_marker_transitive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because package-b==1.0.0 depends on package-c{sys_platform == 'darwin'}>=2.0.0 and only package-c{sys_platform == 'darwin'}<=2.0.0 is available, we can conclude that package-b==1.0.0 depends on package-c{sys_platform == 'darwin'}==2.0.0.
           And because only the following versions of package-c{sys_platform == 'linux'} are available:
@@ -2383,7 +2383,7 @@ fn fork_requires_python_full_prerelease() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 1 package in [TIME]
     "###
     );
@@ -2455,7 +2455,7 @@ fn fork_requires_python_full() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 1 package in [TIME]
     "###
     );
@@ -2530,7 +2530,7 @@ fn fork_requires_python_patch_overlap() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###
     );
@@ -2612,7 +2612,7 @@ fn fork_requires_python() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning.
+    warning: `uv lock` is experimental and may change without warning
     Resolved 1 package in [TIME]
     "###
     );

--- a/crates/uv/tests/pip_check.rs
+++ b/crates/uv/tests/pip_check.rs
@@ -109,7 +109,7 @@ fn check_incompatible_packages() -> Result<()> {
     Installed 1 package in [TIME]
      - idna==3.6
      + idna==2.4
-    warning: The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed.
+    warning: The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed
     "###
     );
 
@@ -121,7 +121,7 @@ fn check_incompatible_packages() -> Result<()> {
     ----- stderr -----
     Checked 5 packages in [TIME]
     Found 1 incompatibility
-    The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed.
+    The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed
     "###
     );
 
@@ -180,8 +180,8 @@ fn check_multiple_incompatible_packages() -> Result<()> {
      + idna==2.4
      - urllib3==2.2.1
      + urllib3==1.20
-    warning: The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed.
-    warning: The package `requests` requires `urllib3<3,>=1.21.1`, but `1.20` is installed.
+    warning: The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed
+    warning: The package `requests` requires `urllib3<3,>=1.21.1`, but `1.20` is installed
     "###
     );
 
@@ -193,8 +193,8 @@ fn check_multiple_incompatible_packages() -> Result<()> {
     ----- stderr -----
     Checked 5 packages in [TIME]
     Found 2 incompatibilities
-    The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed.
-    The package `requests` requires `urllib3<3,>=1.21.1`, but `1.20` is installed.
+    The package `requests` requires `idna<4,>=2.5`, but `2.4` is installed
+    The package `requests` requires `urllib3<3,>=1.21.1`, but `1.20` is installed
     "###
     );
 

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -2906,7 +2906,7 @@ fn compile_yanked_version_direct() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    warning: `attrs==21.1.0` is yanked (reason: "Installable but not importable on Python 3.4.").
+    warning: `attrs==21.1.0` is yanked (reason: "Installable but not importable on Python 3.4.")
     "###
     );
 
@@ -3349,7 +3349,7 @@ fn missing_registry_extra() -> Result<()> {
 
     ----- stderr -----
     Resolved 6 packages in [TIME]
-    warning: The package `black==23.10.1` does not have an extra named `tensorboard`.
+    warning: The package `black==23.10.1` does not have an extra named `tensorboard`
     "###
     );
 
@@ -3389,7 +3389,7 @@ fn missing_url_extra() -> Result<()> {
 
     ----- stderr -----
     Resolved 7 packages in [TIME]
-    warning: The package `flask @ https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl` does not have an extra named `tensorboard`.
+    warning: The package `flask @ https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl` does not have an extra named `tensorboard`
     "###
     );
 
@@ -5084,7 +5084,7 @@ fn allow_unsafe() -> Result<()> {
         # via -r requirements.in
 
     ----- stderr -----
-    warning: pip-compile's `--allow-unsafe` has no effect (uv can safely pin `pip` and other packages).
+    warning: pip-compile's `--allow-unsafe` has no effect (uv can safely pin `pip` and other packages)
     Resolved 2 packages in [TIME]
     "###
     );
@@ -5107,7 +5107,7 @@ fn resolver_legacy() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: pip-compile's `--resolver=legacy` is unsupported (uv always backtracks).
+    error: pip-compile's `--resolver=legacy` is unsupported (uv always backtracks)
     "###
     );
 
@@ -6064,7 +6064,7 @@ fn no_deps_invalid_extra() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    warning: The package `flask==3.0.2` does not have an extra named `empty`.
+    warning: The package `flask==3.0.2` does not have an extra named `empty`
     "###
     );
 
@@ -6161,7 +6161,7 @@ fn editable_invalid_extra() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    warning: The package `black @ file://[WORKSPACE]/scripts/packages/black_editable` does not have an extra named `empty`.
+    warning: The package `black @ file://[WORKSPACE]/scripts/packages/black_editable` does not have an extra named `empty`
     "###);
 
     Ok(())

--- a/crates/uv/tests/pip_freeze.rs
+++ b/crates/uv/tests/pip_freeze.rs
@@ -95,7 +95,7 @@ fn freeze_duplicate() -> Result<()> {
     pip==22.1.1
 
     ----- stderr -----
-    warning: The package `pip` has multiple installed distributions:
+    warning: The package `pip` has multiple installed distributions: 
       - [SITE_PACKAGES]/pip-21.3.1.dist-info
       - [SITE_PACKAGES]/pip-22.1.1.dist-info
     "###
@@ -129,8 +129,8 @@ fn freeze_url() -> Result<()> {
     iniconfig @ https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
 
     ----- stderr -----
-    warning: The package `anyio` requires `idna>=2.8`, but it's not installed.
-    warning: The package `anyio` requires `sniffio>=1.1`, but it's not installed.
+    warning: The package `anyio` requires `idna>=2.8`, but it's not installed
+    warning: The package `anyio` requires `sniffio>=1.1`, but it's not installed
     "###
     );
 
@@ -167,8 +167,8 @@ fn freeze_with_editable() -> Result<()> {
     -e file://[WORKSPACE]/scripts/packages/poetry_editable
 
     ----- stderr -----
-    warning: The package `anyio` requires `idna>=2.8`, but it's not installed.
-    warning: The package `anyio` requires `sniffio>=1.1`, but it's not installed.
+    warning: The package `anyio` requires `idna>=2.8`, but it's not installed
+    warning: The package `anyio` requires `sniffio>=1.1`, but it's not installed
     "###
     );
 
@@ -182,8 +182,8 @@ fn freeze_with_editable() -> Result<()> {
     anyio==4.3.0
 
     ----- stderr -----
-    warning: The package `anyio` requires `idna>=2.8`, but it's not installed.
-    warning: The package `anyio` requires `sniffio>=1.1`, but it's not installed.
+    warning: The package `anyio` requires `idna>=2.8`, but it's not installed
+    warning: The package `anyio` requires `sniffio>=1.1`, but it's not installed
     "###
     );
 

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -761,7 +761,7 @@ fn allow_incompatibilities() -> Result<()> {
     Installed 1 package in [TIME]
      - jinja2==3.1.3
      + jinja2==2.11.3
-    warning: The package `flask` requires `jinja2>=3.1.2`, but `2.11.3` is installed.
+    warning: The package `flask` requires `jinja2>=3.1.2`, but `2.11.3` is installed
     "###
     );
 
@@ -2262,11 +2262,11 @@ fn no_deps() {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + flask==3.0.2
-    warning: The package `flask` requires `werkzeug>=3.0.0`, but it's not installed.
-    warning: The package `flask` requires `jinja2>=3.1.2`, but it's not installed.
-    warning: The package `flask` requires `itsdangerous>=2.1.2`, but it's not installed.
-    warning: The package `flask` requires `click>=8.1.3`, but it's not installed.
-    warning: The package `flask` requires `blinker>=1.6.2`, but it's not installed.
+    warning: The package `flask` requires `werkzeug>=3.0.0`, but it's not installed
+    warning: The package `flask` requires `jinja2>=3.1.2`, but it's not installed
+    warning: The package `flask` requires `itsdangerous>=2.1.2`, but it's not installed
+    warning: The package `flask` requires `click>=8.1.3`, but it's not installed
+    warning: The package `flask` requires `blinker>=1.6.2`, but it's not installed
     "###
     );
 
@@ -5727,7 +5727,7 @@ fn tool_uv_sources_is_in_preview() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv.sources` is experimental and may change without warning.
+    warning: `uv.sources` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -701,7 +701,7 @@ fn missing_extra() {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==1.0.0
-    warning: The package `package-a==1.0.0` does not have an extra named `extra`.
+    warning: The package `package-a==1.0.0` does not have an extra named `extra`
     "###);
 
     // Missing extras are ignored during resolution.
@@ -1074,7 +1074,7 @@ fn extra_does_not_exist_backtrack() {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + package-a==3.0.0
-    warning: The package `package-a==3.0.0` does not have an extra named `extra`.
+    warning: The package `package-a==3.0.0` does not have an extra named `extra`
     "###);
 
     // The resolver should not backtrack to `a==1.0.0` because missing extras are
@@ -4769,7 +4769,7 @@ fn transitive_package_only_yanked_in_range_opt_in() {
     Installed 2 packages in [TIME]
      + package-a==0.1.0
      + package-b==1.0.0
-    warning: `package-b==1.0.0` is yanked (reason: "Yanked for testing").
+    warning: `package-b==1.0.0` is yanked (reason: "Yanked for testing")
     "###);
 
     // Since the user included a dependency on `b` with an exact specifier, the yanked
@@ -4901,7 +4901,7 @@ fn transitive_yanked_and_unyanked_dependency_opt_in() {
      + package-a==1.0.0
      + package-b==1.0.0
      + package-c==2.0.0
-    warning: `package-c==2.0.0` is yanked (reason: "Yanked for testing").
+    warning: `package-c==2.0.0` is yanked (reason: "Yanked for testing")
     "###);
 
     // Since the user explicitly selected the yanked version of `c`, it can be

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -933,7 +933,7 @@ fn warn_on_yanked() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + colorama==0.4.2
-    warning: `colorama==0.4.2` is yanked (reason: "Bad build, missing files, will not install").
+    warning: `colorama==0.4.2` is yanked (reason: "Bad build, missing files, will not install")
     "###
     );
 
@@ -961,7 +961,7 @@ fn warn_on_yanked_dry_run() -> Result<()> {
     Would download 1 package
     Would install 1 package
      + colorama==0.4.2
-    warning: `colorama==0.4.2` is yanked (reason: "Bad build, missing files, will not install").
+    warning: `colorama==0.4.2` is yanked (reason: "Bad build, missing files, will not install")
     "###
     );
 
@@ -1742,7 +1742,7 @@ fn install_url_built_dist_cached() -> Result<()> {
     requirements_txt.write_str("tqdm @ https://files.pythonhosted.org/packages/00/e5/f12a80907d0884e6dff9c16d0c0114d81b8cd07dc3ae54c5e962cc83037e/tqdm-4.66.1-py3-none-any.whl")?;
 
     let filters = if cfg!(windows) {
-        [("warning: The package `tqdm` requires `colorama ; platform_system == 'Windows'`, but it's not installed.\n", "")]
+        [("warning: The package `tqdm` requires `colorama ; platform_system == 'Windows'`, but it's not installed\n", "")]
             .into_iter()
             .chain(context.filters())
             .collect()
@@ -2278,11 +2278,11 @@ fn sync_editable_and_registry() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==24.1.0
-    warning: The package `black` requires `click>=8.0.0`, but it's not installed.
-    warning: The package `black` requires `mypy-extensions>=0.4.3`, but it's not installed.
-    warning: The package `black` requires `packaging>=22.0`, but it's not installed.
-    warning: The package `black` requires `pathspec>=0.9.0`, but it's not installed.
-    warning: The package `black` requires `platformdirs>=2`, but it's not installed.
+    warning: The package `black` requires `click>=8.0.0`, but it's not installed
+    warning: The package `black` requires `mypy-extensions>=0.4.3`, but it's not installed
+    warning: The package `black` requires `packaging>=22.0`, but it's not installed
+    warning: The package `black` requires `pathspec>=0.9.0`, but it's not installed
+    warning: The package `black` requires `platformdirs>=2`, but it's not installed
     "###
     );
 
@@ -2351,11 +2351,11 @@ fn sync_editable_and_registry() -> Result<()> {
     Installed 1 package in [TIME]
      - black==0.1.0 (from file://[TEMP_DIR]/black_editable)
      + black==23.10.0
-    warning: The package `black` requires `click>=8.0.0`, but it's not installed.
-    warning: The package `black` requires `mypy-extensions>=0.4.3`, but it's not installed.
-    warning: The package `black` requires `packaging>=22.0`, but it's not installed.
-    warning: The package `black` requires `pathspec>=0.9.0`, but it's not installed.
-    warning: The package `black` requires `platformdirs>=2`, but it's not installed.
+    warning: The package `black` requires `click>=8.0.0`, but it's not installed
+    warning: The package `black` requires `mypy-extensions>=0.4.3`, but it's not installed
+    warning: The package `black` requires `packaging>=22.0`, but it's not installed
+    warning: The package `black` requires `pathspec>=0.9.0`, but it's not installed
+    warning: The package `black` requires `platformdirs>=2`, but it's not installed
     "###
     );
 

--- a/crates/uv/tests/python_dir.rs
+++ b/crates/uv/tests/python_dir.rs
@@ -17,6 +17,6 @@ fn python_dir() {
     [TEMP_DIR]/python
 
     ----- stderr -----
-    warning: `uv python dir` is experimental and may change without warning.
+    warning: `uv python dir` is experimental and may change without warning
     "###);
 }

--- a/crates/uv/tests/python_pin.rs
+++ b/crates/uv/tests/python_pin.rs
@@ -20,7 +20,7 @@ fn python_pin() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No pinned Python version found.
+    error: No pinned Python version found
     "###);
 
     // Given an argument, we pin to that version

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -171,7 +171,7 @@ fn run_args() -> Result<()> {
     Python 3.12.[X]
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning.
+    warning: `uv run` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -186,7 +186,7 @@ fn run_args() -> Result<()> {
     Python 3.12.[X]
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning.
+    warning: `uv run` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Audited 1 package in [TIME]
     "###);
@@ -324,7 +324,7 @@ fn run_managed_false() -> Result<()> {
     Python 3.12.[X]
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning.
+    warning: `uv run` is experimental and may change without warning
     "###);
 
     Ok(())
@@ -357,7 +357,7 @@ fn run_with() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning.
+    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -378,7 +378,7 @@ fn run_with() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning.
+    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Audited 4 packages in [TIME]
     "###);
@@ -390,7 +390,7 @@ fn run_with() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning.
+    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Audited 4 packages in [TIME]
     Resolved 1 package in [TIME]
@@ -424,7 +424,7 @@ fn run_locked() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning.
+    warning: `uv run` is experimental and may change without warning
     error: Unable to find lockfile at `uv.lock`. To create a lockfile, run `uv lock` or `uv sync`.
     "###);
 
@@ -451,7 +451,7 @@ fn run_locked() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning.
+    warning: `uv run` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
@@ -472,7 +472,7 @@ fn run_locked() -> Result<()> {
     Python 3.12.[X]
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning.
+    warning: `uv run` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -505,7 +505,7 @@ fn run_frozen() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning.
+    warning: `uv run` is experimental and may change without warning
     error: Unable to find lockfile at `uv.lock`. To create a lockfile, run `uv lock` or `uv sync`.
     "###);
 
@@ -530,7 +530,7 @@ fn run_frozen() -> Result<()> {
     Python 3.12.[X]
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning.
+    warning: `uv run` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -30,7 +30,7 @@ fn sync() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -65,7 +65,7 @@ fn locked() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     error: Unable to find lockfile at `uv.lock`. To create a lockfile, run `uv lock` or `uv sync`.
     "###);
 
@@ -92,7 +92,7 @@ fn locked() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
@@ -127,7 +127,7 @@ fn frozen() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     error: Unable to find lockfile at `uv.lock`. To create a lockfile, run `uv lock` or `uv sync`.
     "###);
 
@@ -151,7 +151,7 @@ fn frozen() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning.
+    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0

--- a/crates/uv/tests/tool_dir.rs
+++ b/crates/uv/tests/tool_dir.rs
@@ -21,7 +21,7 @@ fn tool_dir() {
     [TEMP_DIR]/tools
 
     ----- stderr -----
-    warning: `uv tool dir` is experimental and may change without warning.
+    warning: `uv tool dir` is experimental and may change without warning
     "###);
 }
 
@@ -40,6 +40,6 @@ fn tool_dir_bin() {
     [TEMP_DIR]/bin
 
     ----- stderr -----
-    warning: `uv tool dir` is experimental and may change without warning.
+    warning: `uv tool dir` is experimental and may change without warning
     "###);
 }

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -33,7 +33,7 @@ fn tool_install() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -109,7 +109,7 @@ fn tool_install() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -192,7 +192,7 @@ fn tool_install_suggest_other_packages_with_executable() {
     Did you mean `uv tool install fastapi-cli`?
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved 35 packages in [TIME]
     Prepared 35 packages in [TIME]
     Installed 35 packages in [TIME]
@@ -251,7 +251,7 @@ fn tool_install_version() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -337,7 +337,7 @@ fn tool_install_from() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -363,7 +363,7 @@ fn tool_install_from() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     error: Package name (`flask`) provided with `--from` does not match install request (`black`)
     "###);
 
@@ -380,7 +380,7 @@ fn tool_install_from() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     error: Package requirement (`black==24.3.0`) provided with `--from` conflicts with install request (`black==24.2.0`)
     "###);
 }
@@ -405,7 +405,7 @@ fn tool_install_already_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -471,7 +471,7 @@ fn tool_install_already_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     `black` is already installed
     "###);
 
@@ -507,7 +507,7 @@ fn tool_install_already_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -540,7 +540,7 @@ fn tool_install_already_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -563,7 +563,7 @@ fn tool_install_already_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -596,7 +596,7 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -636,7 +636,7 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Installed [N] packages in [TIME]
      + black==24.3.0
@@ -677,7 +677,7 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Installed [N] packages in [TIME]
      + black==24.3.0
@@ -701,7 +701,7 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Installed [N] packages in [TIME]
      + black==24.3.0
@@ -727,7 +727,7 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Installed 2 executables: black, blackd
     "###);
 
@@ -744,7 +744,7 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     `black` is already installed
     "###);
 
@@ -762,7 +762,7 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -868,7 +868,7 @@ fn tool_install_home() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -906,7 +906,7 @@ fn tool_install_xdg_data_home() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -943,7 +943,7 @@ fn tool_install_xdg_bin_home() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -979,7 +979,7 @@ fn tool_install_no_entrypoints() {
     No executables are provided by package `iniconfig`.
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -1005,7 +1005,7 @@ fn tool_install_unnamed_package() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -1092,7 +1092,7 @@ fn tool_install_unnamed_conflict() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     error: Package name (`iniconfig`) provided with `--from` does not match install request (`black`)
     "###);
 }
@@ -1117,7 +1117,7 @@ fn tool_install_unnamed_from() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -1203,7 +1203,7 @@ fn tool_install_unnamed_with() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved 7 packages in [TIME]
     Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
@@ -1293,7 +1293,7 @@ fn tool_install_upgrade() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -1332,7 +1332,7 @@ fn tool_install_upgrade() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Installed 2 executables: black, blackd
     "###);
 
@@ -1363,7 +1363,7 @@ fn tool_install_upgrade() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -1401,7 +1401,7 @@ fn tool_install_upgrade() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
@@ -1449,7 +1449,7 @@ fn tool_install_python_request() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -1475,7 +1475,7 @@ fn tool_install_python_request() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     `black` is already installed
     "###);
 
@@ -1492,7 +1492,7 @@ fn tool_install_python_request() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Existing environment for `black` does not satisfy the requested Python interpreter
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
@@ -1527,7 +1527,7 @@ fn tool_install_preserve_environment() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -1553,7 +1553,7 @@ fn tool_install_preserve_environment() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     error: Because black==24.1.1 depends on packaging>=22.0 and you require black==24.1.1, we can conclude that you require packaging>=22.0.
     And because you require packaging==0.0.1, we can conclude that the requirements are unsatisfiable.
     "###);
@@ -1569,7 +1569,7 @@ fn tool_install_preserve_environment() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     `black==24.1.1` is already installed
     "###);
 }
@@ -1595,7 +1595,7 @@ fn tool_install_warn_path() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]

--- a/crates/uv/tests/tool_list.rs
+++ b/crates/uv/tests/tool_list.rs
@@ -35,7 +35,7 @@ fn tool_list() {
     - blackd
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning.
+    warning: `uv tool list` is experimental and may change without warning
     "###);
 }
 
@@ -65,7 +65,7 @@ fn tool_list_paths() {
     - blackd ([TEMP_DIR]/bin/blackd)
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning.
+    warning: `uv tool list` is experimental and may change without warning
     "###);
 }
 
@@ -83,7 +83,7 @@ fn tool_list_empty() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning.
+    warning: `uv tool list` is experimental and may change without warning
     No tools installed
     "###);
 }
@@ -113,7 +113,7 @@ fn tool_list_missing_receipt() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning.
+    warning: `uv tool list` is experimental and may change without warning
     warning: Ignoring malformed tool `black` (run `uv tool uninstall black` to remove)
     "###);
 }
@@ -163,7 +163,7 @@ fn tool_list_bad_environment() -> Result<()> {
     - ruff
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning.
+    warning: `uv tool list` is experimental and may change without warning
     Python interpreter not found at `[TEMP_DIR]/tools/black/[BIN]/python`
     "###
     );

--- a/crates/uv/tests/tool_run.rs
+++ b/crates/uv/tests/tool_run.rs
@@ -39,7 +39,7 @@ fn tool_run_args() {
     pytest 8.1.1
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -62,7 +62,7 @@ fn tool_run_args() {
     pytest 8.1.1
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     "###);
 }
@@ -84,7 +84,7 @@ fn tool_run_at_version() {
     pytest 8.0.0
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -105,7 +105,7 @@ fn tool_run_at_version() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     error: Failed to parse: `pytest@`
       Caused by: Expected URL
     pytest@
@@ -123,7 +123,7 @@ fn tool_run_at_version() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     error: Distribution not found at: file://[TEMP_DIR]/invalid
     "###);
 
@@ -154,7 +154,7 @@ fn tool_run_at_version() {
     - pytest
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 4 packages in [TIME]
@@ -185,7 +185,7 @@ fn tool_run_from_version() {
     pytest 8.0.0
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -217,7 +217,7 @@ fn tool_run_suggest_valid_commands() {
     - blackd
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -240,7 +240,7 @@ fn tool_run_suggest_valid_commands() {
     The executable `fastapi-cli` was not found.
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
@@ -274,7 +274,7 @@ fn tool_run_warn_executable_not_in_from() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved 35 packages in [TIME]
     Prepared 35 packages in [TIME]
     Installed 35 packages in [TIME]
@@ -344,7 +344,7 @@ fn tool_run_from_install() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     "###);
 
     // Verify that `--isolated` uses an isolated environment.
@@ -361,7 +361,7 @@ fn tool_run_from_install() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 6 packages in [TIME]
@@ -386,7 +386,7 @@ fn tool_run_from_install() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 6 packages in [TIME]
@@ -415,7 +415,7 @@ fn tool_run_from_install() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved 7 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 7 packages in [TIME]
@@ -443,7 +443,7 @@ fn tool_run_from_install() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 6 packages in [TIME]
@@ -477,7 +477,7 @@ fn tool_run_cache() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -504,7 +504,7 @@ fn tool_run_cache() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     "###);
 
@@ -523,7 +523,7 @@ fn tool_run_cache() {
     Python (CPython) 3.11.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -550,7 +550,7 @@ fn tool_run_cache() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     "###);
 
@@ -571,7 +571,7 @@ fn tool_run_cache() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -606,7 +606,7 @@ fn tool_run_url() {
     Werkzeug 3.0.1
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning.
+    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]

--- a/crates/uv/tests/tool_uninstall.rs
+++ b/crates/uv/tests/tool_uninstall.rs
@@ -30,7 +30,7 @@ fn tool_uninstall() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool uninstall` is experimental and may change without warning.
+    warning: `uv tool uninstall` is experimental and may change without warning
     Uninstalled 2 executables: black, blackd
     "###);
 
@@ -43,7 +43,7 @@ fn tool_uninstall() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning.
+    warning: `uv tool list` is experimental and may change without warning
     No tools installed
     "###);
 
@@ -58,7 +58,7 @@ fn tool_uninstall() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning.
+    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + black==24.2.0
@@ -85,7 +85,7 @@ fn tool_uninstall_not_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool uninstall` is experimental and may change without warning.
+    warning: `uv tool uninstall` is experimental and may change without warning
     error: `black` is not installed
     "###);
 }
@@ -115,7 +115,7 @@ fn tool_uninstall_missing_receipt() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool uninstall` is experimental and may change without warning.
+    warning: `uv tool uninstall` is experimental and may change without warning
     Removed dangling environment for `black`
     "###);
 }

--- a/crates/uv/tests/tree.rs
+++ b/crates/uv/tests/tree.rs
@@ -38,7 +38,7 @@ fn nested_dependencies() -> Result<()> {
         └── threadpoolctl v3.4.0
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning.
+    warning: `uv tree` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###
     );
@@ -84,7 +84,7 @@ fn invert() -> Result<()> {
     (*) Package tree already displayed
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning.
+    warning: `uv tree` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###
     );
@@ -107,7 +107,7 @@ fn invert() -> Result<()> {
         └── project v0.1.0
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning.
+    warning: `uv tree` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###
     );
@@ -141,7 +141,7 @@ fn frozen() -> Result<()> {
         └── sniffio v1.3.1
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning.
+    warning: `uv tree` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###
     );
@@ -174,7 +174,7 @@ fn frozen() -> Result<()> {
         └── sniffio v1.3.1
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning.
+    warning: `uv tree` is experimental and may change without warning
     "###
     );
 

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -553,7 +553,7 @@ fn virtualenv_compatibility() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: virtualenv's `--clear` has no effect (uv always clears the virtual environment).
+    warning: virtualenv's `--clear` has no effect (uv always clears the virtual environment)
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: .venv
     Activate with: source .venv/bin/activate


### PR DESCRIPTION
## Summary

Per #5209, we only show periods in messages when the message itself spans more than a single sentence.
