### PR TITLE
Remove preview labeling for uv 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5027,7 +5027,6 @@ dependencies = [
  "url",
  "uv-cache",
  "uv-client",
- "uv-configuration",
  "uv-extract",
  "uv-fs",
  "uv-state",

--- a/crates/bench/benches/uv.rs
+++ b/crates/bench/benches/uv.rs
@@ -91,8 +91,7 @@ mod resolver {
     use uv_cache::Cache;
     use uv_client::RegistryClient;
     use uv_configuration::{
-        BuildOptions, Concurrency, ConfigSettings, IndexStrategy, PreviewMode, SetupPyStrategy,
-        SourceStrategy,
+        BuildOptions, Concurrency, ConfigSettings, IndexStrategy, SetupPyStrategy, SourceStrategy,
     };
     use uv_dispatch::BuildDispatch;
     use uv_distribution::DistributionDatabase;
@@ -188,7 +187,6 @@ mod resolver {
             exclude_newer,
             sources,
             concurrency,
-            PreviewMode::Disabled,
         );
 
         let markers = if universal {
@@ -208,12 +206,7 @@ mod resolver {
             &hashes,
             &build_context,
             installed_packages,
-            DistributionDatabase::new(
-                client,
-                &build_context,
-                concurrency.downloads,
-                PreviewMode::Disabled,
-            ),
+            DistributionDatabase::new(client, &build_context, concurrency.downloads),
         )?;
 
         Ok(resolver.resolve().await?)

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -247,14 +247,14 @@ pub enum Commands {
     #[command(flatten)]
     Project(Box<ProjectCommand>),
 
-    /// Run and install commands provided by Python packages (experimental).
+    /// Run and install commands provided by Python packages.
     #[command(
         after_help = "Use `uv help tool` for more details.",
         after_long_help = ""
     )]
     Tool(ToolNamespace),
 
-    /// Manage Python versions and installations (experimental)
+    /// Manage Python versions and installations
     ///
     /// Generally, uv first searches for Python in a virtual environment, either
     /// active or in a `.venv` directory  in the current working directory or
@@ -265,8 +265,7 @@ pub enum Commands {
     /// On Windows, the `py` launcher is also invoked to find Python
     /// executables.
     ///
-    /// When preview is enabled, i.e., via `--preview` or by using a preview
-    /// command, uv will download Python if a version cannot be found. This
+    /// By default, uv will download Python if a version cannot be found. This
     /// behavior can be disabled with the `--python-downloads` option.
     ///
     /// The `--python` option allows requesting a different interpreter.
@@ -502,7 +501,7 @@ pub enum PipCommand {
 
 #[derive(Subcommand)]
 pub enum ProjectCommand {
-    /// Run a command or script (experimental).
+    /// Run a command or script.
     ///
     /// Ensures that the command runs in a Python environment.
     ///
@@ -529,7 +528,7 @@ pub enum ProjectCommand {
         after_long_help = ""
     )]
     Run(RunArgs),
-    /// Create a new project (experimental).
+    /// Create a new project.
     ///
     /// Follows the `pyproject.toml` specification.
     ///
@@ -544,7 +543,7 @@ pub enum ProjectCommand {
     /// virtual environment (`.venv`) and lockfile (`uv.lock`) are lazily
     /// created during the first sync.
     Init(InitArgs),
-    /// Add dependencies to the project (experimental).
+    /// Add dependencies to the project.
     ///
     /// Dependencies are added to the project's `pyproject.toml` file.
     ///
@@ -571,7 +570,7 @@ pub enum ProjectCommand {
         after_long_help = ""
     )]
     Add(AddArgs),
-    /// Remove dependencies from the project (experimental).
+    /// Remove dependencies from the project.
     ///
     /// Dependencies are removed from the project's `pyproject.toml` file.
     ///
@@ -595,7 +594,7 @@ pub enum ProjectCommand {
         after_long_help = ""
     )]
     Remove(RemoveArgs),
-    /// Update the project's environment (experimental).
+    /// Update the project's environment.
     ///
     /// Syncing ensures that all project dependencies are installed and
     /// up-to-date with the lockfile. Syncing also removes packages that are not
@@ -617,7 +616,7 @@ pub enum ProjectCommand {
         after_long_help = ""
     )]
     Sync(SyncArgs),
-    /// Update the project's lockfile (experimental).
+    /// Update the project's lockfile.
     ///
     /// If the project lockfile (`uv.lock`) does not exist, it will be created.
     /// If a lockfile is present, its contents will be used as preferences for
@@ -630,7 +629,7 @@ pub enum ProjectCommand {
         after_long_help = ""
     )]
     Lock(LockArgs),
-    /// Display the project's dependency tree (experimental).
+    /// Display the project's dependency tree.
     Tree(TreeArgs),
 }
 

--- a/crates/uv-dev/src/build.rs
+++ b/crates/uv-dev/src/build.rs
@@ -11,8 +11,8 @@ use uv_build::{SourceBuild, SourceBuildContext};
 use uv_cache::{Cache, CacheArgs};
 use uv_client::RegistryClientBuilder;
 use uv_configuration::{
-    BuildKind, BuildOptions, Concurrency, ConfigSettings, IndexStrategy, PreviewMode,
-    SetupPyStrategy, SourceStrategy,
+    BuildKind, BuildOptions, Concurrency, ConfigSettings, IndexStrategy, SetupPyStrategy,
+    SourceStrategy,
 };
 use uv_dispatch::BuildDispatch;
 use uv_git::GitResolver;
