### PR TITLE
Use 666 rather than 644 for default permissions

### DIFF
--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -103,13 +103,13 @@ pub fn replace_symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io:
 
 /// Return a [`NamedTempFile`] in the specified directory.
 ///
-/// Sets the permissions of the temporary file to `0o644`, to match the non-temporary file default.
+/// Sets the permissions of the temporary file to `0o666`, to match the non-temporary file default.
 /// ([`NamedTempfile`] defaults to `0o600`.)
 #[cfg(unix)]
 pub fn tempfile_in(path: &Path) -> std::io::Result<NamedTempFile> {
     use std::os::unix::fs::PermissionsExt;
     tempfile::Builder::new()
-        .permissions(std::fs::Permissions::from_mode(0o644))
+        .permissions(std::fs::Permissions::from_mode(0o666))
         .tempfile_in(path)
 }
 


### PR DESCRIPTION
## Summary

I used 644 because that's the default when writing on my own machine. But -- that's because the default umask is 022. In reality, 666 is the correct default: https://github.com/rust-lang/rust/blob/7c2012d0ec3aae89fefc40e5d6b317a0949cda36/library/std/src/sys/pal/unix/fs.rs#L1069 (and then the umask is applied on top of it).

Closes https://github.com/astral-sh/uv/issues/5496.
