### PR TITLE
Bold active nav links for accessibility

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -142,3 +142,8 @@ See https://github.com/astral-sh/uv/issues/5130 */
 .highlight .gp, .highlight .go { /* Generic.Prompt, Generic.Output */
     user-select: none;
 }
+
+/* Bold the active nav link for accessibility */
+.md-nav__link--active {
+  font-weight: bold;
+}


### PR DESCRIPTION
Before
<img width="412" alt="Screenshot 2024-07-31 at 3 47 38 PM" src="https://github.com/user-attachments/assets/d95ebb62-079b-4e20-964c-9876b5978e4c">
After
<img width="412" alt="Screenshot 2024-07-31 at 3 47 21 PM" src="https://github.com/user-attachments/assets/a658d46a-3eeb-4f00-8952-d4c1dd91afe6">