@@ -96,7 +96,6 @@ pub(crate) async fn build(args: BuildArgs) -> Result<PathBuf> {
         exclude_newer,
         sources,
         concurrency,
-        PreviewMode::Enabled,
     );
 
     let builder = SourceBuild::setup(

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -16,11 +16,11 @@ use pypi_types::Requirement;
 use uv_build::{SourceBuild, SourceBuildContext};
 use uv_cache::Cache;
 use uv_client::RegistryClient;
+use uv_configuration::Concurrency;
 use uv_configuration::{
     BuildKind, BuildOptions, ConfigSettings, Constraints, IndexStrategy, Reinstall,
     SetupPyStrategy, SourceStrategy,
 };
-use uv_configuration::{Concurrency, PreviewMode};
 use uv_distribution::DistributionDatabase;
 use uv_git::GitResolver;
 use uv_installer::{Installer, Plan, Planner, Preparer, SitePackages};
@@ -54,7 +54,6 @@ pub struct BuildDispatch<'a> {
     build_extra_env_vars: FxHashMap<OsString, OsString>,
     sources: SourceStrategy,
     concurrency: Concurrency,
-    preview_mode: PreviewMode,
 }
 
 impl<'a> BuildDispatch<'a> {
@@ -77,7 +76,6 @@ impl<'a> BuildDispatch<'a> {
         exclude_newer: Option<ExcludeNewer>,
         sources: SourceStrategy,
         concurrency: Concurrency,
-        preview_mode: PreviewMode,
     ) -> Self {
         Self {
             client,
@@ -100,7 +98,6 @@ impl<'a> BuildDispatch<'a> {
             build_extra_env_vars: FxHashMap::default(),
             sources,
             concurrency,
-            preview_mode,
         }
     }
 
@@ -162,12 +159,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
             &HashStrategy::None,
             self,
             EmptyInstalledPackages,
-            DistributionDatabase::new(
-                self.client,
-                self,
-                self.concurrency.downloads,
-                self.preview_mode,
-            ),
+            DistributionDatabase::new(self.client, self, self.concurrency.downloads),
         )?;
         let graph = resolver.resolve().await.with_context(|| {
             format!(
@@ -250,12 +242,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
                 tags,
                 &HashStrategy::None,
                 self.build_options,
-                DistributionDatabase::new(
-                    self.client,
-                    self,
-                    self.concurrency.downloads,
-                    self.preview_mode,
-                ),
+                DistributionDatabase::new(self.client, self, self.concurrency.downloads),
             );
 
             debug!(

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -25,7 +25,6 @@ use uv_cache::{ArchiveId, ArchiveTimestamp, CacheBucket, CacheEntry, Timestamp, 
 use uv_client::{
     CacheControl, CachedClientError, Connectivity, DataWithCachePolicy, RegistryClient,
 };
-use uv_configuration::PreviewMode;
 use uv_extract::hash::Hasher;
 use uv_fs::write_atomic;
 use uv_types::BuildContext;
@@ -61,11 +60,10 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
         client: &'a RegistryClient,
         build_context: &'a Context,
         concurrent_downloads: usize,
-        preview_mode: PreviewMode,
     ) -> Self {
         Self {
             build_context,
-            builder: SourceDistributionBuilder::new(build_context, preview_mode),
+            builder: SourceDistributionBuilder::new(build_context),
             locks: Rc::new(Locks::default()),
             client: ManagedClient::new(client, concurrent_downloads),
             reporter: None,

--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -9,7 +9,6 @@ use pep508_rs::{VerbatimUrl, VersionOrUrl};
 use pypi_types::{ParsedUrlError, Requirement, RequirementSource, VerbatimParsedUrl};
 use thiserror::Error;
 use url::Url;
-use uv_configuration::PreviewMode;
 use uv_fs::{relative_to, Simplified};
 use uv_git::GitReference;
 use uv_normalize::PackageName;
@@ -36,7 +35,6 @@ impl LoweredRequirement {
         project_dir: &Path,
         project_sources: &BTreeMap<PackageName, Source>,
         workspace: &Workspace,
-        preview: PreviewMode,
     ) -> Result<Self, LoweringError> {
         let (source, origin) = if let Some(source) = project_sources.get(&requirement.name) {
             (Some(source), Origin::Project)
@@ -79,10 +77,6 @@ impl LoweredRequirement {
             }
             return Ok(Self(Requirement::from(requirement)));
         };
-
-        if preview.is_disabled() {
-            warn_user_once!("`uv.sources` is experimental and may change without warning");
-        }
 
         let source = match source {
             Source::Git {
@@ -180,17 +174,12 @@ impl LoweredRequirement {
         requirement: pep508_rs::Requirement<VerbatimParsedUrl>,
         dir: &Path,
         sources: &BTreeMap<PackageName, Source>,
-        preview: PreviewMode,
     ) -> Result<Self, LoweringError> {
         let source = sources.get(&requirement.name).cloned();
 
         let Some(source) = source else {
             return Ok(Self(Requirement::from(requirement)));
         };
-
-        if preview.is_disabled() {
-            warn_user_once!("`uv.sources` is experimental and may change without warning");
-        }
 
         let source = match source {
             Source::Git {

--- a/crates/uv-distribution/src/metadata/mod.rs
+++ b/crates/uv-distribution/src/metadata/mod.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use pep440_rs::{Version, VersionSpecifiers};
 use pypi_types::{HashDigest, Metadata23};
-use uv_configuration::{PreviewMode, SourceStrategy};
+use uv_configuration::SourceStrategy;
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_workspace::WorkspaceError;
 
@@ -61,7 +61,6 @@ impl Metadata {
         install_path: &Path,
         lock_path: &Path,
         sources: SourceStrategy,
-        preview_mode: PreviewMode,
     ) -> Result<Self, MetadataError> {
         // Lower the requirements.
         let RequiresDist {
@@ -78,7 +77,6 @@ impl Metadata {
             install_path,
             lock_path,
             sources,
-            preview_mode,
         )
         .await?;
 

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use uv_configuration::{PreviewMode, SourceStrategy};
+use uv_configuration::SourceStrategy;
 use uv_normalize::{ExtraName, GroupName, PackageName, DEV_DEPENDENCIES};
 use uv_workspace::{DiscoveryOptions, ProjectWorkspace};
 
@@ -39,7 +39,6 @@ impl RequiresDist {
         install_path: &Path,
         lock_path: &Path,
         sources: SourceStrategy,
-        preview_mode: PreviewMode,
     ) -> Result<Self, MetadataError> {
         match sources {
             SourceStrategy::Enabled => {
@@ -55,7 +54,7 @@ impl RequiresDist {
                     return Ok(Self::from_metadata23(metadata));
                 };
 
-                Self::from_project_workspace(metadata, &project_workspace, preview_mode)
+                Self::from_project_workspace(metadata, &project_workspace)
             }
             SourceStrategy::Disabled => Ok(Self::from_metadata23(metadata)),
         }
@@ -64,7 +63,6 @@ impl RequiresDist {
     fn from_project_workspace(
         metadata: pypi_types::RequiresDist,
         project_workspace: &ProjectWorkspace,
-        preview_mode: PreviewMode,
     ) -> Result<Self, MetadataError> {
         // Collect any `tool.uv.sources` and `tool.uv.dev_dependencies` from `pyproject.toml`.
         let empty = BTreeMap::default();
@@ -96,7 +94,6 @@ impl RequiresDist {
                         project_workspace.project_root(),
                         sources,
                         project_workspace.workspace(),
-                        preview_mode,
                     )
                     .map(LoweredRequirement::into_inner)
                     .map_err(|err| MetadataError::LoweringError(requirement_name.clone(), err))
@@ -120,7 +117,6 @@ impl RequiresDist {
                     project_workspace.project_root(),
                     sources,
                     project_workspace.workspace(),
-                    preview_mode,
                 )
                 .map(LoweredRequirement::into_inner)
                 .map_err(|err| MetadataError::LoweringError(requirement_name.clone(), err))
@@ -155,7 +151,6 @@ mod test {
     use indoc::indoc;
     use insta::assert_snapshot;
 
-    use uv_configuration::PreviewMode;
     use uv_workspace::pyproject::PyProjectToml;
     use uv_workspace::{DiscoveryOptions, ProjectWorkspace};
 
@@ -182,7 +177,6 @@ mod test {
         Ok(RequiresDist::from_project_workspace(
             requires_dist,
             &project_workspace,
-            PreviewMode::Enabled,
         )?)
     }
 

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -27,7 +27,7 @@ use uv_cache::{
 use uv_client::{
     CacheControl, CachedClientError, Connectivity, DataWithCachePolicy, RegistryClient,
 };
-use uv_configuration::{BuildKind, PreviewMode};
+use uv_configuration::BuildKind;
 use uv_extract::hash::Hasher;
 use uv_fs::{rename_with_retry, write_atomic, LockedFile};
 use uv_types::{BuildContext, SourceBuildTrait};
@@ -46,7 +46,6 @@ mod revision;
 /// Fetch and build a source distribution from a remote source, or from a local cache.
 pub(crate) struct SourceDistributionBuilder<'a, T: BuildContext> {
     build_context: &'a T,
-    preview_mode: PreviewMode,
     reporter: Option<Arc<dyn Reporter>>,
 }
 
@@ -61,10 +60,9 @@ pub(crate) const METADATA: &str = "metadata.msgpack";
 
 impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     /// Initialize a [`SourceDistributionBuilder`] from a [`BuildContext`].
-    pub(crate) fn new(build_context: &'a T, preview_mode: PreviewMode) -> Self {
+    pub(crate) fn new(build_context: &'a T) -> Self {
         Self {
             build_context,
-            preview_mode,
             reporter: None,
         }
     }
@@ -429,7 +427,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             project_root,
             project_root,
             self.build_context.sources(),
-            self.preview_mode,
         )
         .await?;
         Ok(requires_dist)
@@ -997,7 +994,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     resource.install_path.as_ref(),
                     resource.lock_path.as_ref(),
                     self.build_context.sources(),
-                    self.preview_mode,
                 )
                 .await?,
             ));
@@ -1023,7 +1019,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     resource.install_path.as_ref(),
                     resource.lock_path.as_ref(),
                     self.build_context.sources(),
-                    self.preview_mode,
                 )
                 .await?,
             ));
@@ -1056,7 +1051,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 resource.install_path.as_ref(),
                 resource.lock_path.as_ref(),
                 self.build_context.sources(),
-                self.preview_mode,
             )
             .await?,
         ))
@@ -1234,14 +1228,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
                 debug!("Using cached metadata for: {source}");
                 return Ok(ArchiveMetadata::from(
-                    Metadata::from_workspace(
-                        metadata,
-                        &path,
-                        &path,
-                        self.build_context.sources(),
-                        self.preview_mode,
-                    )
-                    .await?,
+                    Metadata::from_workspace(metadata, &path, &path, self.build_context.sources())
+                        .await?,
                 ));
             }
         }
@@ -1267,14 +1255,8 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             };
 
             return Ok(ArchiveMetadata::from(
-                Metadata::from_workspace(
-                    metadata,
-                    &path,
-                    &path,
-                    self.build_context.sources(),
-                    self.preview_mode,
-                )
-                .await?,
+                Metadata::from_workspace(metadata, &path, &path, self.build_context.sources())
+                    .await?,
             ));
         }
 
@@ -1305,7 +1287,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 fetch.path(),
                 fetch.path(),
                 self.build_context.sources(),
-                self.preview_mode,
             )
             .await?,
         ))

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -22,7 +22,6 @@ platform-tags = { workspace = true }
 pypi-types = { workspace = true }
 uv-cache = { workspace = true }
 uv-client = { workspace = true }
-uv-configuration = { workspace = true }
 uv-extract = { workspace = true }
 uv-fs = { workspace = true }
 uv-state = { workspace = true }

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -12,7 +12,6 @@ use which::{which, which_all};
 
 use pep440_rs::{Version, VersionSpecifiers};
 use uv_cache::Cache;
-use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_warnings::warn_user_once;
 
@@ -1294,15 +1293,12 @@ impl PythonPreference {
         }
     }
 
-    /// Return a default [`PythonPreference`] based on the environment and preview mode.
-    pub fn default_from(preview: PreviewMode) -> Self {
+    /// Return the default [`PythonPreference`], respecting the `UV_TEST_PYTHON_PATH` variable.
+    pub fn default_from_env() -> Self {
         if env::var_os("UV_TEST_PYTHON_PATH").is_some() {
-            debug!("Only considering system interpreters due to `UV_TEST_PYTHON_PATH`");
             Self::OnlySystem
-        } else if preview.is_enabled() {
-            Self::default()
         } else {
-            Self::OnlySystem
+            Self::default()
         }
     }
 

--- a/crates/uv/src/commands/pip/check.rs
+++ b/crates/uv/src/commands/pip/check.rs
@@ -7,7 +7,6 @@ use tracing::debug;
 
 use distribution_types::{Diagnostic, InstalledDist};
 use uv_cache::Cache;
-use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::{SitePackages, SitePackagesDiagnostic};
 use uv_python::{EnvironmentPreference, PythonEnvironment, PythonRequest};
@@ -19,7 +18,6 @@ use crate::printer::Printer;
 pub(crate) fn pip_check(
     python: Option<&str>,
     system: bool,
-    _preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -16,7 +16,7 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, ExtrasSpecification, IndexStrategy, NoBinary,
-    NoBuild, PreviewMode, Reinstall, SetupPyStrategy, SourceStrategy, Upgrade,
+    NoBuild, Reinstall, SetupPyStrategy, SourceStrategy, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::BuildDispatch;
@@ -92,7 +92,6 @@ pub(crate) async fn pip_compile(
     concurrency: Concurrency,
     native_tls: bool,
     quiet: bool,
-    preview: PreviewMode,
     cache: Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
@@ -331,7 +330,6 @@ pub(crate) async fn pip_compile(
         exclude_newer,
         sources,
         concurrency,
-        preview,
     );
 
     let options = OptionsBuilder::new()
@@ -368,7 +366,6 @@ pub(crate) async fn pip_compile(
         options,
         Box::new(DefaultResolveLogger),
         printer,
-        preview,
     )
     .await
     {

--- a/crates/uv/src/commands/pip/freeze.rs
+++ b/crates/uv/src/commands/pip/freeze.rs
@@ -7,7 +7,6 @@ use tracing::debug;
 
 use distribution_types::{Diagnostic, InstalledDist, Name};
 use uv_cache::Cache;
-use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_python::{EnvironmentPreference, PythonEnvironment, PythonRequest};
@@ -21,7 +20,6 @@ pub(crate) fn pip_freeze(
     strict: bool,
     python: Option<&str>,
     system: bool,
-    _preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -14,7 +14,7 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, ExtrasSpecification, HashCheckingMode,
-    IndexStrategy, PreviewMode, Reinstall, SetupPyStrategy, SourceStrategy, Upgrade,
+    IndexStrategy, Reinstall, SetupPyStrategy, SourceStrategy, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::BuildDispatch;
@@ -75,7 +75,6 @@ pub(crate) async fn pip_install(
     prefix: Option<Prefix>,
     concurrency: Concurrency,
     native_tls: bool,
-    preview: PreviewMode,
     cache: Cache,
     dry_run: bool,
     printer: Printer,
@@ -321,7 +320,6 @@ pub(crate) async fn pip_install(
         exclude_newer,
         sources,
         concurrency,
-        preview,
     );
 
     let options = OptionsBuilder::new()
@@ -358,7 +356,6 @@ pub(crate) async fn pip_install(
         options,
         Box::new(DefaultResolveLogger),
         printer,
-        preview,
     )
     .await
     {
@@ -392,7 +389,6 @@ pub(crate) async fn pip_install(
         Box::new(DefaultInstallLogger),
         dry_run,
         printer,
-        preview,
     )
     .await?;
 

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -11,7 +11,6 @@ use unicode_width::UnicodeWidthStr;
 use distribution_types::{Diagnostic, InstalledDist, Name};
 use uv_cache::Cache;
 use uv_cli::ListFormat;
-use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
@@ -30,7 +29,6 @@ pub(crate) fn pip_list(
     strict: bool,
     python: Option<&str>,
     system: bool,
-    _preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -20,8 +20,7 @@ use pypi_types::Requirement;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, RegistryClient};
 use uv_configuration::{
-    BuildOptions, Concurrency, Constraints, ExtrasSpecification, Overrides, PreviewMode, Reinstall,
-    Upgrade,
+    BuildOptions, Concurrency, Constraints, ExtrasSpecification, Overrides, Reinstall, Upgrade,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution::DistributionDatabase;
@@ -110,7 +109,6 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
     options: Options,
     logger: Box<dyn ResolveLogger>,
     printer: Printer,
-    preview: PreviewMode,
 ) -> Result<ResolutionGraph, Error> {
     let start = std::time::Instant::now();
 
@@ -121,7 +119,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
             requirements,
             hasher,
             index,
-            DistributionDatabase::new(client, build_dispatch, concurrency.downloads, preview),
+            DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
         )
         .with_reporter(ResolverReporter::from(printer))
         .resolve()
@@ -134,7 +132,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 extras,
                 hasher,
                 index,
-                DistributionDatabase::new(client, build_dispatch, concurrency.downloads, preview),
+                DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
             )
             .with_reporter(ResolverReporter::from(printer))
             .resolve()
@@ -187,7 +185,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
         overrides,
         hasher,
         index,
-        DistributionDatabase::new(client, build_dispatch, concurrency.downloads, preview),
+        DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
     )
     .with_reporter(ResolverReporter::from(printer))
     .resolve()
@@ -212,7 +210,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 &dev,
                 hasher,
                 index,
-                DistributionDatabase::new(client, build_dispatch, concurrency.downloads, preview),
+                DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
             )
             .with_reporter(ResolverReporter::from(printer))
             .resolve(&markers)
@@ -258,7 +256,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
             hasher,
             build_dispatch,
             installed_packages,
-            DistributionDatabase::new(client, build_dispatch, concurrency.downloads, preview),
+            DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
         )?
         .with_reporter(reporter);
 
@@ -339,7 +337,6 @@ pub(crate) async fn install(
     logger: Box<dyn InstallLogger>,
     dry_run: bool,
     printer: Printer,
-    preview: PreviewMode,
 ) -> Result<Changelog, Error> {
     let start = std::time::Instant::now();
 
@@ -407,7 +404,7 @@ pub(crate) async fn install(
             tags,
             hasher,
             build_options,
-            DistributionDatabase::new(client, build_dispatch, concurrency.downloads, preview),
+            DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
         )
         .with_reporter(PrepareReporter::from(printer).with_length(remote.len() as u64));
 

--- a/crates/uv/src/commands/pip/show.rs
+++ b/crates/uv/src/commands/pip/show.rs
@@ -8,7 +8,6 @@ use tracing::debug;
 
 use distribution_types::{Diagnostic, Name};
 use uv_cache::Cache;
-use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
@@ -23,7 +22,6 @@ pub(crate) fn pip_show(
     strict: bool,
     python: Option<&str>,
     system: bool,
-    _preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -13,7 +13,7 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, ExtrasSpecification, HashCheckingMode,
-    IndexStrategy, PreviewMode, Reinstall, SetupPyStrategy, SourceStrategy, Upgrade,
+    IndexStrategy, Reinstall, SetupPyStrategy, SourceStrategy, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::BuildDispatch;
@@ -67,7 +67,6 @@ pub(crate) async fn pip_sync(
     sources: SourceStrategy,
     concurrency: Concurrency,
     native_tls: bool,
-    preview: PreviewMode,
     cache: Cache,
     dry_run: bool,
     printer: Printer,
@@ -267,7 +266,6 @@ pub(crate) async fn pip_sync(
         exclude_newer,
         sources,
         concurrency,
-        preview,
     );
 
     // Determine the set of installed packages.
@@ -306,7 +304,6 @@ pub(crate) async fn pip_sync(
         options,
         Box::new(DefaultResolveLogger),
         printer,
-        preview,
     )
     .await
     {
@@ -340,7 +337,6 @@ pub(crate) async fn pip_sync(
         Box::new(DefaultInstallLogger),
         dry_run,
         printer,
-        preview,
     )
     .await?;
 

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -11,7 +11,7 @@ use pypi_types::Requirement;
 use pypi_types::VerbatimParsedUrl;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity};
-use uv_configuration::{KeyringProviderType, PreviewMode};
+use uv_configuration::KeyringProviderType;
 use uv_fs::Simplified;
 use uv_python::EnvironmentPreference;
 use uv_python::PythonRequest;
@@ -32,7 +32,6 @@ pub(crate) async fn pip_uninstall(
     cache: Cache,
     connectivity: Connectivity,
     native_tls: bool,
-    _preview: PreviewMode,
     keyring_provider: KeyringProviderType,
     printer: Printer,
 ) -> Result<ExitStatus> {

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -10,9 +10,7 @@ use tracing::debug;
 use uv_auth::{store_credentials_from_url, Credentials};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
-use uv_configuration::{
-    Concurrency, ExtrasSpecification, PreviewMode, SetupPyStrategy, SourceStrategy,
-};
+use uv_configuration::{Concurrency, ExtrasSpecification, SetupPyStrategy, SourceStrategy};
 use uv_dispatch::BuildDispatch;
 use uv_distribution::DistributionDatabase;
 use uv_fs::CWD;
@@ -60,17 +58,13 @@ pub(crate) async fn add(
     script: Option<PathBuf>,
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
-    preview: PreviewMode,
+
     connectivity: Connectivity,
     concurrency: Concurrency,
     native_tls: bool,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv add` is experimental and may change without warning");
-    }
-
     for source in &requirements {
         match source {
             RequirementsSource::PyprojectToml(_) => {
@@ -292,7 +286,6 @@ pub(crate) async fn add(
         settings.exclude_newer,
         sources,
         concurrency,
-        preview,
     );
 
     // Resolve any unnamed requirements.
@@ -300,7 +293,7 @@ pub(crate) async fn add(
         requirements,
         &hasher,
         &state.index,
-        DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads, preview),
+        DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads),
     )
     .with_reporter(ResolverReporter::from(printer))
     .resolve()
@@ -452,7 +445,6 @@ pub(crate) async fn add(
         venv.interpreter(),
         settings.as_ref().into(),
         Box::new(DefaultResolveLogger),
-        preview,
         connectivity,
         concurrency,
         native_tls,
@@ -590,7 +582,6 @@ pub(crate) async fn add(
         settings.as_ref().into(),
         &state,
         Box::new(DefaultInstallLogger),
-        preview,
         connectivity,
         concurrency,
         native_tls,

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -4,7 +4,7 @@ use cache_key::{cache_digest, hash_digest};
 use distribution_types::Resolution;
 use uv_cache::{Cache, CacheBucket};
 use uv_client::Connectivity;
-use uv_configuration::{Concurrency, PreviewMode};
+use uv_configuration::Concurrency;
 use uv_python::{Interpreter, PythonEnvironment};
 use uv_requirements::RequirementsSpecification;
 
@@ -34,7 +34,6 @@ impl CachedEnvironment {
         state: &SharedState,
         resolve: Box<dyn ResolveLogger>,
         install: Box<dyn InstallLogger>,
-        preview: PreviewMode,
         connectivity: Connectivity,
         concurrency: Concurrency,
         native_tls: bool,
@@ -64,7 +63,6 @@ impl CachedEnvironment {
             settings.as_ref().into(),
             state,
             resolve,
-            preview,
             connectivity,
             concurrency,
             native_tls,
@@ -114,7 +112,6 @@ impl CachedEnvironment {
             settings.as_ref().into(),
             state,
             install,
-            preview,
             connectivity,
             concurrency,
             native_tls,

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -8,7 +8,6 @@ use pep440_rs::Version;
 use pep508_rs::PackageName;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity};
-use uv_configuration::PreviewMode;
 use uv_fs::{absolutize_path, Simplified, CWD};
 use uv_python::{
     EnvironmentPreference, PythonDownloads, PythonInstallation, PythonPreference, PythonRequest,
@@ -33,7 +32,6 @@ pub(crate) async fn init(
     no_readme: bool,
     python: Option<String>,
     no_workspace: bool,
-    preview: PreviewMode,
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
     connectivity: Connectivity,
@@ -41,10 +39,6 @@ pub(crate) async fn init(
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv init` is experimental and may change without warning");
-    }
-
     // Default to the current directory if a path was not provided.
     let path = match explicit_path {
         None => CWD.to_path_buf(),

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -11,9 +11,7 @@ use pypi_types::Requirement;
 use uv_auth::store_credentials_from_url;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
-use uv_configuration::{
-    Concurrency, ExtrasSpecification, PreviewMode, Reinstall, SetupPyStrategy, Upgrade,
-};
+use uv_configuration::{Concurrency, ExtrasSpecification, Reinstall, SetupPyStrategy, Upgrade};
 use uv_dispatch::BuildDispatch;
 use uv_distribution::DistributionDatabase;
 use uv_fs::Simplified;
@@ -391,7 +389,6 @@ pub(crate) async fn resolve_names(
     interpreter: &Interpreter,
     settings: &ResolverInstallerSettings,
     state: &SharedState,
-    preview: PreviewMode,
     connectivity: Connectivity,
     concurrency: Concurrency,
     native_tls: bool,
@@ -472,7 +469,6 @@ pub(crate) async fn resolve_names(
         *exclude_newer,
         *sources,
         concurrency,
-        preview,
     );
 
     // Initialize the resolver.
@@ -480,7 +476,7 @@ pub(crate) async fn resolve_names(
         requirements,
         &hasher,
         &state.index,
-        DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads, preview),
+        DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads),
     )
     .with_reporter(ResolverReporter::from(printer));
 
@@ -494,7 +490,6 @@ pub(crate) async fn resolve_environment<'a>(
     settings: ResolverSettingsRef<'_>,
     state: &SharedState,
     logger: Box<dyn ResolveLogger>,
-    preview: PreviewMode,
     connectivity: Connectivity,
     concurrency: Concurrency,
     native_tls: bool,
@@ -610,7 +605,6 @@ pub(crate) async fn resolve_environment<'a>(
         exclude_newer,
         sources,
         concurrency,
-        preview,
     );
 
     // Resolve the requirements.
@@ -639,7 +633,6 @@ pub(crate) async fn resolve_environment<'a>(
         options,
         logger,
         printer,
-        preview,
     )
     .await?)
 }
@@ -651,7 +644,6 @@ pub(crate) async fn sync_environment(
     settings: InstallerSettingsRef<'_>,
     state: &SharedState,
     logger: Box<dyn InstallLogger>,
-    preview: PreviewMode,
     connectivity: Connectivity,
     concurrency: Concurrency,
     native_tls: bool,
@@ -736,7 +728,6 @@ pub(crate) async fn sync_environment(
         exclude_newer,
         sources,
         concurrency,
-        preview,
     );
 
     // Sync the environment.
@@ -760,7 +751,6 @@ pub(crate) async fn sync_environment(
         logger,
         dry_run,
         printer,
-        preview,
     )
     .await?;
 
@@ -794,7 +784,6 @@ pub(crate) async fn update_environment(
     state: &SharedState,
     resolve: Box<dyn ResolveLogger>,
     install: Box<dyn InstallLogger>,
-    preview: PreviewMode,
     connectivity: Connectivity,
     concurrency: Concurrency,
     native_tls: bool,
@@ -933,7 +922,6 @@ pub(crate) async fn update_environment(
         *exclude_newer,
         *sources,
         concurrency,
-        preview,
     );
 
     // Resolve the requirements.
@@ -962,7 +950,6 @@ pub(crate) async fn update_environment(
         options,
         resolve,
         printer,
-        preview,
     )
     .await
     {
@@ -991,7 +978,6 @@ pub(crate) async fn update_environment(
         install,
         dry_run,
         printer,
-        preview,
     )
     .await?;
 

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use pep508_rs::PackageName;
 use uv_cache::Cache;
 use uv_client::Connectivity;
-use uv_configuration::{Concurrency, ExtrasSpecification, PreviewMode};
+use uv_configuration::{Concurrency, ExtrasSpecification};
 use uv_fs::CWD;
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest};
 use uv_scripts::Pep723Script;
@@ -32,17 +32,13 @@ pub(crate) async fn remove(
     script: Option<Pep723Script>,
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
-    preview: PreviewMode,
+
     connectivity: Connectivity,
     concurrency: Concurrency,
     native_tls: bool,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv remove` is experimental and may change without warning");
-    }
-
     let target = if let Some(script) = script {
         // If we found a PEP 723 script and the user provided a project-only setting, warn.
         if package.is_some() {
@@ -167,7 +163,6 @@ pub(crate) async fn remove(
         venv.interpreter(),
         settings.as_ref().into(),
         Box::new(DefaultResolveLogger),
-        preview,
         connectivity,
         concurrency,
         native_tls,
@@ -199,7 +194,6 @@ pub(crate) async fn remove(
         settings.as_ref().into(),
         &state,
         Box::new(DefaultInstallLogger),
-        preview,
         connectivity,
         concurrency,
         native_tls,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -14,7 +14,7 @@ use tracing::debug;
 use uv_cache::Cache;
 use uv_cli::ExternalCommand;
 use uv_client::{BaseClientBuilder, Connectivity};
-use uv_configuration::{Concurrency, ExtrasSpecification, PreviewMode};
+use uv_configuration::{Concurrency, ExtrasSpecification};
 use uv_distribution::LoweredRequirement;
 use uv_fs::{PythonExt, Simplified, CWD};
 use uv_installer::{SatisfiesResult, SitePackages};
@@ -56,7 +56,7 @@ pub(crate) async fn run(
     dev: bool,
     python: Option<String>,
     settings: ResolverInstallerSettings,
-    preview: PreviewMode,
+
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
     connectivity: Connectivity,
@@ -65,10 +65,6 @@ pub(crate) async fn run(
     cache: &Cache,
     printer: Printer,
 ) -> anyhow::Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv run` is experimental and may change without warning");
-    }
-
     // These cases seem quite complex because (in theory) they should change the "current package".
     // Let's ban them entirely for now.
     for source in &requirements {
@@ -158,7 +154,6 @@ pub(crate) async fn run(
                         requirement,
                         script_dir,
                         script_sources,
-                        preview,
                     )
                     .map(LoweredRequirement::into_inner)
                 })
@@ -179,7 +174,6 @@ pub(crate) async fn run(
                 } else {
                     Box::new(SummaryInstallLogger)
                 },
-                preview,
                 connectivity,
                 concurrency,
                 native_tls,
@@ -347,7 +341,6 @@ pub(crate) async fn run(
                     )
                     .await?;
 
-                    // Note we force preview on during `uv run` for now since the entire interface is in preview.
                     PythonInstallation::find_or_download(
                         python_request,
                         EnvironmentPreference::Any,
@@ -398,7 +391,6 @@ pub(crate) async fn run(
                 } else {
                     Box::new(SummaryResolveLogger)
                 },
-                preview,
                 connectivity,
                 concurrency,
                 native_tls,
@@ -432,7 +424,6 @@ pub(crate) async fn run(
                 } else {
                     Box::new(SummaryInstallLogger)
                 },
-                preview,
                 connectivity,
                 concurrency,
                 native_tls,
@@ -545,7 +536,6 @@ pub(crate) async fn run(
                     } else {
                         Box::new(SummaryInstallLogger)
                     },
-                    preview,
                     connectivity,
                     concurrency,
                     native_tls,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -3,9 +3,7 @@ use anyhow::{Context, Result};
 use uv_auth::store_credentials_from_url;
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
-use uv_configuration::{
-    Concurrency, ExtrasSpecification, HashCheckingMode, PreviewMode, SetupPyStrategy,
-};
+use uv_configuration::{Concurrency, ExtrasSpecification, HashCheckingMode, SetupPyStrategy};
 use uv_dispatch::BuildDispatch;
 use uv_fs::CWD;
 use uv_installer::SitePackages;
@@ -13,7 +11,6 @@ use uv_normalize::{PackageName, DEV_DEPENDENCIES};
 use uv_python::{PythonDownloads, PythonEnvironment, PythonPreference, PythonRequest};
 use uv_resolver::{FlatIndex, Lock};
 use uv_types::{BuildIsolation, HashStrategy};
-use uv_warnings::warn_user_once;
 use uv_workspace::{DiscoveryOptions, VirtualProject, Workspace};
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger, InstallLogger};
@@ -37,17 +34,13 @@ pub(crate) async fn sync(
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
     settings: ResolverInstallerSettings,
-    preview: PreviewMode,
+
     connectivity: Connectivity,
     concurrency: Concurrency,
     native_tls: bool,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv sync` is experimental and may change without warning");
-    }
-
     // Identify the project.
     let project = if let Some(package) = package {
         VirtualProject::Project(
@@ -80,7 +73,6 @@ pub(crate) async fn sync(
         venv.interpreter(),
         settings.as_ref().into(),
         Box::new(DefaultResolveLogger),
-        preview,
         connectivity,
         concurrency,
         native_tls,
@@ -114,7 +106,6 @@ pub(crate) async fn sync(
         settings.as_ref().into(),
         &state,
         Box::new(DefaultInstallLogger),
-        preview,
         connectivity,
         concurrency,
         native_tls,
@@ -137,7 +128,7 @@ pub(super) async fn do_sync(
     settings: InstallerSettingsRef<'_>,
     state: &SharedState,
     logger: Box<dyn InstallLogger>,
-    preview: PreviewMode,
+
     connectivity: Connectivity,
     concurrency: Concurrency,
     native_tls: bool,
@@ -241,7 +232,6 @@ pub(super) async fn do_sync(
         exclude_newer,
         sources,
         concurrency,
-        preview,
     );
 
     let site_packages = SitePackages::from_environment(venv)?;
@@ -267,7 +257,6 @@ pub(super) async fn do_sync(
         logger,
         dry_run,
         printer,
-        preview,
     )
     .await?;
 

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -6,11 +6,10 @@ use anyhow::Result;
 use pep508_rs::PackageName;
 use uv_cache::Cache;
 use uv_client::Connectivity;
-use uv_configuration::{Concurrency, PreviewMode, TargetTriple};
+use uv_configuration::{Concurrency, TargetTriple};
 use uv_fs::CWD;
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest, PythonVersion};
 use uv_resolver::TreeDisplay;
-use uv_warnings::warn_user_once;
 use uv_workspace::{DiscoveryOptions, Workspace};
 
 use crate::commands::pip::loggers::DefaultResolveLogger;
@@ -36,17 +35,13 @@ pub(crate) async fn tree(
     settings: ResolverSettings,
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
-    preview: PreviewMode,
+
     connectivity: Connectivity,
     concurrency: Concurrency,
     native_tls: bool,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv tree` is experimental and may change without warning");
-    }
-
     // Find the project requirements.
     let workspace = Workspace::discover(&CWD, &DiscoveryOptions::default()).await?;
 
@@ -72,7 +67,6 @@ pub(crate) async fn tree(
         &interpreter,
         settings.as_ref(),
         Box::new(DefaultResolveLogger),
-        preview,
         connectivity,
         concurrency,
         native_tls,

--- a/crates/uv/src/commands/python/dir.rs
+++ b/crates/uv/src/commands/python/dir.rs
@@ -2,16 +2,11 @@ use anstream::println;
 use anyhow::Context;
 use owo_colors::OwoColorize;
 
-use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_python::managed::ManagedPythonInstallations;
-use uv_warnings::warn_user_once;
 
 /// Show the toolchain directory.
-pub(crate) fn dir(preview: PreviewMode) -> anyhow::Result<()> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv python dir` is experimental and may change without warning");
-    }
+pub(crate) fn dir() -> anyhow::Result<()> {
     let installed_toolchains = ManagedPythonInstallations::from_settings()
         .context("Failed to initialize toolchain settings")?;
     println!(

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -3,10 +3,8 @@ use std::fmt::Write;
 use anyhow::Result;
 
 use uv_cache::Cache;
-use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_python::{EnvironmentPreference, PythonInstallation, PythonPreference, PythonRequest};
-use uv_warnings::warn_user_once;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -15,14 +13,9 @@ use crate::printer::Printer;
 pub(crate) async fn find(
     request: Option<String>,
     python_preference: PythonPreference,
-    preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv python find` is experimental and may change without warning");
-    }
-
     let request = match request {
         Some(request) => PythonRequest::parse(&request),
         None => PythonRequest::Any,

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -11,7 +11,6 @@ use owo_colors::OwoColorize;
 use tracing::debug;
 
 use uv_client::Connectivity;
-use uv_configuration::PreviewMode;
 use uv_fs::CWD;
 use uv_python::downloads::{DownloadResult, ManagedPythonDownload, PythonDownloadRequest};
 use uv_python::managed::{ManagedPythonInstallation, ManagedPythonInstallations};
@@ -19,7 +18,6 @@ use uv_python::{
     requests_from_version_file, PythonDownloads, PythonRequest, PYTHON_VERSIONS_FILENAME,
     PYTHON_VERSION_FILENAME,
 };
-use uv_warnings::warn_user_once;
 
 use crate::commands::python::{ChangeEvent, ChangeEventKind};
 use crate::commands::reporters::PythonDownloadReporter;
@@ -33,14 +31,9 @@ pub(crate) async fn install(
     python_downloads: PythonDownloads,
     native_tls: bool,
     connectivity: Connectivity,
-    preview: PreviewMode,
     no_config: bool,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv python install` is experimental and may change without warning");
-    }
-
     let start = std::time::Instant::now();
 
     let installations = ManagedPythonInstallations::from_settings()?.init()?;

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -5,14 +5,12 @@ use anyhow::Result;
 use owo_colors::OwoColorize;
 
 use uv_cache::Cache;
-use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_python::downloads::PythonDownloadRequest;
 use uv_python::{
     find_python_installations, DiscoveryError, EnvironmentPreference, PythonDownloads,
     PythonInstallation, PythonNotFound, PythonPreference, PythonRequest, PythonSource,
 };
-use uv_warnings::warn_user_once;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -33,14 +31,9 @@ pub(crate) async fn list(
     all_platforms: bool,
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
-    preview: PreviewMode,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv python list` is experimental and may change without warning");
-    }
-
     let mut output = BTreeSet::new();
     if python_preference != PythonPreference::OnlySystem {
         let download_request = match kinds {

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -6,7 +6,6 @@ use owo_colors::OwoColorize;
 use tracing::debug;
 
 use uv_cache::Cache;
-use uv_configuration::PreviewMode;
 use uv_fs::{Simplified, CWD};
 use uv_python::{
     request_from_version_file, requests_from_version_file, write_version_file,
@@ -24,15 +23,10 @@ pub(crate) async fn pin(
     request: Option<String>,
     resolved: bool,
     python_preference: PythonPreference,
-    preview: PreviewMode,
     no_workspace: bool,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv python pin` is experimental and may change without warning");
-    }
-
     let virtual_project = if no_workspace {
         None
     } else {

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -7,11 +7,9 @@ use futures::StreamExt;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 
-use uv_configuration::PreviewMode;
 use uv_python::downloads::PythonDownloadRequest;
 use uv_python::managed::ManagedPythonInstallations;
 use uv_python::PythonRequest;
-use uv_warnings::warn_user_once;
 
 use crate::commands::python::{ChangeEvent, ChangeEventKind};
 use crate::commands::{elapsed, ExitStatus};
@@ -21,13 +19,9 @@ use crate::printer::Printer;
 pub(crate) async fn uninstall(
     targets: Vec<String>,
     all: bool,
-    preview: PreviewMode,
+
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv python uninstall` is experimental and may change without warning");
-    }
-
     let start = std::time::Instant::now();
 
     let installations = ManagedPythonInstallations::from_settings()?.init()?;

--- a/crates/uv/src/commands/tool/dir.rs
+++ b/crates/uv/src/commands/tool/dir.rs
@@ -5,14 +5,9 @@ use owo_colors::OwoColorize;
 use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_tool::{find_executable_directory, InstalledTools};
-use uv_warnings::warn_user_once;
 
 /// Show the tool directory.
-pub(crate) fn dir(bin: bool, preview: PreviewMode) -> anyhow::Result<()> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv tool dir` is experimental and may change without warning");
-    }
-
+pub(crate) fn dir(bin: bool, _preview: PreviewMode) -> anyhow::Result<()> {
     if bin {
         let executable_directory = find_executable_directory()?;
         println!("{}", executable_directory.simplified_display().cyan());

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity};
-use uv_configuration::{Concurrency, PreviewMode};
+use uv_configuration::Concurrency;
 use uv_normalize::PackageName;
 use uv_python::{
     EnvironmentPreference, PythonDownloads, PythonInstallation, PythonPreference, PythonRequest,
@@ -16,7 +16,7 @@ use uv_python::{
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_settings::{ResolverInstallerOptions, ToolOptions};
 use uv_tool::InstalledTools;
-use uv_warnings::{warn_user, warn_user_once};
+use uv_warnings::warn_user;
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
 
@@ -39,7 +39,6 @@ pub(crate) async fn install(
     force: bool,
     options: ResolverInstallerOptions,
     settings: ResolverInstallerSettings,
-    preview: PreviewMode,
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
     connectivity: Connectivity,
@@ -48,10 +47,6 @@ pub(crate) async fn install(
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv tool install` is experimental and may change without warning");
-    }
-
     let client_builder = BaseClientBuilder::new()
         .connectivity(connectivity)
         .native_tls(native_tls);
@@ -104,7 +99,6 @@ pub(crate) async fn install(
                 &interpreter,
                 &settings,
                 &state,
-                preview,
                 connectivity,
                 concurrency,
                 native_tls,
@@ -142,7 +136,6 @@ pub(crate) async fn install(
             &interpreter,
             &settings,
             &state,
-            preview,
             connectivity,
             concurrency,
             native_tls,
@@ -167,7 +160,6 @@ pub(crate) async fn install(
                 &interpreter,
                 &settings,
                 &state,
-                preview,
                 connectivity,
                 concurrency,
                 native_tls,
@@ -284,7 +276,6 @@ pub(crate) async fn install(
             &state,
             Box::new(DefaultResolveLogger),
             Box::new(DefaultInstallLogger),
-            preview,
             connectivity,
             concurrency,
             native_tls,
@@ -310,7 +301,6 @@ pub(crate) async fn install(
             settings.as_ref().into(),
             &state,
             Box::new(DefaultResolveLogger),
-            preview,
             connectivity,
             concurrency,
             native_tls,
@@ -334,7 +324,6 @@ pub(crate) async fn install(
             settings.as_ref().into(),
             &state,
             Box::new(DefaultInstallLogger),
-            preview,
             connectivity,
             concurrency,
             native_tls,

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -4,25 +4,15 @@ use anyhow::Result;
 use owo_colors::OwoColorize;
 
 use uv_cache::Cache;
-use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_tool::InstalledTools;
-use uv_warnings::{warn_user, warn_user_once};
+use uv_warnings::warn_user;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// List installed tools.
-pub(crate) async fn list(
-    show_paths: bool,
-    preview: PreviewMode,
-    cache: &Cache,
-    printer: Printer,
-) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv tool list` is experimental and may change without warning");
-    }
-
+pub(crate) async fn list(show_paths: bool, cache: &Cache, printer: Printer) -> Result<ExitStatus> {
     let installed_tools = InstalledTools::from_settings()?;
     let _lock = match installed_tools.acquire_lock() {
         Ok(lock) => lock,

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -18,7 +18,7 @@ use pypi_types::{Requirement, RequirementSource};
 use uv_cache::{Cache, Refresh, Timestamp};
 use uv_cli::ExternalCommand;
 use uv_client::{BaseClientBuilder, Connectivity};
-use uv_configuration::{Concurrency, PreviewMode};
+use uv_configuration::Concurrency;
 use uv_installer::{SatisfiesResult, SitePackages};
 use uv_normalize::PackageName;
 use uv_python::{
@@ -27,7 +27,7 @@ use uv_python::{
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_tool::{entrypoint_paths, InstalledTools};
-use uv_warnings::{warn_user, warn_user_once};
+use uv_warnings::warn_user;
 
 use crate::commands::pip::loggers::{
     DefaultInstallLogger, DefaultResolveLogger, SummaryInstallLogger, SummaryResolveLogger,
@@ -70,7 +70,6 @@ pub(crate) async fn run(
     settings: ResolverInstallerSettings,
     invocation_source: ToolRunCommand,
     isolated: bool,
-    preview: PreviewMode,
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
     connectivity: Connectivity,
@@ -79,13 +78,9 @@ pub(crate) async fn run(
     cache: Cache,
     printer: Printer,
 ) -> anyhow::Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`{invocation_source}` is experimental and may change without warning");
-    }
-
     // treat empty command as `uv tool list`
     let Some(command) = command else {
-        return tool_list(false, PreviewMode::Enabled, &cache, printer).await;
+        return tool_list(false, &cache, printer).await;
     };
 
     let (target, args) = command.split();
@@ -110,7 +105,6 @@ pub(crate) async fn run(
         python.as_deref(),
         &settings,
         isolated,
-        preview,
         python_preference,
         python_downloads,
         connectivity,
@@ -380,7 +374,6 @@ async fn get_or_create_environment(
     python: Option<&str>,
     settings: &ResolverInstallerSettings,
     isolated: bool,
-    preview: PreviewMode,
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
     connectivity: Connectivity,
@@ -456,7 +449,6 @@ async fn get_or_create_environment(
             &interpreter,
             settings,
             &state,
-            preview,
             connectivity,
             concurrency,
             native_tls,
@@ -486,7 +478,6 @@ async fn get_or_create_environment(
                 &interpreter,
                 settings,
                 &state,
-                preview,
                 connectivity,
                 concurrency,
                 native_tls,
@@ -559,7 +550,6 @@ async fn get_or_create_environment(
         } else {
             Box::new(SummaryInstallLogger)
         },
-        preview,
         connectivity,
         concurrency,
         native_tls,

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -5,25 +5,15 @@ use itertools::Itertools;
 use owo_colors::OwoColorize;
 use tracing::debug;
 
-use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
 use uv_tool::{InstalledTools, Tool, ToolEntrypoint};
-use uv_warnings::warn_user_once;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Uninstall a tool.
-pub(crate) async fn uninstall(
-    name: Option<PackageName>,
-    preview: PreviewMode,
-    printer: Printer,
-) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv tool uninstall` is experimental and may change without warning");
-    }
-
+pub(crate) async fn uninstall(name: Option<PackageName>, printer: Printer) -> Result<ExitStatus> {
     let installed_tools = InstalledTools::from_settings()?.init()?;
     let _lock = match installed_tools.acquire_lock() {
         Ok(lock) => lock,

--- a/crates/uv/src/commands/tool/update_shell.rs
+++ b/crates/uv/src/commands/tool/update_shell.rs
@@ -7,21 +7,15 @@ use owo_colors::OwoColorize;
 use tokio::io::AsyncWriteExt;
 use tracing::debug;
 
-use uv_configuration::PreviewMode;
 use uv_fs::Simplified;
 use uv_shell::Shell;
 use uv_tool::find_executable_directory;
-use uv_warnings::warn_user_once;
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Ensure that the executable directory is in PATH.
-pub(crate) async fn update_shell(preview: PreviewMode, printer: Printer) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv tool update-shell` is experimental and may change without warning");
-    }
-
+pub(crate) async fn update_shell(printer: Printer) -> Result<ExitStatus> {
     let executable_directory = find_executable_directory()?;
     debug!(
         "Ensuring that the executable directory is in PATH: {}",

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -6,12 +6,11 @@ use tracing::debug;
 
 use uv_cache::Cache;
 use uv_client::Connectivity;
-use uv_configuration::{Concurrency, PreviewMode};
+use uv_configuration::Concurrency;
 use uv_normalize::PackageName;
 use uv_requirements::RequirementsSpecification;
 use uv_settings::{Combine, ResolverInstallerOptions, ToolOptions};
 use uv_tool::InstalledTools;
-use uv_warnings::warn_user_once;
 
 use crate::commands::pip::loggers::{SummaryResolveLogger, UpgradeInstallLogger};
 use crate::commands::project::{update_environment, EnvironmentUpdate};
@@ -29,13 +28,9 @@ pub(crate) async fn upgrade(
     concurrency: Concurrency,
     native_tls: bool,
     cache: &Cache,
-    preview: PreviewMode,
+
     printer: Printer,
 ) -> Result<ExitStatus> {
-    if preview.is_disabled() {
-        warn_user_once!("`uv tool upgrade` is experimental and may change without warning");
-    }
-
     // Initialize any shared state.
     let state = SharedState::default();
 
@@ -136,7 +131,6 @@ pub(crate) async fn upgrade(
             &state,
             Box::new(SummaryResolveLogger),
             Box::new(UpgradeInstallLogger::new(name.clone())),
-            preview,
             connectivity,
             concurrency,
             native_tls,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -159,7 +159,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         .combine(filesystem);
 
     // Resolve the global settings.
-    let globals = GlobalSettings::resolve(&cli.command, &cli.global_args, filesystem.as_ref());
+    let globals = GlobalSettings::resolve(&cli.global_args, filesystem.as_ref());
 
     // Resolve the cache settings.
     let cache_settings = CacheSettings::resolve(*cli.cache_args, filesystem.as_ref());
@@ -326,7 +326,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.settings.concurrency,
                 globals.native_tls,
                 globals.quiet,
-                globals.preview,
                 cache,
                 printer,
             )
@@ -399,7 +398,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.settings.sources,
                 args.settings.concurrency,
                 globals.native_tls,
-                globals.preview,
                 cache,
                 args.dry_run,
                 printer,
@@ -492,7 +490,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.settings.prefix,
                 args.settings.concurrency,
                 globals.native_tls,
-                globals.preview,
                 cache,
                 args.dry_run,
                 printer,
@@ -529,7 +526,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 cache,
                 globals.connectivity,
                 globals.native_tls,
-                globals.preview,
                 args.settings.keyring_provider,
                 printer,
             )
@@ -550,7 +546,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.settings.strict,
                 args.settings.python.as_deref(),
                 args.settings.system,
-                globals.preview,
                 &cache,
                 printer,
             )
@@ -574,7 +569,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.settings.strict,
                 args.settings.python.as_deref(),
                 args.settings.system,
-                globals.preview,
                 &cache,
                 printer,
             )
@@ -594,7 +588,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.settings.strict,
                 args.settings.python.as_deref(),
                 args.settings.system,
-                globals.preview,
                 &cache,
                 printer,
             )
@@ -635,7 +628,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             commands::pip_check(
                 args.settings.python.as_deref(),
                 args.settings.system,
-                globals.preview,
                 &cache,
                 printer,
             )
@@ -702,7 +694,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.allow_existing,
                 args.settings.exclude_newer,
                 globals.native_tls,
-                globals.preview,
                 &cache,
                 printer,
                 args.relocatable,
@@ -768,7 +759,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.settings,
                 invocation_source,
                 args.isolated,
-                globals.preview,
                 globals.python_preference,
                 globals.python_downloads,
                 globals.connectivity,
@@ -813,7 +803,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.force,
                 args.options,
                 args.settings,
-                globals.preview,
                 globals.python_preference,
                 globals.python_downloads,
                 globals.connectivity,
@@ -834,7 +823,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             // Initialize the cache.
             let cache = cache.init()?;
 
-            commands::tool_list(args.show_paths, globals.preview, &cache, printer).await
+            commands::tool_list(args.show_paths, &cache, printer).await
         }
         Commands::Tool(ToolNamespace {
             command: ToolCommand::Upgrade(args),
@@ -854,7 +843,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 Concurrency::default(),
                 globals.native_tls,
                 &cache,
-                globals.preview,
                 printer,
             )
             .await
@@ -866,12 +854,12 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             let args = settings::ToolUninstallSettings::resolve(args, filesystem);
             show_settings!(args);
 
-            commands::tool_uninstall(args.name, globals.preview, printer).await
+            commands::tool_uninstall(args.name, printer).await
         }
         Commands::Tool(ToolNamespace {
             command: ToolCommand::UpdateShell,
         }) => {
-            commands::tool_update_shell(globals.preview, printer).await?;
+            commands::tool_update_shell(printer).await?;
             Ok(ExitStatus::Success)
         }
         Commands::Tool(ToolNamespace {
@@ -900,7 +888,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.all_platforms,
                 globals.python_preference,
                 globals.python_downloads,
-                globals.preview,
                 &cache,
                 printer,
             )
@@ -919,7 +906,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 globals.python_downloads,
                 globals.native_tls,
                 globals.connectivity,
-                globals.preview,
                 cli.no_config,
                 printer,
             )
@@ -932,7 +918,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             let args = settings::PythonUninstallSettings::resolve(args, filesystem);
             show_settings!(args);
 
-            commands::python_uninstall(args.targets, args.all, globals.preview, printer).await
+            commands::python_uninstall(args.targets, args.all, printer).await
         }
         Commands::Python(PythonNamespace {
             command: PythonCommand::Find(args),
@@ -943,14 +929,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             // Initialize the cache.
             let cache = cache.init()?;
 
-            commands::python_find(
-                args.request,
-                globals.python_preference,
-                globals.preview,
-                &cache,
-                printer,
-            )
-            .await
+            commands::python_find(args.request, globals.python_preference, &cache, printer).await
         }
         Commands::Python(PythonNamespace {
             command: PythonCommand::Pin(args),
@@ -965,7 +944,6 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.request,
                 args.resolved,
                 globals.python_preference,
-                globals.preview,
                 args.no_workspace,
                 &cache,
                 printer,
@@ -975,7 +953,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         Commands::Python(PythonNamespace {
             command: PythonCommand::Dir,
         }) => {
-            commands::python_dir(globals.preview)?;
+            commands::python_dir()?;
             Ok(ExitStatus::Success)
         }
     }
@@ -1021,7 +999,6 @@ async fn run_project(
                 args.no_readme,
                 args.python,
                 args.no_workspace,
-                globals.preview,
                 globals.python_preference,
                 globals.python_downloads,
                 globals.connectivity,
@@ -1068,7 +1045,6 @@ async fn run_project(
                 args.dev,
                 args.python,
                 args.settings,
-                globals.preview,
                 globals.python_preference,
                 globals.python_downloads,
                 globals.connectivity,
@@ -1102,7 +1078,6 @@ async fn run_project(
                 globals.python_preference,
                 globals.python_downloads,
                 args.settings,
-                globals.preview,
                 globals.connectivity,
                 Concurrency::default(),
                 globals.native_tls,
@@ -1124,7 +1099,6 @@ async fn run_project(
                 args.frozen,
                 args.python,
                 args.settings,
-                globals.preview,
                 globals.python_preference,
                 globals.python_downloads,
                 globals.connectivity,
@@ -1186,7 +1160,6 @@ async fn run_project(
                 args.script,
                 globals.python_preference,
                 globals.python_downloads,
-                globals.preview,
                 globals.connectivity,
                 Concurrency::default(),
                 globals.native_tls,
@@ -1219,7 +1192,6 @@ async fn run_project(
                 script,
                 globals.python_preference,
                 globals.python_downloads,
-                globals.preview,
                 globals.connectivity,
                 Concurrency::default(),
                 globals.native_tls,
@@ -1251,7 +1223,6 @@ async fn run_project(
                 args.resolver,
                 globals.python_preference,
                 globals.python_downloads,
-                globals.preview,
                 globals.connectivity,
                 Concurrency::default(),
                 globals.native_tls,

--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -91,7 +91,6 @@ fn prune_cached_env() {
     pytest 8.0.0
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -31,7 +31,6 @@ fn add_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -125,7 +124,6 @@ fn add_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 4 packages in [TIME]
     "###);
 
@@ -153,7 +151,6 @@ fn add_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -163,7 +160,6 @@ fn add_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -293,7 +289,6 @@ fn add_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 5 packages in [TIME]
     "###);
 
@@ -390,7 +385,6 @@ fn add_git_private_source() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 2 packages in [TIME]
     "###);
 
@@ -489,7 +483,6 @@ fn add_git_private_raw() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 2 packages in [TIME]
     "###);
 
@@ -516,7 +509,6 @@ fn add_git_error() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 1 package in [TIME]
     "###);
 
@@ -526,7 +518,6 @@ fn add_git_error() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
@@ -576,7 +567,6 @@ fn add_git_raw() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -586,7 +576,6 @@ fn add_git_raw() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -704,7 +693,6 @@ fn add_git_raw() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 5 packages in [TIME]
     "###);
 
@@ -732,7 +720,6 @@ fn add_git_implicit() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -742,7 +729,6 @@ fn add_git_implicit() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -892,7 +878,6 @@ fn add_unnamed() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 2 packages in [TIME]
     "###);
 
@@ -919,7 +904,6 @@ fn add_remove_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -1020,7 +1004,6 @@ fn add_remove_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 4 packages in [TIME]
     "###);
 
@@ -1031,7 +1014,6 @@ fn add_remove_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning
     warning: `anyio` is a development dependency; try calling `uv remove --dev`
     error: The dependency `anyio` could not be found in `dependencies`
     "###);
@@ -1043,7 +1025,6 @@ fn add_remove_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 4 packages in [TIME]
@@ -1102,7 +1083,6 @@ fn add_remove_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 1 package in [TIME]
     "###);
 
@@ -1129,7 +1109,6 @@ fn add_remove_optional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -1229,7 +1208,6 @@ fn add_remove_optional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Uninstalled 3 packages in [TIME]
      - anyio==3.7.0
      - idna==3.6
@@ -1243,7 +1221,6 @@ fn add_remove_optional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning
     warning: `anyio` is an optional dependency; try calling `uv remove --optional io`
     error: The dependency `anyio` could not be found in `dependencies`
     "###);
@@ -1255,7 +1232,6 @@ fn add_remove_optional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -1311,7 +1287,6 @@ fn add_remove_optional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 1 package in [TIME]
     "###);
 
@@ -1454,7 +1429,6 @@ fn add_remove_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 2 packages in [TIME]
     "###);
 
@@ -1465,7 +1439,6 @@ fn add_remove_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 2 packages in [TIME]
@@ -1532,7 +1505,6 @@ fn add_remove_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 1 package in [TIME]
     "###);
 
@@ -1655,7 +1627,6 @@ fn add_workspace_editable() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 2 packages in [TIME]
     "###);
 
@@ -1685,7 +1656,6 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###);
 
@@ -1695,7 +1665,6 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + certifi==2024.2.2
@@ -1713,7 +1682,6 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -1747,7 +1715,6 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 3 packages in [TIME]
     Uninstalled 1 package in [TIME]
@@ -1785,8 +1752,6 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 2 packages in [TIME]
     Uninstalled 2 packages in [TIME]
@@ -1944,7 +1909,6 @@ fn update() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 8 packages in [TIME]
     "###);
 
@@ -1972,7 +1936,6 @@ fn add_update_marker() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###);
 
@@ -1982,7 +1945,6 @@ fn add_update_marker() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + certifi==2024.2.2
@@ -2000,7 +1962,6 @@ fn add_update_marker() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -2036,7 +1997,6 @@ fn add_update_marker() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 10 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -2072,7 +2032,6 @@ fn add_update_marker() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 3 packages in [TIME]
     Uninstalled 3 packages in [TIME]
@@ -2113,7 +2072,6 @@ fn add_update_marker() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -2152,7 +2110,6 @@ fn add_update_marker() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 6 packages in [TIME]
@@ -2209,8 +2166,6 @@ fn update_source_replace_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -2268,7 +2223,6 @@ fn add_no_clean() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -2278,7 +2232,6 @@ fn add_no_clean() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -2302,7 +2255,6 @@ fn add_no_clean() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Uninstalled 1 package in [TIME]
@@ -2373,7 +2325,6 @@ fn add_no_clean() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 2 packages in [TIME]
     "###);
 
@@ -2384,7 +2335,6 @@ fn add_no_clean() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Uninstalled 3 packages in [TIME]
      - anyio==3.7.0
      - idna==3.6
@@ -2414,7 +2364,6 @@ fn remove_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -2424,7 +2373,6 @@ fn remove_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -2439,7 +2387,6 @@ fn remove_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 4 packages in [TIME]
@@ -2495,7 +2442,6 @@ fn remove_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Audited 1 package in [TIME]
     "###);
 
@@ -2524,7 +2470,6 @@ fn add_preserves_indentation_in_pyproject_toml() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
@@ -2580,7 +2525,6 @@ fn add_puts_default_indentation_in_pyproject_toml_if_not_observed() -> Result<()
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
@@ -2637,7 +2581,6 @@ fn add_frozen() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     "###);
 
     let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
@@ -2685,7 +2628,6 @@ fn add_no_sync() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -2802,7 +2744,6 @@ fn add_error() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because there are no versions of xyz and your project depends on xyz, we can conclude that your project's requirements are unsatisfiable.
       help: If this is intentional, run `uv add --frozen` to skip the lock and sync steps.
@@ -2814,7 +2755,6 @@ fn add_error() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     "###);
 
     let lock = context.temp_dir.join("uv.lock");
@@ -2844,7 +2784,6 @@ fn add_lower_bound() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -2897,7 +2836,6 @@ fn add_lower_bound_existing() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -2949,7 +2887,6 @@ fn add_lower_bound_raw() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -3001,7 +2938,6 @@ fn add_lower_bound_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -3056,7 +2992,6 @@ fn add_lower_bound_optional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -3171,7 +3106,6 @@ fn add_lower_bound_local() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -3252,7 +3186,6 @@ fn add_virtual() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     error: Found a virtual workspace root, but virtual projects do not support production dependencies (instead, use: `uv add --dev`)
     "###);
 
@@ -3264,7 +3197,6 @@ fn add_virtual() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     error: Found a virtual workspace root, but virtual projects do not support optional dependencies (instead, use: `uv add --dev`)
     "###);
 
@@ -3275,7 +3207,6 @@ fn add_virtual() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -3348,7 +3279,6 @@ fn add_repeat() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -3383,7 +3313,6 @@ fn add_repeat() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Audited 4 packages in [TIME]
     "###);
@@ -3434,7 +3363,6 @@ fn add_requirements_file() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -3479,7 +3407,6 @@ fn add_requirements_file() -> Result<()> {
 
     ----- stderr -----
     warning: `--raw-sources` is a no-op for `requirements.txt` files, which are always treated as raw sources
-    warning: `uv add` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Audited [N] packages in [TIME]
     "###);
@@ -3491,7 +3418,6 @@ fn add_requirements_file() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     error: Adding requirements from a `setup.py` is not supported in `uv add`
     "###);
 
@@ -3542,7 +3468,6 @@ fn add_script() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     "###);
 
     let script_content = fs_err::read_to_string(context.temp_dir.join("script.py"))?;
@@ -3594,7 +3519,6 @@ fn add_script_without_metadata_table() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     "###);
 
     let script_content = fs_err::read_to_string(context.temp_dir.join("script.py"))?;
@@ -3645,7 +3569,6 @@ fn add_script_without_metadata_table_with_shebang() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     "###);
 
     let script_content = fs_err::read_to_string(context.temp_dir.join("script.py"))?;
@@ -3697,7 +3620,6 @@ fn add_script_without_metadata_table_with_docstring() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv add` is experimental and may change without warning
     "###);
 
     let script_content = fs_err::read_to_string(context.temp_dir.join("script.py"))?;
@@ -3757,7 +3679,6 @@ fn remove_script() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning
     "###);
 
     let script_content = fs_err::read_to_string(context.temp_dir.join("script.py"))?;
@@ -3815,7 +3736,6 @@ fn remove_last_dep_script() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv remove` is experimental and may change without warning
     "###);
 
     let script_content = fs_err::read_to_string(context.temp_dir.join("script.py"))?;

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -16,15 +16,15 @@ fn help() {
     Usage: uv [OPTIONS] <COMMAND>
 
     Commands:
-      run                        Run a command or script (experimental)
-      init                       Create a new project (experimental)
-      add                        Add dependencies to the project (experimental)
-      remove                     Remove dependencies from the project (experimental)
-      sync                       Update the project's environment (experimental)
-      lock                       Update the project's lockfile (experimental)
-      tree                       Display the project's dependency tree (experimental)
-      tool                       Run and install commands provided by Python packages (experimental)
-      python                     Manage Python versions and installations (experimental)
+      run                        Run a command or script
+      init                       Create a new project
+      add                        Add dependencies to the project
+      remove                     Remove dependencies from the project
+      sync                       Update the project's environment
+      lock                       Update the project's lockfile
+      tree                       Display the project's dependency tree
+      tool                       Run and install commands provided by Python packages
+      python                     Manage Python versions and installations
       pip                        Manage Python packages with a pip-compatible interface
       venv                       Create a virtual environment
       cache                      Manage uv's cache
@@ -79,15 +79,15 @@ fn help_flag() {
     Usage: uv [OPTIONS] <COMMAND>
 
     Commands:
-      run      Run a command or script (experimental)
-      init     Create a new project (experimental)
-      add      Add dependencies to the project (experimental)
-      remove   Remove dependencies from the project (experimental)
-      sync     Update the project's environment (experimental)
-      lock     Update the project's lockfile (experimental)
-      tree     Display the project's dependency tree (experimental)
-      tool     Run and install commands provided by Python packages (experimental)
-      python   Manage Python versions and installations (experimental)
+      run      Run a command or script
+      init     Create a new project
+      add      Add dependencies to the project
+      remove   Remove dependencies from the project
+      sync     Update the project's environment
+      lock     Update the project's lockfile
+      tree     Display the project's dependency tree
+      tool     Run and install commands provided by Python packages
+      python   Manage Python versions and installations
       pip      Manage Python packages with a pip-compatible interface
       venv     Create a virtual environment
       cache    Manage uv's cache
@@ -140,15 +140,15 @@ fn help_short_flag() {
     Usage: uv [OPTIONS] <COMMAND>
 
     Commands:
-      run      Run a command or script (experimental)
-      init     Create a new project (experimental)
-      add      Add dependencies to the project (experimental)
-      remove   Remove dependencies from the project (experimental)
-      sync     Update the project's environment (experimental)
-      lock     Update the project's lockfile (experimental)
-      tree     Display the project's dependency tree (experimental)
-      tool     Run and install commands provided by Python packages (experimental)
-      python   Manage Python versions and installations (experimental)
+      run      Run a command or script
+      init     Create a new project
+      add      Add dependencies to the project
+      remove   Remove dependencies from the project
+      sync     Update the project's environment
+      lock     Update the project's lockfile
+      tree     Display the project's dependency tree
+      tool     Run and install commands provided by Python packages
+      python   Manage Python versions and installations
       pip      Manage Python packages with a pip-compatible interface
       venv     Create a virtual environment
       cache    Manage uv's cache
@@ -197,7 +197,7 @@ fn help_subcommand() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Manage Python versions and installations (experimental)
+    Manage Python versions and installations
 
     Generally, uv first searches for Python in a virtual environment, either
     active or in a `.venv` directory  in the current working directory or
@@ -208,8 +208,7 @@ fn help_subcommand() {
     On Windows, the `py` launcher is also invoked to find Python
     executables.
 
-    When preview is enabled, i.e., via `--preview` or by using a preview
-    command, uv will download Python if a version cannot be found. This
+    By default, uv will download Python if a version cannot be found. This
     behavior can be disabled with the `--python-downloads` option.
 
     The `--python` option allows requesting a different interpreter.
@@ -513,7 +512,7 @@ fn help_flag_subcommand() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Manage Python versions and installations (experimental)
+    Manage Python versions and installations
 
     Usage: uv python [OPTIONS] <COMMAND>
 
@@ -693,15 +692,15 @@ fn help_with_global_option() {
     Usage: uv [OPTIONS] <COMMAND>
 
     Commands:
-      run                        Run a command or script (experimental)
-      init                       Create a new project (experimental)
-      add                        Add dependencies to the project (experimental)
-      remove                     Remove dependencies from the project (experimental)
-      sync                       Update the project's environment (experimental)
-      lock                       Update the project's lockfile (experimental)
-      tree                       Display the project's dependency tree (experimental)
-      tool                       Run and install commands provided by Python packages (experimental)
-      python                     Manage Python versions and installations (experimental)
+      run                        Run a command or script
+      init                       Create a new project
+      add                        Add dependencies to the project
+      remove                     Remove dependencies from the project
+      sync                       Update the project's environment
+      lock                       Update the project's lockfile
+      tree                       Display the project's dependency tree
+      tool                       Run and install commands provided by Python packages
+      python                     Manage Python versions and installations
       pip                        Manage Python packages with a pip-compatible interface
       venv                       Create a virtual environment
       cache                      Manage uv's cache
@@ -792,15 +791,15 @@ fn help_with_no_pager() {
     Usage: uv [OPTIONS] <COMMAND>
 
     Commands:
-      run                        Run a command or script (experimental)
-      init                       Create a new project (experimental)
-      add                        Add dependencies to the project (experimental)
-      remove                     Remove dependencies from the project (experimental)
-      sync                       Update the project's environment (experimental)
-      lock                       Update the project's lockfile (experimental)
-      tree                       Display the project's dependency tree (experimental)
-      tool                       Run and install commands provided by Python packages (experimental)
-      python                     Manage Python versions and installations (experimental)
+      run                        Run a command or script
+      init                       Create a new project
+      add                        Add dependencies to the project
+      remove                     Remove dependencies from the project
+      sync                       Update the project's environment
+      lock                       Update the project's lockfile
+      tree                       Display the project's dependency tree
+      tool                       Run and install commands provided by Python packages
+      python                     Manage Python versions and installations
       pip                        Manage Python packages with a pip-compatible interface
       venv                       Create a virtual environment
       cache                      Manage uv's cache

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -19,7 +19,6 @@ fn init() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
 
@@ -65,7 +64,6 @@ fn init() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 1 package in [TIME]
     "###);
@@ -86,7 +84,6 @@ fn init_cache() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
 
@@ -103,7 +100,6 @@ fn init_no_readme() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
 
@@ -145,7 +141,6 @@ fn init_current_dir() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Initialized project `foo`
     "###);
 
@@ -191,7 +186,6 @@ fn init_current_dir() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 1 package in [TIME]
     "###);
@@ -212,7 +206,6 @@ fn init_dot_args() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
 
@@ -258,7 +251,6 @@ fn init_dot_args() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 1 package in [TIME]
     "###);
@@ -290,7 +282,6 @@ fn init_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Adding `foo` as member of workspace `[TEMP_DIR]/`
     Initialized project `foo`
     "###);
@@ -356,7 +347,6 @@ fn init_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -386,7 +376,6 @@ fn init_workspace_relative_sub_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Adding `foo` as member of workspace `[TEMP_DIR]/`
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
@@ -452,7 +441,6 @@ fn init_workspace_relative_sub_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -483,7 +471,6 @@ fn init_workspace_outside() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Adding `foo` as member of workspace `[TEMP_DIR]/`
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
@@ -549,7 +536,6 @@ fn init_workspace_outside() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -567,7 +553,6 @@ fn init_invalid_names() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Initialized project `foo-bar` at `[TEMP_DIR]/foo-bar`
     "###);
 
@@ -602,7 +587,6 @@ fn init_invalid_names() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     error: Not a valid package or extra name: "bar baz". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
     "###);
 
@@ -633,7 +617,6 @@ fn init_isolated() -> Result<()> {
 
     ----- stderr -----
     warning: The `--isolated` flag is deprecated and has no effect. Instead, use `--no-config` to prevent uv from discovering configuration files or `--no-workspace` to prevent uv from adding the initialized project to the containing workspace.
-    warning: `uv init` is experimental and may change without warning
     Adding `foo` as member of workspace `[TEMP_DIR]/`
     Initialized project `foo`
     "###);
@@ -682,7 +665,6 @@ fn init_no_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Initialized project `foo`
     "###);
 
@@ -715,7 +697,6 @@ fn init_no_workspace_warning() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     warning: `--no-workspace` was provided, but no workspace was found
     Initialized project `project`
     "###);
@@ -767,7 +748,6 @@ fn init_project_inside_project() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Adding `foo` as member of workspace `[TEMP_DIR]/`
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
@@ -779,7 +759,6 @@ fn init_project_inside_project() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Adding `bar` as member of workspace `[TEMP_DIR]/`
     Initialized project `bar` at `[TEMP_DIR]/foo/bar`
     "###);
@@ -850,7 +829,6 @@ fn init_explicit_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Adding `foo` as member of workspace `[TEMP_DIR]/`
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
@@ -891,7 +869,6 @@ fn init_virtual_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Initialized workspace `foo`
     "###);
 
@@ -913,7 +890,6 @@ fn init_virtual_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Adding `bar` as member of workspace `[TEMP_DIR]/foo`
     Initialized project `bar` at `[TEMP_DIR]/foo/bar`
     "###);
@@ -952,7 +928,6 @@ fn init_nested_virtual_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     warning: Nested workspaces are not supported, but outer workspace (`[TEMP_DIR]/`) includes `[TEMP_DIR]/foo`
     Initialized workspace `foo` at `[TEMP_DIR]/foo`
     "###);
@@ -1009,7 +984,6 @@ fn init_matches_members() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Project `foo` is already a member of workspace `[TEMP_DIR]/`
     Initialized project `foo` at `[TEMP_DIR]/packages/foo`
     "###);
@@ -1052,7 +1026,6 @@ fn init_matches_exclude() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Project `foo` is excluded by workspace `[TEMP_DIR]/`
     Initialized project `foo` at `[TEMP_DIR]/packages/foo`
     "###);
@@ -1098,7 +1071,6 @@ fn init_requires_python_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Adding `foo` as member of workspace `[TEMP_DIR]/`
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
@@ -1152,7 +1124,6 @@ fn init_requires_python_version() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Adding `foo` as member of workspace `[TEMP_DIR]/`
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
@@ -1207,7 +1178,6 @@ fn init_requires_python_specifiers() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Adding `foo` as member of workspace `[TEMP_DIR]/`
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
@@ -1255,7 +1225,6 @@ fn init_unmanaged() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     Initialized project `foo` at `[TEMP_DIR]/foo`
     "###);
 
@@ -1284,7 +1253,6 @@ fn init_hidden() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv init` is experimental and may change without warning
     error: Not a valid package or extra name: ".foo". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
     "###);
 }

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -32,14 +32,13 @@ fn lock_wheel_registry() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 4 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -106,7 +105,6 @@ fn lock_wheel_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -118,7 +116,6 @@ fn lock_wheel_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -129,7 +126,6 @@ fn lock_wheel_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -158,14 +154,13 @@ fn lock_sdist_registry() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock().env_remove("UV_EXCLUDE_NEWER"), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -204,7 +199,6 @@ fn lock_sdist_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -215,7 +209,6 @@ fn lock_sdist_registry() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
@@ -246,15 +239,13 @@ fn lock_sdist_git() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-            success: true
-            exit_code: 0
-            ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-            ----- stderr -----
-            warning: `uv lock` is experimental and may change without warning
-            warning: `uv.sources` is experimental and may change without warning
-            Resolved 2 packages in [TIME]
-            "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -295,8 +286,6 @@ fn lock_sdist_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -308,8 +297,6 @@ fn lock_sdist_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -320,7 +307,6 @@ fn lock_sdist_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
@@ -343,15 +329,13 @@ fn lock_sdist_git() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        warning: `uv.sources` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -401,15 +385,13 @@ fn lock_sdist_git() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        warning: `uv.sources` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -459,15 +441,13 @@ fn lock_sdist_git() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        warning: `uv.sources` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -522,14 +502,13 @@ fn lock_sdist_git_subdirectory() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -570,7 +549,6 @@ fn lock_sdist_git_subdirectory() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -581,7 +559,6 @@ fn lock_sdist_git_subdirectory() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + example-pkg-a==1 (from git+https://github.com/pypa/sample-namespace-packages.git@df7530eeb8fa0cb7dbb8ecb28363e8e36bfa2f45#subdirectory=pkg_resources/pkg_a)
@@ -609,14 +586,13 @@ fn lock_sdist_git_pep508() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -657,7 +633,6 @@ fn lock_sdist_git_pep508() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -674,14 +649,13 @@ fn lock_sdist_git_pep508() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -728,14 +702,13 @@ fn lock_sdist_git_pep508() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -782,14 +755,13 @@ fn lock_sdist_git_pep508() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -843,14 +815,13 @@ fn lock_wheel_url() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 4 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -938,7 +909,6 @@ fn lock_wheel_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -949,7 +919,6 @@ fn lock_wheel_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     error: Failed to download: `anyio @ https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl`
       Caused by: Network connectivity is disabled, but the requested data wasn't found in the cache for: `https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl`
     "###);
@@ -961,7 +930,6 @@ fn lock_wheel_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 3 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0 (from https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl)
@@ -990,14 +958,13 @@ fn lock_sdist_url() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 4 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -1083,7 +1050,6 @@ fn lock_sdist_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -1094,7 +1060,6 @@ fn lock_sdist_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0 (from https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz)
@@ -1126,14 +1091,13 @@ fn lock_project_extra() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 5 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -1217,7 +1181,6 @@ fn lock_project_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -1228,7 +1191,6 @@ fn lock_project_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -1244,7 +1206,6 @@ fn lock_project_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
@@ -1277,7 +1238,6 @@ fn lock_project_with_overrides() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 9 packages in [TIME]
     "###);
 
@@ -1288,7 +1248,6 @@ fn lock_project_with_overrides() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 9 packages in [TIME]
     "###);
 
@@ -1299,7 +1258,6 @@ fn lock_project_with_overrides() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
      + blinker==1.7.0
@@ -1340,7 +1298,6 @@ fn lock_project_with_constraints() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -1351,7 +1308,6 @@ fn lock_project_with_constraints() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -1362,7 +1318,6 @@ fn lock_project_with_constraints() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -1391,14 +1346,13 @@ fn lock_dependency_extra() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 10 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 10 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -1545,7 +1499,6 @@ fn lock_dependency_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 10 packages in [TIME]
     "###);
 
@@ -1556,7 +1509,6 @@ fn lock_dependency_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 9 packages in [TIME]
     Installed 9 packages in [TIME]
      + blinker==1.7.0
@@ -1592,14 +1544,13 @@ fn lock_conditional_dependency_extra() -> Result<()> {
     let lockfile = context.temp_dir.join("uv.lock");
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 7 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 7 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(&lockfile).unwrap();
 
@@ -1798,7 +1749,6 @@ fn lock_conditional_dependency_extra() -> Result<()> {
     // ----- stdout -----
     //
     // ----- stderr -----
-    // warning: `uv lock` is experimental and may change without warning
     // Resolved 7 packages in [TIME]
     // error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     // "###);
@@ -1810,7 +1760,6 @@ fn lock_conditional_dependency_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + certifi==2024.2.2
@@ -1834,7 +1783,6 @@ fn lock_conditional_dependency_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 7 packages in [TIME]
     "###);
 
@@ -1845,7 +1793,6 @@ fn lock_conditional_dependency_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
      + certifi==2024.2.2
@@ -1877,15 +1824,14 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 9 packages in [TIME]
-        warning: The package `flask==3.0.2` does not have an extra named `foo`
-        "###);
+    ----- stderr -----
+    Resolved 9 packages in [TIME]
+    warning: The package `flask==3.0.2` does not have an extra named `foo`
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -2018,7 +1964,6 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 9 packages in [TIME]
     "###);
 
@@ -2029,7 +1974,6 @@ fn lock_dependency_non_existent_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
      + blinker==1.7.0
@@ -2062,14 +2006,13 @@ fn lock_upgrade_log() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 3 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -2124,7 +2067,6 @@ fn lock_upgrade_log() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -2147,7 +2089,6 @@ fn lock_upgrade_log() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     Removed iniconfig v2.0.0
     Updated markupsafe v1.1.1 -> v2.1.5
@@ -2233,14 +2174,13 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 3 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -2302,7 +2242,6 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -2324,7 +2263,6 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Updated markupsafe v1.1.1, v2.0.0 -> v2.1.5
     "###);
@@ -2394,14 +2332,13 @@ fn lock_preference() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -2459,7 +2396,6 @@ fn lock_preference() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -2505,7 +2441,6 @@ fn lock_preference() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Updated iniconfig v1.1.1 -> v2.0.0
     "###);
@@ -2613,19 +2548,17 @@ fn lock_git_sha() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
     // Relock with `--upgrade`.
     uv_snapshot!(context.filters(), context.lock().arg("--upgrade-package").arg("uv-public-pypackage"), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
     "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
@@ -2685,28 +2618,27 @@ fn lock_requires_python() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: false
-        exit_code: 1
-        ----- stdout -----
+    success: false
+    exit_code: 1
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-          × No solution found when resolving dependencies:
-          ╰─▶ Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and the requested Python version (>=3.7) does not satisfy Python>=3.7.9,<3.8, we can conclude that Python>=3.7.9 is incompatible.
-              And because pygls>=1.1.0,<=1.2.1 depends on Python>=3.7.9,<4 and only pygls<=1.3.0 is available, we can conclude that any of:
-                  pygls>=1.1.0,<1.3.0
-                  pygls>1.3.0
-               cannot be used. (1)
+    ----- stderr -----
+      × No solution found when resolving dependencies:
+      ╰─▶ Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and the requested Python version (>=3.7) does not satisfy Python>=3.7.9,<3.8, we can conclude that Python>=3.7.9 is incompatible.
+          And because pygls>=1.1.0,<=1.2.1 depends on Python>=3.7.9,<4 and only pygls<=1.3.0 is available, we can conclude that any of:
+              pygls>=1.1.0,<1.3.0
+              pygls>1.3.0
+           cannot be used. (1)
 
-              Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and pygls==1.3.0 depends on Python>=3.8, we can conclude that pygls==1.3.0 cannot be used.
-              And because we know from (1) that any of:
-                  pygls>=1.1.0,<1.3.0
-                  pygls>1.3.0
-               cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
-              And because your project depends on pygls>=1.1.0, we can conclude that your project's requirements are unsatisfiable.
+          Because the requested Python version (>=3.7) does not satisfy Python>=3.8 and pygls==1.3.0 depends on Python>=3.8, we can conclude that pygls==1.3.0 cannot be used.
+          And because we know from (1) that any of:
+              pygls>=1.1.0,<1.3.0
+              pygls>1.3.0
+           cannot be used, we can conclude that pygls>=1.1.0 cannot be used.
+          And because your project depends on pygls>=1.1.0, we can conclude that your project's requirements are unsatisfiable.
 
-              hint: The `requires-python` value (>=3.7) includes Python versions that are not supported by your dependencies (e.g., pygls>=1.1.0,<=1.2.1 only supports >=3.7.9, <4). Consider using a more restrictive `requires-python` value (like >=3.7.9, <4).
-        "###);
+          hint: The `requires-python` value (>=3.7) includes Python versions that are not supported by your dependencies (e.g., pygls>=1.1.0,<=1.2.1 only supports >=3.7.9, <4). Consider using a more restrictive `requires-python` value (like >=3.7.9, <4).
+    "###);
 
     // Require >=3.7, and allow locking to a version of `pygls` that is compatible (==1.0.1).
     pyproject_toml.write_str(
@@ -2720,14 +2652,13 @@ fn lock_requires_python() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 10 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 10 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(&lockfile).unwrap();
 
@@ -2872,14 +2803,13 @@ fn lock_requires_python() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 9 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 9 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(&lockfile).unwrap();
 
@@ -3014,14 +2944,13 @@ fn lock_requires_python() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 5 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(&lockfile).unwrap();
 
@@ -3118,7 +3047,6 @@ fn lock_requires_python() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -3130,7 +3058,6 @@ fn lock_requires_python() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     error: No interpreter found for Python >=3.12 in system path
     "###);
 
@@ -3157,15 +3084,14 @@ fn lock_requires_python_wheels() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(&lockfile).unwrap();
 
@@ -3225,7 +3151,6 @@ fn lock_requires_python_wheels() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Resolved 2 packages in [TIME]
     "###);
@@ -3242,15 +3167,14 @@ fn lock_requires_python_wheels() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(&lockfile).unwrap();
 
@@ -3325,7 +3249,6 @@ fn lock_requires_python_wheels() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Using Python 3.11.[X] interpreter at: [PYTHON-3.11]
     Resolved 2 packages in [TIME]
     "###);
@@ -3353,14 +3276,13 @@ fn lock_requires_python_star() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 6 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(&lockfile).unwrap();
 
@@ -3449,7 +3371,6 @@ fn lock_requires_python_star() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###);
 
@@ -3477,14 +3398,13 @@ fn lock_requires_python_pre() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 6 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(&lockfile).unwrap();
 
@@ -3573,7 +3493,6 @@ fn lock_requires_python_pre() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###);
 
@@ -3599,15 +3518,14 @@ fn lock_requires_python_unbounded() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        warning: The workspace `requires-python` value does not contain a lower bound: `<=3.12`. Set a lower bound to indicate the minimum compatible Python version (e.g., `>=3.11`).
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    warning: The workspace `requires-python` value does not contain a lower bound: `<=3.12`. Set a lower bound to indicate the minimum compatible Python version (e.g., `>=3.11`).
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(&lockfile).unwrap();
 
@@ -3652,7 +3570,6 @@ fn lock_requires_python_unbounded() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     warning: The workspace `requires-python` value does not contain a lower bound: `<=3.12`. Set a lower bound to indicate the minimum compatible Python version (e.g., `>=3.11`).
     Resolved 2 packages in [TIME]
     "###);
@@ -3692,14 +3609,13 @@ fn lock_python_version_marker_complement() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 4 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(&lockfile).unwrap();
 
@@ -3777,7 +3693,6 @@ fn lock_python_version_marker_complement() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -3804,14 +3719,13 @@ fn lock_dev() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 3 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -3872,7 +3786,6 @@ fn lock_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -3883,7 +3796,6 @@ fn lock_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + iniconfig==2.0.0
@@ -3897,7 +3809,6 @@ fn lock_dev() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Installed 1 package in [TIME]
      + typing-extensions==4.12.2 (from https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl)
     "###);
@@ -3922,14 +3833,13 @@ fn lock_conditional_unconditional() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -3977,7 +3887,6 @@ fn lock_conditional_unconditional() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -4001,14 +3910,13 @@ fn lock_multiple_markers() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 2 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -4056,7 +3964,6 @@ fn lock_multiple_markers() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -4177,8 +4084,6 @@ fn lock_relative_and_absolute_paths() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -4202,14 +4107,13 @@ fn lock_cycles() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 11 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 11 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -4361,7 +4265,6 @@ fn lock_cycles() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 11 packages in [TIME]
     "###);
 
@@ -4372,7 +4275,6 @@ fn lock_cycles() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 11 packages in [TIME]
     Installed 11 packages in [TIME]
      + argparse==1.4.0
@@ -4516,7 +4418,6 @@ fn lock_new_extras() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###);
 
@@ -4655,7 +4556,6 @@ fn lock_new_extras() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 7 packages in [TIME]
     "###);
 
@@ -4734,7 +4634,6 @@ fn lock_invalid_hash() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
@@ -4746,7 +4645,6 @@ fn lock_invalid_hash() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     error: Failed to prepare distributions
       Caused by: Failed to fetch wheel: idna==3.6
       Caused by: Hash mismatch for `idna==3.6`
@@ -4779,14 +4677,13 @@ fn lock_resolution_mode() -> Result<()> {
     )?;
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 4 packages in [TIME]
-        "###);
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
 
@@ -4853,7 +4750,6 @@ fn lock_resolution_mode() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -4864,7 +4760,6 @@ fn lock_resolution_mode() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Ignoring existing lockfile due to change in resolution mode: `highest` vs. `lowest-direct`
     Resolved 4 packages in [TIME]
     Updated anyio v4.3.0 -> v3.0.0
@@ -4936,7 +4831,6 @@ fn lock_resolution_mode() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -4966,7 +4860,6 @@ fn lock_requires_python_no_wheels() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python ABI tag and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
     "###);
@@ -5028,7 +4921,6 @@ fn lock_same_version_multiple_urls() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 7 packages in [TIME]
     "###);
 
@@ -5152,7 +5044,6 @@ fn lock_same_version_multiple_urls() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 7 packages in [TIME]
     "###);
 
@@ -5186,7 +5077,6 @@ fn lock_unsafe_lowest() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -5197,7 +5087,6 @@ fn lock_unsafe_lowest() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -5247,9 +5136,7 @@ fn lock_exclusion() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -5292,7 +5179,6 @@ fn lock_exclusion() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     error: Unable to find lockfile at `uv.lock`. To create a lockfile, run `uv lock` or `uv sync`.
     "###);
 
@@ -5366,9 +5252,7 @@ fn lock_dev_transitive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -5461,7 +5345,6 @@ fn lock_dev_transitive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     error: No `pyproject.toml` found in current directory or any parent directory
     "###);
 
@@ -5490,7 +5373,6 @@ fn lock_redact_https() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -5538,7 +5420,6 @@ fn lock_redact_https() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -5549,7 +5430,6 @@ fn lock_redact_https() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     error: Failed to prepare distributions
       Caused by: Failed to fetch wheel: iniconfig==2.0.0
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
@@ -5562,7 +5442,6 @@ fn lock_redact_https() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     error: Failed to prepare distributions
       Caused by: Failed to fetch wheel: iniconfig==2.0.0
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
@@ -5575,7 +5454,6 @@ fn lock_redact_https() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + foo==0.1.0 (from file://[TEMP_DIR]/)
@@ -5603,7 +5481,6 @@ fn lock_redact_https() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -5643,7 +5520,6 @@ fn lock_redact_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -5686,7 +5562,6 @@ fn lock_redact_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -5697,7 +5572,6 @@ fn lock_redact_git() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + foo==0.1.0 (from file://[TEMP_DIR]/)
@@ -5732,7 +5606,6 @@ fn lock_relative_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -5779,7 +5652,6 @@ fn lock_relative_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -5790,7 +5662,6 @@ fn lock_relative_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + foo==0.1.0 (from file://[TEMP_DIR]/)
@@ -5839,8 +5710,6 @@ fn lock_no_sources() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -5898,8 +5767,6 @@ fn lock_no_sources() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -5910,7 +5777,6 @@ fn lock_no_sources() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Updated anyio v0.1.0 -> v4.3.0
     Added idna v3.6
@@ -5983,7 +5849,6 @@ fn lock_no_sources() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -6063,7 +5928,6 @@ fn lock_migrate() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Added anyio v4.3.0
     Added idna v3.6
@@ -6156,7 +6020,6 @@ fn lock_upgrade_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -6167,7 +6030,6 @@ fn lock_upgrade_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -6252,7 +6114,6 @@ fn lock_upgrade_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Updated anyio v2.0.0 -> v4.3.0
     "###);
@@ -6264,7 +6125,6 @@ fn lock_upgrade_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -6337,7 +6197,6 @@ fn lock_upgrade_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Updated idna v3.0 -> v3.6
     "###);
@@ -6349,7 +6208,6 @@ fn lock_upgrade_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -6479,7 +6337,6 @@ fn lock_warn_missing_transitive_lower_bounds() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     warning: The transitive dependency `packaging` is unpinned. Consider setting a lower bound with a constraint when using `--resolution-strategy lowest` to avoid using outdated versions.
     warning: The transitive dependency `colorama` is unpinned. Consider setting a lower bound with a constraint when using `--resolution-strategy lowest` to avoid using outdated versions.
@@ -6514,7 +6371,6 @@ fn lock_find_links_local_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -6560,7 +6416,6 @@ fn lock_find_links_local_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -6571,7 +6426,6 @@ fn lock_find_links_local_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 1 package in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
@@ -6606,7 +6460,6 @@ fn lock_find_links_local_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -6650,7 +6503,6 @@ fn lock_find_links_local_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -6661,7 +6513,6 @@ fn lock_find_links_local_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
@@ -6697,7 +6548,6 @@ fn lock_find_links_http_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -6744,7 +6594,6 @@ fn lock_find_links_http_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -6755,7 +6604,6 @@ fn lock_find_links_http_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 1 package in [TIME]
     Installed 2 packages in [TIME]
      + packaging==23.2
@@ -6791,7 +6639,6 @@ fn lock_find_links_http_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -6838,7 +6685,6 @@ fn lock_find_links_http_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -6849,7 +6695,6 @@ fn lock_find_links_http_sdist() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 1 package in [TIME]
     Installed 2 packages in [TIME]
      + packaging==23.2
@@ -6911,7 +6756,6 @@ fn lock_local_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -6960,7 +6804,6 @@ fn lock_local_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -6971,7 +6814,6 @@ fn lock_local_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 1 package in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
@@ -7007,7 +6849,6 @@ fn lock_sources_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -7088,7 +6929,6 @@ fn lock_sources_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -7099,7 +6939,6 @@ fn lock_sources_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
      + anyio==4.3.0
@@ -7146,7 +6985,6 @@ fn lock_sources_archive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -7226,7 +7064,6 @@ fn lock_sources_archive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -7237,7 +7074,6 @@ fn lock_sources_archive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
      + anyio==4.3.0
@@ -7299,8 +7135,6 @@ fn lock_sources_source_tree() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -7354,8 +7188,6 @@ fn lock_sources_source_tree() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -7366,7 +7198,6 @@ fn lock_sources_source_tree() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==0.1.0 (from file://[TEMP_DIR]/workspace/anyio)
@@ -7432,8 +7263,6 @@ fn lock_editable() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -7493,8 +7322,6 @@ fn lock_editable() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -7515,8 +7342,6 @@ fn lock_editable() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -7576,8 +7401,6 @@ fn lock_editable() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -7588,7 +7411,6 @@ fn lock_editable() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + library==0.1.0 (from file://[TEMP_DIR]/library)
@@ -7675,9 +7497,7 @@ fn lock_mixed_extras() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###);
 
@@ -7781,9 +7601,7 @@ fn lock_mixed_extras() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###);
 
@@ -7795,7 +7613,6 @@ fn lock_mixed_extras() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: .venv
     Prepared 4 packages in [TIME]
@@ -7815,7 +7632,6 @@ fn lock_mixed_extras() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + typing-extensions==4.10.0
@@ -7871,9 +7687,7 @@ fn lock_transitive_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -7959,9 +7773,7 @@ fn lock_transitive_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -7973,7 +7785,6 @@ fn lock_transitive_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: .venv
     Prepared 2 packages in [TIME]
@@ -7990,7 +7801,6 @@ fn lock_transitive_extra() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + iniconfig==2.0.0
@@ -8028,8 +7838,6 @@ fn lock_mismatched_sources() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     error: Failed to build: `project @ file://[TEMP_DIR]/`
       Caused by: Failed to parse entry for: `uv-public-pypackage`
       Caused by: Can't combine URLs from both `project.dependencies` and `tool.uv.sources`
@@ -8068,8 +7876,6 @@ fn lock_mismatched_versions() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -8112,8 +7918,6 @@ fn lock_mismatched_versions() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -8124,7 +7928,6 @@ fn lock_mismatched_versions() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
      + project==0.1.0 (from file://[TEMP_DIR]/)
@@ -8160,7 +7963,6 @@ fn unconditional_overlapping_marker_disjoint_version_constraints() -> Result<()>
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because your project depends on datasets<2.19 and datasets>=2.19, we can conclude that your project's requirements are unsatisfiable.
     "###);
@@ -8190,7 +7992,6 @@ fn lock_change_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -8237,7 +8038,6 @@ fn lock_change_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -8284,7 +8084,6 @@ fn lock_change_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -8332,8 +8131,6 @@ fn lock_remove_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -8419,8 +8216,6 @@ fn lock_remove_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -8442,7 +8237,6 @@ fn lock_remove_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 1 package in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
@@ -8454,7 +8248,6 @@ fn lock_remove_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Removed anyio v4.3.0
     Removed idna v3.6
@@ -8516,7 +8309,6 @@ fn lock_add_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 1 package in [TIME]
     "###);
 
@@ -8548,7 +8340,6 @@ fn lock_add_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 1 package in [TIME]
     "###);
 
@@ -8585,7 +8376,6 @@ fn lock_add_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
@@ -8597,7 +8387,6 @@ fn lock_add_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because anyio was not found in the cache and leaf depends on anyio>3, we can conclude that leaf's requirements are unsatisfiable.
           And because your workspace requires leaf, we can conclude that your workspace's requirements are unsatisfiable.
@@ -8612,7 +8401,6 @@ fn lock_add_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     Added anyio v4.3.0
     Added idna v3.6
@@ -8627,7 +8415,6 @@ fn lock_add_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -8731,7 +8518,6 @@ fn lock_redundant_add_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -8800,7 +8586,6 @@ fn lock_redundant_add_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -8826,7 +8611,6 @@ fn lock_redundant_add_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
@@ -8838,7 +8622,6 @@ fn lock_redundant_add_member() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -8930,7 +8713,6 @@ fn lock_new_constraints() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -8999,7 +8781,6 @@ fn lock_new_constraints() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -9026,7 +8807,6 @@ fn lock_new_constraints() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
@@ -9038,7 +8818,6 @@ fn lock_new_constraints() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Updated anyio v4.3.0 -> v4.2.0
     "###);
@@ -9140,7 +8919,6 @@ fn lock_remove_member_virtual() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -9214,7 +8992,6 @@ fn lock_remove_member_virtual() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -9233,7 +9010,6 @@ fn lock_remove_member_virtual() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 0 packages in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
@@ -9245,7 +9021,6 @@ fn lock_remove_member_virtual() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 0 packages in [TIME]
     Removed anyio v4.3.0
     Removed idna v3.6
@@ -9296,7 +9071,6 @@ fn lock_rename_project() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -9343,7 +9117,6 @@ fn lock_rename_project() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###);
 
@@ -9365,7 +9138,6 @@ fn lock_rename_project() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
@@ -9377,7 +9149,6 @@ fn lock_rename_project() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Removed project v0.1.0
     Added renamed v0.1.0
@@ -9490,13 +9261,12 @@ fn lock_missing_metadata() -> Result<()> {
 
     // Re-locking should add `[package.metadata]`.
     uv_snapshot!(context.filters(), context.lock(), @r###"
-        success: true
-        exit_code: 0
-        ----- stdout -----
+    success: true
+    exit_code: 0
+    ----- stdout -----
 
-        ----- stderr -----
-        warning: `uv lock` is experimental and may change without warning
-        Resolved 4 packages in [TIME]
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
     "###);
 
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
@@ -9583,7 +9353,6 @@ fn lock_reorder() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -9665,7 +9434,6 @@ fn lock_reorder() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -9687,7 +9455,6 @@ fn lock_reorder() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###);
 
@@ -9730,8 +9497,6 @@ fn lock_narrowed_python_version() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -9797,8 +9562,6 @@ fn lock_narrowed_python_version() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###);
 
@@ -9836,7 +9599,6 @@ fn lock_exclude_unnecessary_python_forks() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 
@@ -9912,7 +9674,6 @@ fn lock_exclude_unnecessary_python_forks() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###);
 

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -73,7 +73,6 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###
     );
@@ -191,7 +190,6 @@ fn fork_allows_non_conflicting_repeated_dependencies() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###
     );
@@ -291,7 +289,6 @@ fn fork_basic() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###
     );
@@ -426,7 +423,6 @@ fn conflict_in_fork() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies for split (sys_platform == 'darwin'):
       ╰─▶ Because only package-b==1.0.0 is available and package-b==1.0.0 depends on package-d==1, we can conclude that all versions of package-b depend on package-d==1.
           And because package-c==1.0.0 depends on package-d==2 and only package-c==1.0.0 is available, we can conclude that all versions of package-b and all versions of package-c are incompatible.
@@ -495,7 +491,6 @@ fn fork_conflict_unsatisfiable() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because your project depends on package-a>=2 and package-a<2, we can conclude that your project's requirements are unsatisfiable.
     "###
@@ -579,7 +574,6 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 7 packages in [TIME]
     "###
     );
@@ -758,7 +752,6 @@ fn fork_upgrade() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###
     );
@@ -879,7 +872,6 @@ fn fork_incomplete_markers() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -1033,7 +1025,6 @@ fn fork_marker_accrue() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###
     );
@@ -1167,7 +1158,6 @@ fn fork_marker_disjoint() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies for split (sys_platform == 'linux'):
       ╰─▶ Because your project depends on package-a{sys_platform == 'linux'}>=2 and package-a{sys_platform == 'linux'}<2, we can conclude that your project's requirements are unsatisfiable.
     "###
@@ -1238,7 +1228,6 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###
     );
@@ -1419,7 +1408,6 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -1589,7 +1577,6 @@ fn fork_marker_inherit_combined() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -1752,7 +1739,6 @@ fn fork_marker_inherit_isolated() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###
     );
@@ -1901,7 +1887,6 @@ fn fork_marker_inherit_transitive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -2058,7 +2043,6 @@ fn fork_marker_inherit() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     "###
     );
@@ -2197,7 +2181,6 @@ fn fork_marker_limited_inherit() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -2353,7 +2336,6 @@ fn fork_marker_selection() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###
     );
@@ -2509,7 +2491,6 @@ fn fork_marker_track() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -2662,7 +2643,6 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###
     );
@@ -2797,7 +2777,6 @@ fn fork_non_local_fork_marker_direct() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because package-b{sys_platform == 'darwin'}==1.0.0 depends on package-c>=2.0.0 and package-a{sys_platform == 'linux'}==1.0.0 depends on package-c<2.0.0, we can conclude that package-a{sys_platform == 'linux'}==1.0.0 and package-b{sys_platform == 'darwin'}==1.0.0 are incompatible.
           And because your project depends on package-a{sys_platform == 'linux'}==1.0.0 and package-b{sys_platform == 'darwin'}==1.0.0, we can conclude that your project's requirements are unsatisfiable.
@@ -2870,7 +2849,6 @@ fn fork_non_local_fork_marker_transitive() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
       × No solution found when resolving dependencies:
       ╰─▶ Because package-b==1.0.0 depends on package-c{sys_platform == 'darwin'}>=2.0.0 and only package-c{sys_platform == 'darwin'}<=2.0.0 is available, we can conclude that package-b==1.0.0 depends on package-c{sys_platform == 'darwin'}==2.0.0.
           And because only the following versions of package-c{sys_platform == 'linux'} are available:
@@ -2964,7 +2942,6 @@ fn fork_overlapping_markers_basic() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###
     );
@@ -3132,7 +3109,6 @@ fn preferences_dependent_forking_bistable() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     "###
     );
@@ -3369,7 +3345,6 @@ fn preferences_dependent_forking_conflicting() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###
     );
@@ -3512,7 +3487,6 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 11 packages in [TIME]
     "###
     );
@@ -3796,7 +3770,6 @@ fn preferences_dependent_forking() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -3971,7 +3944,6 @@ fn fork_remaining_universe_partitioning() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -4124,7 +4096,6 @@ fn fork_requires_python_full_prerelease() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 1 package in [TIME]
     "###
     );
@@ -4209,7 +4180,6 @@ fn fork_requires_python_full() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 1 package in [TIME]
     "###
     );
@@ -4298,7 +4268,6 @@ fn fork_requires_python_patch_overlap() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     "###
     );
@@ -4392,7 +4361,6 @@ fn fork_requires_python() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 1 package in [TIME]
     "###
     );

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -5664,7 +5664,6 @@ fn tool_uv_sources_is_in_preview() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]

--- a/crates/uv/tests/python_dir.rs
+++ b/crates/uv/tests/python_dir.rs
@@ -17,6 +17,5 @@ fn python_dir() {
     [TEMP_DIR]/python
 
     ----- stderr -----
-    warning: `uv python dir` is experimental and may change without warning
     "###);
 }

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -173,7 +173,6 @@ fn run_args() -> Result<()> {
     Python 3.12.[X]
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -188,7 +187,6 @@ fn run_args() -> Result<()> {
     Python 3.12.[X]
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Audited 1 package in [TIME]
     "###);
@@ -453,7 +451,6 @@ fn run_managed_false() -> Result<()> {
     Python 3.12.[X]
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     "###);
 
     Ok(())
@@ -486,7 +483,6 @@ fn run_with() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -507,7 +503,6 @@ fn run_with() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Audited 4 packages in [TIME]
     "###);
@@ -519,7 +514,6 @@ fn run_with() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Audited 4 packages in [TIME]
     Resolved 1 package in [TIME]
@@ -535,7 +529,6 @@ fn run_with() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Audited 4 packages in [TIME]
       × No solution found when resolving `--with` dependencies:
@@ -567,7 +560,6 @@ fn run_locked() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     error: Unable to find lockfile at `uv.lock`. To create a lockfile, run `uv lock` or `uv sync`.
     "###);
 
@@ -594,7 +586,6 @@ fn run_locked() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
@@ -615,7 +606,6 @@ fn run_locked() -> Result<()> {
     Python 3.12.[X]
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -648,7 +638,6 @@ fn run_frozen() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     error: Unable to find lockfile at `uv.lock`. To create a lockfile, run `uv lock` or `uv sync`.
     "###);
 
@@ -673,7 +662,6 @@ fn run_frozen() -> Result<()> {
     Python 3.12.[X]
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -716,7 +704,6 @@ fn run_empty_requirements_txt() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -734,7 +721,6 @@ fn run_empty_requirements_txt() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Audited 4 packages in [TIME]
     warning: Requirements file requirements.txt does not contain any dependencies
@@ -773,7 +759,6 @@ fn run_requirements_txt() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -796,7 +781,6 @@ fn run_requirements_txt() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Audited 4 packages in [TIME]
     "###);
@@ -810,7 +794,6 @@ fn run_requirements_txt() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Audited 4 packages in [TIME]
     Resolved 1 package in [TIME]
@@ -833,7 +816,6 @@ fn run_requirements_txt() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Audited 4 packages in [TIME]
     Resolved 2 packages in [TIME]
@@ -855,7 +837,6 @@ fn run_requirements_txt() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     error: Reading requirements from stdin is not supported in `uv run`
     "###);
 
@@ -897,7 +878,6 @@ fn run_requirements_txt_arguments() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -953,7 +933,6 @@ fn run_editable() -> Result<()> {
     Hello, world!
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -1052,7 +1031,6 @@ fn run_without_output() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Installed 4 packages in [TIME]
     Installed 1 package in [TIME]
     "###);
@@ -1064,7 +1042,6 @@ fn run_without_output() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     "###);
 
     Ok(())
@@ -1110,7 +1087,6 @@ fn run_isolated_python_version() -> Result<()> {
     (3, 8)
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Using Python 3.8.[X] interpreter at: [PYTHON-3.8]
     Creating virtualenv at: .venv
     Resolved 6 packages in [TIME]
@@ -1131,7 +1107,6 @@ fn run_isolated_python_version() -> Result<()> {
     (3, 8)
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 5 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -1156,7 +1131,6 @@ fn run_isolated_python_version() -> Result<()> {
     (3, 12)
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 3 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -1205,7 +1179,6 @@ fn run_no_project() -> Result<()> {
     [VENV]/[BIN]/python
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -1224,7 +1197,6 @@ fn run_no_project() -> Result<()> {
     [VENV]/[BIN]/python
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     "###);
 
     // `run --no-project --isolated` should run in an entirely isolated environment.
@@ -1235,7 +1207,6 @@ fn run_no_project() -> Result<()> {
     [CACHE_DIR]/builds-v0/[TMP]/python
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     "###);
 
     // `run --no-project` should not (but it should still run in the same environment, as it would
@@ -1247,7 +1218,6 @@ fn run_no_project() -> Result<()> {
     [VENV]/[BIN]/python
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     "###);
 
     // `run --no-project --locked` should fail.
@@ -1258,7 +1228,6 @@ fn run_no_project() -> Result<()> {
     [VENV]/[BIN]/python
 
     ----- stderr -----
-    warning: `uv run` is experimental and may change without warning
     warning: `--locked` has no effect when used alongside `--no-project`
     "###);
 

--- a/crates/uv/tests/snapshots/ecosystem__black-uv-lock-output.snap
+++ b/crates/uv/tests/snapshots/ecosystem__black-uv-lock-output.snap
@@ -7,5 +7,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-warning: `uv lock` is experimental and may change without warning
 Resolved 39 packages in [TIME]

--- a/crates/uv/tests/snapshots/ecosystem__github-wikidata-bot-uv-lock-output.snap
+++ b/crates/uv/tests/snapshots/ecosystem__github-wikidata-bot-uv-lock-output.snap
@@ -7,5 +7,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-warning: `uv lock` is experimental and may change without warning
 Resolved 31 packages in [TIME]

--- a/crates/uv/tests/snapshots/ecosystem__home-assistant-core-uv-lock-output.snap
+++ b/crates/uv/tests/snapshots/ecosystem__home-assistant-core-uv-lock-output.snap
@@ -7,5 +7,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-warning: `uv lock` is experimental and may change without warning
 Resolved 97 packages in [TIME]

--- a/crates/uv/tests/snapshots/ecosystem__packse-uv-lock-output.snap
+++ b/crates/uv/tests/snapshots/ecosystem__packse-uv-lock-output.snap
@@ -7,5 +7,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-warning: `uv lock` is experimental and may change without warning
 Resolved 49 packages in [TIME]

--- a/crates/uv/tests/snapshots/ecosystem__transformers-uv-lock-output.snap
+++ b/crates/uv/tests/snapshots/ecosystem__transformers-uv-lock-output.snap
@@ -7,5 +7,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-warning: `uv lock` is experimental and may change without warning
 Resolved 298 packages in [TIME]

--- a/crates/uv/tests/snapshots/ecosystem__warehouse-uv-lock-output.snap
+++ b/crates/uv/tests/snapshots/ecosystem__warehouse-uv-lock-output.snap
@@ -7,5 +7,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-warning: `uv lock` is experimental and may change without warning
 Resolved 323 packages in [TIME]

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -31,7 +31,6 @@ fn sync() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -66,7 +65,6 @@ fn locked() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     error: Unable to find lockfile at `uv.lock`. To create a lockfile, run `uv lock` or `uv sync`.
     "###);
 
@@ -93,7 +91,6 @@ fn locked() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
@@ -128,7 +125,6 @@ fn frozen() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     error: Unable to find lockfile at `uv.lock`. To create a lockfile, run `uv lock` or `uv sync`.
     "###);
 
@@ -152,7 +148,6 @@ fn frozen() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
@@ -183,7 +178,6 @@ fn empty() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Resolved 0 packages in [TIME]
     Audited 0 packages in [TIME]
     "###);
@@ -197,7 +191,6 @@ fn empty() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Resolved 0 packages in [TIME]
     Audited 0 packages in [TIME]
     "###);
@@ -259,8 +252,6 @@ fn package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -331,10 +322,8 @@ fn mixed_requires_python() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: .venv
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
@@ -352,7 +341,6 @@ fn mixed_requires_python() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Using Python 3.8.[X] interpreter at: [PYTHON-3.8]
     error: The requested Python interpreter (3.8.[X]) is incompatible with the project Python requirement: `>=3.12`. However, a workspace member (`bird-feeder`) supports Python >=3.8. To install the workspace member on its own, navigate to `packages/bird-feeder`, then run `uv venv --python 3.8.[X]` followed by `uv pip install -e .`.
     "###);
@@ -409,7 +397,6 @@ fn virtual_workspace_dev_dependencies() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -424,7 +411,6 @@ fn virtual_workspace_dev_dependencies() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
@@ -461,7 +447,6 @@ fn sync_build_isolation() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     error: Failed to download and build: `iniconfig @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
       Caused by: Build backend failed to determine metadata through `prepare_metadata_for_build_wheel` with exit status: 1
     --- stdout:
@@ -502,7 +487,6 @@ fn sync_build_isolation() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -568,7 +552,6 @@ fn sync_reset_state() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
@@ -614,7 +597,6 @@ fn sync_build_isolation_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     error: Failed to download and build: `iniconfig @ https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz`
       Caused by: Build backend failed to determine metadata through `prepare_metadata_for_build_wheel` with exit status: 1
     --- stdout:
@@ -654,7 +636,6 @@ fn sync_build_isolation_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 2 packages in [TIME]
     Uninstalled 9 packages in [TIME]
@@ -718,8 +699,6 @@ fn sync_relative_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 2 packages in [TIME]
@@ -772,8 +751,6 @@ fn sync_relative_wheel() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv sync` is experimental and may change without warning
-    warning: `uv.sources` is experimental and may change without warning
     Resolved 2 packages in [TIME]
     Audited 2 packages in [TIME]
     "###);

--- a/crates/uv/tests/tool_dir.rs
+++ b/crates/uv/tests/tool_dir.rs
@@ -21,7 +21,6 @@ fn tool_dir() {
     [TEMP_DIR]/tools
 
     ----- stderr -----
-    warning: `uv tool dir` is experimental and may change without warning
     "###);
 }
 
@@ -40,6 +39,5 @@ fn tool_dir_bin() {
     [TEMP_DIR]/bin
 
     ----- stderr -----
-    warning: `uv tool dir` is experimental and may change without warning
     "###);
 }

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -35,7 +35,6 @@ fn tool_install() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -114,7 +113,6 @@ fn tool_install() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -199,7 +197,6 @@ fn tool_install_suggest_other_packages_with_executable() {
     Did you mean `uv tool install fastapi-cli`?
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 35 packages in [TIME]
     Prepared 35 packages in [TIME]
     Installed 35 packages in [TIME]
@@ -258,7 +255,6 @@ fn tool_install_version() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -346,7 +342,6 @@ fn tool_install_editable() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -418,7 +413,6 @@ fn tool_install_editable() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Installed 1 executable: black
     "###);
 
@@ -451,7 +445,6 @@ fn tool_install_editable() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Uninstalled 1 package in [TIME]
@@ -502,7 +495,6 @@ fn tool_install_remove_on_empty() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -570,7 +562,6 @@ fn tool_install_remove_on_empty() -> Result<()> {
     No executables are provided by `black`
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 6 packages in [TIME]
@@ -595,7 +586,6 @@ fn tool_install_remove_on_empty() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + black==24.3.0
@@ -648,7 +638,6 @@ fn tool_install_editable_from() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -730,7 +719,6 @@ fn tool_install_from() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -756,7 +744,6 @@ fn tool_install_from() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     error: Package name (`flask`) provided with `--from` does not match install request (`black`)
     "###);
 
@@ -773,7 +760,6 @@ fn tool_install_from() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     error: Package requirement (`black==24.3.0`) provided with `--from` conflicts with install request (`black==24.2.0`)
     "###);
 }
@@ -798,7 +784,6 @@ fn tool_install_already_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -866,7 +851,6 @@ fn tool_install_already_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     `black` is already installed
     "###);
 
@@ -905,7 +889,6 @@ fn tool_install_already_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
@@ -939,7 +922,6 @@ fn tool_install_already_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
@@ -963,7 +945,6 @@ fn tool_install_already_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
@@ -997,7 +978,6 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -1037,7 +1017,6 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -1079,7 +1058,6 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Installed [N] packages in [TIME]
      + black==24.3.0
@@ -1103,7 +1081,6 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Installed [N] packages in [TIME]
      + black==24.3.0
@@ -1129,7 +1106,6 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Installed 2 executables: black, blackd
     "###);
 
@@ -1146,7 +1122,6 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     `black` is already installed
     "###);
 
@@ -1164,7 +1139,6 @@ fn tool_install_entry_point_exists() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
@@ -1277,7 +1251,6 @@ fn tool_install_home() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -1315,7 +1288,6 @@ fn tool_install_xdg_data_home() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -1352,7 +1324,6 @@ fn tool_install_xdg_bin_home() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -1388,7 +1359,6 @@ fn tool_install_tool_bin_dir() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -1424,7 +1394,6 @@ fn tool_install_no_entrypoints() {
     No executables are provided by `iniconfig`
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -1450,7 +1419,6 @@ fn tool_install_unnamed_package() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -1540,7 +1508,6 @@ fn tool_install_unnamed_conflict() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     error: Package name (`iniconfig`) provided with `--from` does not match install request (`black`)
     "###);
 }
@@ -1565,7 +1532,6 @@ fn tool_install_unnamed_from() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -1654,7 +1620,6 @@ fn tool_install_unnamed_with() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 7 packages in [TIME]
     Prepared 7 packages in [TIME]
     Installed 7 packages in [TIME]
@@ -1752,7 +1717,6 @@ fn tool_install_requirements_txt() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -1802,7 +1766,6 @@ fn tool_install_requirements_txt() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
@@ -1862,7 +1825,6 @@ fn tool_install_requirements_txt_arguments() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     warning: Ignoring `--index-url` from requirements file: `https://test.pypi.org/simple`. Instead, use the `--index-url` command-line argument, or set `index-url` in a `uv.toml` or `pyproject.toml` file.
     Resolved 7 packages in [TIME]
     Prepared 7 packages in [TIME]
@@ -1920,7 +1882,6 @@ fn tool_install_requirements_txt_arguments() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Installed 2 executables: black, blackd
     "###);
 
@@ -1948,7 +1909,6 @@ fn tool_install_requirements_txt_arguments() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     Prepared 8 packages in [TIME]
     Installed 8 packages in [TIME]
@@ -1984,7 +1944,6 @@ fn tool_install_upgrade() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -2026,7 +1985,6 @@ fn tool_install_upgrade() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Installed 2 executables: black, blackd
     "###);
 
@@ -2060,7 +2018,6 @@ fn tool_install_upgrade() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -2101,7 +2058,6 @@ fn tool_install_upgrade() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]
@@ -2152,7 +2108,6 @@ fn tool_install_python_request() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -2178,7 +2133,6 @@ fn tool_install_python_request() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     `black` is already installed
     "###);
 
@@ -2195,7 +2149,6 @@ fn tool_install_python_request() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Existing environment for `black` does not satisfy the requested Python interpreter
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
@@ -2230,7 +2183,6 @@ fn tool_install_preserve_environment() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -2256,7 +2208,6 @@ fn tool_install_preserve_environment() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     error: Because black==24.1.1 depends on packaging>=22.0 and you require black==24.1.1, we can conclude that you require packaging>=22.0.
     And because you require packaging==0.0.1, we can conclude that your requirements are unsatisfiable.
     "###);
@@ -2272,7 +2223,6 @@ fn tool_install_preserve_environment() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     `black==24.1.1` is already installed
     "###);
 }
@@ -2298,7 +2248,6 @@ fn tool_install_warn_path() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -2333,7 +2282,6 @@ fn tool_install_bad_receipt() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -2368,7 +2316,6 @@ fn tool_install_bad_receipt() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     warning: Removed existing `black` with invalid receipt
     Resolved [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -2405,7 +2352,6 @@ fn tool_install_malformed_dist_info() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -2479,7 +2425,6 @@ fn tool_install_settings() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -2549,7 +2494,6 @@ fn tool_install_settings() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     `flask>=3` is already installed
     "###);
 
@@ -2585,7 +2529,6 @@ fn tool_install_settings() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Uninstalled [N] packages in [TIME]

--- a/crates/uv/tests/tool_list.rs
+++ b/crates/uv/tests/tool_list.rs
@@ -35,7 +35,6 @@ fn tool_list() {
     - blackd
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning
     "###);
 }
 
@@ -65,7 +64,6 @@ fn tool_list_paths() {
     - blackd ([TEMP_DIR]/bin/blackd)
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning
     "###);
 }
 
@@ -83,7 +81,6 @@ fn tool_list_empty() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning
     No tools installed
     "###);
 }
@@ -113,7 +110,6 @@ fn tool_list_missing_receipt() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning
     warning: Ignoring malformed tool `black` (run `uv tool uninstall black` to remove)
     "###);
 }
@@ -163,7 +159,6 @@ fn tool_list_bad_environment() -> Result<()> {
     - ruff
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning
     Python interpreter not found at `[TEMP_DIR]/tools/black/[BIN]/python`
     "###
     );
@@ -228,7 +223,6 @@ fn tool_list_deprecated() -> Result<()> {
     - blackd
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning
     "###);
 
     // Replace with an invalid receipt.
@@ -253,7 +247,6 @@ fn tool_list_deprecated() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning
     warning: Ignoring malformed tool `black` (run `uv tool uninstall black` to remove)
     "###);
 

--- a/crates/uv/tests/tool_run.rs
+++ b/crates/uv/tests/tool_run.rs
@@ -39,7 +39,6 @@ fn tool_run_args() {
     pytest 8.1.1
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -62,7 +61,6 @@ fn tool_run_args() {
     pytest 8.1.1
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     "###);
 }
@@ -84,7 +82,6 @@ fn tool_run_at_version() {
     pytest 8.0.0
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -105,7 +102,6 @@ fn tool_run_at_version() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     error: Not a valid package or extra name: "pytest@". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
     "###);
 
@@ -120,7 +116,6 @@ fn tool_run_at_version() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     error: Not a valid package or extra name: "pytest@invalid". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
     "###);
 
@@ -151,7 +146,6 @@ fn tool_run_at_version() {
     - pytest
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 4 packages in [TIME]
@@ -182,7 +176,6 @@ fn tool_run_from_version() {
     pytest 8.0.0
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -214,7 +207,6 @@ fn tool_run_suggest_valid_commands() {
     - blackd
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Prepared 6 packages in [TIME]
     Installed 6 packages in [TIME]
@@ -237,7 +229,6 @@ fn tool_run_suggest_valid_commands() {
     The executable `fastapi-cli` was not found.
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved 3 packages in [TIME]
     Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
@@ -271,7 +262,6 @@ fn tool_run_warn_executable_not_in_from() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved 35 packages in [TIME]
     Prepared 35 packages in [TIME]
     Installed 35 packages in [TIME]
@@ -341,7 +331,6 @@ fn tool_run_from_install() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     "###);
 
     // Verify that `--isolated` uses an isolated environment.
@@ -358,7 +347,6 @@ fn tool_run_from_install() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -383,7 +371,6 @@ fn tool_run_from_install() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -412,7 +399,6 @@ fn tool_run_from_install() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -440,7 +426,6 @@ fn tool_run_from_install() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -474,7 +459,6 @@ fn tool_run_cache() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -501,7 +485,6 @@ fn tool_run_cache() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     "###);
 
@@ -521,7 +504,6 @@ fn tool_run_cache() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -550,7 +532,6 @@ fn tool_run_cache() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -577,7 +558,6 @@ fn tool_run_cache() {
     Python (CPython) 3.11.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -604,7 +584,6 @@ fn tool_run_cache() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     "###);
 
@@ -625,7 +604,6 @@ fn tool_run_cache() {
     Python (CPython) 3.12.[X]
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -660,7 +638,6 @@ fn tool_run_url() {
     Werkzeug 3.0.1
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -701,7 +678,6 @@ fn tool_run_requirements_txt() {
     Werkzeug 3.0.1
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -748,7 +724,6 @@ fn tool_run_requirements_txt_arguments() {
     Werkzeug 3.0.1
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     warning: Ignoring `--index-url` from requirements file: `https://test.pypi.org/simple`. Instead, use the `--index-url` command-line argument, or set `index-url` in a `uv.toml` or `pyproject.toml` file.
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
@@ -780,7 +755,6 @@ fn tool_run_list_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     No tools installed
     "###);
 
@@ -805,7 +779,6 @@ fn tool_run_list_installed() {
     - blackd
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     "###);
 }
 
@@ -830,7 +803,6 @@ fn tool_run_without_output() {
     pytest 8.1.1
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Installed [N] packages in [TIME]
     "###);
 
@@ -848,7 +820,6 @@ fn tool_run_without_output() {
     pytest 8.1.1
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     "###);
 }
 
@@ -868,7 +839,6 @@ fn warn_no_executables_found() {
     The executable `requests` was not found.
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     Prepared 5 packages in [TIME]
     Installed 5 packages in [TIME]
@@ -901,7 +871,6 @@ fn tool_run_upgrade_warn() {
 
     ----- stderr -----
     warning: Tools cannot be upgraded via `uv tool run`; use `uv tool upgrade --all` to upgrade all installed tools, or `uv tool run package@latest` to run the latest version of a tool
-    warning: `uv tool run` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -928,7 +897,6 @@ fn tool_run_resolution_error() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
       × No solution found when resolving tool dependencies:
       ╰─▶ Because there are no versions of add and you require add, we can conclude that your requirements are unsatisfiable.
     "###);
@@ -961,7 +929,6 @@ fn tool_run_latest() {
     pytest 7.0.0
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     "###);
 
     // Run `pytest@latest`, which should use the latest version.
@@ -976,7 +943,6 @@ fn tool_run_latest() {
     pytest 8.1.1
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -998,6 +964,5 @@ fn tool_run_latest() {
     pytest 7.0.0
 
     ----- stderr -----
-    warning: `uv tool run` is experimental and may change without warning
     "###);
 }

--- a/crates/uv/tests/tool_uninstall.rs
+++ b/crates/uv/tests/tool_uninstall.rs
@@ -30,7 +30,6 @@ fn tool_uninstall() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool uninstall` is experimental and may change without warning
     Uninstalled 2 executables: black, blackd
     "###);
 
@@ -43,7 +42,6 @@ fn tool_uninstall() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool list` is experimental and may change without warning
     No tools installed
     "###);
 
@@ -58,7 +56,6 @@ fn tool_uninstall() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     Installed 6 packages in [TIME]
      + black==24.2.0
@@ -85,7 +82,6 @@ fn tool_uninstall_not_installed() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool uninstall` is experimental and may change without warning
     error: `black` is not installed
     "###);
 }
@@ -115,7 +111,6 @@ fn tool_uninstall_missing_receipt() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool uninstall` is experimental and may change without warning
     Removed dangling environment for `black`
     "###);
 }
@@ -145,7 +140,6 @@ fn tool_uninstall_all_missing_receipt() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool uninstall` is experimental and may change without warning
     Removed dangling environment for `black`
     "###);
 }

--- a/crates/uv/tests/tool_upgrade.rs
+++ b/crates/uv/tests/tool_upgrade.rs
@@ -27,7 +27,6 @@ fn test_tool_upgrade_name() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -49,7 +48,6 @@ fn test_tool_upgrade_name() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool upgrade` is experimental and may change without warning
     Updated babel v2.6.0 -> v2.14.0
      - babel==2.6.0
      + babel==2.14.0
@@ -79,7 +77,6 @@ fn test_tool_upgrade_all() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -100,7 +97,6 @@ fn test_tool_upgrade_all() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -122,7 +118,6 @@ fn test_tool_upgrade_all() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool upgrade` is experimental and may change without warning
     Updated babel v2.6.0 -> v2.14.0
      - babel==2.6.0
      + babel==2.14.0
@@ -154,7 +149,6 @@ fn test_tool_upgrade_non_existing_package() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool upgrade` is experimental and may change without warning
     `black` is not installed; run `uv tool install black` to install
     "###);
 
@@ -169,7 +163,6 @@ fn test_tool_upgrade_non_existing_package() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool upgrade` is experimental and may change without warning
     Nothing to upgrade
     "###);
 }
@@ -194,7 +187,6 @@ fn test_tool_upgrade_settings() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -218,7 +210,6 @@ fn test_tool_upgrade_settings() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool upgrade` is experimental and may change without warning
     Nothing to upgrade
     "###);
 
@@ -234,7 +225,6 @@ fn test_tool_upgrade_settings() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool upgrade` is experimental and may change without warning
     Updated black v23.1.0 -> v24.3.0
      - black==23.1.0
      + black==24.3.0
@@ -263,7 +253,6 @@ fn test_tool_upgrade_respect_constraints() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -285,7 +274,6 @@ fn test_tool_upgrade_respect_constraints() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool upgrade` is experimental and may change without warning
     Updated babel v2.6.0 -> v2.9.1
      - babel==2.6.0
      + babel==2.9.1
@@ -316,7 +304,6 @@ fn test_tool_upgrade_constraint() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -340,7 +327,6 @@ fn test_tool_upgrade_constraint() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool upgrade` is experimental and may change without warning
     Updated babel v2.6.0 -> v2.13.1
      - babel==2.6.0
      + babel==2.13.1
@@ -362,7 +348,6 @@ fn test_tool_upgrade_constraint() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool upgrade` is experimental and may change without warning
     Updated babel v2.13.1 -> v2.14.0
      - babel==2.13.1
      + babel==2.14.0
@@ -385,7 +370,6 @@ fn test_tool_upgrade_constraint() {
 
     ----- stderr -----
     warning: `--upgrade` is enabled by default on `uv tool upgrade`
-    warning: `uv tool upgrade` is experimental and may change without warning
     Nothing to upgrade
     "###);
 }
@@ -413,7 +397,6 @@ fn test_tool_upgrade_with() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool install` is experimental and may change without warning
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -435,7 +418,6 @@ fn test_tool_upgrade_with() {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv tool upgrade` is experimental and may change without warning
     Modified babel environment
      - pytz==2018.5
      + pytz==2024.1

--- a/crates/uv/tests/tree.rs
+++ b/crates/uv/tests/tree.rs
@@ -39,7 +39,6 @@ fn nested_dependencies() -> Result<()> {
         └── threadpoolctl v3.4.0
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###
     );
@@ -85,7 +84,6 @@ fn invert() -> Result<()> {
     (*) Package tree already displayed
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###
     );
@@ -108,7 +106,6 @@ fn invert() -> Result<()> {
         └── project v0.1.0
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###
     );
@@ -142,7 +139,6 @@ fn frozen() -> Result<()> {
         └── sniffio v1.3.1
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 4 packages in [TIME]
     "###
     );
@@ -175,7 +171,6 @@ fn frozen() -> Result<()> {
         └── sniffio v1.3.1
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     "###
     );
 
@@ -215,7 +210,6 @@ fn platform_dependencies() -> Result<()> {
         └── platformdirs v4.2.0
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     "###);
 
@@ -234,7 +228,6 @@ fn platform_dependencies() -> Result<()> {
         └── platformdirs v4.2.0
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     "###);
 
@@ -254,7 +247,6 @@ fn platform_dependencies() -> Result<()> {
         └── platformdirs v4.2.0
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     "###
     );
@@ -300,7 +292,6 @@ fn repeated_dependencies() -> Result<()> {
         └── sniffio v1.3.1
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 6 packages in [TIME]
     "###
     );
@@ -375,7 +366,6 @@ fn repeated_version() -> Result<()> {
             └── sniffio v1.3.1
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 7 packages in [TIME]
     "###
     );
@@ -417,7 +407,6 @@ fn dev_dependencies() -> Result<()> {
         └── sniffio v1.3.1
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -461,7 +450,6 @@ fn dev_dependencies_inverted() -> Result<()> {
     (*) Package tree already displayed
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 5 packages in [TIME]
     "###
     );
@@ -513,7 +501,6 @@ fn optional_dependencies() -> Result<()> {
         └── sniffio v1.3.1
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 14 packages in [TIME]
     "###
     );
@@ -573,7 +560,6 @@ fn optional_dependencies_inverted() -> Result<()> {
     (*) Package tree already displayed
 
     ----- stderr -----
-    warning: `uv tree` is experimental and may change without warning
     Resolved 14 packages in [TIME]
     "###
     );

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -502,7 +502,7 @@ fn create_venv_unknown_python_minor() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.100 in system path or `py` launcher
+          × No interpreter found for Python 3.100 in managed installations, system path, or `py` launcher
         "###
         );
     } else {
@@ -512,7 +512,7 @@ fn create_venv_unknown_python_minor() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.100 in system path
+          × No interpreter found for Python 3.100 in managed installations or system path
         "###
         );
     }
@@ -540,7 +540,7 @@ fn create_venv_unknown_python_patch() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.12.100 in system path or `py` launcher
+          × No interpreter found for Python 3.12.100 in managed installations, system path, or `py` launcher
         "###
         );
     } else {
@@ -550,7 +550,7 @@ fn create_venv_unknown_python_patch() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.12.100 in system path
+          × No interpreter found for Python 3.12.100 in managed installations or system path
         "###
         );
     }

--- a/crates/uv/tests/workflow.rs
+++ b/crates/uv/tests/workflow.rs
@@ -19,7 +19,6 @@ fn packse_add_remove_one_package() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 49 packages in [TIME]
     "###);
 
@@ -221,7 +220,6 @@ fn packse_add_remove_existing_package_noop() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 49 packages in [TIME]
     "###);
 
@@ -255,7 +253,6 @@ fn packse_promote_transitive_to_direct_then_remove() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 49 packages in [TIME]
     "###);
 
@@ -407,7 +404,6 @@ fn jax_instability() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `uv lock` is experimental and may change without warning
     Resolved 8 packages in [TIME]
     "###);
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -12,23 +12,23 @@ uv [OPTIONS] <COMMAND>
 
 <h3 class="cli-reference">Commands</h3>
 
-<dl class="cli-reference"><dt><a href="#uv-run"><code>uv run</code></a></dt><dd><p>Run a command or script (experimental)</p>
+<dl class="cli-reference"><dt><a href="#uv-run"><code>uv run</code></a></dt><dd><p>Run a command or script</p>
 </dd>
-<dt><a href="#uv-init"><code>uv init</code></a></dt><dd><p>Create a new project (experimental)</p>
+<dt><a href="#uv-init"><code>uv init</code></a></dt><dd><p>Create a new project</p>
 </dd>
-<dt><a href="#uv-add"><code>uv add</code></a></dt><dd><p>Add dependencies to the project (experimental)</p>
+<dt><a href="#uv-add"><code>uv add</code></a></dt><dd><p>Add dependencies to the project</p>
 </dd>
-<dt><a href="#uv-remove"><code>uv remove</code></a></dt><dd><p>Remove dependencies from the project (experimental)</p>
+<dt><a href="#uv-remove"><code>uv remove</code></a></dt><dd><p>Remove dependencies from the project</p>
 </dd>
-<dt><a href="#uv-sync"><code>uv sync</code></a></dt><dd><p>Update the project&#8217;s environment (experimental)</p>
+<dt><a href="#uv-sync"><code>uv sync</code></a></dt><dd><p>Update the project&#8217;s environment</p>
 </dd>
-<dt><a href="#uv-lock"><code>uv lock</code></a></dt><dd><p>Update the project&#8217;s lockfile (experimental)</p>
+<dt><a href="#uv-lock"><code>uv lock</code></a></dt><dd><p>Update the project&#8217;s lockfile</p>
 </dd>
-<dt><a href="#uv-tree"><code>uv tree</code></a></dt><dd><p>Display the project&#8217;s dependency tree (experimental)</p>
+<dt><a href="#uv-tree"><code>uv tree</code></a></dt><dd><p>Display the project&#8217;s dependency tree</p>
 </dd>
-<dt><a href="#uv-tool"><code>uv tool</code></a></dt><dd><p>Run and install commands provided by Python packages (experimental)</p>
+<dt><a href="#uv-tool"><code>uv tool</code></a></dt><dd><p>Run and install commands provided by Python packages</p>
 </dd>
-<dt><a href="#uv-python"><code>uv python</code></a></dt><dd><p>Manage Python versions and installations (experimental)</p>
+<dt><a href="#uv-python"><code>uv python</code></a></dt><dd><p>Manage Python versions and installations</p>
 </dd>
 <dt><a href="#uv-pip"><code>uv pip</code></a></dt><dd><p>Manage Python packages with a pip-compatible interface</p>
 </dd>
@@ -44,7 +44,7 @@ uv [OPTIONS] <COMMAND>
 
 ## uv run
 
-Run a command or script (experimental).
+Run a command or script.
 
 Ensures that the command runs in a Python environment.
 
@@ -332,7 +332,7 @@ uv run [OPTIONS] <COMMAND>
 
 ## uv init
 
-Create a new project (experimental).
+Create a new project.
 
 Follows the `pyproject.toml` specification.
 
@@ -451,7 +451,7 @@ uv init [OPTIONS] [PATH]
 
 ## uv add
 
-Add dependencies to the project (experimental).
+Add dependencies to the project.
 
 Dependencies are added to the project's `pyproject.toml` file.
 
@@ -737,7 +737,7 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 
 ## uv remove
 
-Remove dependencies from the project (experimental).
+Remove dependencies from the project.
 
 Dependencies are removed from the project's `pyproject.toml` file.
 
@@ -997,7 +997,7 @@ uv remove [OPTIONS] <PACKAGES>...
 
 ## uv sync
 
-Update the project's environment (experimental).
+Update the project's environment.
 
 Syncing ensures that all project dependencies are installed and up-to-date with the lockfile. Syncing also removes packages that are not declared as dependencies of the project.
 
@@ -1261,7 +1261,7 @@ uv sync [OPTIONS]
 
 ## uv lock
 
-Update the project's lockfile (experimental).
+Update the project's lockfile.
 
 If the project lockfile (`uv.lock`) does not exist, it will be created. If a lockfile is present, its contents will be used as preferences for the resolution.
 
@@ -1489,7 +1489,7 @@ uv lock [OPTIONS]
 
 ## uv tree
 
-Display the project's dependency tree (experimental)
+Display the project's dependency tree
 
 <h3 class="cli-reference">Usage</h3>
 
@@ -1773,7 +1773,7 @@ uv tree [OPTIONS]
 
 ## uv tool
 
-Run and install commands provided by Python packages (experimental)
+Run and install commands provided by Python packages
 
 <h3 class="cli-reference">Usage</h3>
 
@@ -2854,7 +2854,7 @@ uv tool dir [OPTIONS]
 
 ## uv python
 
-Manage Python versions and installations (experimental)
+Manage Python versions and installations
 
 Generally, uv first searches for Python in a virtual environment, either
 active or in a `.venv` directory  in the current working directory or
@@ -2865,8 +2865,7 @@ searching for Python executables in the `PATH` environment variable.
 On Windows, the `py` launcher is also invoked to find Python
 executables.
 
-When preview is enabled, i.e., via `--preview` or by using a preview
-command, uv will download Python if a version cannot be found. This
+By default, uv will download Python if a version cannot be found. This
 behavior can be disabled with the `--python-downloads` option.
 
 The `--python` option allows requesting a different interpreter.


### PR DESCRIPTION
- Removes "experimental" labels from command documentation
- Removes preview warnings
- Removes `PreviewMode` from most structs and methods — we could keep it around but I figure we can propagate it again easily where needed in the future
- Enables preview behavior by default everywhere, e.g., `uv venv` will download Python versions