### PR TITLE
Avoid setting executable permissions on files we might not own

### DIFF
--- a/crates/install-wheel-rs/src/linker.rs
+++ b/crates/install-wheel-rs/src/linker.rs
@@ -597,7 +597,7 @@ fn symlink_wheel_files(
 
         // The `RECORD` file is modified during installation, so we copy it instead of symlinking.
         if path.ends_with("RECORD") {
-            fs::copy(path, &out_path)?;
+            synchronized_copy(path, &out_path, locks)?;
             count += 1;
             continue;
         }

--- a/crates/uv-extract/src/stream.rs
+++ b/crates/uv-extract/src/stream.rs
@@ -87,11 +87,13 @@ pub async fn unzip<R: tokio::io::AsyncRead + Unpin>(
                 let path = target.join(path);
 
                 let permissions = fs_err::tokio::metadata(&path).await?.permissions();
-                fs_err::tokio::set_permissions(
-                    &path,
-                    Permissions::from_mode(permissions.mode() | 0o111),
-                )
-                .await?;
+                if permissions.mode() & 0o111 != 0o111 {
+                    fs_err::tokio::set_permissions(
+                        &path,
+                        Permissions::from_mode(permissions.mode() | 0o111),
+                    )
+                    .await?;
+                }
             }
         }
     }
@@ -137,11 +139,13 @@ async fn untar_in<R: tokio::io::AsyncRead + Unpin, P: AsRef<Path>>(
                 if has_any_executable_bit != 0 {
                     if let Some(path) = crate::tar::unpacked_at(dst.as_ref(), &file.path()?) {
                         let permissions = fs_err::tokio::metadata(&path).await?.permissions();
-                        fs_err::tokio::set_permissions(
-                            &path,
-                            Permissions::from_mode(permissions.mode() | 0o111),
-                        )
-                        .await?;
+                        if permissions.mode() & 0o111 != 0o111 {
+                            fs_err::tokio::set_permissions(
+                                &path,
+                                Permissions::from_mode(permissions.mode() | 0o111),
+                            )
+                            .await?;
+                        }
                     }
                 }
             }

--- a/crates/uv-extract/src/sync.rs
+++ b/crates/uv-extract/src/sync.rs
@@ -69,10 +69,12 @@ pub fn unzip<R: Send + std::io::Read + std::io::Seek + HasLength>(
                     let has_any_executable_bit = mode & 0o111;
                     if has_any_executable_bit != 0 {
                         let permissions = fs_err::metadata(&path)?.permissions();
-                        fs_err::set_permissions(
-                            &path,
-                            Permissions::from_mode(permissions.mode() | 0o111),
-                        )?;
+                        if permissions.mode() & 0o111 != 0o111 {
+                            fs_err::set_permissions(
+                                &path,
+                                Permissions::from_mode(permissions.mode() | 0o111),
+                            )?;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

If we just created an entrypoint script, we can of course set the permissions (we just created it). However, if we're copying from the cache, we might _not_ own the file. In that case, if we need to change the permissions (we shouldn't, since the script is likely already executable -- we set the permissions when we unzip, but I guess they could _not_ be properly set in the zip itself), we have to copy it.

Closes https://github.com/astral-sh/uv/issues/5581.
