### PR TITLE
Normalize marker expression order

### DIFF
--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -1804,8 +1804,11 @@ mod tests {
 
     #[test]
     fn no_space_after_operator() {
+        let requirement = Requirement::<Url>::from_str("pytest;python_version<='4.0'").unwrap();
+        assert_eq!(requirement.to_string(), "pytest ; python_version <= '4.0'");
+
         let requirement = Requirement::<Url>::from_str("pytest;'4.0'>=python_version").unwrap();
-        assert_eq!(requirement.to_string(), "pytest ; '4.0' >= python_version");
+        assert_eq!(requirement.to_string(), "pytest ; python_version <= '4.0'");
     }
 
     #[test]

--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -391,16 +391,10 @@ impl ResolutionGraph {
         /// Add all marker parameters from the given tree to the given set.
         fn add_marker_params_from_tree(marker_tree: &MarkerTree, set: &mut IndexSet<MarkerParam>) {
             match marker_tree {
-                MarkerTree::Expression(
-                    MarkerExpression::Version { key, .. }
-                    | MarkerExpression::VersionInverted { key, .. },
-                ) => {
+                MarkerTree::Expression(MarkerExpression::Version { key, .. }) => {
                     set.insert(MarkerParam::Version(key.clone()));
                 }
-                MarkerTree::Expression(
-                    MarkerExpression::String { key, .. }
-                    | MarkerExpression::StringInverted { key, .. },
-                ) => {
+                MarkerTree::Expression(MarkerExpression::String { key, .. }) => {
                     set.insert(MarkerParam::String(key.clone()));
                 }
                 MarkerTree::And(ref exprs) | MarkerTree::Or(ref exprs) => {


### PR DESCRIPTION
## Summary

Normalize the order of marker expressions on construction. This removes the distinction between expressions like `os_name == 'Linux'` vs. `'Linux' == os_name` throughout the codebase. One caveat here is that the `in` operator does not have a direct inverse, so we introduce `MarkerOperator::Contains` to handle that case.

I wanted to land this smaller change before some more intrusive changes as it simplifies the existing code quite a bit.