### PR TITLE
Support relative path wheels

### DIFF
--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -216,8 +216,12 @@ pub struct DirectUrlBuiltDist {
 #[derive(Debug, Clone, Hash)]
 pub struct PathBuiltDist {
     pub filename: WheelFilename,
-    /// The path to the wheel.
-    pub path: PathBuf,
+    /// The resolved, absolute path to the wheel which we use for installing.
+    pub install_path: PathBuf,
+    /// The absolute path or path relative to the workspace root pointing to the wheel
+    /// which we use for locking. Unlike `given` on the verbatim URL all environment variables
+    /// are resolved, and unlike the install path, we did not yet join it on the base directory.
+    pub lock_path: PathBuf,
     /// The URL as it was provided by the user.
     pub url: VerbatimUrl,
 }
@@ -372,7 +376,8 @@ impl Dist {
                 }
                 Ok(Self::Built(BuiltDist::Path(PathBuiltDist {
                     filename,
-                    path: canonicalized_path,
+                    install_path: canonicalized_path.clone(),
+                    lock_path: lock_path.to_path_buf(),
                     url,
                 })))
             }

--- a/crates/distribution-types/src/resolution.rs
+++ b/crates/distribution-types/src/resolution.rs
@@ -147,8 +147,8 @@ impl From<&ResolvedDist> for Requirement {
                     }
                 }
                 Dist::Built(BuiltDist::Path(wheel)) => RequirementSource::Path {
-                    install_path: wheel.path.clone(),
-                    lock_path: wheel.path.clone(),
+                    install_path: wheel.install_path.clone(),
+                    lock_path: wheel.lock_path.clone(),
                     url: wheel.url.clone(),
                     ext: DistExtension::Wheel,
                 },

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -453,7 +453,7 @@ impl RegistryClient {
                 .await?
             }
             BuiltDist::Path(wheel) => {
-                let file = fs_err::tokio::File::open(&wheel.path)
+                let file = fs_err::tokio::File::open(&wheel.install_path)
                     .await
                     .map_err(ErrorKind::Io)?;
                 let reader = tokio::io::BufReader::new(file);

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -89,7 +89,7 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             io::Error::new(
                 io::ErrorKind::TimedOut,
                 format!(
-                    "Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: {}s).",  self.client.unmanaged.timeout()
+                    "Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: {}s).", self.client.unmanaged.timeout()
                 ),
             )
         } else {
@@ -351,8 +351,14 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                     wheel.filename.stem(),
                 );
 
