### PR TITLE
Show symbolic links in `uv python list`

### DIFF
--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -142,11 +142,21 @@ pub(crate) async fn list(
     for (key, path) in include {
         let key = key.to_string();
         if let Some(path) = path {
-            writeln!(
-                printer.stdout(),
-                "{key:width$}    {}",
-                path.user_display().cyan()
-            )?;
+            let is_symlink = fs_err::symlink_metadata(path)?.is_symlink();
+            if is_symlink {
+                writeln!(
+                    printer.stdout(),
+                    "{key:width$}    {} -> {}",
+                    path.user_display().cyan(),
+                    path.read_link()?.user_display().cyan()
+                )?;
+            } else {
+                writeln!(
+                    printer.stdout(),
+                    "{key:width$}    {}",
+                    path.user_display().cyan()
+                )?;
+            }
         } else {
             writeln!(
                 printer.stdout(),


### PR DESCRIPTION
## Summary

This PR displays symbolic links in `uv python list` and produces output similar to the following:

```
:) uv python list --preview
cpython-3.12.1-macos-aarch64-none     /Users/eth/workspace/astral-sh/uv/bin/python3.12 -> versions/cpython@3.12.1/install/bin/python3
cpython-3.12.1-macos-aarch64-none     /Users/eth/workspace/astral-sh/uv/bin/python3 -> versions/cpython@3.12.1/install/bin/python3
cpython-3.12.1-macos-aarch64-none     /Users/eth/workspace/astral-sh/uv/bin/python -> versions/cpython@3.12.1/install/bin/python3
cpython-3.11.7-macos-aarch64-none     /Users/eth/workspace/astral-sh/uv/bin/python3.11 -> versions/cpython@3.11.7/install/bin/python3
cpython-3.10.13-macos-aarch64-none    /Users/eth/workspace/astral-sh/uv/bin/python3.10 -> versions/cpython@3.10.13/install/bin/python3
cpython-3.9.18-macos-aarch64-none     /Users/eth/workspace/astral-sh/uv/bin/python3.9 -> versions/cpython@3.9.18/install/bin/python3
cpython-3.8.18-macos-aarch64-none     /Users/eth/workspace/astral-sh/uv/bin/python3.8 -> versions/cpython@3.8.18/install/bin/python3

```


Resolves #5308 

## Test Plan

```
$ cargo run python list
```
