### PR TITLE
Make more informative warning message when failed to parse pyproject.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5127,6 +5127,7 @@ dependencies = [
  "pypi-types",
  "schemars",
  "serde",
+ "textwrap",
  "thiserror",
  "toml",
  "tracing",

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -31,6 +31,7 @@ dirs-sys = { workspace = true }
 fs-err = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
+textwrap = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -72,9 +72,12 @@ impl FilesystemOptions {
                 Ok(None) => {
                     // Continue traversing the directory tree.
                 }
-                Err(Error::PyprojectToml(file, _err)) => {
+                Err(Error::PyprojectToml(file, err)) => {
                     // If we see an invalid `pyproject.toml`, warn but continue.
-                    warn_user!("Failed to parse `{file}` during settings discovery; skipping...");
+                    warn_user!(
+                        "Failed to parse `{file}` during settings discovery: {}; skipping...",
+                        err.message()
+                    );
                 }
                 Err(err) => {
                     // Otherwise, warn and stop.

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -75,8 +75,9 @@ impl FilesystemOptions {
                 Err(Error::PyprojectToml(file, err)) => {
                     // If we see an invalid `pyproject.toml`, warn but continue.
                     warn_user!(
-                        "Failed to parse `{file}` during settings discovery: {}; skipping...",
-                        err.message()
+                        "Failed to parse `{}` during settings discovery:\n{}",
+                        file.cyan(),
+                        textwrap::indent(&err.to_string(), "  ")
                     );
                 }
                 Err(err) => {

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -3263,7 +3263,9 @@ fn override_dependency_from_workspace_invalid_syntax() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery; skipping...
+    warning: Failed to parse `pyproject.toml` during settings discovery: no such comparison operator "=", must be one of ~= == != <= >= < > ===
+    werkzeug=2.3.0
+            ^^^^^^; skipping...
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 9, column 29
       |

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -3263,9 +3263,15 @@ fn override_dependency_from_workspace_invalid_syntax() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery: no such comparison operator "=", must be one of ~= == != <= >= < > ===
-    werkzeug=2.3.0
-            ^^^^^^; skipping...
+    warning: Failed to parse `pyproject.toml` during settings discovery:
+      TOML parse error at line 9, column 29
+        |
+      9 |     override-dependencies = [
+        |                             ^
+      no such comparison operator "=", must be one of ~= == != <= >= < > ===
+      werkzeug=2.3.0
+              ^^^^^^
+
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 9, column 29
       |

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -125,7 +125,7 @@ fn invalid_pyproject_toml_syntax() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery; skipping...
+    warning: Failed to parse `pyproject.toml` during settings discovery: expected `.`, `=`; skipping...
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 1, column 5
       |

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -125,7 +125,13 @@ fn invalid_pyproject_toml_syntax() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Failed to parse `pyproject.toml` during settings discovery: expected `.`, `=`; skipping...
+    warning: Failed to parse `pyproject.toml` during settings discovery:
+      TOML parse error at line 1, column 5
+        |
+      1 | 123 - 456
+        |     ^
+      expected `.`, `=`
+
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 1, column 5
       |


### PR DESCRIPTION
## Summary

Added the actual error message to the warning when uv fails to parse `pyproject.toml`.

Resolves https://github.com/astral-sh/uv/issues/5934

## Test Plan

Took the case from the issue:
- have `pyproject.toml` which contains
```
[tool.uv]
foobar = false
```
- 
```
$ uv venv --preview -v
```
- Expect the message that contains the actual problem in the `pyproject.toml` like:
```
warning: Failed to parse `pyproject.toml` during settings discovery: unknown field `foobar`; skipping...
```