### PR TITLE
Remove uses of `Option<MarkerTree>`

### DIFF
--- a/crates/distribution-types/src/resolution.rs
+++ b/crates/distribution-types/src/resolution.rs
@@ -1,4 +1,5 @@
 use distribution_filename::DistExtension;
+use pep508_rs::MarkerTree;
 use pypi_types::{HashDigest, Requirement, RequirementSource};
 use std::collections::BTreeMap;
 use uv_normalize::{ExtraName, GroupName, PackageName};
@@ -211,7 +212,7 @@ impl From<&ResolvedDist> for Requirement {
         Requirement {
             name: resolved_dist.name().clone(),
             extras: vec![],
-            marker: None,
+            marker: MarkerTree::TRUE,
             source,
             origin: None,
         }

--- a/crates/pep508-rs/src/marker/mod.rs
+++ b/crates/pep508-rs/src/marker/mod.rs
@@ -21,3 +21,24 @@ pub use tree::{
     MarkerOperator, MarkerTree, MarkerTreeContents, MarkerTreeKind, MarkerValue, MarkerValueString,
     MarkerValueVersion, MarkerWarningKind, StringMarkerTree, StringVersion, VersionMarkerTree,
 };
+
+/// `serde` helpers for [`MarkerTree`].
+pub mod ser {
+    use super::MarkerTree;
+    use serde::Serialize;
+
+    /// A helper for `serde(skip_serializing_if)`.
+    pub fn is_empty(marker: &MarkerTree) -> bool {
+        marker.contents().is_none()
+    }
+
+    /// A helper for `serde(serialize_with)`.
+    ///
+    /// Note this will panic if `marker.contents()` is `None`, and so should be paired with `is_empty`.
+    pub fn serialize<S>(marker: &MarkerTree, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        marker.contents().unwrap().serialize(s)
+    }
+}

--- a/crates/pep508-rs/src/marker/tree.rs
+++ b/crates/pep508-rs/src/marker/tree.rs
@@ -564,6 +564,12 @@ impl Display for MarkerExpression {
 #[derive(Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct MarkerTree(NodeId);
 
+impl Default for MarkerTree {
+    fn default() -> Self {
+        MarkerTree::TRUE
+    }
+}
+
 impl<'de> Deserialize<'de> for MarkerTree {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/pep508-rs/src/unnamed.rs
+++ b/crates/pep508-rs/src/unnamed.rs
@@ -75,7 +75,7 @@ pub struct UnnamedRequirement<Url: UnnamedRequirementUrl = VerbatimUrl> {
     /// The markers such as `python_version > "3.8"` in
     /// `requests [security,tests] >= 2.8.1, == 2.8.* ; python_version > "3.8"`.
     /// Those are a nested and/or tree.
-    pub marker: Option<MarkerTree>,
+    pub marker: MarkerTree,
     /// The source file containing the requirement.
     pub origin: Option<RequirementOrigin>,
 }
@@ -92,11 +92,7 @@ impl<Url: UnnamedRequirementUrl> UnnamedRequirement<Url> {
         env: Option<&MarkerEnvironment>,
         extras: &[ExtraName],
     ) -> bool {
-        if let Some(marker) = &self.marker {
-            marker.evaluate_optional_environment(env, extras)
-        } else {
-            true
-        }
+        self.marker.evaluate_optional_environment(env, extras)
     }
 
     /// Set the source file containing the requirement.
@@ -136,7 +132,7 @@ impl<Url: UnnamedRequirementUrl> Display for UnnamedRequirement<Url> {
                     .join(",")
             )?;
         }
-        if let Some(marker) = self.marker.as_ref().and_then(MarkerTree::contents) {
+        if let Some(marker) = self.marker.contents() {
             write!(f, " ; {marker}")?;
         }
         Ok(())
@@ -207,7 +203,7 @@ fn parse_unnamed_requirement<Url: UnnamedRequirementUrl>(
     Ok(UnnamedRequirement {
         url,
         extras,
-        marker,
+        marker: marker.unwrap_or_default(),
         origin: None,
     })
 }

--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -1691,7 +1691,7 @@ mod test {
                                 ),
                                 extras: [],
                                 version_or_url: None,
-                                marker: None,
+                                marker: true,
                                 origin: Some(
                                     File(
                                         "<REQUIREMENTS_DIR>/subdir/sibling.txt",
@@ -1755,7 +1755,7 @@ mod test {
                                 ),
                                 extras: [],
                                 version_or_url: None,
-                                marker: None,
+                                marker: true,
                                 origin: Some(
                                     File(
                                         "<REQUIREMENTS_DIR>/requirements.txt",
@@ -1864,7 +1864,7 @@ mod test {
                                     },
                                 },
                                 extras: [],
-                                marker: None,
+                                marker: true,
                                 origin: Some(
                                     File(
                                         "<REQUIREMENTS_DIR>/grandchild.txt",
@@ -1978,7 +1978,7 @@ mod test {
                                 ),
                                 extras: [],
                                 version_or_url: None,
-                                marker: None,
+                                marker: true,
                                 origin: Some(
                                     File(
                                         "<REQUIREMENTS_DIR>/./sibling.txt",
@@ -2007,7 +2007,7 @@ mod test {
                                         ),
                                     ),
                                 ),
-                                marker: None,
+                                marker: true,
                                 origin: Some(
                                     File(
                                         "<REQUIREMENTS_DIR>/requirements.txt",
@@ -2038,7 +2038,7 @@ mod test {
                                         ),
                                     ),
                                 ),
-                                marker: None,
+                                marker: true,
                                 origin: Some(
                                     File(
                                         "<REQUIREMENTS_DIR>/requirements.txt",
@@ -2069,7 +2069,7 @@ mod test {
                                         ),
                                     ),
                                 ),
-                                marker: None,
+                                marker: true,
                                 origin: Some(
                                     File(
                                         "<REQUIREMENTS_DIR>/requirements.txt",
@@ -2098,7 +2098,7 @@ mod test {
                                         ),
                                     ),
                                 ),
-                                marker: None,
+                                marker: true,
                                 origin: Some(
                                     File(
                                         "<REQUIREMENTS_DIR>/requirements.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-basic.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-basic.txt.snap
@@ -23,7 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",
@@ -52,7 +52,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",
@@ -81,7 +81,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",
@@ -110,7 +110,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",
@@ -139,7 +139,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",
@@ -168,7 +168,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-a.txt.snap
@@ -23,7 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/constraints-a.txt",
@@ -52,7 +52,7 @@ RequirementsTxt {
                     ),
                 ),
             ),
-            marker: None,
+            marker: true,
             origin: Some(
                 File(
                     "<REQUIREMENTS_DIR>/constraints-b.txt",
@@ -76,7 +76,7 @@ RequirementsTxt {
                     ),
                 ),
             ),
-            marker: None,
+            marker: true,
             origin: Some(
                 File(
                     "<REQUIREMENTS_DIR>/constraints-b.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-constraints-b.txt.snap
@@ -23,7 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/constraints-b.txt",
@@ -52,7 +52,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/constraints-b.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-for-poetry.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-for-poetry.txt.snap
@@ -23,7 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/for-poetry.txt",
@@ -52,7 +52,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/for-poetry.txt",
@@ -70,7 +70,7 @@ RequirementsTxt {
                     ),
                     extras: [],
                     version_or_url: None,
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/for-poetry.txt",
@@ -107,7 +107,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/for-poetry.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-a.txt.snap
@@ -12,7 +12,7 @@ RequirementsTxt {
                     ),
                     extras: [],
                     version_or_url: None,
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/include-b.txt",
@@ -41,7 +41,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/include-a.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-include-b.txt.snap
@@ -12,7 +12,7 @@ RequirementsTxt {
                     ),
                     extras: [],
                     version_or_url: None,
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/include-b.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-poetry-with-hashes.txt.snap
@@ -23,9 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: Some(
-                        python_version >= '3.8' and python_version < '4.0',
-                    ),
+                    marker: python_version >= '3.8' and python_version < '4.0',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/poetry-with-hashes.txt",
@@ -56,9 +54,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: Some(
-                        python_version >= '3.8' and python_version < '4.0',
-                    ),
+                    marker: python_version >= '3.8' and python_version < '4.0',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/poetry-with-hashes.txt",
@@ -89,9 +85,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: Some(
-                        python_version >= '3.8' and python_version < '4.0' and platform_system == 'Windows',
-                    ),
+                    marker: python_version >= '3.8' and python_version < '4.0' and platform_system == 'Windows',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/poetry-with-hashes.txt",
@@ -122,9 +116,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: Some(
-                        python_version >= '3.8' and python_version < '4.0',
-                    ),
+                    marker: python_version >= '3.8' and python_version < '4.0',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/poetry-with-hashes.txt",
@@ -156,9 +148,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: Some(
-                        python_version >= '3.8' and python_version < '4.0',
-                    ),
+                    marker: python_version >= '3.8' and python_version < '4.0',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/poetry-with-hashes.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-small.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-small.txt.snap
@@ -23,7 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/small.txt",
@@ -52,7 +52,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/small.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-whitespace.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__line-endings-whitespace.txt.snap
@@ -12,7 +12,7 @@ RequirementsTxt {
                     ),
                     extras: [],
                     version_or_url: None,
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/whitespace.txt",
@@ -83,7 +83,7 @@ RequirementsTxt {
                             },
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/whitespace.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-basic.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-basic.txt.snap
@@ -23,7 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",
@@ -52,7 +52,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",
@@ -81,7 +81,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",
@@ -110,7 +110,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",
@@ -139,7 +139,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",
@@ -168,7 +168,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/basic.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-a.txt.snap
@@ -23,7 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/constraints-a.txt",
@@ -52,7 +52,7 @@ RequirementsTxt {
                     ),
                 ),
             ),
-            marker: None,
+            marker: true,
             origin: Some(
                 File(
                     "<REQUIREMENTS_DIR>/constraints-b.txt",
@@ -76,7 +76,7 @@ RequirementsTxt {
                     ),
                 ),
             ),
-            marker: None,
+            marker: true,
             origin: Some(
                 File(
                     "<REQUIREMENTS_DIR>/constraints-b.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-constraints-b.txt.snap
@@ -23,7 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/constraints-b.txt",
@@ -52,7 +52,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/constraints-b.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-for-poetry.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-for-poetry.txt.snap
@@ -23,7 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/for-poetry.txt",
@@ -52,7 +52,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/for-poetry.txt",
@@ -70,7 +70,7 @@ RequirementsTxt {
                     ),
                     extras: [],
                     version_or_url: None,
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/for-poetry.txt",
@@ -107,7 +107,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/for-poetry.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-a.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-a.txt.snap
@@ -12,7 +12,7 @@ RequirementsTxt {
                     ),
                     extras: [],
                     version_or_url: None,
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/include-b.txt",
@@ -41,7 +41,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/include-a.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-b.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-include-b.txt.snap
@@ -12,7 +12,7 @@ RequirementsTxt {
                     ),
                     extras: [],
                     version_or_url: None,
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/include-b.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-poetry-with-hashes.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-poetry-with-hashes.txt.snap
@@ -23,9 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: Some(
-                        python_version >= '3.8' and python_version < '4.0',
-                    ),
+                    marker: python_version >= '3.8' and python_version < '4.0',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/poetry-with-hashes.txt",
@@ -56,9 +54,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: Some(
-                        python_version >= '3.8' and python_version < '4.0',
-                    ),
+                    marker: python_version >= '3.8' and python_version < '4.0',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/poetry-with-hashes.txt",
@@ -89,9 +85,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: Some(
-                        python_version >= '3.8' and python_version < '4.0' and platform_system == 'Windows',
-                    ),
+                    marker: python_version >= '3.8' and python_version < '4.0' and platform_system == 'Windows',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/poetry-with-hashes.txt",
@@ -122,9 +116,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: Some(
-                        python_version >= '3.8' and python_version < '4.0',
-                    ),
+                    marker: python_version >= '3.8' and python_version < '4.0',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/poetry-with-hashes.txt",
@@ -156,9 +148,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: Some(
-                        python_version >= '3.8' and python_version < '4.0',
-                    ),
+                    marker: python_version >= '3.8' and python_version < '4.0',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/poetry-with-hashes.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-small.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-small.txt.snap
@@ -23,7 +23,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/small.txt",
@@ -52,7 +52,7 @@ RequirementsTxt {
                             ),
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/small.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-bare-url.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-bare-url.txt.snap
@@ -44,7 +44,7 @@ RequirementsTxt {
                         },
                     },
                     extras: [],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/bare-url.txt",
@@ -98,7 +98,7 @@ RequirementsTxt {
                             "dev",
                         ),
                     ],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/bare-url.txt",
@@ -148,7 +148,7 @@ RequirementsTxt {
                         },
                     },
                     extras: [],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/bare-url.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-editable.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-editable.txt.snap
@@ -53,7 +53,7 @@ RequirementsTxt {
                             "dev",
                         ),
                     ],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",
@@ -110,7 +110,7 @@ RequirementsTxt {
                             "dev",
                         ),
                     ],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",
@@ -167,9 +167,7 @@ RequirementsTxt {
                             "dev",
                         ),
                     ],
-                    marker: Some(
-                        python_version >= '3.9' and os_name == 'posix',
-                    ),
+                    marker: python_version >= '3.9' and os_name == 'posix',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",
@@ -226,9 +224,7 @@ RequirementsTxt {
                             "dev",
                         ),
                     ],
-                    marker: Some(
-                        python_version >= '3.9' and os_name == 'posix',
-                    ),
+                    marker: python_version >= '3.9' and os_name == 'posix',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",
@@ -278,9 +274,7 @@ RequirementsTxt {
                         },
                     },
                     extras: [],
-                    marker: Some(
-                        python_version >= '3.9' and os_name == 'posix',
-                    ),
+                    marker: python_version >= '3.9' and os_name == 'posix',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",
@@ -330,7 +324,7 @@ RequirementsTxt {
                         },
                     },
                     extras: [],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-whitespace.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-whitespace.txt.snap
@@ -12,7 +12,7 @@ RequirementsTxt {
                     ),
                     extras: [],
                     version_or_url: None,
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/whitespace.txt",
@@ -83,7 +83,7 @@ RequirementsTxt {
                             },
                         ),
                     ),
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/whitespace.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-bare-url.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-bare-url.txt.snap
@@ -44,7 +44,7 @@ RequirementsTxt {
                         },
                     },
                     extras: [],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/bare-url.txt",
