### PR TITLE
Add support for `python_version in ...` markers

### DIFF
--- a/crates/pep508-rs/src/marker/parse.rs
+++ b/crates/pep508-rs/src/marker/parse.rs
@@ -132,7 +132,9 @@ pub(crate) fn parse_marker_key_op_value<T: Pep508Url>(
     // Convert a `<marker_value> <marker_op> <marker_value>` expression into it's
     // typed equivalent.
     let expr = match l_value {
-        // The only sound choice for this is `<version key> <version op> <quoted PEP 440 version>`
+        // Either:
+        // - `<version key> <version op> <quoted PEP 440 version>`
+        // - `<version key> in <list of quoted PEP 440 versions>` and ("not in")
         MarkerValue::MarkerEnvVersion(key) => {
             let MarkerValue::QuotedString(value) = r_value else {
                 reporter.report(
@@ -146,6 +148,12 @@ pub(crate) fn parse_marker_key_op_value<T: Pep508Url>(
                 return Ok(None);
             };
 
+            // Check for `in` and `not in` expressions
+            if let Some(expr) = parse_version_in_expr(key.clone(), operator, &value, reporter) {
+                return Ok(Some(expr));
+            }
+
+            // Otherwise, it's a normal version expression
             parse_version_expr(key.clone(), operator, &value, reporter)
         }
         // The only sound choice for this is `<env key> <op> <string>`
@@ -236,6 +244,72 @@ pub(crate) fn parse_marker_key_op_value<T: Pep508Url>(
     };
 
     Ok(expr)
+}
+
+/// Creates an instance of [`MarkerExpression::VersionIn`] with the given values.
+///
+/// Some important caveats apply here.
+///
+/// While the specification defines this operation as a substring search, for versions, we use a
+/// version-aware match so we can perform algebra on the expressions. This means that some markers
+/// will not be evaluated according to the specification, but these marker expressions are
+/// relatively rare so the trade-off is acceptable.
+///
+/// The following limited expression is supported:
+///     
+///      [not] in '<version> [additional versions]'
+///
+/// where the version is PEP 440 compliant. Arbitrary whitespace is allowed between versions.
+///
+/// Returns `None` if the [`MarkerOperator`] is not relevant.
+/// Reports a warning if an invalid version is encountered, and returns `None`.
+fn parse_version_in_expr(
+    key: MarkerValueVersion,
+    operator: MarkerOperator,
+    value: &str,
+    reporter: &mut impl Reporter,
+) -> Option<MarkerExpression> {
+    if !matches!(operator, MarkerOperator::In | MarkerOperator::NotIn) {
+        return None;
+    }
+    let negated = matches!(operator, MarkerOperator::NotIn);
+
+    let mut cursor = Cursor::new(value);
+    let mut versions = Vec::new();
+
+    // Parse all of the values in the list as versions
+    loop {
+        // Allow arbitrary whitespace between versions
+        cursor.eat_whitespace();
+
+        let (start, len) = cursor.take_while(|c| !c.is_whitespace());
+        if len == 0 {
+            break;
+        }
+
+        let version = match Version::from_str(cursor.slice(start, len)) {
+            Ok(version) => version,
+            Err(err) => {
+                reporter.report(
+                    MarkerWarningKind::Pep440Error,
+                    format!(
+                        "Expected PEP 440 versions to compare with {key}, found {value},
+                        will be ignored: {err}"
+                    ),
+                );
+
+                return None;
+            }
+        };
+
+        versions.push(version);
+    }
+
+    Some(MarkerExpression::VersionIn {
+        key,
+        versions,
+        negated,
+    })
 }
 
 /// Creates an instance of [`MarkerExpression::Version`] with the given values.

--- a/crates/pep508-rs/src/marker/simplify.rs
+++ b/crates/pep508-rs/src/marker/simplify.rs
@@ -378,6 +378,22 @@ fn is_negation(left: &MarkerExpression, right: &MarkerExpression) -> bool {
                     .negate()
                     .is_some_and(|negated| negated == *specifier2.operator())
         }
+        MarkerExpression::VersionIn {
+            key,
+            versions,
+            negated,
+        } => {
+            let MarkerExpression::VersionIn {
+                key: key2,
+                versions: versions2,
+                negated: negated2,
+            } = right
+            else {
+                return false;
+            };
+
+            key == key2 && versions == versions2 && negated != negated2
+        }
         MarkerExpression::String {
             key,
             operator,

--- a/crates/uv/tests/snapshots/ecosystem__black-lock-file.snap
+++ b/crates/uv/tests/snapshots/ecosystem__black-lock-file.snap
@@ -511,18 +511,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathlib2"
-version = "2.3.7.post1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/31/51/99caf463dc7c18eb18dad1fffe465a3cf3ee50ac3d1dccbd1781336fe9c7/pathlib2-2.3.7.post1.tar.gz", hash = "sha256:9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641", size = 211190 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/eb/4af4bcd5b8731366b676192675221c5324394a580dfae469d498313b5c4a/pathlib2-2.3.7.post1-py2.py3-none-any.whl", hash = "sha256:5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b", size = 18027 },
-]
-
-[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -547,9 +535,6 @@ wheels = [
 name = "pickleshare"
 version = "0.7.5"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pathlib2" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/b6/df3c1c9b616e9c0edbc4fbab6ddd09df9535849c64ba51fcb6531c32d4d8/pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca", size = 6161 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/41/220f49aaea88bc6fa6cba8d05ecf24676326156c23b991e80b3f2fc24c77/pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56", size = 6877 },

--- a/crates/uv/tests/snapshots/ecosystem__black-uv-lock-output.snap
+++ b/crates/uv/tests/snapshots/ecosystem__black-uv-lock-output.snap
@@ -8,4 +8,4 @@ exit_code: 0
 
 ----- stderr -----
 warning: `uv lock` is experimental and may change without warning
-Resolved 40 packages in [TIME]
+Resolved 39 packages in [TIME]


### PR DESCRIPTION
Closes #3683 

Note our semantics do not exactly match the specification so we can perform algebra on the markers. See the caveats in the documentation (and in the discussion below).