### PR TITLE
Allow `uv init` in unmanaged projects

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -94,6 +94,7 @@ pub(crate) async fn init(
         {
             Ok(workspace) => Some(workspace),
             Err(WorkspaceError::MissingPyprojectToml) => None,
+            Err(WorkspaceError::NonWorkspace(_)) => None,
             Err(err) => return Err(err.into()),
         }
     };

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -1043,3 +1043,41 @@ fn init_requires_python_specifiers() -> Result<()> {
 
     Ok(())
 }
+
+/// Run `uv init` from within an unmanaged project.
+#[test]
+fn init_unmanaged() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {
+        r"
+        [tool.uv]
+        managed = false
+        ",
+    })?;
+
+    uv_snapshot!(context.filters(), context.init().arg("foo"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv init` is experimental and may change without warning
+    Initialized project `foo` at `[TEMP_DIR]/foo`
+    "###);
+
+    let workspace = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            workspace, @r###"
+        [tool.uv]
+        managed = false
+        "###
+        );
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/5368.
