### PR TITLE
Add support for defining credentials for uv in an environment variable

### DIFF
--- a/crates/uv-auth/src/cache.rs
+++ b/crates/uv-auth/src/cache.rs
@@ -109,6 +109,14 @@ impl CredentialsCache {
         urls.insert(url, credentials);
     }
 
+    /// Update _only_ the URL cache with the given credentials.
+    ///
+    /// This will not allow realm-level matches.
+    pub fn insert_url(&self, url: &Url, credentials: Arc<Credentials>) {
+        let mut urls = self.urls.write().unwrap();
+        urls.insert(url, credentials);
+    }
+
     /// Private interface to update a realm cache entry.
     ///
     /// Returns replaced credentials, if any.

--- a/crates/uv-auth/src/lib.rs
+++ b/crates/uv-auth/src/lib.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, LazyLock};
 
-use tracing::trace;
+use tracing::{debug, trace};
 use url::Url;
 
 use cache::CredentialsCache;
@@ -34,4 +34,62 @@ pub fn store_credentials_from_url(url: &Url) -> bool {
     } else {
         false
     }
+}
+
+/// Populate the global authentication store with credentials from the environment, if any.
+///
+/// Respects `UV_BASIC_AUTH_URLS` with whitespace separated URLs.
+///
+/// Supports formats like:
+///
+/// - `UV_BASIC_AUTH_URLS="username:password@hostname"`
+/// - `UV_BASIC_AUTH_URLS="username@hostname"`
+/// - `UV_BASIC_AUTH_URLS="username:password@hostname username:password@other-hostname"`
+/// - `UV_BASIC_AUTH_URLS="username:password@hostname/path"`
+///
+/// Only `https` URLs are supported, URLs with other schemes are ignored.
+///
+/// Populates the URL prefix cache in the global [`CredentialsCache`]. The credentials are not
+/// added the the realm-level cache to ensure that a URL with a path is not used unless a request
+/// is made to a child of the provided URL.
+pub fn store_credentials_from_environment() -> bool {
+    let Some(urls) = std::env::var_os("UV_BASIC_AUTH_URLS") else {
+        return false;
+    };
+
+    let mut populated = false;
+    for mut url in urls
+        .to_string_lossy()
+        .split_ascii_whitespace()
+        .filter_map(parse_url_from_env)
+    {
+        if let Some(credentials) = Credentials::from_url(&url) {
+            CREDENTIALS_CACHE.insert_url(&url, Arc::new(credentials));
+            // Redact the password for display
+            if url.password().is_some() {
+                let _ = url.set_password(Some("***"));
+            }
+            debug!("Added credentials for `{url}`");
+            populated = true;
+        } else {
+            debug!("Ignoring URL without credentials in `UV_BASIC_AUTH_URLS`: {url}");
+        }
+    }
+
+    populated
+}
+
+/// Parse a URL, allowing the scheme to be missing (and inferred as `https://`)
+fn parse_url_from_env(url: &str) -> Option<Url> {
+    if url.starts_with("https://") {
+        Url::parse(url)
+    } else if url.starts_with("http://") {
+        debug!("Ignoring insecure URL in `UV_BASIC_AUTH_URLS`: {url}");
+        return None;
+    } else {
+        let url = format!("https://{url}");
+        Url::parse(&url)
+    }
+    .inspect_err(|err| debug!("Ignoring invalid URL in `UV_BASIC_AUTH_URLS`: {err}"))
+    .ok()
 }

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 use distribution_types::{IndexLocations, UnresolvedRequirementSpecification, Verbatim};
 use install_wheel_rs::linker::LinkMode;
 use pypi_types::{Requirement, SupportedEnvironments};
