### PR TITLE
uv/tests: tweak cache clean all test

### DIFF
--- a/crates/uv/tests/cache_clean.rs
+++ b/crates/uv/tests/cache_clean.rs
@@ -25,7 +25,7 @@ fn clean_all() -> Result<()> {
         .assert()
         .success();
 
-    uv_snapshot!(context.filters(), context.clean().arg("--verbose"), @r###"
+    uv_snapshot!(context.with_filtered_counts().filters(), context.clean().arg("--verbose"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -33,7 +33,7 @@ fn clean_all() -> Result<()> {
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Clearing cache at: [CACHE_DIR]/
-    Removed 28 files ([SIZE])
+    Removed [N] files ([SIZE])
     "###);
 
     Ok(())


### PR DESCRIPTION
The test asserts that 28 files were removed. But on my system, 27 files
are removed.

This PR is first about debugging what the difference is (since CI
presumably passes with the status quo snapshot). And then I'm thinking
the right way to fix the test failure is with a filter that replaces the
specific number of files removed (limited to what we know to be
correct) with a placeholder.
