### PR TITLE
Remove Simple API cache files for alternative indexes in `cache clean`

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -676,7 +676,7 @@ impl CacheBucket {
             Self::FlatIndex => "flat-index-v0",
             Self::Git => "git-v0",
             Self::Interpreter => "interpreter-v2",
-            Self::Simple => "simple-v9",
+            Self::Simple => "simple-v10",
             Self::Wheels => "wheels-v1",
             Self::Archive => "archive-v0",
             Self::Builds => "builds-v0",
@@ -706,8 +706,8 @@ impl CacheBucket {
                 let root = cache.bucket(self).join(WheelCacheKind::Pypi);
                 summary += rm_rf(root.join(name.to_string()))?;
 
-                // For alternate indices, we expect a directory for every index, followed by a
-                // directory per package (indexed by name).
+                // For alternate indices, we expect a directory for every index (under an `index`
+                // subdirectory), followed by a directory per package (indexed by name).
                 let root = cache.bucket(self).join(WheelCacheKind::Index);
                 for directory in directories(root) {
                     summary += rm_rf(directory.join(name.to_string()))?;
@@ -725,8 +725,8 @@ impl CacheBucket {
                 let root = cache.bucket(self).join(WheelCacheKind::Pypi);
                 summary += rm_rf(root.join(name.to_string()))?;
 
-                // For alternate indices, we expect a directory for every index, followed by a
-                // directory per package (indexed by name).
+                // For alternate indices, we expect a directory for every index (under an `index`
+                // subdirectory), followed by a directory per package (indexed by name).
                 let root = cache.bucket(self).join(WheelCacheKind::Index);
                 for directory in directories(root) {
                     summary += rm_rf(directory.join(name.to_string()))?;
@@ -769,9 +769,9 @@ impl CacheBucket {
                 let root = cache.bucket(self).join(WheelCacheKind::Pypi);
                 summary += rm_rf(root.join(format!("{name}.rkyv")))?;
 
-                // For alternate indices, we expect a directory for every index, followed by a
-                // MsgPack file per package, indexed by name.
-                let root = cache.bucket(self).join(WheelCacheKind::Url);
+                // For alternate indices, we expect a directory for every index (under an `index`
+                // subdirectory), followed by a directory per package (indexed by name).
+                let root = cache.bucket(self).join(WheelCacheKind::Index);
                 for directory in directories(root) {
                     summary += rm_rf(directory.join(format!("{name}.rkyv")))?;
                 }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use async_http_range_reader::AsyncHttpRangeReader;
@@ -268,11 +268,7 @@ impl RegistryClient {
 
         let cache_entry = self.cache.entry(
             CacheBucket::Simple,
-            Path::new(&match index {
-                IndexUrl::Pypi(_) => "pypi".to_string(),
-                IndexUrl::Url(url) => cache_key::digest(&cache_key::CanonicalUrl::new(url)),
-                IndexUrl::Path(url) => cache_key::digest(&cache_key::CanonicalUrl::new(url)),
-            }),
+            WheelCache::Index(index).root(),
             format!("{package_name}.rkyv"),
         );
         let cache_control = match self.connectivity {


### PR DESCRIPTION
## Summary

The `simple-v9` directory was missing the `index` segment. See before:


![Screenshot 2024-07-23 at 1 29 18 PM](https://github.com/user-attachments/assets/3af9ccbf-ba45-4910-ad3b-4f52806dc8c9)

And after:

![Screenshot 2024-07-23 at 1 29 38 PM](https://github.com/user-attachments/assets/15535534-3304-4209-93e8-7f5e572929f0)

Every other bucket has this `index` segment for non-PyPI indexes, e.g.:

![Screenshot 2024-07-23 at 1 29 24 PM](https://github.com/user-attachments/assets/7354c9ad-7757-4a5f-a7b8-ff987a100e39)

Closes https://github.com/astral-sh/uv/issues/5352.
