### PR TITLE
Add `git-ref` group for `uv add`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2054,15 +2054,15 @@ pub struct AddArgs {
     pub raw_sources: bool,
 
     /// Specific commit to use when adding from Git.
-    #[arg(long)]
+    #[arg(long, group = "git-ref", action = clap::ArgAction::Set)]
     pub rev: Option<String>,
 
     /// Tag to use when adding from git.
-    #[arg(long)]
+    #[arg(long, group = "git-ref", action = clap::ArgAction::Set)]
     pub tag: Option<String>,
 
     /// Branch to use when adding from git.
-    #[arg(long)]
+    #[arg(long, group = "git-ref", action = clap::ArgAction::Set)]
     pub branch: Option<String>,
 
     /// Extras to activate for the dependency; may be provided more than once.

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -2033,3 +2033,71 @@ fn add_frozen() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn add_reject_multiple_git_ref_flags() {
+    let context = TestContext::new("3.12");
+
+    // --tag and --branch
+    uv_snapshot!(context
+        .add(&[])
+        .arg("foo")
+        .arg("--tag")
+        .arg("0.0.1")
+        .arg("--branch")
+        .arg("test"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--tag <TAG>' cannot be used with '--branch <BRANCH>'
+
+    Usage: uv add --cache-dir [CACHE_DIR] --tag <TAG> --exclude-newer <EXCLUDE_NEWER> <REQUIREMENTS>...
+
+    For more information, try '--help'.
+    "###
+    );
+
+    // --tag and --rev
+    uv_snapshot!(context
+        .add(&[])
+        .arg("foo")
+        .arg("--tag")
+        .arg("0.0.1")
+        .arg("--rev")
+        .arg("326b943"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--tag <TAG>' cannot be used with '--rev <REV>'
+
+    Usage: uv add --cache-dir [CACHE_DIR] --tag <TAG> --exclude-newer <EXCLUDE_NEWER> <REQUIREMENTS>...
+
+    For more information, try '--help'.
+    "###
+    );
+
+    // --tag and --tag
+    uv_snapshot!(context
+        .add(&[])
+        .arg("foo")
+        .arg("--tag")
+        .arg("0.0.1")
+        .arg("--tag")
+        .arg("0.0.2"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--tag <TAG>' cannot be used multiple times
+
+    Usage: uv add [OPTIONS] <REQUIREMENTS>...
+
+    For more information, try '--help'.
+    "###
+    );
+}


### PR DESCRIPTION
## Summary

This PR allows us to reject specifying more than one git-ref at the cli level.

## Test Plan

Test cases included.
