### PR TITLE
Avoid URL parsing when deserializing wheels

### DIFF
--- a/crates/distribution-types/src/error.rs
+++ b/crates/distribution-types/src/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     WheelFilename(#[from] distribution_filename::WheelFilenameError),
 
     #[error("Could not extract path segments from URL: {0}")]
-    MissingPathSegments(Url),
+    MissingPathSegments(String),
 
     #[error("Distribution not found at: {0}")]
     NotFound(Url),

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -743,10 +743,33 @@ impl RemoteSource for Url {
         // Identify the last segment of the URL as the filename.
         let path_segments = self
             .path_segments()
-            .ok_or_else(|| Error::MissingPathSegments(self.clone()))?;
+            .ok_or_else(|| Error::MissingPathSegments(self.to_string()))?;
 
         // This is guaranteed by the contract of `Url::path_segments`.
         let last = path_segments.last().expect("path segments is non-empty");
+
+        // Decode the filename, which may be percent-encoded.
+        let filename = urlencoding::decode(last)?;
+
+        Ok(filename)
+    }
+
+    fn size(&self) -> Option<u64> {
+        None
+    }
+}
+
+impl RemoteSource for UrlString {
+    fn filename(&self) -> Result<Cow<'_, str>, Error> {
+        // Take the last segment, stripping any query or fragment.
+        let last = self
+            .as_ref()
+            .split_once(['#', '?'])
+            .map(|(path, _)| path)
+            .unwrap_or(self.as_ref())
+            .split('/')
+            .last()
+            .ok_or_else(|| Error::MissingPathSegments(self.to_string()))?;
 
         // Decode the filename, which may be percent-encoded.
         let filename = urlencoding::decode(last)?;
@@ -1215,7 +1238,8 @@ impl Identifier for BuildableSource<'_> {
 
 #[cfg(test)]
 mod test {
-    use crate::{BuiltDist, Dist, SourceDist};
+    use crate::{BuiltDist, Dist, RemoteSource, SourceDist, UrlString};
+    use url::Url;
 
     /// Ensure that we don't accidentally grow the `Dist` sizes.
     #[test]
@@ -1235,5 +1259,22 @@ mod test {
             "{}",
             std::mem::size_of::<SourceDist>()
         );
+    }
+
+    #[test]
+    fn remote_source() {
+        for url in [
+            "https://example.com/foo-0.1.0.tar.gz",
+            "https://example.com/foo-0.1.0.tar.gz#fragment",
+            "https://example.com/foo-0.1.0.tar.gz?query",
+            "https://example.com/foo-0.1.0.tar.gz?query#fragment",
+            "https://example.com/foo-0.1.0.tar.gz?query=1/2#fragment",
+            "https://example.com/foo-0.1.0.tar.gz?query=1/2#fragment/3",
+        ] {
+            let url = Url::parse(url).unwrap();
+            assert_eq!(url.filename().unwrap(), "foo-0.1.0.tar.gz", "{url}");
+            let url = UrlString::from(url.clone());
+            assert_eq!(url.filename().unwrap(), "foo-0.1.0.tar.gz", "{url}");
+        }
     }
 }

--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -33,8 +33,6 @@ use pyo3::{
     create_exception, exceptions::PyNotImplementedError, pyclass, pyclass::CompareOp, pymethods,
     pymodule, types::PyModule, IntoPy, PyObject, PyResult, Python,
 };
-use schemars::gen::SchemaGenerator;
-use schemars::schema::Schema;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 use url::Url;
@@ -497,7 +495,7 @@ impl<T: Pep508Url> schemars::JsonSchema for Requirement<T> {
         "Requirement".to_string()
     }
 
-    fn json_schema(_gen: &mut SchemaGenerator) -> Schema {
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         schemars::schema::SchemaObject {
             instance_type: Some(schemars::schema::InstanceType::String.into()),
             metadata: Some(Box::new(schemars::schema::Metadata {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
@@ -32,21 +32,9 @@ Ok(
                 },
                 sdist: Some(
                     Url {
-                        url: Url {
-                            scheme: "https",
-                            cannot_be_a_base: false,
-                            username: "",
-                            password: None,
-                            host: Some(
-                                Domain(
-                                    "example.com",
-                                ),
-                            ),
-                            port: None,
-                            path: "/",
-                            query: None,
-                            fragment: None,
-                        },
+                        url: UrlString(
+                            "https://example.com",
+                        ),
                         metadata: SourceDistMetadata {
                             hash: Some(
                                 Hash(
@@ -93,21 +81,9 @@ Ok(
                 },
                 sdist: Some(
                     Url {
-                        url: Url {
-                            scheme: "https",
-                            cannot_be_a_base: false,
-                            username: "",
-                            password: None,
-                            host: Some(
-                                Domain(
-                                    "example.com",
-                                ),
-                            ),
-                            port: None,
-                            path: "/",
-                            query: None,
-                            fragment: None,
-                        },
+                        url: UrlString(
+                            "https://example.com",
+                        ),
                         metadata: SourceDistMetadata {
                             hash: Some(
                                 Hash(

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
@@ -32,21 +32,9 @@ Ok(
                 },
                 sdist: Some(
                     Url {
-                        url: Url {
-                            scheme: "https",
-                            cannot_be_a_base: false,
-                            username: "",
-                            password: None,
-                            host: Some(
-                                Domain(
-                                    "example.com",
-                                ),
-                            ),
-                            port: None,
-                            path: "/",
-                            query: None,
-                            fragment: None,
-                        },
+                        url: UrlString(
+                            "https://example.com",
+                        ),
                         metadata: SourceDistMetadata {
                             hash: Some(
                                 Hash(
@@ -93,21 +81,9 @@ Ok(
                 },
                 sdist: Some(
                     Url {
-                        url: Url {
-                            scheme: "https",
-                            cannot_be_a_base: false,
-                            username: "",
-                            password: None,
-                            host: Some(
-                                Domain(
-                                    "example.com",
-                                ),
-                            ),
-                            port: None,
-                            path: "/",
-                            query: None,
-                            fragment: None,
-                        },
+                        url: UrlString(
+                            "https://example.com",
+                        ),
                         metadata: SourceDistMetadata {
                             hash: Some(
                                 Hash(

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
@@ -32,21 +32,9 @@ Ok(
                 },
                 sdist: Some(
                     Url {
-                        url: Url {
-                            scheme: "https",
-                            cannot_be_a_base: false,
-                            username: "",
-                            password: None,
-                            host: Some(
-                                Domain(
-                                    "example.com",
-                                ),
-                            ),
-                            port: None,
-                            path: "/",
-                            query: None,
-                            fragment: None,
-                        },
+                        url: UrlString(
+                            "https://example.com",
+                        ),
                         metadata: SourceDistMetadata {
                             hash: Some(
                                 Hash(
@@ -93,21 +81,9 @@ Ok(
                 },
                 sdist: Some(
                     Url {
-                        url: Url {
-                            scheme: "https",
-                            cannot_be_a_base: false,
-                            username: "",
-                            password: None,
-                            host: Some(
-                                Domain(
-                                    "example.com",
-                                ),
-                            ),
-                            port: None,
-                            path: "/",
-                            query: None,
-                            fragment: None,
-                        },
+                        url: UrlString(
+                            "https://example.com",
+                        ),
                         metadata: SourceDistMetadata {
                             hash: Some(
                                 Hash(


### PR DESCRIPTION
## Summary

This PR slots in `UrlString` for `WheelWire`, which IIUC should avoid parsing URLs during deserialization?