@@ -98,7 +98,7 @@ RequirementsTxt {
                             "dev",
                         ),
                     ],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/bare-url.txt",
@@ -148,7 +148,7 @@ RequirementsTxt {
                         },
                     },
                     extras: [],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/bare-url.txt",

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-editable.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-editable.txt.snap
@@ -53,7 +53,7 @@ RequirementsTxt {
                             "dev",
                         ),
                     ],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",
@@ -110,7 +110,7 @@ RequirementsTxt {
                             "dev",
                         ),
                     ],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",
@@ -167,9 +167,7 @@ RequirementsTxt {
                             "dev",
                         ),
                     ],
-                    marker: Some(
-                        python_version >= '3.9' and os_name == 'posix',
-                    ),
+                    marker: python_version >= '3.9' and os_name == 'posix',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",
@@ -226,9 +224,7 @@ RequirementsTxt {
                             "dev",
                         ),
                     ],
-                    marker: Some(
-                        python_version >= '3.9' and os_name == 'posix',
-                    ),
+                    marker: python_version >= '3.9' and os_name == 'posix',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",
@@ -278,9 +274,7 @@ RequirementsTxt {
                         },
                     },
                     extras: [],
-                    marker: Some(
-                        python_version >= '3.9' and os_name == 'posix',
-                    ),
+                    marker: python_version >= '3.9' and os_name == 'posix',
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",
@@ -330,7 +324,7 @@ RequirementsTxt {
                         },
                     },
                     extras: [],
