### PR TITLE
Attempt to fix nav in production documentation

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -148,12 +148,13 @@ See https://github.com/astral-sh/uv/issues/5130 */
 }
 
 /* Increase the size of the sections headings, remove the bold */
-.md-nav__item--section>.md-nav__link {
+.md-nav__container > .md-nav__link:first-child {
   font-size: 16px;
   font-weight: normal;
+  margin-bottom: 0.1em;
 }
 /* Increase the size of the index nav item to match the sections */
-.md-nav__item:first-child {
+.md-nav_link:first-child {
   font-size: 16px;
   font-weight: normal;
 }


### PR DESCRIPTION
My deployment to production does not properly render the nav, as it does locally, e.g.:

<img width="602" alt="Screenshot 2024-08-19 at 6 58 45 PM" src="https://github.com/user-attachments/assets/32c93ad5-5a36-4843-a835-41431de962dc">
