### PR TITLE
fix(docs): replace underscore with dash for dev-dependencies

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -183,13 +183,13 @@ default in `uv run` and `uv sync`, but will not appear in the project's publishe
 
     ```toml
     [tool.uv]
-    dev_dependencies = ["ruff==0.5.0"]
+    dev-dependencies = ["ruff==0.5.0"]
     ```
 === "uv.toml"
 
     ```toml
     
-    dev_dependencies = ["ruff==0.5.0"]
+    dev-dependencies = ["ruff==0.5.0"]
     ```
 
 ---


### PR DESCRIPTION
Docs show an underscore which should be a dash in dev-dependencies: `dev_dependencies = ["ruff==0.5.0"]`


## Summary
I followed the example in the references settings and used dev_dependencies in my pyproject.toml but it seems like this needs to be a dash instead of an underscore:

 => ERROR [stage-0 5/5] RUN uv sync                                                                                                                                                                                                                                   6.9s
------
 > [stage-0 5/5] RUN uv sync:
0.085 warning: Failed to parse `pyproject.toml` during settings discovery:
0.085   TOML parse error at line 65, column 1
0.085      |
0.085   65 | [tool.uv]
0.085      | ^^^^^^^^^
0.085   unknown field `dev_dependencies`
0.085

