### PR TITLE
Ignore hidden directories in workspace discovery

### DIFF
--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -1045,3 +1045,18 @@ fn init_unmanaged() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn init_hidden() {
+    let context = TestContext::new("3.12");
+
+    uv_snapshot!(context.filters(), context.init().arg(".foo"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv init` is experimental and may change without warning
+    error: Not a valid package or extra name: ".foo". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
+    "###);
+}


### PR DESCRIPTION
## Summary

This is surprisingly complex because we need to decide what happens if you run `uv run` from within a hidden folder, etc. For now, I did the simplest thing: we just ignore workspace members that are hidden directories if they lack a `pyproject.toml`, so you can still include hidden members, they're just ignored if they don't seem to be projects.

Closes https://github.com/astral-sh/uv/issues/5403.
