### PR TITLE
Increase the size of nav entries

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -136,7 +136,7 @@ See https://github.com/astral-sh/uv/issues/5130 */
 }
 /* Retain larger spacing for each top-level section in the nav */
 .md-nav__item--nested {
-  margin-top: 0.6em;
+  margin-top: 1em;
 }
 /* Retain larger spacing for the right-side table-of-contents nav */
 .md-nav--secondary .md-nav__link {
@@ -149,18 +149,19 @@ See https://github.com/astral-sh/uv/issues/5130 */
 
 /* Increase the size of the sections headings, remove the bold */
 .md-nav__container > .md-nav__link:first-child {
-  font-size: 16px;
+  font-size: 17.5px;
   font-weight: normal;
   margin-bottom: 0.1em;
 }
+
 /* Increase the size of the index nav item to match the sections */
-.md-nav_link:first-child {
-  font-size: 16px;
+.md-nav__item:first-child {
+  font-size: 17.5px;
   font-weight: normal;
 }
 /* But do not increase the size of other nav items */
 .md-nav__item--section > .md-nav > .md-nav__list > .md-nav__item {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: normal;
 }
 


### PR DESCRIPTION
It's a common complaint that these are two small. I'm a bit on the fence here, but we can make them bigger.

Before
<img width="1324" alt="Screenshot 2024-08-19 at 4 30 30 PM" src="https://github.com/user-attachments/assets/a874b67a-cbd3-4e5c-a3f6-10a259f6b7dc">
After
<img width="1324" alt="Screenshot 2024-08-19 at 4 30 24 PM" src="https://github.com/user-attachments/assets/9f1f3559-07a1-4926-b6ab-fa3acc44045c">

Before
<img width="602" alt="Screenshot 2024-08-19 at 4 30 59 PM" src="https://github.com/user-attachments/assets/b9727b3a-cb33-41a5-8880-02b0c36025a2">
After
<img width="602" alt="Screenshot 2024-08-19 at 4 31 24 PM" src="https://github.com/user-attachments/assets/edc2e66b-1e19-45fa-b658-1d0dc8b849bd">
