### PR TITLE
Update URL to distutils configuration files docs

### DIFF
--- a/crates/uv-virtualenv/src/_virtualenv.py
+++ b/crates/uv-virtualenv/src/_virtualenv.py
@@ -11,7 +11,7 @@ VIRTUALENV_PATCH_FILE = os.path.join(__file__)
 def patch_dist(dist):
     """
     Distutils allows user to configure some arguments via a configuration file:
-    https://docs.python.org/3/install/index.html#distutils-configuration-files.
+    https://docs.python.org/3.11/install/index.html#distutils-configuration-files.
 
     Some of this arguments though don't make sense in context of the virtual environment files, let's fix them up.
     """  # noqa: D205


### PR DESCRIPTION
## Summary

The existing URL 404s:
https://docs.python.org/3/install/index.html#distutils-configuration-files

...since the `/3/` route now resolves to Python 3.12, where `distutils` has been removed:
https://docs.python.org/3.12/whatsnew/3.12.html#distutils

The Python 3.11 docs are the most recent where the page still exists:
https://docs.python.org/3.11/install/index.html#distutils-configuration-files

## Test Plan

N/A
