### PR TITLE
Display the default value of `--link-mode` in help

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -8,6 +8,7 @@ use clap::builder::styling::Style;
 use clap::{Args, Parser, Subcommand};
 
 use distribution_types::{FlatIndexLocation, IndexUrl};
+use install_wheel_rs::linker::LinkMode;
 use pep508_rs::Requirement;
 use pypi_types::VerbatimParsedUrl;
 use uv_cache::CacheArgs;
@@ -1999,8 +2000,8 @@ pub struct VenvArgs {
     ///
     /// Defaults to `clone` (also known as Copy-on-Write) on macOS, and `hardlink` on Linux and
     /// Windows.
-    #[arg(long, value_enum, env = "UV_LINK_MODE")]
-    pub link_mode: Option<install_wheel_rs::linker::LinkMode>,
+    #[arg(long, value_enum, env = "UV_LINK_MODE", default_value_t=LinkMode::default())]
+    pub link_mode: LinkMode,
 
     #[command(flatten)]
     pub compat_args: compat::VenvCompatArgs,
@@ -3288,9 +3289,10 @@ pub struct InstallerArgs {
         long,
         value_enum,
         env = "UV_LINK_MODE",
-        help_heading = "Installer options"
+        help_heading = "Installer options",
+        default_value_t=LinkMode::default()
     )]
-    pub link_mode: Option<install_wheel_rs::linker::LinkMode>,
+    pub link_mode: LinkMode,
 
     /// Compile Python files to bytecode after installation.
     ///
@@ -3464,9 +3466,10 @@ pub struct ResolverArgs {
         long,
         value_enum,
         env = "UV_LINK_MODE",
-        help_heading = "Installer options"
+        help_heading = "Installer options",
+        default_value_t=LinkMode::default()
     )]
-    pub link_mode: Option<install_wheel_rs::linker::LinkMode>,
+    pub link_mode: LinkMode,
 
     /// Ignore the `tool.uv.sources` table when resolving dependencies. Used to lock against the
     /// standards-compliant, publishable package metadata, as opposed to using any local or Git
@@ -3634,9 +3637,10 @@ pub struct ResolverInstallerArgs {
         long,
         value_enum,
         env = "UV_LINK_MODE",
-        help_heading = "Installer options"
+        help_heading = "Installer options",
+        default_value_t=LinkMode::default()
     )]
-    pub link_mode: Option<install_wheel_rs::linker::LinkMode>,
+    pub link_mode: LinkMode,
 
     /// Compile Python files to bytecode after installation.
     ///

--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -66,7 +66,7 @@ impl From<ResolverArgs> for PipOptions {
             no_build_isolation: flag(no_build_isolation, build_isolation),
             no_build_isolation_package: Some(no_build_isolation_package),
             exclude_newer,
-            link_mode,
+            link_mode: Some(link_mode),
             no_sources: if no_sources { Some(true) } else { None },
             ..PipOptions::from(index_args)
         }
