### PR TITLE
Always strip in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,8 +203,12 @@ rc_buffer = "warn"
 rc_mutex = "warn"
 rest_pat_in_fully_bound_structs = "warn"
 
+[profile.release]
+strip = true
+
 [profile.profiling]
 inherits = "release"
+strip = false
 debug = true
 
 [profile.fast-build]


### PR DESCRIPTION
Decreases linux release wheel size by 2MB.

See https://github.com/rust-lang/cargo/issues/14346

Fixes #5683