### PR TITLE
Stable sorting of requirements.txt in universal mode

### DIFF
--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -241,6 +241,7 @@ impl ResolutionGraph {
                 // Add the distribution to the graph.
                 let index = petgraph.add_node(ResolutionGraphNode::Dist(AnnotatedDist {
                     dist,
+                    version: version.clone(),
                     extra: extra.clone(),
                     dev: dev.clone(),
                     hashes,

--- a/crates/uv-resolver/src/resolution/mod.rs
+++ b/crates/uv-resolver/src/resolution/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 
 use distribution_types::{DistributionMetadata, Name, ResolvedDist, VersionOrUrlRef};
+use pep440_rs::Version;
 use pypi_types::HashDigest;
 use uv_distribution::Metadata;
 use uv_normalize::{ExtraName, GroupName, PackageName};
@@ -20,6 +21,7 @@ mod requirements_txt;
 #[derive(Debug, Clone)]
 pub(crate) struct AnnotatedDist {
     pub(crate) dist: ResolvedDist,
+    pub(crate) version: Version,
     pub(crate) extra: Option<ExtraName>,
     pub(crate) dev: Option<GroupName>,
     pub(crate) hashes: Vec<HashDigest>,

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -7250,13 +7250,13 @@ fn universal_nested_overlapping_local_requirement() -> Result<()> {
         # via torch
     tbb==2021.11.0 ; platform_machine != 'x86_64' and platform_system == 'Windows'
         # via mkl
-    torch==2.3.0 ; platform_machine != 'x86_64'
-        # via -r requirements.in
     torch==2.0.0+cu118 ; platform_machine == 'x86_64'
         # via
         #   -r requirements.in
         #   example
         #   triton
+    torch==2.3.0 ; platform_machine != 'x86_64'
+        # via -r requirements.in
     triton==2.0.0 ; platform_machine == 'x86_64' and platform_system == 'Linux'
         # via torch
     typing-extensions==4.10.0
@@ -7324,13 +7324,13 @@ fn universal_nested_overlapping_local_requirement() -> Result<()> {
         # via torch
     tbb==2021.11.0 ; platform_machine != 'x86_64' and platform_system == 'Windows'
         # via mkl
-    torch==2.3.0 ; platform_machine != 'x86_64'
-        # via -r requirements.in
     torch==2.0.0+cu118 ; platform_machine == 'x86_64'
         # via
         #   -r requirements.in
         #   example
         #   triton
+    torch==2.3.0 ; platform_machine != 'x86_64'
+        # via -r requirements.in
     triton==2.0.0 ; platform_machine == 'x86_64' and platform_system == 'Linux'
         # via torch
     typing-extensions==4.10.0
@@ -7440,6 +7440,10 @@ fn universal_nested_disjoint_local_requirement() -> Result<()> {
         # via torch
     tbb==2021.11.0 ; os_name != 'Linux' and platform_system == 'Windows'
         # via mkl
+    torch==2.0.0+cpu ; os_name == 'Linux'
+        # via
+        #   -r requirements.in
+        #   example
     torch==2.0.0+cu118 ; os_name == 'Linux'
         # via
         #   -r requirements.in
@@ -7447,10 +7451,6 @@ fn universal_nested_disjoint_local_requirement() -> Result<()> {
         #   triton
     torch==2.3.0 ; os_name != 'Linux'
         # via -r requirements.in
-    torch==2.0.0+cpu ; os_name == 'Linux'
-        # via
-        #   -r requirements.in
-        #   example
     triton==2.0.0 ; os_name == 'Linux' and platform_machine == 'x86_64' and platform_system == 'Linux'
         # via torch
     typing-extensions==4.10.0


### PR DESCRIPTION
The `RequirementsTxtComparator` was written assuming there is one distribution per package name. This changed with the universal resolution, which allows multiple versions or urls for the same package name. The sorting we emitted for these new entries was incidental.

With this change, we properly sort these entries by name, version and then url in universal mode.

This is an output format change for `--universal` users.