### PR TITLE
Skip copying to empty entries in seekable zip

### DIFF
--- a/crates/uv-extract/src/sync.rs
+++ b/crates/uv-extract/src/sync.rs
@@ -48,12 +48,14 @@ pub fn unzip<R: Send + std::io::Read + std::io::Seek + HasLength>(
             // Copy the file contents.
             let outfile = fs_err::File::create(&path)?;
             let size = file.size();
-            let mut writer = if let Ok(size) = usize::try_from(size) {
-                std::io::BufWriter::with_capacity(std::cmp::min(size, 1024 * 1024), outfile)
-            } else {
-                std::io::BufWriter::new(outfile)
-            };
-            std::io::copy(&mut file, &mut writer)?;
+            if size > 0 {
+                let mut writer = if let Ok(size) = usize::try_from(size) {
+                    std::io::BufWriter::with_capacity(std::cmp::min(size, 1024 * 1024), outfile)
+                } else {
+                    std::io::BufWriter::new(outfile)
+                };
+                std::io::copy(&mut file, &mut writer)?;
+            }
 
             // See `uv_extract::stream::unzip`. For simplicity, this is identical with the code there except for being
             // sync.


### PR DESCRIPTION
## Summary

We cannot do this when streaming, since we may not have the metadata for the entry.

Closes https://github.com/astral-sh/uv/issues/5565.
