### PR TITLE
Display Python installation key for discovered interpreters

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -17,7 +17,7 @@ use uv_fs::Simplified;
 use uv_warnings::warn_user_once;
 
 use crate::downloads::PythonDownloadRequest;
-use crate::implementation::{ImplementationName, LenientImplementationName};
+use crate::implementation::ImplementationName;
 use crate::installation::PythonInstallation;
 use crate::interpreter::Error as InterpreterError;
 use crate::managed::ManagedPythonInstallations;
@@ -271,7 +271,7 @@ fn python_executables_from_installed<'a>(
                                 version.matches_version(&installation.version())
                             })
                     })
-                    .inspect(|installation| debug!("Found managed Python `{installation}`"))
+                    .inspect(|installation| debug!("Found managed installation `{installation}`"))
                     .map(|installation| (PythonSource::Managed, installation.executable())))
             })
     })
@@ -508,9 +508,8 @@ fn python_interpreters_from_executables<'a>(
             .map(|interpreter| (source, interpreter))
             .inspect(|(source, interpreter)| {
                 debug!(
-                    "Found {} {} at `{}` ({source})",
-                    LenientImplementationName::from(interpreter.implementation_name()),
-                    interpreter.python_full_version(),
+                    "Found `{}` at `{}` ({source})",
+                    interpreter.key(),
                     path.display()
                 );
             })

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -166,15 +166,7 @@ impl PythonInstallation {
     }
 
     pub fn key(&self) -> PythonInstallationKey {
-        PythonInstallationKey::new(
-            LenientImplementationName::from(self.interpreter.implementation_name()),
-            self.interpreter.python_major(),
-            self.interpreter.python_minor(),
-            self.interpreter.python_patch(),
-            self.os(),
-            self.arch(),
-            self.libc(),
-        )
+        self.interpreter.key()
     }
 
     /// Return the Python [`Version`] of the Python installation as reported by its interpreter.
@@ -189,17 +181,17 @@ impl PythonInstallation {
 
     /// Return the [`Arch`] of the Python installation as reported by its interpreter.
     pub fn arch(&self) -> Arch {
-        Arch::from(&self.interpreter.platform().arch())
+        self.interpreter.arch()
     }
 
     /// Return the [`Libc`] of the Python installation as reported by its interpreter.
     pub fn libc(&self) -> Libc {
-        Libc::from(self.interpreter.platform().os())
+        self.interpreter.libc()
     }
 
     /// Return the [`Os`] of the Python installation as reported by its interpreter.
     pub fn os(&self) -> Os {
-        Os::from(self.interpreter.platform().os())
+        self.interpreter.os()
     }
 
     /// Return the [`Interpreter`] for the Python installation.

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -21,8 +21,10 @@ use pypi_types::Scheme;
 use uv_cache::{Cache, CacheBucket, CachedByTimestamp, Freshness, Timestamp};
 use uv_fs::{write_atomic_sync, PythonExt, Simplified};
 
+use crate::implementation::LenientImplementationName;
+use crate::platform::{Arch, Libc, Os};
 use crate::pointer_size::PointerSize;
-use crate::{Prefix, PythonVersion, Target, VirtualEnvironment};
+use crate::{Prefix, PythonInstallationKey, PythonVersion, Target, VirtualEnvironment};
 
 /// A Python executable and its associated platform markers.
 #[derive(Debug, Clone)]
@@ -170,6 +172,34 @@ impl Interpreter {
     #[inline]
     pub const fn markers(&self) -> &MarkerEnvironment {
         &self.markers
+    }
+
+    /// Returns the [`PythonInstallationKey`] for this interpreter.
+    pub fn key(&self) -> PythonInstallationKey {
+        PythonInstallationKey::new(
+            LenientImplementationName::from(self.implementation_name()),
+            self.python_major(),
+            self.python_minor(),
+            self.python_patch(),
+            self.os(),
+            self.arch(),
+            self.libc(),
+        )
+    }
+
+    /// Return the [`Arch`] reported by the interpreter platform tags.
+    pub fn arch(&self) -> Arch {
+        Arch::from(&self.platform().arch())
+    }
+
+    /// Return the [`Libc`] reported by the interpreter platform tags.
+    pub fn libc(&self) -> Libc {
+        Libc::from(self.platform().os())
+    }
+
+    /// Return the [`Os`] reported by the interpreter platform tags.
+    pub fn os(&self) -> Os {
+        Os::from(self.platform().os())
     }
 
     /// Returns the [`Tags`] for this Python executable.


### PR DESCRIPTION
> DEBUG Found `cpython-3.12.1-macos-aarch64-none` at `/Users/zb/Library/Application Support/uv/python/cpython-3.12.1-macos-aarch64-none/bin/python3` (managed installations)

Instead of `<implementation> <version>`

> DEBUG Found cpython 3.12.1 at `/Users/zb/Library/Application Support/uv/python/cpython-3.12.1-macos-aarch64-none/bin/python3` (managed installations)