### PR TITLE
Reframe use of `--isolated` in `tool run`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2291,6 +2291,10 @@ pub struct ToolRunArgs {
     #[arg(long, value_parser = parse_maybe_file_path)]
     pub with_requirements: Vec<Maybe<PathBuf>>,
 
+    /// Run the tool in an isolated virtual environment, ignoring any already-installed tools.
+    #[arg(long)]
+    pub isolated: bool,
+
     #[command(flatten)]
     pub installer: ResolverInstallerArgs,
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -654,7 +654,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.python,
                 args.settings,
                 invocation_source,
-                globals.isolated,
+                args.isolated || globals.isolated,
                 globals.preview,
                 globals.python_preference,
                 globals.python_fetch,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -261,6 +261,7 @@ pub(crate) struct ToolRunSettings {
     pub(crate) from: Option<String>,
     pub(crate) with: Vec<String>,
     pub(crate) with_requirements: Vec<PathBuf>,
+    pub(crate) isolated: bool,
     pub(crate) show_resolution: bool,
     pub(crate) python: Option<String>,
     pub(crate) refresh: Refresh,
@@ -276,6 +277,7 @@ impl ToolRunSettings {
             from,
             with,
             with_requirements,
+            isolated,
             show_resolution,
             installer,
             build,
@@ -291,6 +293,7 @@ impl ToolRunSettings {
                 .into_iter()
                 .filter_map(Maybe::into_option)
                 .collect(),
+            isolated,
             show_resolution,
             python,
             refresh: Refresh::from(refresh),


### PR DESCRIPTION
## Summary

This PR gets rid of the global `--isolated` flag (which serves a bunch of independent responsibilities right now) on `uv tool run` in favor of a dedicated `--isolated` flag, which tells uv to avoid re-using an existing tool environment for this invocation. We'll add the same thing to `uv run`, to avoid using the base project environment.

This will become a bit clearer in #5466, when we deprecate the `--isolated` flag on the preview APIs.
