### PR TITLE
Update README.md: Mention uvx is an alias for uv tool run

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See the [project documentation](https://docs.astral.sh/uv/guides/projects/) to g
 
 uv executes and installs command-line tools provided by Python packages, similar to `pipx`.
 
-Run a tool in an ephemeral environment using uvx (an alias for `uv tool run`):
+Run a tool in an ephemeral environment using `uvx` (an alias for `uv tool run`):
 
 ```console
 $ uvx pycowsay 'hello world!'

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See the [project documentation](https://docs.astral.sh/uv/guides/projects/) to g
 
 uv executes and installs command-line tools provided by Python packages, similar to `pipx`.
 
-Run a tool in an ephemeral environment with `uvx`:
+Run a tool in an ephemeral environment using uvx (an alias for `uv tool run`):
 
 ```console
 $ uvx pycowsay 'hello world!'

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ See the [project guide](./guides/projects.md) to get started.
 
 uv executes and installs command-line tools provided by Python packages, similar to `pipx`.
 
-Run a tool in an ephemeral environment with `uvx`:
+Run a tool in an ephemeral environment using `uvx` (an alias for `uv tool run`):
 
 ```console
 $ uvx pycowsay 'hello world!'


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I think it's important to clarify that `uvx` is simply an alias for `uv tool run`. This distinction helps avoid confusion about when to use `uv` versus `uvx`.  I thought the [blog post](https://astral.sh/blog/uv-unified-python-packaging) explained this well.

Just something that I ran into, I understand others may have a different perspective!  

## Test Plan

n/a
