### PR TITLE
Fix `python-build-standalone` workflow

### DIFF
--- a/.github/workflows/python-build-standalone.yml
+++ b/.github/workflows/python-build-standalone.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Sync Python Releases
         run: |
           uv run --isolated -- fetch-download-metadata.py
-          uv run --isolated --with chevron-blue -- template-download-metadata.py
+          uv run --isolated -- template-download-metadata.py
         working-directory: ./crates/uv-python
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Create Pull Request"
         uses: peter-evans/create-pull-request@v6

--- a/.github/workflows/python-build-standalone.yml
+++ b/.github/workflows/python-build-standalone.yml
@@ -24,7 +24,7 @@ jobs:
           uv run --isolated -- template-download-metadata.py
         working-directory: ./crates/uv-python
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Create Pull Request"
         uses: peter-evans/create-pull-request@v6

--- a/crates/uv-python/fetch-download-metadata.py
+++ b/crates/uv-python/fetch-download-metadata.py
@@ -360,10 +360,10 @@ def render(downloads: list[PythonDownload]) -> None:
 
 
 async def find() -> None:
-    token = os.environ.get("GH_TOKEN")
+    token = os.environ.get("GITHUB_TOKEN")
     if not token:
         logging.warning(
-            "`GH_TOKEN` env var not found, you may hit rate limits for GitHub API requests."
+            "`GITHUB_TOKEN` env var not found, you may hit rate limits for GitHub API requests."
         )
 
     headers = {"X-GitHub-Api-Version": "2022-11-28"}


### PR DESCRIPTION
## Summary

The script reads `GITHUB_TOKEN` instead. And since #4853 merged, there is no need to use `uv run --with`.
