### PR TITLE
Hide global option in `uv generate-shell-completion`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -349,7 +349,7 @@ pub enum Commands {
     },
     /// Generate shell completion
     #[command(alias = "--generate-shell-completion", hide = true)]
-    GenerateShellCompletion { shell: clap_complete_command::Shell },
+    GenerateShellCompletion(GenerateShellCompletionArgs),
     /// Display documentation for a command.
     // To avoid showing the global options when displaying help for the help command, we are
     // responsible for maintaining the options using the `after_help`.
@@ -3035,6 +3035,45 @@ pub struct PythonPinArgs {
     /// the workspace's `requires-python` constraint.
     #[arg(long)]
     pub no_workspace: bool,
+}
+
+#[derive(Args)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct GenerateShellCompletionArgs {
+    /// The shell to generate the completion script for
+    pub shell: clap_complete_command::Shell,
+
+    // Hide unused global options.
+    #[arg(long, short, hide = true)]
+    pub no_cache: bool,
+    #[arg(long, hide = true)]
+    pub cache_dir: Option<PathBuf>,
+
+    #[arg(long, hide = true)]
+    pub python_preference: Option<PythonPreference>,
+    #[arg(long, hide = true)]
+    pub no_python_downloads: bool,
+
+    #[arg(long, short, conflicts_with = "verbose", hide = true)]
+    pub quiet: bool,
+    #[arg(long, short, action = clap::ArgAction::Count, conflicts_with = "quiet", hide = true)]
+    pub verbose: u8,
+    #[arg(long, default_value = "auto", conflicts_with = "no_color", hide = true)]
+    pub color: ColorChoice,
+    #[arg(long, hide = true)]
+    pub native_tls: bool,
+    #[arg(long, hide = true)]
+    pub offline: bool,
+    #[arg(long, hide = true)]
+    pub no_progress: bool,
+    #[arg(long, hide = true)]
+    pub config_file: Option<PathBuf>,
+    #[arg(long, hide = true)]
+    pub no_config: bool,
+    #[arg(long, short, action = clap::ArgAction::HelpShort, hide = true)]
+    pub help: Option<bool>,
+    #[arg(short = 'V', long, hide = true)]
+    pub version: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -723,8 +723,8 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             commands::version(output_format, &mut stdout())?;
             Ok(ExitStatus::Success)
         }
-        Commands::GenerateShellCompletion { shell } => {
-            shell.generate(&mut Cli::command(), &mut stdout());
+        Commands::GenerateShellCompletion(args) => {
+            args.shell.generate(&mut Cli::command(), &mut stdout());
             Ok(ExitStatus::Success)
         }
         Commands::Tool(ToolNamespace {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5709,83 +5709,16 @@ Generate shell completion
 <h3 class="cli-reference">Usage</h3>
 
 ```
-uv generate-shell-completion [OPTIONS] <SHELL>
+uv generate-shell-completion <SHELL>
 ```
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt><code>SHELL</code></dt></dl>
-
-<h3 class="cli-reference">Options</h3>
-
-<dl class="cli-reference"><dt><code>--cache-dir</code> <i>cache-dir</i></dt><dd><p>Path to the cache directory.</p>
-
-<p>Defaults to <code>$HOME/Library/Caches/uv</code> on macOS, <code>$XDG_CACHE_HOME/uv</code> or <code>$HOME/.cache/uv</code> on Linux, and <code>{FOLDERID_LocalAppData}\uv\cache</code> on Windows.</p>
-
-</dd><dt><code>--color</code> <i>color-choice</i></dt><dd><p>Control colors in output</p>
-
-<p>[default: auto]</p>
-<p>Possible values:</p>
-
-<ul>
-<li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
-
-<li><code>always</code>:  Enables colored output regardless of the detected environment</li>
-
-<li><code>never</code>:  Disables colored output</li>
-</ul>
-</dd><dt><code>--config-file</code> <i>config-file</i></dt><dd><p>The path to a <code>uv.toml</code> file to use for configuration.</p>
-
-<p>While uv configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
-
-</dd><dt><code>--help</code>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
-
-</dd><dt><code>--native-tls</code></dt><dd><p>Whether to load TLS certificates from the platform&#8217;s native certificate store.</p>
-
-<p>By default, uv loads certificates from the bundled <code>webpki-roots</code> crate. The <code>webpki-roots</code> are a reliable set of trust roots from Mozilla, and including them in uv improves portability and performance (especially on macOS).</p>
-
-<p>However, in some cases, you may want to use the platform&#8217;s native certificate store, especially if you&#8217;re relying on a corporate trust root (e.g., for a mandatory proxy) that&#8217;s included in your system&#8217;s certificate store.</p>
-
-</dd><dt><code>--no-cache</code>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>
-
-</dd><dt><code>--no-config</code></dt><dd><p>Avoid discovering configuration files (<code>pyproject.toml</code>, <code>uv.toml</code>).</p>
-
-<p>Normally, configuration files are discovered in the current directory, parent directories, or user configuration directories.</p>
-
-</dd><dt><code>--no-progress</code></dt><dd><p>Hide all progress outputs.</p>
-
-<p>For example, spinners or progress bars.</p>
-
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
-
-</dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
-
-<p>When disabled, uv will only use locally cached data and locally available files.</p>
-
-</dd><dt><code>--python-preference</code> <i>python-preference</i></dt><dd><p>Whether to prefer uv-managed or system Python installations.</p>
-
-<p>By default, uv prefers using Python versions it manages. However, it will use system Python installations if a uv-managed Python is not installed. This option allows prioritizing or ignoring system Python installations.</p>
-
-<p>Possible values:</p>
-
-<ul>
-<li><code>only-managed</code>:  Only use managed Python installations; never use system Python installations</li>
-
-<li><code>managed</code>:  Prefer managed Python installations over system Python installations</li>
-
-<li><code>system</code>:  Prefer system Python installations over managed Python installations</li>
-
-<li><code>only-system</code>:  Only use system Python installations; never use managed Python installations</li>
-</ul>
-</dd><dt><code>--quiet</code>, <code>-q</code></dt><dd><p>Do not print any output</p>
-
-</dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
-
-<p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
-
-</dd><dt><code>--version</code>, <code>-V</code></dt><dd><p>Display the uv version</p>
+<dl class="cli-reference"><dt><code>SHELL</code></dt><dd><p>The shell to generate the completion script for</p>
 
 </dd></dl>
+
+
 
 ## uv help
 


### PR DESCRIPTION
Resolve #6152 

## Summary

## Test Plan

Execution result of `cargo run generate-shell-completion --help`

```bash
Generate shell completion

Usage: uv generate-shell-completion <SHELL>

Arguments:
  <SHELL>  The shell to generate the completion script for [possible values: bash, elvish, fish, nushell, powershell, zsh]
```

Execution result of `cargo run help generate-shell-completion`

```bash
Generate shell completion

Usage: uv generate-shell-completion <SHELL>

Arguments:
  <SHELL>
          The shell to generate the completion script for
          
          [possible values: bash, elvish, fish, nushell, powershell, zsh]
```