### PR TITLE
Add `requires-python` to `uv init`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1797,6 +1797,20 @@ pub struct InitArgs {
     /// Do not create a readme file.
     #[arg(long)]
     pub no_readme: bool,
+
+    /// The Python interpreter to use to determine the minimum supported Python version.
+    ///
+    /// By default, uv uses the virtual environment in the current working directory or any parent
+    /// directory, falling back to searching for a Python executable in `PATH`. The `--python`
+    /// option allows you to specify a different interpreter.
+    ///
+    /// Supported formats:
+    /// - `3.10` looks for an installed Python 3.10 using `py --list-paths` on Windows, or
+    ///   `python3.10` on Linux and macOS.
+    /// - `python3.10` or `python.exe` looks for a binary with the given name in `PATH`.
+    /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
+    #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
+    pub python: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/uv-resolver/src/requires_python.rs
+++ b/crates/uv-resolver/src/requires_python.rs
@@ -49,6 +49,21 @@ impl RequiresPython {
         }
     }
 
+    /// Returns a [`RequiresPython`] from a version specifier.
+    pub fn from_specifiers(specifiers: &VersionSpecifiers) -> Result<Self, RequiresPythonError> {
+        let bound = RequiresPythonBound(
+            crate::pubgrub::PubGrubSpecifier::from_release_specifiers(specifiers)?
+                .iter()
+                .next()
+                .map(|(lower, _)| lower.clone())
+                .unwrap_or(Bound::Unbounded),
+        );
+        Ok(Self {
+            specifiers: specifiers.clone(),
+            bound,
+        })
+    }
+
     /// Returns a [`RequiresPython`] to express the union of the given version specifiers.
     ///
     /// For example, given `>=3.8` and `>=3.9`, this would return `>=3.8`.

--- a/crates/uv-workspace/src/lib.rs
+++ b/crates/uv-workspace/src/lib.rs
@@ -1,4 +1,6 @@
-pub use workspace::{ProjectWorkspace, VirtualProject, Workspace, WorkspaceError, WorkspaceMember};
+pub use workspace::{
+    DiscoveryOptions, ProjectWorkspace, VirtualProject, Workspace, WorkspaceError, WorkspaceMember,
+};
 
 pub mod pyproject;
 pub mod pyproject_mut;

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -14,7 +14,7 @@ use uv_types::{BuildIsolation, HashStrategy};
 use uv_warnings::warn_user_once;
 use uv_workspace::pyproject::{DependencyType, Source, SourceError};
 use uv_workspace::pyproject_mut::PyProjectTomlMut;
