### PR TITLE
Show generate-shell-completion command in `uv help`

### DIFF
--- a/crates/uv/src/commands/help.rs
+++ b/crates/uv/src/commands/help.rs
@@ -12,8 +12,15 @@ use super::ExitStatus;
 use crate::printer::Printer;
 use uv_cli::Cli;
 
+// hidden subcommands to show in the help command
+const SHOW_HIDDEN_COMMANDS: &[&str] = &["generate-shell-completion"];
+
 pub(crate) fn help(query: &[String], printer: Printer, no_pager: bool) -> Result<ExitStatus> {
-    let mut uv = Cli::command();
+    let mut uv: clap::Command = SHOW_HIDDEN_COMMANDS
+        .iter()
+        .fold(Cli::command(), |uv, &name| {
+            uv.mut_subcommand(name, |cmd| cmd.hide(false))
+        });
 
     // It is very important to build the command before beginning inspection or subcommands
     // will be missing all of the propagated options.

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -16,20 +16,21 @@ fn help() {
     Usage: uv [OPTIONS] <COMMAND>
 
     Commands:
-      run      Run a command or script (experimental)
-      init     Create a new project (experimental)
-      add      Add dependencies to the project (experimental)
-      remove   Remove dependencies from the project (experimental)
-      sync     Update the project's environment (experimental)
-      lock     Update the project's lockfile (experimental)
-      tree     Display the project's dependency tree (experimental)
-      tool     Run and install commands provided by Python packages (experimental)
-      python   Manage Python versions and installations (experimental)
-      pip      Manage Python packages with a pip-compatible interface
-      venv     Create a virtual environment
-      cache    Manage uv's cache
-      version  Display uv's version
-      help     Display documentation for a command
+      run                        Run a command or script (experimental)
+      init                       Create a new project (experimental)
+      add                        Add dependencies to the project (experimental)
+      remove                     Remove dependencies from the project (experimental)
+      sync                       Update the project's environment (experimental)
+      lock                       Update the project's lockfile (experimental)
+      tree                       Display the project's dependency tree (experimental)
+      tool                       Run and install commands provided by Python packages (experimental)
+      python                     Manage Python versions and installations (experimental)
+      pip                        Manage Python packages with a pip-compatible interface
+      venv                       Create a virtual environment
+      cache                      Manage uv's cache
+      version                    Display uv's version
+      generate-shell-completion  Generate shell completion
+      help                       Display documentation for a command
 
     Cache options:
       -n, --no-cache               Avoid reading from or writing to the cache, instead using a temporary
@@ -632,6 +633,7 @@ fn help_unknown_subcommand() {
         venv
         cache
         version
+        generate-shell-completion
     "###);
 
     uv_snapshot!(context.filters(), context.help().arg("foo").arg("bar"), @r###"
@@ -654,6 +656,7 @@ fn help_unknown_subcommand() {
         venv
         cache
         version
+        generate-shell-completion
     "###);
 }
 
@@ -690,20 +693,21 @@ fn help_with_global_option() {
     Usage: uv [OPTIONS] <COMMAND>
 
     Commands:
-      run      Run a command or script (experimental)
-      init     Create a new project (experimental)
-      add      Add dependencies to the project (experimental)
-      remove   Remove dependencies from the project (experimental)
-      sync     Update the project's environment (experimental)
-      lock     Update the project's lockfile (experimental)
-      tree     Display the project's dependency tree (experimental)
-      tool     Run and install commands provided by Python packages (experimental)
-      python   Manage Python versions and installations (experimental)
-      pip      Manage Python packages with a pip-compatible interface
-      venv     Create a virtual environment
-      cache    Manage uv's cache
-      version  Display uv's version
-      help     Display documentation for a command
+      run                        Run a command or script (experimental)
+      init                       Create a new project (experimental)
+      add                        Add dependencies to the project (experimental)
+      remove                     Remove dependencies from the project (experimental)
+      sync                       Update the project's environment (experimental)
+      lock                       Update the project's lockfile (experimental)
+      tree                       Display the project's dependency tree (experimental)
+      tool                       Run and install commands provided by Python packages (experimental)
+      python                     Manage Python versions and installations (experimental)
+      pip                        Manage Python packages with a pip-compatible interface
+      venv                       Create a virtual environment
+      cache                      Manage uv's cache
+      version                    Display uv's version
+      generate-shell-completion  Generate shell completion
+      help                       Display documentation for a command
 
     Cache options:
       -n, --no-cache               Avoid reading from or writing to the cache, instead using a temporary
@@ -788,20 +792,21 @@ fn help_with_no_pager() {
     Usage: uv [OPTIONS] <COMMAND>
 
     Commands:
-      run      Run a command or script (experimental)
-      init     Create a new project (experimental)
-      add      Add dependencies to the project (experimental)
-      remove   Remove dependencies from the project (experimental)
-      sync     Update the project's environment (experimental)
-      lock     Update the project's lockfile (experimental)
-      tree     Display the project's dependency tree (experimental)
-      tool     Run and install commands provided by Python packages (experimental)
-      python   Manage Python versions and installations (experimental)
-      pip      Manage Python packages with a pip-compatible interface
-      venv     Create a virtual environment
-      cache    Manage uv's cache
-      version  Display uv's version
-      help     Display documentation for a command
+      run                        Run a command or script (experimental)
+      init                       Create a new project (experimental)
+      add                        Add dependencies to the project (experimental)
+      remove                     Remove dependencies from the project (experimental)
+      sync                       Update the project's environment (experimental)
+      lock                       Update the project's lockfile (experimental)
+      tree                       Display the project's dependency tree (experimental)
+      tool                       Run and install commands provided by Python packages (experimental)
+      python                     Manage Python versions and installations (experimental)
+      pip                        Manage Python packages with a pip-compatible interface
+      venv                       Create a virtual environment
+      cache                      Manage uv's cache
+      version                    Display uv's version
+      generate-shell-completion  Generate shell completion
+      help                       Display documentation for a command
 
     Cache options:
       -n, --no-cache               Avoid reading from or writing to the cache, instead using a temporary


### PR DESCRIPTION
Resolve #6151

## Test Plan

Execution result of `cargo run -- help`

```bash
An extremely fast Python package manager.

Usage: uv [OPTIONS] <COMMAND>

Commands:
  run                        Run a command or script (experimental)
  init                       Create a new project (experimental)
  add                        Add dependencies to the project (experimental)
  remove                     Remove dependencies from the project (experimental)
  sync                       Update the project's environment (experimental)
  lock                       Update the project's lockfile (experimental)
  tree                       Display the project's dependency tree (experimental)
  tool                       Run and install commands provided by Python packages (experimental)
  python                     Manage Python versions and installations (experimental)
  pip                        Manage Python packages with a pip-compatible interface
  venv                       Create a virtual environment
  cache                      Manage uv's cache
  version                    Display uv's version
  generate-shell-completion  Generate shell completion
  help                       Display documentation for a command
...
```

Execution result of `cargo run -- -h` and `cargo run -- --help` 

```bash
An extremely fast Python package manager.

Usage: uv [OPTIONS] <COMMAND>

Commands:
  run      Run a command or script (experimental)
  init     Create a new project (experimental)
  add      Add dependencies to the project (experimental)
  remove   Remove dependencies from the project (experimental)
  sync     Update the project's environment (experimental)
  lock     Update the project's lockfile (experimental)
  tree     Display the project's dependency tree (experimental)
  tool     Run and install commands provided by Python packages (experimental)
  python   Manage Python versions and installations (experimental)
  pip      Manage Python packages with a pip-compatible interface
  venv     Create a virtual environment
  cache    Manage uv's cache
  version  Display uv's version
  help     Display documentation for a command
...
```
