### PR TITLE
Create tool environment from scratch on change

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -796,7 +796,7 @@ pub(crate) async fn update_environment(
         project,
         &extras,
         preferences,
-        site_packages.clone(),
+        EmptyInstalledPackages,
         &hasher,
         reinstall,
         upgrade,

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -30,7 +30,7 @@ use uv_warnings::{warn_user, warn_user_once};
 use crate::commands::reporters::PythonDownloadReporter;
 
 use crate::commands::{
-    project::{resolve_environment, resolve_names, sync_environment, update_environment},
+    project::{resolve_environment, resolve_names, sync_environment},
     tool::common::matching_packages,
 };
 use crate::commands::{ExitStatus, SharedState};
@@ -275,21 +275,7 @@ pub(crate) async fn install(
     // This lets us confirm the environment is valid before removing an existing install. However,
     // entrypoints always contain an absolute path to the relevant Python interpreter, which would
     // be invalidated by moving the environment.
-    let environment = if let Some(environment) = existing_environment {
-        update_environment(
-            environment,
-            spec,
-            &settings,
-            &state,
-            preview,
-            connectivity,
-            concurrency,
-            native_tls,
-            cache,
-            printer,
-        )
-        .await?
-    } else {
+    let environment = {
         // If we're creating a new environment, ensure that we can resolve the requirements prior
         // to removing any existing tools.
         let resolution = resolve_environment(

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -410,7 +410,16 @@ fn tool_install_editable() {
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning
-    Installed 1 executable: black
+    Resolved 6 packages in [TIME]
+    Prepared 6 packages in [TIME]
+    Installed 6 packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
+    Installed 2 executables: black, blackd
     "###);
 
     insta::with_settings!({
@@ -422,6 +431,7 @@ fn tool_install_editable() {
         requirements = ["black"]
         entrypoints = [
             { name = "black", install-path = "[TEMP_DIR]/bin/black" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd" },
         ]
         "###);
     });
@@ -441,10 +451,8 @@ fn tool_install_editable() {
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
-    Prepared 6 packages in [TIME]
-    Uninstalled 1 package in [TIME]
+    Prepared 1 package in [TIME]
     Installed 6 packages in [TIME]
-     - black==0.1.0 (from file://[WORKSPACE]/scripts/packages/black_editable)
      + black==24.2.0
      + click==8.1.7
      + mypy-extensions==1.0.0
@@ -741,19 +749,12 @@ fn tool_install_already_installed() {
     warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
-    Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
-     - black==24.3.0
      + black==24.3.0
-     - click==8.1.7
      + click==8.1.7
-     - mypy-extensions==1.0.0
      + mypy-extensions==1.0.0
-     - packaging==24.0
      + packaging==24.0
-     - pathspec==0.12.1
      + pathspec==0.12.1
-     - platformdirs==4.2.0
      + platformdirs==4.2.0
     Installed 2 executables: black, blackd
     "###);
@@ -775,10 +776,13 @@ fn tool_install_already_installed() {
     warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
-    Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
-     - black==24.3.0
      + black==24.3.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
     Installed 2 executables: black, blackd
     "###);
 
@@ -799,10 +803,13 @@ fn tool_install_already_installed() {
     warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
-    Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
-     - click==8.1.7
+     + black==24.3.0
      + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
     Installed 2 executables: black, blackd
     "###);
 }
@@ -963,6 +970,14 @@ fn tool_install_entry_point_exists() {
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning
+    Resolved [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
     Installed 2 executables: black, blackd
     "###);
 
@@ -1000,19 +1015,12 @@ fn tool_install_entry_point_exists() {
     warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
-    Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
-     - black==24.3.0
      + black==24.3.0
-     - click==8.1.7
      + click==8.1.7
-     - mypy-extensions==1.0.0
      + mypy-extensions==1.0.0
-     - packaging==24.0
      + packaging==24.0
-     - pathspec==0.12.1
      + pathspec==0.12.1
-     - platformdirs==4.2.0
      + platformdirs==4.2.0
     Installed 2 executables: black, blackd
     "###);
@@ -1040,7 +1048,7 @@ fn tool_install_entry_point_exists() {
     }, {
         // Should run black in the virtual environment
         assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
-        #![TEMP_DIR]/tools/black/bin/python3
+        #![TEMP_DIR]/tools/black/bin/python
         # -*- coding: utf-8 -*-
         import re
         import sys
@@ -1584,10 +1592,14 @@ fn tool_install_requirements_txt() {
     warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
-    Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
      + idna==3.6
-     - iniconfig==2.0.0
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
     Installed 2 executables: black, blackd
     "###);
 
@@ -1694,6 +1706,15 @@ fn tool_install_requirements_txt_arguments() {
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning
+    Resolved 7 packages in [TIME]
+    Installed 7 packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
+     + idna==3.6
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
     Installed 2 executables: black, blackd
     "###);
 
@@ -1797,6 +1818,15 @@ fn tool_install_upgrade() {
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
     Installed 2 executables: black, blackd
     "###);
 
@@ -1831,7 +1861,13 @@ fn tool_install_upgrade() {
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
      + iniconfig==2.0.0 (from https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
     Installed 2 executables: black, blackd
     "###);
 
@@ -1867,12 +1903,13 @@ fn tool_install_upgrade() {
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
-    Prepared [N] packages in [TIME]
-    Uninstalled [N] packages in [TIME]
     Installed [N] packages in [TIME]
-     - black==24.1.1
      + black==24.3.0
-     - iniconfig==2.0.0 (from https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
     Installed 2 executables: black, blackd
     "###);
 


### PR DESCRIPTION
## Summary

Right now, if you install a tool with some new requirements, we attempt to reuse the environment and update it in-place. This leads to some unintuitive behaviors with editables and direct URLs.

For example, if you `tool install ./scripts/packages/black_editable` and then `tool install black`, we don't actually make any changes to the environment. This _does_ match our `pip install ./scripts/packages/black_editable` and then `pip install black` behavior, but I'd argue that users don't think of tool installs as stateful in this way.
