### PR TITLE
Tolerate missing `[project]` table in `uv venv`

### DIFF
--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -159,9 +159,13 @@ async fn venv_impl(
     if preview.is_enabled() && interpreter_request.is_none() {
         let project = match VirtualProject::discover(&CWD, &DiscoveryOptions::default()).await {
             Ok(project) => Some(project),
+            Err(WorkspaceError::MissingProject(_)) => None,
             Err(WorkspaceError::MissingPyprojectToml) => None,
             Err(WorkspaceError::NonWorkspace(_)) => None,
-            Err(err) => return Err(err).into_diagnostic(),
+            Err(err) => {
+                warn_user_once!("{err}");
+                None
+            }
         };
 
         if let Some(project) = project {

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -307,9 +307,13 @@ impl TestContext {
                 .map(|pattern| (pattern, "[WORKSPACE]/".to_string())),
         );
 
-        // Make virtual environment activation cross-platform
+        // Make virtual environment activation cross-platform and shell-agnostic
         filters.push((
             r"Activate with: (?:.*)\\Scripts\\activate".to_string(),
+            "Activate with: source .venv/bin/activate".to_string(),
+        ));
+        filters.push((
+            r"Activate with: source .venv/bin/activate(?:\.\w+)".to_string(),
             "Activate with: source .venv/bin/activate".to_string(),
         ));
 

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -351,6 +351,64 @@ fn create_venv_respects_pyproject_requires_python() -> Result<()> {
 }
 
 #[test]
+fn create_venv_ignores_missing_pyproject_metadata() -> Result<()> {
+    let context = TestContext::new_with_versions(&["3.12"]);
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r"[tool.no.project.here]" })?;
+
+    uv_snapshot!(context.filters(), context.venv()
+        .arg("--preview"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtualenv at: .venv
+    Activate with: source .venv/bin/activate
+    "###
+    );
+
+    context.venv.assert(predicates::path::is_dir());
+
+    Ok(())
+}
+
+#[test]
+fn create_venv_warns_user_on_requires_python_discovery_error() -> Result<()> {
+    let context = TestContext::new_with_versions(&["3.12"]);
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(indoc! { r"invalid toml" })?;
+
+    uv_snapshot!(context.filters(), context.venv()
+        .arg("--preview"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: Failed to parse `pyproject.toml` during settings discovery:
+      TOML parse error at line 1, column 9
+        |
+      1 | invalid toml
+        |         ^
+      expected `.`, `=`
+
+    warning: Failed to parse: `pyproject.toml`
+    Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
+    Creating virtualenv at: .venv
+    Activate with: source .venv/bin/activate
+    "###
+    );
+
+    context.venv.assert(predicates::path::is_dir());
+
+    Ok(())
+}
+
+#[test]
 fn create_venv_explicit_request_takes_priority_over_python_version_file() {
     let context = TestContext::new_with_versions(&["3.11", "3.12"]);
 


### PR DESCRIPTION
## Summary

Fixes #6177

This ensures a `pyproject.toml` file without a `[project]` table is not a fatal error for `uv venv`, which is just trying to discover/respect the project's `python-requires` (#5592).

Similarly, any caught `WorkspaceError` is now also non-fatal and instead prints a warning message (feeback welcome here, felt less surprising than e.g. a malformed `pyproject.toml` breaking `uv venv`).

## Test Plan

I added two test cases: `cargo test -p uv --test venv`

Also, existing venv tests were failing for me since I use fish and the printed activation script was `source .venv/bin/activate.fish` (to repro, just run the tests with `SHELL=fish`). So added an insta filter to normalize that.
