### PR TITLE
Add trampoline tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,9 @@ jobs:
         target-arch: ["x86_64", "i686", "aarch64"]
     steps:
       - uses: actions/checkout@v4
+      - name: "Install Rust toolchain"
+        working-directory: ${{ github.workspace }}/crates/uv-trampoline
+        run: rustup component add rust-src ${{ matrix.target-arch }}-pc-windows-msvc
       # It's so fast that caching isn't worth it.
       - name: "Test"
         working-directory: ${{ github.workspace }}/crates/uv-trampoline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,8 +278,8 @@ jobs:
           uv venv
           uv pip install ruff
 
-  # Separate job for the nightly crate
-  windows-trampoline:
+  # Separate jobs for the nightly crate
+  windows-trampoline-check:
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
@@ -335,12 +335,22 @@ jobs:
           XWIN_ARCH: "x86_64"
           XWIN_CACHE_DIR: "${{ github.workspace }}/.xwin"
 
-      - name: "Build"
+  # Separate jobs for the nightly crate
+  windows-trampoline-test:
+    needs: determine_changes
+    if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+    runs-on: windows-latest
+    name: "test windows trampoline | ${{ matrix.target-arch }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        target-arch: ["x86_64", "i686", "aarch64"]
+    steps:
+      - uses: actions/checkout@v4
+      # It's so fast that caching isn't worth it.
+      - name: "Test"
         working-directory: ${{ github.workspace }}/crates/uv-trampoline
-        run: cargo xwin build --release --target ${{ matrix.target-arch }}-pc-windows-msvc
-        env:
-          XWIN_ARCH: "${{ matrix.target-arch == 'i686' && 'x86' || matrix.target-arch }}"
-          XWIN_CACHE_DIR: "${{ github.workspace }}/.xwin"
+        run: cargo test --target ${{ matrix.target-arch }}-pc-windows-msvc
 
   typos:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Install Rust toolchain"
         working-directory: ${{ github.workspace }}/crates/uv-trampoline
-        run: rustup component add rust-src ${{ matrix.target-arch }}-pc-windows-msvc
+        run: |
+          rustup target add ${{ matrix.target-arch }}-pc-windows-msvc
+          rustup component add rust-src --target ${{ matrix.target-arch }}-pc-windows-msvc
       # It's so fast that caching isn't worth it.
       - name: "Test"
         working-directory: ${{ github.workspace }}/crates/uv-trampoline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-arch: ["x86_64", "i686", "aarch64"]
+        target-arch: ["x86_64", "i686"]
     steps:
       - uses: actions/checkout@v4
       - name: "Install Rust toolchain"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,9 @@ jobs:
         run: |
           rustup target add ${{ matrix.target-arch }}-pc-windows-msvc
           rustup component add rust-src --target ${{ matrix.target-arch }}-pc-windows-msvc
-      # It's so fast that caching isn't worth it.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ github.workspace }}/crates/uv-trampoline
       - name: "Test"
         working-directory: ${{ github.workspace }}/crates/uv-trampoline
         run: cargo test --target ${{ matrix.target-arch }}-pc-windows-msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,7 +357,7 @@ jobs:
           workspaces: ${{ github.workspace }}/crates/uv-trampoline
       - name: "Test"
         working-directory: ${{ github.workspace }}/crates/uv-trampoline
-        run: cargo test --target ${{ matrix.target-arch }}-pc-windows-msvc
+        run: cargo test --target ${{ matrix.target-arch }}-pc-windows-msvc --test *
 
   typos:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ${{ github.workspace }}/crates/uv-trampoline
+      # Build and copy the new binaries
+      - name: "Build"
+        working-directory: ${{ github.workspace }}/crates/uv-trampoline
+        run: |
+          cargo build --target ${{ matrix.target-arch }}-pc-windows-msvc
+          cp target/${{ matrix.target-arch }}-pc-windows-msvc/debug/uv-trampoline-console.exe trampolines/uv-trampoline-${{ matrix.target-arch }}-console.exe
+          cp target/${{ matrix.target-arch }}-pc-windows-msvc/debug/uv-trampoline-gui.exe trampolines/uv-trampoline-${{ matrix.target-arch }}-gui.exe
       - name: "Test"
         working-directory: ${{ github.workspace }}/crates/uv-trampoline
         run: cargo test --target ${{ matrix.target-arch }}-pc-windows-msvc --test *


### PR DESCRIPTION
Add the tests added in #5204 to CI. The crate is not part of the workspace (it requires nightly) and is windows only, so we have to test it separately.