-                self.load_wheel(&wheel.path, &wheel.filename, cache_entry, dist, hashes)
-                    .await
+                self.load_wheel(
+                    &wheel.install_path,
+                    &wheel.filename,
+                    cache_entry,
+                    dist,
+                    hashes,
+                )
+                .await
             }
         }
     }

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -330,13 +330,14 @@ impl<'a> Planner<'a> {
                             let wheel = PathBuiltDist {
                                 filename,
                                 url: url.clone(),
-                                path,
+                                install_path: install_path.clone(),
+                                lock_path: lock_path.clone(),
                             };
 
                             if !wheel.filename.is_compatible(tags) {
                                 bail!(
                                 "A path dependency is incompatible with the current platform: {}",
-                                wheel.path.user_display()
+                                wheel.lock_path.user_display()
                             );
                             }
 
@@ -357,7 +358,7 @@ impl<'a> Planner<'a> {
                                 .entry(format!("{}.rev", wheel.filename.stem()));
 
                             if let Some(pointer) = LocalArchivePointer::read_from(&cache_entry)? {
-                                let timestamp = ArchiveTimestamp::from_file(&wheel.path)?;
+                                let timestamp = ArchiveTimestamp::from_file(&wheel.install_path)?;
                                 if pointer.is_up_to_date(timestamp) {
                                     let archive = pointer.into_archive();
                                     if archive.satisfies(hasher.get(&wheel)) {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
@@ -28,9 +28,11 @@ Ok(
                 sdist: None,
                 wheels: [
                     Wheel {
-                        url: UrlString(
-                            "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl",
-                        ),
+                        url: Url {
+                            url: UrlString(
+                                "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl",
+                            ),
+                        },
                         hash: None,
                         size: None,
                         filename: WheelFilename {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
@@ -28,9 +28,11 @@ Ok(
                 sdist: None,
                 wheels: [
                     Wheel {
-                        url: UrlString(
-                            "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl",
-                        ),
+                        url: Url {
+                            url: UrlString(
+                                "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl",
+                            ),
+                        },
                         hash: Some(
                             Hash(
                                 HashDigest {

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_required_present.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_required_present.snap
@@ -26,9 +26,11 @@ Ok(
                 sdist: None,
                 wheels: [
                     Wheel {
-                        url: UrlString(
-                            "file:///foo/bar/anyio-4.3.0-py3-none-any.whl",
-                        ),
+                        url: Url {
+                            url: UrlString(
+                                "file:///foo/bar/anyio-4.3.0-py3-none-any.whl",
+                            ),
+                        },
                         hash: Some(
                             Hash(
                                 HashDigest {

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
+use insta::assert_snapshot;
 
 use common::{uv_snapshot, TestContext};
 
@@ -674,6 +675,107 @@ fn sync_build_isolation_package() -> Result<()> {
     "###);
 
     assert!(context.temp_dir.child("uv.lock").exists());
+
+    Ok(())
+}
+
+/// Test that relative wheel paths are correctly preserved.
+#[test]
+fn sync_relative_wheel() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let requirements = r#"[project]
+    name = "relative_wheel"
+    version = "0.1.0"
+    requires-python = ">=3.12"
+    dependencies = ["ok"]
+
+    [tool.uv.sources]
+    ok = { path = "wheels/ok-1.0.0-py3-none-any.whl" }
+
+    [build-system]
+    requires = ["hatchling"]
+    build-backend = "hatchling.build"
+    "#;
+
+    context
+        .temp_dir
+        .child("src/relative_wheel/__init__.py")
+        .touch()?;
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(requirements)?;
+
+    context.temp_dir.child("wheels").create_dir_all()?;
+    fs_err::copy(
+        "../../scripts/links/ok-1.0.0-py3-none-any.whl",
+        context.temp_dir.join("wheels/ok-1.0.0-py3-none-any.whl"),
+    )?;
+
+    uv_snapshot!(context.filters(), context.sync(), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv sync` is experimental and may change without warning
+    warning: `uv.sources` is experimental and may change without warning
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 2 packages in [TIME]
+     + ok==1.0.0 (from file://[TEMP_DIR]/wheels/ok-1.0.0-py3-none-any.whl)
+     + relative-wheel==0.1.0 (from file://[TEMP_DIR]/)
+    "###);
+
+    let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock"))?;
+
+    insta::with_settings!(
+        {
+            filters => context.filters(),
+        },
+        {
+            assert_snapshot!(
+                lock, @r###"
+            version = 1
+            requires-python = ">=3.12"
+
+            [options]
+            exclude-newer = "2024-03-25 00:00:00 UTC"
+
+            [[package]]
+            name = "ok"
+            version = "1.0.0"
+            source = { path = "wheels/ok-1.0.0-py3-none-any.whl" }
+            wheels = [
+                { filename = "ok-1.0.0-py3-none-any.whl", hash = "sha256:79f0b33e6ce1e09eaa1784c8eee275dfe84d215d9c65c652f07c18e85fdaac5f" },
+            ]
+
+            [[package]]
+            name = "relative-wheel"
+            version = "0.1.0"
+            source = { editable = "." }
+            dependencies = [
+                { name = "ok" },
+            ]
+            "###
+            );
+        }
+    );
+
+    // Check that we can re-read the lockfile.
+    uv_snapshot!(context.filters(), context.sync(), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv sync` is experimental and may change without warning
+    warning: `uv.sources` is experimental and may change without warning
+    Resolved 2 packages in [TIME]
+    Audited 2 packages in [TIME]
+    "###);
 
     Ok(())
 }

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -714,7 +714,7 @@ fn sync_relative_wheel() -> Result<()> {
         context.temp_dir.join("wheels/ok-1.0.0-py3-none-any.whl"),
     )?;
 
-    uv_snapshot!(context.sync(), @r###"
+    uv_snapshot!(context.sync().arg("--verbose"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -714,7 +714,7 @@ fn sync_relative_wheel() -> Result<()> {
         context.temp_dir.join("wheels/ok-1.0.0-py3-none-any.whl"),
     )?;
 
-    uv_snapshot!(context.filters(), context.sync(), @r###"
+    uv_snapshot!(context.sync(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -682,7 +682,12 @@ fn sync_build_isolation_package() -> Result<()> {
 /// Test that relative wheel paths are correctly preserved.
 #[test]
 fn sync_relative_wheel() -> Result<()> {
-    let context = TestContext::new("3.12");
+    // TODO(charlie): On Windows, this test currently prepares two packages (vs. one of Unix). This
+    // is due to an error in path canonicalization, and GitHub Actions on Windows have a symlink
+    // in the path.
+    //
+    // See: https://github.com/astral-sh/uv/issues/5979
+    let context = TestContext::new("3.12").with_filtered_counts();
 
     let requirements = r#"[project]
     name = "relative_wheel"
@@ -714,7 +719,7 @@ fn sync_relative_wheel() -> Result<()> {
         context.temp_dir.join("wheels/ok-1.0.0-py3-none-any.whl"),
     )?;
 
-    uv_snapshot!(context.sync().arg("--verbose"), @r###"
+    uv_snapshot!(context.filters(), context.sync(), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -722,9 +727,9 @@ fn sync_relative_wheel() -> Result<()> {
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning
     warning: `uv.sources` is experimental and may change without warning
-    Resolved 2 packages in [TIME]
-    Prepared 1 package in [TIME]
-    Installed 2 packages in [TIME]
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
      + ok==1.0.0 (from file://[TEMP_DIR]/wheels/ok-1.0.0-py3-none-any.whl)
      + relative-wheel==0.1.0 (from file://[TEMP_DIR]/)
     "###);
@@ -773,8 +778,8 @@ fn sync_relative_wheel() -> Result<()> {
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning
     warning: `uv.sources` is experimental and may change without warning
-    Resolved 2 packages in [TIME]
-    Audited 2 packages in [TIME]
+    Resolved [N] packages in [TIME]
+    Audited [N] packages in [TIME]
     "###);
 
     Ok(())


### PR DESCRIPTION
Surprisingly, this is a lockfile schema change: We can't store relative paths in urls, so we have to store a `filename` entry instead of the whole url.

Fixes #4355
