### PR TITLE
Respect `.python-version` files in `uv run` outside projects

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -441,8 +441,16 @@ pub(crate) async fn run(
                     .connectivity(connectivity)
                     .native_tls(native_tls);
 
+                // (1) Explicit request from user
+                let python_request = if let Some(request) = python.as_deref() {
+                    Some(PythonRequest::parse(request))
+                // (2) Request from `.python-version`
+                } else {
+                    request_from_version_file(&CWD).await?
+                };
+
                 let python = PythonInstallation::find_or_download(
-                    python.as_deref().map(PythonRequest::parse),
+                    python_request,
                     // No opt-in is required for system environments, since we are not mutating it.
                     EnvironmentPreference::Any,
                     python_preference,


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/6285

Introduces a new problem if the user says `python` but it doesn't exist with that name:

```
❯ cargo run -q -- -v run python --version
DEBUG uv 0.3.0
DEBUG Found project root: `/Users/zb/workspace/uv`
DEBUG Project `uv` is marked as unmanaged
DEBUG No project found; searching for Python interpreter
DEBUG Reading requests from `/Users/zb/workspace/uv/.python-version`
DEBUG Searching for Python 3.11 in managed installations or system path
DEBUG Found `cpython-3.12.4-macos-aarch64-none` at `/Users/zb/workspace/uv/.venv/bin/python3` (virtual environment)
DEBUG Searching for managed installations at `/Users/zb/Library/Application Support/uv/python`
DEBUG Found `cpython-3.11.9-macos-aarch64-none` at `/opt/homebrew/bin/python3.11` (search path)
DEBUG Using Python 3.11.9 interpreter at: /opt/homebrew/opt/python@3.11/bin/python3.11
DEBUG Running `python --version`
error: Failed to spawn: `python`
  Caused by: No such file or directory (os error 2)
```

I'll fix this separately.