### PR TITLE
Retain editable designation for cached wheel installs

### DIFF
--- a/crates/uv-distribution/src/index/cached_wheel.rs
+++ b/crates/uv-distribution/src/index/cached_wheel.rs
@@ -59,6 +59,17 @@ impl CachedWheel {
         }
     }
 
+    /// Convert a [`CachedWheel`] into an editable [`CachedDirectUrlDist`].
+    pub fn into_editable(self, url: VerbatimUrl) -> CachedDirectUrlDist {
+        CachedDirectUrlDist {
+            filename: self.filename,
+            url,
+            path: self.entry.into_path_buf(),
+            editable: true,
+            hashes: self.hashes,
+        }
+    }
+
     /// Read a cached wheel from a `.http` pointer (e.g., `anyio-4.0.0-py3-none-any.http`).
     pub fn from_http_pointer(path: impl AsRef<Path>, cache: &Cache) -> Option<Self> {
         let path = path.as_ref();

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -287,7 +287,11 @@ impl<'a> Planner<'a> {
                     // Find the most-compatible wheel from the cache, since we don't know
                     // the filename in advance.
                     if let Some(wheel) = built_index.directory(&sdist)? {
-                        let cached_dist = wheel.into_url_dist(url.clone());
+                        let cached_dist = if *editable {
+                            wheel.into_editable(url.clone())
+                        } else {
+                            wheel.into_url_dist(url.clone())
+                        };
                         debug!("Directory source requirement already cached: {cached_dist}");
                         cached.push(CachedDist::Url(cached_dist));
                         continue;


### PR DESCRIPTION
## Summary

The package was being installed as editable, but it wasn't marked as such in `uv pip list`, as the `direct-url.json` was wrong.

Closes https://github.com/astral-sh/uv/issues/5543.
