### PR TITLE
Enable LTO optimizations in release builds to reduce binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,7 @@ rest_pat_in_fully_bound_structs = "warn"
 
 [profile.release]
 strip = true
+lto = true
 
 [profile.profiling]
 inherits = "release"


### PR DESCRIPTION
## Summary

In the same spirit as #5745, release builds could be a bit slightly more size efficient by enabling LTO, which removes dead code (either in uv through fully inlined functions or the libraries it depends on). Also has the side-effect (more what LTO was created for) of slighly speeding up uv.

In this case, I have measured a 5MB size decrease!.

Unfortunately, this change also comes with the disadvantage of more than doubling the build time of a clean build on my machine (see "Test Plan"). I have opened this pull request to show my findings and suggest this as an option. 

*I have also started looking into what effects optimizing for size rather than speed could have, but that calls for another pr*

## Test Plan

Comparing the binary size before and after (starting off in just a simple clone of the repository)

System info:
```
CPU: AMD Ryzen 7 3700X (16) @ 3.600GHz
Memory: 32GB @ 3200 MT/s
Uname: Linux galaxy 6.6.44-1-MANJARO #1 SMP PREEMPT_DYNAMIC Sat Aug  3 10:09:33 UTC 2024 x86_64 GNU/Linux
```

Before:
```
$ cargo build --release
<snip>
Finished `release` profile [optimized] target(s) in 1m 29s

$ du target/release/uv -h
30M	target/release/uv
```

After:
```
$ cargo build --release
<snip>
Finished `release` profile [optimized] target(s) in 3m 43s

$ du target/release/uv -h
25M	target/release/uv
```
