### PR TITLE
Redact Git credentials from `pyproject.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4885,6 +4885,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "uv-auth",
  "uv-fs",
 ]
 

--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 use url::Url;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct Credentials {
+pub struct Credentials {
     /// The name of the user for authentication.
     username: Username,
     /// The password to use for authentication.
@@ -114,7 +114,7 @@ impl Credentials {
     /// Parse [`Credentials`] from a URL, if any.
     ///
     /// Returns [`None`] if both [`Url::username`] and [`Url::password`] are not populated.
-    pub(crate) fn from_url(url: &Url) -> Option<Self> {
+    pub fn from_url(url: &Url) -> Option<Self> {
         if url.username().is_empty() && url.password().is_none() {
             return None;
         }
@@ -201,6 +201,20 @@ impl Credentials {
         let mut header = HeaderValue::from_bytes(&buf).expect("base64 is always valid HeaderValue");
         header.set_sensitive(true);
         header
+    }
+
+    /// Apply the credentials to the given URL.
+    ///
+    /// Any existing credentials will be overridden.
+    #[must_use]
+    pub fn apply(&self, mut url: Url) -> Url {
+        if let Some(username) = self.username() {
+            let _ = url.set_username(username);
+        }
+        if let Some(password) = self.password() {
+            let _ = url.set_password(Some(password));
+        }
+        url
     }
 
     /// Attach the credentials to the given request.

--- a/crates/uv-auth/src/lib.rs
+++ b/crates/uv-auth/src/lib.rs
@@ -1,19 +1,19 @@
+use std::sync::{Arc, LazyLock};
+
+use tracing::trace;
+use url::Url;
+
+use cache::CredentialsCache;
+pub use credentials::Credentials;
+pub use keyring::KeyringProvider;
+pub use middleware::AuthMiddleware;
+use realm::Realm;
+
 mod cache;
 mod credentials;
 mod keyring;
 mod middleware;
 mod realm;
-
-use std::sync::{Arc, LazyLock};
-
-use cache::CredentialsCache;
-use credentials::Credentials;
-
-pub use keyring::KeyringProvider;
-pub use middleware::AuthMiddleware;
-use realm::Realm;
-use tracing::trace;
-use url::Url;
 
 // TODO(zanieb): Consider passing a cache explicitly throughout
 

--- a/crates/uv-git/Cargo.toml
+++ b/crates/uv-git/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 cache-key = { workspace = true }
 uv-fs = { workspace = true }
+uv-auth = { workspace = true }
 
 anyhow = { workspace = true }
 cargo-util = { workspace = true }

--- a/crates/uv-git/src/credentials.rs
+++ b/crates/uv-git/src/credentials.rs
@@ -1,0 +1,21 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use cache_key::RepositoryUrl;
+use uv_auth::Credentials;
+
+/// A store for Git credentials.
+#[derive(Debug, Default)]
+pub struct GitStore(RwLock<HashMap<RepositoryUrl, Arc<Credentials>>>);
+
+impl GitStore {
+    /// Insert [`Credentials`] for the given URL into the store.
+    pub fn insert(&self, url: RepositoryUrl, credentials: Credentials) -> Option<Arc<Credentials>> {
+        self.0.write().unwrap().insert(url, Arc::new(credentials))
+    }
+
+    /// Get the [`Credentials`] for the given URL, if they exist.
+    pub fn get(&self, url: &RepositoryUrl) -> Option<Arc<Credentials>> {
+        self.0.read().unwrap().get(url).cloned()
+    }
+}

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -1,5 +1,8 @@
+use std::sync::LazyLock;
+
 use url::Url;
 
+use crate::credentials::GitStore;
 pub use crate::git::GitReference;
 pub use crate::resolver::{
     GitResolver, GitResolverError, RepositoryReference, ResolvedRepositoryReference,
@@ -7,10 +10,16 @@ pub use crate::resolver::{
 pub use crate::sha::{GitOid, GitSha, OidParseError};
 pub use crate::source::{Fetch, GitSource, Reporter};
 
+mod credentials;
 mod git;
 mod resolver;
 mod sha;
 mod source;
+
+/// Global authentication cache for a uv invocation.
+///
+/// This is used to share Git credentials within a single process.
+pub static GIT_STORE: LazyLock<GitStore> = LazyLock::new(GitStore::default);
 
 /// A URL reference to a Git repository.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Hash, Ord)]
@@ -44,6 +53,7 @@ impl GitUrl {
         }
     }
 
+    /// Set the precise [`GitSha`] to use for this Git URL.
     #[must_use]
     pub fn with_precise(mut self, precise: GitSha) -> Self {
         self.precise = Some(precise);

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -5271,9 +5271,6 @@ fn lock_redact_git() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = ["uv-private-pypackage @ git+https://{token}@github.com/astral-test/uv-private-pypackage"]
-
-        [tool.uv]
-        index-url = "https://public:heron@pypi-proxy.fly.dev/basic-auth/simple"
         "#,
         token = token,
     })?;


### PR DESCRIPTION
## Summary

We retain them if you use `--raw-sources`, but otherwise they're removed. We still respect them in the subsequent `uv.lock` via an in-process store.

Closes #6056.
