### PR TITLE
Remove `requires-python` application in lock deserialization

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -710,7 +710,7 @@ pub(crate) async fn commit(lock: &Lock, workspace: &Workspace) -> Result<(), Pro
 /// Returns `Ok(None)` if the lockfile does not exist.
 pub(crate) async fn read(workspace: &Workspace) -> Result<Option<Lock>, ProjectError> {
     match fs_err::tokio::read_to_string(&workspace.install_path().join("uv.lock")).await {
-        Ok(encoded) => match Lock::from_toml(&encoded) {
+        Ok(encoded) => match toml::from_str(&encoded) {
             Ok(lock) => Ok(Some(lock)),
             Err(err) => {
                 eprint!("Failed to parse lockfile; ignoring locked requirements: {err}");


### PR DESCRIPTION
## Summary

This is no longer required since we no longer implement `Eq` on `Lock`. It will also sometimes be "wrong" as of #6076, since we now apply different `requires-python` filtering to different parts of the tree during resolution.
