### PR TITLE
Add 32-bit Windows target

### DIFF
--- a/crates/uv-configuration/src/target_triple.rs
+++ b/crates/uv-configuration/src/target_triple.rs
@@ -21,10 +21,15 @@ pub enum TargetTriple {
     /// An alias for `aarch64-apple-darwin`, the default target for macOS.
     Macos,
 
-    /// An x86 Windows target.
+    /// A 64-bit x86 Windows target.
     #[cfg_attr(feature = "clap", value(name = "x86_64-pc-windows-msvc"))]
     #[cfg_attr(feature = "schemars", schemars(rename = "x86_64-pc-windows-msvc"))]
     X8664PcWindowsMsvc,
+
+    /// A 32-bit x86 Windows target.
+    #[cfg_attr(feature = "clap", value(name = "i686-pc-windows-msvc"))]
+    #[cfg_attr(feature = "schemars", schemars(rename = "i686-pc-windows-msvc"))]
+    I686PcWindowsMsvc,
 
     /// An x86 Linux target. Equivalent to `x86_64-manylinux_2_17`.
     #[cfg_attr(feature = "clap", value(name = "x86_64-unknown-linux-gnu"))]
@@ -112,6 +117,7 @@ impl TargetTriple {
                 });
                 Platform::new(Os::Macos { major, minor }, Arch::Aarch64)
             }
