### PR TITLE
Treat Git sources as immutable in lockfile

### DIFF
--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -1808,8 +1808,10 @@ impl Source {
     ///
     /// We assume that registry sources are immutable. In other words, we expect that once a
     /// package-version is published to a registry, its metadata will not change.
+    ///
+    /// We also assume that Git sources are immutable, since a Git source encodes a specific commit.
     fn is_immutable(&self) -> bool {
-        matches!(self, Self::Registry(..))
+        matches!(self, Self::Registry(..) | Self::Git(_, _))
     }
 
     fn to_toml(&self, table: &mut Table) {

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -1924,16 +1924,6 @@ fn update() -> Result<()> {
             { name = "chardet" },
         ]
 
-        [package.metadata]
-        requires-dist = [
-            { name = "certifi", specifier = ">=2017.4.17" },
-            { name = "chardet", marker = "extra == 'use-chardet-on-py3'", specifier = "<6,>=3.0.2" },
-            { name = "charset-normalizer", specifier = "<4,>=2" },
-            { name = "idna", specifier = "<4,>=2.5" },
-            { name = "pysocks", marker = "extra == 'socks'", specifier = "!=1.5.7,>=1.5.6" },
-            { name = "urllib3", specifier = "<3,>=1.21.1" },
-        ]
-
         [[package]]
         name = "urllib3"
         version = "2.2.1"


### PR DESCRIPTION
## Summary

We don't need to write metadata for Git sources, since we lock a specific SHA (and so the metadata is immutable).
