### PR TITLE
docs: fix tip markup in python-versions.md

### DIFF
--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -171,8 +171,8 @@ during `uv python install`.
 
 !!! tip
 
-The `--python-downloads` option can be passed to any uv command, or it can be set in a
-[persistent configuration file](../configuration/files.md) to change the default behavior.
+    The `--python-downloads` option can be passed to any uv command, or it can be set in a
+    [persistent configuration file](../configuration/files.md) to change the default behavior.
 
 ## Adjusting Python version preferences
 


### PR DESCRIPTION
## Summary

Currently there's an empty tip box.

## Test Plan

Docs only, therefore eyeballed. :)