+            Self::I686PcWindowsMsvc => Platform::new(Os::Windows, Arch::X86),
             Self::X8664AppleDarwin => {
                 let (major, minor) = macos_deployment_target().map_or((12, 0), |(major, minor)| {
                     debug!("Found macOS deployment target: {}.{}", major, minor);
@@ -183,6 +189,7 @@ impl TargetTriple {
             Self::Windows | Self::X8664PcWindowsMsvc => "x86_64",
             Self::Linux | Self::X8664UnknownLinuxGnu => "x86_64",
             Self::Macos | Self::Aarch64AppleDarwin => "arm64",
+            Self::I686PcWindowsMsvc => "x86",
             Self::X8664AppleDarwin => "x86_64",
             Self::Aarch64UnknownLinuxGnu => "aarch64",
             Self::Aarch64UnknownLinuxMusl => "aarch64",
@@ -202,6 +209,7 @@ impl TargetTriple {
             Self::Windows | Self::X8664PcWindowsMsvc => "Windows",
             Self::Linux | Self::X8664UnknownLinuxGnu => "Linux",
             Self::Macos | Self::Aarch64AppleDarwin => "Darwin",
+            Self::I686PcWindowsMsvc => "Windows",
             Self::X8664AppleDarwin => "Darwin",
             Self::Aarch64UnknownLinuxGnu => "Linux",
             Self::Aarch64UnknownLinuxMusl => "Linux",
@@ -221,6 +229,7 @@ impl TargetTriple {
             Self::Windows | Self::X8664PcWindowsMsvc => "",
             Self::Linux | Self::X8664UnknownLinuxGnu => "",
             Self::Macos | Self::Aarch64AppleDarwin => "",
+            Self::I686PcWindowsMsvc => "",
             Self::X8664AppleDarwin => "",
             Self::Aarch64UnknownLinuxGnu => "",
             Self::Aarch64UnknownLinuxMusl => "",
@@ -240,6 +249,7 @@ impl TargetTriple {
             Self::Windows | Self::X8664PcWindowsMsvc => "",
             Self::Linux | Self::X8664UnknownLinuxGnu => "",
             Self::Macos | Self::Aarch64AppleDarwin => "",
+            Self::I686PcWindowsMsvc => "",
             Self::X8664AppleDarwin => "",
             Self::Aarch64UnknownLinuxGnu => "",
             Self::Aarch64UnknownLinuxMusl => "",
@@ -259,6 +269,7 @@ impl TargetTriple {
             Self::Windows | Self::X8664PcWindowsMsvc => "nt",
             Self::Linux | Self::X8664UnknownLinuxGnu => "posix",
             Self::Macos | Self::Aarch64AppleDarwin => "posix",
+            Self::I686PcWindowsMsvc => "nt",
             Self::X8664AppleDarwin => "posix",
             Self::Aarch64UnknownLinuxGnu => "posix",
             Self::Aarch64UnknownLinuxMusl => "posix",
@@ -278,6 +289,7 @@ impl TargetTriple {
             Self::Windows | Self::X8664PcWindowsMsvc => "win32",
             Self::Linux | Self::X8664UnknownLinuxGnu => "linux",
             Self::Macos | Self::Aarch64AppleDarwin => "darwin",
+            Self::I686PcWindowsMsvc => "win32",
             Self::X8664AppleDarwin => "darwin",
             Self::Aarch64UnknownLinuxGnu => "linux",
             Self::Aarch64UnknownLinuxMusl => "linux",

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1691,7 +1691,9 @@ uv tree [OPTIONS]
 
 <li><code>macos</code>:  An alias for <code>aarch64-apple-darwin</code>, the default target for macOS</li>
 
-<li><code>x86_64-pc-windows-msvc</code>:  An x86 Windows target</li>
+<li><code>x86_64-pc-windows-msvc</code>:  A 64-bit x86 Windows target</li>
+
+<li><code>i686-pc-windows-msvc</code>:  A 32-bit x86 Windows target</li>
 
 <li><code>x86_64-unknown-linux-gnu</code>:  An x86 Linux target. Equivalent to <code>x86_64-manylinux_2_17</code></li>
 
@@ -3808,7 +3810,9 @@ uv pip compile [OPTIONS] <SRC_FILE>...
 
 <li><code>macos</code>:  An alias for <code>aarch64-apple-darwin</code>, the default target for macOS</li>
 
-<li><code>x86_64-pc-windows-msvc</code>:  An x86 Windows target</li>
+<li><code>x86_64-pc-windows-msvc</code>:  A 64-bit x86 Windows target</li>
+
+<li><code>i686-pc-windows-msvc</code>:  A 32-bit x86 Windows target</li>
 
 <li><code>x86_64-unknown-linux-gnu</code>:  An x86 Linux target. Equivalent to <code>x86_64-manylinux_2_17</code></li>
 
@@ -4104,7 +4108,9 @@ uv pip sync [OPTIONS] <SRC_FILE>...
 
 <li><code>macos</code>:  An alias for <code>aarch64-apple-darwin</code>, the default target for macOS</li>
 
-<li><code>x86_64-pc-windows-msvc</code>:  An x86 Windows target</li>
+<li><code>x86_64-pc-windows-msvc</code>:  A 64-bit x86 Windows target</li>
+
+<li><code>i686-pc-windows-msvc</code>:  A 32-bit x86 Windows target</li>
 
 <li><code>x86_64-unknown-linux-gnu</code>:  An x86 Linux target. Equivalent to <code>x86_64-manylinux_2_17</code></li>
 
@@ -4434,7 +4440,9 @@ uv pip install [OPTIONS] <PACKAGE|--requirement <REQUIREMENT>|--editable <EDITAB
 
 <li><code>macos</code>:  An alias for <code>aarch64-apple-darwin</code>, the default target for macOS</li>
 
-<li><code>x86_64-pc-windows-msvc</code>:  An x86 Windows target</li>
+<li><code>x86_64-pc-windows-msvc</code>:  A 64-bit x86 Windows target</li>
+
+<li><code>i686-pc-windows-msvc</code>:  A 32-bit x86 Windows target</li>
 
 <li><code>x86_64-unknown-linux-gnu</code>:  An x86 Linux target. Equivalent to <code>x86_64-manylinux_2_17</code></li>
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1310,10 +1310,17 @@
           ]
         },
         {
-          "description": "An x86 Windows target.",
+          "description": "A 64-bit x86 Windows target.",
           "type": "string",
           "enum": [
             "x86_64-pc-windows-msvc"
+          ]
+        },
+        {
+          "description": "A 32-bit x86 Windows target.",
+          "type": "string",
+          "enum": [
+            "i686-pc-windows-msvc"
           ]
         },
         {


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/6245.

## Test Plan

```
❯ cargo run pip install sqlalchemy --python-platform i686-pc-windows-msvc --verbose --no-cache --reinstall
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/uv pip install sqlalchemy --python-platform i686-pc-windows-msvc --verbose --no-cache --reinstall`
DEBUG uv 0.2.37
DEBUG Searching for Python interpreter in system path
DEBUG Found `cpython-3.12.3-macos-aarch64-none` at `/Users/crmarsh/workspace/uv/.venv/bin/python3` (virtual environment)
DEBUG Using Python 3.12.3 environment at .venv/bin/python3
DEBUG Acquired lock for `.venv`
DEBUG Using request timeout of 30s
DEBUG Solving with installed Python version: 3.12.3
DEBUG Adding direct dependency: sqlalchemy*
DEBUG No cache entry for: https://pypi.org/simple/sqlalchemy/
WARN Skipping file for sqlalchemy: SQLAlchemy-0.1.1-py2.4.egg
WARN Skipping file for sqlalchemy: SQLAlchemy-0.1.2-py2.4.egg
WARN Skipping file for sqlalchemy: SQLAlchemy-0.1.3-py2.4.egg
WARN Skipping file for sqlalchemy: SQLAlchemy-0.1.4-py2.4.egg
DEBUG Searching for a compatible version of sqlalchemy (*)
DEBUG Selecting: sqlalchemy==2.0.32 [compatible] (SQLAlchemy-2.0.32-cp312-cp312-win32.whl)
DEBUG No cache entry for: https://files.pythonhosted.org/packages/50/ef/973e0bbf2be5c12e34dca92139ca100f51ba078e36c3c06fd1dc8480c209/SQLAlchemy-2.0.32-cp312-cp312-win32.whl.metadata
DEBUG Adding transitive dependency for sqlalchemy==2.0.32: typing-extensions>=4.6.0
DEBUG No cache entry for: https://pypi.org/simple/typing-extensions/
DEBUG Searching for a compatible version of typing-extensions (>=4.6.0)
DEBUG Selecting: typing-extensions==4.12.2 [compatible] (typing_extensions-4.12.2-py3-none-any.whl)
DEBUG No cache entry for: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl.metadata
DEBUG Tried 2 versions: sqlalchemy 1, typing-extensions 1
DEBUG Split specific environment resolution took 0.390s
Resolved 2 packages in 391ms
DEBUG Must revalidate requirement: sqlalchemy
DEBUG Must revalidate requirement: typing-extensions
DEBUG Unnecessary package: markupsafe==2.1.5
DEBUG Unnecessary package: filelock==3.15.4
DEBUG Unnecessary package: fsspec==2024.6.1
DEBUG Unnecessary package: jinja2==3.1.4
DEBUG Unnecessary package: mpmath==1.3.0
DEBUG Unnecessary package: networkx==3.3
DEBUG Unnecessary package: setuptools==72.2.0
DEBUG Unnecessary package: sympy==1.13.2
DEBUG Unnecessary package: torch==2.4.0
DEBUG No cache entry for: https://files.pythonhosted.org/packages/50/ef/973e0bbf2be5c12e34dca92139ca100f51ba078e36c3c06fd1dc8480c209/SQLAlchemy-2.0.32-cp312-cp312-win32.whl
DEBUG No cache entry for: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
Prepared 2 packages in 150ms
DEBUG Uninstalled sqlalchemy (275 files, 25 directories)
DEBUG Uninstalled typing-extensions (7 files, 1 directory)
```