-use uv_auth::store_credentials_from_url;
+use uv_auth::{store_credentials_from_environment, store_credentials_from_url};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
@@ -275,6 +275,7 @@ pub(crate) async fn pip_compile(
     for url in index_locations.urls() {
         store_credentials_from_url(url);
     }
+    store_credentials_from_environment();
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -9,7 +9,7 @@ use distribution_types::{IndexLocations, Resolution, UnresolvedRequirementSpecif
 use install_wheel_rs::linker::LinkMode;
 use pep508_rs::PackageName;
 use pypi_types::Requirement;
-use uv_auth::store_credentials_from_url;
+use uv_auth::{store_credentials_from_environment, store_credentials_from_url};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
@@ -268,6 +268,7 @@ pub(crate) async fn pip_install(
     for url in index_locations.urls() {
         store_credentials_from_url(url);
     }
+    store_credentials_from_environment();
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 use distribution_types::{IndexLocations, Resolution};
 use install_wheel_rs::linker::LinkMode;
 use pep508_rs::PackageName;
-use uv_auth::store_credentials_from_url;
+use uv_auth::{store_credentials_from_environment, store_credentials_from_url};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
@@ -218,6 +218,7 @@ pub(crate) async fn pip_sync(
     for url in index_locations.urls() {
         store_credentials_from_url(url);
     }
+    store_credentials_from_environment();
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 use cache_key::RepositoryUrl;
 use pep508_rs::{ExtraName, Requirement, VersionOrUrl};
 use pypi_types::redact_git_credentials;
-use uv_auth::{store_credentials_from_url, Credentials};
+use uv_auth::{store_credentials_from_environment, store_credentials_from_url, Credentials};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{Concurrency, ExtrasSpecification, InstallOptions, SourceStrategy};
@@ -255,6 +255,7 @@ pub(crate) async fn add(
     for url in settings.index_locations.urls() {
         store_credentials_from_url(url);
     }
+    store_credentials_from_environment();
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::try_from(client_builder)?

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -11,7 +11,7 @@ use tracing::debug;
 use distribution_types::{IndexLocations, UnresolvedRequirementSpecification};
 use pep440_rs::Version;
 use pypi_types::{Requirement, SupportedEnvironments};
-use uv_auth::store_credentials_from_url;
+use uv_auth::{store_credentials_from_environment, store_credentials_from_url};
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{Concurrency, ExtrasSpecification, Reinstall, Upgrade};
@@ -351,6 +351,7 @@ async fn do_lock(
     for url in index_locations.urls() {
         store_credentials_from_url(url);
     }
+    store_credentials_from_environment();
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -9,7 +9,7 @@ use distribution_types::{Resolution, UnresolvedRequirementSpecification};
 use pep440_rs::{Version, VersionSpecifiers};
 use pep508_rs::MarkerTreeContents;
 use pypi_types::Requirement;
-use uv_auth::store_credentials_from_url;
+use uv_auth::{store_credentials_from_environment, store_credentials_from_url};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{Concurrency, ExtrasSpecification, Reinstall, Upgrade};
@@ -449,6 +449,7 @@ pub(crate) async fn resolve_names(
     for url in index_locations.urls() {
         store_credentials_from_url(url);
     }
+    store_credentials_from_environment();
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())
@@ -564,6 +565,7 @@ pub(crate) async fn resolve_environment<'a>(
     for url in index_locations.urls() {
         store_credentials_from_url(url);
     }
+    store_credentials_from_environment();
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())
@@ -707,6 +709,7 @@ pub(crate) async fn sync_environment(
     for url in index_locations.urls() {
         store_credentials_from_url(url);
     }
+    store_credentials_from_environment();
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())
@@ -890,6 +893,7 @@ pub(crate) async fn update_environment(
     for url in index_locations.urls() {
         store_credentials_from_url(url);
     }
+    store_credentials_from_environment();
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -3,7 +3,8 @@ use itertools::Itertools;
 
 use distribution_types::{Dist, ResolvedDist, SourceDist};
 use pep508_rs::MarkerTree;
-use uv_auth::store_credentials_from_url;
+
+use uv_auth::{store_credentials_from_environment, store_credentials_from_url};
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{Concurrency, ExtrasSpecification, HashCheckingMode, InstallOptions};
@@ -225,6 +226,7 @@ pub(super) async fn do_sync(
     for url in index_locations.urls() {
         store_credentials_from_url(url);
     }
+    store_credentials_from_environment();
 
     // Initialize the registry client.
     let client = RegistryClientBuilder::new(cache.clone())

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use distribution_types::IndexLocations;
 use install_wheel_rs::linker::LinkMode;
 use pypi_types::Requirement;
-use uv_auth::store_credentials_from_url;
+use uv_auth::{store_credentials_from_environment, store_credentials_from_url};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
@@ -201,6 +201,7 @@ async fn venv_impl(
     for url in index_locations.urls() {
         store_credentials_from_url(url);
     }
+    store_credentials_from_environment();
 
     if managed {
         writeln!(
@@ -247,6 +248,7 @@ async fn venv_impl(
         for url in index_locations.urls() {
             store_credentials_from_url(url);
         }
+        store_credentials_from_environment();
 
         // Instantiate a client.
         let client = RegistryClientBuilder::try_from(client_builder)

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -5985,6 +5985,20 @@ fn lock_redact_https() -> Result<()> {
      ~ iniconfig==2.0.0
     "###);
 
+    // Installing with credentials from with `UV_BASIC_AUTH_URLS` should succeed.
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen").arg("--reinstall").arg("--no-cache").env("UV_BASIC_AUTH_URLS", "public:heron@pypi-proxy.fly.dev"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Prepared 2 packages in [TIME]
+    Uninstalled 2 packages in [TIME]
+    Installed 2 packages in [TIME]
+     ~ foo==0.1.0 (from file://[TEMP_DIR]/)
+     ~ iniconfig==2.0.0
+    "###);
+
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(
         r#"


### PR DESCRIPTION
Adds `UV_AUTH_URLS` which defines credentials that should be used for URLs if we make a request there.

This is helpful for cases where, e.g., you want to provide credentials for an index but you don't want to change the index URL semantics by setting `UV_INDEX_URL`.

Implemented by seeding the URL authentication cache with the value of the variable.

Supports things like:

- `UV_AUTH_URLS="username:password@hostname"`
- `UV_AUTH_URLS="username@hostname"`
- `UV_AUTH_URLS="username:password@hostname username:password@other-hostname"`
- `UV_AUTH_URLS="username:password@hostname/prefix"`

There's a small caveat here, that if you use an index URL like `foo@hostname/simple` and you provide a password `bar:password@hostname` — the password should not be used but requests to fetch wheels from a different, parent path e.g.`hostname/files` can allow use of `bar:password`. This requires #4583 to address. In the meantime, credentials should just be properly scoped.