### PR TITLE
Gate `FromStr` to `pep508` feature

### DIFF
--- a/crates/pep508-rs/src/marker/environment.rs
+++ b/crates/pep508-rs/src/marker/environment.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "pyo3")]
 use std::str::FromStr;
 use std::sync::Arc;
 


### PR DESCRIPTION
## Summary

This is triggering when you run without `--all-features` (but we always use `--all-features` in CI, so it went unnoticed).