### PR TITLE
Omit interpreter path during `uv venv` with managed Python

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1244,6 +1244,12 @@ impl PythonRequest {
     }
 }
 
+impl PythonSource {
+    pub fn is_managed(&self) -> bool {
+        matches!(self, Self::Managed)
+    }
+}
+
 impl PythonPreference {
     fn allows(self, source: PythonSource) -> bool {
         // If not dealing with a system interpreter source, we don't care about the preference


### PR DESCRIPTION
e.g. 
```
❯ cargo run -q -- venv --preview
Using Python 3.12.1
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
```

instead of 

```
❯ cargo run -q -- venv --preview
Using Python 3.12.1 interpreter at: /Users/zb/Library/Application Support/uv/python/cpython-3.12.1-macos-aarch64-none/bin/python3
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
```