### PR TITLE
Use a larger runner for Windows test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on:
-      labels: "windows-latest-large"
+      labels: "windows-latest-xlarge"
     name: "cargo test | windows"
     steps:
       - name: Create Dev Drive using ReFS
@@ -281,7 +281,7 @@ jobs:
           CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
           RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
         run: |
-          cargo nextest run --no-default-features --features python,pypi,git --workspace --status-level skip --failure-output immediate-final --no-fail-fast -j 12 --final-status-level slow
+          cargo nextest run --no-default-features --features python,pypi,git --workspace --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 
       - name: "Smoke test"
         working-directory: ${{ env.DEV_DRIVE }}/uv


### PR DESCRIPTION
From 8 to 16 cores, 32 to 64 GB ram. Testing on Windows first because it's the bottleneck.

Previously tested in #2515 to no effect, maybe better now that we have a development drive?
