### PR TITLE
Hide python options in `uv tool list` help

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2772,7 +2772,7 @@ pub struct ToolListArgs {
     #[arg(long)]
     pub show_paths: bool,
 
-    // Hide unsupported python options.
+    // Hide unused global Python options.
     #[arg(long, hide = true)]
     pub python_preference: Option<PythonPreference>,
     #[arg(long, hide = true)]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2771,6 +2771,12 @@ pub struct ToolListArgs {
     /// Whether to display the path to each tool environment and installed executable.
     #[arg(long)]
     pub show_paths: bool,
+
+    // Hide unsupported python options.
+    #[arg(long, hide = true)]
+    pub python_preference: Option<PythonPreference>,
+    #[arg(long, hide = true)]
+    pub no_python_downloads: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -423,7 +423,7 @@ impl ToolListSettings {
     /// Resolve the [`ToolListSettings`] from the CLI and filesystem configuration.
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn resolve(args: ToolListArgs, _filesystem: Option<FilesystemOptions>) -> Self {
-        let ToolListArgs { show_paths } = args;
+        let ToolListArgs { show_paths, .. } = args;
 
         Self { show_paths }
     }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2529,27 +2529,10 @@ uv tool list [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
-
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
 <p>When disabled, uv will only use locally cached data and locally available files.</p>
 
-</dd><dt><code>--python-preference</code> <i>python-preference</i></dt><dd><p>Whether to prefer uv-managed or system Python installations.</p>
-
-<p>By default, uv prefers using Python versions it manages. However, it will use system Python installations if a uv-managed Python is not installed. This option allows prioritizing or ignoring system Python installations.</p>
-
-<p>Possible values:</p>
-
-<ul>
-<li><code>only-managed</code>:  Only use managed Python installations; never use system Python installations</li>
-
-<li><code>managed</code>:  Prefer managed Python installations over system Python installations</li>
-
-<li><code>system</code>:  Prefer system Python installations over managed Python installations</li>
-
-<li><code>only-system</code>:  Only use system Python installations; never use managed Python installations</li>
-</ul>
 </dd><dt><code>--quiet</code>, <code>-q</code></dt><dd><p>Do not print any output</p>
 
 </dd><dt><code>--show-paths</code></dt><dd><p>Whether to display the path to each tool environment and installed executable</p>


### PR DESCRIPTION
## Summary

Closes #5982 .

## Test Plan

```
cargo run tool list --help
```
