### PR TITLE
Add note on cache growth for self-hosted GitHub runners

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -267,13 +267,14 @@ Its effect on performance is dependent on the packages being installed.
 
     If using `uv pip`, use `requirements.txt` instead of `uv.lock` in the cache key.
 
-!!! warning
+!!! note
 
     [post-job-hook]: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
 
-    When using non-ephemeral self-hosted runners and the default cache directory, the cache can grow
-    over time and become problematic. In such cases, it's recommend to move the cache to inside the
-    GitHub Workspace and clean it once the job finishes using a [Post Job Hook][post-job-hook].
+    When using non-ephemeral, self-hosted runners the default cache directory can grow unbounded.
+    In this case, it may not be optimal to share the cache between jobs. Instead, move the cache
+    inside the GitHub Workspace and remove it once the job finishes using a
+    [Post Job Hook][post-job-hook].
 
     ```yaml
     install_job:
@@ -285,9 +286,9 @@ Its effect on performance is dependent on the packages being installed.
     Using a post job hook requires setting the `ACTIONS_RUNNER_HOOK_JOB_STARTED` environment
     variable on the self-hosted runner to the path of a cleanup script such as the one shown below.
 
-    ```sh title="clean-workspace.sh"
+    ```sh title="clean-uv-cache.sh"
     #!/usr/bin/env sh
-    rm -rf $GITHUB_WORKSPACE/*
+    uv cache clean
     ```
 
 ## Using `uv pip`

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -271,8 +271,8 @@ Its effect on performance is dependent on the packages being installed.
 
     [post-job-hook]: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
 
-    When using non-ephemeral self-hosted runners and the default cache directory, the cache can grow over time 
-    and become problematic. In such cases, it's recommend to move the cache to inside the
+    When using non-ephemeral self-hosted runners and the default cache directory, the cache can grow
+    over time and become problematic. In such cases, it's recommend to move the cache to inside the
     GitHub Workspace and clean it once the job finishes using a [Post Job Hook][post-job-hook].
 
     ```yaml

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -280,7 +280,6 @@ Its effect on performance is dependent on the packages being installed.
       env:
         # Configure a relative location for the uv cache
         UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
-      # ... restore uv cache ...
     ```
 
     Using a post job hook requires setting the `ACTIONS_RUNNER_HOOK_JOB_STARTED` environment

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -267,6 +267,30 @@ Its effect on performance is dependent on the packages being installed.
 
     If using `uv pip`, use `requirements.txt` instead of `uv.lock` in the cache key.
 
+!!! warning
+
+    [post-job-hook]: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
+
+    When using non-ephemeral self-hosted runners the default cache location can grow over time,
+    becoming problematic. In such cases its possible to set the caching location relative to the
+    GitHub Workspace and clean it once the job finishes using a [Post Job Hook][post-job-hook].
+
+    ```yaml
+    install_job:
+      env:
+        # Configure a relative location for the uv cache
+        UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
+      # ... restore uv cache ...
+    ```
+
+    Using a post job hook requires setting the `ACTIONS_RUNNER_HOOK_JOB_STARTED` environment
+    variable on the self-hosted runner to the path of a cleanup script such as the one shown below.
+
+    ```sh
+    #!/usr/bin/env sh
+    rm -rf $GITHUB_WORKSPACE/*
+    ```
+
 ## Using `uv pip`
 
 If using the `uv pip` interface instead of the uv project interface, uv requires a virtual

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -286,7 +286,7 @@ Its effect on performance is dependent on the packages being installed.
     Using a post job hook requires setting the `ACTIONS_RUNNER_HOOK_JOB_STARTED` environment
     variable on the self-hosted runner to the path of a cleanup script such as the one shown below.
 
-    ```sh
+    ```sh title="clean-workspace.sh"
     #!/usr/bin/env sh
     rm -rf $GITHUB_WORKSPACE/*
     ```

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -271,8 +271,8 @@ Its effect on performance is dependent on the packages being installed.
 
     [post-job-hook]: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job
 
-    When using non-ephemeral self-hosted runners the default cache location can grow over time,
-    becoming problematic. In such cases its possible to set the caching location relative to the
+    When using non-ephemeral self-hosted runners and the default cache directory, the cache can grow over time 
+    and become problematic. In such cases, it's recommend to move the cache to inside the
     GitHub Workspace and clean it once the job finishes using a [Post Job Hook][post-job-hook].
 
     ```yaml


### PR DESCRIPTION
## Summary

Related discussion: #5731

This adds a warning section for caching on non-ephemeral (e.g. ec2) self hosted github runners.

## Test Plan

Prettier was ran on the file.