### PR TITLE
Unify resolutions only during graph building

### DIFF
--- a/crates/uv-resolver/src/pins.rs
+++ b/crates/uv-resolver/src/pins.rs
@@ -29,15 +29,4 @@ impl FilePins {
     ) -> Option<&ResolvedDist> {
         self.0.get(name)?.get(version)
     }
-
-    /// Add the pins in `other` to `self`.
-    ///
-    /// This assumes that if a version for a particular package exists in
-    /// both `self` and `other`, then they will both correspond to identical
-    /// distributions.
-    pub(crate) fn union(&mut self, other: FilePins) {
-        for (name, versions) in other.0 {
-            self.0.entry(name).or_default().extend(versions);
-        }
-    }
 }


### PR DESCRIPTION
With our previous eager union, we were losing the fork markers. We now carry this information into the resolution graph construction and, in the next step, can read the markers there.

Part of https://github.com/astral-sh/uv/issues/5180#issuecomment-2247696198