### PR TITLE
Make `--upgrade` imply `--refresh`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3104,7 +3104,8 @@ pub struct ResolverArgs {
     #[command(flatten)]
     pub index_args: IndexArgs,
 
-    /// Allow package upgrades, ignoring pinned versions in any existing output file.
+    /// Allow package upgrades, ignoring pinned versions in any existing output file. Implies
+    /// `--refresh`.
     #[arg(
         long,
         short = 'U',
@@ -3122,7 +3123,7 @@ pub struct ResolverArgs {
     pub no_upgrade: bool,
 
     /// Allow upgrades for a specific package, ignoring pinned versions in any existing output
-    /// file.
+    /// file. Implies `--refresh-package`.
     #[arg(long, short = 'P', help_heading = "Resolver options")]
     pub upgrade_package: Vec<Requirement<VerbatimParsedUrl>>,
 
@@ -3252,7 +3253,8 @@ pub struct ResolverInstallerArgs {
     #[command(flatten)]
     pub index_args: IndexArgs,
 
-    /// Allow package upgrades, ignoring pinned versions in any existing output file.
+    /// Allow package upgrades, ignoring pinned versions in any existing output file. Implies
+    /// `--refresh`.
     #[arg(
         long,
         short = 'U',
@@ -3270,7 +3272,7 @@ pub struct ResolverInstallerArgs {
     pub no_upgrade: bool,
 
     /// Allow upgrades for a specific package, ignoring pinned versions in any existing output
-    /// file.
+    /// file. Implies `--refresh-package`.
     #[arg(long, short = 'P', help_heading = "Resolver options")]
     pub upgrade_package: Vec<Requirement<VerbatimParsedUrl>>,
 

--- a/crates/uv-configuration/src/package_options.rs
+++ b/crates/uv-configuration/src/package_options.rs
@@ -136,7 +136,9 @@ impl From<Upgrade> for Refresh {
         match value {
             Upgrade::None => Self::None(Timestamp::now()),
             Upgrade::All => Self::All(Timestamp::now()),
-            Upgrade::Packages(packages) => Self::Packages(packages.into_keys().collect::<Vec<_>>(), Timestamp::now()),
+            Upgrade::Packages(packages) => {
+                Self::Packages(packages.into_keys().collect::<Vec<_>>(), Timestamp::now())
+            }
         }
     }
 }

--- a/crates/uv-configuration/src/package_options.rs
+++ b/crates/uv-configuration/src/package_options.rs
@@ -3,7 +3,7 @@ use pep508_rs::PackageName;
 
 use pypi_types::Requirement;
 use rustc_hash::FxHashMap;
-use uv_cache::Refresh;
+use uv_cache::{Refresh, Timestamp};
 
 /// Whether to reinstall packages.
 #[derive(Debug, Default, Clone)]
@@ -44,30 +44,15 @@ impl Reinstall {
     pub fn is_all(&self) -> bool {
         matches!(self, Self::All)
     }
+}
 
-    /// Create a [`Refresh`] policy by integrating the [`Reinstall`] policy.
-    pub fn to_refresh(self, refresh: Refresh) -> Refresh {
-        match (self, refresh) {
-            // If the policy is `None`, return the existing refresh policy.
-            (Self::None, Refresh::None(timestamp)) => Refresh::None(timestamp),
-            (Self::None, Refresh::All(timestamp)) => Refresh::All(timestamp),
-            (Self::None, Refresh::Packages(packages, timestamp)) => {
-                Refresh::Packages(packages, timestamp)
-            }
-
-            // If the policy is `All`, refresh all packages.
-            (Self::All, Refresh::None(timestamp)) => Refresh::All(timestamp),
-            (Self::All, Refresh::All(timestamp)) => Refresh::All(timestamp),
-            (Self::All, Refresh::Packages(_packages, timestamp)) => Refresh::All(timestamp),
-
-            // If the policy is `Packages`, take the "max" of the two policies.
-            (Self::Packages(packages), Refresh::None(timestamp)) => {
-                Refresh::Packages(packages, timestamp)
-            }
-            (Self::Packages(_packages), Refresh::All(timestamp)) => Refresh::All(timestamp),
-            (Self::Packages(packages1), Refresh::Packages(packages2, timestamp)) => {
-                Refresh::Packages(packages1.into_iter().chain(packages2).collect(), timestamp)
-            }
+/// Create a [`Refresh`] policy by integrating the [`Reinstall`] policy.
+impl From<Reinstall> for Refresh {
+    fn from(value: Reinstall) -> Self {
+        match value {
+            Reinstall::None => Self::None(Timestamp::now()),
+            Reinstall::All => Self::All(Timestamp::now()),
+            Reinstall::Packages(packages) => Self::Packages(packages, Timestamp::now()),
         }
     }
 }
@@ -141,6 +126,17 @@ impl Upgrade {
             )
         } else {
             Either::Left(std::iter::empty())
+        }
+    }
+}
+
+/// Create a [`Refresh`] policy by integrating the [`Upgrade`] policy.
+impl From<Upgrade> for Refresh {
+    fn from(value: Upgrade) -> Self {
+        match value {
+            Upgrade::None => Self::None(Timestamp::now()),
+            Upgrade::All => Self::All(Timestamp::now()),
+            Upgrade::Packages(packages) => Self::Packages(packages.into_keys().collect::<Vec<_>>(), Timestamp::now()),
         }
     }
 }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -224,9 +224,11 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .expect("failed to initialize global rayon pool");
 
             // Initialize the cache.
-            let cache = cache
-                .init()?
-                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
+            let cache = cache.init()?.with_refresh(
+                args.refresh
+                    .combine(Refresh::from(args.settings.reinstall.clone()))
+                    .combine(Refresh::from(args.settings.upgrade.clone())),
+            );
 
             let requirements = args
                 .src_file
@@ -317,9 +319,11 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .expect("failed to initialize global rayon pool");
 
             // Initialize the cache.
-            let cache = cache
-                .init()?
-                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
+            let cache = cache.init()?.with_refresh(
+                args.refresh
+                    .combine(Refresh::from(args.settings.reinstall.clone()))
+                    .combine(Refresh::from(args.settings.upgrade.clone())),
+            );
 
             let requirements = args
                 .src_file
@@ -389,9 +393,11 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 .expect("failed to initialize global rayon pool");
 
             // Initialize the cache.
-            let cache = cache
-                .init()?
-                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
+            let cache = cache.init()?.with_refresh(
+                args.refresh
+                    .combine(Refresh::from(args.settings.reinstall.clone()))
+                    .combine(Refresh::from(args.settings.upgrade.clone())),
+            );
 
             let requirements = args
                 .package
@@ -705,9 +711,11 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache
-                .init()?
-                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
+            let cache = cache.init()?.with_refresh(
+                args.refresh
+                    .combine(Refresh::from(args.settings.reinstall.clone()))
+                    .combine(Refresh::from(args.settings.upgrade.clone())),
+            );
 
             let requirements = args
                 .with
@@ -748,9 +756,11 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache
-                .init()?
-                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
+            let cache = cache.init()?.with_refresh(
+                args.refresh
+                    .combine(Refresh::from(args.settings.reinstall.clone()))
+                    .combine(Refresh::from(args.settings.upgrade.clone())),
+            );
 
             let requirements = args
                 .with
@@ -996,9 +1006,11 @@ async fn run_project(
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache
-                .init()?
-                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
+            let cache = cache.init()?.with_refresh(
+                args.refresh
+                    .combine(Refresh::from(args.settings.reinstall.clone()))
+                    .combine(Refresh::from(args.settings.upgrade.clone())),
+            );
 
             let requirements = args
                 .with
@@ -1041,9 +1053,11 @@ async fn run_project(
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache
-                .init()?
-                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
+            let cache = cache.init()?.with_refresh(
+                args.refresh
+                    .combine(Refresh::from(args.settings.reinstall.clone()))
+                    .combine(Refresh::from(args.settings.upgrade.clone())),
+            );
 
             commands::sync(
                 args.locked,
@@ -1095,9 +1109,11 @@ async fn run_project(
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache
-                .init()?
-                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
+            let cache = cache.init()?.with_refresh(
+                args.refresh
+                    .combine(Refresh::from(args.settings.reinstall.clone()))
+                    .combine(Refresh::from(args.settings.upgrade.clone())),
+            );
 
             commands::add(
                 args.locked,
@@ -1131,9 +1147,11 @@ async fn run_project(
             show_settings!(args);
 
             // Initialize the cache.
-            let cache = cache
-                .init()?
-                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
+            let cache = cache.init()?.with_refresh(
+                args.refresh
+                    .combine(Refresh::from(args.settings.reinstall.clone()))
+                    .combine(Refresh::from(args.settings.upgrade.clone())),
+            );
 
             commands::remove(
                 args.locked,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -12,7 +12,7 @@ use owo_colors::OwoColorize;
 use tracing::{debug, instrument};
 
 use settings::PipTreeSettings;
-use uv_cache::Cache;
+use uv_cache::{Cache, Refresh};
 use uv_cli::{
     compat::CompatArgs, CacheCommand, CacheNamespace, Cli, Commands, PipCommand, PipNamespace,
     ProjectCommand,
@@ -226,7 +226,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             // Initialize the cache.
             let cache = cache
                 .init()?
-                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
+                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
 
             let requirements = args
                 .src_file
@@ -319,7 +319,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             // Initialize the cache.
             let cache = cache
                 .init()?
-                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
+                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
 
             let requirements = args
                 .src_file
@@ -391,7 +391,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             // Initialize the cache.
             let cache = cache
                 .init()?
-                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
+                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
 
             let requirements = args
                 .package
@@ -707,7 +707,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             // Initialize the cache.
             let cache = cache
                 .init()?
-                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
+                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
 
             let requirements = args
                 .with
@@ -750,7 +750,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             // Initialize the cache.
             let cache = cache
                 .init()?
-                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
+                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
 
             let requirements = args
                 .with
@@ -998,7 +998,7 @@ async fn run_project(
             // Initialize the cache.
             let cache = cache
                 .init()?
-                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
+                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
 
             let requirements = args
                 .with
@@ -1043,7 +1043,7 @@ async fn run_project(
             // Initialize the cache.
             let cache = cache
                 .init()?
-                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
+                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
 
             commands::sync(
                 args.locked,
@@ -1097,7 +1097,7 @@ async fn run_project(
             // Initialize the cache.
             let cache = cache
                 .init()?
-                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
+                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
 
             commands::add(
                 args.locked,
@@ -1133,7 +1133,7 @@ async fn run_project(
             // Initialize the cache.
             let cache = cache
                 .init()?
-                .with_refresh(args.settings.reinstall.clone().to_refresh(args.refresh));
+                .with_refresh(Refresh::from(args.settings.reinstall.clone()).combine(args.refresh));
 
             commands::remove(
                 args.locked,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -315,9 +315,9 @@ uv run [OPTIONS] <COMMAND>
 
 <li><code>lowest-direct</code>:  Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies</li>
 </ul>
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
@@ -734,9 +734,9 @@ uv add [OPTIONS] <REQUIREMENTS>...
 
 </dd><dt><code>--tag</code> <i>tag</i></dt><dd><p>Tag to use when adding a dependency from Git</p>
 
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
@@ -995,9 +995,9 @@ uv remove [OPTIONS] <PACKAGES>...
 
 <li><code>lowest-direct</code>:  Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies</li>
 </ul>
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
@@ -1248,9 +1248,9 @@ uv sync [OPTIONS]
 
 <li><code>lowest-direct</code>:  Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies</li>
 </ul>
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
@@ -1477,9 +1477,9 @@ uv lock [OPTIONS]
 
 <li><code>lowest-direct</code>:  Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies</li>
 </ul>
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
@@ -1768,9 +1768,9 @@ uv tree [OPTIONS]
 
 <p>Multiple versions may be shown for a each package.</p>
 
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
@@ -2031,9 +2031,9 @@ uv tool run [OPTIONS] [COMMAND]
 
 <li><code>lowest-direct</code>:  Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies</li>
 </ul>
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
@@ -2274,9 +2274,9 @@ uv tool install [OPTIONS] <PACKAGE>
 
 <li><code>lowest-direct</code>:  Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies</li>
 </ul>
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
@@ -2511,9 +2511,9 @@ uv tool upgrade [OPTIONS] <NAME>
 
 <li><code>lowest-direct</code>:  Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies</li>
 </ul>
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
@@ -3921,9 +3921,9 @@ uv pip compile [OPTIONS] <SRC_FILE>...
 
 <p>Implies <code>--no-strip-markers</code>.</p>
 
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
@@ -4573,9 +4573,9 @@ uv pip install [OPTIONS] <PACKAGE|--requirement <REQUIREMENT>|--editable <EDITAB
 
 </dd><dt><code>--target</code> <i>target</i></dt><dd><p>Install packages into the specified directory, rather than into the virtual or system Python environment. The packages will be installed at the top-level of the directory</p>
 
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file</p>
+</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
 
 </dd><dt><code>--user</code></dt><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 


### PR DESCRIPTION
## Summary

I think this seems reasonable... Otherwise, we might not go back to PyPI to revalidate the list of available versions despite the user passing `--upgrade`.
