### PR TITLE
Correct guide typo

### DIFF
--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -18,7 +18,7 @@ Note this is exactly equivalent to:
 $ uv tool run ruff
 ```
 
-Arguments can be passed afted the tool name:
+Arguments can be passed after the tool name:
 
 ```console
 $ uvx pycowsay hello from uv


### PR DESCRIPTION
## Summary

Typo correction for the tools guide.

Fixes #5243
