### PR TITLE
Initialize the cache in `uv init`

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -904,6 +904,9 @@ async fn run_project(
             let args = settings::InitSettings::resolve(args, filesystem);
             show_settings!(args);
 
+            // Initialize the cache.
+            let cache = cache.init()?;
+
             commands::init(
                 args.path,
                 args.name,

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -73,6 +73,26 @@ fn init() -> Result<()> {
     Ok(())
 }
 
+/// Ensure that `uv init` initializes the cache.
+#[test]
+fn init_cache() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    fs_err::remove_dir_all(&context.cache_dir)?;
+
+    uv_snapshot!(context.filters(), context.init().arg("foo"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv init` is experimental and may change without warning
+    Initialized project `foo` at `[TEMP_DIR]/foo`
+    "###);
+
+    Ok(())
+}
+
 #[test]
 fn init_no_readme() -> Result<()> {
     let context = TestContext::new("3.12");


### PR DESCRIPTION
## Summary

We now query the Python interpreter here, which means we need cache access.
