### PR TITLE
Add `update` alias for `uv tool upgrade`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2556,6 +2556,7 @@ pub enum ToolCommand {
     /// Install a tool.
     Install(ToolInstallArgs),
     /// Upgrade a tool.
+    #[command(alias = "update")]
     Upgrade(ToolUpgradeArgs),
     /// List installed tools.
     List(ToolListArgs),


### PR DESCRIPTION
## Summary

I always get this wrong with `brew`, it'd be nice for it to "just work" either way.
