### PR TITLE
feat: more rust in trampoline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,8 +349,7 @@ jobs:
         if: matrix.target-arch == 'x86_64'
         run: |
           cargo xwin bloat --release --target x86_64-pc-windows-msvc | \
-          grep -v -i -E 'core::fmt::write|core::fmt::getcount' | \
-          grep -q -E 'core::fmt|std::panicking|std::backtrace_rs' && exit 1 || exit 0
+          grep -q -E 'std::panicking|std::backtrace_rs' && exit 1 || exit 0
         env:
           XWIN_ARCH: "x86_64"
           XWIN_CACHE_DIR: "${{ github.workspace }}/.xwin"

--- a/crates/install-wheel-rs/src/wheel.rs
+++ b/crates/install-wheel-rs/src/wheel.rs
@@ -1018,14 +1018,14 @@ mod test {
     #[test]
     #[cfg(all(windows, target_arch = "x86"))]
     fn test_launchers_are_small() {
-        // At time of writing, they are 45kb~ bytes.
+        // At time of writing, they are 80kb~ bytes.
         assert!(
-            super::LAUNCHER_I686_GUI.len() < 45 * 1024,
+            super::LAUNCHER_I686_GUI.len() < 80 * 1024,
             "GUI launcher: {}",
             super::LAUNCHER_I686_GUI.len()
         );
         assert!(
-            super::LAUNCHER_I686_CONSOLE.len() < 45 * 1024,
+            super::LAUNCHER_I686_CONSOLE.len() < 80 * 1024,
             "CLI launcher: {}",
             super::LAUNCHER_I686_CONSOLE.len()
         );
@@ -1034,14 +1034,14 @@ mod test {
     #[test]
     #[cfg(all(windows, target_arch = "x86_64"))]
     fn test_launchers_are_small() {
-        // At time of writing, they are 45kb~ bytes.
+        // At time of writing, they are 80kb~ bytes.
         assert!(
-            super::LAUNCHER_X86_64_GUI.len() < 45 * 1024,
+            super::LAUNCHER_X86_64_GUI.len() < 80 * 1024,
             "GUI launcher: {}",
             super::LAUNCHER_X86_64_GUI.len()
         );
         assert!(
-            super::LAUNCHER_X86_64_CONSOLE.len() < 45 * 1024,
+            super::LAUNCHER_X86_64_CONSOLE.len() < 80 * 1024,
             "CLI launcher: {}",
             super::LAUNCHER_X86_64_CONSOLE.len()
         );
@@ -1050,14 +1050,14 @@ mod test {
     #[test]
     #[cfg(all(windows, target_arch = "aarch64"))]
     fn test_launchers_are_small() {
-        // At time of writing, they are 45kb~ bytes.
+        // At time of writing, they are 80kb~ bytes.
         assert!(
-            super::LAUNCHER_AARCH64_GUI.len() < 45 * 1024,
+            super::LAUNCHER_AARCH64_GUI.len() < 80 * 1024,
             "GUI launcher: {}",
             super::LAUNCHER_AARCH64_GUI.len()
         );
         assert!(
-            super::LAUNCHER_AARCH64_CONSOLE.len() < 45 * 1024,
+            super::LAUNCHER_AARCH64_CONSOLE.len() < 80 * 1024,
             "CLI launcher: {}",
             super::LAUNCHER_AARCH64_CONSOLE.len()
         );

--- a/crates/uv-trampoline/Cargo.toml
+++ b/crates/uv-trampoline/Cargo.toml
@@ -37,7 +37,6 @@ windows = { version = "0.58.0", features = [
   "Win32_Foundation",
   "Win32_Security",
   "Win32_System_Console",
-  "Win32_System_Environment",
   "Win32_System_JobObjects",
   "Win32_System_Threading",
   "Win32_UI_WindowsAndMessaging",

--- a/crates/uv-trampoline/src/bounce.rs
+++ b/crates/uv-trampoline/src/bounce.rs
@@ -1,30 +1,30 @@
 #![allow(clippy::disallowed_types)]
-use std::ffi::{c_void, CString};
+use std::ffi::{c_void, OsString};
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::mem::size_of;
+use std::os::windows::io::AsRawHandle;
+use std::os::windows::process::ChildExt;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::process::Stdio;
 use std::vec::Vec;
 
-use windows::core::{s, PSTR};
+use windows::core::s;
 use windows::Win32::{
-    Foundation::{
-        CloseHandle, SetHandleInformation, BOOL, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE,
-        TRUE,
-    },
+    Foundation::{CloseHandle, BOOL, HANDLE, INVALID_HANDLE_VALUE, TRUE},
     System::Console::{
         GetStdHandle, SetConsoleCtrlHandler, SetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE,
         STD_OUTPUT_HANDLE,
     },
-    System::Environment::GetCommandLineA,
     System::JobObjects::{
         AssignProcessToJobObject, CreateJobObjectA, JobObjectExtendedLimitInformation,
         QueryInformationJobObject, SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
         JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK,
     },
     System::Threading::{
-        CreateProcessA, GetExitCodeProcess, GetStartupInfoA, WaitForInputIdle, WaitForSingleObject,
-        INFINITE, PROCESS_CREATION_FLAGS, PROCESS_INFORMATION, STARTF_USESTDHANDLES, STARTUPINFOA,
+        GetExitCodeProcess, GetStartupInfoA, WaitForInputIdle, WaitForSingleObject, INFINITE,
+        STARTUPINFOA,
     },
     UI::WindowsAndMessaging::{
         CreateWindowExA, DestroyWindow, GetMessageA, PeekMessageA, PostMessageA, HWND_MESSAGE, MSG,
@@ -37,55 +37,6 @@ use crate::{eprintln, format};
 const MAGIC_NUMBER: [u8; 4] = [b'U', b'V', b'U', b'V'];
 const PATH_LEN_SIZE: usize = size_of::<u32>();
 const MAX_PATH_LEN: u32 = 32 * 1024;
-
-/// Transform `<command> <arguments>` to `python <command> <arguments>`.
-fn make_child_cmdline() -> CString {
-    let executable_name = std::env::current_exe().unwrap_or_else(|_| {
-        eprintln!("Failed to get executable name");
-        exit_with_status(1);
-    });
-    let python_exe = find_python_exe(executable_name.as_ref());
-    let mut child_cmdline = Vec::<u8>::new();
-
-    push_quoted_path(python_exe.as_ref(), &mut child_cmdline);
-    child_cmdline.push(b' ');
-
-    // Use the full executable name because CMD only passes the name of the executable (but not the path)
-    // when e.g. invoking `black` instead of `<PATH_TO_VENV>/Scripts/black` and Python then fails
-    // to find the file. Unfortunately, this complicates things because we now need to split the executable
-    // from the arguments string...
-    push_quoted_path(executable_name.as_ref(), &mut child_cmdline);
-
-    push_arguments(&mut child_cmdline);
-
-    child_cmdline.push(b'\0');
-
-    // Helpful when debugging trampoline issues
-    // eprintln!(
-    //     "executable_name: '{}'\nnew_cmdline: {}",
-    //     &*executable_name.to_string_lossy(),
-    //     std::str::from_utf8(child_cmdline.as_slice()).unwrap()
-    // );
-
-    CString::from_vec_with_nul(child_cmdline).unwrap_or_else(|_| {
-        eprintln!("Child command line is not correctly null terminated");
-        exit_with_status(1);
-    })
-}
-
-fn push_quoted_path(path: &Path, command: &mut Vec<u8>) {
-    command.push(b'"');
-    for byte in path.as_os_str().as_encoded_bytes() {
-        if *byte == b'"' {
-            // 3 double quotes: one to end the quoted span, one to become a literal double-quote,
-            // and one to start a new quoted span.
-            command.extend(br#"""""#);
-        } else {
-            command.push(*byte);
-        }
-    }
-    command.extend(br#"""#);
-}
 
 /// Reads the executable binary from the back to find the path to the Python executable that is written
 /// after the ZIP file content.
@@ -208,48 +159,6 @@ fn find_python_exe(executable_name: &Path) -> PathBuf {
     })
 }
 
-fn push_arguments(output: &mut Vec<u8>) {
-    // SAFETY: We rely on `GetCommandLineA` to return a valid pointer to a null terminated string.
-    let arguments_as_str = unsafe { GetCommandLineA() };
-    let arguments_as_bytes = unsafe { arguments_as_str.as_bytes() };
-
-    // Skip over the executable name and then push the rest of the arguments
-    let after_executable = skip_one_argument(arguments_as_bytes);
-
-    output.extend_from_slice(after_executable)
-}
-
-fn skip_one_argument(arguments: &[u8]) -> &[u8] {
-    let mut quoted = false;
-    let mut offset = 0;
-    let mut bytes_iter = arguments.iter().peekable();
-
-    // Implements https://learn.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments?view=msvc-170
-    while let Some(byte) = bytes_iter.next().copied() {
-        match byte {
-            b'"' => {
-                quoted = !quoted;
-            }
-            b'\\' => {
-                // Skip over escaped quotes or even number of backslashes.
-                if matches!(bytes_iter.peek().copied(), Some(&b'\"' | &b'\\')) {
-                    offset += 1;
-                    bytes_iter.next();
-                }
-            }
-            byte => {
-                if byte.is_ascii_whitespace() && !quoted {
-                    break;
-                }
-            }
-        }
-
-        offset += 1;
-    }
-
-    &arguments[offset..]
-}
-
 fn make_job_object() -> HANDLE {
     let job = unsafe { CreateJobObjectA(None, None) }
         .unwrap_or_else(|_| print_last_error_and_exit("Job creation failed"));
@@ -283,44 +192,6 @@ fn make_job_object() -> HANDLE {
         print_last_error_and_exit("Job information setting failed");
     }
     job
-}
-
-fn spawn_child(si: &STARTUPINFOA, child_cmdline: CString) -> HANDLE {
-    // See distlib/PC/launcher.c::run_child
-    if (si.dwFlags & STARTF_USESTDHANDLES).0 != 0 {
-        // ignore errors, if the handles are not inheritable/valid, then nothing we can do
-        unsafe { SetHandleInformation(si.hStdInput, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT) }
-            .unwrap_or_else(|_| eprintln!("Making stdin inheritable failed"));
-        unsafe { SetHandleInformation(si.hStdOutput, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT) }
-            .unwrap_or_else(|_| eprintln!("Making stdout inheritable failed"));
-        unsafe { SetHandleInformation(si.hStdError, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT) }
-            .unwrap_or_else(|_| eprintln!("Making stderr inheritable failed"));
-    }
-    let mut child_process_info = PROCESS_INFORMATION::default();
-    unsafe {
-        CreateProcessA(
-            None,
-            // Why does this have to be mutable? Who knows. But it's not a mistake --
-            // MS explicitly documents that this buffer might be mutated by CreateProcess.
-            PSTR::from_raw(child_cmdline.as_ptr() as *mut _),
-            None,
-            None,
-            true,
-            PROCESS_CREATION_FLAGS(0),
-            None,
-            None,
-            si,
-            &mut child_process_info,
-        )
-    }
-    .unwrap_or_else(|_| {
-        print_last_error_and_exit("Failed to spawn the python child process");
-    });
-    unsafe { CloseHandle(child_process_info.hThread) }.unwrap_or_else(|_| {
-        print_last_error_and_exit("Failed to close handle to python child process main thread");
-    });
-    // Return handle to child process.
-    child_process_info.hProcess
 }
 
 // Apparently, the Windows C runtime has a secret way to pass file descriptors into child
@@ -416,12 +287,39 @@ fn clear_app_starting_state(child_handle: HANDLE) {
 }
 
 pub fn bounce(is_gui: bool) -> ! {
-    let child_cmdline = make_child_cmdline();
+    let launcher_exe = std::env::current_exe().unwrap_or_else(|_| {
+        eprintln!("Failed to get executable name");
+        exit_with_status(1);
+    });
+    let python_exe = find_python_exe(launcher_exe.as_ref());
+    let arguments: Vec<OsString> = std::env::args_os().skip(1).collect();
 
     let mut si = STARTUPINFOA::default();
     unsafe { GetStartupInfoA(&mut si) }
 
-    let child_handle = spawn_child(&si, child_cmdline);
+    let child_process_info = Command::new(python_exe.as_os_str())
+        .arg(launcher_exe.as_os_str())
+        .args(arguments)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap_or_else(|_| {
+            print_last_error_and_exit("Failed to spawn the python child process");
+        });
+    // https://github.com/rust-lang/rust/issues/96723
+    // We need to close the main_thread_handle to align with distlib implementation
+    unsafe {
+        CloseHandle(HANDLE(
+            child_process_info.main_thread_handle().as_raw_handle() as _,
+        ))
+    }
+    .unwrap_or_else(|_| {
+        print_last_error_and_exit("Failed to close handle to python child process main thread");
+    });
+
+    let child_handle = HANDLE(child_process_info.as_raw_handle() as _);
+
     let job = make_job_object();
 
     if unsafe { AssignProcessToJobObject(job, child_handle) }.is_err() {

--- a/crates/uv-trampoline/src/lib.rs
+++ b/crates/uv-trampoline/src/lib.rs
@@ -1,2 +1,3 @@
+#![feature(windows_process_extensions_main_thread_handle)]
 pub mod bounce;
 mod diagnostics;


### PR DESCRIPTION
## Summary

This is an experimental PR to replace more unsafe calls with more rust while still trying to keep the binary size small enough. These changes roughly increase the size of the trampolines to about 80kb~ due to usage of `Command` which brings a large chunk of `core::fmt`. This was a alternate PR to #5750.

The primary changes here include changes from #5750 (post merge)
* Switch to use rust path components for ease of path management
* Leverage `std::process::exit` for process exit and cleanup
* Use `std::io::Error::last_os_error` for IO Errors to remove `FormatMessage` complexity
* Use `std::env::current_exe` to get the current executable instead of `GetModuleFileNameA`

In addition, this PR also includes
* Switching to using `Command` instead of `CreateProcessA` and remove the need for CLI argument parsing
* Switching to use `std::env::args_os` instead of `GetCommandLineA`

## Test Plan

Existings tests / local tests.