### PR TITLE
Fix blurring from nav title box shadow

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -104,6 +104,14 @@
   background-color: var(--md-code-bg-color);
 }
 
+/* Prevent the shadow from the nav title from blurring the top link.
+The box shadow isn't really doing anything anyway.
+
+This is a consequence of the reduced nav spacing below. */
+.md-nav--primary .md-nav__title {
+  box-shadow: none;
+}
+
 /* Reducing spacing between nav items to fit more content */
 .md-nav__link {
   margin-top: 0.3em;


### PR DESCRIPTION
Fixes blur noted in https://github.com/astral-sh/uv/pull/5316 but doesn't drop the title entirely. https://github.com/astral-sh/uv/pull/5316 is my preferred design, if the implementation was cost-free.


<img width="1259" alt="Screenshot 2024-07-23 at 3 53 48 PM" src="https://github.com/user-attachments/assets/6f9b828b-884f-447d-8508-ba4023152e2f">

(nothing to see at the rest of the breakpoints >1220)

<img width="1259" alt="Screenshot 2024-07-23 at 3 53 56 PM" src="https://github.com/user-attachments/assets/b892cd76-cd91-4e78-b8c8-58e16a8b1130">
