### PR TITLE
Disable collapsible navigation in the documentation

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,14 @@
+# Getting started
+
+To help you get started with uv, we'll cover a few important topics:
+
+- [Installing uv](./installation.md)
+- [First steps after installation](./first-steps.md)
+- [An overview of uv's features](./features.md)
+- [How to get help](./help.md)
+
+Read on, or jump ahead to another section:
+
+- Get going quickly with [guides](../guides/index.md) for common workflows.
+- Learn more about the core [concepts](../concepts/index.md) in uv.
+- Use the [reference](../reference/index.md) documentation to find details about something specific.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,11 @@
+# Reference
+
+The reference section provides information about specific parts of uv:
+
+- [Commands](./cli.md): A reference for uv's command line interface.
+- [Settings](./settings.md): A reference for uv's configuration schema.
+- [Resolver](./resolver-internals.md): Details about the internals of uv's resolver.
+- [Versioning](./versioning.md): uv's versioning policy.
+- [Platform support](./platforms.md): uv's supported operating systems and architectures.
+
+Looking for a broader overview? Check out the [concepts](../concepts/index.md) documentation.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -126,9 +126,13 @@ See https://github.com/astral-sh/uv/issues/5130 */
   }
 }
 
+
 /* Reducing spacing between nav items to fit more content */
 .md-nav__link {
   margin-top: 0.25em;
+}
+.md-nav__item--section {
+  margin: 0.75em 0;
 }
 /* Retain larger spacing for each top-level section in the nav */
 .md-nav__item--nested {
@@ -141,6 +145,22 @@ See https://github.com/astral-sh/uv/issues/5130 */
 /* See: https://mkdocstrings.github.io/recipes/#prevent-selection-of-prompts-and-output-in-python-code-blocks */
 .highlight .gp, .highlight .go { /* Generic.Prompt, Generic.Output */
     user-select: none;
+}
+
+/* Increase the size of the sections headings, remove the bold */
+.md-nav__item--section>.md-nav__link {
+  font-size: 16px;
+  font-weight: normal;
+}
+/* Increase the size of the index nav item to match the sections */
+.md-nav__item:first-child {
+  font-size: 16px;
+  font-weight: normal;
+}
+/* But do not increase the size of other nav items */
+.md-nav__item--section > .md-nav > .md-nav__list > .md-nav__item {
+  font-size: 14px;
+  font-weight: normal;
 }
 
 /* Bold the active nav link for accessibility */

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -7,7 +7,7 @@ theme:
     - navigation.instant
     - navigation.instant.prefetch
     - navigation.instant.progress
-    - navigation.expand
+    - navigation.sections
     - navigation.indexes
     - navigation.tracking
     - content.code.annotate

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -82,6 +82,7 @@ extra:
 nav:
   - Introduction: index.md
   - Getting started:
+      - getting-started/index.md
       - Installation: getting-started/installation.md
       - First steps: getting-started/first-steps.md
       - Features: getting-started/features.md
@@ -122,6 +123,7 @@ nav:
       - Locking environments: pip/compile.md
       - Compatibility with pip: pip/compatibility.md
   - Reference:
+      - reference/index.md
       - Commands: reference/cli.md
       - Settings: reference/settings.md
       - Resolver: reference/resolver-internals.md


### PR DESCRIPTION
Removes the collapsible sections in favor of larger font navigation headings. I found the bold to be too distracting from the content itself — it might be okay in the future if the navigation bar is further left.

Before:

<img width="1356" alt="Screenshot 2024-08-16 at 6 03 57 PM" src="https://github.com/user-attachments/assets/75e49216-dc0d-4d26-a0d8-0283c29f9b81">

After:

<img width="1324" alt="Screenshot 2024-08-16 at 6 05 36 PM" src="https://github.com/user-attachments/assets/cbce96ce-0969-46c5-80b6-e163481b8bfa">

(No change to the mobile view)

<img width="823" alt="Screenshot 2024-08-16 at 6 05 03 PM" src="https://github.com/user-attachments/assets/b450e413-d5a4-4d2d-9905-e8eb6ac6f546">
<img width="823" alt="Screenshot 2024-08-16 at 6 05 13 PM" src="https://github.com/user-attachments/assets/bd251ea0-58d8-456e-bdc8-4e3699061e6c">

