### PR TITLE
Avoid displaying "failed to download" on build failures for local source distributions

### DIFF
--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -46,8 +46,8 @@ pub enum Error {
     CacheEncode(#[from] rmp_serde::encode::Error),
 
     // Build error
-    #[error("Failed to build: `{0}`")]
-    Build(String, #[source] anyhow::Error),
+    #[error(transparent)]
+    Build(anyhow::Error),
     #[error("Failed to build editable: `{0}`")]
     BuildEditable(String, #[source] anyhow::Error),
     #[error("Built wheel has an invalid filename")]

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1458,10 +1458,10 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 },
             )
             .await
-            .map_err(|err| Error::Build(source.to_string(), err))?
+            .map_err(Error::Build)?
             .wheel(cache_shard)
             .await
-            .map_err(|err| Error::Build(source.to_string(), err))?;
+            .map_err(Error::Build)?;
 
         // Read the metadata from the wheel.
         let filename = WheelFilename::from_str(&disk_filename)?;
@@ -1549,13 +1549,10 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 },
             )
             .await
-            .map_err(|err| Error::Build(source.to_string(), err))?;
+            .map_err(Error::Build)?;
 
         // Build the metadata.
-        let dist_info = builder
-            .metadata()
-            .await
-            .map_err(|err| Error::Build(source.to_string(), err))?;
+        let dist_info = builder.metadata().await.map_err(Error::Build)?;
         let Some(dist_info) = dist_info else {
             return Ok(None);
         };

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1767,7 +1767,11 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         }
                         Dist::Built(built_dist) => ResolveError::Fetch(Box::new(built_dist), err),
                         Dist::Source(source_dist) => {
-                            ResolveError::FetchAndBuild(Box::new(source_dist), err)
+                            if source_dist.is_local() {
+                                ResolveError::Build(Box::new(source_dist), err)
+                            } else {
+                                ResolveError::FetchAndBuild(Box::new(source_dist), err)
+                            }
                         }
                     })?;
 
@@ -1914,7 +1918,11 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                         ResolveError::Fetch(Box::new(built_dist), err)
                                     }
                                     Dist::Source(source_dist) => {
-                                        ResolveError::FetchAndBuild(Box::new(source_dist), err)
+                                        if source_dist.is_local() {
+                                            ResolveError::Build(Box::new(source_dist), err)
+                                        } else {
+                                            ResolveError::FetchAndBuild(Box::new(source_dist), err)
+                                        }
                                     }
                                 })?;
 

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -7517,7 +7517,7 @@ fn lock_mismatched_sources() -> Result<()> {
     ----- stderr -----
     warning: `uv lock` is experimental and may change without warning
     warning: `uv.sources` is experimental and may change without warning
-    error: Failed to download and build: `project @ file://[TEMP_DIR]/`
+    error: Failed to build: `project @ file://[TEMP_DIR]/`
       Caused by: Failed to parse entry for: `uv-public-pypackage`
       Caused by: Can't combine URLs from both `project.dependencies` and `tool.uv.sources`
     "###);

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -11776,7 +11776,6 @@ fn incompatible_build_constraint() -> Result<()> {
 
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      Caused by: Failed to build: `requests==1.2.0`
       Caused by: Failed to install requirements from setup.py build (resolve)
       Caused by: No solution found when resolving: setuptools>=40.8.0
       Caused by: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that the requirements are unsatisfiable.

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -176,7 +176,6 @@ dependencies = ["flask==1.0.x"]
 
     ----- stderr -----
     error: Failed to build: `project @ file://[TEMP_DIR]/path_dep`
-      Caused by: Failed to build: `project @ file://[TEMP_DIR]/path_dep`
       Caused by: Build backend failed to determine extra requires with `build_wheel()` with exit code: 1
     --- stdout:
     configuration error: `project.dependencies[0]` must be pep508
@@ -3413,7 +3412,6 @@ fn no_build_isolation() -> Result<()> {
 
     ----- stderr -----
     error: Failed to download and build: `anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz`
-      Caused by: Failed to build: `anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz`
       Caused by: Build backend failed to determine metadata through `prepare_metadata_for_build_wheel` with exit status: 1
     --- stdout:
 
@@ -3484,7 +3482,6 @@ fn respect_no_build_isolation_env_var() -> Result<()> {
 
     ----- stderr -----
     error: Failed to download and build: `anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz`
-      Caused by: Failed to build: `anyio @ https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz`
       Caused by: Build backend failed to determine metadata through `prepare_metadata_for_build_wheel` with exit status: 1
     --- stdout:
 
@@ -6261,7 +6258,6 @@ fn incompatible_build_constraint() -> Result<()> {
 
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      Caused by: Failed to build: `requests==1.2.0`
       Caused by: Failed to install requirements from setup.py build (resolve)
       Caused by: No solution found when resolving: setuptools>=40.8.0
       Caused by: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that the requirements are unsatisfiable.
@@ -6338,7 +6334,6 @@ fn install_build_isolation_package() -> Result<()> {
 
     ----- stderr -----
     error: Failed to download and build: `iniconfig @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
-      Caused by: Failed to build: `iniconfig @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
       Caused by: Build backend failed to determine metadata through `prepare_metadata_for_build_wheel` with exit status: 1
     --- stdout:
 

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -175,7 +175,7 @@ dependencies = ["flask==1.0.x"]
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download and build: `project @ file://[TEMP_DIR]/path_dep`
+    error: Failed to build: `project @ file://[TEMP_DIR]/path_dep`
       Caused by: Failed to build: `project @ file://[TEMP_DIR]/path_dep`
       Caused by: Build backend failed to determine extra requires with `build_wheel()` with exit code: 1
     --- stdout:

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -5371,7 +5371,6 @@ fn incompatible_build_constraint() -> Result<()> {
 
     ----- stderr -----
     error: Failed to download and build `requests==1.2.0`
-      Caused by: Failed to build: `requests==1.2.0`
       Caused by: Failed to install requirements from setup.py build (resolve)
       Caused by: No solution found when resolving: setuptools>=40.8.0
       Caused by: Because you require setuptools>=40.8.0 and setuptools==1, we can conclude that the requirements are unsatisfiable.

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -463,7 +463,6 @@ fn sync_build_isolation() -> Result<()> {
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning
     error: Failed to download and build: `iniconfig @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
-      Caused by: Failed to build: `iniconfig @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
       Caused by: Build backend failed to determine metadata through `prepare_metadata_for_build_wheel` with exit status: 1
     --- stdout:
 
@@ -617,7 +616,6 @@ fn sync_build_isolation_package() -> Result<()> {
     ----- stderr -----
     warning: `uv sync` is experimental and may change without warning
     error: Failed to download and build: `iniconfig @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
-      Caused by: Failed to build: `iniconfig @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
       Caused by: Build backend failed to determine metadata through `prepare_metadata_for_build_wheel` with exit status: 1
     --- stdout:
 


### PR DESCRIPTION
Especially with workspace members (e.g., [this new test case](https://github.com/astral-sh/uv/pull/6073/files#diff-273076013b4f5a8139defd5dcd24f5d1eb91c0266dceb4448fdeddceb79f7738R1377-R1379)), I find it very confusing that we say we failed to download these distributions.