### PR TITLE
Remove lingering executables after failed installs

### DIFF
--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -196,10 +196,10 @@ pub(crate) async fn install(
     //
     // (If we find existing entrypoints later on, and the tool _doesn't_ exist, we'll avoid removing
     // the external tool's entrypoints (without `--force`).)
-    let (existing_tool_receipt, reinstall_entry_points) =
+    let (existing_tool_receipt, invalid_tool_receipt) =
         match installed_tools.get_tool_receipt(&from.name) {
             Ok(None) => (None, false),
-            Ok(Some(receipt)) => (Some(receipt), true),
+            Ok(Some(receipt)) => (Some(receipt), false),
             Err(_) => {
                 // If the tool is not installed properly, remove the environment and continue.
                 match installed_tools.remove_environment(&from.name) {
@@ -276,7 +276,7 @@ pub(crate) async fn install(
     // entrypoints always contain an absolute path to the relevant Python interpreter, which would
     // be invalidated by moving the environment.
     let environment = if let Some(environment) = existing_environment {
-        update_environment(
+        let environment = update_environment(
             environment,
             spec,
             &settings,
@@ -288,7 +288,15 @@ pub(crate) async fn install(
             cache,
             printer,
         )
-        .await?
+        .await?;
+
+        // At this point, we updated the existing environment, so we should remove any of its
+        // existing executables.
+        if let Some(existing_receipt) = existing_tool_receipt {
+            remove_entrypoints(&existing_receipt);
+        }
+
+        environment
     } else {
         // If we're creating a new environment, ensure that we can resolve the requirements prior
         // to removing any existing tools.
@@ -307,6 +315,12 @@ pub(crate) async fn install(
         .await?;
 
         let environment = installed_tools.create_environment(&from.name, interpreter)?;
+
+        // At this point, we removed any existing environment, so we should remove any of its
+        // executables.
+        if let Some(existing_receipt) = existing_tool_receipt {
+            remove_entrypoints(&existing_receipt);
+        }
 
         // Sync the environment with the resolved requirements.
         sync_environment(
@@ -370,8 +384,9 @@ pub(crate) async fn install(
 
         hint_executable_from_dependency(&from, &environment, printer)?;
 
-        // Clean up the environment we just created
+        // Clean up the environment we just created.
         installed_tools.remove_environment(&from.name)?;
+
         return Ok(ExitStatus::Failure);
     }
 
@@ -381,9 +396,9 @@ pub(crate) async fn install(
         .filter(|(_, _, target_path)| target_path.exists())
         .peekable();
 
-    // Note we use `reinstall_entry_points` here instead of `reinstall`; requesting reinstall
-    // will _not_ remove existing entry points when they are not managed by uv.
-    if force || reinstall_entry_points {
+    // Ignore any existing entrypoints if the user passed `--force`, or the existing recept was
+    // broken.
+    if force || invalid_tool_receipt {
         for (name, _, target) in existing_entry_points {
             debug!("Removing existing executable: `{name}`");
             fs_err::remove_file(target)?;
@@ -476,6 +491,23 @@ pub(crate) async fn install(
     }
 
     Ok(ExitStatus::Success)
+}
+
+/// Remove any entrypoints attached to the [`Tool`].
+fn remove_entrypoints(tool: &Tool) {
+    for executable in tool
+        .entrypoints()
+        .iter()
+        .map(|entrypoint| &entrypoint.install_path)
+    {
+        debug!("Removing executable: `{}`", executable.simplified_display());
+        if let Err(err) = fs_err::remove_file(executable) {
+            warn!(
+                "Failed to remove executable: `{}`: {err}",
+                executable.simplified_display()
+            );
+        }
+    }
 }
 
 /// Displays a hint if an executable matching the package name can be found in a dependency of the package.


### PR DESCRIPTION
## Summary

This could still be made more robust, but it's not critical, since you can always `--force`. It's good to handle this case, though, since we have an explicit error for it.

Closes https://github.com/astral-sh/uv/issues/5490.
