### PR TITLE
Mark uv itself as unmanaged

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,3 +69,6 @@ version_files = [
   "crates/uv-version/Cargo.toml",
   "docs/guides/integration/pre-commit.md",
 ]
+
+[tool.uv]
+managed = false


### PR DESCRIPTION
I like to create dummy packages in the workspace, which interacts badly with our pyproject.toml.
