### PR TITLE
Add test coverage for direct URLs with sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4536,6 +4536,7 @@ dependencies = [
  "uv-warnings",
  "uv-workspace",
  "which",
+ "zip",
 ]
 
 [[package]]

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -91,8 +91,9 @@ ignore = { version = "0.4.22" }
 indoc = { version = "2.0.4" }
 insta = { version = "1.36.1", features = ["filters", "json"] }
 predicates = { version = "3.0.4" }
-regex = { version = "1.10.3" }
+regex = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"], default-features = false }
+zip = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["flate2"]


### PR DESCRIPTION
## Summary

Ensures that we don't respect `tool.uv.sources` for (eg.) direct URL requirements, as intended.

Related to https://github.com/astral-sh/uv/issues/3943.

Closes https://github.com/astral-sh/uv/issues/6048.
