### PR TITLE
If multiple indices contain the same version, use the first index

### DIFF
--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -232,8 +232,19 @@ impl CandidateSelector {
                 Self::select_candidate(
                     version_maps
                         .iter()
-                        .map(|version_map| version_map.iter().rev())
-                        .kmerge_by(|(version1, _), (version2, _)| version1 > version2),
+                        .enumerate()
+                        .map(|(map_index, version_map)| {
+                            version_map.iter().rev().map(move |item| (map_index, item))
+                        })
+                        .kmerge_by(
+                            |(index1, (version1, _)), (index2, (version2, _))| match version2
+                                .cmp(version1)
+                            {
+                                std::cmp::Ordering::Equal => index1 < index2,
+                                _ => version1 > version2,
+                            },
+                        )
+                        .map(|(_, item)| item),
                     package_name,
                     range,
                     allow_prerelease,
@@ -242,8 +253,19 @@ impl CandidateSelector {
                 Self::select_candidate(
                     version_maps
                         .iter()
-                        .map(VersionMap::iter)
-                        .kmerge_by(|(version1, _), (version2, _)| version1 < version2),
+                        .enumerate()
+                        .map(|(map_index, version_map)| {
+                            version_map.iter().map(move |item| (map_index, item))
+                        })
+                        .kmerge_by(
+                            |(index1, (version1, _)), (index2, (version2, _))| match version2
+                                .cmp(version1)
+                            {
+                                std::cmp::Ordering::Equal => index1 < index2,
+                                _ => version1 < version2,
+                            },
+                        )
+                        .map(|(_, item)| item),
                     package_name,
                     range,
                     allow_prerelease,

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -237,11 +237,12 @@ impl CandidateSelector {
                             version_map.iter().rev().map(move |item| (map_index, item))
                         })
                         .kmerge_by(
-                            |(index1, (version1, _)), (index2, (version2, _))| match version2
-                                .cmp(version1)
+                            |(index1, (version1, _)), (index2, (version2, _))| match version1
+                                .cmp(version2)
                             {
                                 std::cmp::Ordering::Equal => index1 < index2,
-                                _ => version1 > version2,
+                                std::cmp::Ordering::Less => false,
+                                std::cmp::Ordering::Greater => true,
                             },
                         )
                         .map(|(_, item)| item),
@@ -258,11 +259,12 @@ impl CandidateSelector {
                             version_map.iter().map(move |item| (map_index, item))
                         })
                         .kmerge_by(
-                            |(index1, (version1, _)), (index2, (version2, _))| match version2
-                                .cmp(version1)
+                            |(index1, (version1, _)), (index2, (version2, _))| match version1
+                                .cmp(version2)
                             {
                                 std::cmp::Ordering::Equal => index1 < index2,
-                                _ => version1 < version2,
+                                std::cmp::Ordering::Less => true,
+                                std::cmp::Ordering::Greater => false,
                             },
                         )
                         .map(|(_, item)| item),


### PR DESCRIPTION
This fixes resolving packages that publish an invalid stub to pypi, such as tensorrt-llm.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

In https://github.com/astral-sh/uv/pull/3138 , we implemented `unsafe-best-match`. However, it seems to not quite work as expected. When multiple indices contain the same version, it's not clear which index the current code uses. This PR fixes that to use the first index the package is in.

## Test Plan

```console
$ echo 'tensorrt-llm==0.11.0' | ./target/debug/uv pip compile - --extra-index-url https://pypi.nvidia.com --python-version=3.10 --index-strategy=unsafe-best-match --annotation-style=line
```


cc: @charliermarsh 
