### PR TITLE
Group resolver options in lockfile

### DIFF
--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
@@ -7,9 +7,11 @@ Ok(
         version: 1,
         fork_markers: None,
         requires_python: None,
-        resolution_mode: Highest,
-        prerelease_mode: IfNecessaryOrExplicit,
-        exclude_newer: None,
+        options: ResolverOptions {
+            resolution_mode: Highest,
+            prerelease_mode: IfNecessaryOrExplicit,
+            exclude_newer: None,
+        },
         distributions: [
             Distribution {
                 id: DistributionId {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
@@ -7,9 +7,11 @@ Ok(
         version: 1,
         fork_markers: None,
         requires_python: None,
-        resolution_mode: Highest,
-        prerelease_mode: IfNecessaryOrExplicit,
-        exclude_newer: None,
+        options: ResolverOptions {
+            resolution_mode: Highest,
+            prerelease_mode: IfNecessaryOrExplicit,
+            exclude_newer: None,
+        },
         distributions: [
             Distribution {
                 id: DistributionId {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_required_present.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_required_present.snap
@@ -7,9 +7,11 @@ Ok(
         version: 1,
         fork_markers: None,
         requires_python: None,
-        resolution_mode: Highest,
-        prerelease_mode: IfNecessaryOrExplicit,
-        exclude_newer: None,
+        options: ResolverOptions {
+            resolution_mode: Highest,
+            prerelease_mode: IfNecessaryOrExplicit,
+            exclude_newer: None,
+        },
         distributions: [
             Distribution {
                 id: DistributionId {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
@@ -7,9 +7,11 @@ Ok(
         version: 1,
         fork_markers: None,
         requires_python: None,
-        resolution_mode: Highest,
-        prerelease_mode: IfNecessaryOrExplicit,
-        exclude_newer: None,
+        options: ResolverOptions {
+            resolution_mode: Highest,
+            prerelease_mode: IfNecessaryOrExplicit,
+            exclude_newer: None,
+        },
         distributions: [
             Distribution {
                 id: DistributionId {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
@@ -7,9 +7,11 @@ Ok(
         version: 1,
         fork_markers: None,
         requires_python: None,
-        resolution_mode: Highest,
-        prerelease_mode: IfNecessaryOrExplicit,
-        exclude_newer: None,
+        options: ResolverOptions {
+            resolution_mode: Highest,
+            prerelease_mode: IfNecessaryOrExplicit,
+            exclude_newer: None,
+        },
         distributions: [
             Distribution {
                 id: DistributionId {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
@@ -7,9 +7,11 @@ Ok(
         version: 1,
         fork_markers: None,
         requires_python: None,
-        resolution_mode: Highest,
-        prerelease_mode: IfNecessaryOrExplicit,
-        exclude_newer: None,
+        options: ResolverOptions {
+            resolution_mode: Highest,
+            prerelease_mode: IfNecessaryOrExplicit,
+            exclude_newer: None,
+        },
         distributions: [
             Distribution {
                 id: DistributionId {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
@@ -7,9 +7,11 @@ Ok(
         version: 1,
         fork_markers: None,
         requires_python: None,
-        resolution_mode: Highest,
-        prerelease_mode: IfNecessaryOrExplicit,
-        exclude_newer: None,
+        options: ResolverOptions {
+            resolution_mode: Highest,
+            prerelease_mode: IfNecessaryOrExplicit,
+            exclude_newer: None,
+        },
         distributions: [
             Distribution {
                 id: DistributionId {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
@@ -7,9 +7,11 @@ Ok(
         version: 1,
         fork_markers: None,
         requires_python: None,
-        resolution_mode: Highest,
-        prerelease_mode: IfNecessaryOrExplicit,
-        exclude_newer: None,
+        options: ResolverOptions {
+            resolution_mode: Highest,
+            prerelease_mode: IfNecessaryOrExplicit,
+            exclude_newer: None,
+        },
         distributions: [
             Distribution {
                 id: DistributionId {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_directory.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_directory.snap
@@ -7,9 +7,11 @@ Ok(
         version: 1,
         fork_markers: None,
         requires_python: None,
-        resolution_mode: Highest,
-        prerelease_mode: IfNecessaryOrExplicit,
-        exclude_newer: None,
+        options: ResolverOptions {
+            resolution_mode: Highest,
+            prerelease_mode: IfNecessaryOrExplicit,
+            exclude_newer: None,
+        },
         distributions: [
             Distribution {
                 id: DistributionId {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_editable.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_editable.snap
@@ -7,9 +7,11 @@ Ok(
         version: 1,
         fork_markers: None,
         requires_python: None,
-        resolution_mode: Highest,
-        prerelease_mode: IfNecessaryOrExplicit,
-        exclude_newer: None,
+        options: ResolverOptions {
+            resolution_mode: Highest,
+            prerelease_mode: IfNecessaryOrExplicit,
+            exclude_newer: None,
+        },
         distributions: [
             Distribution {
                 id: DistributionId {

--- a/crates/uv/tests/branching_urls.rs
+++ b/crates/uv/tests/branching_urls.rs
@@ -212,6 +212,8 @@ fn root_package_splits_transitive_too() -> Result<()> {
         "python_version < '3.12'",
         "python_version >= '3.12'",
     ]
+
+    [options]
     exclude-newer = "2024-03-25 00:00:00 UTC"
 
     [[distribution]]
@@ -386,6 +388,8 @@ fn root_package_splits_other_dependencies_too() -> Result<()> {
         "python_version < '3.12'",
         "python_version >= '3.12'",
     ]
+
+    [options]
     exclude-newer = "2024-03-25 00:00:00 UTC"
 
     [[distribution]]
@@ -531,6 +535,8 @@ fn branching_between_registry_and_direct_url() -> Result<()> {
         "python_version < '3.12'",
         "python_version >= '3.12'",
     ]
+
+    [options]
     exclude-newer = "2024-03-25 00:00:00 UTC"
 
     [[distribution]]
@@ -608,6 +614,8 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
         "python_version < '3.12'",
         "python_version >= '3.12'",
     ]
+
+    [options]
     exclude-newer = "2024-03-25 00:00:00 UTC"
 
     [[distribution]]
@@ -723,6 +731,8 @@ fn dont_pre_visit_url_packages() -> Result<()> {
     assert_snapshot!(fs_err::read_to_string(context.temp_dir.join("uv.lock"))?, @r###"
     version = 1
     requires-python = ">=3.11, <3.13"
+
+    [options]
     exclude-newer = "2024-03-25 00:00:00 UTC"
 
     [[distribution]]

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -69,6 +69,8 @@ fn add_registry() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -222,6 +224,8 @@ fn add_git() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -427,6 +431,8 @@ fn add_git_raw() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -581,6 +587,8 @@ fn add_unnamed() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -674,6 +682,8 @@ fn add_remove_dev() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -790,6 +800,8 @@ fn add_remove_dev() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -875,6 +887,8 @@ fn add_remove_optional() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -992,6 +1006,8 @@ fn add_remove_optional() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -1116,6 +1132,8 @@ fn add_remove_workspace() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -1189,6 +1207,8 @@ fn add_remove_workspace() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -1298,6 +1318,8 @@ fn add_workspace_editable() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -1493,6 +1515,8 @@ fn update() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -1760,6 +1784,8 @@ fn add_no_clean() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -1892,6 +1918,8 @@ fn remove_registry() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -2462,6 +2490,8 @@ fn add_lower_bound_optional() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -2667,6 +2697,8 @@ fn add_virtual() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -66,6 +66,8 @@ fn lock_wheel_registry() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -238,6 +240,8 @@ fn lock_sdist_git() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -310,6 +314,8 @@ fn lock_wheel_url() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -409,6 +415,8 @@ fn lock_sdist_url() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -509,6 +517,8 @@ fn lock_project_extra() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -735,6 +745,8 @@ fn lock_dependency_extra() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -922,6 +934,8 @@ fn lock_conditional_dependency_extra() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.7"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -1173,6 +1187,8 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -1343,6 +1359,8 @@ fn lock_upgrade_log() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -1419,6 +1437,8 @@ fn lock_upgrade_log() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -1504,6 +1524,8 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
                 "sys_platform == 'win32'",
                 "sys_platform != 'win32'",
             ]
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -1584,6 +1606,8 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
             "sys_platform == 'win32'",
             "sys_platform != 'win32'",
         ]
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -1654,6 +1678,8 @@ fn lock_preference() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -1710,6 +1736,8 @@ fn lock_preference() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -1752,6 +1780,8 @@ fn lock_preference() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -1814,6 +1844,8 @@ fn lock_git_sha() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -1871,6 +1903,8 @@ fn lock_git_sha() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -1912,6 +1946,8 @@ fn lock_git_sha() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -2011,6 +2047,8 @@ fn lock_requires_python() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.7"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -2160,6 +2198,8 @@ fn lock_requires_python() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.7.9"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -2299,6 +2339,8 @@ fn lock_requires_python() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -2429,6 +2471,8 @@ fn lock_requires_python_wheels() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12, <3.13"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -2499,6 +2543,8 @@ fn lock_requires_python_wheels() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.11, <3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -2594,6 +2640,8 @@ fn lock_requires_python_star() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.11, <3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -2704,6 +2752,8 @@ fn lock_requires_python_pre() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.11"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -2813,6 +2863,8 @@ fn lock_requires_python_unbounded() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = "<=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -2900,6 +2952,8 @@ fn lock_python_version_marker_complement() -> Result<()> {
                 "python_full_version > '3.10' and python_version < '3.10' and python_version > '3.10'",
                 "python_full_version > '3.10' and python_version > '3.10'",
             ]
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -2985,6 +3039,8 @@ fn lock_dev() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -3086,6 +3142,8 @@ fn lock_conditional_unconditional() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -3148,6 +3206,8 @@ fn lock_multiple_markers() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -3250,6 +3310,8 @@ fn relative_and_absolute_paths() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.11, <3.13"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -3314,6 +3376,8 @@ fn lock_cycles() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -3502,6 +3566,8 @@ fn lock_new_extras() -> Result<()> {
                 lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -3612,6 +3678,8 @@ fn lock_new_extras() -> Result<()> {
             lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -3829,6 +3897,8 @@ fn lock_resolution_mode() -> Result<()> {
             lock, @r###"
             version = 1
             requires-python = ">=3.12"
+
+            [options]
             exclude-newer = "2024-03-25 00:00:00 UTC"
 
             [[distribution]]
@@ -3906,6 +3976,8 @@ fn lock_resolution_mode() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         resolution-mode = "lowest-direct"
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
@@ -4057,6 +4129,8 @@ fn lock_same_version_multiple_urls() -> Result<()> {
             "sys_platform == 'darwin'",
             "sys_platform != 'darwin'",
         ]
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -4238,6 +4312,8 @@ fn lock_exclusion() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -4341,6 +4417,8 @@ fn lock_dev_transitive() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -4428,6 +4506,8 @@ fn lock_redact() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -4546,6 +4626,8 @@ fn lock_no_sources() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]
@@ -4600,6 +4682,8 @@ fn lock_no_sources() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
+
+        [options]
         exclude-newer = "2024-03-25 00:00:00 UTC"
 
         [[distribution]]


### PR DESCRIPTION
There are three options that determine resolver behavior:

* resolution mode
* prerelease mode
* exclude newer

They are different from the other top level options: If they mismatch, we recreate the resolution. To distinguish them from the rest of the lockfile, we group them under an `[options]` header.

1/3 for #4893