### PR TITLE
Add `uv sync --no-locals` to skip syncing local dependencies

### DIFF
--- a/crates/distribution-types/src/resolution.rs
+++ b/crates/distribution-types/src/resolution.rs
@@ -70,6 +70,28 @@ impl Resolution {
     pub fn diagnostics(&self) -> &[ResolutionDiagnostic] {
         &self.diagnostics
     }
+
+    /// Filter the resolution to only include packages that match the given predicate.
+    pub fn filter(&self, predicate: impl Fn(&ResolvedDist) -> bool) -> Self {
+        let packages = self
+            .packages
+            .iter()
+            .filter(|(_, dist)| predicate(dist))
+            .map(|(name, dist)| (name.clone(), dist.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let hashes = self
+            .hashes
+            .iter()
+            .filter(|(name, _)| packages.contains_key(name))
+            .map(|(name, hashes)| (name.clone(), hashes.clone()))
+            .collect();
+        let diagnostics = self.diagnostics.clone();
+        Self {
+            packages,
+            hashes,
+            diagnostics,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Hash)]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2273,6 +2273,16 @@ pub struct SyncArgs {
     #[arg(long, overrides_with("inexact"), hide = true)]
     pub exact: bool,
 
+    /// Avoid syncing any local packages, including the current project and any workspace members
+    /// or path dependencies in the lockfile.
+    ///
+    /// This is useful for priming an environment with remote dependencies, without relying on any
+    /// local or mutable sources. For example, `uv sync --no-locals` could be used in a Docker image
+    /// to create a highly cacheable intermediate layer prior to installing local packages, which
+    /// change frequently.
+    #[arg(long)]
+    pub no_locals: bool,
+
     /// Assert that the `uv.lock` will remain unchanged.
     ///
     /// Requires that the lockfile is up-to-date. If the lockfile is missing or

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -603,6 +603,7 @@ pub(crate) async fn add(
         &lock,
         &extras,
         dev,
+        false,
         Modifications::Sufficient,
         settings.as_ref().into(),
         &state,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -190,6 +190,7 @@ pub(crate) async fn remove(
     // TODO(ibraheem): Should we accept CLI overrides for this? Should we even sync here?
     let extras = ExtrasSpecification::All;
     let dev = true;
+    let no_locals = false;
 
     // Initialize any shared state.
     let state = SharedState::default();
@@ -200,6 +201,7 @@ pub(crate) async fn remove(
         &lock,
         &extras,
         dev,
+        no_locals,
         Modifications::Exact,
         settings.as_ref().into(),
         &state,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -419,6 +419,7 @@ pub(crate) async fn run(
                 result.lock(),
                 &extras,
                 dev,
+                false,
                 Modifications::Sufficient,
                 settings.as_ref().into(),
                 &state,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1081,6 +1081,7 @@ async fn run_project(
                 args.package,
                 args.extras,
                 args.dev,
+                args.no_locals,
                 args.modifications,
                 args.python,
                 globals.python_preference,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -618,6 +618,7 @@ pub(crate) struct SyncSettings {
     pub(crate) frozen: bool,
     pub(crate) extras: ExtrasSpecification,
     pub(crate) dev: bool,
+    pub(crate) no_locals: bool,
     pub(crate) modifications: Modifications,
     pub(crate) package: Option<PackageName>,
     pub(crate) python: Option<String>,
@@ -630,8 +631,6 @@ impl SyncSettings {
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn resolve(args: SyncArgs, filesystem: Option<FilesystemOptions>) -> Self {
         let SyncArgs {
-            locked,
-            frozen,
             extra,
             all_extras,
             no_all_extras,
@@ -639,6 +638,9 @@ impl SyncSettings {
             no_dev,
             inexact,
             exact,
+            no_locals,
+            locked,
+            frozen,
             installer,
             build,
             refresh,
@@ -669,6 +671,7 @@ impl SyncSettings {
                 extra.unwrap_or_default(),
             ),
             dev: flag(dev, no_dev).unwrap_or(true),
+            no_locals,
             modifications,
             package,
             python,

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -59,8 +59,8 @@ If you're using uv to manage your project, you can copy it into the image and in
 ADD . /app
 WORKDIR /app
 
-# Sync the project into a new environment
-RUN uv sync
+# Sync the project into a new environment, using the frozen lockfile
+RUN uv sync --frozen
 ```
 
 Once the project is installed, you can either _activate_ the virtual environment:
@@ -169,3 +169,33 @@ ENV UV_CACHE_DIR=/opt/uv-cache/
 ```
 
 If not mounting the cache, image size can be reduced with `--no-cache` flag.
+
+### Intermediate layers
+
+If you're using uv to manage your project, you can improve build times by moving your transitive
+dependency installation into its own layer via `uv sync --no-locals`.
+
+`uv sync --no-locals` will install all remote dependencies, but ignore any local dependencies,
+including the project itself. Since remote dependencies are typically immutable (whereas local
+dependencies change frequently), installing remote dependencies upfront can be a significant time
+saver.
+
+```dockerfile title="Dockerfile"
+# Install uv
+FROM python:3.12-slim-bullseye
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+# Copy the lockfile into the image
+ADD uv.lock /app/uv.lock
+
+# Install remote dependencies
+WORKDIR /app
+RUN uv sync --frozen --no-locals
+
+# Copy the project into the image
+ADD . /app
+WORKDIR /app
+
+# Sync the remaining dependencies
+RUN uv sync --frozen
+```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1170,6 +1170,10 @@ uv sync [OPTIONS]
 
 </dd><dt><code>--no-index</code></dt><dd><p>Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those provided via <code>--find-links</code></p>
 
+</dd><dt><code>--no-locals</code></dt><dd><p>Avoid syncing any local packages, including the current project and any workspace members or path dependencies in the lockfile.</p>
+
+<p>This is useful for priming an environment with remote dependencies, without relying on any local or mutable sources. For example, <code>uv sync --no-locals</code> could be used in a Docker image to create a highly cacheable intermediate layer prior to installing local packages, which change frequently.</p>
+
 </dd><dt><code>--no-progress</code></dt><dd><p>Hide all progress outputs.</p>
 
 <p>For example, spinners or progress bars.</p>


### PR DESCRIPTION
## Summary

This PR adds a flag (name TBD) that skips the installation of any local dependencies, allowing users to prime a Docker layer by copying over _just_ the lockfile.

See: https://github.com/astral-sh/uv/issues/4028
