### PR TITLE
Detect python version from python project by default in `uv venv`

### DIFF
--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -3,8 +3,8 @@
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
-use uv_python::{PYTHON_VERSIONS_FILENAME, PYTHON_VERSION_FILENAME};
 use indoc::indoc;
+use uv_python::{PYTHON_VERSIONS_FILENAME, PYTHON_VERSION_FILENAME};
 
 use crate::common::{uv_snapshot, TestContext};
 

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -244,7 +244,7 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
         [project]
         name = "foo"
         version = "1.0.0"
-        requires-python = "==3.11.*"
+        requires-python = ">=3.11,<3.12"
         dependencies = []
         "#
     })?;
@@ -268,7 +268,18 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
         [project]
         name = "foo"
         version = "1.0.0"
-        requires-python = ">=3.10"
+        requires-python = ">=3.11"
+        dependencies = []
+        "#
+    })?;
+
+    // With `requires-python = ">=3.11"`, we should prefer first possible version 3.11
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r#"
+        [project]
+        name = "foo"
+        version = "1.0.0"
+        requires-python = ">=3.11"
         dependencies = []
         "#
     })?;
@@ -286,13 +297,13 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
     "#
     );
 
-    // With `requires-python = ">=3.11"`, we should prefer first possible version 3.11
+    // With `requires-python = ">3.11"`, we should prefer first possible version 3.11
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(indoc! { r#"
         [project]
         name = "foo"
         version = "1.0.0"
-        requires-python = ">=3.10"
+        requires-python = ">3.11"
         dependencies = []
         "#
     })?;
@@ -316,7 +327,7 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
         [project]
         name = "foo"
         version = "1.0.0"
-        requires-python = ">=3.10"
+        requires-python = ">=3.12"
         dependencies = []
         "#
     })?;
@@ -328,7 +339,7 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
+    Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: .venv
     Activate with: source .venv/bin/activate
     "#

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -178,7 +178,7 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
 
     // Without the file, we should use the first on the PATH
     uv_snapshot!(context.filters(), context.venv()
-        .arg("--preview"), @r###"
+        .arg("--preview"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -187,22 +187,22 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtualenv at: .venv
     Activate with: source .venv/bin/activate
-    "###
+    "#
     );
 
     // With `requires-python = "<3.11"`, we should prefer newest possible version 3.10
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(indoc! { r###"
+    pyproject_toml.write_str(indoc! { r#"
         [project]
         name = "foo"
         version = "1.0.0"
         requires-python = "<3.11"
         dependencies = []
-        "###
+        "#
     })?;
 
     uv_snapshot!(context.filters(), context.venv()
-        .arg("--preview"), @r###"
+        .arg("--preview"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -211,22 +211,22 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
     Using Python 3.10.[X] interpreter at: [PYTHON-3.10]
     Creating virtualenv at: .venv
     Activate with: source .venv/bin/activate
-    "###
+    "#
     );
 
     // With `requires-python = "==3.11.*"`, we should prefer exact version 3.11
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(indoc! { r###"
+    pyproject_toml.write_str(indoc! { r#"
         [project]
         name = "foo"
         version = "1.0.0"
         requires-python = "==3.11.*"
         dependencies = []
-        "###
+        "#
     })?;
 
     uv_snapshot!(context.filters(), context.venv()
-        .arg("--preview"), @r###"
+        .arg("--preview"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -235,22 +235,22 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtualenv at: .venv
     Activate with: source .venv/bin/activate
-    "###
+    "#
     );
 
     // With `requires-python = ">=3.11,<3.12"`, we should prefer exact version 3.11
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(indoc! { r###"
+    pyproject_toml.write_str(indoc! { r#"
         [project]
         name = "foo"
         version = "1.0.0"
         requires-python = "==3.11.*"
         dependencies = []
-        "###
+        "#
     })?;
 
     uv_snapshot!(context.filters(), context.venv()
-        .arg("--preview"), @r###"
+        .arg("--preview"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -259,22 +259,22 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtualenv at: .venv
     Activate with: source .venv/bin/activate
-    "###
+    "#
     );
 
     // With `requires-python = ">=3.10"`, we should prefer first possible version 3.11
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(indoc! { r###"
+    pyproject_toml.write_str(indoc! { r#"
         [project]
         name = "foo"
         version = "1.0.0"
         requires-python = ">=3.10"
         dependencies = []
-        "###
+        "#
     })?;
 
     uv_snapshot!(context.filters(), context.venv()
-        .arg("--preview"), @r###"
+        .arg("--preview"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -283,22 +283,22 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtualenv at: .venv
     Activate with: source .venv/bin/activate
-    "###
+    "#
     );
 
     // With `requires-python = ">=3.11"`, we should prefer first possible version 3.11
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(indoc! { r###"
+    pyproject_toml.write_str(indoc! { r#"
         [project]
         name = "foo"
         version = "1.0.0"
         requires-python = ">=3.10"
         dependencies = []
-        "###
+        "#
     })?;
 
     uv_snapshot!(context.filters(), context.venv()
-        .arg("--preview"), @r###"
+        .arg("--preview"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -307,22 +307,22 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtualenv at: .venv
     Activate with: source .venv/bin/activate
-    "###
+    "#
     );
 
     // With `requires-python = ">=3.12"`, we should prefer first possible version 3.12
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(indoc! { r###"
+    pyproject_toml.write_str(indoc! { r#"
         [project]
         name = "foo"
         version = "1.0.0"
         requires-python = ">=3.10"
         dependencies = []
-        "###
+        "#
     })?;
 
     uv_snapshot!(context.filters(), context.venv()
-        .arg("--preview"), @r###"
+        .arg("--preview"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -331,7 +331,7 @@ fn create_venv_reads_request_from_pyproject_toml() -> Result<()> {
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Creating virtualenv at: .venv
     Activate with: source .venv/bin/activate
-    "###
+    "#
     );
 
     context.venv.assert(predicates::path::is_dir());


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

`uv venv` should support adopting python version specified in `requires-python` from `pyproject.toml`. This allows customization on the venv setup when syncing from python project.

Closes https://github.com/astral-sh/uv/issues/5552.

It also serves as a workaround to close https://github.com/astral-sh/uv/issues/5258.

## Test Plan

<!-- How was it tested? -->

1. Run `uv venv` in folder with `pyroject.toml` specifying `requries-python = "<3.10"`. Python 3.9 is selected for venv.
2. Change to `requries-python = "<3.11"` and run `uv venv` again. Python 3.10 is selected now.
3. Switch to a folder without `pyproject.toml` then run `uv venv`. Python 3.12 is selected now.