### PR TITLE
Docs: Fix link to tools concept page

### DIFF
--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -153,7 +153,7 @@ $ uv tool install mkdocs --with mkdocs-material
 
 ## Next steps
 
-To learn more about managing tools with uv, see the [Tools concept](../concepts/projects.md) page
+To learn more about managing tools with uv, see the [Tools concept](../concepts/tools.md) page
 and the [command reference](../reference/cli.md#uv-tool).
 
 Or, read on to learn how to to [work on projects](./projects.md).

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -153,7 +153,7 @@ $ uv tool install mkdocs --with mkdocs-material
 
 ## Next steps
 
-To learn more about managing tools with uv, see the [Tools concept](../concepts/tools.md) page
-and the [command reference](../reference/cli.md#uv-tool).
+To learn more about managing tools with uv, see the [Tools concept](../concepts/tools.md) page and
+the [command reference](../reference/cli.md#uv-tool).
 
 Or, read on to learn how to to [work on projects](./projects.md).


### PR DESCRIPTION
This link previously went to the wrong "concept" page; it now goes to the one the page intended.