### PR TITLE
add pronunciation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Actions status](https://github.com/astral-sh/uv/actions/workflows/ci.yml/badge.svg)](https://github.com/astral-sh/uv/actions)
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?logo=discord&logoColor=white)](https://discord.gg/astral-sh)
 
-An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in
+[`/juː viː/`](https://en.wikipedia.org/wiki/Help:IPA/English#Key) -  An extremely fast Python package installer and resolver, written in Rust. Designed as a drop-in
 replacement for common `pip` and `pip-tools` workflows.
 
 <p align="center">


### PR DESCRIPTION
## Summary

Adds an IPA pronunciation to the very top of the README, for the sake of clarity. This is a minor thing, but it's nice to know that there's a 'standard' pronunciation for uv.

I have no idea whether this will seem like a "reasonable" place to put this; I looked over the README and didn't see any obviously more appropriate places to put it. Maybe this is unobtrusive enough that it's fine where it is; maybe there should be a new section added somewhere; maybe somebody who has a better feel for the project goals will have a clever suggestion.

Closes #5309 