### PR TITLE
Upstream konstin/pep508_rs#17

### DIFF
--- a/crates/pep508-rs/src/verbatim_url.rs
+++ b/crates/pep508-rs/src/verbatim_url.rs
@@ -1,6 +1,8 @@
 use regex::Regex;
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::fmt::Debug;
+use std::hash::Hash;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
@@ -12,16 +14,24 @@ use uv_fs::{normalize_absolute_path, normalize_url_path, Simplified};
 use crate::Pep508Url;
 
 /// A wrapper around [`Url`] that preserves the original string.
-#[derive(Debug, Clone, Eq, derivative::Derivative)]
-#[derivative(PartialEq, Hash, Ord)]
+#[derive(Debug, Clone, Eq)]
 pub struct VerbatimUrl {
     /// The parsed URL.
     url: Url,
     /// The URL as it was provided by the user.
-    #[derivative(PartialEq = "ignore")]
-    #[derivative(Ord = "ignore")]
-    #[derivative(Hash = "ignore")]
     given: Option<String>,
+}
+
+impl Hash for VerbatimUrl {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.url.hash(state);
+    }
+}
+
+impl PartialEq for VerbatimUrl {
+    fn eq(&self, other: &Self) -> bool {
+        self.url == other.url
+    }
 }
 
 impl VerbatimUrl {
@@ -167,12 +177,14 @@ impl VerbatimUrl {
     }
 }
 
-// This impl is written out because the `derive` doesn't seem to get it right.
-// Or does it in a way where Clippy complains about non-canonical `PartialOrd`
-// impls. So we just do it by hand by deferring to the derived `Ord` impl. This
-// guarantees they are consistent.
+impl Ord for VerbatimUrl {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.url.cmp(&other.url)
+    }
+}
+
 impl PartialOrd for VerbatimUrl {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }


### PR DESCRIPTION
Upstream https://github.com/konstin/pep508_rs/pull/17

> This removes the `derivative` dependency which [seems to be unmaintained](https://github.com/mcarton/rust-derivative/issues/117) and depends on old versions of some crates, especially `syn`.
>
> I could also replace it with another crate like `educe` or `derive-where` but the implementation seems simple enough.
