### PR TITLE
Use tag error rather than requires-python error for ABI filtering

### DIFF
--- a/crates/distribution-types/src/prioritized_distribution.rs
+++ b/crates/distribution-types/src/prioritized_distribution.rs
@@ -150,10 +150,15 @@ pub enum WheelCompatibility {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum IncompatibleWheel {
+    /// The wheel was published after the exclude newer time.
     ExcludeNewer(Option<i64>),
+    /// The wheel tags do not match those of the target Python platform.
     Tag(IncompatibleTag),
+    /// The required Python version is not a superset of the target Python version range.
     RequiresPython(VersionSpecifiers, PythonRequirementKind),
+    /// The wheel was yanked.
     Yanked(Yanked),
+    /// The use of binary wheels is disabled.
     NoBinary,
 }
 

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -11,7 +11,7 @@ use distribution_types::{
     WheelCompatibility,
 };
 use pep440_rs::Version;
-use platform_tags::{TagCompatibility, Tags};
+use platform_tags::{IncompatibleTag, TagCompatibility, Tags};
 use pypi_types::{HashDigest, Yanked};
 use uv_client::{OwnedArchive, SimpleMetadata, VersionFiles};
 use uv_configuration::BuildOptions;
@@ -512,9 +512,8 @@ impl VersionMapLazy {
         // is not less than the `requires-python` minimum version).
         if let Some(requires_python) = self.requires_python.as_ref() {
             if !requires_python.matches_wheel_tag(filename) {
-                return WheelCompatibility::Incompatible(IncompatibleWheel::RequiresPython(
-                    requires_python.specifiers().clone(),
-                    PythonRequirementKind::Target,
+                return WheelCompatibility::Incompatible(IncompatibleWheel::Tag(
+                    IncompatibleTag::Abi,
                 ));
             }
         }

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -7,8 +7,7 @@ use tracing::instrument;
 use distribution_filename::{DistFilename, WheelFilename};
 use distribution_types::{
     HashComparison, IncompatibleSource, IncompatibleWheel, IndexUrl, PrioritizedDist,
-    PythonRequirementKind, RegistryBuiltWheel, RegistrySourceDist, SourceDistCompatibility,
-    WheelCompatibility,
+    RegistryBuiltWheel, RegistrySourceDist, SourceDistCompatibility, WheelCompatibility,
 };
 use pep440_rs::Version;
 use platform_tags::{IncompatibleTag, TagCompatibility, Tags};

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -4268,8 +4268,6 @@ fn lock_resolution_mode() -> Result<()> {
 fn lock_requires_python_no_wheels() -> Result<()> {
     let context = TestContext::new("3.12");
 
-    let lockfile = context.temp_dir.join("uv.lock");
-
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"
@@ -4281,37 +4279,17 @@ fn lock_requires_python_no_wheels() -> Result<()> {
         "#,
     )?;
 
-    deterministic! { context =>
-        uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    uv_snapshot!(context.filters(), context.lock(), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 6 packages in [TIME]
-        "###);
-
-        let lock = fs_err::read_to_string(&lockfile).unwrap();
-
-        insta::with_settings!({
-            filters => context.filters(),
-        }, {
-            assert_snapshot!(
-                lock, @r###"
-            success: false
-            exit_code: 1
-            ----- stdout -----
-
-            ----- stderr -----
-            warning: `uv lock` is experimental and may change without warning
-              × No solution found when resolving dependencies:
-              ╰─▶ Because dearpygui==1.9.1 has no wheels are available with a matching Python ABI and project==0.1.0 depends on dearpygui==1.9.1, we can conclude that project==0.1.0 cannot be used.
-                  And because only project==0.1.0 is available and you require project, we can conclude that the requirements are unsatisfiable.
-            "###
-            );
-        });
-    }
+    ----- stderr -----
+    warning: `uv lock` is experimental and may change without warning
+      × No solution found when resolving dependencies:
+      ╰─▶ Because dearpygui==1.9.1 has no wheels are available with a matching Python ABI and project==0.1.0 depends on dearpygui==1.9.1, we can conclude that project==0.1.0 cannot be used.
+          And because only project==0.1.0 is available and you require project, we can conclude that the requirements are unsatisfiable.
+    "###);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`dearpygui==1.9.1 has no wheels are available with a matching Python ABI` is way better than `he requested Python version (>=3.12.3) does not satisfy Python>=3.12.3`.

Closes https://github.com/astral-sh/uv/issues/5284.
