### PR TITLE
Enable mirror for `python-build-standalone` downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,10 @@ uv accepts the following command-line arguments as environment variables:
   packages.
 - `UV_EXCLUDE_NEWER`: Equivalent to the `--exclude-newer` command-line argument. If set, uv will
   exclude distributions published after the specified date.
+- `UV_PYTHON_INSTALL_MIRROR`: Managed Python installations are downloaded from [`python-build-standalone`](https://github.com/indygreg/python-build-standalone).
+  This variable can be set to a mirror URL to use a different source for Python installations.
+  The provided URL will replace `https://github.com/indygreg/python-build-standalone/releases/download` in,
+  e.g., `https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz`.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 

--- a/README.md
+++ b/README.md
@@ -618,10 +618,16 @@ uv accepts the following command-line arguments as environment variables:
   packages.
 - `UV_EXCLUDE_NEWER`: Equivalent to the `--exclude-newer` command-line argument. If set, uv will
   exclude distributions published after the specified date.
-- `UV_PYTHON_INSTALL_MIRROR`: Managed Python installations are downloaded from [`python-build-standalone`](https://github.com/indygreg/python-build-standalone).
-  This variable can be set to a mirror URL to use a different source for Python installations.
-  The provided URL will replace `https://github.com/indygreg/python-build-standalone/releases/download` in,
-  e.g., `https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz`.
+- `UV_PYTHON_INSTALL_MIRROR`: Managed Python installations are downloaded from
+  [`python-build-standalone`](https://github.com/indygreg/python-build-standalone). This variable
+  can be set to a mirror URL to use a different source for Python installations. The provided URL
+  will replace `https://github.com/indygreg/python-build-standalone/releases/download` in, e.g.,
+  `https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz`.
+- `UV_PYPY_INSTALL_MIRROR`: Managed PyPy installations are downloaded from
+  [python.org](https://downloads.python.org/). This variable can be set to a mirror URL to use a
+  different source for PyPy installations. The provided URL will replace
+  `https://downloads.python.org/pypy` in, e.g.,
+  `https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2`.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -235,9 +235,9 @@ pub(crate) async fn install(
         for (key, err) in errors {
             writeln!(
                 printer.stderr(),
-                "Failed to install {}: {}",
+                "{}: Failed to install {}: {err}",
+                "error".red().bold(),
                 key.green(),
-                err
             )?;
         }
         return Ok(ExitStatus::Failure);

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -53,6 +53,16 @@ uv accepts the following command-line arguments as environment variables:
   packages.
 - `UV_EXCLUDE_NEWER`: Equivalent to the `--exclude-newer` command-line argument. If set, uv will
   exclude distributions published after the specified date.
+- `UV_PYTHON_INSTALL_MIRROR`: Managed Python installations are downloaded from
+  [`python-build-standalone`](https://github.com/indygreg/python-build-standalone). This variable
+  can be set to a mirror URL to use a different source for Python installations. The provided URL
+  will replace `https://github.com/indygreg/python-build-standalone/releases/download` in, e.g.,
+  `https://github.com/indygreg/python-build-standalone/releases/download/20240713/cpython-3.12.4%2B20240713-aarch64-apple-darwin-install_only.tar.gz`.
+- `UV_PYPY_INSTALL_MIRROR`: Managed PyPy installations are downloaded from
+  [python.org](https://downloads.python.org/). This variable can be set to a mirror URL to use a
+  different source for PyPy installations. The provided URL will replace
+  `https://downloads.python.org/pypy` in, e.g.,
+  `https://downloads.python.org/pypy/pypy3.8-v7.3.7-osx64.tar.bz2`.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 


### PR DESCRIPTION
## Summary

This came up again recently, so decided to do it real quick.

Closes https://github.com/astral-sh/uv/issues/5224.
