### PR TITLE
Deprecate `--system` and `--no-system` in `uv venv`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1837,15 +1837,22 @@ pub struct VenvArgs {
     )]
     pub python: Option<String>,
 
-    // TODO(zanieb): Hide me, I do nothing.
+    /// Ignore virtual environments when searching for the Python interpreter.
+    ///
+    /// This is the default behavior and has no effect.
     #[arg(
         long,
         env = "UV_SYSTEM_PYTHON",
         value_parser = clap::builder::BoolishValueParser::new(),
-        overrides_with("no_system")
+        overrides_with("no_system"),
+        hide = true,
     )]
     pub system: bool,
 
+    /// This flag is included for compatibility only, it has no effect.
+    ///
+    /// uv will never search for interpreters in virtual environments when
+    /// creating a virtual environment.
     #[arg(long, overrides_with("system"), hide = true)]
     pub no_system: bool,
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -24,7 +24,7 @@ use uv_configuration::Concurrency;
 use uv_fs::CWD;
 use uv_requirements::RequirementsSource;
 use uv_settings::{Combine, FilesystemOptions};
-use uv_warnings::warn_user;
+use uv_warnings::{warn_user, warn_user_once};
 use uv_workspace::{DiscoveryOptions, Workspace};
 
 use crate::commands::{ExitStatus, ToolRunCommand};
@@ -626,6 +626,14 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         }
         Commands::Venv(args) => {
             args.compat_args.validate()?;
+
+            if args.no_system {
+                warn_user_once!("The `--no-system` flag has no effect, a system Python interpreter is always used in `uv venv`");
+            }
+
+            if args.system {
+                warn_user_once!("The `--system` flag has no effect, a system Python interpreter is always used in `uv venv`");
+            }
 
             // Resolve the settings from the command-line arguments and workspace configuration.
             let args = settings::VenvSettings::resolve(args, filesystem);


### PR DESCRIPTION
e.g.

```
❯ cargo run -- venv --no-system
    Blocking waiting for file lock on build directory
   Compiling uv v0.2.34 (/Users/zb/workspace/uv/crates/uv)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.85s
     Running `target/debug/uv venv --no-system`
warning: The `--no-system` flag has no effect, a system Python interpreter is always used in `uv venv`
Using Python 3.12.4 interpreter at: /opt/homebrew/opt/python@3.12/bin/python3.12
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate

❯ cargo run -- venv --system
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/uv venv --system`
warning: The `--system` flag has no effect, a system Python interpreter is always used in `uv venv`
Using Python 3.12.4 interpreter at: /opt/homebrew/opt/python@3.12/bin/python3.12
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
```