### PR TITLE
Create member `pyproject.toml` prior to workspace discovery

### DIFF
--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -724,3 +724,45 @@ fn init_virtual_workspace() -> Result<()> {
 
     Ok(())
 }
+
+/// Run `uv init` from within a workspace. The path is already included via `members`.
+#[test]
+fn init_matches_member() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {
+        r"
+        [tool.uv.workspace]
+        members = ['packages/*']
+        ",
+    })?;
+
+    let packages = context.temp_dir.join("packages");
+    fs_err::create_dir_all(packages)?;
+
+    uv_snapshot!(context.filters(), context.init().current_dir(context.temp_dir.join("packages")).arg("foo"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv init` is experimental and may change without warning
+    Adding `foo` as member of workspace `[TEMP_DIR]/`
+    Initialized project `foo` at `[TEMP_DIR]/packages/foo`
+    "###);
+
+    let workspace = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            workspace, @r###"
+        [tool.uv.workspace]
+        members = ['packages/*', "packages/foo"]
+        "###
+        );
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Otherwise, if the path is already a member, discovery fails.

Also adds a failing test for "adding members that are already covered by `members`".
