### PR TITLE
Retain dependency specifier in `uv add` with sources

### DIFF
--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -370,7 +370,7 @@ fn update_requirement(old: &mut Requirement, new: Requirement, has_source: bool)
 
     // Clear the requirement source if we are going to add to `tool.uv.sources`.
     if has_source {
-        old.version_or_url = None;
+        old.clear_url();
     }
 
     // Update the source if a new one was specified.


### PR DESCRIPTION
## Summary

Only clear the version if it's a URL.

Closes https://github.com/astral-sh/uv/issues/5339.
