### PR TITLE
Hint at missing quote in marker

### DIFF
--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -1645,9 +1645,10 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err(r"name; invalid_name"),
             @"
-            Expected a valid marker name, found 'invalid_name'
+            Expected a quoted string or a valid marker name, found 'invalid_name'
             name; invalid_name
-                  ^^^^^^^^^^^^"
+                  ^^^^^^^^^^^^
+            "
         );
     }
 
@@ -1656,9 +1657,10 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("name; '3.7' <= invalid_name"),
             @"
-            Expected a valid marker name, found 'invalid_name'
+            Expected a quoted string or a valid marker name, found 'invalid_name'
             name; '3.7' <= invalid_name
-                           ^^^^^^^^^^^^"
+                           ^^^^^^^^^^^^
+            "
         );
     }
 
@@ -1670,6 +1672,18 @@ mod tests {
             Expected a valid marker operator (such as '>=' or 'not in'), found 'notin'
             name; '3.7' notin python_version
                         ^^^^^"
+        );
+    }
+
+    #[test]
+    fn error_missing_quote() {
+        assert_snapshot!(
+            parse_pep508_err("name; python_version == 3.10"),
+            @"
+            Expected a quoted string or a valid marker name, found '3.10'
+            name; python_version == 3.10
+                                    ^^^^
+            "
         );
     }
 

--- a/crates/pep508-rs/src/marker/parse.rs
+++ b/crates/pep508-rs/src/marker/parse.rs
@@ -103,7 +103,7 @@ pub(crate) fn parse_marker_value<T: Pep508Url>(
             let key = cursor.slice(start, len);
             MarkerValue::from_str(key).map_err(|_| Pep508Error {
                 message: Pep508ErrorSource::String(format!(
-                    "Expected a valid marker name, found '{key}'"
+                    "Expected a quoted string or a valid marker name, found '{key}'"
                 )),
                 start,
                 len,


### PR DESCRIPTION
For https://github.com/astral-sh/uv/issues/6379#issuecomment-2303074836.

Input: `name; python_version == 3.10`
Error:
```
Expected a quoted string or a valid marker name, found '3.10'
name; python_version == 3.10
                        ^^^^
```