### PR TITLE
Fix priority for `.python-versions` files in `uv python install`

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -125,7 +125,7 @@ pub(crate) async fn add(
             let python_request = if let Some(request) = python.as_deref() {
                 // (1) Explicit request from user
                 PythonRequest::parse(request)
-            } else if let Some(request) = PythonVersionFile::discover(&*CWD, false)
+            } else if let Some(request) = PythonVersionFile::discover(&*CWD, false, false)
                 .await?
                 .and_then(PythonVersionFile::into_version)
             {
@@ -156,7 +156,7 @@ pub(crate) async fn add(
         let python_request = if let Some(request) = python.as_deref() {
             // (1) Explicit request from user
             Some(PythonRequest::parse(request))
-        } else if let Some(request) = PythonVersionFile::discover(&*CWD, false)
+        } else if let Some(request) = PythonVersionFile::discover(&*CWD, false, false)
             .await?
             .and_then(PythonVersionFile::into_version)
         {

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -177,9 +177,10 @@ impl WorkspacePython {
         let python_request = if let Some(request) = python_request {
             Some(request)
             // (2) Request from `.python-version`
-        } else if let Some(request) = PythonVersionFile::discover(workspace.install_path(), false)
-            .await?
-            .and_then(PythonVersionFile::into_version)
+        } else if let Some(request) =
+            PythonVersionFile::discover(workspace.install_path(), false, false)
+                .await?
+                .and_then(PythonVersionFile::into_version)
         {
             Some(request)
             // (3) `Requires-Python` in `pyproject.toml`

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -109,7 +109,7 @@ pub(crate) async fn run(
         let python_request = if let Some(request) = python.as_deref() {
             Some(PythonRequest::parse(request))
             // (2) Request from `.python-version`
-        } else if let Some(request) = PythonVersionFile::discover(&*CWD, false)
+        } else if let Some(request) = PythonVersionFile::discover(&*CWD, false, false)
             .await?
             .and_then(PythonVersionFile::into_version)
         {
@@ -449,7 +449,7 @@ pub(crate) async fn run(
                     Some(PythonRequest::parse(request))
                 // (2) Request from `.python-version`
                 } else {
-                    PythonVersionFile::discover(&*CWD, no_config)
+                    PythonVersionFile::discover(&*CWD, no_config, false)
                         .await?
                         .and_then(PythonVersionFile::into_version)
                 };

--- a/crates/uv/src/commands/python/find.rs
+++ b/crates/uv/src/commands/python/find.rs
@@ -26,7 +26,7 @@ pub(crate) async fn find(
 
     // (2) Request from `.python-version`
     if request.is_none() {
-        request = PythonVersionFile::discover(&*CWD, no_config)
+        request = PythonVersionFile::discover(&*CWD, no_config, false)
             .await?
             .and_then(PythonVersionFile::into_version);
     }

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -38,7 +38,7 @@ pub(crate) async fn install(
 
     let targets = targets.into_iter().collect::<BTreeSet<_>>();
     let requests: Vec<_> = if targets.is_empty() {
-        PythonVersionFile::discover(&*CWD, no_config)
+        PythonVersionFile::discover(&*CWD, no_config, true)
             .await?
             .map(uv_python::PythonVersionFile::into_versions)
             .unwrap_or_else(|| vec![PythonRequest::Any])

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -38,7 +38,7 @@ pub(crate) async fn pin(
         }
     };
 
-    let version_file = PythonVersionFile::discover(&*CWD, false).await;
+    let version_file = PythonVersionFile::discover(&*CWD, false, false).await;
 
     let Some(request) = request else {
         // Display the current pinned Python version

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -146,7 +146,7 @@ async fn venv_impl(
     // (2) Request from `.python-version`
     if interpreter_request.is_none() {
         // TODO(zanieb): Support `--no-config` here
-        interpreter_request = PythonVersionFile::discover(&*CWD, false)
+        interpreter_request = PythonVersionFile::discover(&*CWD, false, false)
             .await
             .into_diagnostic()?
             .and_then(PythonVersionFile::into_version);


### PR DESCRIPTION
In https://github.com/astral-sh/uv/pull/6359, I accidentally made `uv python install` prefer `.python-version` files over `.python-versions` files -.-, kind of niche but it's a regression.