### PR TITLE
Improve resolver error messages for single-project workspaces

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -13,7 +13,9 @@ use uv_normalize::PackageName;
 use crate::candidate_selector::CandidateSelector;
 use crate::dependency_provider::UvDependencyProvider;
 use crate::fork_urls::ForkUrls;
-use crate::pubgrub::{PubGrubPackage, PubGrubReportFormatter, PubGrubSpecifierError};
+use crate::pubgrub::{
+    PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter, PubGrubSpecifierError,
+};
 use crate::python_requirement::PythonRequirement;
 use crate::resolver::{IncompletePackage, ResolverMarkers, UnavailablePackage, UnavailableReason};
 
@@ -221,6 +223,11 @@ impl std::fmt::Display for NoSolutionError {
         let mut tree = self.error.clone();
         collapse_unavailable_workspace_members(&mut tree);
 
+        if self.workspace_members.len() == 1 {
+            let project = self.workspace_members.iter().next().unwrap();
+            drop_root_dependency_on_project(&mut tree, project);
+        }
+
         let report = DefaultStringReporter::report_with_formatter(&tree, &formatter);
         write!(f, "{report}")?;
 
@@ -280,6 +287,62 @@ fn collapse_unavailable_workspace_members(
                 _ => {
                     collapse_unavailable_workspace_members(Arc::make_mut(&mut derived.cause1));
                     collapse_unavailable_workspace_members(Arc::make_mut(&mut derived.cause2));
+                }
+            }
+        }
+    }
+}
+
+/// Given a [`DerivationTree`], drop dependency incompatibilities from the root
+/// to the project.
+///
+/// Intended to effectively change the root to a workspace member in single project
+/// workspaces, avoiding a level of indirection like "And because your project
+/// requires your project, we can conclude that your projects's requirements are
+/// unsatisfiable."
+fn drop_root_dependency_on_project(
+    tree: &mut DerivationTree<PubGrubPackage, Range<Version>, UnavailableReason>,
+    project: &PackageName,
+) {
+    match tree {
+        DerivationTree::External(_) => {}
+        DerivationTree::Derived(derived) => {
+            match (
+                Arc::make_mut(&mut derived.cause1),
+                Arc::make_mut(&mut derived.cause2),
+            ) {
+                // If one node is a dependency incompatibility...
+                (
+                    DerivationTree::External(External::FromDependencyOf(package, _, dependency, _)),
+                    ref mut other,
+                )
+                | (
+                    ref mut other,
+                    DerivationTree::External(External::FromDependencyOf(package, _, dependency, _)),
+                ) => {
+                    // And the parent is the root package...
+                    if !matches!(&**package, PubGrubPackageInner::Root(_)) {
+                        return;
+                    }
+
+                    // And the dependency is the project...
+                    let PubGrubPackageInner::Package { name, .. } = &**dependency else {
+                        return;
+                    };
+                    if name != project {
+                        return;
+                    }
+
+                    // Recursively collapse the other side of the tree
+                    drop_root_dependency_on_project(other, project);
+
+                    // Then, replace this node with the other tree
+                    *tree = other.clone();
+                }
+                // If not, just recurse
+                _ => {
+                    drop_root_dependency_on_project(Arc::make_mut(&mut derived.cause1), project);
+                    drop_root_dependency_on_project(Arc::make_mut(&mut derived.cause2), project);
                 }
             }
         }

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -330,6 +330,9 @@ impl PubGrubReportFormatter<'_> {
     fn format_root_requires(&self, package: &PubGrubPackage) -> Option<String> {
         if self.is_workspace() {
             if matches!(&**package, PubGrubPackageInner::Root(_)) {
+                if self.is_single_project_workspace() {
+                    return Some("your project requires".to_string());
+                }
                 return Some("your workspace requires".to_string());
             }
         }
@@ -347,7 +350,10 @@ impl PubGrubReportFormatter<'_> {
     fn format_root(&self, package: &PubGrubPackage) -> Option<String> {
         if self.is_workspace() {
             if matches!(&**package, PubGrubPackageInner::Root(_)) {
-                return Some("your workspace's requirements".to_string());
+                if self.is_single_project_workspace() {
+                    return Some("your projects's requirements".to_string());
+                }
+                return Some("your workspaces's requirements".to_string());
             }
         }
         match &**package {
@@ -362,6 +368,11 @@ impl PubGrubReportFormatter<'_> {
         !self.workspace_members.is_empty()
     }
 
+    /// Whether the resolution error is for a workspace with a exactly one project.
+    fn is_single_project_workspace(&self) -> bool {
+        self.workspace_members.len() == 1
+    }
+
     /// Return a display name for the package if it is a workspace member.
     fn format_workspace_member(&self, package: &PubGrubPackage) -> Option<String> {
         match &**package {
@@ -369,7 +380,11 @@ impl PubGrubReportFormatter<'_> {
             | PubGrubPackageInner::Extra { name, .. }
             | PubGrubPackageInner::Dev { name, .. } => {
                 if self.workspace_members.contains(name) {
-                    Some(format!("{name}"))
+                    if self.is_single_project_workspace() {
+                        Some("your project".to_string())
+                    } else {
+                        Some(format!("{name}"))
+                    }
                 } else {
                     None
                 }

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -353,7 +353,7 @@ impl PubGrubReportFormatter<'_> {
                 if self.is_single_project_workspace() {
                     return Some("your projects's requirements".to_string());
                 }
-                return Some("your workspaces's requirements".to_string());
+                return Some("your workspace's requirements".to_string());
             }
         }
         match &**package {

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -2579,7 +2579,6 @@ fn add_error() -> Result<()> {
     warning: `uv add` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because there are no versions of xyz and your project depends on xyz, we can conclude that your project's requirements are unsatisfiable.
-          And because your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
       help: If this is intentional, run `uv add --frozen` to skip the lock and sync steps.
     "###);
 

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -2578,8 +2578,8 @@ fn add_error() -> Result<()> {
     ----- stderr -----
     warning: `uv add` is experimental and may change without warning
       × No solution found when resolving dependencies:
-      ╰─▶ Because there are no versions of xyz and project depends on xyz, we can conclude that project's requirements are unsatisfiable.
-          And because your workspace requires project, we can conclude that your workspace's requirements are unsatisfiable.
+      ╰─▶ Because there are no versions of xyz and your project depends on xyz, we can conclude that your project's requirements are unsatisfiable.
+          And because your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
       help: If this is intentional, run `uv add --frozen` to skip the lock and sync steps.
     "###);
 

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -2748,7 +2748,7 @@ fn lock_requires_python() -> Result<()> {
                   pygls>=1.1.0,<1.3.0
                   pygls>1.3.0
                cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
-              And because project depends on pygls>=1.1.0 and your workspace requires project, we can conclude that your workspace's requirements are unsatisfiable.
+              And because your project depends on pygls>=1.1.0 and your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
 
               hint: The `requires-python` value (>=3.7) includes Python versions that are not supported by your dependencies (e.g., pygls>=1.1.0,<=1.2.1 only supports >=3.7.9, <4). Consider using a more restrictive `requires-python` value (like >=3.7.9, <4).
         "###);
@@ -5015,8 +5015,8 @@ fn lock_requires_python_no_wheels() -> Result<()> {
     ----- stderr -----
     warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
-      ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python ABI tag and project depends on dearpygui==1.9.1, we can conclude that project's requirements are unsatisfiable.
-          And because your workspace requires project, we can conclude that your workspace's requirements are unsatisfiable.
+      ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python ABI tag and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
+          And because your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
     "###);
 
     Ok(())
@@ -8210,8 +8210,8 @@ fn unconditional_overlapping_marker_disjoint_version_constraints() -> Result<()>
     ----- stderr -----
     warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies for split (python_version > '3.10'):
-      ╰─▶ Because only datasets{python_version > '3.10'}<2.19 is available and project depends on datasets{python_version > '3.10'}>=2.19, we can conclude that project's requirements are unsatisfiable.
-          And because your workspace requires project, we can conclude that your workspace's requirements are unsatisfiable.
+      ╰─▶ Because only datasets{python_version > '3.10'}<2.19 is available and your project depends on datasets{python_version > '3.10'}>=2.19, we can conclude that your project's requirements are unsatisfiable.
+          And because your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
     "###);
 
     Ok(())

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -2748,7 +2748,7 @@ fn lock_requires_python() -> Result<()> {
                   pygls>=1.1.0,<1.3.0
                   pygls>1.3.0
                cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
-              And because your project depends on pygls>=1.1.0 and your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
+              And because your project depends on pygls>=1.1.0, we can conclude that your project's requirements are unsatisfiable.
 
               hint: The `requires-python` value (>=3.7) includes Python versions that are not supported by your dependencies (e.g., pygls>=1.1.0,<=1.2.1 only supports >=3.7.9, <4). Consider using a more restrictive `requires-python` value (like >=3.7.9, <4).
         "###);
@@ -5016,7 +5016,6 @@ fn lock_requires_python_no_wheels() -> Result<()> {
     warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python ABI tag and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
-          And because your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
     "###);
 
     Ok(())
@@ -8211,7 +8210,6 @@ fn unconditional_overlapping_marker_disjoint_version_constraints() -> Result<()>
     warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies for split (python_version > '3.10'):
       ╰─▶ Because only datasets{python_version > '3.10'}<2.19 is available and your project depends on datasets{python_version > '3.10'}>=2.19, we can conclude that your project's requirements are unsatisfiable.
-          And because your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
     "###);
 
     Ok(())

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -474,7 +474,7 @@ fn conflict_in_fork() -> Result<()> {
               package-a{sys_platform == 'darwin'}==1.0.0
               package-a{sys_platform == 'darwin'}>=2
           we can conclude that package-a{sys_platform == 'darwin'}<2 is incompatible.
-          And because project depends on package-a{sys_platform == 'darwin'}<2 and your workspace requires project, we can conclude that your workspace's requirements are unsatisfiable.
+          And because your project depends on package-a{sys_platform == 'darwin'}<2 and your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
     "###
     );
 
@@ -537,8 +537,8 @@ fn fork_conflict_unsatisfiable() -> Result<()> {
     ----- stderr -----
     warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
-      ╰─▶ Because project depends on package-a>=2 and package-a<2, we can conclude that project's requirements are unsatisfiable.
-          And because your workspace requires project, we can conclude that your workspace's requirements are unsatisfiable.
+      ╰─▶ Because your project depends on package-a>=2 and package-a<2, we can conclude that your project's requirements are unsatisfiable.
+          And because your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
     "###
     );
 
@@ -1262,8 +1262,8 @@ fn fork_marker_disjoint() -> Result<()> {
     ----- stderr -----
     warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies for split (sys_platform == 'linux'):
-      ╰─▶ Because project depends on package-a{sys_platform == 'linux'}>=2 and package-a{sys_platform == 'linux'}<2, we can conclude that project's requirements are unsatisfiable.
-          And because your workspace requires project, we can conclude that your workspace's requirements are unsatisfiable.
+      ╰─▶ Because your project depends on package-a{sys_platform == 'linux'}>=2 and package-a{sys_platform == 'linux'}<2, we can conclude that your project's requirements are unsatisfiable.
+          And because your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
     "###
     );
 
@@ -3024,8 +3024,8 @@ fn fork_non_local_fork_marker_direct() -> Result<()> {
     warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because package-b{sys_platform == 'darwin'}==1.0.0 depends on package-c>=2.0.0 and package-a{sys_platform == 'linux'}==1.0.0 depends on package-c<2.0.0, we can conclude that package-a{sys_platform == 'linux'}==1.0.0 and package-b{sys_platform == 'darwin'}==1.0.0 are incompatible.
-          And because project depends on package-a{sys_platform == 'linux'}==1.0.0, we can conclude that project and package-b{sys_platform == 'darwin'}==1.0.0 are incompatible.
-          And because project depends on package-b{sys_platform == 'darwin'}==1.0.0 and your workspace requires project, we can conclude that your workspace's requirements are unsatisfiable.
+          And because your project depends on package-a{sys_platform == 'linux'}==1.0.0, we can conclude that your project and package-b{sys_platform == 'darwin'}==1.0.0 are incompatible.
+          And because your project depends on package-b{sys_platform == 'darwin'}==1.0.0 and your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
     "###
     );
 
@@ -3102,8 +3102,8 @@ fn fork_non_local_fork_marker_transitive() -> Result<()> {
               package-c{sys_platform == 'linux'}==1.0.0
               package-c{sys_platform == 'linux'}>=2.0.0
           we can conclude that package-b==1.0.0 and package-c{sys_platform == 'linux'}<2.0.0 are incompatible.
-          And because package-a==1.0.0 depends on package-c{sys_platform == 'linux'}<2.0.0 and project depends on package-a==1.0.0, we can conclude that package-b==1.0.0 and project are incompatible.
-          And because project depends on package-b==1.0.0 and your workspace requires project, we can conclude that your workspace's requirements are unsatisfiable.
+          And because package-a==1.0.0 depends on package-c{sys_platform == 'linux'}<2.0.0 and your project depends on package-a==1.0.0, we can conclude that package-b==1.0.0 and your project are incompatible.
+          And because your project depends on package-b==1.0.0 and your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
     "###
     );
 

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -468,13 +468,12 @@ fn conflict_in_fork() -> Result<()> {
     warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies for split (sys_platform == 'darwin'):
       ╰─▶ Because only package-b==1.0.0 is available and package-b==1.0.0 depends on package-d==1, we can conclude that all versions of package-b depend on package-d==1.
-          And because package-c==1.0.0 depends on package-d==2, we can conclude that all versions of package-b and package-c==1.0.0 are incompatible.
-          And because only package-c==1.0.0 is available and package-a{sys_platform == 'darwin'}==1.0.0 depends on package-b, we can conclude that package-a{sys_platform == 'darwin'}==1.0.0 and all versions of package-c are incompatible.
-          And because package-a{sys_platform == 'darwin'}==1.0.0 depends on package-c and only the following versions of package-a{sys_platform == 'darwin'} are available:
+          And because package-c==1.0.0 depends on package-d==2 and only package-c==1.0.0 is available, we can conclude that all versions of package-b and all versions of package-c are incompatible.
+          And because package-a{sys_platform == 'darwin'}==1.0.0 depends on package-b and package-c, we can conclude that package-a{sys_platform == 'darwin'}==1.0.0 cannot be used.
+          And because only the following versions of package-a{sys_platform == 'darwin'} are available:
               package-a{sys_platform == 'darwin'}==1.0.0
               package-a{sys_platform == 'darwin'}>=2
-          we can conclude that package-a{sys_platform == 'darwin'}<2 is incompatible.
-          And because your project depends on package-a{sys_platform == 'darwin'}<2 and your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
+          and your project depends on package-a{sys_platform == 'darwin'}<2, we can conclude that your project's requirements are unsatisfiable.
     "###
     );
 
@@ -538,7 +537,6 @@ fn fork_conflict_unsatisfiable() -> Result<()> {
     warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because your project depends on package-a>=2 and package-a<2, we can conclude that your project's requirements are unsatisfiable.
-          And because your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
     "###
     );
 
@@ -1263,7 +1261,6 @@ fn fork_marker_disjoint() -> Result<()> {
     warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies for split (sys_platform == 'linux'):
       ╰─▶ Because your project depends on package-a{sys_platform == 'linux'}>=2 and package-a{sys_platform == 'linux'}<2, we can conclude that your project's requirements are unsatisfiable.
-          And because your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
     "###
     );
 
@@ -3024,8 +3021,7 @@ fn fork_non_local_fork_marker_direct() -> Result<()> {
     warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because package-b{sys_platform == 'darwin'}==1.0.0 depends on package-c>=2.0.0 and package-a{sys_platform == 'linux'}==1.0.0 depends on package-c<2.0.0, we can conclude that package-a{sys_platform == 'linux'}==1.0.0 and package-b{sys_platform == 'darwin'}==1.0.0 are incompatible.
-          And because your project depends on package-a{sys_platform == 'linux'}==1.0.0, we can conclude that your project and package-b{sys_platform == 'darwin'}==1.0.0 are incompatible.
-          And because your project depends on package-b{sys_platform == 'darwin'}==1.0.0 and your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
+          And because your project depends on package-a{sys_platform == 'linux'}==1.0.0 and package-b{sys_platform == 'darwin'}==1.0.0, we can conclude that your project's requirements are unsatisfiable.
     "###
     );
 
@@ -3101,9 +3097,8 @@ fn fork_non_local_fork_marker_transitive() -> Result<()> {
           And because only the following versions of package-c{sys_platform == 'linux'} are available:
               package-c{sys_platform == 'linux'}==1.0.0
               package-c{sys_platform == 'linux'}>=2.0.0
-          we can conclude that package-b==1.0.0 and package-c{sys_platform == 'linux'}<2.0.0 are incompatible.
-          And because package-a==1.0.0 depends on package-c{sys_platform == 'linux'}<2.0.0 and your project depends on package-a==1.0.0, we can conclude that package-b==1.0.0 and your project are incompatible.
-          And because your project depends on package-b==1.0.0 and your project requires your project, we can conclude that your projects's requirements are unsatisfiable.
+          and package-a==1.0.0 depends on package-c{sys_platform == 'linux'}<2.0.0, we can conclude that package-a==1.0.0 and package-b==1.0.0 are incompatible.
+          And because your project depends on package-a==1.0.0 and package-b==1.0.0, we can conclude that your project's requirements are unsatisfiable.
     "###
     );
 

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -1009,7 +1009,7 @@ fn workspace_inherit_sources() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
       × No solution found when resolving dependencies:
       ╰─▶ Because library was not found in the cache and leaf depends on library, we can conclude that leaf's requirements are unsatisfiable.
-          And because your workspace requires leaf, we can conclude that your workspaces's requirements are unsatisfiable.
+          And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
 
           hint: Packages were unavailable because the network was disabled
     "###
@@ -1201,7 +1201,7 @@ fn workspace_unsatisfiable_member_dependencies() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
       × No solution found when resolving dependencies:
       ╰─▶ Because only httpx<=9999 is available and leaf depends on httpx>9999, we can conclude that leaf's requirements are unsatisfiable.
-          And because your workspace requires leaf, we can conclude that your workspaces's requirements are unsatisfiable.
+          And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
     "###
     );
 
@@ -1257,7 +1257,7 @@ fn workspace_unsatisfiable_member_dependencies_conflicting() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
       × No solution found when resolving dependencies:
       ╰─▶ Because bar depends on anyio==4.2.0 and foo depends on anyio==4.1.0, we can conclude that bar and foo are incompatible.
-          And because your workspace requires bar and foo, we can conclude that your workspaces's requirements are unsatisfiable.
+          And because your workspace requires bar and foo, we can conclude that your workspace's requirements are unsatisfiable.
     "###
     );
 
@@ -1324,7 +1324,7 @@ fn workspace_unsatisfiable_member_dependencies_conflicting_threeway() -> Result<
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
       × No solution found when resolving dependencies:
       ╰─▶ Because bird depends on anyio==4.3.0 and knot depends on anyio==4.2.0, we can conclude that bird and knot are incompatible.
-          And because your workspace requires bird and knot, we can conclude that your workspaces's requirements are unsatisfiable.
+          And because your workspace requires bird and knot, we can conclude that your workspace's requirements are unsatisfiable.
     "###
     );
 

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -1009,7 +1009,7 @@ fn workspace_inherit_sources() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
       × No solution found when resolving dependencies:
       ╰─▶ Because library was not found in the cache and leaf depends on library, we can conclude that leaf's requirements are unsatisfiable.
-          And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
+          And because your workspace requires leaf, we can conclude that your workspaces's requirements are unsatisfiable.
 
           hint: Packages were unavailable because the network was disabled
     "###
@@ -1201,7 +1201,7 @@ fn workspace_unsatisfiable_member_dependencies() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
       × No solution found when resolving dependencies:
       ╰─▶ Because only httpx<=9999 is available and leaf depends on httpx>9999, we can conclude that leaf's requirements are unsatisfiable.
-          And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
+          And because your workspace requires leaf, we can conclude that your workspaces's requirements are unsatisfiable.
     "###
     );
 
@@ -1257,7 +1257,7 @@ fn workspace_unsatisfiable_member_dependencies_conflicting() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
       × No solution found when resolving dependencies:
       ╰─▶ Because bar depends on anyio==4.2.0 and foo depends on anyio==4.1.0, we can conclude that bar and foo are incompatible.
-          And because your workspace requires bar and foo, we can conclude that your workspace's requirements are unsatisfiable.
+          And because your workspace requires bar and foo, we can conclude that your workspaces's requirements are unsatisfiable.
     "###
     );
 
@@ -1324,7 +1324,7 @@ fn workspace_unsatisfiable_member_dependencies_conflicting_threeway() -> Result<
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
       × No solution found when resolving dependencies:
       ╰─▶ Because bird depends on anyio==4.3.0 and knot depends on anyio==4.2.0, we can conclude that bird and knot are incompatible.
-          And because your workspace requires bird and knot, we can conclude that your workspace's requirements are unsatisfiable.
+          And because your workspace requires bird and knot, we can conclude that your workspaces's requirements are unsatisfiable.
     "###
     );
 


### PR DESCRIPTION
Extends https://github.com/astral-sh/uv/pull/6092 to improve resolver error messages for workspaces that have a single member.

As before, this requires a two-step approach of

1. Traversing the derivation tree and collapsing some members. In this case, we drop the empty root node in favor of the project.
2. Using special-case formatting for packages. In this case, the workspace package is referred to with "your project" instead of its name.