### PR TITLE
Omit transitive development dependencies from workspace lockfile

### DIFF
--- a/crates/uv-resolver/src/resolution_mode.rs
+++ b/crates/uv-resolver/src/resolution_mode.rs
@@ -56,7 +56,7 @@ impl ResolutionStrategy {
             ResolutionMode::LowestDirect => Self::LowestDirect(
                 manifest
                     .user_requirements(markers, dependencies)
-                    .map(|requirement| (*requirement).clone())
+                    .map(|requirement| requirement.name.clone())
                     .collect(),
             ),
         }

--- a/crates/uv-resolver/src/resolver/groups.rs
+++ b/crates/uv-resolver/src/resolver/groups.rs
@@ -1,0 +1,35 @@
+use rustc_hash::FxHashMap;
+
+use pep508_rs::MarkerEnvironment;
+use uv_normalize::{GroupName, PackageName};
+
+use crate::Manifest;
+
+/// A map of package names to their activated dependency groups.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct Groups(FxHashMap<PackageName, Vec<GroupName>>);
+
+impl Groups {
+    /// Determine the set of enabled dependency groups in the [`Manifest`].
+    pub(crate) fn from_manifest(manifest: &Manifest, markers: Option<&MarkerEnvironment>) -> Self {
+        let mut groups = FxHashMap::default();
+
+        // Enable the groups for all direct dependencies. In practice, this tends to mean: when
+        // development dependencies are enabled, enable them for all direct dependencies.
+        for group in &manifest.dev {
+            for requirement in manifest.direct_requirements(markers) {
+                groups
+                    .entry(requirement.name.clone())
+                    .or_insert_with(Vec::new)
+                    .push(group.clone());
+            }
+        }
+
+        Self(groups)
+    }
+
+    /// Retrieve the enabled dependency groups for a given package.
+    pub(crate) fn get(&self, package: &PackageName) -> Option<&[GroupName]> {
+        self.0.get(package).map(Vec::as_slice)
+    }
+}


### PR DESCRIPTION
## Summary

Omit development dependencies from (e.g.) path dependencies.

Closes https://github.com/astral-sh/uv/issues/5593.
