### PR TITLE
Use availability range display type in formatting

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -115,7 +115,7 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                         };
                         format!(
                             "only {} is available",
-                            self.compatible_range(
+                            self.availability_range(
                                 package,
                                 &Range::from_range_bounds((lower, upper))
                             )


### PR DESCRIPTION
We're using the wrong type here, which never mattered since it was a single bound but will matter in the future :)