### PR TITLE
Mark `--raw-sources` as conflicting with sources-specific arguments

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2010,10 +2010,18 @@ pub struct AddArgs {
     #[arg(long, overrides_with = "editable")]
     pub no_editable: bool,
 
-    /// Add source requirements to the `project.dependencies` section of the `pyproject.toml`.
+    /// Add source requirements to `project.dependencies`, rather than `tool.uv.sources`.
     ///
-    /// Without this flag, uv will try to use `tool.uv.sources` for any sources.
-    #[arg(long)]
+    /// By default, uv will use the `tool.uv.sources` section to record source information for Git,
+    /// local, editable, and direct URL requirements.
+    #[arg(
+        long,
+        conflicts_with = "editable",
+        conflicts_with = "no_editable",
+        conflicts_with = "rev",
+        conflicts_with = "tag",
+        conflicts_with = "branch"
+    )]
     pub raw_sources: bool,
 
     /// Specific commit to use when adding from Git.

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -490,6 +490,37 @@ fn add_git_raw() -> Result<()> {
     Ok(())
 }
 
+/// `--raw-sources` should be considered conflicting with sources-specific arguments, like `--tag`.
+#[test]
+fn add_raw_error() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    // Provide a tag without a Git source.
+    uv_snapshot!(context.filters(), context.add(&[]).arg("uv-public-pypackage @ git+https://github.com/astral-test/uv-public-pypackage").arg("--tag").arg("0.0.1").arg("--raw-sources").arg("--preview"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--tag <TAG>' cannot be used with '--raw-sources'
+
+    Usage: uv add --cache-dir [CACHE_DIR] --tag <TAG> --exclude-newer <EXCLUDE_NEWER> <REQUIREMENTS>...
+
+    For more information, try '--help'.
+    "###);
+
+    Ok(())
+}
+
 /// Add an unnamed requirement.
 #[test]
 fn add_unnamed() -> Result<()> {


### PR DESCRIPTION
## Summary

We should error on, e.g., `--raw-sources --tag 0.0.1`.
