### PR TITLE
Avoid reusing incompatible distributions across lock and sync

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -259,9 +259,6 @@ pub(crate) async fn add(
         .with_pyproject_toml(pyproject.to_toml()?)
         .context("Failed to update `pyproject.toml`")?;
 
-    // Initialize any shared state.
-    let state = SharedState::default();
-
     // Lock and sync the environment, if necessary.
     let lock = match project::lock::do_safe_lock(
         locked,
@@ -269,7 +266,6 @@ pub(crate) async fn add(
         project.workspace(),
         venv.interpreter(),
         settings.as_ref().into(),
-        &state,
         preview,
         connectivity,
         concurrency,
@@ -386,6 +382,9 @@ pub(crate) async fn add(
             (extras, dev)
         }
     };
+
+    // Initialize any shared state.
+    let state = SharedState::default();
 
     project::sync::do_sync(
         &project,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -104,9 +104,6 @@ pub(crate) async fn remove(
     )
     .await?;
 
-    // Initialize any shared state.
-    let state = SharedState::default();
-
     // Lock and sync the environment, if necessary.
     let lock = project::lock::do_safe_lock(
         locked,
@@ -114,7 +111,6 @@ pub(crate) async fn remove(
         project.workspace(),
         venv.interpreter(),
         settings.as_ref().into(),
-        &state,
         preview,
         connectivity,
         concurrency,
@@ -128,6 +124,9 @@ pub(crate) async fn remove(
     // TODO(ibraheem): Should we accept CLI overrides for this? Should we even sync here?
     let extras = ExtrasSpecification::All;
     let dev = true;
+
+    // Initialize any shared state.
+    let state = SharedState::default();
 
     project::sync::do_sync(
         &VirtualProject::Project(project),

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -259,7 +259,6 @@ pub(crate) async fn run(
                 project.workspace(),
                 venv.interpreter(),
                 settings.as_ref().into(),
-                &state,
                 preview,
                 connectivity,
                 concurrency,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -72,16 +72,12 @@ pub(crate) async fn sync(
     )
     .await?;
 
-    // Initialize any shared state.
-    let state = SharedState::default();
-
     let lock = match do_safe_lock(
         locked,
         frozen,
         project.workspace(),
         venv.interpreter(),
         settings.as_ref().into(),
-        &state,
         preview,
         connectivity,
         concurrency,
@@ -101,6 +97,9 @@ pub(crate) async fn sync(
         }
         Err(err) => return Err(err.into()),
     };
+
+    // Initialize any shared state.
+    let state = SharedState::default();
 
     // Perform the sync operation.
     do_sync(

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -18,8 +18,6 @@ use crate::commands::{project, ExitStatus};
 use crate::printer::Printer;
 use crate::settings::ResolverSettings;
 
-use super::SharedState;
-
 /// Run a command.
 #[allow(clippy::fn_params_excessive_bools)]
 pub(crate) async fn tree(
@@ -72,7 +70,6 @@ pub(crate) async fn tree(
         &workspace,
         &interpreter,
         settings.as_ref(),
-        &SharedState::default(),
         preview,
         connectivity,
         concurrency,


### PR DESCRIPTION
## Summary

We need to avoid using incompatible versions for build dependencies that are also part of the resolved
environment. This is a very subtle issue, but: when locking, we don't enforce platform
compatibility. So, if we reuse the resolver state to install, and the install itself has to
preform a resolution (e.g., for the build dependencies of a source distribution), that
resolution may choose incompatible versions.

The key property here is that there's a shared package between the build dependencies and the
project dependencies.

Closes https://github.com/astral-sh/uv/issues/5836.