### PR TITLE
Allow `uv pip install` for unmanaged projects

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -736,9 +736,12 @@ impl ProjectWorkspace {
             return Ok(None);
         };
 
-        Ok(Some(
-            Self::from_project(install_path, lock_path, &project, &pyproject_toml, options).await?,
-        ))
+        match Self::from_project(install_path, lock_path, &project, &pyproject_toml, options).await
+        {
+            Ok(workspace) => Ok(Some(workspace)),
+            Err(WorkspaceError::NonWorkspace(_)) => Ok(None),
+            Err(err) => Err(err),
+        }
     }
 
     /// Returns the directory containing the closest `pyproject.toml` that defines the current

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -6151,3 +6151,40 @@ fn accept_existing_prerelease() -> Result<()> {
 
     Ok(())
 }
+
+/// Allow `pip install` of an unmanaged project.
+#[test]
+fn unmanaged() -> Result<()> {
+    let context = TestContext::new("3.12");
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"[project]
+    name = "example"
+    version = "0.0.0"
+    dependencies = [
+      "anyio==3.7.0"
+    ]
+
+    [tool.uv]
+    managed = false
+    "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.pip_install().arg("."), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Prepared 4 packages in [TIME]
+    Installed 4 packages in [TIME]
+     + anyio==3.7.0
+     + example==0.0.0 (from file://[TEMP_DIR]/)
+     + idna==3.6
+     + sniffio==1.3.1
+    "###
+    );
+
+    Ok(())
+}

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -178,13 +178,15 @@ fn test_albatross_project_in_excluded() {
         .join("packages")
         .join("seeds");
     uv_snapshot!(context.filters(), install_workspace(&context, &current_dir), @r###"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download and build: `seeds @ file://[WORKSPACE]/scripts/workspaces/albatross-project-in-excluded/packages/seeds`
-      Caused by: The project is marked as unmanaged: `[WORKSPACE]/scripts/workspaces/albatross-project-in-excluded/packages/seeds`
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + seeds==1.0.0 (from file://[WORKSPACE]/scripts/workspaces/albatross-project-in-excluded/packages/seeds)
     "###
     );
 }


### PR DESCRIPTION
## Summary

Just an oversight.

Closes: https://github.com/astral-sh/uv/issues/5500.
