### PR TITLE
Warn when `--upgrade` is passed to `tool run`

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -154,6 +154,11 @@ impl Cache {
         &self.root
     }
 
+    /// Return the [`Refresh`] policy for the cache.
+    pub fn refresh(&self) -> &Refresh {
+        &self.refresh
+    }
+
     /// The folder for a specific cache bucket
     pub fn bucket(&self, cache_bucket: CacheBucket) -> PathBuf {
         self.root.join(cache_bucket.to_str())

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -89,7 +89,7 @@ impl CachedEnvironment {
         // Search in the content-addressed cache.
         let cache_entry = cache.entry(CacheBucket::Environments, interpreter_hash, resolution_hash);
 
-        if settings.reinstall.is_none() {
+        if cache.refresh().is_none() {
             if let Ok(root) = fs_err::read_link(cache_entry.path()) {
                 if let Ok(environment) = PythonEnvironment::from_root(root, cache) {
                     return Ok(Self(environment));

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -499,11 +499,7 @@ async fn get_or_create_environment(
     };
 
     // Check if the tool is already installed in a compatible environment.
-    if !isolated
-        && !target.is_latest()
-        && settings.reinstall.is_none()
-        && settings.upgrade.is_none()
-    {
+    if !isolated && !target.is_latest() {
         let installed_tools = InstalledTools::from_settings()?.init()?;
         let _lock = installed_tools.acquire_lock()?;
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -738,7 +738,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             };
 
             // Resolve the settings from the command-line arguments and workspace configuration.
-            let args = settings::ToolRunSettings::resolve(args, filesystem);
+            let args = settings::ToolRunSettings::resolve(args, filesystem, invocation_source);
             show_settings!(args);
 
             // Initialize the cache.

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -36,6 +36,7 @@ use uv_warnings::warn_user_once;
 use uv_workspace::pyproject::DependencyType;
 
 use crate::commands::pip::operations::Modifications;
+use crate::commands::ToolRunCommand;
 
 /// The resolved global settings to use for any invocation of the CLI.
 #[allow(clippy::struct_excessive_bools)]
@@ -275,7 +276,11 @@ pub(crate) struct ToolRunSettings {
 impl ToolRunSettings {
     /// Resolve the [`ToolRunSettings`] from the CLI and filesystem configuration.
     #[allow(clippy::needless_pass_by_value)]
-    pub(crate) fn resolve(args: ToolRunArgs, filesystem: Option<FilesystemOptions>) -> Self {
+    pub(crate) fn resolve(
+        args: ToolRunArgs,
+        filesystem: Option<FilesystemOptions>,
+        invocation_source: ToolRunCommand,
+    ) -> Self {
         let ToolRunArgs {
             command,
             from,
@@ -288,6 +293,16 @@ impl ToolRunSettings {
             refresh,
             python,
         } = args;
+
+        // If `--upgrade` was passed explicitly, warn.
+        if installer.upgrade || !installer.upgrade_package.is_empty() {
+            warn_user_once!("Tools cannot be upgraded via `{invocation_source}`; use `uv tool upgrade --all` to upgrade all installed tools, or `{invocation_source} package@latest` to run the latest version of a tool");
+        }
+
+        // If `--reinstall` was passed explicitly, warn.
+        if installer.reinstall || !installer.reinstall_package.is_empty() {
+            warn_user_once!("Tools cannot be reinstalled via `{invocation_source}`; use `uv tool upgrade --reinstall` to reinstall all installed tools, or `{invocation_source} package@latest` to run the latest version of a tool");
+        }
 
         Self {
             command,


### PR DESCRIPTION
## Summary

Passing `--upgrade` to `tool run` is confusing, because it doesn't upgrade the installed tool. It just causes us to use an isolated tool environment, which seems wrong.
