### PR TITLE
Invalidate `uv.lock` when virtual `dev-dependencies` change

### DIFF
--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_missing.snap
@@ -79,6 +79,7 @@ Ok(
         },
         manifest: ResolverManifest {
             members: {},
+            requirements: {},
             constraints: {},
             overrides: {},
         },

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_optional_present.snap
@@ -86,6 +86,7 @@ Ok(
         },
         manifest: ResolverManifest {
             members: {},
+            requirements: {},
             constraints: {},
             overrides: {},
         },

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_required_present.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__hash_required_present.snap
@@ -82,6 +82,7 @@ Ok(
         },
         manifest: ResolverManifest {
             members: {},
+            requirements: {},
             constraints: {},
             overrides: {},
         },

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
@@ -141,6 +141,7 @@ Ok(
         },
         manifest: ResolverManifest {
             members: {},
+            requirements: {},
             constraints: {},
             overrides: {},
         },

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
@@ -141,6 +141,7 @@ Ok(
         },
         manifest: ResolverManifest {
             members: {},
+            requirements: {},
             constraints: {},
             overrides: {},
         },

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
@@ -141,6 +141,7 @@ Ok(
         },
         manifest: ResolverManifest {
             members: {},
+            requirements: {},
             constraints: {},
             overrides: {},
         },

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_has_subdir.snap
@@ -63,6 +63,7 @@ Ok(
         },
         manifest: ResolverManifest {
             members: {},
+            requirements: {},
             constraints: {},
             overrides: {},
         },

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_direct_no_subdir.snap
@@ -59,6 +59,7 @@ Ok(
         },
         manifest: ResolverManifest {
             members: {},
+            requirements: {},
             constraints: {},
             overrides: {},
         },

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_directory.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_directory.snap
@@ -49,6 +49,7 @@ Ok(
         },
         manifest: ResolverManifest {
             members: {},
+            requirements: {},
             constraints: {},
             overrides: {},
         },

--- a/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_editable.snap
+++ b/crates/uv-resolver/src/snapshots/uv_resolver__lock__tests__source_editable.snap
@@ -49,6 +49,7 @@ Ok(
         },
         manifest: ResolverManifest {
             members: {},
+            requirements: {},
             constraints: {},
             overrides: {},
         },

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -3227,6 +3227,9 @@ fn add_virtual() -> Result<()> {
         [options]
         exclude-newer = "2024-03-25T00:00:00Z"
 
+        [manifest]
+        requirements = [{ name = "iniconfig" }]
+
         [[package]]
         name = "iniconfig"
         version = "2.0.0"

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -10027,3 +10027,142 @@ fn lock_overlapping_environment() -> Result<()> {
 
     Ok(())
 }
+
+/// Lock a requirement from PyPI.
+#[test]
+fn lock_virtual() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [tool.uv.workspace]
+        members = []
+
+        [tool.uv]
+        dev-dependencies = [
+            "anyio"
+        ]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    "###);
+
+    let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r###"
+        version = 1
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [manifest]
+        requirements = [{ name = "anyio" }]
+
+        [[package]]
+        name = "anyio"
+        version = "4.3.0"
+        source = { registry = "https://pypi.org/simple" }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
+        sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6", size = 159642 }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", hash = "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8", size = 85584 },
+        ]
+
+        [[package]]
+        name = "idna"
+        version = "3.6"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
+        ]
+
+        [[package]]
+        name = "sniffio"
+        version = "1.3.1"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+        ]
+        "###
+        );
+    });
+
+    // Re-run with `--locked`.
+    uv_snapshot!(context.filters(), context.lock().arg("--locked"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    "###);
+
+    // Re-run with `--offline`. We shouldn't need a network connection to validate an
+    // already-correct lockfile with immutable metadata.
+    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--offline").arg("--no-cache"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    "###);
+
+    // Add `iniconfig`.
+    pyproject_toml.write_str(
+        r#"
+        [tool.uv.workspace]
+        members = []
+
+        [tool.uv]
+        dev-dependencies = [
+            "anyio",
+            "iniconfig"
+        ]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 4 packages in [TIME]
+    Added iniconfig v2.0.0
+    "###);
+
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Prepared 4 packages in [TIME]
+    Installed 4 packages in [TIME]
+     + anyio==4.3.0
+     + idna==3.6
+     + iniconfig==2.0.0
+     + sniffio==1.3.1
+    "###);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

For non-virtual workspaces, these are covered by the _members_. But for virtual workspaces, they aren't captured anywhere else in the lock. So, we weren't invalidating `uv.lock` when the dev dependencies changed, which led to a panic.

Closes https://github.com/astral-sh/uv/issues/6288
