### PR TITLE
Improve display of available package ranges

### DIFF
--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -2934,9 +2934,9 @@ fn compile_yanked_version_indirect() -> Result<()> {
     ----- stderr -----
       × No solution found when resolving dependencies:
       ╰─▶ Because only the following versions of attrs are available:
-              attrs<=20.3.0
+              attrs<20.3.0
               attrs==21.1.0
-              attrs>=21.2.0
+              attrs>21.2.0
           and attrs==21.1.0 was yanked (reason: Installable but not importable on Python 3.4), we can conclude that attrs>20.3.0,<21.2.0 cannot be used.
           And because you require attrs>20.3.0,<21.2.0, we can conclude that your requirements are unsatisfiable.
     "###

--- a/crates/uv/tests/pip_install_scenarios.rs
+++ b/crates/uv/tests/pip_install_scenarios.rs
@@ -449,7 +449,7 @@ fn dependency_excludes_range_of_compatible_versions() {
       × No solution found when resolving dependencies:
       ╰─▶ Because package-a==1.0.0 depends on package-b==1.0.0 and only the following versions of package-a are available:
               package-a==1.0.0
-              package-a>=2.0.0,<=3.0.0
+              package-a>2.0.0,<=3.0.0
           we can conclude that package-a<2.0.0 depends on package-b==1.0.0. (1)
 
           Because only the following versions of package-c are available:
@@ -574,7 +574,7 @@ fn dependency_excludes_non_contiguous_range_of_compatible_versions() {
       × No solution found when resolving dependencies:
       ╰─▶ Because package-a==1.0.0 depends on package-b==1.0.0 and only the following versions of package-a are available:
               package-a==1.0.0
-              package-a>=2.0.0,<=3.0.0
+              package-a>2.0.0,<=3.0.0
           we can conclude that package-a<2.0.0 depends on package-b==1.0.0. (1)
 
           Because only the following versions of package-c are available:
@@ -1941,7 +1941,7 @@ fn local_greater_than() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a<=1.2.3 is available and you require package-a>1.2.3, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only package-a==1.2.3+foo is available and you require package-a>1.2.3, we can conclude that your requirements are unsatisfiable.
     "###);
 
     assert_not_installed(&context.venv, "local_greater_than_a", &context.temp_dir);
@@ -2019,7 +2019,7 @@ fn local_less_than() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a>=1.2.3 is available and you require package-a<1.2.3, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only package-a==1.2.3+foo is available and you require package-a<1.2.3, we can conclude that your requirements are unsatisfiable.
     "###);
 
     assert_not_installed(&context.venv, "local_less_than_a", &context.temp_dir);
@@ -2054,7 +2054,7 @@ fn local_less_than_or_equal() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a>1.2.3 is available and you require package-a<=1.2.3, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only package-a==1.2.3+foo is available and you require package-a<=1.2.3, we can conclude that your requirements are unsatisfiable.
     "###);
 
     // The version '1.2.3+foo' satisfies the constraint '<=1.2.3'.
@@ -2172,7 +2172,7 @@ fn post_greater_than() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a<=1.2.3 is available and you require package-a>1.2.3, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only package-a==1.2.3.post1 is available and you require package-a>1.2.3, we can conclude that your requirements are unsatisfiable.
     "###);
 
     assert_not_installed(&context.venv, "post_greater_than_a", &context.temp_dir);
@@ -2298,7 +2298,7 @@ fn post_less_than_or_equal() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a>1.2.3 is available and you require package-a<=1.2.3, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only package-a==1.2.3.post1 is available and you require package-a<=1.2.3, we can conclude that your requirements are unsatisfiable.
     "###);
 
     assert_not_installed(
@@ -2337,7 +2337,7 @@ fn post_less_than() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a>=1.2.3 is available and you require package-a<1.2.3, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only package-a==1.2.3.post1 is available and you require package-a<1.2.3, we can conclude that your requirements are unsatisfiable.
     "###);
 
     assert_not_installed(&context.venv, "post_less_than_a", &context.temp_dir);
@@ -2374,7 +2374,7 @@ fn post_local_greater_than() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a<=1.2.3 is available and you require package-a>1.2.3, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only package-a<=1.2.3.post1+local is available and you require package-a>1.2.3, we can conclude that your requirements are unsatisfiable.
     "###);
 
     assert_not_installed(
@@ -2415,7 +2415,7 @@ fn post_local_greater_than_post() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a<1.2.3.post2 is available and you require package-a>=1.2.3.post2, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only package-a<=1.2.3.post1+local is available and you require package-a>=1.2.3.post2, we can conclude that your requirements are unsatisfiable.
     "###);
 
     assert_not_installed(
@@ -2543,7 +2543,7 @@ fn post_greater_than_post_not_available() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a<1.2.3.post3 is available and you require package-a>=1.2.3.post3, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only package-a<=1.2.3.post1 is available and you require package-a>=1.2.3.post3, we can conclude that your requirements are unsatisfiable.
     "###);
 
     assert_not_installed(
@@ -2629,7 +2629,7 @@ fn package_only_prereleases_in_range() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-a<=0.1.0 is available and you require package-a>0.1.0, we can conclude that your requirements are unsatisfiable.
+      ╰─▶ Because only package-a<0.1.0 is available and you require package-a>0.1.0, we can conclude that your requirements are unsatisfiable.
 
           hint: Pre-releases are available for package-a in the requested range (e.g., 1.0.0a1), but pre-releases weren't enabled (try: `--prerelease=allow`)
     "###);
@@ -3077,7 +3077,7 @@ fn transitive_package_only_prereleases_in_range() {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because only package-b<=0.1 is available and package-a==0.1.0 depends on package-b>0.1, we can conclude that package-a==0.1.0 cannot be used.
+      ╰─▶ Because only package-b<0.1 is available and package-a==0.1.0 depends on package-b>0.1, we can conclude that package-a==0.1.0 cannot be used.
           And because only package-a==0.1.0 is available and you require package-a, we can conclude that your requirements are unsatisfiable.
 
           hint: Pre-releases are available for package-b in the requested range (e.g., 1.0.0a1), but pre-releases weren't enabled (try: `--prerelease=allow`)
@@ -3451,7 +3451,7 @@ fn transitive_prerelease_and_stable_dependency_many_versions_holes() {
     ----- stderr -----
       × No solution found when resolving dependencies:
       ╰─▶ Because only the following versions of package-c are available:
-              package-c<=1.0.0
+              package-c<1.0.0
               package-c>=2.0.0a5,<=2.0.0a7
               package-c==2.0.0b1
               package-c>=2.0.0b5
@@ -4515,7 +4515,7 @@ fn package_only_yanked_in_range() {
     ----- stderr -----
       × No solution found when resolving dependencies:
       ╰─▶ Because only the following versions of package-a are available:
-              package-a<=0.1.0
+              package-a<0.1.0
               package-a==1.0.0
           and package-a==1.0.0 was yanked (reason: Yanked for testing), we can conclude that package-a>0.1.0 cannot be used.
           And because you require package-a>0.1.0, we can conclude that your requirements are unsatisfiable.
@@ -4707,7 +4707,7 @@ fn transitive_package_only_yanked_in_range() {
     ----- stderr -----
       × No solution found when resolving dependencies:
       ╰─▶ Because only the following versions of package-b are available:
-              package-b<=0.1
+              package-b<0.1
               package-b==1.0.0
           and package-b==1.0.0 was yanked (reason: Yanked for testing), we can conclude that package-b>0.1 cannot be used.
           And because package-a==0.1.0 depends on package-b>0.1, we can conclude that package-a==0.1.0 cannot be used.

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -1200,7 +1200,7 @@ fn workspace_unsatisfiable_member_dependencies() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
       × No solution found when resolving dependencies:
-      ╰─▶ Because only httpx<=9999 is available and leaf depends on httpx>9999, we can conclude that leaf's requirements are unsatisfiable.
+      ╰─▶ Because only httpx<=1.0.0b0 is available and leaf depends on httpx>9999, we can conclude that leaf's requirements are unsatisfiable.
           And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
     "###
     );


### PR DESCRIPTION
Includes the changes from https://github.com/astral-sh/uv/pull/6071 but takes them way further.

When we have the set of available versions for a package, we can do a much better job displaying an error.

For example:

```
❯ uv add 'httpx>999,<9999'
  × No solution found when resolving dependencies:
  ╰─▶ Because only the following versions of httpx are available:
          httpx<=999
          httpx>=9999
      and example==0.1.0 depends on httpx>999,<9999, we can conclude that example==0.1.0 cannot be used.
      And because only example==0.1.0 is available and you require example, we can conclude that the requirements are unsatisfiable.
```

The resolver has demonstrated that the requested range cannot be used because there are only versions in ranges _outside_ the requested range. However, the display of the range of available versions is pretty bad! We say there are versions of httpx available in ranges that definitely have no versions available.

With this pull request, the error becomes:

```
❯ uv add 'httpx>999,<9999'
  × No solution found when resolving dependencies:
  ╰─▶ Because only httpx<=1.0.0b0 is available and example depends on httpx>999,<9999, we can conclude that example's
      requirements are unsatisfiable.
      And because your workspace requires example, we can conclude that your workspace's requirements are unsatisfiable.
```

We achieve this by:

1. Dropping ranges disjoint with the range of available versions, e.g., this removes `httpx>=9999`
2. Replacing ranges that capture the _entire_ range of available versions with the smaller range, e.g., this replaces `httpx<=999` with `<=1.0.0b0`.

~Note that when we perform (2), we may include an additional bound that is not relevant, e.g., we include the lower bound of `>=0.6.7`. This is a bit extraneous, but I don't think it's confusing. We can consider some advanced logic to avoid that later.~ (edit: I did this, it wasn't hard)

We also improve error messages when there is _only_ one version available by showing that version instead of a range.