### PR TITLE
Avoid requires-python warning in virtual-only workspace

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -239,11 +239,17 @@ impl Workspace {
         }
     }
 
+    /// Returns `true` if the workspace has a virtual root.
     pub fn is_virtual(&self) -> bool {
         !self
             .packages
             .values()
             .any(|member| *member.root() == self.install_path)
+    }
+
+    /// Returns `true` if the workspace consists solely of a virtual root.
+    pub fn only_virtual(&self) -> bool {
+        self.packages.is_empty()
     }
 
     /// Returns the set of requirements that include all packages in the workspace.

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -265,7 +265,13 @@ async fn do_lock(
     } else {
         let default =
             RequiresPython::greater_than_equal_version(&interpreter.python_minor_version());
-        warn_user!("No `requires-python` value found in the workspace. Defaulting to `{default}`.");
+        if workspace.only_virtual() {
+            debug!("No `requires-python` in virtual-only workspace. Defaulting to `{default}`.");
+        } else {
+            warn_user!(
+                "No `requires-python` value found in the workspace. Defaulting to `{default}`."
+            );
+        }
         default
     };
 

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -2771,7 +2771,6 @@ fn add_virtual() -> Result<()> {
 
     ----- stderr -----
     warning: `uv add` is experimental and may change without warning
-    warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -183,7 +183,6 @@ fn empty() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning
-    warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
     Resolved 0 packages in [TIME]
     Audited 0 packages in [TIME]
     "###);
@@ -198,7 +197,6 @@ fn empty() -> Result<()> {
 
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning
-    warning: No `requires-python` value found in the workspace. Defaulting to `>=3.12`.
     Resolved 0 packages in [TIME]
     Audited 0 packages in [TIME]
     "###);


### PR DESCRIPTION
## Summary

There's no way for the user to address this, so we shouldn't show it.
