### PR TITLE
Fix typo in projects.md

### DIFF
--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -106,7 +106,7 @@ virtual environment before executing a command:
 
 ```console
 $ uv sync
-$ source .venv/bin/active
+$ source .venv/bin/activate
 $ python my_script.py
 ```
 


### PR DESCRIPTION
Fixes typo: `.venv/bin/active` -> `.venv/bin/activate`


## Summary

It's a quick documentation typo fix!

## Test Plan

I read it over, twice. And checked my own `.venv/bin/` directory to ensure it does not contain an unexpectedly spelled `active` file or symlink.