### PR TITLE
Filter mixed sources from `--find-links` entries in lockfile

### DIFF
--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -6099,7 +6099,6 @@ fn lock_find_links_http_wheel() -> Result<()> {
         sdist = { url = "https://raw.githubusercontent.com/astral-sh/packse/0.3.34/vendor/build/packaging-23.2.tar.gz" }
         wheels = [
             { url = "https://raw.githubusercontent.com/astral-sh/packse/0.3.34/vendor/build/packaging-23.2-py3-none-any.whl" },
-            { url = "https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7", size = 53011 },
         ]
 
         [[package]]
@@ -6191,7 +6190,6 @@ fn lock_find_links_http_sdist() -> Result<()> {
         sdist = { url = "https://raw.githubusercontent.com/astral-sh/packse/0.3.34/vendor/build/packaging-23.2.tar.gz" }
         wheels = [
             { url = "https://raw.githubusercontent.com/astral-sh/packse/0.3.34/vendor/build/packaging-23.2-py3-none-any.whl" },
-            { url = "https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7", size = 53011 },
         ]
 
         [[package]]


### PR DESCRIPTION
## Summary

Our current handling of `--find-links` merges the entries in each index. As a result, we can end up with `AnnotatedDist` entries that reference distributions across indexes.

I'd like to change `--find-links` such that each `--find-links` entry is just treated as its own index (so, e.g., if `requests` exists in the first `--find-links` entry, we don't even check the registry by default), which would _also_ fix this problem automatically. But that's a behavior change... So for now, in the lockfile, we filter distributions that don't match the source index URL.

There are two cases to consider:

- There's a source distribution. Then, for the ID to reference the `--find-links` registry, the source distribution _must_ have come from the `--find-links` entry, so it's fine to discard any wheels from the "wrong" registry without breaking any compatibility guarantees.
- There's no source distribution. Then the best wheel must come from the `--find-links` registry. We might lose some platform coverage by discarding the other wheels, but it shouldn't break any of the "guarantees", since we have at least one wheel that fits in the version range.

Closes https://github.com/astral-sh/uv/issues/6015.
