### PR TITLE
Include URLs on graph edges

### DIFF
--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -10,7 +10,7 @@ use distribution_types::{
 };
 use pep440_rs::{Version, VersionSpecifier};
 use pep508_rs::{MarkerEnvironment, MarkerTree};
-use pypi_types::{ParsedUrlError, Requirement, Yanked};
+use pypi_types::{ParsedUrlError, Requirement, VerbatimParsedUrl, Yanked};
 use uv_configuration::{Constraints, Overrides};
 use uv_git::GitResolver;
 use uv_normalize::{ExtraName, GroupName, PackageName};
@@ -68,6 +68,7 @@ impl ResolutionGraph {
         type NodeKey<'a> = (
             &'a PackageName,
             &'a Version,
+            Option<&'a VerbatimParsedUrl>,
             Option<&'a ExtraName>,
             Option<&'a GroupName>,
         );
@@ -245,7 +246,10 @@ impl ResolutionGraph {
                     hashes,
                     metadata,
                 }));
-                inverse.insert((name, version, extra.as_ref(), dev.as_ref()), index);
+                inverse.insert(
+                    (name, version, url.as_ref(), extra.as_ref(), dev.as_ref()),
+                    index,
+                );
             }
         }
 
@@ -255,6 +259,7 @@ impl ResolutionGraph {
                 inverse[&(
                     from,
                     &edge.from_version,
+                    edge.from_url.as_ref(),
                     edge.from_extra.as_ref(),
                     edge.from_dev.as_ref(),
                 )]
@@ -262,6 +267,7 @@ impl ResolutionGraph {
             let to_index = inverse[&(
                 &edge.to,
                 &edge.to_version,
+                edge.to_url.as_ref(),
                 edge.to_extra.as_ref(),
                 edge.to_dev.as_ref(),
             )];

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2227,6 +2227,7 @@ impl ForkState {
 
                     _ => continue,
                 };
+                let self_url = self_name.as_ref().and_then(|name| self.fork_urls.get(name));
 
                 match **dependency_package {
                     PubGrubPackageInner::Package {
@@ -2238,13 +2239,16 @@ impl ForkState {
                         if self_name.is_some_and(|self_name| self_name == dependency_name) {
                             continue;
                         }
+                        let to_url = self.fork_urls.get(dependency_name);
                         let edge = ResolutionDependencyEdge {
                             from: self_name.cloned(),
                             from_version: self_version.clone(),
+                            from_url: self_url.cloned(),
                             from_extra: self_extra.cloned(),
                             from_dev: self_dev.cloned(),
                             to: dependency_name.clone(),
                             to_version: dependency_version.clone(),
+                            to_url: to_url.cloned(),
                             to_extra: dependency_extra.clone(),
                             to_dev: dependency_dev.clone(),
                             marker: None,
@@ -2260,13 +2264,16 @@ impl ForkState {
                         if self_name.is_some_and(|self_name| self_name == dependency_name) {
                             continue;
                         }
+                        let to_url = self.fork_urls.get(dependency_name);
                         let edge = ResolutionDependencyEdge {
                             from: self_name.cloned(),
                             from_version: self_version.clone(),
+                            from_url: self_url.cloned(),
                             from_extra: self_extra.cloned(),
                             from_dev: self_dev.cloned(),
                             to: dependency_name.clone(),
                             to_version: dependency_version.clone(),
+                            to_url: to_url.cloned(),
                             to_extra: None,
                             to_dev: None,
                             marker: Some(dependency_marker.clone()),
@@ -2283,13 +2290,16 @@ impl ForkState {
                         if self_name.is_some_and(|self_name| self_name == dependency_name) {
                             continue;
                         }
+                        let to_url = self.fork_urls.get(dependency_name);
                         let edge = ResolutionDependencyEdge {
                             from: self_name.cloned(),
                             from_version: self_version.clone(),
+                            from_url: self_url.cloned(),
                             from_extra: self_extra.cloned(),
                             from_dev: self_dev.cloned(),
                             to: dependency_name.clone(),
                             to_version: dependency_version.clone(),
+                            to_url: to_url.cloned(),
                             to_extra: Some(dependency_extra.clone()),
                             to_dev: None,
                             marker: dependency_marker.clone(),
@@ -2306,13 +2316,16 @@ impl ForkState {
                         if self_name.is_some_and(|self_name| self_name == dependency_name) {
                             continue;
                         }
+                        let to_url = self.fork_urls.get(dependency_name);
                         let edge = ResolutionDependencyEdge {
                             from: self_name.cloned(),
                             from_version: self_version.clone(),
+                            from_url: self_url.cloned(),
                             from_extra: self_extra.cloned(),
                             from_dev: self_dev.cloned(),
                             to: dependency_name.clone(),
                             to_version: dependency_version.clone(),
+                            to_url: to_url.cloned(),
                             to_extra: None,
                             to_dev: Some(dependency_dev.clone()),
                             marker: dependency_marker.clone(),
@@ -2390,10 +2403,12 @@ pub(crate) struct ResolutionDependencyEdge {
     /// This value is `None` if the dependency comes from the root package.
     pub(crate) from: Option<PackageName>,
     pub(crate) from_version: Version,
+    pub(crate) from_url: Option<VerbatimParsedUrl>,
     pub(crate) from_extra: Option<ExtraName>,
     pub(crate) from_dev: Option<GroupName>,
     pub(crate) to: PackageName,
     pub(crate) to_version: Version,
+    pub(crate) to_url: Option<VerbatimParsedUrl>,
     pub(crate) to_extra: Option<ExtraName>,
     pub(crate) to_dev: Option<GroupName>,
     pub(crate) marker: Option<MarkerTree>,


### PR DESCRIPTION
## Summary

Excellent find from @konstin. If we have a package that's included in two forks at the same version, but with different URLs, we need to avoid collapsing them in the lockfile.

Closes https://github.com/astral-sh/uv/issues/5294.
