### PR TITLE
Use cache for Python install temporary directories

### DIFF
--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -129,7 +129,9 @@ impl PythonInstallation {
         let client = client_builder.build();
 
         info!("Fetching requested Python...");
-        let result = download.fetch(&client, installations_dir, reporter).await?;
+        let result = download
+            .fetch(&client, installations_dir, cache, reporter)
+            .await?;
 
         let path = match result {
             DownloadResult::AlreadyAvailable(path) => path,

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeSet;
 use std::fmt::Write;
 use std::path::PathBuf;
 use tracing::debug;
+use uv_cache::Cache;
 use uv_client::Connectivity;
 use uv_configuration::PreviewMode;
 use uv_fs::CWD;
@@ -31,6 +32,7 @@ pub(crate) async fn install(
     connectivity: Connectivity,
     preview: PreviewMode,
     no_config: bool,
+    cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
     if preview.is_disabled() {
@@ -149,7 +151,7 @@ pub(crate) async fn install(
             (
                 download.key(),
                 download
-                    .fetch(&client, installations_dir, Some(&reporter))
+                    .fetch(&client, installations_dir, cache, Some(&reporter))
                     .await,
             )
         });

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -827,6 +827,9 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             let args = settings::PythonInstallSettings::resolve(args, filesystem);
             show_settings!(args);
 
+            // Initialize the cache.
+            let cache = cache.init()?;
+
             commands::python_install(
                 args.targets,
                 args.reinstall,
@@ -834,6 +837,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 globals.connectivity,
                 globals.preview,
                 cli.no_config,
+                &cache,
                 printer,
             )
             .await


### PR DESCRIPTION
## Summary

It's fine for this to be in the cache, I think, since we don't necessarily need to colocate it with the Python directory.

Closes https://github.com/astral-sh/uv/issues/5747.
