### PR TITLE
Use a larger runner for macOS test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on:
-      labels: "macos-14"
+      labels: "macos-latest-xlarge"
     name: "cargo test | macos"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
From 3 to 6 (+8 GPU) cores, 7 to 14 GB ram.

Related:
- https://github.com/astral-sh/uv/pull/5873
