### PR TITLE
Show build and install summaries in `uv run` and `uv tool run`

### DIFF
--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -38,6 +38,7 @@ use uv_resolver::{
 use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
 use uv_warnings::warn_user;
 
+use crate::commands::pip::loggers::DefaultResolveLogger;
 use crate::commands::pip::{operations, resolution_environment};
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -360,9 +361,9 @@ pub(crate) async fn pip_compile(
         &build_dispatch,
         concurrency,
         options,
+        Box::new(DefaultResolveLogger),
         printer,
         preview,
-        false,
     )
     .await
     {

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -29,7 +29,7 @@ use uv_resolver::{
 };
 use uv_types::{BuildIsolation, HashStrategy};
 
-use crate::commands::pip::loggers::DefaultInstallLogger;
+use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::{operations, resolution_environment};
 use crate::commands::{elapsed, ExitStatus, SharedState};
@@ -351,9 +351,9 @@ pub(crate) async fn pip_install(
         &build_dispatch,
         concurrency,
         options,
+        Box::new(DefaultResolveLogger),
         printer,
         preview,
-        false,
     )
     .await
     {

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -29,6 +29,7 @@ use uv_resolver::{
 };
 use uv_types::{BuildIsolation, HashStrategy};
 
+use crate::commands::pip::loggers::DefaultInstallLogger;
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::{operations, resolution_environment};
 use crate::commands::{elapsed, ExitStatus, SharedState};
@@ -383,6 +384,7 @@ pub(crate) async fn pip_install(
         &build_dispatch,
         &cache,
         &environment,
+        Box::new(DefaultInstallLogger),
         dry_run,
         printer,
         preview,

--- a/crates/uv/src/commands/pip/loggers.rs
+++ b/crates/uv/src/commands/pip/loggers.rs
@@ -1,0 +1,214 @@
+use std::fmt;
+use std::fmt::Write;
+
+use itertools::Itertools;
+use owo_colors::OwoColorize;
+
+use distribution_types::{CachedDist, InstalledDist, InstalledMetadata, LocalDist, Name};
+
+use crate::commands::{elapsed, ChangeEvent, ChangeEventKind};
+use crate::printer::Printer;
+
+/// A trait to handle logging during install operations.
+pub(crate) trait InstallLogger {
+    /// Log the completion of the audit phase.
+    fn on_audit(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result;
+
+    /// Log the completion of the preparation phase.
+    fn on_prepare(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result;
+
+    /// Log the completion of the uninstallation phase.
+    fn on_uninstall(
+        &self,
+        count: usize,
+        start: std::time::Instant,
+        printer: Printer,
+    ) -> fmt::Result;
+
+    /// Log the completion of the installation phase.
+    fn on_install(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result;
+
+    /// Log the completion of the operation.
+    fn on_complete(
+        &self,
+        installed: Vec<CachedDist>,
+        reinstalled: Vec<InstalledDist>,
+        uninstalled: Vec<InstalledDist>,
+        printer: Printer,
+    ) -> fmt::Result;
+}
+
+/// The default logger for install operations.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct DefaultInstallLogger;
+
+impl InstallLogger for DefaultInstallLogger {
+    fn on_audit(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result {
+        let s = if count == 1 { "" } else { "s" };
+        writeln!(
+            printer.stderr(),
+            "{}",
+            format!(
+                "Audited {} {}",
+                format!("{} package{}", count, s).bold(),
+                format!("in {}", elapsed(start.elapsed())).dimmed()
+            )
+            .dimmed()
+        )
+    }
+
+    fn on_prepare(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result {
+        let s = if count == 1 { "" } else { "s" };
+        writeln!(
+            printer.stderr(),
+            "{}",
+            format!(
+                "Prepared {} {}",
+                format!("{} package{}", count, s).bold(),
+                format!("in {}", elapsed(start.elapsed())).dimmed()
+            )
+            .dimmed()
+        )
+    }
+
+    fn on_uninstall(
+        &self,
+        count: usize,
+        start: std::time::Instant,
+        printer: Printer,
+    ) -> fmt::Result {
+        let s = if count == 1 { "" } else { "s" };
+        writeln!(
+            printer.stderr(),
+            "{}",
+            format!(
+                "Uninstalled {} {}",
+                format!("{} package{}", count, s).bold(),
+                format!("in {}", elapsed(start.elapsed())).dimmed()
+            )
+            .dimmed()
+        )
+    }
+
+    fn on_install(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result {
+        let s = if count == 1 { "" } else { "s" };
+        writeln!(
+            printer.stderr(),
+            "{}",
+            format!(
+                "Installed {} {}",
+                format!("{} package{}", count, s).bold(),
+                format!("in {}", elapsed(start.elapsed())).dimmed()
+            )
+            .dimmed()
+        )
+    }
+
+    fn on_complete(
+        &self,
+        installed: Vec<CachedDist>,
+        reinstalled: Vec<InstalledDist>,
+        uninstalled: Vec<InstalledDist>,
+        printer: Printer,
+    ) -> fmt::Result {
+        for event in uninstalled
+            .into_iter()
+            .chain(reinstalled)
+            .map(|distribution| ChangeEvent {
+                dist: LocalDist::from(distribution),
+                kind: ChangeEventKind::Removed,
+            })
+            .chain(installed.into_iter().map(|distribution| ChangeEvent {
+                dist: LocalDist::from(distribution),
+                kind: ChangeEventKind::Added,
+            }))
+            .sorted_unstable_by(|a, b| {
+                a.dist
+                    .name()
+                    .cmp(b.dist.name())
+                    .then_with(|| a.kind.cmp(&b.kind))
+                    .then_with(|| a.dist.installed_version().cmp(&b.dist.installed_version()))
+            })
+        {
+            match event.kind {
+                ChangeEventKind::Added => {
+                    writeln!(
+                        printer.stderr(),
+                        " {} {}{}",
+                        "+".green(),
+                        event.dist.name().bold(),
+                        event.dist.installed_version().dimmed()
+                    )?;
+                }
+                ChangeEventKind::Removed => {
+                    writeln!(
+                        printer.stderr(),
+                        " {} {}{}",
+                        "-".red(),
+                        event.dist.name().bold(),
+                        event.dist.installed_version().dimmed()
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A logger that only shows installs and uninstalls, the minimal logging necessary to understand
+/// environment changes.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct SummaryInstallLogger;
+
+impl InstallLogger for SummaryInstallLogger {
+    fn on_audit(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result {
+        Ok(())
+    }
+
+    fn on_prepare(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result {
+        Ok(())
+    }
+
+    fn on_uninstall(
+        &self,
+        count: usize,
+        start: std::time::Instant,
+        printer: Printer,
+    ) -> fmt::Result {
+        let s = if count == 1 { "" } else { "s" };
+        writeln!(
+            printer.stderr(),
+            "{}",
+            format!(
+                "Uninstalled {} {}",
+                format!("{} package{}", count, s).bold(),
+                format!("in {}", elapsed(start.elapsed())).dimmed()
+            )
+            .dimmed()
+        )
+    }
+
+    fn on_install(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result {
+        let s = if count == 1 { "" } else { "s" };
+        writeln!(
+            printer.stderr(),
+            "{}",
+            format!(
+                "Installed {} {}",
+                format!("{} package{}", count, s).bold(),
+                format!("in {}", elapsed(start.elapsed())).dimmed()
+            )
+            .dimmed()
+        )
+    }
+
+    fn on_complete(
+        &self,
+        installed: Vec<CachedDist>,
+        reinstalled: Vec<InstalledDist>,
+        uninstalled: Vec<InstalledDist>,
+        printer: Printer,
+    ) -> fmt::Result {
+        Ok(())
+    }
+}

--- a/crates/uv/src/commands/pip/loggers.rs
+++ b/crates/uv/src/commands/pip/loggers.rs
@@ -50,7 +50,7 @@ impl InstallLogger for DefaultInstallLogger {
             "{}",
             format!(
                 "Audited {} {}",
-                format!("{} package{}", count, s).bold(),
+                format!("{count} package{s}").bold(),
                 format!("in {}", elapsed(start.elapsed())).dimmed()
             )
             .dimmed()
@@ -64,7 +64,7 @@ impl InstallLogger for DefaultInstallLogger {
             "{}",
             format!(
                 "Prepared {} {}",
-                format!("{} package{}", count, s).bold(),
+                format!("{count} package{s}").bold(),
                 format!("in {}", elapsed(start.elapsed())).dimmed()
             )
             .dimmed()
@@ -83,7 +83,7 @@ impl InstallLogger for DefaultInstallLogger {
             "{}",
             format!(
                 "Uninstalled {} {}",
-                format!("{} package{}", count, s).bold(),
+                format!("{count} package{s}").bold(),
                 format!("in {}", elapsed(start.elapsed())).dimmed()
             )
             .dimmed()
@@ -97,7 +97,7 @@ impl InstallLogger for DefaultInstallLogger {
             "{}",
             format!(
                 "Installed {} {}",
-                format!("{} package{}", count, s).bold(),
+                format!("{count} package{s}").bold(),
                 format!("in {}", elapsed(start.elapsed())).dimmed()
             )
             .dimmed()
@@ -161,11 +161,21 @@ impl InstallLogger for DefaultInstallLogger {
 pub(crate) struct SummaryInstallLogger;
 
 impl InstallLogger for SummaryInstallLogger {
-    fn on_audit(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result {
+    fn on_audit(
+        &self,
+        _count: usize,
+        _start: std::time::Instant,
+        _printer: Printer,
+    ) -> fmt::Result {
         Ok(())
     }
 
-    fn on_prepare(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result {
+    fn on_prepare(
+        &self,
+        _count: usize,
+        _start: std::time::Instant,
+        _printer: Printer,
+    ) -> fmt::Result {
         Ok(())
     }
 
@@ -181,7 +191,7 @@ impl InstallLogger for SummaryInstallLogger {
             "{}",
             format!(
                 "Uninstalled {} {}",
-                format!("{} package{}", count, s).bold(),
+                format!("{count} package{s}").bold(),
                 format!("in {}", elapsed(start.elapsed())).dimmed()
             )
             .dimmed()
@@ -195,7 +205,7 @@ impl InstallLogger for SummaryInstallLogger {
             "{}",
             format!(
                 "Installed {} {}",
-                format!("{} package{}", count, s).bold(),
+                format!("{count} package{s}").bold(),
                 format!("in {}", elapsed(start.elapsed())).dimmed()
             )
             .dimmed()
@@ -204,10 +214,57 @@ impl InstallLogger for SummaryInstallLogger {
 
     fn on_complete(
         &self,
-        installed: Vec<CachedDist>,
-        reinstalled: Vec<InstalledDist>,
-        uninstalled: Vec<InstalledDist>,
+        _installed: Vec<CachedDist>,
+        _reinstalled: Vec<InstalledDist>,
+        _uninstalled: Vec<InstalledDist>,
+        _printer: Printer,
+    ) -> fmt::Result {
+        Ok(())
+    }
+}
+
+/// A trait to handle logging during resolve operations.
+pub(crate) trait ResolveLogger {
+    /// Log the completion of the operation.
+    fn on_complete(&self, count: usize, start: std::time::Instant, printer: Printer)
+        -> fmt::Result;
+}
+
+/// The default logger for resolve operations.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct DefaultResolveLogger;
+
+impl ResolveLogger for DefaultResolveLogger {
+    fn on_complete(
+        &self,
+        count: usize,
+        start: std::time::Instant,
         printer: Printer,
+    ) -> fmt::Result {
+        let s = if count == 1 { "" } else { "s" };
+        writeln!(
+            printer.stderr(),
+            "{}",
+            format!(
+                "Resolved {} {}",
+                format!("{count} package{s}").bold(),
+                format!("in {}", elapsed(start.elapsed())).dimmed()
+            )
+            .dimmed()
+        )
+    }
+}
+
+/// A logger that doesn't show any output.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct SummaryResolveLogger;
+
+impl ResolveLogger for SummaryResolveLogger {
+    fn on_complete(
+        &self,
+        _count: usize,
+        _start: std::time::Instant,
+        _printer: Printer,
     ) -> fmt::Result {
         Ok(())
     }

--- a/crates/uv/src/commands/pip/mod.rs
+++ b/crates/uv/src/commands/pip/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod compile;
 pub(crate) mod freeze;
 pub(crate) mod install;
 pub(crate) mod list;
+pub(crate) mod loggers;
 pub(crate) mod operations;
 pub(crate) mod show;
 pub(crate) mod sync;

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -1,11 +1,10 @@
 //! Common operations shared across the `pip` API and subcommands.
 
-use std::fmt::{self, Write};
-use std::path::PathBuf;
-
 use anyhow::{anyhow, Context};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
+use std::fmt::{self, Write};
+use std::path::PathBuf;
 use tracing::debug;
 
 use distribution_types::{
@@ -40,6 +39,7 @@ use uv_resolver::{
 use uv_types::{HashStrategy, InFlight, InstalledPackagesProvider};
 use uv_warnings::warn_user;
 
+use crate::commands::pip::loggers::InstallLogger;
 use crate::commands::reporters::{InstallReporter, PrepareReporter, ResolverReporter};
 use crate::commands::{compile_bytecode, elapsed, ChangeEvent, ChangeEventKind, DryRunEvent};
 use crate::printer::Printer;
@@ -322,6 +322,7 @@ pub(crate) async fn install(
     build_dispatch: &BuildDispatch<'_>,
     cache: &Cache,
     venv: &PythonEnvironment,
+    logger: Box<dyn InstallLogger>,
     dry_run: bool,
     printer: Printer,
     preview: PreviewMode,
@@ -365,17 +366,7 @@ pub(crate) async fn install(
 
     // Nothing to do.
     if remote.is_empty() && cached.is_empty() && reinstalls.is_empty() && extraneous.is_empty() {
-        let s = if resolution.len() == 1 { "" } else { "s" };
-        writeln!(
-            printer.stderr(),
-            "{}",
-            format!(
-                "Audited {} {}",
-                format!("{} package{}", resolution.len(), s).bold(),
-                format!("in {}", elapsed(start.elapsed())).dimmed()
-            )
-            .dimmed()
-        )?;
+        logger.on_audit(resolution.len(), start, printer)?;
         return Ok(());
     }
 
@@ -410,17 +401,7 @@ pub(crate) async fn install(
             .await
             .context("Failed to prepare distributions")?;
 
-        let s = if wheels.len() == 1 { "" } else { "s" };
-        writeln!(
-            printer.stderr(),
-            "{}",
-            format!(
-                "Prepared {} {}",
-                format!("{} package{}", wheels.len(), s).bold(),
-                format!("in {}", elapsed(start.elapsed())).dimmed()
-            )
-            .dimmed()
-        )?;
+        logger.on_prepare(wheels.len(), start, printer)?;
 
         wheels
     };
@@ -453,21 +434,7 @@ pub(crate) async fn install(
             }
         }
 
-        let s = if extraneous.len() + reinstalls.len() == 1 {
-            ""
-        } else {
-            "s"
-        };
-        writeln!(
-            printer.stderr(),
-            "{}",
-            format!(
-                "Uninstalled {} {}",
-                format!("{} package{}", extraneous.len() + reinstalls.len(), s).bold(),
-                format!("in {}", elapsed(start.elapsed())).dimmed()
-            )
-            .dimmed()
-        )?;
+        logger.on_uninstall(extraneous.len() + reinstalls.len(), start, printer)?;
     }
 
     // Install the resolved distributions.
@@ -483,17 +450,7 @@ pub(crate) async fn install(
             // task.
             .install_blocking(wheels)?;
 
-        let s = if wheels.len() == 1 { "" } else { "s" };
-        writeln!(
-            printer.stderr(),
-            "{}",
-            format!(
-                "Installed {} {}",
-                format!("{} package{}", wheels.len(), s).bold(),
-                format!("in {}", elapsed(start.elapsed())).dimmed()
-            )
-            .dimmed()
-        )?;
+        logger.on_install(wheels.len(), start, printer)?;
     }
 
     if compile {
@@ -501,7 +458,7 @@ pub(crate) async fn install(
     }
 
     // Notify the user of any environment modifications.
-    report_modifications(wheels, reinstalls, extraneous, printer)?;
+    logger.on_complete(wheels, reinstalls, extraneous, printer)?;
 
     Ok(())
 }

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -28,6 +28,7 @@ use uv_resolver::{
 };
 use uv_types::{BuildIsolation, HashStrategy};
 
+use crate::commands::pip::loggers::DefaultInstallLogger;
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::{operations, resolution_environment};
 use crate::commands::{ExitStatus, SharedState};
@@ -331,6 +332,7 @@ pub(crate) async fn pip_sync(
         &build_dispatch,
         &cache,
         &environment,
+        Box::new(DefaultInstallLogger),
         dry_run,
         printer,
         preview,

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -28,7 +28,7 @@ use uv_resolver::{
 };
 use uv_types::{BuildIsolation, HashStrategy};
 
-use crate::commands::pip::loggers::DefaultInstallLogger;
+use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::{operations, resolution_environment};
 use crate::commands::{ExitStatus, SharedState};
@@ -299,9 +299,9 @@ pub(crate) async fn pip_sync(
         &build_dispatch,
         concurrency,
         options,
+        Box::new(DefaultResolveLogger),
         printer,
         preview,
-        false,
     )
     .await
     {

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -24,6 +24,7 @@ use uv_workspace::pyproject::{DependencyType, Source, SourceError};
 use uv_workspace::pyproject_mut::{ArrayEdit, PyProjectTomlMut};
 use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace};
 
+use crate::commands::pip::loggers::DefaultInstallLogger;
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::resolution_environment;
 use crate::commands::project::ProjectError;
@@ -400,6 +401,7 @@ pub(crate) async fn add(
         Modifications::Sufficient,
         settings.as_ref().into(),
         &state,
+        Box::new(DefaultInstallLogger),
         preview,
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -24,7 +24,7 @@ use uv_workspace::pyproject::{DependencyType, Source, SourceError};
 use uv_workspace::pyproject_mut::{ArrayEdit, PyProjectTomlMut};
 use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace};
 
-use crate::commands::pip::loggers::DefaultInstallLogger;
+use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::resolution_environment;
 use crate::commands::project::ProjectError;
@@ -268,6 +268,7 @@ pub(crate) async fn add(
         project.workspace(),
         venv.interpreter(),
         settings.as_ref().into(),
+        Box::new(DefaultResolveLogger),
         preview,
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -1,6 +1,6 @@
 use tracing::debug;
 
-use crate::commands::pip::loggers::InstallLogger;
+use crate::commands::pip::loggers::{InstallLogger, ResolveLogger};
 use crate::commands::project::{resolve_environment, sync_environment};
 use crate::commands::SharedState;
 use crate::printer::Printer;
@@ -31,6 +31,7 @@ impl CachedEnvironment {
         interpreter: Interpreter,
         settings: &ResolverInstallerSettings,
         state: &SharedState,
+        resolve: Box<dyn ResolveLogger>,
         install: Box<dyn InstallLogger>,
         preview: PreviewMode,
         connectivity: Connectivity,
@@ -56,13 +57,12 @@ impl CachedEnvironment {
         };
 
         // Resolve the requirements with the interpreter.
-        // STOPSHIP(charlie): We should suppress all output here, but show progress (so we show
-        // builds).
         let graph = resolve_environment(
             &interpreter,
             spec,
             settings.as_ref().into(),
             state,
+            resolve,
             preview,
             connectivity,
             concurrency,
@@ -107,8 +107,6 @@ impl CachedEnvironment {
             true,
         )?;
 
-        // STOPSHIP(charlie): We should suppress all output here, but show progress (so we show
-        // downloads and builds), and show a summary at the end.
         sync_environment(
             venv,
             &resolution,

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -27,6 +27,7 @@ use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
 use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::{DiscoveryOptions, Workspace};
 
+use crate::commands::pip::loggers::{DefaultResolveLogger, ResolveLogger, SummaryResolveLogger};
 use crate::commands::project::{find_requires_python, FoundInterpreter, ProjectError, SharedState};
 use crate::commands::{pip, ExitStatus};
 use crate::printer::Printer;
@@ -84,6 +85,7 @@ pub(crate) async fn lock(
         &workspace,
         &interpreter,
         settings.as_ref(),
+        Box::new(DefaultResolveLogger),
         preview,
         connectivity,
         concurrency,
@@ -117,6 +119,7 @@ pub(super) async fn do_safe_lock(
     workspace: &Workspace,
     interpreter: &Interpreter,
     settings: ResolverSettingsRef<'_>,
+    logger: Box<dyn ResolveLogger>,
     preview: PreviewMode,
     connectivity: Connectivity,
     concurrency: Concurrency,
@@ -157,6 +160,7 @@ pub(super) async fn do_safe_lock(
             Some(&existing),
             settings,
             &state,
+            logger,
             preview,
             connectivity,
             concurrency,
@@ -186,6 +190,7 @@ pub(super) async fn do_safe_lock(
             existing.as_ref(),
             settings,
             &state,
+            logger,
             preview,
             connectivity,
             concurrency,
@@ -213,6 +218,7 @@ async fn do_lock(
     existing_lock: Option<&Lock>,
     settings: ResolverSettingsRef<'_>,
     state: &SharedState,
+    logger: Box<dyn ResolveLogger>,
     preview: PreviewMode,
     connectivity: Connectivity,
     concurrency: Concurrency,
@@ -469,9 +475,9 @@ async fn do_lock(
                 &build_dispatch,
                 concurrency,
                 options,
+                Box::new(SummaryResolveLogger),
                 printer,
                 preview,
-                true,
             )
             .await
             .inspect_err(|err| debug!("Resolution with `uv.lock` failed: {err}"))
@@ -547,16 +553,16 @@ async fn do_lock(
                 &build_dispatch,
                 concurrency,
                 options,
+                Box::new(SummaryResolveLogger),
                 printer,
                 preview,
-                true,
             )
             .await?
         }
     };
 
     // Print the success message after completing resolution.
-    pip::operations::resolution_success(&resolution, start, printer)?;
+    logger.on_complete(resolution.len(), start, printer)?;
 
     // Notify the user of any resolution diagnostics.
     pip::operations::diagnose_resolution(resolution.diagnostics(), printer)?;

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -31,7 +31,7 @@ use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
 use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::Workspace;
 
-use crate::commands::pip::loggers::{DefaultInstallLogger, InstallLogger};
+use crate::commands::pip::loggers::{InstallLogger, ResolveLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::reporters::{PythonDownloadReporter, ResolverReporter};
 use crate::commands::{pip, SharedState};
@@ -489,6 +489,7 @@ pub(crate) async fn resolve_environment<'a>(
     spec: RequirementsSpecification,
     settings: ResolverSettingsRef<'_>,
     state: &SharedState,
+    logger: Box<dyn ResolveLogger>,
     preview: PreviewMode,
     connectivity: Connectivity,
     concurrency: Concurrency,
@@ -627,9 +628,9 @@ pub(crate) async fn resolve_environment<'a>(
         &resolve_dispatch,
         concurrency,
         options,
+        logger,
         printer,
         preview,
-        false,
     )
     .await?)
 }
@@ -766,6 +767,8 @@ pub(crate) async fn update_environment(
     spec: RequirementsSpecification,
     settings: &ResolverInstallerSettings,
     state: &SharedState,
+    resolve: Box<dyn ResolveLogger>,
+    install: Box<dyn InstallLogger>,
     preview: PreviewMode,
     connectivity: Connectivity,
     concurrency: Concurrency,
@@ -925,9 +928,9 @@ pub(crate) async fn update_environment(
         &build_dispatch,
         concurrency,
         options,
+        resolve,
         printer,
         preview,
-        false,
     )
     .await
     {
@@ -953,7 +956,7 @@ pub(crate) async fn update_environment(
         &build_dispatch,
         cache,
         &venv,
-        Box::new(DefaultInstallLogger),
+        install,
         dry_run,
         printer,
         preview,

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -31,6 +31,7 @@ use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy};
 use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::Workspace;
 
+use crate::commands::pip::loggers::{DefaultInstallLogger, InstallLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::reporters::{PythonDownloadReporter, ResolverReporter};
 use crate::commands::{pip, SharedState};
@@ -639,6 +640,7 @@ pub(crate) async fn sync_environment(
     resolution: &Resolution,
     settings: InstallerSettingsRef<'_>,
     state: &SharedState,
+    logger: Box<dyn InstallLogger>,
     preview: PreviewMode,
     connectivity: Connectivity,
     concurrency: Concurrency,
@@ -745,6 +747,7 @@ pub(crate) async fn sync_environment(
         &build_dispatch,
         cache,
         &venv,
+        logger,
         dry_run,
         printer,
         preview,
@@ -950,6 +953,7 @@ pub(crate) async fn update_environment(
         &build_dispatch,
         cache,
         &venv,
+        Box::new(DefaultInstallLogger),
         dry_run,
         printer,
         preview,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -11,7 +11,7 @@ use uv_workspace::pyproject::DependencyType;
 use uv_workspace::pyproject_mut::PyProjectTomlMut;
 use uv_workspace::{DiscoveryOptions, ProjectWorkspace, VirtualProject, Workspace};
 
-use crate::commands::pip::loggers::DefaultInstallLogger;
+use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::{project, ExitStatus, SharedState};
 use crate::printer::Printer;
@@ -114,6 +114,7 @@ pub(crate) async fn remove(
         project.workspace(),
         venv.interpreter(),
         settings.as_ref().into(),
+        Box::new(DefaultResolveLogger),
         preview,
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -11,6 +11,7 @@ use uv_workspace::pyproject::DependencyType;
 use uv_workspace::pyproject_mut::PyProjectTomlMut;
 use uv_workspace::{DiscoveryOptions, ProjectWorkspace, VirtualProject, Workspace};
 
+use crate::commands::pip::loggers::DefaultInstallLogger;
 use crate::commands::pip::operations::Modifications;
 use crate::commands::{project, ExitStatus, SharedState};
 use crate::printer::Printer;
@@ -143,6 +144,7 @@ pub(crate) async fn remove(
         Modifications::Exact,
         settings.as_ref().into(),
         &state,
+        Box::new(DefaultInstallLogger),
         preview,
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -16,6 +16,7 @@ use uv_types::{BuildIsolation, HashStrategy};
 use uv_warnings::warn_user_once;
 use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace};
 
+use crate::commands::pip::loggers::{DefaultInstallLogger, InstallLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::project::lock::do_safe_lock;
 use crate::commands::project::{ProjectError, SharedState};
@@ -111,6 +112,7 @@ pub(crate) async fn sync(
         modifications,
         settings.as_ref().into(),
         &state,
+        Box::new(DefaultInstallLogger),
         preview,
         connectivity,
         concurrency,
@@ -133,6 +135,7 @@ pub(super) async fn do_sync(
     modifications: Modifications,
     settings: InstallerSettingsRef<'_>,
     state: &SharedState,
+    logger: Box<dyn InstallLogger>,
     preview: PreviewMode,
     connectivity: Connectivity,
     concurrency: Concurrency,
@@ -260,6 +263,7 @@ pub(super) async fn do_sync(
         &build_dispatch,
         cache,
         venv,
+        logger,
         dry_run,
         printer,
         preview,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -16,7 +16,7 @@ use uv_types::{BuildIsolation, HashStrategy};
 use uv_warnings::warn_user_once;
 use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace};
 
-use crate::commands::pip::loggers::{DefaultInstallLogger, InstallLogger};
+use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger, InstallLogger};
 use crate::commands::pip::operations::Modifications;
 use crate::commands::project::lock::do_safe_lock;
 use crate::commands::project::{ProjectError, SharedState};
@@ -79,6 +79,7 @@ pub(crate) async fn sync(
         project.workspace(),
         venv.interpreter(),
         settings.as_ref().into(),
+        Box::new(DefaultResolveLogger),
         preview,
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -13,6 +13,7 @@ use uv_resolver::TreeDisplay;
 use uv_warnings::warn_user_once;
 use uv_workspace::{DiscoveryOptions, Workspace};
 
+use crate::commands::pip::loggers::DefaultResolveLogger;
 use crate::commands::project::FoundInterpreter;
 use crate::commands::{project, ExitStatus};
 use crate::printer::Printer;
@@ -70,6 +71,7 @@ pub(crate) async fn tree(
         &workspace,
         &interpreter,
         settings.as_ref(),
+        Box::new(DefaultResolveLogger),
         preview,
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -28,7 +28,7 @@ use uv_warnings::{warn_user, warn_user_once};
 
 use crate::commands::reporters::PythonDownloadReporter;
 
-use crate::commands::pip::loggers::DefaultInstallLogger;
+use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
 use crate::commands::{
     project::{resolve_environment, resolve_names, sync_environment, update_environment},
     tool::common::matching_packages,
@@ -276,6 +276,8 @@ pub(crate) async fn install(
             spec,
             &settings,
             &state,
+            Box::new(DefaultResolveLogger),
+            Box::new(DefaultInstallLogger),
             preview,
             connectivity,
             concurrency,
@@ -300,6 +302,7 @@ pub(crate) async fn install(
             spec,
             settings.as_ref().into(),
             &state,
+            Box::new(DefaultResolveLogger),
             preview,
             connectivity,
             concurrency,

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -28,6 +28,7 @@ use uv_warnings::{warn_user, warn_user_once};
 
 use crate::commands::reporters::PythonDownloadReporter;
 
+use crate::commands::pip::loggers::DefaultInstallLogger;
 use crate::commands::{
     project::{resolve_environment, resolve_names, sync_environment, update_environment},
     tool::common::matching_packages,
@@ -322,6 +323,7 @@ pub(crate) async fn install(
             &resolution.into(),
             settings.as_ref().into(),
             &state,
+            Box::new(DefaultInstallLogger),
             preview,
             connectivity,
             concurrency,

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -38,6 +38,7 @@ use crate::printer::Printer;
 use crate::settings::ResolverInstallerSettings;
 
 /// The user-facing command used to invoke a tool run.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum ToolRunCommand {
     /// via the `uvx` alias
     Uvx,
@@ -412,6 +413,8 @@ async fn get_or_create_environment(
 
     // TODO(zanieb): When implementing project-level tools, discover the project and check if it has the tool.
     // TODO(zanieb): Determine if we should layer on top of the project environment if it is present.
+
+    // STOPSHIP(charlie): Same deal here with respect to spinners.
 
     let environment = CachedEnvironment::get_or_create(
         spec,

--- a/crates/uv/src/printer.rs
+++ b/crates/uv/src/printer.rs
@@ -45,16 +45,6 @@ impl Printer {
             Self::NoProgress => Stderr::Enabled,
         }
     }
-
-    /// Filter the [`Printer`], casting to [`Printer::Quiet`] if the condition is false.
-    #[must_use]
-    pub(crate) fn filter(self, condition: bool) -> Self {
-        if condition {
-            self
-        } else {
-            Self::Quiet
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -926,6 +926,19 @@ fn run_without_output() -> Result<()> {
        "
     })?;
 
+    // On the first run, we only show the summary line for each environment.
+    uv_snapshot!(context.filters(), context.run().env_remove("UV_SHOW_RESOLUTION").arg("--with").arg("iniconfig").arg("main.py"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv run` is experimental and may change without warning
+    Installed 4 packages in [TIME]
+    Installed 1 package in [TIME]
+    "###);
+
+    // Subsequent runs are quiet.
     uv_snapshot!(context.filters(), context.run().env_remove("UV_SHOW_RESOLUTION").arg("--with").arg("iniconfig").arg("main.py"), @r###"
     success: true
     exit_code: 0

--- a/crates/uv/tests/tool_run.rs
+++ b/crates/uv/tests/tool_run.rs
@@ -838,6 +838,25 @@ fn tool_run_without_output() {
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
+    // On the first run, only show the summary line.
+    uv_snapshot!(context.filters(), context.tool_run()
+        .env_remove("UV_SHOW_RESOLUTION")
+        .arg("--")
+        .arg("pytest")
+        .arg("--version")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    pytest 8.1.1
+
+    ----- stderr -----
+    warning: `uv tool run` is experimental and may change without warning
+    Installed [N] packages in [TIME]
+    "###);
+
+    // Subsequent runs are quiet.
     uv_snapshot!(context.filters(), context.tool_run()
         .env_remove("UV_SHOW_RESOLUTION")
         .arg("--")


### PR DESCRIPTION
## Summary

Initially, we showed _all_ resolver and installer output in `uv run` and `uv tool run`, since it was way too much for workhorse commands. Then, we moved to showing _no_ output by default, which was way too little -- you had no idea why anything was happening, and commands appeared to hang.

This PR adds a more nuanced middle-ground. With `--verbose`, we continue to show everything. But by default, in `uv run` and `uv tool run`...

- During resolution, we show any "Building" and "Build" messages, if you need to build a source distribution. But we don't show any other output. (This _could_ be too little for expensive resolutions; we may want to show a spinner.)
- If there are no changes to be made after resolving, we don't show any other output.
- If we have to install, we show the progress bars for downloads (which disappear on completion) followed by a single summary line stating the number of packages installed.

This feels pretty good, in my limited testing. When everything is built / cached, you don't get _any_ additional output. When there's work to do, you have a sense for what's happening, and we leave you with a single summary line ("Installed X packages") at the end.

Closes https://github.com/astral-sh/uv/issues/5758.

## Test Plan

Notice that the first `tool run` ends with an install line; the second shows no additional output:

![Screenshot 2024-08-07 at 8 33 21 PM](https://github.com/user-attachments/assets/6b0c7824-f14f-4d0b-86d0-a334ba486ce4)

If you run `uv run` in a package for the first time, we _do_ tell you that we're building / built it:

![Screenshot 2024-08-07 at 8 34 02 PM](https://github.com/user-attachments/assets/6a4c7b05-3aa5-410e-af5d-916eb6e745b0)

But on the second run, there's no output:

![Screenshot 2024-08-07 at 8 34 10 PM](https://github.com/user-attachments/assets/2b32f83e-0370-45fa-9e8f-407d9b93d468)

If you add a `--with`, we'll show you all the installer progress bars (which disappear once they're done), and then a single summary line:

![Screenshot 2024-08-07 at 8 34 39 PM](https://github.com/user-attachments/assets/e975d75c-01d2-4eb6-b3ff-e4d25d5ea9e2)
