### PR TITLE
Improve interactions between `.python-version` files and project `requires-python`

### DIFF
--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -155,7 +155,7 @@ pub(crate) async fn pin(
     Ok(ExitStatus::Success)
 }
 
-fn pep440_version_from_request(request: &PythonRequest) -> Option<pep440_rs::Version> {
+pub(crate) fn pep440_version_from_request(request: &PythonRequest) -> Option<pep440_rs::Version> {
     let version_request = match request {
         PythonRequest::Version(ref version)
         | PythonRequest::ImplementationVersion(_, ref version) => version,

--- a/crates/uv/tests/python_find.rs
+++ b/crates/uv/tests/python_find.rs
@@ -197,6 +197,38 @@ fn python_find_pin() {
 
     ----- stderr -----
     "###);
+
+    let child_dir = context.temp_dir.child("child");
+    child_dir.create_dir_all().unwrap();
+
+    // We should also find pinned versions in the parent directory
+    uv_snapshot!(context.filters(), context.python_find().current_dir(&child_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [PYTHON-3.12]
+
+    ----- stderr -----
+    "###);
+
+    uv_snapshot!(context.filters(), context.python_pin().arg("3.11").current_dir(&child_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Updated `.python-version` from `3.12` -> `3.11`
+
+    ----- stderr -----
+    "###);
+
+    // Unless the child directory also has a pin
+    uv_snapshot!(context.filters(), context.python_find().current_dir(&child_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    [PYTHON-3.11]
+
+    ----- stderr -----
+    "###);
 }
 
 #[test]

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -623,8 +623,8 @@ fn run_with() -> Result<()> {
 
     // Requesting an unsatisfied requirement should install it.
     uv_snapshot!(context.filters(), context.run().arg("--with").arg("iniconfig").arg("main.py"), @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
@@ -637,6 +637,10 @@ fn run_with() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
+    Traceback (most recent call last):
+      File "[TEMP_DIR]/main.py", line 1, in <module>
+        import sniffio
+    ModuleNotFoundError: No module named 'sniffio'
     "###);
 
     // Requesting a satisfied requirement should use the base environment.
@@ -755,8 +759,8 @@ fn run_with_editable() -> Result<()> {
 
     // Requesting an editable requirement should install it in a layer.
     uv_snapshot!(context.filters(), context.run().arg("--with-editable").arg("./src/black_editable").arg("main.py"), @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
@@ -771,12 +775,16 @@ fn run_with_editable() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + black==0.1.0 (from file://[TEMP_DIR]/src/black_editable)
+    Traceback (most recent call last):
+      File "[TEMP_DIR]/main.py", line 1, in <module>
+        import sniffio
+    ModuleNotFoundError: No module named 'sniffio'
     "###);
 
     // Requesting an editable requirement should install it in a layer, even if it satisfied
     uv_snapshot!(context.filters(), context.run().arg("--with-editable").arg("./src/anyio_local").arg("main.py"), @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
@@ -786,6 +794,10 @@ fn run_with_editable() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + anyio==4.3.0+foo (from file://[TEMP_DIR]/src/anyio_local)
+    Traceback (most recent call last):
+      File "[TEMP_DIR]/main.py", line 1, in <module>
+        import sniffio
+    ModuleNotFoundError: No module named 'sniffio'
     "###);
 
     // Requesting the project itself should use the base environment.
@@ -1154,8 +1166,8 @@ fn run_requirements_txt() -> Result<()> {
     requirements_txt.write_str("iniconfig")?;
 
     uv_snapshot!(context.filters(), context.run().arg("--with-requirements").arg(requirements_txt.as_os_str()).arg("main.py"), @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
@@ -1170,6 +1182,10 @@ fn run_requirements_txt() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
+    Traceback (most recent call last):
+      File "[TEMP_DIR]/main.py", line 1, in <module>
+        import sniffio
+    ModuleNotFoundError: No module named 'sniffio'
     "###);
 
     // Requesting a satisfied requirement should use the base environment.
@@ -1276,8 +1292,8 @@ fn run_requirements_txt_arguments() -> Result<()> {
     })?;
 
     uv_snapshot!(context.filters(), context.run().arg("--with-requirements").arg(requirements_txt.as_os_str()).arg("main.py"), @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
@@ -1291,6 +1307,10 @@ fn run_requirements_txt_arguments() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + idna==3.6
+    Traceback (most recent call last):
+      File "[TEMP_DIR]/main.py", line 1, in <module>
+        import typing_extensions
+    ModuleNotFoundError: No module named 'typing_extensions'
     "###);
 
     Ok(())
@@ -1330,10 +1350,9 @@ fn run_editable() -> Result<()> {
 
     // We treat arguments before the command as uv arguments
     uv_snapshot!(context.filters(), context.run().arg("--with").arg("iniconfig").arg("main.py"), @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
-    Hello, world!
 
     ----- stderr -----
     Resolved 1 package in [TIME]
@@ -1344,6 +1363,10 @@ fn run_editable() -> Result<()> {
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
+    Traceback (most recent call last):
+      File "[TEMP_DIR]/main.py", line 1, in <module>
+        import foo
+    ModuleNotFoundError: No module named 'foo'
     "###);
 
     Ok(())
@@ -1539,22 +1562,30 @@ fn run_without_output() -> Result<()> {
 
     // On the first run, we only show the summary line for each environment.
     uv_snapshot!(context.filters(), context.run().env_remove("UV_SHOW_RESOLUTION").arg("--with").arg("iniconfig").arg("main.py"), @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Installed 4 packages in [TIME]
     Installed 1 package in [TIME]
+    Traceback (most recent call last):
+      File "[TEMP_DIR]/main.py", line 1, in <module>
+        import sniffio
+    ModuleNotFoundError: No module named 'sniffio'
     "###);
 
     // Subsequent runs are quiet.
     uv_snapshot!(context.filters(), context.run().env_remove("UV_SHOW_RESOLUTION").arg("--with").arg("iniconfig").arg("main.py"), @r###"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
+    Traceback (most recent call last):
+      File "[TEMP_DIR]/main.py", line 1, in <module>
+        import sniffio
+    ModuleNotFoundError: No module named 'sniffio'
     "###);
 
     Ok(())


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/5228
Required for https://github.com/astral-sh/uv/pull/6370

This ensures that we

1. Ignore`.python-version` files outside of projects if they specify a version that's incompatible with the `requires-python`
2. Warn when `.python-version` files inside a project are incompatible with the `requires-python`

Unfortunately, this totally falls apart if the `.python-version` file isn't a version specifier, e.g., if it's an interpreter path.

This begins to create a unified place to determine the `PythonRequest` to use — it's getting really complicated.