### PR TITLE
Ignore workspace discovery errors with `--no-workspace`

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -142,7 +142,7 @@ impl<'a> BaseClientBuilder<'a> {
                 if !path_exists {
                     warn_user_once!(
                         "Ignoring invalid `SSL_CERT_FILE`. File does not exist: {}.",
-                        path.simplified_display()
+                        path.simplified_display().cyan()
                     );
                 }
                 path_exists

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1011,8 +1011,7 @@ fn warn_on_requirements_txt_setting(
         if let Some(index_url) = index_url {
             if settings.index_locations.index() != Some(index_url) {
                 warn_user_once!(
-                    "Ignoring `--index-url` from requirements file: `{}`. Instead, use the `--index-url` command-line argument, or set `index-url` in a `uv.toml` or `pyproject.toml` file.",
-                    index_url
+                    "Ignoring `--index-url` from requirements file: `{index_url}`. Instead, use the `--index-url` command-line argument, or set `index-url` in a `uv.toml` or `pyproject.toml` file."
                 );
             }
         }
@@ -1023,16 +1022,15 @@ fn warn_on_requirements_txt_setting(
                 .contains(extra_index_url)
             {
                 warn_user_once!(
-                    "Ignoring `--extra-index-url` from requirements file: `{}`. Instead, use the `--extra-index-url` command-line argument, or set `extra-index-url` in a `uv.toml` or `pyproject.toml` file.`",
-                    extra_index_url
+                    "Ignoring `--extra-index-url` from requirements file: `{extra_index_url}`. Instead, use the `--extra-index-url` command-line argument, or set `extra-index-url` in a `uv.toml` or `pyproject.toml` file.`"
+
                 );
             }
         }
         for find_link in find_links {
             if !settings.index_locations.flat_index().contains(find_link) {
                 warn_user_once!(
-                    "Ignoring `--find-links` from requirements file: `{}`. Instead, use the `--find-links` command-line argument, or set `find-links` in a `uv.toml` or `pyproject.toml` file.`",
-                    find_link
+                    "Ignoring `--find-links` from requirements file: `{find_link}`. Instead, use the `--find-links` command-line argument, or set `find-links` in a `uv.toml` or `pyproject.toml` file.`"
                 );
             }
         }

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -100,7 +100,7 @@ pub(crate) async fn pin(
                     if resolved {
                         return Err(err);
                     };
-                    warn_user_once!("{}", err);
+                    warn_user_once!("{err}");
                 }
             }
         };
@@ -180,7 +180,7 @@ fn warn_if_existing_pin_incompatible_with_project(
             },
             virtual_project,
         ) {
-            warn_user_once!("{}", err);
+            warn_user_once!("{err}");
             return;
         }
     }
@@ -209,14 +209,13 @@ fn warn_if_existing_pin_incompatible_with_project(
                 },
                 virtual_project,
             ) {
-                warn_user_once!("{}", err);
+                warn_user_once!("{err}");
             }
         }
         Err(err) => {
             warn_user_once!(
-                "Failed to resolve pinned Python version `{}`: {}",
+                "Failed to resolve pinned Python version `{}`: {err}",
                 pin.to_canonical_string(),
-                err
             );
         }
     }


### PR DESCRIPTION
## Summary

It's useful to try to discover the workspace, so we can warn, but it's not good to fail.

Closes https://github.com/astral-sh/uv/issues/6320.
