### PR TITLE
Delete the preview default value of python-preference in the document.

### DIFF
--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -150,7 +150,7 @@ pub struct GlobalOptions {
     /// Whether to prefer using Python installations that are already present on the system, or
     /// those that are downloaded and installed by uv.
     #[option(
-        default = "\"only-system\" (stable) or \"managed\" (preview)",
+        default = "\"managed\"",
         value_type = "str",
         example = r#"
             python-preference = "managed"

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -866,7 +866,7 @@ Whether to allow Python downloads.
 Whether to prefer using Python installations that are already present on the system, or
 those that are downloaded and installed by uv.
 
-**Default value**: `"only-system" (stable) or "managed" (preview)`
+**Default value**: `"managed"`
 
 **Possible values**:
 


### PR DESCRIPTION
## Summary
I believe the default for the stable ``uv venv`` in UV version 0.3.0 is managed.
## Test Plan
Running a document server locally.
![image](https://github.com/user-attachments/assets/0f582f07-1332-424b-bb1b-82b19533e14e)
