### PR TITLE
Use lockfile directly in `uv tree`

### DIFF
--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -3,7 +3,7 @@ pub use error::{NoSolutionError, ResolveError};
 pub use exclude_newer::ExcludeNewer;
 pub use exclusions::Exclusions;
 pub use flat_index::FlatIndex;
-pub use lock::{Lock, LockError};
+pub use lock::{Lock, LockError, TreeDisplay};
 pub use manifest::Manifest;
 pub use options::{Options, OptionsBuilder};
 pub use preferences::{Preference, PreferenceError, Preferences};

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -1,8 +1,6 @@
 use std::fmt::Write;
 
 use anyhow::Result;
-use indexmap::IndexMap;
-use owo_colors::OwoColorize;
 
 use pep508_rs::PackageName;
 use uv_cache::Cache;
@@ -10,10 +8,10 @@ use uv_client::Connectivity;
 use uv_configuration::{Concurrency, PreviewMode};
 use uv_fs::CWD;
 use uv_python::{PythonFetch, PythonPreference, PythonRequest};
+use uv_resolver::TreeDisplay;
 use uv_warnings::warn_user_once;
 use uv_workspace::{DiscoveryOptions, Workspace};
 
-use crate::commands::pip::tree::DisplayDependencyGraph;
 use crate::commands::project::FoundInterpreter;
 use crate::commands::{project, ExitStatus};
 use crate::printer::Printer;
@@ -31,7 +29,6 @@ pub(crate) async fn tree(
     package: Vec<PackageName>,
     no_dedupe: bool,
     invert: bool,
-    show_version_specifiers: bool,
     python: Option<String>,
     settings: ResolverSettings,
     python_preference: PythonPreference,
@@ -81,38 +78,10 @@ pub(crate) async fn tree(
     )
     .await?;
 
-    // Read packages from the lockfile.
-    let mut packages: IndexMap<_, Vec<_>> = IndexMap::new();
-    for dist in lock.lock.into_distributions() {
-        let name = dist.name().clone();
-        let metadata = dist.to_metadata(workspace.install_path())?;
-        packages.entry(name).or_default().push(metadata);
-    }
-
     // Render the tree.
-    let rendered_tree = DisplayDependencyGraph::new(
-        depth.into(),
-        prune,
-        package,
-        no_dedupe,
-        invert,
-        show_version_specifiers,
-        interpreter.markers(),
-        packages,
-    )
-    .render()
-    .join("\n");
+    let tree = TreeDisplay::new(&lock.lock, depth.into(), prune, package, no_dedupe, invert);
 
-    writeln!(printer.stdout(), "{rendered_tree}")?;
-
-    if rendered_tree.contains('*') {
-        let message = if no_dedupe {
-            "(*) Package tree is a cycle and cannot be shown".italic()
-        } else {
-            "(*) Package tree already displayed".italic()
-        };
-        writeln!(printer.stdout(), "{message}")?;
-    }
+    write!(printer.stdout(), "{tree}")?;
 
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1122,7 +1122,6 @@ async fn run_project(
                 args.package,
                 args.no_dedupe,
                 args.invert,
-                args.show_version_specifiers,
                 args.python,
                 args.resolver,
                 globals.python_preference,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -774,7 +774,6 @@ pub(crate) struct TreeSettings {
     pub(crate) package: Vec<PackageName>,
     pub(crate) no_dedupe: bool,
     pub(crate) invert: bool,
-    pub(crate) show_version_specifiers: bool,
     pub(crate) python: Option<String>,
     pub(crate) resolver: ResolverSettings,
 }
@@ -799,7 +798,6 @@ impl TreeSettings {
             package: tree.package,
             no_dedupe: tree.no_dedupe,
             invert: tree.invert,
-            show_version_specifiers: tree.show_version_specifiers,
             python,
             resolver: ResolverSettings::combine(resolver_options(resolver, build), filesystem),
         }


### PR DESCRIPTION
## Summary

Ensures that we properly handle (1) duplicated packages and (2) packages that aren't relevant to the current platform.

Closes https://github.com/astral-sh/uv/issues/5716.
Closes https://github.com/astral-sh/uv/issues/5253.
