### PR TITLE
docs: Update pip compatibility pages to mention configuration files support

### DIFF
--- a/docs/pip/compatibility.md
+++ b/docs/pip/compatibility.md
@@ -34,9 +34,9 @@ drawbacks:
    behavior, and many users may _not_ expect uv to read configuration files intended for other
    tools.
 
-Instead, uv supports its own environment variables, like `UV_INDEX_URL`. uv also
-supports persistent configuration in a `uv.toml` file or a `[tool.uv.pip]` section of `pyproject.toml`.
-For more information, see [Configuration files](../configuration/files.md).
+Instead, uv supports its own environment variables, like `UV_INDEX_URL`. uv also supports persistent
+configuration in a `uv.toml` file or a `[tool.uv.pip]` section of `pyproject.toml`. For more
+information, see [Configuration files](../configuration/files.md).
 
 ## Pre-release compatibility
 

--- a/docs/pip/compatibility.md
+++ b/docs/pip/compatibility.md
@@ -34,9 +34,9 @@ drawbacks:
    behavior, and many users may _not_ expect uv to read configuration files intended for other
    tools.
 
-Instead, uv supports its own environment variables, like `UV_INDEX_URL`. In the future, uv will also
-support persistent configuration in its own configuration file format (e.g., `pyproject.toml` or
-`uv.toml` or similar). For more, see [#651](https://github.com/astral-sh/uv/issues/651).
+Instead, uv supports its own environment variables, like `UV_INDEX_URL`. uv also
+supports persistent configuration in a `uv.toml` file or a `[tool.uv.pip]` section of `pyproject.toml`.
+For more information, see [Configuration files](https://docs.astral.sh/uv/configuration/files/).
 
 ## Pre-release compatibility
 

--- a/docs/pip/compatibility.md
+++ b/docs/pip/compatibility.md
@@ -36,7 +36,7 @@ drawbacks:
 
 Instead, uv supports its own environment variables, like `UV_INDEX_URL`. uv also
 supports persistent configuration in a `uv.toml` file or a `[tool.uv.pip]` section of `pyproject.toml`.
-For more information, see [Configuration files](https://docs.astral.sh/uv/configuration/files/).
+For more information, see [Configuration files](../configuration/files.md).
 
 ## Pre-release compatibility
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Docs at https://docs.astral.sh/uv/pip/compatibility/ still say:

> the future, uv will also support persistent configuration in its own configuration file format (e.g., pyproject.toml or uv.toml or similar). For more, see [#651](https://github.com/astral-sh/uv/issues/651).

I think that's done now (?), so updated these to link to https://docs.astral.sh/uv/configuration/files/ 