### PR TITLE
Add `--no-config` to replace `--isolated`

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,9 @@ uv accepts the following command-line arguments as environment variables:
   will use this value as the keyring provider.
 - `UV_CONFIG_FILE`: Equivalent to the `--config-file` command-line argument. Expects a path to a
   local `uv.toml` file to use as the configuration file.
+- `UV_NO_CONFIG`: Equivalent to the `--no-config` command-line argument. If set, uv will not read
+  any configuration files from the current directory, parent directories, or user configuration
+  directories.
 - `UV_CONCURRENT_DOWNLOADS`: Sets the maximum number of in-flight concurrent downloads that `uv`
   will perform at any given time.
 - `UV_CONCURRENT_BUILDS`: Sets the maximum number of source distributions that `uv` will build

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -75,6 +75,11 @@ pub struct Cli {
     #[arg(global = true, long, env = "UV_CONFIG_FILE")]
     pub config_file: Option<PathBuf>,
 
+    /// Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) in the current directory,
+    /// parent directories, or user configuration directories.
+    #[arg(global = true, long, env = "UV_NO_CONFIG", value_parser = clap::builder::BoolishValueParser::new())]
+    pub no_config: bool,
+
     /// Print help.
     #[arg(global = true, short, long, action = clap::ArgAction::HelpShort)]
     help: Option<bool>,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -71,7 +71,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
     //    search for `pyproject.toml` files, since we're not in a workspace.
     let filesystem = if let Some(config_file) = cli.config_file.as_ref() {
         Some(FilesystemOptions::from_file(config_file)?)
-    } else if cli.global_args.isolated {
+    } else if cli.global_args.isolated || cli.no_config {
         None
     } else if let Ok(project) =
         Workspace::discover(&std::env::current_dir()?, &DiscoveryOptions::default()).await

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -55,6 +55,9 @@ fn help() {
               Path to the cache directory [env: UV_CACHE_DIR=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
+          --no-config
+              Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) in the current
+              directory, parent directories, or user configuration directories [env: UV_NO_CONFIG=]
       -h, --help
               Print help
       -V, --version
@@ -118,6 +121,9 @@ fn help_flag() {
               Path to the cache directory [env: UV_CACHE_DIR=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
+          --no-config
+              Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) in the current
+              directory, parent directories, or user configuration directories [env: UV_NO_CONFIG=]
       -h, --help
               Print help
       -V, --version
@@ -180,6 +186,9 @@ fn help_short_flag() {
               Path to the cache directory [env: UV_CACHE_DIR=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
+          --no-config
+              Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) in the current
+              directory, parent directories, or user configuration directories [env: UV_NO_CONFIG=]
       -h, --help
               Print help
       -V, --version
@@ -296,6 +305,12 @@ fn help_subcommand() {
               The path to a `uv.toml` file to use for configuration
               
               [env: UV_CONFIG_FILE=]
+
+          --no-config
+              Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) in the current
+              directory, parent directories, or user configuration directories
+              
+              [env: UV_NO_CONFIG=]
 
       -h, --help
               Print help
@@ -419,6 +434,12 @@ fn help_subsubcommand() {
               
               [env: UV_CONFIG_FILE=]
 
+          --no-config
+              Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) in the current
+              directory, parent directories, or user configuration directories
+              
+              [env: UV_NO_CONFIG=]
+
       -h, --help
               Print help
 
@@ -481,6 +502,9 @@ fn help_flag_subcommand() {
               Path to the cache directory [env: UV_CACHE_DIR=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
+          --no-config
+              Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) in the current
+              directory, parent directories, or user configuration directories [env: UV_NO_CONFIG=]
       -h, --help
               Print help
       -V, --version
@@ -540,6 +564,9 @@ fn help_flag_subsubcommand() {
               Path to the cache directory [env: UV_CACHE_DIR=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
+          --no-config
+              Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) in the current
+              directory, parent directories, or user configuration directories [env: UV_NO_CONFIG=]
       -h, --help
               Print help
       -V, --version
@@ -656,6 +683,9 @@ fn help_with_global_option() {
               Path to the cache directory [env: UV_CACHE_DIR=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
+          --no-config
+              Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) in the current
+              directory, parent directories, or user configuration directories [env: UV_NO_CONFIG=]
       -h, --help
               Print help
       -V, --version
@@ -752,6 +782,9 @@ fn test_with_no_pager() {
               Path to the cache directory [env: UV_CACHE_DIR=]
           --config-file <CONFIG_FILE>
               The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
+          --no-config
+              Avoid discovering configuration files (`pyproject.toml`, `uv.toml`) in the current
+              directory, parent directories, or user configuration directories [env: UV_NO_CONFIG=]
       -h, --help
               Print help
       -V, --version


### PR DESCRIPTION
## Summary

I'll deprecate `--isolated` separately, since it _is_ still used for some other behaviors.

Closes #5428.
