### PR TITLE
Reject `pyproject.toml` in `--config-file`

### DIFF
--- a/crates/uv-settings/src/combine.rs
+++ b/crates/uv-settings/src/combine.rs
@@ -97,3 +97,9 @@ impl Combine for Option<ConfigSettings> {
         }
     }
 }
+
+impl Combine for serde::de::IgnoredAny {
+    fn combine(self, _other: Self) -> Self {
+        self
+    }
+}

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -31,7 +31,7 @@ pub(crate) struct Tools {
 /// A `[tool.uv]` section.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Default, Deserialize, CombineOptions, OptionsMetadata)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Options {
     #[serde(flatten)]
@@ -49,6 +49,24 @@ pub struct Options {
     )]
     pub override_dependencies: Option<Vec<Requirement<VerbatimParsedUrl>>>,
     pub constraint_dependencies: Option<Vec<Requirement<VerbatimParsedUrl>>>,
+
+    // NOTE(charlie): These fields should be kept in-sync with `ToolUv` in
+    // `crates/uv-workspace/src/pyproject.rs`.
+    #[serde(default, skip_serializing)]
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    workspace: serde::de::IgnoredAny,
+
+    #[serde(default, skip_serializing)]
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    sources: serde::de::IgnoredAny,
+
+    #[serde(default, skip_serializing)]
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    dev_dependencies: serde::de::IgnoredAny,
+
+    #[serde(default, skip_serializing)]
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    managed: serde::de::IgnoredAny,
 }
 
 /// Global settings, relevant to all invocations.

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -76,10 +76,14 @@ pub struct Tool {
     pub uv: Option<ToolUv>,
 }
 
+// NOTE(charlie): When adding fields to this struct, mark them as ignored on `Options` in
+// `crates/uv-settings/src/settings.rs`.
 #[derive(Serialize, Deserialize, OptionsMetadata, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct ToolUv {
+    /// The sources to use (e.g., workspace members, Git repositories, local paths) when resolving
+    /// dependencies.
     pub sources: Option<BTreeMap<PackageName, Source>>,
     /// The workspace definition for the project, if any.
     #[option_group]

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -110,6 +110,12 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
     //    found, this file is combined with the user configuration file. In this case, we don't
     //    search for `pyproject.toml` files, since we're not in a workspace.
     let filesystem = if let Some(config_file) = cli.config_file.as_ref() {
+        if config_file
+            .file_name()
+            .is_some_and(|file_name| file_name == "pyproject.toml")
+        {
+            warn_user!("The `--config-file` argument expects to receive a `uv.toml` file, not a `pyproject.toml`. If you're trying to run a command from another project, use the `--directory` argument instead.");
+        }
         Some(FilesystemOptions::from_file(config_file)?)
     } else if deprecated_isolated || cli.no_config {
         None

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -295,6 +295,7 @@
       ]
     },
     "sources": {
+      "description": "The sources to use (e.g., workspace members, Git repositories, local paths) when resolving dependencies.",
       "type": [
         "object",
         "null"


### PR DESCRIPTION
This already rejects `pyproject.toml`... but because the schema validation is relaxed (we allow unknown fields, and all fields are optional), a `pyproject.toml` doesn't get properly rejected here.

This PR makes the schema stricter, but in a safe way (by adding the other `tool.uv` fields, like `workspace`, as any).

Closes #5832.