### PR TITLE
Intern package, extra, and group names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,7 +1535,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -4376,6 +4389,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "ustr"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e904a2279a4a36d2356425bb20be271029cc650c335bc82af8bfae30085a3d0"
+dependencies = [
+ "ahash 0.8.11",
+ "byteorder",
+ "lazy_static",
+ "parking_lot 0.12.3",
+ "serde",
+]
+
+[[package]]
 name = "usvg"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4669,6 +4695,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
+ "ustr",
  "uv-auth",
  "uv-normalize",
 ]
@@ -4899,9 +4926,11 @@ dependencies = [
 name = "uv-normalize"
 version = "0.0.1"
 dependencies = [
+ "byteorder",
  "rkyv",
  "schemars",
  "serde",
+ "ustr",
 ]
 
 [[package]]
@@ -5770,6 +5799,26 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "1dcb
 axoupdater = { version = "0.6.0", default-features = false }
 backoff = { version = "0.4.0" }
 base64 = { version = "0.22.0" }
+byteorder = { version = "1.5.0" }
 cachedir = { version = "0.3.1" }
 cargo-util = { version = "0.2.8" }
 chrono = { version = "0.4.31" }
@@ -152,6 +153,7 @@ unicode-width = { version = "0.1.11" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.0" }
 urlencoding = { version = "2.1.3" }
+ustr = { version = "1.0.0" , features = ["serde"]}
 walkdir = { version = "2.5.0" }
 which = { version = "6.0.0", features = ["regex"] }
 winapi = { version = "0.3.9", features = ["fileapi", "handleapi", "ioapiset", "winbase", "winioctl", "winnt"] }

--- a/crates/uv-configuration/Cargo.toml
+++ b/crates/uv-configuration/Cargo.toml
@@ -26,6 +26,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+ustr = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/uv-configuration/src/constraints.rs
+++ b/crates/uv-configuration/src/constraints.rs
@@ -1,20 +1,19 @@
 use std::borrow::Cow;
 
 use either::Either;
-use rustc_hash::FxHashMap;
 
 use pep508_rs::MarkerTree;
 use pypi_types::{Requirement, RequirementSource};
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 
 /// A set of constraints for a set of requirements.
 #[derive(Debug, Default, Clone)]
-pub struct Constraints(FxHashMap<PackageName, Vec<Requirement>>);
+pub struct Constraints(InternedMap<PackageName, Vec<Requirement>>);
 
 impl Constraints {
     /// Create a new set of constraints from a set of requirements.
     pub fn from_requirements(requirements: impl Iterator<Item = Requirement>) -> Self {
-        let mut constraints: FxHashMap<PackageName, Vec<Requirement>> = FxHashMap::default();
+        let mut constraints: InternedMap<PackageName, Vec<Requirement>> = InternedMap::default();
         for requirement in requirements {
             // Skip empty constraints.
             if let RequirementSource::Registry { specifier, .. } = &requirement.source {

--- a/crates/uv-configuration/src/overrides.rs
+++ b/crates/uv-configuration/src/overrides.rs
@@ -1,21 +1,20 @@
 use std::borrow::Cow;
 
 use either::Either;
-use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use pep508_rs::MarkerTree;
 use pypi_types::Requirement;
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 
 /// A set of overrides for a set of requirements.
 #[derive(Debug, Default, Clone)]
-pub struct Overrides(FxHashMap<PackageName, Vec<Requirement>>);
+pub struct Overrides(InternedMap<PackageName, Vec<Requirement>>);
 
 impl Overrides {
     /// Create a new set of overrides from a set of requirements.
     pub fn from_requirements(requirements: Vec<Requirement>) -> Self {
-        let mut overrides: FxHashMap<PackageName, Vec<Requirement>> =
-            FxHashMap::with_capacity_and_hasher(requirements.len(), FxBuildHasher);
+        let mut overrides: InternedMap<PackageName, Vec<Requirement>> =
+            InternedMap::with_capacity_and_hasher(requirements.len(), Default::default());
         for requirement in requirements {
             overrides
                 .entry(requirement.name.clone())

--- a/crates/uv-configuration/src/package_options.rs
+++ b/crates/uv-configuration/src/package_options.rs
@@ -2,7 +2,7 @@ use either::Either;
 use pep508_rs::PackageName;
 
 use pypi_types::Requirement;
-use rustc_hash::FxHashMap;
+use uv_normalize::InternedMap;
 
 /// Whether to reinstall packages.
 #[derive(Debug, Default, Clone)]
@@ -56,7 +56,7 @@ pub enum Upgrade {
     All,
 
     /// Allow package upgrades, but only for the specified packages.
-    Packages(FxHashMap<PackageName, Vec<Requirement>>),
+    Packages(InternedMap<PackageName, Vec<Requirement>>),
 }
 
 impl Upgrade {
@@ -70,7 +70,7 @@ impl Upgrade {
                     Self::None
                 } else {
                     Self::Packages(upgrade_package.into_iter().fold(
-                        FxHashMap::default(),
+                        InternedMap::default(),
                         |mut map, requirement| {
                             map.entry(requirement.name.clone())
                                 .or_default()

--- a/crates/uv-installer/src/site_packages.rs
+++ b/crates/uv-installer/src/site_packages.rs
@@ -12,7 +12,7 @@ use distribution_types::{
 };
 use pep440_rs::{Version, VersionSpecifiers};
 use pypi_types::{Requirement, VerbatimParsedUrl};
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 use uv_python::{Interpreter, PythonEnvironment};
 use uv_types::InstalledPackagesProvider;
 
@@ -31,7 +31,7 @@ pub struct SitePackages {
     /// The installed distributions, keyed by name. Although the Python runtime does not support it,
     /// it is possible to have multiple distributions with the same name to be present in the
     /// virtual environment, which we handle gracefully.
-    by_name: FxHashMap<PackageName, Vec<usize>>,
+    by_name: InternedMap<PackageName, Vec<usize>>,
     /// The installed editable distributions, keyed by URL.
     by_url: FxHashMap<Url, Vec<usize>>,
 }
@@ -45,7 +45,7 @@ impl SitePackages {
     /// Build an index of installed packages from the given Python executable.
     pub fn from_interpreter(interpreter: &Interpreter) -> Result<Self> {
         let mut distributions: Vec<Option<InstalledDist>> = Vec::new();
-        let mut by_name = FxHashMap::default();
+        let mut by_name = InternedMap::default();
         let mut by_url = FxHashMap::default();
 
         for site_packages in interpreter.site_packages() {

--- a/crates/uv-normalize/Cargo.toml
+++ b/crates/uv-normalize/Cargo.toml
@@ -8,6 +8,8 @@ description = "Normalization for distribution, package and extra names."
 workspace = true
 
 [dependencies]
+byteorder = { workspace = true }
 rkyv = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
+ustr = { workspace = true }

--- a/crates/uv-normalize/src/lib.rs
+++ b/crates/uv-normalize/src/lib.rs
@@ -1,25 +1,36 @@
+use std::borrow::Cow;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 
-pub use extra_name::ExtraName;
-pub use group_name::GroupName;
-pub use package_name::PackageName;
+pub use extra_name::*;
+pub use group_name::*;
+pub use package_name::*;
 
 mod extra_name;
 mod group_name;
 mod package_name;
+mod string;
 
 /// Validate and normalize an owned package or extra name.
 pub(crate) fn validate_and_normalize_owned(name: String) -> Result<String, InvalidNameError> {
     if is_normalized(&name)? {
         Ok(name)
     } else {
-        validate_and_normalize_ref(name)
+        validate_and_normalize_name(name)
     }
 }
 
 /// Validate and normalize an unowned package or extra name.
-pub(crate) fn validate_and_normalize_ref(
+pub(crate) fn validate_and_normalize_ref(name: &str) -> Result<Cow<str>, InvalidNameError> {
+    if is_normalized(name)? {
+        Ok(Cow::Borrowed(name))
+    } else {
+        Ok(Cow::Owned(validate_and_normalize_name(name)?))
+    }
+}
+
+/// Validate and normalize an unowned package or extra name.
+pub(crate) fn validate_and_normalize_name(
     name: impl AsRef<str>,
 ) -> Result<String, InvalidNameError> {
     let mut normalized = String::with_capacity(name.as_ref().len());
@@ -92,7 +103,7 @@ fn is_normalized(name: impl AsRef<str>) -> Result<bool, InvalidNameError> {
     Ok(true)
 }
 
-/// Invalid [`crate::PackageName`] or [`crate::ExtraName`].
+/// Invalid [`PackageName`] or [`ExtraName`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InvalidNameError(String);
 

--- a/crates/uv-normalize/src/string.rs
+++ b/crates/uv-normalize/src/string.rs
@@ -1,0 +1,86 @@
+use rkyv::{
+    ser::{ScratchSpace, Serializer},
+    string::{ArchivedString, StringResolver},
+    Archive, Deserialize, Fallible, Serialize,
+};
+use std::borrow::Cow;
+
+use ustr::Ustr;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize)]
+pub struct InternedString(Ustr);
+
+impl InternedString {
+    pub fn as_str(&self) -> &'static str {
+        self.0.as_str()
+    }
+}
+
+impl From<&str> for InternedString {
+    fn from(s: &str) -> Self {
+        InternedString(Ustr::from(s))
+    }
+}
+
+impl From<String> for InternedString {
+    fn from(s: String) -> Self {
+        InternedString(Ustr::from(s.as_str()))
+    }
+}
+
+impl From<Cow<'_, str>> for InternedString {
+    fn from(s: Cow<'_, str>) -> Self {
+        InternedString(Ustr::from(s.as_ref()))
+    }
+}
+
+impl AsRef<str> for InternedString {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for InternedString {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for InternedString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl Archive for InternedString {
+    type Archived = ArchivedString;
+    type Resolver = StringResolver;
+
+    #[inline]
+    #[allow(unsafe_code)]
+    unsafe fn resolve(&self, pos: usize, resolver: Self::Resolver, out: *mut Self::Archived) {
+        ArchivedString::resolve_from_str(self.0.as_str(), pos, resolver, out);
+    }
+}
+
+impl<S: ScratchSpace + Serializer + ?Sized> Serialize<S> for InternedString {
+    #[inline]
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        ArchivedString::serialize_from_str(self.0.as_str(), serializer)
+    }
+}
+
+impl<D: Fallible + ?Sized> Deserialize<InternedString, D> for ArchivedString {
+    #[inline]
+    fn deserialize(&self, _deserializer: &mut D) -> Result<InternedString, D::Error> {
+        Ok(InternedString::from(self.as_str()))
+    }
+}
+
+impl PartialEq<InternedString> for ArchivedString {
+    fn eq(&self, other: &InternedString) -> bool {
+        other.as_str() == self.as_str()
+    }
+}

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -30,7 +30,6 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use rustc_hash::FxHashSet;
 use tracing::instrument;
 
 use cache_key::CanonicalUrl;
@@ -44,7 +43,7 @@ use requirements_txt::{RequirementsTxt, RequirementsTxtRequirement};
 use uv_client::BaseClientBuilder;
 use uv_configuration::{NoBinary, NoBuild};
 use uv_fs::Simplified;
-use uv_normalize::{ExtraName, PackageName};
+use uv_normalize::{ExtraName, InternedSet, PackageName};
 use uv_workspace::pyproject::PyProjectToml;
 
 use crate::RequirementsSource;
@@ -62,7 +61,7 @@ pub struct RequirementsSpecification {
     /// The source trees from which to extract requirements.
     pub source_trees: Vec<PathBuf>,
     /// The extras used to collect requirements.
-    pub extras: FxHashSet<ExtraName>,
+    pub extras: InternedSet<ExtraName>,
     /// The index URL to use for fetching packages.
     pub index_url: Option<IndexUrl>,
     /// The extra index URLs to use for fetching packages.

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashMap;
 use distribution_types::{BuiltDist, IndexLocations, InstalledDist, SourceDist};
 use pep440_rs::Version;
 use pep508_rs::{MarkerTree, Requirement};
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 
 use crate::candidate_selector::CandidateSelector;
 use crate::dependency_provider::UvDependencyProvider;
@@ -122,8 +122,8 @@ pub struct NoSolutionError {
     selector: CandidateSelector,
     python_requirement: PythonRequirement,
     index_locations: IndexLocations,
-    unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
-    incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, IncompletePackage>>,
+    unavailable_packages: InternedMap<PackageName, UnavailablePackage>,
+    incomplete_packages: InternedMap<PackageName, BTreeMap<Version, IncompletePackage>>,
     fork_urls: ForkUrls,
     markers: ResolverMarkers,
 }
@@ -146,8 +146,8 @@ impl NoSolutionError {
         selector: CandidateSelector,
         python_requirement: PythonRequirement,
         index_locations: IndexLocations,
-        unavailable_packages: FxHashMap<PackageName, UnavailablePackage>,
-        incomplete_packages: FxHashMap<PackageName, BTreeMap<Version, IncompletePackage>>,
+        unavailable_packages: InternedMap<PackageName, UnavailablePackage>,
+        incomplete_packages: InternedMap<PackageName, BTreeMap<Version, IncompletePackage>>,
         fork_urls: ForkUrls,
         markers: ResolverMarkers,
     ) -> Self {

--- a/crates/uv-resolver/src/exclusions.rs
+++ b/crates/uv-resolver/src/exclusions.rs
@@ -1,6 +1,6 @@
 use pep508_rs::PackageName;
-use rustc_hash::FxHashSet;
 use uv_configuration::{Reinstall, Upgrade};
+use uv_normalize::InternedSet;
 
 /// Tracks locally installed packages that should not be selected during resolution.
 #[derive(Debug, Default, Clone)]
@@ -8,7 +8,7 @@ pub enum Exclusions {
     #[default]
     None,
     /// Exclude some local packages from consideration, e.g. from `--reinstall-package foo --upgrade-package bar`
-    Some(FxHashSet<PackageName>),
+    Some(InternedSet<PackageName>),
     /// Exclude all local packages from consideration, e.g. from `--reinstall` or `--upgrade`
     All,
 }
@@ -18,11 +18,11 @@ impl Exclusions {
         if upgrade.is_all() || reinstall.is_all() {
             Self::All
         } else {
-            let mut exclusions: FxHashSet<PackageName> =
+            let mut exclusions: InternedSet<PackageName> =
                 if let Reinstall::Packages(packages) = reinstall {
-                    FxHashSet::from_iter(packages)
+                    InternedSet::from_iter(packages)
                 } else {
-                    FxHashSet::default()
+                    InternedSet::default()
                 };
 
             if let Upgrade::Packages(packages) = upgrade {

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -1,7 +1,6 @@
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 
-use rustc_hash::FxHashMap;
 use tracing::instrument;
 
 use distribution_filename::{DistFilename, SourceDistFilename, WheelFilename};
@@ -15,7 +14,7 @@ use platform_tags::{TagCompatibility, Tags};
 use pypi_types::HashDigest;
 use uv_client::FlatIndexEntries;
 use uv_configuration::BuildOptions;
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 use uv_types::HashStrategy;
 
 /// A set of [`PrioritizedDist`] from a `--find-links` entry, indexed by [`PackageName`]
@@ -23,7 +22,7 @@ use uv_types::HashStrategy;
 #[derive(Debug, Clone, Default)]
 pub struct FlatIndex {
     /// The list of [`FlatDistributions`] from the `--find-links` entries, indexed by package name.
-    index: FxHashMap<PackageName, FlatDistributions>,
+    index: InternedMap<PackageName, FlatDistributions>,
     /// Whether any `--find-links` entries could not be resolved due to a lack of network
     /// connectivity.
     offline: bool,
@@ -39,7 +38,7 @@ impl FlatIndex {
         build_options: &BuildOptions,
     ) -> Self {
         // Collect compatible distributions.
-        let mut index = FxHashMap::default();
+        let mut index = InternedMap::default();
         for (filename, file, url) in entries.entries {
             let distributions = index.entry(filename.name().clone()).or_default();
             Self::add_file(

--- a/crates/uv-resolver/src/fork_urls.rs
+++ b/crates/uv-resolver/src/fork_urls.rs
@@ -1,17 +1,15 @@
 use std::collections::hash_map::Entry;
 
-use rustc_hash::FxHashMap;
-
 use distribution_types::Verbatim;
 use pypi_types::VerbatimParsedUrl;
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 
 use crate::resolver::ResolverMarkers;
 use crate::ResolveError;
 
 /// See [`crate::resolver::SolveState`].
 #[derive(Default, Debug, Clone)]
-pub(crate) struct ForkUrls(FxHashMap<PackageName, VerbatimParsedUrl>);
+pub(crate) struct ForkUrls(InternedMap<PackageName, VerbatimParsedUrl>);
 
 impl ForkUrls {
     /// Get the URL previously used for a package in this fork.

--- a/crates/uv-resolver/src/pins.rs
+++ b/crates/uv-resolver/src/pins.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashMap;
 
 use distribution_types::{CompatibleDist, ResolvedDist};
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 
 use crate::candidate_selector::Candidate;
 
@@ -10,7 +10,7 @@ use crate::candidate_selector::Candidate;
 /// For example, given `Flask==3.0.0`, the [`FilePins`] would contain a mapping from `Flask` to
 /// `3.0.0` to the specific wheel or source distribution archive that was pinned for that version.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct FilePins(FxHashMap<PackageName, FxHashMap<pep440_rs::Version, ResolvedDist>>);
+pub(crate) struct FilePins(InternedMap<PackageName, FxHashMap<pep440_rs::Version, ResolvedDist>>);
 
 impl FilePins {
     /// Pin a candidate package.

--- a/crates/uv-resolver/src/preferences.rs
+++ b/crates/uv-resolver/src/preferences.rs
@@ -1,7 +1,6 @@
 use std::collections::hash_map::Entry;
 use std::str::FromStr;
 
-use rustc_hash::FxHashMap;
 use tracing::trace;
 
 use distribution_types::{InstalledDist, InstalledMetadata, InstalledVersion, Name};
@@ -9,7 +8,7 @@ use pep440_rs::{Operator, Version};
 use pep508_rs::{MarkerEnvironment, MarkerTree, VersionOrUrl};
 use pypi_types::{HashDigest, HashError};
 use requirements_txt::{RequirementEntry, RequirementsTxtRequirement};
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 
 #[derive(thiserror::Error, Debug)]
 pub enum PreferenceError {
@@ -99,7 +98,7 @@ impl Preference {
 
 /// A set of pinned packages that should be preserved during resolution, if possible.
 #[derive(Debug, Clone, Default)]
-pub struct Preferences(FxHashMap<PackageName, Pin>);
+pub struct Preferences(InternedMap<PackageName, Pin>);
 
 impl Preferences {
     /// Create a map of pinned packages from an iterator of [`Preference`] entries.

--- a/crates/uv-resolver/src/pubgrub/priority.rs
+++ b/crates/uv-resolver/src/pubgrub/priority.rs
@@ -1,12 +1,11 @@
 use std::cmp::Reverse;
 
 use pubgrub::range::Range;
-use rustc_hash::FxHashMap;
+
+use pep440_rs::Version;
+use uv_normalize::{InternedMap, PackageName};
 
 use crate::fork_urls::ForkUrls;
-use pep440_rs::Version;
-use uv_normalize::PackageName;
-
 use crate::pubgrub::package::PubGrubPackage;
 use crate::pubgrub::PubGrubPackageInner;
 
@@ -20,7 +19,7 @@ use crate::pubgrub::PubGrubPackageInner;
 ///
 /// See: <https://github.com/pypa/pip/blob/ef78c129b1a966dbbbdb8ebfffc43723e89110d1/src/pip/_internal/resolution/resolvelib/provider.py#L120>
 #[derive(Clone, Debug, Default)]
-pub(crate) struct PubGrubPriorities(FxHashMap<PackageName, PubGrubPriority>);
+pub(crate) struct PubGrubPriorities(InternedMap<PackageName, PubGrubPriority>);
 
 impl PubGrubPriorities {
     /// Add a [`PubGrubPackage`] to the priority map.

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -14,7 +14,7 @@ use rustc_hash::FxHashMap;
 
 use distribution_types::IndexLocations;
 use pep440_rs::Version;
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 
 use crate::candidate_selector::CandidateSelector;
 use crate::fork_urls::ForkUrls;
@@ -405,8 +405,8 @@ impl PubGrubReportFormatter<'_> {
         derivation_tree: &DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
         selector: &CandidateSelector,
         index_locations: &IndexLocations,
-        unavailable_packages: &FxHashMap<PackageName, UnavailablePackage>,
-        incomplete_packages: &FxHashMap<PackageName, BTreeMap<Version, IncompletePackage>>,
+        unavailable_packages: &InternedMap<PackageName, UnavailablePackage>,
+        incomplete_packages: &InternedMap<PackageName, BTreeMap<Version, IncompletePackage>>,
         fork_urls: &ForkUrls,
         markers: &ResolverMarkers,
     ) -> IndexSet<PubGrubHint> {
@@ -490,8 +490,8 @@ impl PubGrubReportFormatter<'_> {
         name: &PackageName,
         set: &Range<Version>,
         index_locations: &IndexLocations,
-        unavailable_packages: &FxHashMap<PackageName, UnavailablePackage>,
-        incomplete_packages: &FxHashMap<PackageName, BTreeMap<Version, IncompletePackage>>,
+        unavailable_packages: &InternedMap<PackageName, UnavailablePackage>,
+        incomplete_packages: &InternedMap<PackageName, BTreeMap<Version, IncompletePackage>>,
         hints: &mut IndexSet<PubGrubHint>,
     ) {
         let no_find_links = index_locations.flat_index().peekable().peek().is_none();

--- a/crates/uv-resolver/src/resolution_mode.rs
+++ b/crates/uv-resolver/src/resolution_mode.rs
@@ -1,7 +1,5 @@
-use rustc_hash::FxHashSet;
-
 use pep508_rs::MarkerEnvironment;
-use uv_normalize::PackageName;
+use uv_normalize::{InternedSet, PackageName};
 
 use crate::{DependencyMode, Manifest};
 
@@ -40,7 +38,7 @@ pub(crate) enum ResolutionStrategy {
     Lowest,
     /// Resolve the lowest compatible version of any direct dependencies, and the highest
     /// compatible version of any transitive dependencies.
-    LowestDirect(FxHashSet<PackageName>),
+    LowestDirect(InternedSet<PackageName>),
 }
 
 impl ResolutionStrategy {

--- a/crates/uv-resolver/src/resolver/fork_map.rs
+++ b/crates/uv-resolver/src/resolver/fork_map.rs
@@ -1,6 +1,6 @@
 use pep508_rs::{MarkerTree, PackageName};
 use pypi_types::Requirement;
-use rustc_hash::FxHashMap;
+use uv_normalize::InternedMap;
 
 use crate::marker::is_disjoint;
 use crate::ResolverMarkers;
@@ -10,7 +10,7 @@ pub(crate) type ForkSet = ForkMap<()>;
 
 /// A map from package names to their values for a given fork.
 #[derive(Debug, Clone)]
-pub(crate) struct ForkMap<T>(FxHashMap<PackageName, Vec<Entry<T>>>);
+pub(crate) struct ForkMap<T>(InternedMap<PackageName, Vec<Entry<T>>>);
 
 /// An entry in a [`ForkMap`].
 #[derive(Debug, Clone)]
@@ -21,7 +21,7 @@ struct Entry<T> {
 
 impl<T> Default for ForkMap<T> {
     fn default() -> Self {
-        Self(FxHashMap::default())
+        Self(InternedMap::default())
     }
 }
 

--- a/crates/uv-resolver/src/resolver/urls.rs
+++ b/crates/uv-resolver/src/resolver/urls.rs
@@ -1,6 +1,5 @@
 use std::iter;
 
-use rustc_hash::FxHashMap;
 use same_file::is_same_file;
 use tracing::debug;
 
@@ -9,7 +8,7 @@ use distribution_types::Verbatim;
 use pep508_rs::{MarkerEnvironment, VerbatimUrl};
 use pypi_types::{ParsedDirectoryUrl, ParsedUrl, VerbatimParsedUrl};
 use uv_git::GitResolver;
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 
 use crate::{DependencyMode, Manifest, ResolveError};
 
@@ -27,10 +26,10 @@ pub(crate) struct Urls {
     /// URL requirements in overrides. There can only be a single URL per package in overrides
     /// (since it replaces all other URLs), and an override URL replaces all requirements and
     /// constraints URLs.
-    overrides: FxHashMap<PackageName, VerbatimParsedUrl>,
+    overrides: InternedMap<PackageName, VerbatimParsedUrl>,
     /// URLs from regular requirements or from constraints. There can be multiple URLs for the same
     /// package as long as they are in different forks.
-    regular: FxHashMap<PackageName, Vec<VerbatimParsedUrl>>,
+    regular: InternedMap<PackageName, Vec<VerbatimParsedUrl>>,
 }
 
 impl Urls {
@@ -40,8 +39,8 @@ impl Urls {
         git: &GitResolver,
         dependencies: DependencyMode,
     ) -> Result<Self, ResolveError> {
-        let mut urls: FxHashMap<PackageName, Vec<VerbatimParsedUrl>> = FxHashMap::default();
-        let mut overrides: FxHashMap<PackageName, VerbatimParsedUrl> = FxHashMap::default();
+        let mut urls: InternedMap<PackageName, Vec<VerbatimParsedUrl>> = InternedMap::default();
+        let mut overrides: InternedMap<PackageName, VerbatimParsedUrl> = InternedMap::default();
 
         // Add all direct regular requirements and constraints URL.
         for requirement in manifest.requirements_no_overrides(markers, dependencies) {

--- a/crates/uv-resolver/src/yanks.rs
+++ b/crates/uv-resolver/src/yanks.rs
@@ -1,17 +1,17 @@
 use pypi_types::RequirementSource;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use std::sync::Arc;
 
 use pep440_rs::Version;
 use pep508_rs::MarkerEnvironment;
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 
 use crate::{DependencyMode, Manifest};
 
 /// A set of package versions that are permitted, even if they're marked as yanked by the
 /// relevant index.
 #[derive(Debug, Default, Clone)]
-pub struct AllowedYanks(Arc<FxHashMap<PackageName, FxHashSet<Version>>>);
+pub struct AllowedYanks(Arc<InternedMap<PackageName, FxHashSet<Version>>>);
 
 impl AllowedYanks {
     pub fn from_manifest(
@@ -19,7 +19,7 @@ impl AllowedYanks {
         markers: Option<&MarkerEnvironment>,
         dependencies: DependencyMode,
     ) -> Self {
-        let mut allowed_yanks = FxHashMap::<PackageName, FxHashSet<Version>>::default();
+        let mut allowed_yanks = InternedMap::<PackageName, FxHashSet<Version>>::default();
 
         // Allow yanks for any pinned input requirements.
         for requirement in manifest.requirements(markers, dependencies) {

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -306,7 +306,7 @@ impl PyProjectTomlMut {
                     let Some(dependencies) = dependencies.as_array() else {
                         continue;
                     };
-                    let Ok(extra) = ExtraName::new(extra.to_string()) else {
+                    let Ok(extra) = ExtraName::from_str(extra) else {
                         continue;
                     };
 

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -13,7 +13,7 @@ use uv_cache::Cache;
 use uv_distribution::Metadata;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
-use uv_normalize::PackageName;
+use uv_normalize::{InternedMap, PackageName};
 use uv_python::EnvironmentPreference;
 use uv_python::PythonEnvironment;
 use uv_python::PythonRequest;
@@ -115,9 +115,9 @@ pub(crate) struct DisplayDependencyGraph {
     /// Map from package name to its requirements.
     ///
     /// If `--invert` is given the map is inverted.
-    requirements: FxHashMap<PackageName, Vec<PackageName>>,
+    requirements: InternedMap<PackageName, Vec<PackageName>>,
     /// Map from requirement package name-to-parent-to-dependency metadata.
-    dependencies: FxHashMap<PackageName, FxHashMap<PackageName, Dependency>>,
+    dependencies: InternedMap<PackageName, InternedMap<PackageName, Dependency>>,
 }
 
 impl DisplayDependencyGraph {
@@ -132,9 +132,9 @@ impl DisplayDependencyGraph {
         markers: &MarkerEnvironment,
         packages: IndexMap<PackageName, Vec<Metadata>>,
     ) -> Self {
-        let mut requirements: FxHashMap<_, Vec<_>> = FxHashMap::default();
-        let mut dependencies: FxHashMap<PackageName, FxHashMap<PackageName, Dependency>> =
-            FxHashMap::default();
+        let mut requirements: InternedMap<_, Vec<_>> = InternedMap::default();
+        let mut dependencies: InternedMap<PackageName, InternedMap<PackageName, Dependency>> =
+            InternedMap::default();
 
         // Add all transitive requirements.
         for metadata in packages.values().flatten() {


### PR DESCRIPTION
## Summary

This PR uses [ustr](https://github.com/anderslanglands/ustr) to intern package, extra, and group names.

In theory this should reduce allocations and make hashing and comparisons much cheaper.

Interestingly, though, I'm seeing about a 3-5% regression in local benchmarking:

```
❯ python -m scripts.bench \
    --uv-path ./target/release/uv \
    --uv-path ./target/release/main \
    ./scripts/requirements/jupyter.in --benchmark resolve-warm --min-runs 100
Benchmark 1: ./target/release/uv (resolve-warm)
  Time (mean ± σ):      22.2 ms ±   1.0 ms    [User: 17.5 ms, System: 46.1 ms]
  Range (min … max):    19.6 ms …  24.9 ms    114 runs

Benchmark 2: ./target/release/main (resolve-warm)
  Time (mean ± σ):      21.4 ms ±   0.8 ms    [User: 17.5 ms, System: 44.2 ms]
  Range (min … max):    19.3 ms …  23.6 ms    114 runs

Summary
  './target/release/main (resolve-warm)' ran
    1.04 ± 0.06 times faster than './target/release/uv (resolve-warm)'
```

Probably won't proceed much further, so just putting this up for posterity.
