### PR TITLE
Allow symlinks with `--find-links`

### DIFF
--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -228,7 +228,7 @@ impl<'a> FlatIndexClient<'a> {
         for entry in fs_err::read_dir(path)? {
             let entry = entry?;
             let metadata = entry.metadata()?;
-            if !metadata.is_file() {
+            if !metadata.is_file() && !metadata.is_symlink() {
                 continue;
             }
 

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -228,8 +228,22 @@ impl<'a> FlatIndexClient<'a> {
         for entry in fs_err::read_dir(path)? {
             let entry = entry?;
             let metadata = entry.metadata()?;
-            if !metadata.is_file() && !metadata.is_symlink() {
+
+            if metadata.is_dir() {
                 continue;
+            }
+
+            if metadata.is_symlink() {
+                let Ok(target) = entry.path().read_link() else {
+                    warn!(
+                        "Skipping unreadable symlink in `--find-links` directory: {}",
+                        entry.path().display()
+                    );
+                    continue;
+                };
+                if target.is_dir() {
+                    continue;
+                }
             }
 
             let Ok(filename) = entry.file_name().into_string() else {


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

In my setup, I have a directory of wheels symlinked from different directories. I can point `--find-links` at it with `pip` and it works but not `uv`.

Currently, `uv` checks if a candidate file `is_file` which is for regular files. By also checking `is_symlink` I was able to install a symlinked wheel. I'm not *exactly* sure where, but some other place is eventually resolving the absolute path of the wheel. (`uv`? The OS?)

## Test Plan

<!-- How was it tested? -->
Manually tested - I didn't see any tests for `FlatIndexClient` in the `uv-client` crate.

```
mkdir /tmp/a /tmp/b                               # Create a directory of wheels (/tmp/a) and a directory of symlinked wheels (/tmp/b)
cp test-0.0.1-py3-none-any.whl /tmp/a             # Add a wheel to the directory of wheels
ln -s /tmp/a/test-0.0.1-py3-none-any.whl /tmp/b/  # Create a symlink to that wheel
uv pip install test --find-links /tmp/b           # Install pointing at the symlinked wheels directory
```