### PR TITLE
Change the definition of `--locked` to require satisfaction check

### DIFF
--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -40,7 +40,7 @@ use crate::{ExcludeNewer, PrereleaseMode, RequiresPython, ResolutionGraph, Resol
 /// The current version of the lockfile format.
 const VERSION: u32 = 1;
 
-#[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, serde::Deserialize)]
 #[serde(try_from = "LockWire")]
 pub struct Lock {
     version: u32,

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -441,7 +441,7 @@ pub(crate) async fn add(
     )
     .await
     {
-        Ok(lock) => lock,
+        Ok(result) => result.into_lock(),
         Err(ProjectError::Operation(pip::operations::Error::Resolve(
             uv_resolver::ResolveError::NoSolution(err),
         ))) => {
@@ -463,8 +463,8 @@ pub(crate) async fn add(
     if !raw_sources {
         // Extract the minimum-supported version for each dependency.
         let mut minimum_version =
-            FxHashMap::with_capacity_and_hasher(lock.lock.packages().len(), FxBuildHasher);
-        for dist in lock.lock.packages() {
+            FxHashMap::with_capacity_and_hasher(lock.packages().len(), FxBuildHasher);
+        for dist in lock.packages() {
             let name = dist.name();
             let version = dist.version();
             match minimum_version.entry(name) {
@@ -563,7 +563,7 @@ pub(crate) async fn add(
     project::sync::do_sync(
         &project,
         &venv,
-        &lock.lock,
+        &lock,
         &extras,
         dev,
         Modifications::Sufficient,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -174,7 +174,8 @@ pub(crate) async fn remove(
         cache,
         printer,
     )
-    .await?;
+    .await?
+    .into_lock();
 
     if no_sync {
         return Ok(ExitStatus::Success);
@@ -191,7 +192,7 @@ pub(crate) async fn remove(
     project::sync::do_sync(
         &project,
         &venv,
-        &lock.lock,
+        &lock,
         &extras,
         dev,
         Modifications::Exact,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -89,7 +89,7 @@ pub(crate) async fn sync(
     )
     .await
     {
-        Ok(lock) => lock,
+        Ok(result) => result.into_lock(),
         Err(ProjectError::Operation(pip::operations::Error::Resolve(
             uv_resolver::ResolveError::NoSolution(err),
         ))) => {
@@ -107,7 +107,7 @@ pub(crate) async fn sync(
     do_sync(
         &project,
         &venv,
-        &lock.lock,
+        &lock,
         &extras,
         dev,
         modifications,

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -79,7 +79,8 @@ pub(crate) async fn tree(
         cache,
         printer,
     )
-    .await?;
+    .await?
+    .into_lock();
 
     // Apply the platform tags to the markers.
     let markers = match (python_platform, python_version) {
@@ -93,7 +94,7 @@ pub(crate) async fn tree(
 
     // Render the tree.
     let tree = TreeDisplay::new(
-        &lock.lock,
+        &lock,
         (!universal).then(|| markers.as_ref()),
         depth.into(),
         prune,

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -128,19 +128,6 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -248,19 +235,6 @@ fn fork_allows_non_conflicting_repeated_dependencies() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())
@@ -382,19 +356,6 @@ fn fork_basic() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())
@@ -743,19 +704,6 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -865,19 +813,6 @@ fn fork_upgrade() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())
@@ -1040,19 +975,6 @@ fn fork_incomplete_markers() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -1182,19 +1104,6 @@ fn fork_marker_accrue() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())
@@ -1447,19 +1356,6 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -1623,19 +1519,6 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())
@@ -1812,19 +1695,6 @@ fn fork_marker_inherit_combined() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -1962,19 +1832,6 @@ fn fork_marker_inherit_isolated() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())
@@ -2142,19 +1999,6 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -2282,19 +2126,6 @@ fn fork_marker_inherit() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())
@@ -2463,19 +2294,6 @@ fn fork_marker_limited_inherit() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -2614,19 +2432,6 @@ fn fork_marker_selection() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())
@@ -2801,19 +2606,6 @@ fn fork_marker_track() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -2942,19 +2734,6 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())
@@ -3246,19 +3025,6 @@ fn fork_overlapping_markers_basic() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -3494,19 +3260,6 @@ fn preferences_dependent_forking_bistable() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())
@@ -3941,19 +3694,6 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -4156,19 +3896,6 @@ fn preferences_dependent_forking() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -4352,19 +4079,6 @@ fn fork_remaining_universe_partitioning() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -4450,19 +4164,6 @@ fn fork_requires_python_full_prerelease() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -4542,19 +4243,6 @@ fn fork_requires_python_full() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())
@@ -4662,19 +4350,6 @@ fn fork_requires_python_patch_overlap() -> Result<()> {
         .assert()
         .success();
 
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
     Ok(())
 }
 
@@ -4751,19 +4426,6 @@ fn fork_requires_python() -> Result<()> {
     context
         .lock()
         .arg("--locked")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
         .env_remove("UV_EXCLUDE_NEWER")
         .arg("--index-url")
         .arg(packse_index_url())

--- a/scripts/scenarios/templates/lock.mustache
+++ b/scripts/scenarios/templates/lock.mustache
@@ -80,19 +80,6 @@ fn {{module_name}}() -> Result<()> {
         .arg(packse_index_url())
         .assert()
         .success();
-
-    // Assert the idempotence of `uv lock` when resolving with the lockfile preferences,
-    // by upgrading an irrelevant package.
-    context
-        .lock()
-        .arg("--locked")
-        .arg("--upgrade-package")
-        .arg("packse")
-        .env_remove("UV_EXCLUDE_NEWER")
-        .arg("--index-url")
-        .arg(packse_index_url())
-        .assert()
-        .success();
     {{/expected.satisfiable}}
 
     Ok(())


### PR DESCRIPTION
## Summary

This PR changes the definition of `--locked` from:

> Produces the same `Lock`

To:

> Passes `Lock::satisfies`

This is a subtle but important difference. Previous, if `Lock::satisfies` failed, we would run a resolution, then do `existing_lock == lock`. If the two weren't equal, and `--locked` was specified, we'd throw an error.

The equality check is hard to get right. For example, it means that we can't ship #6076 without changing our marker representation, since the deserialized lockfile "loses" some of the internal marker state that gets accumulated during resolution.

The downside of this change is that there could be scenarios in which `uv lock --locked` fails even though the lockfile would actually work and the exact TOML would be unchanged. But... I think it's ok if `--locked` fails after the user modifies something?
