### PR TITLE
[docs/installation.md] Document how to install to custom locations

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,6 +30,15 @@ uv is installed to `~/.cargo/bin`.
 
     Alternatively, the installer or binaries can be downloaded directly from [GitHub](#github-releases).
 
+!!! tip
+
+    Setting only specific environment variables enable custom install directories:
+    ```bash
+    # On macOS and Linux.
+    $ curl --proto '=https' --tlsv1.2 -OLsSf https://github.com/astral-sh/uv/releases/download/0.2.29/uv-installer.sh
+    $ env -i CARGO_HOME=/tmp/foo/cargo HOME=/tmp/foo/home /usr/bin/bash uv-installer.sh --no-modify-path
+    ```
+
 A specific release can be requested by including the version in the URL:
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #5449

## Test Plan

``` 
$ curl --proto '=https' --tlsv1.2 -OLsSf https://github.com/astral-sh/uv/releases/download/0.2.29/uv-installer.sh
$ env -i CARGO_HOME=/tmp/foo/cargo HOME=/tmp/foo/home /usr/bin/bash uv-installer.sh --no-modify-path
downloading uv 0.2.29 x86_64-unknown-linux-gnu
installing to /tmp/foo/cargo/bin
  uv
  uvx
everything's installed!
$ tree -a /tmp/foo
/tmp/foo
├── cargo
│   └── bin
│       ├── uv
│       └── uvx
└── home
    └── .config
        └── uv
            └── uv-receipt.json

6 directories, 3 files
```