### PR TITLE
Add debug representation for `MarkerTree`

### DIFF
--- a/crates/pep508-rs/src/marker/simplify.rs
+++ b/crates/pep508-rs/src/marker/simplify.rs
@@ -76,7 +76,7 @@ fn collect_dnf(
             }
         }
         MarkerTreeKind::String(marker) => {
-            for (tree, range) in collect_edges(marker.children()) {
+            for (tree, range) in collect_edges(marker.edges()) {
                 // Detect whether the range for this edge can be simplified as an inequality.
                 if let Some(excluded) = range_inequality(&range) {
                     let current = path.len();
@@ -109,7 +109,7 @@ fn collect_dnf(
             }
         }
         MarkerTreeKind::In(marker) => {
-            for (value, tree) in marker.children() {
+            for (value, tree) in marker.edges() {
                 let operator = if value {
                     MarkerOperator::In
                 } else {
@@ -128,7 +128,7 @@ fn collect_dnf(
             }
         }
         MarkerTreeKind::Contains(marker) => {
-            for (value, tree) in marker.children() {
+            for (value, tree) in marker.edges() {
                 let operator = if value {
                     MarkerOperator::Contains
                 } else {
@@ -147,7 +147,7 @@ fn collect_dnf(
             }
         }
         MarkerTreeKind::Extra(marker) => {
-            for (value, tree) in marker.children() {
+            for (value, tree) in marker.edges() {
                 let operator = if value {
                     ExtraOperator::Equal
                 } else {
@@ -267,7 +267,7 @@ fn simplify(dnf: &mut Vec<Vec<MarkerExpression>>) {
 }
 
 /// Merge any edges that lead to identical subtrees into a single range.
-fn collect_edges<'a, T>(
+pub(crate) fn collect_edges<'a, T>(
     map: impl ExactSizeIterator<Item = (&'a Range<T>, MarkerTree)>,
 ) -> IndexMap<MarkerTree, Range<T>, FxBuildHasher>
 where

--- a/crates/uv-resolver/src/marker.rs
+++ b/crates/uv-resolver/src/marker.rs
@@ -24,22 +24,22 @@ pub(crate) fn requires_python(tree: &MarkerTree) -> Option<RequiresPythonBound> 
                 }
             },
             MarkerTreeKind::String(marker) => {
-                for (_, tree) in marker.children() {
+                for (_, tree) in marker.edges() {
                     collect_python_markers(&tree, markers);
                 }
             }
             MarkerTreeKind::In(marker) => {
-                for (_, tree) in marker.children() {
+                for (_, tree) in marker.edges() {
                     collect_python_markers(&tree, markers);
                 }
             }
             MarkerTreeKind::Contains(marker) => {
-                for (_, tree) in marker.children() {
+                for (_, tree) in marker.edges() {
                     collect_python_markers(&tree, markers);
                 }
             }
             MarkerTreeKind::Extra(marker) => {
-                for (_, tree) in marker.children() {
+                for (_, tree) in marker.edges() {
                     collect_python_markers(&tree, markers);
                 }
             }

--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -531,19 +531,19 @@ impl ResolutionGraph {
                 }
                 MarkerTreeKind::String(marker) => {
                     set.insert(MarkerParam::String(marker.key().clone()));
-                    for (_, tree) in marker.children() {
+                    for (_, tree) in marker.edges() {
                         add_marker_params_from_tree(&tree, set);
                     }
                 }
                 MarkerTreeKind::In(marker) => {
                     set.insert(MarkerParam::String(marker.key().clone()));
-                    for (_, tree) in marker.children() {
+                    for (_, tree) in marker.edges() {
                         add_marker_params_from_tree(&tree, set);
                     }
                 }
                 MarkerTreeKind::Contains(marker) => {
                     set.insert(MarkerParam::String(marker.key().clone()));
-                    for (_, tree) in marker.children() {
+                    for (_, tree) in marker.edges() {
                         add_marker_params_from_tree(&tree, set);
                     }
                 }
@@ -553,7 +553,7 @@ impl ResolutionGraph {
                 // user. We don't track those here, since we're only
                 // interested in which markers are used.
                 MarkerTreeKind::Extra(marker) => {
-                    for (_, tree) in marker.children() {
+                    for (_, tree) in marker.edges() {
                         add_marker_params_from_tree(&tree, set);
                     }
                 }


### PR DESCRIPTION
## Summary

Adds a simple `Debug` representation for `MarkerTree` based on the underlying decision diagram. For example, `python_version == '3.7' and os_name == 'Linux') or os_name == 'Windows'` is displayed as:
```
python_version<3.7 | >3.7 -> 
  os_name<Windows | >Windows -> false
  os_name==Windows -> true
python_version==3.7 -> 
  os_name<Linux | >Linux, <Windows | >Windows -> false
  os_name==Linux | ==Windows -> true
```
 
I'm not sure we want to use this form for our debug logs because it could be confusing to users but we've also run into issues where markers looked equal when simplified despite being represented slightly differently..