### PR TITLE
Omit the nav bar title when it has no use

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -112,6 +112,20 @@ This is a consequence of the reduced nav spacing below. */
   box-shadow: none;
 }
 
+/* Omits the nav title "uv" entirely unless on a small screen, in which case
+the nav title is needed for backwards navigation in the collapsible
+nav variant.
+
+See https://github.com/astral-sh/uv/issues/5130 */
+.md-nav__title {
+  display: none;
+}
+@media screen and (max-width: 1219px) {
+  .md-nav__title {
+    display: flex ;
+  }
+}
+
 /* Reducing spacing between nav items to fit more content */
 .md-nav__link {
   margin-top: 0.25em;


### PR DESCRIPTION
Turns out this is needed for navigation on mobile, but useless on larger screens. 

Closes #5130

<img width="1551" alt="Screenshot 2024-07-22 at 5 47 49 PM" src="https://github.com/user-attachments/assets/2173549e-e65d-4691-be83-5e3bf0191dd5">
<img width="1551" alt="Screenshot 2024-07-22 at 5 48 02 PM" src="https://github.com/user-attachments/assets/81012ba8-ce85-4276-8ffa-5c7ef556c389">
<img width="1551" alt="Screenshot 2024-07-22 at 5 48 08 PM" src="https://github.com/user-attachments/assets/ecf8fcd7-e5d4-45c4-8d46-d09d91a8bbe9">
