### PR TITLE
Make `--reinstall` imply `--refresh`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4668,6 +4668,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "uv-auth",
+ "uv-cache",
  "uv-normalize",
 ]
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2548,14 +2548,16 @@ pub struct InstallerArgs {
     #[command(flatten)]
     pub index_args: IndexArgs,
 
-    /// Reinstall all packages, regardless of whether they're already installed.
+    /// Reinstall all packages, regardless of whether they're already installed. Implies
+    /// `--refresh`.
     #[arg(long, alias = "force-reinstall", overrides_with("no_reinstall"))]
     pub reinstall: bool,
 
     #[arg(long, overrides_with("reinstall"), hide = true)]
     pub no_reinstall: bool,
 
-    /// Reinstall a specific package, regardless of whether it's already installed.
+    /// Reinstall a specific package, regardless of whether it's already installed. Implies
+    /// `--refresh-package`.
     #[arg(long)]
     pub reinstall_package: Vec<PackageName>,
 
@@ -2712,14 +2714,16 @@ pub struct ResolverInstallerArgs {
     #[arg(long, short = 'P')]
     pub upgrade_package: Vec<Requirement<VerbatimParsedUrl>>,
 
-    /// Reinstall all packages, regardless of whether they're already installed.
+    /// Reinstall all packages, regardless of whether they're already installed. Implies
+    /// `--refresh`.
     #[arg(long, alias = "force-reinstall", overrides_with("no_reinstall"))]
     pub reinstall: bool,
 
     #[arg(long, overrides_with("reinstall"), hide = true)]
     pub no_reinstall: bool,
 
-    /// Reinstall a specific package, regardless of whether it's already installed.
+    /// Reinstall a specific package, regardless of whether it's already installed. Implies
+    /// `--refresh-package`.
     #[arg(long)]
     pub reinstall_package: Vec<PackageName>,
 

--- a/crates/uv-configuration/Cargo.toml
+++ b/crates/uv-configuration/Cargo.toml
@@ -17,6 +17,7 @@ pep508_rs = { workspace = true, features = ["schemars"] }
 platform-tags = { workspace = true }
 pypi-types = { workspace = true }
 uv-auth = { workspace = true }
+uv-cache = { workspace = true }
 uv-normalize = { workspace = true }
 
 clap = { workspace = true, features = ["derive"], optional = true }

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -380,7 +380,7 @@ pub struct ResolverInstallerOptions {
         "#
     )]
     pub upgrade_package: Option<Vec<Requirement<VerbatimParsedUrl>>>,
-    /// Reinstall all packages, regardless of whether they're already installed.
+    /// Reinstall all packages, regardless of whether they're already installed. Implies `refresh`.
     #[option(
         default = "false",
         value_type = "bool",
@@ -389,7 +389,8 @@ pub struct ResolverInstallerOptions {
         "#
     )]
     pub reinstall: Option<bool>,
-    /// Reinstall a specific package, regardless of whether it's already installed.
+    /// Reinstall a specific package, regardless of whether it's already installed. Implies
+    /// `refresh-package`.
     #[option(
         default = "[]",
         value_type = "list[str]",
@@ -1056,7 +1057,7 @@ pub struct PipOptions {
         "#
     )]
     pub upgrade_package: Option<Vec<Requirement<VerbatimParsedUrl>>>,
-    /// Reinstall all packages, regardless of whether they're already installed.
+    /// Reinstall all packages, regardless of whether they're already installed. Implies `refresh`.
     #[option(
         default = "false",
         value_type = "bool",
@@ -1065,7 +1066,8 @@ pub struct PipOptions {
         "#
     )]
     pub reinstall: Option<bool>,
-    /// Reinstall a specific package, regardless of whether it's already installed.
+    /// Reinstall a specific package, regardless of whether it's already installed. Implies
+    /// `refresh-package`.
     #[option(
         default = "[]",
         value_type = "list[str]",

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -179,6 +179,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .expect("failed to initialize global rayon pool");
 
             // Initialize the cache.
+
             let cache = cache.init()?.with_refresh(args.refresh);
 
             let requirements = args
@@ -262,7 +263,9 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .expect("failed to initialize global rayon pool");
 
             // Initialize the cache.
-            let cache = cache.init()?.with_refresh(args.refresh);
+            let cache = cache
+                .init()?
+                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
 
             let requirements = args
                 .src_file
@@ -324,7 +327,10 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .expect("failed to initialize global rayon pool");
 
             // Initialize the cache.
-            let cache = cache.init()?.with_refresh(args.refresh);
+            let cache = cache
+                .init()?
+                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
+
             let requirements = args
                 .package
                 .into_iter()
