### PR TITLE
Rename `environment-markers` to `resolution-markers`

### DIFF
--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -493,7 +493,7 @@ impl Lock {
                     .filter_map(MarkerTree::contents)
                     .map(|marker| marker.to_string()),
             );
-            doc.insert("environment-markers", value(fork_markers));
+            doc.insert("resolution-markers", value(fork_markers));
         }
 
         // Write the settings that were used to generate the resolution.
@@ -949,7 +949,7 @@ struct LockWire {
     requires_python: Option<RequiresPython>,
     /// If this lockfile was built from a forking resolution with non-identical forks, store the
     /// forks in the lockfile so we can recreate them in subsequent resolutions.
-    #[serde(rename = "environment-markers", default)]
+    #[serde(rename = "resolution-markers", default)]
     fork_markers: Vec<MarkerTree>,
     /// We discard the lockfile if these options match.
     #[serde(default)]
@@ -1019,7 +1019,7 @@ pub struct Package {
     /// the fork(s) that contained this version or source, so we can set the correct preferences in
     /// the next resolution.
     ///
-    /// Named `environment-markers` in `uv.lock`.
+    /// Named `resolution-markers` in `uv.lock`.
     fork_markers: Vec<MarkerTree>,
     /// The resolved dependencies of the package.
     dependencies: Vec<Dependency>,
@@ -1326,7 +1326,7 @@ impl Package {
                     .filter_map(MarkerTree::contents)
                     .map(|marker| marker.to_string()),
             );
-            table.insert("environment-markers", value(wheels));
+            table.insert("resolution-markers", value(wheels));
         }
 
         if !self.dependencies.is_empty() {
@@ -1536,7 +1536,7 @@ struct PackageWire {
     sdist: Option<SourceDist>,
     #[serde(default)]
     wheels: Vec<Wheel>,
-    #[serde(default, rename = "environment-markers")]
+    #[serde(default, rename = "resolution-markers")]
     fork_markers: Vec<MarkerTree>,
     #[serde(default)]
     dependencies: Vec<DependencyWire>,

--- a/crates/uv/tests/branching_urls.rs
+++ b/crates/uv/tests/branching_urls.rs
@@ -208,7 +208,7 @@ fn root_package_splits_transitive_too() -> Result<()> {
     assert_snapshot!(fs_err::read_to_string(context.temp_dir.join("uv.lock"))?, @r###"
     version = 1
     requires-python = ">=3.11, <3.13"
-    environment-markers = [
+    resolution-markers = [
         "python_full_version < '3.12'",
         "python_full_version >= '3.12'",
     ]
@@ -237,7 +237,7 @@ fn root_package_splits_transitive_too() -> Result<()> {
     name = "anyio"
     version = "4.2.0"
     source = { registry = "https://pypi.org/simple" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version < '3.12'",
     ]
     dependencies = [
@@ -253,7 +253,7 @@ fn root_package_splits_transitive_too() -> Result<()> {
     name = "anyio"
     version = "4.3.0"
     source = { registry = "https://pypi.org/simple" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version >= '3.12'",
     ]
     dependencies = [
@@ -315,7 +315,7 @@ fn root_package_splits_transitive_too() -> Result<()> {
     name = "iniconfig"
     version = "1.1.1"
     source = { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version < '3.12'",
     ]
     wheels = [
@@ -326,7 +326,7 @@ fn root_package_splits_transitive_too() -> Result<()> {
     name = "iniconfig"
     version = "2.0.0"
     source = { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version >= '3.12'",
     ]
     wheels = [
@@ -403,7 +403,7 @@ fn root_package_splits_other_dependencies_too() -> Result<()> {
     assert_snapshot!(fs_err::read_to_string(context.temp_dir.join("uv.lock"))?, @r###"
     version = 1
     requires-python = ">=3.11, <3.13"
-    environment-markers = [
+    resolution-markers = [
         "python_full_version < '3.12'",
         "python_full_version >= '3.12'",
     ]
@@ -434,7 +434,7 @@ fn root_package_splits_other_dependencies_too() -> Result<()> {
     name = "anyio"
     version = "4.2.0"
     source = { registry = "https://pypi.org/simple" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version < '3.12'",
     ]
     dependencies = [
@@ -450,7 +450,7 @@ fn root_package_splits_other_dependencies_too() -> Result<()> {
     name = "anyio"
     version = "4.3.0"
     source = { registry = "https://pypi.org/simple" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version >= '3.12'",
     ]
     dependencies = [
@@ -497,7 +497,7 @@ fn root_package_splits_other_dependencies_too() -> Result<()> {
     name = "iniconfig"
     version = "1.1.1"
     source = { registry = "https://pypi.org/simple" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version < '3.12'",
     ]
     sdist = { url = "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32", size = 8104 }
@@ -509,7 +509,7 @@ fn root_package_splits_other_dependencies_too() -> Result<()> {
     name = "iniconfig"
     version = "2.0.0"
     source = { registry = "https://pypi.org/simple" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version >= '3.12'",
     ]
     sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
@@ -564,7 +564,7 @@ fn branching_between_registry_and_direct_url() -> Result<()> {
     assert_snapshot!(fs_err::read_to_string(context.temp_dir.join("uv.lock"))?, @r###"
     version = 1
     requires-python = ">=3.11, <3.13"
-    environment-markers = [
+    resolution-markers = [
         "python_full_version < '3.12'",
         "python_full_version >= '3.12'",
     ]
@@ -591,7 +591,7 @@ fn branching_between_registry_and_direct_url() -> Result<()> {
     name = "iniconfig"
     version = "1.1.1"
     source = { registry = "https://pypi.org/simple" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version < '3.12'",
     ]
     sdist = { url = "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32", size = 8104 }
@@ -603,7 +603,7 @@ fn branching_between_registry_and_direct_url() -> Result<()> {
     name = "iniconfig"
     version = "2.0.0"
     source = { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version >= '3.12'",
     ]
     wheels = [
@@ -649,7 +649,7 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     assert_snapshot!(fs_err::read_to_string(context.temp_dir.join("uv.lock"))?, @r###"
     version = 1
     requires-python = ">=3.11, <3.13"
-    environment-markers = [
+    resolution-markers = [
         "python_full_version < '3.12'",
         "python_full_version >= '3.12'",
     ]
@@ -676,7 +676,7 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     name = "iniconfig"
     version = "1.1.1"
     source = { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version < '3.12'",
     ]
     wheels = [
@@ -687,7 +687,7 @@ fn branching_urls_of_different_sources_disjoint() -> Result<()> {
     name = "iniconfig"
     version = "2.0.0"
     source = { git = "https://github.com/pytest-dev/iniconfig?rev=93f5930e668c0d1ddf4597e38dd0dea4e2665e7a#93f5930e668c0d1ddf4597e38dd0dea4e2665e7a" }
-    environment-markers = [
+    resolution-markers = [
         "python_full_version >= '3.12'",
     ]
     "###);

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -1610,7 +1610,7 @@ fn lock_conditional_dependency_extra() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.7"
-        environment-markers = [
+        resolution-markers = [
             "python_full_version < '3.10'",
             "python_full_version >= '3.10'",
         ]
@@ -2251,7 +2251,7 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform != 'win32'",
             "sys_platform == 'win32'",
         ]
@@ -2263,7 +2263,7 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
         name = "markupsafe"
         version = "1.1.1"
         source = { registry = "https://pypi.org/simple" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform != 'win32'",
         ]
         sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b", size = 19151 }
@@ -2272,7 +2272,7 @@ fn lock_upgrade_log_multi_version() -> Result<()> {
         name = "markupsafe"
         version = "2.0.0"
         source = { registry = "https://pypi.org/simple" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'win32'",
         ]
         sdist = { url = "https://files.pythonhosted.org/packages/67/6a/5b3ed5c122e20c33d2562df06faf895a6b91b0a6b96a4626440ffe1d5c8e/MarkupSafe-2.0.0.tar.gz", hash = "sha256:4fae0677f712ee090721d8b17f412f1cbceefbf0dc180fe91bab3232f38b4527", size = 18466 }
@@ -3710,7 +3710,7 @@ fn lock_python_version_marker_complement() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "python_full_version < '3.10'",
             "python_full_version == '3.10'",
             "python_full_version > '3.10' and python_full_version < '3.11'",
@@ -5041,7 +5041,7 @@ fn lock_same_version_multiple_urls() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
             "sys_platform != 'darwin'",
         ]
@@ -5053,7 +5053,7 @@ fn lock_same_version_multiple_urls() -> Result<()> {
         name = "anyio"
         version = "3.0.0"
         source = { registry = "https://pypi.org/simple" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform != 'darwin'",
         ]
         dependencies = [
@@ -5069,7 +5069,7 @@ fn lock_same_version_multiple_urls() -> Result<()> {
         name = "anyio"
         version = "3.7.0"
         source = { registry = "https://pypi.org/simple" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
         ]
         dependencies = [
@@ -5085,7 +5085,7 @@ fn lock_same_version_multiple_urls() -> Result<()> {
         name = "dependency"
         version = "0.0.1"
         source = { directory = "[TEMP_DIR]/v1" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
         ]
         dependencies = [
@@ -5099,7 +5099,7 @@ fn lock_same_version_multiple_urls() -> Result<()> {
         name = "dependency"
         version = "0.0.1"
         source = { directory = "[TEMP_DIR]/v2" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform != 'darwin'",
         ]
         dependencies = [
@@ -6440,7 +6440,7 @@ fn lock_upgrade_drop_fork_markers() -> Result<()> {
         .assert()
         .success();
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
-    assert!(lock.contains("environment-markers"));
+    assert!(lock.contains("resolution-markers"));
 
     // Remove the bound and lock with `--upgrade`.
     pyproject_toml.write_str(&requirements.replace("fork-upgrade-foo==1", "fork-upgrade-foo"))?;
@@ -6453,7 +6453,7 @@ fn lock_upgrade_drop_fork_markers() -> Result<()> {
         .assert()
         .success();
     let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
-    assert!(!lock.contains("environment-markers"));
+    assert!(!lock.contains("resolution-markers"));
     Ok(())
 }
 
@@ -9744,7 +9744,7 @@ fn lock_narrowed_python_version() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.7"
-        environment-markers = [
+        resolution-markers = [
             "python_full_version < '3.9'",
             "python_full_version >= '3.9' and python_full_version < '3.11'",
             "python_full_version >= '3.11'",
@@ -9849,7 +9849,7 @@ fn lock_exclude_unnecessary_python_forks() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.12"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
             "sys_platform != 'darwin'",
         ]

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -86,7 +86,7 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
             "sys_platform == 'linux'",
             "sys_platform != 'darwin' and sys_platform != 'linux'",
@@ -304,7 +304,7 @@ fn fork_basic() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
             "sys_platform == 'linux'",
             "sys_platform != 'darwin' and sys_platform != 'linux'",
@@ -314,7 +314,7 @@ fn fork_basic() -> Result<()> {
         name = "package-a"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_basic_a-1.0.0.tar.gz", hash = "sha256:9bd6d9d74d8928854f79ea3ed4cd0d8a4906eeaa40f5f3d63460a1c2d5f6d773" }
@@ -326,7 +326,7 @@ fn fork_basic() -> Result<()> {
         name = "package-a"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_basic_a-2.0.0.tar.gz", hash = "sha256:c0ce6dfb6d712eb42a4bbe9402a1f823627b9d3773f31d259c49478fc7d8d082" }
@@ -592,7 +592,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
             "sys_platform == 'darwin'",
             "sys_platform != 'darwin' and sys_platform != 'linux'",
@@ -602,7 +602,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         name = "package-a"
         version = "4.3.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_filter_sibling_dependencies_a-4.3.0.tar.gz", hash = "sha256:5389f0927f61393ba8bd940622329299d769e79b725233604a6bdac0fd088c49" }
@@ -614,7 +614,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         name = "package-a"
         version = "4.4.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_filter_sibling_dependencies_a-4.4.0.tar.gz", hash = "sha256:7dbb8575aec8f87063954917b6ee628191cd53ca233ec810f6d926b4954e578b" }
@@ -650,7 +650,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         name = "package-d"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_filter_sibling_dependencies_d-1.0.0.tar.gz", hash = "sha256:cc1af60e53faf957fd0542349441ea79a909cd5feb30fb8933c39dc33404e4b2" }
@@ -662,7 +662,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         name = "package-d"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_filter_sibling_dependencies_d-2.0.0.tar.gz", hash = "sha256:68e380efdea5206363f5397e4cd560a64f5f4927396dc0b6f6f36dd3f026281f" }
@@ -892,7 +892,7 @@ fn fork_incomplete_markers() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "python_full_version < '3.10'",
             "python_full_version == '3.10.*'",
             "python_full_version >= '3.11'",
@@ -902,7 +902,7 @@ fn fork_incomplete_markers() -> Result<()> {
         name = "package-a"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "python_full_version < '3.10'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_incomplete_markers_a-1.0.0.tar.gz", hash = "sha256:dd56de2e560b3f95c529c44cbdae55d9b1ada826ddd3e19d3ea45438224ad603" }
@@ -914,7 +914,7 @@ fn fork_incomplete_markers() -> Result<()> {
         name = "package-a"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "python_full_version >= '3.11'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_incomplete_markers_a-2.0.0.tar.gz", hash = "sha256:580f1454a172036c89f5cfbefe52f175b011806a61f243eb476526bcc186e0be" }
@@ -1251,7 +1251,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
             "implementation_name == 'cpython' and sys_platform == 'darwin'",
             "implementation_name != 'cpython' and implementation_name != 'pypy' and sys_platform == 'darwin'",
@@ -1263,7 +1263,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         name = "package-a"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
             "implementation_name == 'cpython' and sys_platform == 'darwin'",
             "implementation_name != 'cpython' and implementation_name != 'pypy' and sys_platform == 'darwin'",
@@ -1281,7 +1281,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         name = "package-a"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_combined_allowed_a-2.0.0.tar.gz", hash = "sha256:0dcb58c8276afbe439e1c94708fb71954fb8869cc65c230ce8f462c911992ceb" }
@@ -1293,7 +1293,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         name = "package-b"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
         ]
         dependencies = [
@@ -1308,7 +1308,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         name = "package-b"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'cpython' and sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_combined_allowed_b-2.0.0.tar.gz", hash = "sha256:4533845ba671575a25ceb32f10f0bc6836949bef37b7da6e7dd37d9be389871c" }
@@ -1432,7 +1432,7 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
             "implementation_name == 'cpython' and sys_platform == 'darwin'",
             "implementation_name != 'cpython' and implementation_name != 'pypy' and sys_platform == 'darwin'",
@@ -1444,7 +1444,7 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         name = "package-a"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
             "implementation_name == 'cpython' and sys_platform == 'darwin'",
             "implementation_name != 'cpython' and implementation_name != 'pypy' and sys_platform == 'darwin'",
@@ -1462,7 +1462,7 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         name = "package-a"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_combined_disallowed_a-2.0.0.tar.gz", hash = "sha256:9d48383b0699f575af15871f6f7a928b835cd5ad4e13f91a675ee5aba722dabc" }
@@ -1474,7 +1474,7 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         name = "package-b"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_combined_disallowed_b-1.0.0.tar.gz", hash = "sha256:d44b87bd8d39240bca55eaae84a245e74197ed0b7897c27af9f168c713cc63bd" }
@@ -1486,7 +1486,7 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         name = "package-b"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'cpython' and sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_combined_disallowed_b-2.0.0.tar.gz", hash = "sha256:75a48bf2d44a0a0be6ca33820f5076665765be7b43dabf5f94f7fd5247071097" }
@@ -1602,7 +1602,7 @@ fn fork_marker_inherit_combined() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
             "implementation_name == 'cpython' and sys_platform == 'darwin'",
             "implementation_name != 'cpython' and implementation_name != 'pypy' and sys_platform == 'darwin'",
@@ -1614,7 +1614,7 @@ fn fork_marker_inherit_combined() -> Result<()> {
         name = "package-a"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
             "implementation_name == 'cpython' and sys_platform == 'darwin'",
             "implementation_name != 'cpython' and implementation_name != 'pypy' and sys_platform == 'darwin'",
@@ -1632,7 +1632,7 @@ fn fork_marker_inherit_combined() -> Result<()> {
         name = "package-a"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_combined_a-2.0.0.tar.gz", hash = "sha256:47958d1659220ee7722b0f26e8c1fe41217a2816881ffa929f0ba794a87ceebf" }
@@ -1644,7 +1644,7 @@ fn fork_marker_inherit_combined() -> Result<()> {
         name = "package-b"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'pypy' and sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_combined_b-1.0.0.tar.gz", hash = "sha256:6992d194cb5a0f0eed9ed6617d3212af4e3ff09274bf7622c8a1008b072128da" }
@@ -1656,7 +1656,7 @@ fn fork_marker_inherit_combined() -> Result<()> {
         name = "package-b"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "implementation_name == 'cpython' and sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_combined_b-2.0.0.tar.gz", hash = "sha256:e340061505d621a340d10ec1dbaf02dfce0c66358ee8190f61f78018f9999989" }
@@ -1765,7 +1765,7 @@ fn fork_marker_inherit_isolated() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
             "sys_platform == 'linux'",
             "sys_platform != 'darwin' and sys_platform != 'linux'",
@@ -1775,7 +1775,7 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         name = "package-a"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_isolated_a-1.0.0.tar.gz", hash = "sha256:724ffc24debfa2bc6b5c2457df777c523638ec3586cc953f8509dad581aa6887" }
@@ -1787,7 +1787,7 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         name = "package-a"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         dependencies = [
@@ -1914,7 +1914,7 @@ fn fork_marker_inherit_transitive() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
             "sys_platform == 'linux'",
             "sys_platform != 'darwin' and sys_platform != 'linux'",
@@ -1924,7 +1924,7 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         name = "package-a"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
         ]
         dependencies = [
@@ -1939,7 +1939,7 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         name = "package-a"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_transitive_a-2.0.0.tar.gz", hash = "sha256:4437ac14c340fec0b451cbc9486f5b8e106568634264ecad339a8de565a93be6" }
@@ -2071,7 +2071,7 @@ fn fork_marker_inherit() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
             "sys_platform == 'linux'",
             "sys_platform != 'darwin' and sys_platform != 'linux'",
@@ -2081,7 +2081,7 @@ fn fork_marker_inherit() -> Result<()> {
         name = "package-a"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_a-1.0.0.tar.gz", hash = "sha256:177511ec69a2f04de39867d43f167a33194ae983e8f86a1cc9b51f59fc379d4b" }
@@ -2093,7 +2093,7 @@ fn fork_marker_inherit() -> Result<()> {
         name = "package-a"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_inherit_a-2.0.0.tar.gz", hash = "sha256:43e24ce6fcbfbbff1db5eb20b583c20c2aa0888138bfafeab205c4ccc6e7e0a4" }
@@ -2210,7 +2210,7 @@ fn fork_marker_limited_inherit() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
             "sys_platform == 'linux'",
             "sys_platform != 'darwin' and sys_platform != 'linux'",
@@ -2220,7 +2220,7 @@ fn fork_marker_limited_inherit() -> Result<()> {
         name = "package-a"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_limited_inherit_a-1.0.0.tar.gz", hash = "sha256:ab1fde8d0acb9a2fe99b7a005939962b1c26c6d876e4a55e81fb9d1a1e5e9f76" }
@@ -2232,7 +2232,7 @@ fn fork_marker_limited_inherit() -> Result<()> {
         name = "package-a"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_limited_inherit_a-2.0.0.tar.gz", hash = "sha256:009fdb8872cf52324c1bcdebef31feaba3c262fd76d150a753152aeee3d55b10" }
@@ -2366,7 +2366,7 @@ fn fork_marker_selection() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
             "sys_platform == 'linux'",
             "sys_platform != 'darwin' and sys_platform != 'linux'",
@@ -2385,7 +2385,7 @@ fn fork_marker_selection() -> Result<()> {
         name = "package-b"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_selection_b-1.0.0.tar.gz", hash = "sha256:6f5ea28cadb8b5dfa15d32c9e38818f8f7150fc4f9a58e49aec4e10b23342be4" }
@@ -2397,7 +2397,7 @@ fn fork_marker_selection() -> Result<()> {
         name = "package-b"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_selection_b-2.0.0.tar.gz", hash = "sha256:d32033ecdf37d605e4b3b3e88df6562bb7ca01c6ed3fb9a55ec078eccc1df9d1" }
@@ -2522,7 +2522,7 @@ fn fork_marker_track() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
             "sys_platform == 'linux'",
             "sys_platform != 'darwin' and sys_platform != 'linux'",
@@ -2544,7 +2544,7 @@ fn fork_marker_track() -> Result<()> {
         name = "package-b"
         version = "2.7"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'darwin'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_track_b-2.7.tar.gz", hash = "sha256:855bf45837a4ba669a5850b14b0253cb138925fdd2b06a2f15c6582b8fabb8a0" }
@@ -2556,7 +2556,7 @@ fn fork_marker_track() -> Result<()> {
         name = "package-b"
         version = "2.8"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_marker_track_b-2.8.tar.gz", hash = "sha256:2e14b0ff1fb7f5cf491bd31d876218adee1d6a208ff197dc30363cdf25262e80" }
@@ -2977,7 +2977,7 @@ fn fork_overlapping_markers_basic() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "python_full_version < '3.10'",
             "python_full_version == '3.10.*'",
             "python_full_version >= '3.11'",
@@ -3145,7 +3145,7 @@ fn preferences_dependent_forking_bistable() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
             "sys_platform != 'linux'",
         ]
@@ -3169,7 +3169,7 @@ fn preferences_dependent_forking_bistable() -> Result<()> {
         name = "package-fork-if-not-forked"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform != 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/preferences_dependent_forking_bistable_fork_if_not_forked-2.0.0.tar.gz", hash = "sha256:1f130c437449e7f0752938bff562addd287b6df96784122885e83563f7624798" }
@@ -3181,7 +3181,7 @@ fn preferences_dependent_forking_bistable() -> Result<()> {
         name = "package-fork-if-not-forked"
         version = "3.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/preferences_dependent_forking_bistable_fork_if_not_forked-3.0.0.tar.gz", hash = "sha256:72aee18148130c3287f2e07f31cd8883f1b35d91d6ef5230961e5fcc57667943" }
@@ -3205,7 +3205,7 @@ fn preferences_dependent_forking_bistable() -> Result<()> {
         name = "package-reject-cleaver1"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/preferences_dependent_forking_bistable_reject_cleaver1-1.0.0.tar.gz", hash = "sha256:bf19f244de469bb73c7fb9dc438bca2fac829d865e546327694b2f292192c042" }
@@ -3217,7 +3217,7 @@ fn preferences_dependent_forking_bistable() -> Result<()> {
         name = "package-reject-cleaver1"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform != 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/preferences_dependent_forking_bistable_reject_cleaver1-2.0.0.tar.gz", hash = "sha256:b671f6112e6829557bec5c1aa86e55e79a9883a28117025523a132ff24cd9be3" }
@@ -3525,7 +3525,7 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
             "sys_platform != 'linux'",
         ]
@@ -3534,7 +3534,7 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
         name = "package-bar"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform != 'linux'",
         ]
         dependencies = [
@@ -3550,7 +3550,7 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
         name = "package-bar"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/preferences_dependent_forking_tristable_bar-2.0.0.tar.gz", hash = "sha256:cc856e6aca342176e6ba518a298198258b7be3ee7a6b86319c1d8b731e54991e" }
@@ -3562,7 +3562,7 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
         name = "package-c"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/preferences_dependent_forking_tristable_c-2.0.0.tar.gz", hash = "sha256:f0d941b83146d72e05fde266be4a500400683e6c62ae86dab11af78c2d26587b" }
@@ -3574,7 +3574,7 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
         name = "package-c"
         version = "3.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform != 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/preferences_dependent_forking_tristable_c-3.0.0.tar.gz", hash = "sha256:3531c0ec88cc79cde8106e949c7062854bbd48e3bc60803246372cdc4f4c4864" }
@@ -3638,7 +3638,7 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
         name = "package-unrelated-dep2"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/preferences_dependent_forking_tristable_unrelated_dep2-1.0.0.tar.gz", hash = "sha256:bbeb0f558aff8c48bac6fdab42ed52f49d68d2b51a7de82ff9357925a6e5023a" }
@@ -3650,7 +3650,7 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
         name = "package-unrelated-dep2"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform != 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/preferences_dependent_forking_tristable_unrelated_dep2-2.0.0.tar.gz", hash = "sha256:ac23c6208b6340b2542e730e1df770ed4ca65f234de86d2216add6c2b975f95c" }
@@ -3809,7 +3809,7 @@ fn preferences_dependent_forking() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
             "sys_platform != 'linux'",
         ]
@@ -3818,7 +3818,7 @@ fn preferences_dependent_forking() -> Result<()> {
         name = "package-bar"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform != 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/preferences_dependent_forking_bar-1.0.0.tar.gz", hash = "sha256:7eef4e0c910b9e4cadf6c707e60a2151f7dc6407d815112ec93a467d76226f5e" }
@@ -3830,7 +3830,7 @@ fn preferences_dependent_forking() -> Result<()> {
         name = "package-bar"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'linux'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/preferences_dependent_forking_bar-2.0.0.tar.gz", hash = "sha256:f440dbb8c3b848be467c9d3cd4970963fae3144de12454fd48fe9077eb76e9ea" }
@@ -3984,7 +3984,7 @@ fn fork_remaining_universe_partitioning() -> Result<()> {
             lock, @r###"
         version = 1
         requires-python = ">=3.8"
-        environment-markers = [
+        resolution-markers = [
             "os_name == 'darwin' and sys_platform == 'illumos'",
             "os_name == 'linux' and sys_platform == 'illumos'",
             "os_name != 'darwin' and os_name != 'linux' and sys_platform == 'illumos'",
@@ -3996,7 +3996,7 @@ fn fork_remaining_universe_partitioning() -> Result<()> {
         name = "package-a"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "os_name == 'darwin' and sys_platform == 'illumos'",
             "os_name == 'linux' and sys_platform == 'illumos'",
             "os_name != 'darwin' and os_name != 'linux' and sys_platform == 'illumos'",
@@ -4014,7 +4014,7 @@ fn fork_remaining_universe_partitioning() -> Result<()> {
         name = "package-a"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "sys_platform == 'windows'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_remaining_universe_partitioning_a-2.0.0.tar.gz", hash = "sha256:c6166efba9da6cbe32221dd425873c9de605343db1cd8d732c4c1624635944b0" }
@@ -4026,7 +4026,7 @@ fn fork_remaining_universe_partitioning() -> Result<()> {
         name = "package-b"
         version = "1.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "os_name == 'darwin' and sys_platform == 'illumos'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_remaining_universe_partitioning_b-1.0.0.tar.gz", hash = "sha256:83755cf4f9d97909bc295a3fbb10006747c02b2344f3f017cff276fa7922b756" }
@@ -4038,7 +4038,7 @@ fn fork_remaining_universe_partitioning() -> Result<()> {
         name = "package-b"
         version = "2.0.0"
         source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }
-        environment-markers = [
+        resolution-markers = [
             "os_name == 'linux' and sys_platform == 'illumos'",
         ]
         sdist = { url = "https://astral-sh.github.io/packse/PACKSE_VERSION/files/fork_remaining_universe_partitioning_b-2.0.0.tar.gz", hash = "sha256:32cf6efcab24453f11a3bf2c230536b99a41e9611f5e96b2eee589c0d81f2348" }

--- a/crates/uv/tests/snapshots/ecosystem__black-lock-file.snap
+++ b/crates/uv/tests/snapshots/ecosystem__black-lock-file.snap
@@ -4,7 +4,7 @@ expression: lock
 ---
 version = 1
 requires-python = ">=3.8"
-environment-markers = [
+resolution-markers = [
     "implementation_name == 'pypy' and sys_platform == 'win32'",
     "implementation_name != 'pypy' or sys_platform != 'win32'",
 ]

--- a/crates/uv/tests/snapshots/ecosystem__github-wikidata-bot-lock-file.snap
+++ b/crates/uv/tests/snapshots/ecosystem__github-wikidata-bot-lock-file.snap
@@ -4,7 +4,7 @@ expression: lock
 ---
 version = 1
 requires-python = ">=3.12"
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.13'",
     "python_full_version >= '3.13'",
 ]

--- a/crates/uv/tests/snapshots/ecosystem__transformers-lock-file.snap
+++ b/crates/uv/tests/snapshots/ecosystem__transformers-lock-file.snap
@@ -4,7 +4,7 @@ expression: lock
 ---
 version = 1
 requires-python = ">=3.9.0"
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
@@ -774,7 +774,7 @@ wheels = [
 name = "datasets"
 version = "2.14.4"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
 ]
 dependencies = [
@@ -801,7 +801,7 @@ wheels = [
 name = "datasets"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -1087,7 +1087,7 @@ wheels = [
 name = "flatbuffers"
 version = "2.0.7"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -1109,7 +1109,7 @@ wheels = [
 name = "flatbuffers"
 version = "24.3.25"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version >= '3.13' and platform_system == 'Darwin'",
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
@@ -1213,7 +1213,7 @@ wheels = [
 name = "fsspec"
 version = "2024.5.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -1243,7 +1243,7 @@ http = [
 name = "fsspec"
 version = "2024.6.1"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/b6/eba5024a9889fcfff396db543a34bef0ab9d002278f163129f9f01005960/fsspec-2024.6.1.tar.gz", hash = "sha256:fad7d7e209dd4c1208e3bbfda706620e0da5142bebbd9c384afb95b07e798e49", size = 284584 }
@@ -1306,7 +1306,7 @@ wheels = [
 name = "gast"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -1328,7 +1328,7 @@ wheels = [
 name = "gast"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version >= '3.13' and platform_system == 'Darwin'",
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
@@ -1824,7 +1824,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/97/76/6a7479e3546d34ee4
 name = "keras"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -1845,7 +1845,7 @@ wheels = [
 name = "keras"
 version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version >= '3.13' and platform_system == 'Darwin'",
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
@@ -2179,7 +2179,7 @@ wheels = [
 name = "ml-dtypes"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version >= '3.13' and platform_system == 'Darwin'",
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
@@ -2212,7 +2212,7 @@ wheels = [
 name = "ml-dtypes"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -4523,7 +4523,7 @@ wheels = [
 name = "tensorboard"
 version = "2.15.2"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version >= '3.13' and platform_system == 'Darwin'",
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
@@ -4551,7 +4551,7 @@ wheels = [
 name = "tensorboard"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -4607,7 +4607,7 @@ wheels = [
 name = "tensorflow"
 version = "2.7.2"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -4653,7 +4653,7 @@ wheels = [
 name = "tensorflow"
 version = "2.15.1"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version >= '3.13' and platform_system == 'Darwin'",
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
@@ -4705,7 +4705,7 @@ wheels = [
 name = "tensorflow-cpu"
 version = "2.7.2"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -4751,7 +4751,7 @@ wheels = [
 name = "tensorflow-cpu"
 version = "2.15.1"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version >= '3.13' and platform_system == 'Darwin'",
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
@@ -4831,7 +4831,7 @@ wheels = [
 name = "tensorflow-estimator"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -4852,7 +4852,7 @@ wheels = [
 name = "tensorflow-estimator"
 version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version >= '3.13' and platform_system == 'Darwin'",
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
@@ -4951,7 +4951,7 @@ wheels = [
 name = "tensorflow-text"
 version = "2.7.3"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -4978,7 +4978,7 @@ wheels = [
 name = "tensorflow-text"
 version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version >= '3.13' and platform_system == 'Darwin'",
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
@@ -5053,7 +5053,7 @@ wheels = [
 name = "tf-keras"
 version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
@@ -5075,7 +5075,7 @@ wheels = [
 name = "tf-keras"
 version = "2.15.1"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version >= '3.13' and platform_system == 'Darwin'",
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and platform_system == 'Linux'",
@@ -5093,7 +5093,7 @@ wheels = [
 name = "tf2onnx"
 version = "1.8.4"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system == 'Linux'",
     "python_full_version == '3.10.*' and platform_system == 'Darwin'",
     "python_full_version == '3.10.*' and platform_machine == 'aarch64' and platform_system == 'Linux'",
@@ -5124,7 +5124,7 @@ wheels = [
 name = "tf2onnx"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10' and platform_machine == 'arm64' and platform_system == 'Darwin'",
     "(python_full_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (python_full_version < '3.10' and platform_machine == 'aarch64' and platform_system != 'Linux') or (python_full_version < '3.10' and platform_machine == 'arm64' and platform_system != 'Darwin')",
 ]

--- a/crates/uv/tests/snapshots/ecosystem__warehouse-lock-file.snap
+++ b/crates/uv/tests/snapshots/ecosystem__warehouse-lock-file.snap
@@ -4,7 +4,7 @@ expression: lock
 ---
 version = 1
 requires-python = "==3.11.*"
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.12'",
     "python_full_version < '3.13'",
     "python_full_version >= '3.13' and python_full_version < '4'",

--- a/crates/uv/tests/snapshots/workflow__jax_instability-2.snap
+++ b/crates/uv/tests/snapshots/workflow__jax_instability-2.snap
@@ -4,7 +4,7 @@ expression: lock
 ---
 version = 1
 requires-python = ">=3.9.0"
-environment-markers = [
+resolution-markers = [
     "python_full_version < '3.10'",
     "python_full_version == '3.10.*'",
     "python_full_version == '3.11.*'",


### PR DESCRIPTION
## Summary

I probably won't land https://github.com/astral-sh/uv/pull/6210 for the release, but I do want to make one breaking change to prep for it: renaming `environment-markers` to `resolution-markers` (or `solution-markers`?) so that it's delineated from the user-defined markers in that PR.