-                    marker: None,
+                    marker: true,
                     origin: Some(
                         File(
                             "<REQUIREMENTS_DIR>/editable.txt",

--- a/crates/uv-configuration/src/constraints.rs
+++ b/crates/uv-configuration/src/constraints.rs
@@ -60,11 +60,7 @@ impl Constraints {
 
             // ASSUMPTION: There is one `extra = "..."`, and it's either the only marker or part
             // of the main conjunction.
-            let Some(extra_expression) = requirement
-                .marker
-                .as_ref()
-                .and_then(MarkerTree::top_level_extra)
-            else {
+            let Some(extra_expression) = requirement.marker.top_level_extra() else {
                 // Case 2: A non-optional dependency with constraint(s).
                 return Either::Right(Either::Right(
                     std::iter::once(requirement).chain(constraints.iter().map(Cow::Borrowed)),
@@ -79,11 +75,9 @@ impl Constraints {
                 constraints.iter().cloned().map(move |constraint| {
                     // Add the extra to the override marker.
                     let mut joint_marker = MarkerTree::expression(extra_expression.clone());
-                    if let Some(marker) = &constraint.marker {
-                        joint_marker.and(marker.clone());
-                    }
+                    joint_marker.and(constraint.marker.clone());
                     Cow::Owned(Requirement {
-                        marker: Some(joint_marker.clone()),
+                        marker: joint_marker,
                         ..constraint
                     })
                 }),

--- a/crates/uv-configuration/src/overrides.rs
+++ b/crates/uv-configuration/src/overrides.rs
@@ -50,11 +50,7 @@ impl Overrides {
 
             // ASSUMPTION: There is one `extra = "..."`, and it's either the only marker or part
             // of the main conjunction.
-            let Some(extra_expression) = requirement
-                .marker
-                .as_ref()
-                .and_then(MarkerTree::top_level_extra)
-            else {
+            let Some(extra_expression) = requirement.marker.top_level_extra() else {
                 // Case 2: A non-optional dependency with override(s).
                 return Either::Right(Either::Right(overrides.iter().map(Cow::Borrowed)));
             };
@@ -67,11 +63,9 @@ impl Overrides {
                 move |override_requirement| {
                     // Add the extra to the override marker.
                     let mut joint_marker = MarkerTree::expression(extra_expression.clone());
-                    if let Some(marker) = &override_requirement.marker {
-                        joint_marker.and(marker.clone());
-                    }
+                    joint_marker.and(override_requirement.marker.clone());
                     Cow::Owned(Requirement {
-                        marker: Some(joint_marker.clone()),
+                        marker: joint_marker,
                         ..override_requirement.clone()
                     })
                 },

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -104,10 +104,7 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
             .into_iter()
             .map(|requirement| Requirement {
                 origin: Some(origin.clone()),
-                marker: requirement
-                    .marker
-                    .map(|marker| marker.simplify_extras(extras))
-                    .filter(|marker| !marker.is_true()),
+                marker: requirement.marker.simplify_extras(extras),
                 ..requirement
             })
             .collect();
@@ -117,7 +114,7 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
             // Find the first recursive requirement.
             // TODO(charlie): Respect markers on recursive extras.
             let Some(index) = requirements.iter().position(|requirement| {
-                requirement.name == metadata.name && requirement.marker.is_none()
+                requirement.name == metadata.name && requirement.marker.is_true()
             }) else {
                 break;
             };
@@ -129,9 +126,8 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
             for requirement in &mut requirements {
                 requirement.marker = requirement
                     .marker
-                    .take()
-                    .map(|marker| marker.simplify_extras(&recursive.extras))
-                    .filter(|marker| !marker.is_true());
+                    .clone()
+                    .simplify_extras(&recursive.extras);
             }
         }
 

--- a/crates/uv-requirements/src/specification.rs
+++ b/crates/uv-requirements/src/specification.rs
@@ -37,7 +37,7 @@ use cache_key::CanonicalUrl;
 use distribution_types::{
     FlatIndexLocation, IndexUrl, UnresolvedRequirement, UnresolvedRequirementSpecification,
 };
-use pep508_rs::{UnnamedRequirement, UnnamedRequirementUrl};
+use pep508_rs::{MarkerTree, UnnamedRequirement, UnnamedRequirementUrl};
 use pypi_types::Requirement;
 use pypi_types::VerbatimParsedUrl;
 use requirements_txt::{RequirementsTxt, RequirementsTxtRequirement};
@@ -193,7 +193,7 @@ impl RequirementsSpecification {
                         requirement: UnresolvedRequirement::Unnamed(UnnamedRequirement {
                             url: VerbatimParsedUrl::parse_absolute_path(path)?,
                             extras: vec![],
-                            marker: None,
+                            marker: MarkerTree::TRUE,
                             origin: None,
                         }),
                         hashes: vec![],

--- a/crates/uv-resolver/src/preferences.rs
+++ b/crates/uv-resolver/src/preferences.rs
@@ -23,7 +23,7 @@ pub struct Preference {
     name: PackageName,
     version: Version,
     /// The markers on the requirement itself (those after the semicolon).
-    marker: Option<MarkerTree>,
+    marker: MarkerTree,
     /// If coming from a package with diverging versions, the markers of the forks this preference
     /// is part of, otherwise `None`.
     fork_markers: Option<BTreeSet<MarkerTree>>,
@@ -77,7 +77,7 @@ impl Preference {
         Self {
             name: dist.name().clone(),
             version: version.clone(),
-            marker: None,
+            marker: MarkerTree::TRUE,
             // Installed distributions don't have fork annotations.
             fork_markers: None,
             hashes: Vec::new(),
@@ -89,7 +89,7 @@ impl Preference {
         Self {
             name: package.id.name.clone(),
             version: package.id.version.clone(),
-            marker: None,
+            marker: MarkerTree::TRUE,
             fork_markers: package.fork_markers().cloned(),
             hashes: Vec::new(),
         }
@@ -128,11 +128,7 @@ impl Preferences {
         for preference in preferences {
             // Filter non-matching preferences when resolving for an environment.
             if let Some(markers) = markers {
-                if !preference
-                    .marker
-                    .as_ref()
-                    .map_or(true, |marker| marker.evaluate(markers, &[]))
-                {
+                if !preference.marker.evaluate(markers, &[]) {
                     trace!("Excluding {preference} from preferences due to unmatched markers");
                     continue;
                 }

--- a/crates/uv-resolver/src/pubgrub/package.rs
+++ b/crates/uv-resolver/src/pubgrub/package.rs
@@ -94,16 +94,14 @@ impl PubGrubPackage {
     pub(crate) fn from_package(
         name: PackageName,
         extra: Option<ExtraName>,
-        marker: Option<MarkerTree>,
+        marker: MarkerTree,
     ) -> Self {
         // Remove all extra expressions from the marker, since we track extras
         // separately. This also avoids an issue where packages added via
         // extras end up having two distinct marker expressions, which in turn
         // makes them two distinct packages. This results in PubGrub being
         // unable to unify version constraints across such packages.
-        let marker = marker
-            .map(|m| m.simplify_extras_with(|_| true))
-            .and_then(|marker| marker.contents());
+        let marker = marker.simplify_extras_with(|_| true).contents();
         if let Some(extra) = extra {
             Self(Arc::new(PubGrubPackageInner::Extra {
                 name,

--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -587,10 +587,7 @@ impl ResolutionGraph {
                 .constraints
                 .apply(self.overrides.apply(archive.metadata.requires_dist.iter()))
             {
-                let Some(ref marker_tree) = req.marker else {
-                    continue;
-                };
-                add_marker_params_from_tree(marker_tree, &mut seen_marker_values);
+                add_marker_params_from_tree(&req.marker, &mut seen_marker_values);
             }
         }
 
@@ -599,10 +596,7 @@ impl ResolutionGraph {
             .constraints
             .apply(self.overrides.apply(self.requirements.iter()))
         {
-            let Some(ref marker_tree) = direct_req.marker else {
-                continue;
-            };
-            add_marker_params_from_tree(marker_tree, &mut seen_marker_values);
+            add_marker_params_from_tree(&direct_req.marker, &mut seen_marker_values);
         }
 
         // Generate the final marker expression as a conjunction of

--- a/crates/uv-resolver/src/resolver/fork_map.rs
+++ b/crates/uv-resolver/src/resolver/fork_map.rs
@@ -15,7 +15,7 @@ pub(crate) struct ForkMap<T>(FxHashMap<PackageName, Vec<Entry<T>>>);
 #[derive(Debug, Clone)]
 struct Entry<T> {
     value: T,
-    marker: Option<MarkerTree>,
+    marker: MarkerTree,
 }
 
 impl<T> Default for ForkMap<T> {
@@ -67,12 +67,7 @@ impl<T> ForkMap<T> {
             // with the current fork, i.e. the markers are not disjoint.
             ResolverMarkers::Fork(fork) => values
                 .iter()
-                .filter(|entry| {
-                    !entry
-                        .marker
-                        .as_ref()
-                        .is_some_and(|marker| fork.is_disjoint(marker))
-                })
+                .filter(|entry| !fork.is_disjoint(&entry.marker))
                 .map(|entry| &entry.value)
                 .collect(),
 

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
@@ -99,7 +99,7 @@ Ok(
                             ),
                         },
                         extra: {},
-                        marker: None,
+                        marker: true,
                     },
                 ],
                 optional_dependencies: {},

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
@@ -99,7 +99,7 @@ Ok(
                             ),
                         },
                         extra: {},
-                        marker: None,
+                        marker: true,
                     },
                 ],
                 optional_dependencies: {},

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
@@ -99,7 +99,7 @@ Ok(
                             ),
                         },
                         extra: {},
-                        marker: None,
+                        marker: true,
                     },
                 ],
                 optional_dependencies: {},

--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -522,8 +522,8 @@ fn update_requirement(old: &mut Requirement, new: &Requirement, has_source: bool
     }
 
     // Update the marker expression.
-    if let Some(marker) = new.marker.clone() {
-        old.marker = Some(marker);
+    if new.marker.contents().is_some() {
+        old.marker = new.marker.clone();
     }
 }
 

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -8,7 +8,7 @@ use glob::{glob, GlobError, PatternError};
 use rustc_hash::FxHashSet;
 use tracing::{debug, trace, warn};
 
-use pep508_rs::{RequirementOrigin, VerbatimUrl};
+use pep508_rs::{MarkerTree, RequirementOrigin, VerbatimUrl};
 use pypi_types::{Requirement, RequirementSource};
 use uv_fs::{absolutize_path, normalize_path, relative_to, Simplified};
 use uv_normalize::{GroupName, PackageName, DEV_DEPENDENCIES};
@@ -282,7 +282,7 @@ impl Workspace {
             Some(Requirement {
                 name: project.name.clone(),
                 extras,
-                marker: None,
+                marker: MarkerTree::TRUE,
                 source: RequirementSource::Directory {
                     install_path: member.root.clone(),
                     lock_path: member

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -139,12 +139,11 @@ impl DisplayDependencyGraph {
         // Add all transitive requirements.
         for metadata in packages.values().flatten() {
             // Ignore any optional dependencies.
-            for required in metadata.requires_dist.iter().filter(|requirement| {
-                requirement
-                    .marker
-                    .as_ref()
-                    .map_or(true, |m| m.evaluate(markers, &[]))
-            }) {
+            for required in metadata
+                .requires_dist
+                .iter()
+                .filter(|requirement| requirement.marker.evaluate(markers, &[]))
+            {
                 let dependency = if invert {
                     Dependency::Inverted(
                         required.name.clone(),


### PR DESCRIPTION
## Summary

Follow up to https://github.com/astral-sh/uv/pull/5898. This should fix some of the failures in https://github.com/astral-sh/uv/pull/5887 where `uv lock --locked` is failing due to `Some(true)` and `None` markers not comparing equal.