### PR TITLE
Special case "only available" bounds in resolver errors

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -115,7 +115,7 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                         };
                         format!(
                             "only {} is available",
-                            self.compatible_range(
+                            self.availability_range(
                                 package,
                                 &Range::from_range_bounds((lower, upper))
                             )

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -161,7 +161,7 @@ fn requires_greater_version_does_not_exist() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a<=1.0.0 is available and you require package-a>1.0.0, we can conclude that the requirements are unsatisfiable.
+      ╰─▶ Because only package-a<1.0.0 is available and you require package-a>1.0.0, we can conclude that the requirements are unsatisfiable.
     "###);
 
     assert_not_installed(
@@ -203,7 +203,7 @@ fn requires_less_version_does_not_exist() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a>=2.0.0 is available and you require package-a<2.0.0, we can conclude that the requirements are unsatisfiable.
+      ╰─▶ Because only package-a>2.0.0 is available and you require package-a<2.0.0, we can conclude that the requirements are unsatisfiable.
     "###);
 
     assert_not_installed(
@@ -1941,7 +1941,7 @@ fn local_greater_than() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a<=1.2.3 is available and you require package-a>1.2.3, we can conclude that the requirements are unsatisfiable.
+      ╰─▶ Because only package-a<1.2.3 is available and you require package-a>1.2.3, we can conclude that the requirements are unsatisfiable.
     "###);
 
     assert_not_installed(&context.venv, "local_greater_than_a", &context.temp_dir);
@@ -2019,7 +2019,7 @@ fn local_less_than() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a>=1.2.3 is available and you require package-a<1.2.3, we can conclude that the requirements are unsatisfiable.
+      ╰─▶ Because only package-a>1.2.3 is available and you require package-a<1.2.3, we can conclude that the requirements are unsatisfiable.
     "###);
 
     assert_not_installed(&context.venv, "local_less_than_a", &context.temp_dir);
@@ -2172,7 +2172,7 @@ fn post_greater_than() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a<=1.2.3 is available and you require package-a>1.2.3, we can conclude that the requirements are unsatisfiable.
+      ╰─▶ Because only package-a<1.2.3 is available and you require package-a>1.2.3, we can conclude that the requirements are unsatisfiable.
     "###);
 
     assert_not_installed(&context.venv, "post_greater_than_a", &context.temp_dir);
@@ -2337,7 +2337,7 @@ fn post_less_than() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a>=1.2.3 is available and you require package-a<1.2.3, we can conclude that the requirements are unsatisfiable.
+      ╰─▶ Because only package-a>1.2.3 is available and you require package-a<1.2.3, we can conclude that the requirements are unsatisfiable.
     "###);
 
     assert_not_installed(&context.venv, "post_less_than_a", &context.temp_dir);
@@ -2374,7 +2374,7 @@ fn post_local_greater_than() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a<=1.2.3 is available and you require package-a>1.2.3, we can conclude that the requirements are unsatisfiable.
+      ╰─▶ Because only package-a<1.2.3 is available and you require package-a>1.2.3, we can conclude that the requirements are unsatisfiable.
     "###);
 
     assert_not_installed(
@@ -2629,7 +2629,7 @@ fn package_only_prereleases_in_range() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a<=0.1.0 is available and you require package-a>0.1.0, we can conclude that the requirements are unsatisfiable.
+      ╰─▶ Because only package-a<0.1.0 is available and you require package-a>0.1.0, we can conclude that the requirements are unsatisfiable.
 
           hint: Pre-releases are available for package-a in the requested range (e.g., 1.0.0a1), but pre-releases weren't enabled (try: `--prerelease=allow`)
     "###);
@@ -3077,7 +3077,7 @@ fn transitive_package_only_prereleases_in_range() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-b<=0.1 is available and package-a==0.1.0 depends on package-b>0.1, we can conclude that package-a==0.1.0 cannot be used.
+      ╰─▶ Because only package-b<0.1 is available and package-a==0.1.0 depends on package-b>0.1, we can conclude that package-a==0.1.0 cannot be used.
           And because only package-a==0.1.0 is available and you require package-a, we can conclude that the requirements are unsatisfiable.
 
           hint: Pre-releases are available for package-b in the requested range (e.g., 1.0.0a1), but pre-releases weren't enabled (try: `--prerelease=allow`)

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -1200,7 +1200,7 @@ fn workspace_unsatisfiable_member_dependencies() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
       × No solution found when resolving dependencies:
-      ╰─▶ Because only httpx<=9999 is available and leaf depends on httpx>9999, we can conclude that leaf's requirements are unsatisfiable.
+      ╰─▶ Because only httpx<9999 is available and leaf depends on httpx>9999, we can conclude that leaf's requirements are unsatisfiable.
           And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
     "###
     );


### PR DESCRIPTION
So, this is a little nuanced, but it confused me a couple times and I'm poking around in this code so I figured I'd give it a try.

In the following:

```
❯  uv pip install 'httpx>9999'
  × No solution found when resolving dependencies:
  ╰─▶ Because only httpx<=9999 is available and you require httpx>9999, we can conclude that the requirements are
      unsatisfiable.
```

We say **`only httpx<=9999 is available`**, which _suggests_ that `httpx 9999` is available — but it's not, and we know that. The problem is that we naively take the complement of the requirement (`httpx>9999`).

Here, we special case inclusive bounds to check if the version in question is actually available — if not, we switch to an exclusive bound. 

Note this also applies to the reverse case

```
❯ uv pip install 'httpx<0.000001'
  × No solution found when resolving dependencies:
  ╰─▶ Because only httpx>=0.1 is available and you require httpx<0.1, we can conclude that the requirements are
      unsatisfiable.
```

However, for simplicity, I haven't tackled the case where we display multiple version segments yet. So for more complex requests, our messaging is still confusing:

```
❯ uv pip install 'httpx>99,<999'
  × No solution found when resolving dependencies:
  ╰─▶ Because only the following versions of httpx are available:
          httpx<=99
          httpx>=999
      and you require httpx>99,<999, we can conclude that the requirements are unsatisfiable.
```

This will require further refactoring, which I'll track in a new issue.