@@ -880,7 +886,9 @@ async fn run_project(
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache.init()?.with_refresh(args.refresh);
+            let cache = cache
+                .init()?
+                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
 
             let requirements = args
                 .with
@@ -921,7 +929,9 @@ async fn run_project(
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache.init()?.with_refresh(args.refresh);
+            let cache = cache
+                .init()?
+                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
 
             commands::sync(
                 args.locked,
@@ -948,7 +958,7 @@ async fn run_project(
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache.init()?.with_refresh(args.refresh);
+            let cache = cache.init()?;
 
             commands::lock(
                 args.locked,
@@ -972,7 +982,9 @@ async fn run_project(
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache.init()?.with_refresh(args.refresh);
+            let cache = cache
+                .init()?
+                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
 
             commands::add(
                 args.locked,
@@ -1005,7 +1017,9 @@ async fn run_project(
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache.init()?.with_refresh(args.refresh);
+            let cache = cache
+                .init()?
+                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
 
             commands::remove(
                 args.locked,

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -10091,7 +10091,7 @@ requires-python = ">3.8"
         # via -r requirements.in
     idna==3.6
         # via anyio
-    lib @ file://[TEMP_DIR]/lib/
+    lib @ file://[TEMP_DIR]/lib
         # via example
 
     ----- stderr -----

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -4489,7 +4489,6 @@ fn already_installed_dependent_editable() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - first-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/first_local)
@@ -4588,7 +4587,6 @@ fn already_installed_local_path_dependent() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - first-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/first_local)
@@ -4673,6 +4671,7 @@ fn already_installed_local_version_of_remote_package() {
     );
 
     // Request install with a different version
+    //
     // We should attempt to pull from the index since the installed version does not match
     // but we disable it here to preserve this dependency for future tests
     uv_snapshot!(context.filters(), context.pip_install()
@@ -4705,8 +4704,8 @@ fn already_installed_local_version_of_remote_package() {
     "###
     );
 
-    // Request reinstall with the full path, this should reinstall from the path
-    // and not pull from the index
+    // Request reinstall with the full path, this should reinstall from the path and not pull from
+    // the index (or rebuild).
     uv_snapshot!(context.filters(), context.pip_install()
         .arg(root_path.join("anyio_local"))
         .arg("--reinstall")
@@ -4717,7 +4716,6 @@ fn already_installed_local_version_of_remote_package() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==4.3.0+foo (from file://[WORKSPACE]/scripts/packages/anyio_local)
@@ -4755,7 +4753,6 @@ fn already_installed_local_version_of_remote_package() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==4.3.0

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -585,6 +585,7 @@ fn respect_installed_and_reinstall() -> Result<()> {
 
     ----- stderr -----
     Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
      - flask==3.0.2
@@ -1816,6 +1817,7 @@ fn reinstall_no_binary() {
 
     ----- stderr -----
     Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
      - anyio==4.3.0
@@ -4489,6 +4491,7 @@ fn already_installed_dependent_editable() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - first-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/first_local)
@@ -4587,6 +4590,7 @@ fn already_installed_local_path_dependent() {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - first-local==0.1.0 (from file://[WORKSPACE]/scripts/packages/dependent_locals/first_local)
@@ -4716,6 +4720,7 @@ fn already_installed_local_version_of_remote_package() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==4.3.0+foo (from file://[WORKSPACE]/scripts/packages/anyio_local)
@@ -4972,6 +4977,7 @@ fn already_installed_remote_url() {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -1962,6 +1962,7 @@ fn reinstall() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
+    Prepared 2 packages in [TIME]
     Uninstalled 2 packages in [TIME]
     Installed 2 packages in [TIME]
      - markupsafe==2.1.3
@@ -2016,6 +2017,7 @@ fn reinstall_package() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - tomli==2.0.1
@@ -2069,6 +2071,7 @@ fn reinstall_git() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
@@ -2258,6 +2261,7 @@ fn sync_editable() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - poetry-editable==0.1.0 (from file://[TEMP_DIR]/poetry_editable)
@@ -2308,10 +2312,7 @@ fn sync_editable() -> Result<()> {
 
     ----- stderr -----
     Resolved 3 packages in [TIME]
-    Uninstalled 1 package in [TIME]
-    Installed 1 package in [TIME]
-     - poetry-editable==0.1.0 (from file://[TEMP_DIR]/poetry_editable)
-     + poetry-editable==0.1.0 (from file://[TEMP_DIR]/poetry_editable)
+    Audited 3 packages in [TIME]
     "###
     );
 
@@ -2781,6 +2782,7 @@ fn find_links_wheel_cache() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - tqdm==1000.0.0
@@ -2831,6 +2833,7 @@ fn find_links_source_cache() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - tqdm==999.0.0
@@ -3746,6 +3749,7 @@ fn require_hashes_source_url() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - source-distribution==0.0.1 (from https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz)
@@ -3847,6 +3851,7 @@ fn require_hashes_wheel_url() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==4.0.0 (from https://files.pythonhosted.org/packages/36/55/ad4de788d84a630656ece71059665e01ca793c04294c463fd84132f40fe6/anyio-4.0.0-py3-none-any.whl)
@@ -4059,6 +4064,7 @@ fn require_hashes_re_download() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==4.0.0
@@ -4459,6 +4465,7 @@ fn require_hashes_at_least_one() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==4.0.0
@@ -4481,6 +4488,7 @@ fn require_hashes_at_least_one() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
      - anyio==4.0.0
@@ -4716,6 +4724,7 @@ fn require_hashes_find_links_invalid_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + example-a-961b4c22==1.0.0
     "###
@@ -4922,6 +4931,7 @@ fn require_hashes_registry_invalid_hash() -> Result<()> {
 
     ----- stderr -----
     Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + example-a-961b4c22==1.0.0
     "###

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -107,7 +107,7 @@ fn run_with_python_version() -> Result<()> {
     Removed virtual environment at: .venv
     Creating virtualenv at: .venv
     Resolved 5 packages in [TIME]
-    Prepared 4 packages in [TIME]
+    Prepared 3 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.6.0
      + foo==1.0.0 (from file://[TEMP_DIR]/)

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -672,7 +672,7 @@ those that are downloaded and installed by uv.
 
 #### [`reinstall`](#reinstall) {: #reinstall }
 
-Reinstall all packages, regardless of whether they're already installed.
+Reinstall all packages, regardless of whether they're already installed. Implies `refresh`.
 
 **Default value**: `false`
 
@@ -697,7 +697,8 @@ Reinstall all packages, regardless of whether they're already installed.
 
 #### [`reinstall-package`](#reinstall-package) {: #reinstall-package }
 
-Reinstall a specific package, regardless of whether it's already installed.
+Reinstall a specific package, regardless of whether it's already installed. Implies
+`refresh-package`.
 
 **Default value**: `[]`
 
@@ -2062,7 +2063,7 @@ mapped to `3.8.0`.
 #### [`reinstall`](#pip_reinstall) {: #pip_reinstall }
 <span id="reinstall"></span>
 
-Reinstall all packages, regardless of whether they're already installed.
+Reinstall all packages, regardless of whether they're already installed. Implies `refresh`.
 
 **Default value**: `false`
 
@@ -2088,7 +2089,8 @@ Reinstall all packages, regardless of whether they're already installed.
 #### [`reinstall-package`](#pip_reinstall-package) {: #pip_reinstall-package }
 <span id="reinstall-package"></span>
 
-Reinstall a specific package, regardless of whether it's already installed.
+Reinstall a specific package, regardless of whether it's already installed. Implies
+`refresh-package`.
 
 **Default value**: `[]`
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -253,14 +253,14 @@
       ]
     },
     "reinstall": {
-      "description": "Reinstall all packages, regardless of whether they're already installed.",
+      "description": "Reinstall all packages, regardless of whether they're already installed. Implies `refresh`.",
       "type": [
         "boolean",
         "null"
       ]
     },
     "reinstall-package": {
-      "description": "Reinstall a specific package, regardless of whether it's already installed.",
+      "description": "Reinstall a specific package, regardless of whether it's already installed. Implies `refresh-package`.",
       "type": [
         "array",
         "null"
@@ -845,14 +845,14 @@
           ]
         },
         "reinstall": {
-          "description": "Reinstall all packages, regardless of whether they're already installed.",
+          "description": "Reinstall all packages, regardless of whether they're already installed. Implies `refresh`.",
           "type": [
             "boolean",
             "null"
           ]
         },
         "reinstall-package": {
-          "description": "Reinstall a specific package, regardless of whether it's already installed.",
+          "description": "Reinstall a specific package, regardless of whether it's already installed. Implies `refresh-package`.",
           "type": [
             "array",
             "null"


### PR DESCRIPTION
## Summary

It's hard for me to imagine a scenario in which a user passed `--reinstall`, but wanted us to keep respecting cached data for a package. For example, to actually "rebuild and reinstall" an editable today, you have to pass both `--reinstall` and `--refresh`.

This PR makes `--reinstall` imply `--refresh`, so we always validate that the cached data is fresh.

Closes https://github.com/astral-sh/uv/issues/5424.
