### PR TITLE
Avoid treating `uv add -r` as `--raw-sources`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2382,8 +2382,6 @@ pub struct AddArgs {
     pub packages: Vec<String>,
 
     /// Add all packages listed in the given `requirements.txt` files.
-    ///
-    /// Implies `--raw-sources`.
     #[arg(long, short, group = "sources", value_parser = parse_file_path)]
     pub requirements: Vec<PathBuf>,
 

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -622,7 +622,7 @@ fn resolve_requirement(
     let source = match result {
         Ok(source) => source,
         Err(SourceError::UnresolvedReference(rev)) => {
-            anyhow::bail!(
+            bail!(
                 "Cannot resolve Git reference `{rev}` for requirement `{name}`. Specify the reference with one of `--tag`, `--branch`, or `--rev`, or use the `--raw-sources` flag.",
                 name = requirement.name
             )

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1113,16 +1113,6 @@ async fn run_project(
                     .combine(Refresh::from(args.settings.upgrade.clone())),
             );
 
-            // Use raw sources if requirements files are provided as input.
-            let raw_sources = if args.requirements.is_empty() {
-                args.raw_sources
-            } else {
-                if args.raw_sources {
-                    warn_user!("`--raw-sources` is a no-op for `requirements.txt` files, which are always treated as raw sources");
-                }
-                true
-            };
-
             let requirements = args
                 .packages
                 .into_iter()
@@ -1141,7 +1131,7 @@ async fn run_project(
                 requirements,
                 args.editable,
                 args.dependency_type,
-                raw_sources,
+                args.raw_sources,
                 args.rev,
                 args.tag,
                 args.branch,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -702,9 +702,7 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 
 </dd><dt><code>--reinstall-package</code> <i>reinstall-package</i></dt><dd><p>Reinstall a specific package, regardless of whether it&#8217;s already installed. Implies <code>--refresh-package</code></p>
 
-</dd><dt><code>--requirements</code>, <code>-r</code> <i>requirements</i></dt><dd><p>Add all packages listed in the given <code>requirements.txt</code> files.</p>
-
-<p>Implies <code>--raw-sources</code>.</p>
+</dd><dt><code>--requirements</code>, <code>-r</code> <i>requirements</i></dt><dd><p>Add all packages listed in the given <code>requirements.txt</code> files</p>
 
 </dd><dt><code>--resolution</code> <i>resolution</i></dt><dd><p>The strategy to use when selecting between the different compatible versions for a given package requirement.</p>
 


### PR DESCRIPTION
## Summary

I suspect this was added because there's no way for users to pass (e.g.) `--tag`, so the references are ambiguous. I think it's better to write them as `rev` than to fail, though. It's just less efficient when we fetch.

Closes https://github.com/astral-sh/uv/issues/6276.

Closes https://github.com/astral-sh/uv/issues/6275.
