### PR TITLE
Respect subdirectories when locating Git workspaces

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1249,11 +1249,17 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 .await
                 .map_err(Error::CacheWrite)?;
 
+            let path = if let Some(subdirectory) = resource.subdirectory {
+                Cow::Owned(fetch.path().join(subdirectory))
+            } else {
+                Cow::Borrowed(fetch.path())
+            };
+
             return Ok(ArchiveMetadata::from(
                 Metadata::from_workspace(
                     metadata,
-                    fetch.path(),
-                    fetch.path(),
+                    &path,
+                    &path,
                     self.build_context.sources(),
                     self.preview_mode,
                 )


### PR DESCRIPTION
## Summary

We were discovering the workspace from the Git repository root, so attempting to build any subdirectories would fail.

Closes https://github.com/astral-sh/uv/issues/5942.

## Test Plan

```
cargo run pip install \
	git+https://github.com/flyteorg/flytekit.git@master#subdirectory=plugins/flytekit-flyteinteractive
```
