### PR TITLE
Use intersection rather than union for `requires-python`

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -101,7 +101,7 @@ pub(crate) enum ProjectError {
 pub(crate) fn find_requires_python(
     workspace: &Workspace,
 ) -> Result<Option<RequiresPython>, uv_resolver::RequiresPythonError> {
-    RequiresPython::union(workspace.packages().values().filter_map(|member| {
+    RequiresPython::intersection(workspace.packages().values().filter_map(|member| {
         member
             .pyproject_toml()
             .project


### PR DESCRIPTION
## Summary

As-is, if you have a workspace with mixed `requires-python` requirements, resolution will _never_ succeed, since we'll use the union as the `requires-python` bound (i.e., take the lowest value), and fail when we see the package that only supports some more narrow range.

This PR modifies the behavior to take the intersection (i.e., the highest value), so if you have one package that supports Python 3.12 and later, and another that supports Python 3.8 and later, we lock for Python 3.12. If you try to sync or run with Python 3.8, we raise an error, since the lockfile will be incompatible with that request.

Konsti has a write-up in https://github.com/astral-sh/uv/issues/5594 that outlines what could be a longer-term strategy.

Closes https://github.com/astral-sh/uv/issues/5578.
