### PR TITLE
Fix invalid TOML syntax in examples of "config-settings" docs

### DIFF
--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -312,7 +312,7 @@ pub struct ResolverInstallerOptions {
         default = "{}",
         value_type = "dict",
         example = r#"
-            config-settings = { "editable_mode": "compat" }
+            config-settings = { editable_mode = "compat" }
         "#
     )]
     pub config_settings: Option<ConfigSettings>,
@@ -843,7 +843,7 @@ pub struct PipOptions {
         default = "{}",
         value_type = "dict",
         example = r#"
-            config-settings = { "editable_mode": "compat" }
+            config-settings = { editable_mode = "compat" }
         "#
     )]
     pub config_settings: Option<ConfigSettings>,

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -76,13 +76,13 @@ specified as `KEY=VALUE` pairs.
 
     ```toml
     [tool.uv]
-    config-settings = { "editable_mode": "compat" }
+    config-settings = { editable_mode = "compat" }
     ```
 === "uv.toml"
 
     ```toml
     
-    config-settings = { "editable_mode": "compat" }
+    config-settings = { editable_mode = "compat" }
     ```
 
 ---
@@ -1063,13 +1063,13 @@ specified as `KEY=VALUE` pairs.
 
     ```toml
     [tool.uv.pip]
-    config-settings = { "editable_mode": "compat" }
+    config-settings = { editable_mode = "compat" }
     ```
 === "uv.toml"
 
     ```toml
     [pip]
-    config-settings = { "editable_mode": "compat" }
+    config-settings = { editable_mode = "compat" }
     ```
 
 ---


### PR DESCRIPTION
## Summary

The snippet generated TOML errors when I copy/pasted it in my config file, I believe there was a typo.  :+1: 

## Test Plan

N/A