@@ -101,7 +101,7 @@ impl From<InstallerArgs> for PipOptions {
                 .map(|config_settings| config_settings.into_iter().collect::<ConfigSettings>()),
             no_build_isolation: flag(no_build_isolation, build_isolation),
             exclude_newer,
-            link_mode,
+            link_mode: Some(link_mode),
             compile_bytecode: flag(compile_bytecode, no_compile_bytecode),
             no_sources: if no_sources { Some(true) } else { None },
             ..PipOptions::from(index_args)
@@ -153,7 +153,7 @@ impl From<ResolverInstallerArgs> for PipOptions {
             no_build_isolation: flag(no_build_isolation, build_isolation),
             no_build_isolation_package: Some(no_build_isolation_package),
             exclude_newer,
-            link_mode,
+            link_mode: Some(link_mode),
             compile_bytecode: flag(compile_bytecode, no_compile_bytecode),
             no_sources: if no_sources { Some(true) } else { None },
             ..PipOptions::from(index_args)
@@ -244,7 +244,7 @@ pub fn resolver_options(resolver_args: ResolverArgs, build_args: BuildArgs) -> R
         no_build_isolation: flag(no_build_isolation, build_isolation),
         no_build_isolation_package: Some(no_build_isolation_package),
         exclude_newer,
-        link_mode,
+        link_mode: Some(link_mode),
         no_build: flag(no_build, build),
         no_build_package: Some(no_build_package),
         no_binary: flag(no_binary, binary),
@@ -334,7 +334,7 @@ pub fn resolver_installer_options(
             Some(no_build_isolation_package)
         },
         exclude_newer,
-        link_mode,
+        link_mode: Some(link_mode),
         compile_bytecode: flag(compile_bytecode, no_compile_bytecode),
         no_build: flag(no_build, build),
         no_build_package: if no_build_package.is_empty() {

--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -1,4 +1,3 @@
-use install_wheel_rs::linker::LinkMode;
 use uv_cache::Refresh;
 use uv_configuration::ConfigSettings;
 use uv_resolver::PrereleaseMode;
@@ -67,7 +66,7 @@ impl From<ResolverArgs> for PipOptions {
             no_build_isolation: flag(no_build_isolation, build_isolation),
             no_build_isolation_package: Some(no_build_isolation_package),
             exclude_newer,
-            link_mode: (link_mode != LinkMode::default()).then_some(link_mode),
+            link_mode: Some(link_mode),
             no_sources: if no_sources { Some(true) } else { None },
             ..PipOptions::from(index_args)
         }
@@ -102,7 +101,7 @@ impl From<InstallerArgs> for PipOptions {
                 .map(|config_settings| config_settings.into_iter().collect::<ConfigSettings>()),
             no_build_isolation: flag(no_build_isolation, build_isolation),
             exclude_newer,
-            link_mode: (link_mode != LinkMode::default()).then_some(link_mode),
+            link_mode: Some(link_mode),
             compile_bytecode: flag(compile_bytecode, no_compile_bytecode),
             no_sources: if no_sources { Some(true) } else { None },
             ..PipOptions::from(index_args)
@@ -154,7 +153,7 @@ impl From<ResolverInstallerArgs> for PipOptions {
             no_build_isolation: flag(no_build_isolation, build_isolation),
             no_build_isolation_package: Some(no_build_isolation_package),
             exclude_newer,
-            link_mode: (link_mode != LinkMode::default()).then_some(link_mode),
+            link_mode: Some(link_mode),
             compile_bytecode: flag(compile_bytecode, no_compile_bytecode),
             no_sources: if no_sources { Some(true) } else { None },
             ..PipOptions::from(index_args)
@@ -245,7 +244,7 @@ pub fn resolver_options(resolver_args: ResolverArgs, build_args: BuildArgs) -> R
         no_build_isolation: flag(no_build_isolation, build_isolation),
         no_build_isolation_package: Some(no_build_isolation_package),
         exclude_newer,
-        link_mode: (link_mode != LinkMode::default()).then_some(link_mode),
+        link_mode: Some(link_mode),
         no_build: flag(no_build, build),
         no_build_package: Some(no_build_package),
         no_binary: flag(no_binary, binary),
@@ -335,7 +334,7 @@ pub fn resolver_installer_options(
             Some(no_build_isolation_package)
         },
         exclude_newer,
-        link_mode: (link_mode != LinkMode::default()).then_some(link_mode),
+        link_mode: Some(link_mode),
         compile_bytecode: flag(compile_bytecode, no_compile_bytecode),
         no_build: flag(no_build, build),
         no_build_package: if no_build_package.is_empty() {

--- a/crates/uv-cli/src/options.rs
+++ b/crates/uv-cli/src/options.rs
@@ -1,3 +1,4 @@
+use install_wheel_rs::linker::LinkMode;
 use uv_cache::Refresh;
 use uv_configuration::ConfigSettings;
 use uv_resolver::PrereleaseMode;
@@ -66,7 +67,7 @@ impl From<ResolverArgs> for PipOptions {
             no_build_isolation: flag(no_build_isolation, build_isolation),
             no_build_isolation_package: Some(no_build_isolation_package),
             exclude_newer,
-            link_mode: Some(link_mode),
+            link_mode: (link_mode != LinkMode::default()).then_some(link_mode),
             no_sources: if no_sources { Some(true) } else { None },
             ..PipOptions::from(index_args)
         }
@@ -101,7 +102,7 @@ impl From<InstallerArgs> for PipOptions {
                 .map(|config_settings| config_settings.into_iter().collect::<ConfigSettings>()),
             no_build_isolation: flag(no_build_isolation, build_isolation),
             exclude_newer,
-            link_mode: Some(link_mode),
+            link_mode: (link_mode != LinkMode::default()).then_some(link_mode),
             compile_bytecode: flag(compile_bytecode, no_compile_bytecode),
             no_sources: if no_sources { Some(true) } else { None },
             ..PipOptions::from(index_args)
@@ -153,7 +154,7 @@ impl From<ResolverInstallerArgs> for PipOptions {
             no_build_isolation: flag(no_build_isolation, build_isolation),
             no_build_isolation_package: Some(no_build_isolation_package),
             exclude_newer,
-            link_mode: Some(link_mode),
+            link_mode: (link_mode != LinkMode::default()).then_some(link_mode),
             compile_bytecode: flag(compile_bytecode, no_compile_bytecode),
             no_sources: if no_sources { Some(true) } else { None },
             ..PipOptions::from(index_args)
@@ -244,7 +245,7 @@ pub fn resolver_options(resolver_args: ResolverArgs, build_args: BuildArgs) -> R
         no_build_isolation: flag(no_build_isolation, build_isolation),
         no_build_isolation_package: Some(no_build_isolation_package),
         exclude_newer,
-        link_mode: Some(link_mode),
+        link_mode: (link_mode != LinkMode::default()).then_some(link_mode),
         no_build: flag(no_build, build),
         no_build_package: Some(no_build_package),
         no_binary: flag(no_binary, binary),
@@ -334,7 +335,7 @@ pub fn resolver_installer_options(
             Some(no_build_isolation_package)
         },
         exclude_newer,
-        link_mode: Some(link_mode),
+        link_mode: (link_mode != LinkMode::default()).then_some(link_mode),
         compile_bytecode: flag(compile_bytecode, no_compile_bytecode),
         no_build: flag(no_build, build),
         no_build_package: if no_build_package.is_empty() {

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -1303,7 +1303,11 @@ impl From<ResolverInstallerOptions> for ToolOptions {
             no_build_isolation: value.no_build_isolation,
             no_build_isolation_package: value.no_build_isolation_package,
             exclude_newer: value.exclude_newer,
-            link_mode: value.link_mode,
+            link_mode: if value.link_mode == Some(LinkMode::default()) {
+                None
+            } else {
+                value.link_mode
+            },
             compile_bytecode: value.compile_bytecode,
             no_sources: value.no_sources,
             no_build: value.no_build,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1546,7 +1546,7 @@ impl VenvSettings {
                     index_strategy,
                     keyring_provider,
                     exclude_newer,
-                    link_mode,
+                    link_mode: Some(link_mode),
                     ..PipOptions::from(index_args)
                 },
                 filesystem,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -172,6 +172,7 @@ uv run [OPTIONS] <COMMAND>
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -575,6 +576,7 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -853,6 +855,7 @@ uv remove [OPTIONS] <PACKAGES>...
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -1107,6 +1110,7 @@ uv sync [OPTIONS]
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -1353,6 +1357,7 @@ uv lock [OPTIONS]
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -1584,6 +1589,7 @@ uv tree [OPTIONS]
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -1909,6 +1915,7 @@ uv tool run [OPTIONS] [COMMAND]
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -2149,6 +2156,7 @@ uv tool install [OPTIONS] <PACKAGE>
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -2387,6 +2395,7 @@ uv tool upgrade [OPTIONS] <NAME>
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -3661,6 +3670,7 @@ uv pip compile [OPTIONS] <SRC_FILE>...
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -4000,6 +4010,7 @@ uv pip sync [OPTIONS] <SRC_FILE>...
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -4295,6 +4306,7 @@ uv pip install [OPTIONS] <PACKAGE|--requirement <REQUIREMENT>|--editable <EDITAB
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>
@@ -5258,6 +5270,7 @@ uv venv [OPTIONS] [NAME]
 
 <p>Defaults to <code>clone</code> (also known as Copy-on-Write) on macOS, and <code>hardlink</code> on Linux and Windows.</p>
 
+<p>[default: clone]</p>
 <p>Possible values:</p>
 
 <ul>


### PR DESCRIPTION
## Summary

Part of #6173 .

## Test Plan
Inspect the help output for the following commands.

`cargo run pip install --help`
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3272ca28-ba07-4760-a33c-cc304b112050">

`cargo run pip sync --help`
<img width="1504" alt="image" src="https://github.com/user-attachments/assets/ababcc9e-424e-459f-8855-ae10948a1b92">

`cargo run pip venv --help`
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/65042a5b-aaba-4584-9ff4-db9959fe6436">
