### PR TITLE
Fix `uv init .`

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -34,19 +34,6 @@ pub(crate) async fn init(
         Some(ref path) => PathBuf::from(path),
     };
 
-    // Default to the directory name if a name was not provided.
-    let name = match name {
-        Some(name) => name,
-        None => {
-            let name = path
-                .file_name()
-                .and_then(|path| path.to_str())
-                .expect("Invalid package name");
-
-            PackageName::new(name.to_string())?
-        }
-    };
-
     // Make sure a project does not already exist in the given directory.
     if path.join("pyproject.toml").exists() {
         let path = path
@@ -61,6 +48,19 @@ pub(crate) async fn init(
 
     // Canonicalize the path to the project.
     let path = absolutize_path(&path)?;
+
+    // Default to the directory name if a name was not provided.
+    let name = match name {
+        Some(name) => name,
+        None => {
+            let name = path
+                .file_name()
+                .and_then(|path| path.to_str())
+                .expect("Invalid package name");
+
+            PackageName::new(name.to_string())?
+        }
+    };
 
     // Create the `pyproject.toml`.
     let pyproject = indoc::formatdoc! {r#"

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
 
 use pep508_rs::PackageName;
@@ -56,7 +56,7 @@ pub(crate) async fn init(
             let name = path
                 .file_name()
                 .and_then(|path| path.to_str())
-                .expect("Invalid package name");
+                .context("Missing directory name")?;
 
             PackageName::new(name.to_string())?
         }


### PR DESCRIPTION
## Summary

This PR avoids an `Invalid package name` error that occurs when using `uv init .`. This is achieved by slightly reorganizing the code block to determine the name after the path is canonicalized. The dot path is expanded to the current directory, and the `file_name` then works as expected.

Resolve #5329 .


