### PR TITLE
Add better `tool upgrade` tests

### DIFF
--- a/crates/uv/tests/tool_upgrade.rs
+++ b/crates/uv/tests/tool_upgrade.rs
@@ -14,9 +14,11 @@ fn test_tool_upgrade_name() {
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
-    // Install `black`.
+    // Install `babel` from Test PyPI, to get an outdated version.
     uv_snapshot!(context.filters(), context.tool_install()
-        .arg("black>=23.1")
+        .arg("babel")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
         .env("UV_TOOL_DIR", tool_dir.as_os_str())
         .env("XDG_BIN_HOME", bin_dir.as_os_str())
         .env("PATH", bin_dir.as_os_str()), @r###"
@@ -29,18 +31,16 @@ fn test_tool_upgrade_name() {
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
-     + black==24.3.0
-     + click==8.1.7
-     + mypy-extensions==1.0.0
-     + packaging==24.0
-     + pathspec==0.12.1
-     + platformdirs==4.2.0
-    Installed 2 executables: black, blackd
+     + babel==2.6.0
+     + pytz==2018.5
+    Installed 1 executable: pybabel
     "###);
 
-    // Upgrade `black`. This should be a no-op, since we have the latest version already.
+    // Upgrade `babel` by installing from PyPI, which should upgrade to the latest version.
     uv_snapshot!(context.filters(), context.tool_upgrade()
-        .arg("black")
+        .arg("babel")
+        .arg("--index-url")
+        .arg("https://pypi.org/simple/")
         .env("UV_TOOL_DIR", tool_dir.as_os_str())
         .env("XDG_BIN_HOME", bin_dir.as_os_str())
         .env("PATH", bin_dir.as_os_str()), @r###"
@@ -51,8 +51,13 @@ fn test_tool_upgrade_name() {
     ----- stderr -----
     warning: `uv tool upgrade` is experimental and may change without warning
     Resolved [N] packages in [TIME]
-    Audited [N] packages in [TIME]
-    Updated 2 executables: black, blackd
+    Prepared [N] packages in [TIME]
+    Uninstalled [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     - babel==2.6.0
+     + babel==2.14.0
+     - pytz==2018.5
+    Updated 1 executable: pybabel
     "###);
 }
 
@@ -64,9 +69,11 @@ fn test_tool_upgrade_all() {
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
-    // Install `black==23.1`.
+    // Install `python-dotenv` from Test PyPI, to get an outdated version.
     uv_snapshot!(context.filters(), context.tool_install()
-        .arg("black==23.1")
+        .arg("python-dotenv")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
         .env("UV_TOOL_DIR", tool_dir.as_os_str())
         .env("XDG_BIN_HOME", bin_dir.as_os_str())
         .env("PATH", bin_dir.as_os_str()), @r###"
@@ -79,18 +86,15 @@ fn test_tool_upgrade_all() {
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
-     + black==23.1.0
-     + click==8.1.7
-     + mypy-extensions==1.0.0
-     + packaging==24.0
-     + pathspec==0.12.1
-     + platformdirs==4.2.0
-    Installed 2 executables: black, blackd
+     + python-dotenv==0.10.2.post2
+    Installed 1 executable: dotenv
     "###);
 
-    // Install `pytest==8.0`.
+    // Install `babel` from Test PyPI, to get an outdated version.
     uv_snapshot!(context.filters(), context.tool_install()
-        .arg("pytest==8.0")
+        .arg("babel")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
         .env("UV_TOOL_DIR", tool_dir.as_os_str())
         .env("XDG_BIN_HOME", bin_dir.as_os_str())
         .env("PATH", bin_dir.as_os_str()), @r###"
@@ -103,16 +107,16 @@ fn test_tool_upgrade_all() {
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
-     + iniconfig==2.0.0
-     + packaging==24.0
-     + pluggy==1.4.0
-     + pytest==8.0.0
-    Installed 2 executables: py.test, pytest
+     + babel==2.6.0
+     + pytz==2018.5
+    Installed 1 executable: pybabel
     "###);
 
-    // Upgrade all. This is a no-op, since we have the latest versions already.
+    // Upgrade all from PyPI.
     uv_snapshot!(context.filters(), context.tool_upgrade()
         .arg("--all")
+        .arg("--index-url")
+        .arg("https://pypi.org/simple/")
         .env("UV_TOOL_DIR", tool_dir.as_os_str())
         .env("XDG_BIN_HOME", bin_dir.as_os_str())
         .env("PATH", bin_dir.as_os_str()), @r###"
@@ -123,11 +127,20 @@ fn test_tool_upgrade_all() {
     ----- stderr -----
     warning: `uv tool upgrade` is experimental and may change without warning
     Resolved [N] packages in [TIME]
-    Audited [N] packages in [TIME]
-    Updated 2 executables: black, blackd
+    Prepared [N] packages in [TIME]
+    Uninstalled [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     - babel==2.6.0
+     + babel==2.14.0
+     - pytz==2018.5
+    Updated 1 executable: pybabel
     Resolved [N] packages in [TIME]
-    Audited [N] packages in [TIME]
-    Updated 2 executables: py.test, pytest
+    Prepared [N] packages in [TIME]
+    Uninstalled [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     - python-dotenv==0.10.2.post2
+     + python-dotenv==1.0.1
+    Updated 1 executable: dotenv
     "###);
 }
 
@@ -240,6 +253,62 @@ fn test_tool_upgrade_settings() {
      - black==23.1.0
      + black==24.3.0
     Updated 2 executables: black, blackd
+    "###);
+}
+
+#[test]
+fn test_tool_upgrade_respect_constraints() {
+    let context = TestContext::new("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `babel` from Test PyPI, to get an outdated version.
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("babel<2.10")
+        .arg("--index-url")
+        .arg("https://test.pypi.org/simple/")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str())
+        .env("PATH", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv tool install` is experimental and may change without warning
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + babel==2.6.0
+     + pytz==2018.5
+    Installed 1 executable: pybabel
+    "###);
+
+    // Upgrade `babel` from PyPI. It should be updated, but not beyond the constraint.
+    uv_snapshot!(context.filters(), context.tool_upgrade()
+        .arg("babel")
+        .arg("--index-url")
+        .arg("https://pypi.org/simple/")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str())
+        .env("PATH", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv tool upgrade` is experimental and may change without warning
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Uninstalled [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     - babel==2.6.0
+     + babel==2.9.1
+     - pytz==2018.5
+     + pytz==2024.1
+    Updated 1 executable: pybabel
     "###);
 }
 


### PR DESCRIPTION
## Summary

A lot of the existing tests were no-ops. For convenience, we now use the trick of: install from Test PyPI (to get an outdated "latest"), then upgrade from PyPI.
