### PR TITLE
Fix non-registry serialization for receipts

### DIFF
--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -240,12 +240,7 @@ pub(crate) async fn install(
     // If the requested and receipt requirements are the same...
     if existing_environment.is_some() {
         if let Some(tool_receipt) = existing_tool_receipt.as_ref() {
-            let receipt = tool_receipt
-                .requirements()
-                .iter()
-                .cloned()
-                .map(Requirement::from)
-                .collect::<Vec<_>>();
+            let receipt = tool_receipt.requirements().to_vec();
             if requirements == receipt {
                 // And the user didn't request a reinstall or upgrade...
                 if !force && settings.reinstall.is_none() && settings.upgrade.is_none() {

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -408,7 +408,7 @@ fn tool_install_editable() {
 
     ----- stderr -----
     warning: `uv tool install` is experimental and may change without warning
-    `black` is already installed
+    Installed 1 executable: black
     "###);
 
     insta::with_settings!({
@@ -417,7 +417,7 @@ fn tool_install_editable() {
         // We should have a tool receipt
         assert_snapshot!(fs_err::read_to_string(tool_dir.join("black").join("uv-receipt.toml")).unwrap(), @r###"
         [tool]
-        requirements = [{ name = "black", editable = "[WORKSPACE]/scripts/packages/black_editable" }]
+        requirements = [{ name = "black" }]
         entrypoints = [
             { name = "black", install-path = "[TEMP_DIR]/bin/black" },
         ]


### PR DESCRIPTION
## Summary

Fixes a bug in #5494. The `RequirementSourceWire` representation was ambiguous, and so the order of the fields meant that all variants were mapped to `Registry` when deserializing. (So the snapshots were right, but behaviors were wrong.)
