### PR TITLE
Change to show only the python installed on the system if `--python-preference only-system` is specified

### DIFF
--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -41,27 +41,40 @@ pub(crate) async fn list(
         warn_user_once!("`uv python list` is experimental and may change without warning.");
     }
 
-    let download_request = match kinds {
-        PythonListKinds::Installed => None,
-        PythonListKinds::Default => {
-            if python_fetch.is_automatic() {
-                Some(if all_platforms {
-                    PythonDownloadRequest::default()
+    let mut output = BTreeSet::new();
+    if python_preference != PythonPreference::OnlySystem {
+        let download_request = match kinds {
+            PythonListKinds::Installed => None,
+            PythonListKinds::Default => {
+                if python_fetch.is_automatic() {
+                    Some(if all_platforms {
+                        PythonDownloadRequest::default()
+                    } else {
+                        PythonDownloadRequest::from_env()?
+                    })
                 } else {
-                    PythonDownloadRequest::from_env()?
-                })
-            } else {
-                // If fetching is not automatic, then don't show downloads as available by default
-                None
+                    // If fetching is not automatic, then don't show downloads as available by default
+                    None
+                }
             }
+        };
+
+        let downloads = download_request
+            .as_ref()
+            .map(uv_python::downloads::PythonDownloadRequest::iter_downloads)
+            .into_iter()
+            .flatten();
+
+        for download in downloads {
+            output.insert((
+                download.python_version().version().clone(),
+                download.os().to_string(),
+                download.key().clone(),
+                Kind::Download,
+                None,
+            ));
         }
     };
-
-    let downloads = download_request
-        .as_ref()
-        .map(uv_python::downloads::PythonDownloadRequest::iter_downloads)
-        .into_iter()
-        .flatten();
 
     let installed = find_python_installations(
         &PythonRequest::Any,
@@ -81,7 +94,6 @@ pub(crate) async fn list(
     // Drop any "missing" installations
     .filter_map(Result::ok);
 
-    let mut output = BTreeSet::new();
     for installation in installed {
         let kind = if matches!(installation.source(), PythonSource::Managed) {
             Kind::Managed
@@ -94,15 +106,6 @@ pub(crate) async fn list(
             installation.key().clone(),
             kind,
             Some(installation.interpreter().sys_executable().to_path_buf()),
-        ));
-    }
-    for download in downloads {
-        output.insert((
-            download.python_version().version().clone(),
-            download.os().to_string(),
-            download.key().clone(),
-            Kind::Download,
-            None,
         ));
     }
 


### PR DESCRIPTION
Fix #5211

## Summary

Change to show only the python installed on the system if `--python-preference only-system` is specified.

Below is an example of running the command before the change, showing Python not installed on the system.

#### Before
```bash
# Check system python
$ uv python --preview list --python-preference only-system
cpython-3.12.4-linux-x86_64-gnu     <download available>
cpython-3.12.3-linux-x86_64-gnu     /usr/bin/python3.12
cpython-3.12.3-linux-x86_64-gnu     /usr/bin/python3
cpython-3.12.3-linux-x86_64-gnu     /bin/python3.12
cpython-3.12.3-linux-x86_64-gnu     /bin/python3
cpython-3.11.9-linux-x86_64-gnu     <download available>
cpython-3.10.14-linux-x86_64-gnu    <download available>
cpython-3.9.19-linux-x86_64-gnu     <download available>
cpython-3.8.19-linux-x86_64-gnu     <download available>
cpython-3.7.9-linux-x86_64-gnu      <download available>
```

This PR changes the display to show only Python installed on the system.

#### After

```bash
$ cargo run python --preview list --python-preference only-system
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/uv python list --python-preference only-system --preview`
cpython-3.12.3-linux-x86_64-gnu    /usr/bin/python3.12
cpython-3.12.3-linux-x86_64-gnu    /usr/bin/python3
cpython-3.12.3-linux-x86_64-gnu    /bin/python3.12
cpython-3.12.3-linux-x86_64-gnu    /bin/python3
```

## Test Plan
- `cargo run python list --python-preference only-system` in Ubuntu 24.04 to verify the display.
- `cargo run python list` in Ubuntu 24.04 to verify that the results before and after the change were the same.