### PR TITLE
Make `pip list --editable` conflicts with `--exlcude-editable`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1465,7 +1465,7 @@ pub struct PipListArgs {
     pub editable: bool,
 
     /// Exclude any editable packages from output.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "editable")]
     pub exclude_editable: bool,
 
     /// Exclude the specified package(s) from the output.

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -24,8 +24,7 @@ use crate::printer::Printer;
 /// Enumerate the installed packages in the current environment.
 #[allow(clippy::fn_params_excessive_bools)]
 pub(crate) fn pip_list(
-    editable: bool,
-    exclude_editable: bool,
+    editable: Option<bool>,
     exclude: &[PackageName],
     format: &ListFormat,
     strict: bool,
@@ -54,9 +53,7 @@ pub(crate) fn pip_list(
     // Filter if `--editable` is specified; always sort by name.
     let results = site_packages
         .iter()
-        .filter(|dist| {
-            (!dist.is_editable() && !editable) || (dist.is_editable() && !exclude_editable)
-        })
+        .filter(|dist| editable.is_none() || editable == Some(dist.is_editable()))
         .filter(|dist| !exclude.contains(dist.name()))
         .sorted_unstable_by(|a, b| a.name().cmp(b.name()).then(a.version().cmp(b.version())))
         .collect_vec();

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -465,7 +465,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
 
             commands::pip_list(
                 args.editable,
-                args.exclude_editable,
                 &args.exclude,
                 &args.format,
                 args.settings.strict,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1240,8 +1240,7 @@ impl PipFreezeSettings {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct PipListSettings {
-    pub(crate) editable: bool,
-    pub(crate) exclude_editable: bool,
+    pub(crate) editable: Option<bool>,
     pub(crate) exclude: Vec<PackageName>,
     pub(crate) format: ListFormat,
     pub(crate) settings: PipSettings,
@@ -1264,8 +1263,7 @@ impl PipListSettings {
         } = args;
 
         Self {
-            editable,
-            exclude_editable,
+            editable: flag(editable, exclude_editable),
             exclude,
             format,
             settings: PipSettings::combine(

--- a/crates/uv/tests/pip_list.rs
+++ b/crates/uv/tests/pip_list.rs
@@ -213,11 +213,16 @@ fn list_editable_only() {
     uv_snapshot!(filters, list_command(&context)
         .arg("--editable")
         .arg("--exclude-editable"), @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
+    error: the argument '--editable' cannot be used with '--exclude-editable'
+
+    Usage: uv pip list --cache-dir [CACHE_DIR] --editable
+
+    For more information, try '--help'.
     "###
     );
 }
@@ -367,19 +372,6 @@ fn list_format_json() {
     ----- stderr -----
     "###
     );
-
-    uv_snapshot!(filters, list_command(&context)
-    .arg("--format=json")
-    .arg("--editable")
-    .arg("--exclude-editable"), @r###"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    []
-
-    ----- stderr -----
-    "###
-    );
 }
 
 #[test]
@@ -447,18 +439,6 @@ fn list_format_freeze() {
     anyio==4.3.0
     idna==3.6
     sniffio==1.3.1
-
-    ----- stderr -----
-    "###
-    );
-
-    uv_snapshot!(filters, list_command(&context)
-    .arg("--format=freeze")
-    .arg("--editable")
-    .arg("--exclude-editable"), @r###"
-    success: true
-    exit_code: 0
-    ----- stdout -----
 
     ----- stderr -----
     "###


### PR DESCRIPTION
## Summary

I think it makes no sense to allow `--editable` and `--exclude-editable` at the same time.

## Test Plan
```console
$ cargo run -- pip list --editable --exclude-editable
error: the argument '--editable' cannot be used with '--exclude-editable'

Usage: uv.exe pip list --editable

For more information, try '--help'.

```
