### PR TITLE
Implement `uv run --directory`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1932,6 +1932,10 @@ pub struct RunArgs {
     /// - `/home/ferris/.local/bin/python3.10` uses the exact Python at the given path.
     #[arg(long, short, env = "UV_PYTHON", verbatim_doc_comment)]
     pub python: Option<String>,
+
+    /// The path to the project. Defaults to the current working directory.
+    #[arg(long, hide = true)]
+    pub directory: Option<PathBuf>,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -161,7 +161,9 @@ impl FoundInterpreter {
         let python_request = if let Some(request) = python_request {
             Some(request)
             // (2) Request from `.python-version`
-        } else if let Some(request) = request_from_version_file().await? {
+        } else if let Some(request) =
+            request_from_version_file(Some(workspace.install_path())).await?
+        {
             Some(request)
             // (3) `Requires-Python` in `pyproject.toml`
         } else {

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -102,7 +102,7 @@ pub(crate) async fn run(
             let python_request = if let Some(request) = python.as_deref() {
                 Some(PythonRequest::parse(request))
                 // (2) Request from `.python-version`
-            } else if let Some(request) = request_from_version_file().await? {
+            } else if let Some(request) = request_from_version_file(None).await? {
                 Some(request)
                 // (3) `Requires-Python` in `pyproject.toml`
             } else {

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -55,7 +55,7 @@ pub(crate) async fn install(
             }
             None
         } else {
-            requests_from_version_file().await?
+            requests_from_version_file(None).await?
         };
         version_file_requests.unwrap_or_else(|| vec![PythonRequest::Any])
     } else {

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -49,7 +49,7 @@ pub(crate) async fn pin(
 
     let Some(request) = request else {
         // Display the current pinned Python version
-        if let Some(pins) = requests_from_version_file().await? {
+        if let Some(pins) = requests_from_version_file(None).await? {
             for pin in pins {
                 writeln!(printer.stdout(), "{}", pin.to_canonical_string())?;
                 if let Some(virtual_project) = &virtual_project {
@@ -126,7 +126,7 @@ pub(crate) async fn pin(
         request.to_canonical_string()
     };
 
-    let existing = request_from_version_file().await.ok().flatten();
+    let existing = request_from_version_file(None).await.ok().flatten();
     write_version_file(&output).await?;
 
     if let Some(existing) = existing

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -140,7 +140,7 @@ async fn venv_impl(
 
     let mut interpreter_request = python_request.map(PythonRequest::parse);
     if preview.is_enabled() && interpreter_request.is_none() {
-        interpreter_request = request_from_version_file().await.into_diagnostic()?;
+        interpreter_request = request_from_version_file(None).await.into_diagnostic()?;
     }
     if preview.is_disabled() && relocatable {
         warn_user_once!("`--relocatable` is experimental and may change without warning");

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -916,6 +916,7 @@ async fn run_project(
                 args.extras,
                 args.dev,
                 args.python,
+                args.directory,
                 args.settings,
                 globals.isolated,
                 globals.preview,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -193,6 +193,7 @@ pub(crate) struct RunSettings {
     pub(crate) with_requirements: Vec<PathBuf>,
     pub(crate) package: Option<PackageName>,
     pub(crate) python: Option<String>,
+    pub(crate) directory: Option<PathBuf>,
     pub(crate) refresh: Refresh,
     pub(crate) settings: ResolverInstallerSettings,
 }
@@ -217,6 +218,7 @@ impl RunSettings {
             refresh,
             package,
             python,
+            directory,
         } = args;
 
         Self {
@@ -235,6 +237,7 @@ impl RunSettings {
                 .collect(),
             package,
             python,
+            directory,
             refresh: Refresh::from(refresh),
             settings: ResolverInstallerSettings::combine(
                 resolver_installer_options(installer, build),

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -858,8 +858,6 @@ fn run_from_directory() -> Result<()> {
        "
     })?;
 
-    // Our tests change files in <1s, so we must disable CPython bytecode caching with `-B` or we'll
-    // get stale files, see https://github.com/python/cpython/issues/75953.
     let mut command = context.run();
     let command_with_args = command
         .arg("--preview")

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -5,6 +5,8 @@ use assert_cmd::assert::OutputAssertExt;
 use assert_fs::{fixture::ChildPath, prelude::*};
 use indoc::indoc;
 
+use uv_python::PYTHON_VERSION_FILENAME;
+
 use common::{uv_snapshot, TestContext};
 
 mod common;
@@ -819,6 +821,67 @@ fn run_editable() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn run_from_directory() -> Result<()> {
+    // default 3.11 so that the .python-version is meaningful
+    let context = TestContext::new_with_versions(&["3.11", "3.12"]);
+
+    let project_dir = context.temp_dir.child("project");
+    project_dir.create_dir_all()?;
+    project_dir
+        .child(PYTHON_VERSION_FILENAME)
+        .write_str("3.12")?;
+
+    let pyproject_toml = project_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.11, <4"
+        dependencies = []
+
+        [project.scripts]
+        main = "main:main"
+        "#
+    })?;
+    let main_script = project_dir.child("main.py");
+    main_script.write_str(indoc! { r"
+        import platform
+
+        def main():
+            print(platform.python_version())
+       "
+    })?;
+
+    // Our tests change files in <1s, so we must disable CPython bytecode caching with `-B` or we'll
+    // get stale files, see https://github.com/python/cpython/issues/75953.
+    let mut command = context.run();
+    let command_with_args = command
+        .arg("--preview")
+        .arg("--directory")
+        .arg("project")
+        .arg("main");
+
+    let mut filters = context.filters();
+    filters.push((r"project(\\|/).venv", "[VENV]"));
+    uv_snapshot!(filters, command_with_args, @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    3.12.[X]
+
+    ----- stderr -----
+    Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtualenv at: [VENV]
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + foo==1.0.0 (from file://[TEMP_DIR]/project)
     "###);
 
     Ok(())


### PR DESCRIPTION
## Summary

uv run --directory <path> means that one doesn't have to change to a
project's directory to run programs from it. It makes it possible to use
projects as if they are tool installations.

To support this, first the code reading .python-version was updated so that
it can read such markers outside the current directory. Note the minor
change this causes (if I'm right), described in the commit.

## Test Plan

One test has been added.

## --directory

Not sure what the name of the argument should be, but it's following uv
sync's directory for now.

Other alternatives could be "--project". Uv run and uv tool run should
probably find common agreement on this (relevant for project-locked tools).

I've implemented this same change in Rye, some time ago, and then we went
with --pyproject `<`path to pyproject.toml file`>`. I think using
pyproject.toml file path and not directory was probably a mistake, an
overgeneralization one doesn't need.
