### PR TITLE
Support xz compressed packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,6 +2040,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "mailparse"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,7 +2724,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset 0.9.1",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -4795,6 +4806,7 @@ dependencies = [
  "tokio-tar",
  "tokio-util",
  "tracing",
+ "xz2",
  "zip",
 ]
 
@@ -5749,6 +5761,15 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+ "xz2",
  "zstd",
  "zstd-safe",
 ]
@@ -4806,7 +4807,6 @@ dependencies = [
  "tokio-tar",
  "tokio-util",
  "tracing",
- "xz2",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ ci = ["github"]
 installers = ["shell", "powershell"]
 # The archive format to use for windows builds (defaults .zip)
 windows-archive = ".zip"
-# The archive format to use for non-windows builds (defaults .tar.gz)
+# The archive format to use for non-windows builds (defaults .tar.xz)
 unix-archive = ".tar.gz"
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ ci = ["github"]
 installers = ["shell", "powershell"]
 # The archive format to use for windows builds (defaults .zip)
 windows-archive = ".zip"
-# The archive format to use for non-windows builds (defaults .tar.xz)
+# The archive format to use for non-windows builds (defaults .tar.gz)
 unix-archive = ".tar.gz"
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -30,3 +30,4 @@ tokio-tar = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }
 tracing = { workspace = true }
 zip = { workspace = true }
+xz2 = { workspace = true, features = ["tokio"] }

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 pypi-types = { workspace = true }
 
-async-compression = { workspace = true, features = ["bzip2", "gzip", "zstd"] }
+async-compression = { workspace = true, features = ["bzip2", "gzip", "zstd", "xz"] }
 async_zip = { workspace = true, features = ["tokio"] }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
@@ -30,4 +30,3 @@ tokio-tar = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }
 tracing = { workspace = true }
 zip = { workspace = true }
-xz2 = { workspace = true, features = ["tokio"] }

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -198,6 +198,23 @@ pub async fn untar_zst<R: tokio::io::AsyncRead + Unpin>(
     Ok(untar_in(&mut archive, target.as_ref()).await?)
 }
 
+/// Unzip a `.tar.xz` archive into the target directory, without requiring `Seek`.
+///
+/// This is useful for unpacking files as they're being downloaded.
+pub async fn untar_xz<R: tokio::io::AsyncRead + Unpin>(
+    reader: R,
+    target: impl AsRef<Path>,
+) -> Result<(), Error> {
+    let reader = tokio::io::BufReader::new(reader);
+    let decompressed_bytes = async_compression::tokio::bufread::XzDecoder::new(reader);
+
+    let mut archive = tokio_tar::ArchiveBuilder::new(decompressed_bytes)
+        .set_preserve_mtime(false)
+        .build();
+    untar_in(&mut archive, target.as_ref()).await?;
+    Ok(())
+}
+
 /// Unzip a `.zip`, `.tar.gz`, or `.tar.bz2` archive into the target directory, without requiring `Seek`.
 pub async fn archive<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
@@ -255,6 +272,21 @@ pub async fn archive<R: tokio::io::AsyncRead + Unpin>(
         })
     {
         untar_zst(reader, target).await?;
+        return Ok(());
+    }
+
+    // `.tar.xz`
+    if source
+        .as_ref()
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("xz"))
+        && source.as_ref().file_stem().is_some_and(|stem| {
+            Path::new(stem)
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("tar"))
+        })
+    {
+        untar_xz(reader, target).await?;
         return Ok(());
     }
 

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -215,7 +215,8 @@ pub async fn untar_xz<R: tokio::io::AsyncRead + Unpin>(
     Ok(())
 }
 
-/// Unzip a `.zip`, `.tar.gz`, or `.tar.bz2` archive into the target directory, without requiring `Seek`.
+/// Unzip a `.zip`, `.tar.gz`, `.tar.bz2`, `.tar.zst`, or `.tar.xz` archive into the target directory,
+/// without requiring `Seek`.
 pub async fn archive<R: tokio::io::AsyncRead + Unpin>(
     reader: R,
     source: impl AsRef<Path>,


### PR DESCRIPTION
## Summary

Closes #2187.

The [xz backdoor](https://gist.github.com/thesamesam/223949d5a074ebc3dce9ee78baad9e27) is still fairly recent, but luckily the [Rust `xz2` crate bundles version 5.2.5 of the C `xz` package](https://github.com/alexcrichton/xz2-rs/tree/main/lzma-sys), which is before the backdoor was introduced.

It's worth noting that a security risk still exists if you have a compromised version of `xz` installed on your system, but that risk is not introduced by `uv` or the Rust packages in general.

## Test Plan

Tried installing the package mentioned in the linked issue: `python-apt @ https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/python-apt/2.7.6/python-apt_2.7.6.tar.xz`

(Note that this will only work on Ubuntu - I tried on a Mac and while the archive was extracted properly, the package did not install because of some missing files)
