### PR TITLE
Avoid including empty extras in resolution

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -195,7 +195,17 @@ impl Workspace {
                     .as_ref()
                     .map(|optional_dependencies| {
                         // It's a `BTreeMap` so the keys are sorted.
-                        optional_dependencies.keys().cloned().collect::<Vec<_>>()
+                        optional_dependencies
+                            .iter()
+                            .filter_map(|(name, dependencies)| {
+                                if dependencies.is_empty() {
+                                    None
+                                } else {
+                                    Some(name)
+                                }
+                            })
+                            .cloned()
+                            .collect::<Vec<_>>()
                     })
                     .unwrap_or_default();
 


### PR DESCRIPTION
## Summary

You can still generate instabilities, but at least it's consistent between including and excluding the extra.

For example, this resolves to 54 and then 52 packages on re-run:

```toml
[project]
name = "transformers"
version = "4.39.0.dev0"
description = "State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow"
requires-python = ">=3.9.0"

dependencies = []

[project.optional-dependencies]
flax = ["jaxlib>=0.4.1,<=0.4.13"]
onnxruntime = ["onnxruntime>=1.4.0"]
ray = ["ray[tune]>=2.7.0"]
deepspeed-testing = [
  "dill<0.3.5",
  "datasets!=2.5.0",
]

[build-system]
requires = ["hatchling"]
build-backend = "hatchling.build"
```

I think the difference is just somewhere in PubGrub -- like, we add an extra dependency, so the iteration order gets changed, and we end up with a different resolution at the end.

Closes https://github.com/astral-sh/uv/issues/5285.
