### PR TITLE
Combine fetch and resolve steps in Git resolver

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1121,29 +1121,12 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             return Err(Error::HashesNotSupportedGit(source.to_string()));
         }
 
-        // Resolve to a precise Git SHA.
-        let url = if let Some(url) = self
-            .build_context
-            .git()
-            .resolve(
-                resource.git,
-                client.unmanaged.uncached_client().client(),
-                self.build_context.cache().bucket(CacheBucket::Git),
-                self.reporter.clone().map(Facade::from),
-            )
-            .await?
-        {
-            Cow::Owned(url)
-        } else {
-            Cow::Borrowed(resource.git)
-        };
-
         // Fetch the Git repository.
         let fetch = self
             .build_context
             .git()
             .fetch(
-                &url,
+                resource.git,
                 client.unmanaged.uncached_client().client(),
                 self.build_context.cache().bucket(CacheBucket::Git),
                 self.reporter.clone().map(Facade::from),
@@ -1208,29 +1191,12 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             return Err(Error::HashesNotSupportedGit(source.to_string()));
         }
 
-        // Resolve to a precise Git SHA.
-        let url = if let Some(url) = self
-            .build_context
-            .git()
-            .resolve(
-                resource.git,
-                client.unmanaged.uncached_client().client(),
-                self.build_context.cache().bucket(CacheBucket::Git),
-                self.reporter.clone().map(Facade::from),
-            )
-            .await?
-        {
-            Cow::Owned(url)
-        } else {
-            Cow::Borrowed(resource.git)
-        };
-
         // Fetch the Git repository.
         let fetch = self
             .build_context
             .git()
             .fetch(
-                &url,
+                resource.git,
                 client.unmanaged.uncached_client().client(),
                 self.build_context.cache().bucket(CacheBucket::Git),
                 self.reporter.clone().map(Facade::from),

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -2436,7 +2436,7 @@ fn lock_git_sha() -> Result<()> {
         [[distribution]]
         name = "uv-public-pypackage"
         version = "0.1.0"
-        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=main#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
+        source = { git = "https://github.com/astral-test/uv-public-pypackage?rev=main#b270df1a2fb5d012294e9aaf05e7e0bab1e6a389" }
         "###
         );
     });


### PR DESCRIPTION
## Summary

Whenever we call `resolve`, we immediately call `fetch` after. And in some cases `resolve` actually calls `fetch` internally. It seems a lot simpler to just merge these into one method that returns a `Fetch` (which itself contains the fully-resolved URL).

Closes https://github.com/astral-sh/uv/issues/5876.
