### PR TITLE
Install `ca-certificates` in docker and use pipefail

### DIFF
--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -22,8 +22,8 @@ Or with the standalone installer:
 
 ```dockerfile title="Dockerfile"
 FROM python:3.12-slim-bullseye
-RUN apt-get update && apt-get install -y curl --no-install-recommends
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN apt-get update && apt-get install -y curl
+RUN curl -LsSf https://astral.sh/uv/install.sh > /tmp/uv-installer.sh && sh /tmp/uv-installer.sh && rm /tmp/uv-installer.sh
 ENV PATH="/root/.cargo/bin/:$PATH"
 ```
 

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -22,7 +22,7 @@ Or with the standalone installer:
 
 ```dockerfile title="Dockerfile"
 FROM python:3.12-slim-bullseye
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
 RUN curl -LsSf https://astral.sh/uv/install.sh > /tmp/uv-installer.sh && sh /tmp/uv-installer.sh && rm /tmp/uv-installer.sh
 ENV PATH="/root/.cargo/bin/:$PATH"
 ```


### PR DESCRIPTION
A dockerfile using `ubuntu` instead of `python` as base image currently silently fails to install.

```dockerfile
FROM ubuntu
RUN apt-get update && apt-get install -y curl --no-install-recommends
RUN curl -LsSf https://astral.sh/uv/install.sh | sh
RUN uv --version
```

```console
$ docker buildx build --progress plain --no-cache .
[...]
#6 [3/4] RUN curl -LsSf https://astral.sh/uv/install.sh | sh
#6 0.144 curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt
#6 DONE 0.2s

#7 [4/4] RUN uv --version
#7 0.113 /bin/sh: 1: uv: not found
#7 ERROR: process "/bin/sh -c uv --version" did not complete successfully: exit code: 127
```

There's two underlying problems: Pipefail, and missing `ca-certificates`.

In most shells, the source of a pipe erroring doesn't fail the entire command, so `curl -LsSf https://astral.sh/uv/install.sh | sh` passes even if the curl part fails. In bash, you can prefix the command with `set -o pipefail &&` to change this behavior. But in the `ubuntu` docker container, dash is the default shell, not bash. dash doesn't have a pipefail option (in the version in ubuntu), so the [best practice](https://docs.docker.com/build/building/best-practices/#using-pipes) is `RUN ["/bin/bash", "-c", "set -o pipefail && curl -LsSf https://astral.sh/uv/install.sh | sh"]`. That's not very readable, so i'm going for `RUN curl -LsSf https://astral.sh/uv/install.sh > /tmp/uv-installer.sh && sh /tmp/uv-installer.sh && rm /tmp/uv-installer.sh` instead.

```dockerfile
FROM ubuntu
RUN apt-get update && apt-get install -y curl --no-install-recommends
RUN curl -LsSf https://astral.sh/uv/install.sh > /tmp/uv-installer.sh && sh /tmp/uv-installer.sh && rm /tmp/uv-installer.sh \
RUN uv --version
```

```console
$ docker buildx build --progress plain --no-cache .
[...]
#6 [3/3] RUN curl -LsSf https://astral.sh/uv/install.sh > /tmp/uv-installer.sh && sh /tmp/uv-installer.sh && rm /tmp/uv-installer.sh RUN uv --version
#6 0.179 curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt
#6 ERROR: process "/bin/sh -c curl -LsSf https://astral.sh/uv/install.sh > /tmp/uv-installer.sh && sh /tmp/uv-installer.sh && rm /tmp/uv-installer.sh RUN uv --version" did not complete successfully: exit code: 77
```

The source for this error is `ca-certificates` missing, which is a recommended package. We need to drop `--no-install-recommends` and the installation passes again.