### PR TITLE
Allow downloading wheels for metadata with `--no-binary`

### DIFF
--- a/PIP_COMPATIBILITY.md
+++ b/PIP_COMPATIBILITY.md
@@ -337,6 +337,15 @@ package is "allowed" in such cases without building its metadata.
 Both pip and uv allow editables requirements to be built and installed even when `--only-binary` is
 provided. For example, `uv pip install -e . --only-binary :all:` is allowed.
 
+## `--no-binary` enforcement
+
+The `--no-binary` argument is used to restrict installation to source distributions. When
+`--no-binary` is provided, uv will refuse to install pre-built binary distributions, but _will_
+reuse any binary distributions that are already present in the local cache.
+
+Additionally, and in contrast to pip, uv's resolver will still read metadata from pre-built binary
+distributions when `--no-binary` is provided.
+
 ## Bytecode compilation
 
 Unlike pip, uv does not compile `.py` files to `.pyc` files during installation by default (i.e., uv

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -249,6 +249,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
                 self.cache,
                 tags,
                 &HashStrategy::None,
+                self.build_options,
                 DistributionDatabase::new(
                     self.client,
                     self,

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -145,14 +145,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         dist: &BuiltDist,
         hashes: HashPolicy<'_>,
     ) -> Result<LocalWheel, Error> {
-        if self
-            .build_context
-            .build_options()
-            .no_binary_package(dist.name())
-        {
-            return Err(Error::NoBinary);
-        }
-
         match dist {
             BuiltDist::Registry(wheels) => {
                 let wheel = wheels.best_wheel();

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -16,8 +16,6 @@ use uv_normalize::PackageName;
 pub enum Error {
     #[error("Building source distributions is disabled")]
     NoBuild,
-    #[error("Using pre-built wheels is disabled")]
-    NoBinary,
 
     // Network error
     #[error("Failed to parse URL: {0}")]

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -400,6 +400,7 @@ pub(crate) async fn install(
             cache,
             tags,
             hasher,
+            build_options,
             DistributionDatabase::new(client, build_dispatch, concurrency.downloads, preview),
         )
         .with_reporter(PrepareReporter::from(printer).with_length(remote.len() as u64));


### PR DESCRIPTION
## Summary

We allow the use of (e.g.) `.whl.metadata` files when `--no-binary` is enabled, so it makes sense that we'd also also allow wheels to be downloaded for metadata extraction. So now, we validate `--no-binary` at install time, rather than metadata-fetch time.

Closes https://github.com/astral-sh/uv/issues/5699.