-use uv_workspace::{ProjectWorkspace, VirtualProject, Workspace};
+use uv_workspace::{DiscoveryOptions, ProjectWorkspace, VirtualProject, Workspace};
 
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::resolution_environment;
@@ -54,12 +54,12 @@ pub(crate) async fn add(
 
     // Find the project in the workspace.
     let project = if let Some(package) = package {
-        Workspace::discover(&std::env::current_dir()?, None)
+        Workspace::discover(&std::env::current_dir()?, &DiscoveryOptions::default())
             .await?
             .with_current_project(package.clone())
             .with_context(|| format!("Package `{package}` not found in workspace"))?
     } else {
-        ProjectWorkspace::discover(&std::env::current_dir()?, None).await?
+        ProjectWorkspace::discover(&std::env::current_dir()?, &DiscoveryOptions::default()).await?
     };
 
     // Discover or create the virtual environment.

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -24,7 +24,7 @@ use uv_resolver::{
 };
 use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
 use uv_warnings::{warn_user, warn_user_once};
-use uv_workspace::Workspace;
+use uv_workspace::{DiscoveryOptions, Workspace};
 
 use crate::commands::project::{find_requires_python, FoundInterpreter, ProjectError, SharedState};
 use crate::commands::{pip, ExitStatus};
@@ -51,7 +51,8 @@ pub(crate) async fn lock(
     }
 
     // Find the project requirements.
-    let workspace = Workspace::discover(&std::env::current_dir()?, None).await?;
+    let workspace =
+        Workspace::discover(&std::env::current_dir()?, &DiscoveryOptions::default()).await?;
 
     // Find an interpreter for the project
     let interpreter = FoundInterpreter::discover(

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -8,7 +8,7 @@ use uv_python::{PythonFetch, PythonPreference, PythonRequest};
 use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::pyproject::DependencyType;
 use uv_workspace::pyproject_mut::PyProjectTomlMut;
-use uv_workspace::{ProjectWorkspace, VirtualProject, Workspace};
+use uv_workspace::{DiscoveryOptions, ProjectWorkspace, VirtualProject, Workspace};
 
 use crate::commands::pip::operations::Modifications;
 use crate::commands::{project, ExitStatus, SharedState};
@@ -39,12 +39,12 @@ pub(crate) async fn remove(
 
     // Find the project in the workspace.
     let project = if let Some(package) = package {
-        Workspace::discover(&std::env::current_dir()?, None)
+        Workspace::discover(&std::env::current_dir()?, &DiscoveryOptions::default())
             .await?
             .with_current_project(package.clone())
             .with_context(|| format!("Package `{package}` not found in workspace"))?
     } else {
-        ProjectWorkspace::discover(&std::env::current_dir()?, None).await?
+        ProjectWorkspace::discover(&std::env::current_dir()?, &DiscoveryOptions::default()).await?
     };
 
     let mut pyproject = PyProjectTomlMut::from_toml(project.current_project().pyproject_toml())?;

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -23,7 +23,7 @@ use uv_python::{
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_warnings::warn_user_once;
-use uv_workspace::{VirtualProject, Workspace, WorkspaceError};
+use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace, WorkspaceError};
 
 use crate::commands::pip::operations::Modifications;
 use crate::commands::project::environment::CachedEnvironment;
@@ -144,13 +144,15 @@ pub(crate) async fn run(
             // We need a workspace, but we don't need to have a current package, we can be e.g. in
             // the root of a virtual workspace and then switch into the selected package.
             Some(VirtualProject::Project(
-                Workspace::discover(&std::env::current_dir()?, None)
+                Workspace::discover(&std::env::current_dir()?, &DiscoveryOptions::default())
                     .await?
                     .with_current_project(package.clone())
                     .with_context(|| format!("Package `{package}` not found in workspace"))?,
             ))
         } else {
-            match VirtualProject::discover(&std::env::current_dir()?, None).await {
+            match VirtualProject::discover(&std::env::current_dir()?, &DiscoveryOptions::default())
+                .await
+            {
                 Ok(project) => Some(project),
                 Err(WorkspaceError::MissingPyprojectToml) => None,
                 Err(WorkspaceError::NonWorkspace(_)) => None,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -12,7 +12,7 @@ use uv_python::{PythonEnvironment, PythonFetch, PythonPreference, PythonRequest}
 use uv_resolver::{FlatIndex, Lock};
 use uv_types::{BuildIsolation, HashStrategy};
 use uv_warnings::warn_user_once;
-use uv_workspace::VirtualProject;
+use uv_workspace::{DiscoveryOptions, VirtualProject};
 
 use crate::commands::pip::operations::Modifications;
 use crate::commands::project::lock::do_safe_lock;
@@ -45,7 +45,8 @@ pub(crate) async fn sync(
     }
 
     // Identify the project
-    let project = VirtualProject::discover(&std::env::current_dir()?, None).await?;
+    let project =
+        VirtualProject::discover(&std::env::current_dir()?, &DiscoveryOptions::default()).await?;
 
     // Discover or create the virtual environment.
     let venv = project::get_or_init_environment(

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -10,7 +10,7 @@ use uv_client::Connectivity;
 use uv_configuration::{Concurrency, PreviewMode};
 use uv_python::{PythonFetch, PythonPreference, PythonRequest};
 use uv_warnings::warn_user_once;
-use uv_workspace::Workspace;
+use uv_workspace::{DiscoveryOptions, Workspace};
 
 use crate::commands::pip::tree::DisplayDependencyGraph;
 use crate::commands::project::FoundInterpreter;
@@ -47,7 +47,8 @@ pub(crate) async fn tree(
     }
 
     // Find the project requirements.
-    let workspace = Workspace::discover(&std::env::current_dir()?, None).await?;
+    let workspace =
+        Workspace::discover(&std::env::current_dir()?, &DiscoveryOptions::default()).await?;
 
     // Find an interpreter for the project
     let interpreter = FoundInterpreter::discover(

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -14,7 +14,7 @@ use uv_python::{
     PYTHON_VERSION_FILENAME,
 };
 use uv_warnings::warn_user_once;
-use uv_workspace::VirtualProject;
+use uv_workspace::{DiscoveryOptions, VirtualProject};
 
 use crate::commands::{project::find_requires_python, ExitStatus};
 use crate::printer::Printer;
@@ -33,14 +33,17 @@ pub(crate) async fn pin(
         warn_user_once!("`uv python pin` is experimental and may change without warning");
     }
 
-    let virtual_project = match VirtualProject::discover(&std::env::current_dir()?, None).await {
-        Ok(virtual_project) if !isolated => Some(virtual_project),
-        Ok(_) => None,
-        Err(err) => {
-            debug!("Failed to discover virtual project: {err}");
-            None
-        }
-    };
+    let virtual_project =
+        match VirtualProject::discover(&std::env::current_dir()?, &DiscoveryOptions::default())
+            .await
+        {
+            Ok(virtual_project) if !isolated => Some(virtual_project),
+            Ok(_) => None,
+            Err(err) => {
+                debug!("Failed to discover virtual project: {err}");
+                None
+            }
+        };
 
     let Some(request) = request else {
         // Display the current pinned Python version

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::ffi::OsString;
 use std::fmt::Write;
 use std::io::stdout;
@@ -24,7 +23,7 @@ use uv_cli::{SelfCommand, SelfNamespace};
 use uv_configuration::Concurrency;
 use uv_requirements::RequirementsSource;
 use uv_settings::{Combine, FilesystemOptions};
-use uv_workspace::Workspace;
+use uv_workspace::{DiscoveryOptions, Workspace};
 
 use crate::commands::{ExitStatus, ToolRunCommand};
 use crate::printer::Printer;
@@ -74,12 +73,14 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         Some(FilesystemOptions::from_file(config_file)?)
     } else if cli.global_args.isolated {
         None
-    } else if let Ok(project) = Workspace::discover(&env::current_dir()?, None).await {
+    } else if let Ok(project) =
+        Workspace::discover(&std::env::current_dir()?, &DiscoveryOptions::default()).await
+    {
         let project = FilesystemOptions::from_directory(project.install_path())?;
         let user = FilesystemOptions::user()?;
         project.combine(user)
     } else {
-        let project = FilesystemOptions::find(env::current_dir()?)?;
+        let project = FilesystemOptions::find(std::env::current_dir()?)?;
         let user = FilesystemOptions::user()?;
         project.combine(user)
     };
@@ -130,7 +131,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .break_words(false)
                 .word_separator(textwrap::WordSeparator::AsciiSpace)
                 .word_splitter(textwrap::WordSplitter::NoHyphenation)
-                .wrap_lines(env::var("UV_NO_WRAP").map(|_| false).unwrap_or(true))
+                .wrap_lines(std::env::var("UV_NO_WRAP").map(|_| false).unwrap_or(true))
                 .build(),
         )
     }))?;
@@ -1106,7 +1107,7 @@ where
     // We support increasing the stack size to avoid stack overflows in debug mode on Windows. In
     // addition, we box types and futures in various places. This includes the `Box::pin(run())`
     // here, which prevents the large (non-send) main future alone from overflowing the stack.
-    let result = if let Ok(stack_size) = env::var("UV_STACK_SIZE") {
+    let result = if let Ok(stack_size) = std::env::var("UV_STACK_SIZE") {
         let stack_size = stack_size.parse().expect("Invalid stack size");
         let tokio_main = move || {
             let runtime = tokio::runtime::Builder::new_current_thread()

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -834,8 +834,14 @@ async fn run_project(
                 args.path,
                 args.name,
                 args.no_readme,
+                args.python,
                 globals.isolated,
                 globals.preview,
+                globals.python_preference,
+                globals.python_fetch,
+                globals.connectivity,
+                globals.native_tls,
+                &cache,
                 printer,
             )
             .await

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -154,6 +154,7 @@ pub(crate) struct InitSettings {
     pub(crate) path: Option<String>,
     pub(crate) name: Option<PackageName>,
     pub(crate) no_readme: bool,
+    pub(crate) python: Option<String>,
 }
 
 impl InitSettings {
@@ -164,12 +165,14 @@ impl InitSettings {
             path,
             name,
             no_readme,
+            python,
         } = args;
 
         Self {
             path,
             name,
             no_readme,
+            python,
         }
     }
 }

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -207,6 +207,7 @@ fn init_dot_args() -> Result<()> {
         version = "0.1.0"
         description = "Add your description here"
         readme = "README.md"
+        requires-python = ">=3.12"
         dependencies = []
 
         [tool.uv]
@@ -235,7 +236,6 @@ fn init_dot_args() -> Result<()> {
     ----- stderr -----
     warning: `uv lock` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    warning: No `requires-python` field found in the workspace. Defaulting to `>=3.12`.
     Resolved 1 package in [TIME]
     "###);
 
@@ -354,7 +354,6 @@ fn init_workspace_relative_sub_package() -> Result<()> {
     })?;
 
     let child = context.temp_dir.join("foo");
-    fs_err::create_dir(&child)?;
 
     uv_snapshot!(context.filters(), context.init().current_dir(&context.temp_dir).arg("foo"), @r###"
     success: true
@@ -450,7 +449,6 @@ fn init_workspace_outside() -> Result<()> {
     })?;
 
     let child = context.temp_dir.join("foo");
-    fs_err::create_dir(&child)?;
 
     // Run `uv init <path>` outside the workspace.
     uv_snapshot!(context.filters(), context.init().current_dir(&context.home_dir).arg(&child), @r###"
@@ -810,8 +808,11 @@ fn init_matches_members() -> Result<()> {
         ",
     })?;
 
+    // Create the parent directory (`packages`) and the child directory (`foo`), to ensure that
+    // the empty child directory does _not_ trigger a workspace discovery error despite being a
+    // valid member.
     let packages = context.temp_dir.join("packages");
-    fs_err::create_dir_all(packages)?;
+    fs_err::create_dir_all(packages.join("foo"))?;
 
     uv_snapshot!(context.filters(), context.init().current_dir(context.temp_dir.join("packages")).arg("foo"), @r###"
     success: true


### PR DESCRIPTION
## Summary

Prefers, in order:

- The major-minor version of an interpreter discovered via `--python`.
- The `requires-python` from the workspace.
- The major-minor version of the default interpreter.

If the `--python` request is a version or a version range, we use that without fetching an interpreter.

Closes https://github.com/astral-sh/uv/issues/5299.
