### PR TITLE
use exclude newer env var instead of the flag

### DIFF
--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -514,21 +514,10 @@ impl TestContext {
 
     /// Create a `uv tool install` command with options shared across scenarios.
     pub fn tool_install(&self) -> Command {
-        let mut command = self.tool_install_without_exclude_newer();
-        command.env("UV_EXCLUDE_NEWER", EXCLUDE_NEWER);
-        command
-    }
-
-    /// Create a `uv tool install` command with no `--exclude-newer` option.
-    ///
-    /// One should avoid using this in tests to the extent possible because
-    /// it can result in tests failing when the index state changes. Therefore,
-    /// if you use this, there should be some other kind of mitigation in place.
-    /// For example, pinning package versions.
-    pub fn tool_install_without_exclude_newer(&self) -> Command {
         let mut command = Command::new(get_bin());
         command.arg("tool").arg("install");
         self.add_shared_args(&mut command);
+        command.env("UV_EXCLUDE_NEWER", EXCLUDE_NEWER);
         command
     }
 

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -515,7 +515,7 @@ impl TestContext {
     /// Create a `uv tool install` command with options shared across scenarios.
     pub fn tool_install(&self) -> Command {
         let mut command = self.tool_install_without_exclude_newer();
-        command.arg("--exclude-newer").arg(EXCLUDE_NEWER);
+        command.env("UV_EXCLUDE_NEWER", EXCLUDE_NEWER);
         command
     }
 

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -178,7 +178,8 @@ fn tool_install_suggest_other_packages_with_executable() {
     let mut filters = context.filters();
     filters.push(("\\+ uvloop(.+)\n ", ""));
 
-    uv_snapshot!(filters, context.tool_install_without_exclude_newer()
+    uv_snapshot!(filters, context.tool_install()
+    .env_remove("UV_EXCLUDE_NEWER")
     .arg("fastapi==0.111.0")
     .env("UV_EXCLUDE_NEWER", "2024-05-04T00:00:00Z") // TODO: Remove this once EXCLUDE_NEWER is bumped past 2024-05-04
     // (FastAPI 0.111 is only available from this date onwards)


### PR DESCRIPTION
## Summary
resolves https://github.com/astral-sh/uv/issues/5879
<!-- What's the purpose of the change? What does it do, and why? -->
