### PR TITLE
`uv init` ignores workspace when `--isolated` flag is used

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -834,6 +834,7 @@ async fn run_project(
                 args.path,
                 args.name,
                 args.no_readme,
+                globals.isolated,
                 globals.preview,
                 printer,
             )

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -511,3 +511,48 @@ fn init_invalid_names() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn init_workspace_isolated() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "#,
+    })?;
+
+    let child = context.temp_dir.join("foo");
+    fs_err::create_dir(&child)?;
+
+    uv_snapshot!(context.filters(), context.init().current_dir(&child).arg("--isolated"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv init` is experimental and may change without warning
+    Initialized project foo
+    "###);
+
+    let workspace = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            workspace, @r###"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        "###
+        );
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Per https://github.com/astral-sh/uv/pull/5250#issuecomment-2242137762

> It would also be great to have an argument (perhaps leveraging the global isolated option) that allows us to disable workspace discovery when we don't want to add a project as a member.


## Test Plan

```sh

$cargo run -- init work
$ cargo run -- init work/pkg-a --isolated
warning: `uv init` is experimental and may change without warning
Initialized project sub-c in /tmp/work
```
