### PR TITLE
Avoid redundant members update in `uv init`

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -345,6 +345,13 @@ impl Workspace {
         }
     }
 
+    /// Returns `true` if the path is a workspace member.
+    pub fn includes(&self, project_path: &Path) -> bool {
+        self.packages
+            .values()
+            .any(|member| project_path == member.root())
+    }
+
     /// Collect the workspace member projects from the `members` and `excludes` entries.
     async fn collect_members(
         workspace_root: PathBuf,

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -330,6 +330,21 @@ impl Workspace {
         &self.pyproject_toml
     }
 
+    /// Returns `true` if the path is excluded by the workspace.
+    pub fn excludes(&self, project_path: &Path) -> Result<bool, WorkspaceError> {
+        if let Some(workspace) = self
+            .pyproject_toml
+            .tool
+            .as_ref()
+            .and_then(|tool| tool.uv.as_ref())
+            .and_then(|uv| uv.workspace.as_ref())
+        {
+            is_excluded_from_workspace(project_path, &self.install_path, workspace)
+        } else {
+            Ok(false)
+        }
+    }
+
     /// Collect the workspace member projects from the `members` and `excludes` entries.
     async fn collect_members(
         workspace_root: PathBuf,

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -123,6 +123,14 @@ pub(crate) async fn init(
                 name.cyan(),
                 workspace.install_path().simplified_display().cyan()
             )?;
+        } else if workspace.includes(&path) {
+            // If the member is already included in the workspace, skip the `members` addition.
+            writeln!(
+                printer.stderr(),
+                "Project `{}` is already a member of workspace `{}`",
+                name.cyan(),
+                workspace.install_path().simplified_display().cyan()
+            )?;
         } else {
             // Add the package to the workspace.
             let mut pyproject = PyProjectTomlMut::from_toml(workspace.pyproject_toml())?;

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -748,7 +748,7 @@ fn init_matches_members() -> Result<()> {
 
     ----- stderr -----
     warning: `uv init` is experimental and may change without warning
-    Adding `foo` as member of workspace `[TEMP_DIR]/`
+    Project `foo` is already a member of workspace `[TEMP_DIR]/`
     Initialized project `foo` at `[TEMP_DIR]/packages/foo`
     "###);
 
@@ -759,7 +759,7 @@ fn init_matches_members() -> Result<()> {
         assert_snapshot!(
             workspace, @r###"
         [tool.uv.workspace]
-        members = ['packages/*', "packages/foo"]
+        members = ['packages/*']
         "###
         );
     });


### PR DESCRIPTION
## Summary

If the path is already covered by `members`, we don't need to update it.

Closes https://github.com/astral-sh/uv/issues/5320.
