### PR TITLE
Merge identical forks

### DIFF
--- a/crates/uv-resolver/src/resolver/resolver_markers.rs
+++ b/crates/uv-resolver/src/resolver/resolver_markers.rs
@@ -28,11 +28,18 @@ impl ResolverMarkers {
         }
     }
 
-    /// If solving for a specific environment, return this environment
+    /// If solving for a specific environment, return this environment.
     pub fn marker_environment(&self) -> Option<&MarkerEnvironment> {
         match self {
             ResolverMarkers::Universal | ResolverMarkers::Fork(_) => None,
             ResolverMarkers::SpecificEnvironment(env) => Some(env),
+        }
+    }
+    /// If solving a fork, return that fork's markers.
+    pub fn fork_markers(&self) -> Option<&MarkerTree> {
+        match self {
+            ResolverMarkers::SpecificEnvironment(_) | ResolverMarkers::Universal => None,
+            ResolverMarkers::Fork(markers) => Some(markers),
         }
     }
 }


### PR DESCRIPTION
Consider these requirements from pylint 3.2.5:

```
Requires-Dist: dill >=0.3.6 ; python_version >= "3.11"
Requires-Dist: dill >=0.3.7 ; python_version >= "3.12"
```

We will split on the python version, but then we may pick a version of `dill` that's `>=0.3.7` in both branches and also have an otherwise identical resolution in both forks. In this case, we merge both forks and store only their conjoined markers.