### PR TITLE
Simplify version ranges reported for unavailable packages

### DIFF
--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -120,9 +120,10 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                             format!("{}{reason}", Padded::new("", &package, " "))
                         }
                         UnavailableReason::Version(reason) => {
+                            let set = self.simplify_set(set, package);
                             format!(
                                 "{}{reason}",
-                                Padded::new("", &self.compatible_range(package, set), " ")
+                                Padded::new("", &self.compatible_range(package, &set), " ")
                             )
                         }
                     }

--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -242,12 +242,8 @@ fn prune_unzipped() -> Result<()> {
               iniconfig<=0.1
               iniconfig>=1.0.0
           and any of:
-              iniconfig==0.1
-              iniconfig==1.0.0
-              iniconfig==1.0.1
-              iniconfig==1.1.0
-              iniconfig==1.1.1
-              iniconfig==2.0.0
+              iniconfig<=0.1
+              iniconfig>=1.0.0
           needs to be downloaded from a registry, we can conclude that iniconfig<1.0.0 cannot be used.
           And because you require iniconfig, we can conclude that your requirements are unsatisfiable.
 

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1926,42 +1926,11 @@ fn install_only_binary_all_and_no_binary_all() {
               anyio>=3.7.0,<=3.7.1
               anyio>=4.0.0
           and any of:
-              anyio==1.0.0
-              anyio==1.1.0
-              anyio==1.2.0
-              anyio==1.2.1
-              anyio==1.2.2
-              anyio==1.2.3
-              anyio==1.3.0
-              anyio==1.3.1
-              anyio==1.4.0
-              anyio==2.0.0
-              anyio==2.0.1
-              anyio==2.0.2
-              anyio==2.1.0
-              anyio==2.2.0
-              anyio==3.0.0
-              anyio==3.0.1
-              anyio==3.1.0
-              anyio==3.2.0
-              anyio==3.2.1
-              anyio==3.3.0
-              anyio==3.3.1
-              anyio==3.3.2
-              anyio==3.3.3
-              anyio==3.3.4
-              anyio==3.4.0
-              anyio==3.5.0
-              anyio==3.6.0
-              anyio==3.6.1
-              anyio==3.6.2
-              anyio==3.7.0
-              anyio==3.7.1
-              anyio==4.0.0
-              anyio==4.1.0
-              anyio==4.2.0
-              anyio==4.3.0
-              anyio==4.4.0
+              anyio>=1.0.0,<=1.4.0
+              anyio>=2.0.0,<=2.2.0
+              anyio>=3.0.0,<=3.6.2
+              anyio>=3.7.0,<=3.7.1
+              anyio>=4.0.0
           has no usable wheels and building from source is disabled, we can conclude that any of:
               anyio<1.1.0
               anyio>1.4.0,<2.0.0


### PR DESCRIPTION
Now that these incompatibilities are collected into a single range (https://github.com/astral-sh/uv/pull/6154), we can simplify the range using the known available versions to reduce verbosity.