### PR TITLE
tests: fix marker emitting tests

### DIFF
--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -9989,7 +9989,7 @@ fn dynamic_dependencies() -> Result<()> {
 #[cfg(target_os = "linux")]
 #[test]
 fn emit_marker_expression_exciting_linux() -> Result<()> {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12.1");
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("anyio")?;
 
@@ -10026,7 +10026,7 @@ fn emit_marker_expression_exciting_linux() -> Result<()> {
 #[cfg(target_os = "linux")]
 #[test]
 fn emit_marker_expression_direct() -> Result<()> {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12.1");
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("anyio ; sys_platform == 'linux'")?;
 
@@ -10106,7 +10106,7 @@ fn emit_marker_expression_conditional() -> Result<()> {
 #[cfg(target_os = "linux")]
 #[test]
 fn emit_marker_expression_pypy() -> Result<()> {
-    let context = TestContext::new("3.12");
+    let context = TestContext::new("3.12.1");
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("pendulum")?;
 


### PR DESCRIPTION
The test output seems to depend on using Python 3.12.1 specifically.
While I'm not sure how it happens, it seems like these can get out of
sync between CI and local testing. In this case, I had a problem where
the marker expressions emitted locally were tied to Python 3.12.4, but
the tests in CI were tied to Python 3.12.1. Changing the test to require
3.12.1 specifically fixes this.