### PR TITLE
Use `sitecustomize.py` to implement environment layering

### DIFF
--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -123,17 +123,6 @@ pub(crate) async fn run(
     )?;
     process.env("PATH", new_path);
 
-    // Construct the `PYTHONPATH` environment variable.
-    let new_python_path = std::env::join_paths(
-        environment.site_packages().map(PathBuf::from).chain(
-            std::env::var_os("PYTHONPATH")
-                .as_ref()
-                .iter()
-                .flat_map(std::env::split_paths),
-        ),
-    )?;
-    process.env("PYTHONPATH", new_python_path);
-
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
     // TODO(zanieb): Throw a nicer error message if the command is not found

--- a/crates/uv/tests/tool_run.rs
+++ b/crates/uv/tests/tool_run.rs
@@ -630,7 +630,6 @@ fn tool_run_requirements_txt() {
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str("iniconfig").unwrap();
 
-    // We treat arguments before the command as uv arguments
     uv_snapshot!(context.filters(), context.tool_run()
         .arg("--with-requirements")
         .arg("requirements.txt")
@@ -680,7 +679,6 @@ fn tool_run_requirements_txt_arguments() {
         })
         .unwrap();
 
-    // We treat arguments before the command as uv arguments
     uv_snapshot!(context.filters(), context.tool_run()
         .arg("--with-requirements")
         .arg("requirements.txt")


### PR DESCRIPTION
## Summary

After consultation with @carljm, we learned that modifying `PYTHONPATH` is insufficient, because Python won't resolve `.pth` files (editables) in the base environment. We also saw in https://github.com/astral-sh/uv/issues/5459 that continuously appending to `PYTHONPATH` can have some unintended effects.

This PR instead uses a `sitecustomize.py` in the ephemeral environment to add the base environment's `site-packages`.

Closes https://github.com/astral-sh/uv/issues/5459.
