### PR TITLE
cargo: remove unused 'derivative' dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2466,7 +2466,6 @@ name = "pep508_rs"
 version = "0.6.0"
 dependencies = [
  "boxcar",
- "derivative",
  "indexmap",
  "insta",
  "itertools 0.13.0",

--- a/crates/pep508-rs/Cargo.toml
+++ b/crates/pep508-rs/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 
 [dependencies]
 boxcar = { workspace = true }
-derivative = { workspace = true }
 itertools = { workspace = true }
 indexmap = { workspace = true }
 pubgrub = { workspace = true }


### PR DESCRIPTION
This seems to be failing the `cargo shear` check on `main`. It looks
like this was caused by #6200.
