### PR TITLE
Add an automated job to sync `python-build-standalone` releases

### DIFF
--- a/.github/workflows/python-build-standalone.yml
+++ b/.github/workflows/python-build-standalone.yml
@@ -1,0 +1,37 @@
+# Sync Python releases from `python-build-standalone`.
+#
+# Based on: https://github.com/astral-sh/rye/blob/57b7c089e494138aae29a130afb2e17f447970bf/.github/workflows/sync-python-releases.yml
+name: python-build-standalone
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    if: github.repository == 'astral-sh/uv'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hynek/setup-cached-uv@v1
+      - name: Sync Python Releases
+        run: |
+          uv run --isolated -- fetch-download-metadata.py
+          uv run --isolated --with chevron-blue -- template-download-metadata.py
+        working-directory: ./crates/uv-python
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Create Pull Request"
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Sync latest python-build-standalone releases"
+          add-paths: "crates/uv-python/src/downloads.inc"
+          branch: "sync-python-build-standalone"
+          title: "Sync python-build-standalone downloads"
+          body: "Automated update for python-build-standalone downloads."
+          base: "main"


### PR DESCRIPTION
## Summary

Perhaps in the future we can trigger this directly on release in `python-build-standalone`, but for now it's a cron job.
