### PR TITLE
Install Python versions with previous uv release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,8 @@ jobs:
 
       - name: "Install required Python versions"
         run: |
-          cargo run python install
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv python install
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
@@ -193,7 +194,8 @@ jobs:
 
       - name: "Install required Python versions"
         run: |
-          cargo run python install
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv python install
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
Part of https://github.com/astral-sh/uv/issues/5713

Shaves 50s or ~25% off the Ubuntu test run. Maybe 30s or 8% off macOS.
Windows already uses the GitHub distributions.

Note this is some of our only test coverage for Python version installs, we may want to add separate coverage to compensate. 