### PR TITLE
Assume `git+` prefix when URLs end in `.git`

### DIFF
--- a/crates/pypi-types/src/parsed_url.rs
+++ b/crates/pypi-types/src/parsed_url.rs
@@ -347,6 +347,11 @@ impl TryFrom<Url> for ParsedUrl {
                     message: "Unknown scheme",
                 }),
             }
+        } else if Path::new(url.path())
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("git"))
+        {
+            Ok(Self::Git(ParsedGitUrl::try_from(url)?))
         } else if url.scheme().eq_ignore_ascii_case("file") {
             let path = url
                 .to_file_path()

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -106,7 +106,7 @@ pub(crate) async fn add(
 
     // Read the requirements.
     let RequirementsSpecification { requirements, .. } =
-        RequirementsSpecification::from_sources(&requirements, &[], &[], &client_builder).await?;
+        RequirementsSpecification::from_simple_sources(&requirements, &client_builder).await?;
 
     // TODO(charlie): These are all default values. We should consider whether we want to make them
     // optional on the downstream APIs.

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1357,6 +1357,31 @@ fn install_git_public_https() {
     context.assert_installed("uv_public_pypackage", "0.1.0");
 }
 
+/// Install a package from a public GitHub repository, omitting the `git+` prefix
+#[test]
+#[cfg(feature = "git")]
+fn install_implicit_git_public_https() {
+    let context = TestContext::new("3.8");
+
+    uv_snapshot!(
+        context
+        .pip_install()
+        .arg("uv-public-pypackage @ https://github.com/astral-test/uv-public-pypackage.git"),
+        @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage.git@b270df1a2fb5d012294e9aaf05e7e0bab1e6a389)
+    "###);
+
+    context.assert_installed("uv_public_pypackage", "0.1.0");
+}
+
 /// Install and update a package from a public GitHub repository
 #[test]
 #[cfg(feature = "git")]


### PR DESCRIPTION
## Summary

Right now, this applies _everywhere_, so the following also works:

```
pip install "elmer-circuitbuilder @ https://github.com/ElmerCSC/elmer_circuitbuilder.git"
```

I actually think that's ok?

Closes https://github.com/astral-sh/uv/issues/5866.
