### PR TITLE
Fix the default value of python-preference in docs/reference/settings.md

### DIFF
--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -117,7 +117,7 @@ pub struct GlobalOptions {
     /// Whether to prefer using Python installations that are already present on the system, or
     /// those that are downloaded and installed by uv.
     #[option(
-        default = "\"installed\"",
+        default = "\"only-system\" (stable) or \"managed\" (preview)",
         value_type = "str",
         example = r#"
             python-preference = "managed"

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -643,7 +643,7 @@ Whether to automatically download Python when required.
 Whether to prefer using Python installations that are already present on the system, or
 those that are downloaded and installed by uv.
 
-**Default value**: `"only-system"` (`"managed"` in preview)
+**Default value**: `"only-system" (stable) or "managed" (preview)`
 
 **Possible values**:
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -643,7 +643,7 @@ Whether to automatically download Python when required.
 Whether to prefer using Python installations that are already present on the system, or
 those that are downloaded and installed by uv.
 
-**Default value**: `"installed"`
+**Default value**: `"only-system"` (`"managed"` in preview)
 
 **Possible values**:
 


### PR DESCRIPTION
## Summary
After referring to https://github.com/astral-sh/uv/pull/5637 and doing additional testing.
The default value in a stable state seems more reasonable to be ``only-system``.  ``managed`` in preview.
```
cpython-3.11.9-windows-x86_64-none     C:\Users\name\AppData\Local\Programs\Python\Python311\python.exe

cpython-3.10.14-windows-x86_64-none    C:\Users\name\AppData\Roaming\uv\data\python\cpython-3.10.14-windows-x86_64-none\install\python.exe
cpython-3.10.11-windows-x86_64-none    C:\Users\name\AppData\Local\Programs\Python\Python310\python.exe

cpython-3.9.19-windows-x86_64-none     C:\Users\name\AppData\Roaming\uv\data\python\cpython-3.9.19-windows-x86_64-none\python.exe
```
test on uv  0.2.33  (build from https://github.com/astral-sh/uv/tree/257007ccaf0912a41dfe91b534527a7b1f54e19a)
### Stable version
``uv venv -p 3.10`` is ``3.10.11`` (System Python)
``uv venv -p 3.9`` is ``No interpreter found``(3.9.19 for managed Python)
``uv venv -p 3.9 --python-preference only-system`` is ``No interpreter found``(fail)
``uv venv -p 3.9 --python-preference only-managed`` is ``3.9.19``(success)
Do not use managed Python, only use the system Python, so it can be determined as ``only-system``.
### Preview mode
**Note:**  ``3.10.14`` is managed python, ``3.10.11`` is system python.
``uv venv -p 3.11 --preview`` is ``3.11.9`` (System Python)
``uv venv -p 3.10 --preview`` is ``3.10.14``
``uv venv -p 3.10 --preview --python-preference only-managed`` is ``3.10.14``
``uv venv -p 3.10 --preview --python-preference managed`` is ``3.10.14``
``uv venv -p 3.10 --preview --python-preference system`` is ``3.10.11``
``venv -p 3.10 --preview --python-preference only-system`` is ``3.10.11``
Prioritize the managed Python and then select the system Python, so it can be determined as ``managed``.

-----
fixed #5754 
## Test Plan
Run website in local.
![image](https://github.com/user-attachments/assets/02b81d44-1a99-4165-aca5-6ce46345b539)

