### PR TITLE
docs(integration): show pinned version example on GH Actions

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -2,46 +2,66 @@
 
 ## Installation
 
-uv installation differs depending on the platform.
+uv installation differs depending on the platform:
 
-### Unix
+=== "Unix"
 
-```yaml title="example.yml"
-name: Example on Unix
+    ```yaml title="example.yml"
+    name: Example on Unix
 
-jobs:
-  uv-example-linux:
-    name: python-linux
-    runs-on: ubuntu-latest
+    jobs:
+      uv-example-linux:
+        name: python-linux
+        runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+        steps:
+          - uses: actions/checkout@v4
 
-      - name: Set up uv
-        # Install uv using the standalone installer
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-```
+          - name: Set up uv
+            # Install latest uv version using the installer
+            run: curl -LsSf https://astral.sh/uv/install.sh | sh
+    ```
 
-### Windows
+=== "macOS"
 
-```yaml title="example.yml"
-name: Example on Windows
+    ```yaml title="example.yml"
+    name: Example on macOS
 
-jobs:
-  uv-example-windows:
-    name: python-windows
-    runs-on: windows-latest
+    jobs:
+      uv-example-macos:
+        name: python-macos
+        runs-on: macos-latest
 
-    steps:
-      - uses: actions/checkout@v4
+        steps:
+          - uses: actions/checkout@v4
 
-      - name: Set up uv
-        # Install uv using the standalone installer
-        run: irm https://astral.sh/uv/install.ps1 | iex
-        shell: powershell
-```
+          - name: Set up uv
+            # Install latest uv version using the installer
+            run: curl -LsSf https://astral.sh/uv/install.sh | sh
+    ```
+
+=== "Windows"
+
+    ```yaml title="example.yml"
+    name: Example on Windows
+
+    jobs:
+      uv-example-windows:
+        name: python-windows
+        runs-on: windows-latest
+
+        steps:
+          - uses: actions/checkout@v4
+
+          - name: Set up uv
+            # Install latest uv version using the installer
+            run: irm https://astral.sh/uv/install.ps1 | iex
+            shell: powershell
+    ```
 
 ### Using a matrix
+
+If you need to support multiple platforms, you can use a matrix:
 
 ```yaml title="example.yml"
 name: Example

--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -59,6 +59,63 @@ uv installation differs depending on the platform:
             shell: powershell
     ```
 
+It is considered best practice to pin to a specific uv version, e.g., with:
+
+=== "Unix"
+
+    ```yaml title="example.yml"
+    name: Example on Unix
+
+    jobs:
+      uv-example-linux:
+        name: python-linux
+        runs-on: ubuntu-latest
+
+        steps:
+          - uses: actions/checkout@v4
+
+          - name: Set up uv
+            # Install a specific uv version using the installer
+            run: curl -LsSf https://astral.sh/uv/0.2.37/install.sh | sh
+    ```
+
+=== "macOS"
+
+    ```yaml title="example.yml"
+    name: Example on macOS
+
+    jobs:
+      uv-example-macos:
+        name: python-macos
+        runs-on: macos-latest
+
+        steps:
+          - uses: actions/checkout@v4
+
+          - name: Set up uv
+            # Install a specific uv version using the installer
+            run: curl -LsSf https://astral.sh/uv/0.2.37/install.sh | sh
+    ```
+
+=== "Windows"
+
+    ```yaml title="example.yml"
+    name: Example on Windows
+
+    jobs:
+      uv-example-windows:
+        name: python-windows
+        runs-on: windows-latest
+
+        steps:
+          - uses: actions/checkout@v4
+
+          - name: Set up uv
+            # Install a specific uv version using the installer
+            run: irm https://astral.sh/uv/0.2.37/install.ps1 | iex
+            shell: powershell
+    ```
+
 ### Using a matrix
 
 If you need to support multiple platforms, you can use a matrix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ version_files = [
   "crates/uv/Cargo.toml",
   "crates/uv-version/Cargo.toml",
   "docs/guides/integration/pre-commit.md",
+  "docs/guides/integration/github.md",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary

Suggestion from https://github.com/astral-sh/uv/pull/6216#discussion_r1722204667.

I did not think of a clean way to avoid repetition, so tried to use tabs for the platforms to only show the pin recommendation in one additional block.

![Screenshot from 2024-08-19 23-54-36](https://github.com/user-attachments/assets/8a870c68-da60-460a-8bda-4afb72d16b86)

## Test Plan

Local run of the documentation.