### PR TITLE
Use a larger runner for Linux test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on:
-      labels: "ubuntu-latest-large"
+      labels: "ubuntu-latest-xlarge"
     name: "cargo test | ubuntu"
     steps:
       - uses: actions/checkout@v4
@@ -171,7 +171,7 @@ jobs:
           cargo nextest run \
             --features python-patch \
             --workspace \
-            --status-level skip --failure-output immediate-final --no-fail-fast -j 12 --final-status-level slow
+            --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 
       - name: "Smoke test"
         run: |


### PR DESCRIPTION
From 8 to 16 cores, 32 to 64 GB RAM for a 2x per minute cost increase.

As in:

- #5874 
- #5873 