### PR TITLE
Move introduction to the "Getting started" section index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+# uv
+
 An extremely fast Python package and project manager, written in Rust.
 
 <p align="center">

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -81,8 +81,8 @@ extra:
     - icon: fontawesome/brands/x-twitter
       link: https://x.com/astral_sh
 nav:
-  - Introduction: index.md
   - Getting started:
+      - index.md
       - Installation: installation.md
       - First steps: first-steps.md
       - Features: features.md


### PR DESCRIPTION
We have an index for nearly every section. Should we have one for "Getting started"? Should it be this page?

Also solves https://github.com/astral-sh/uv/issues/5671 but I fixed that in #5676 