### PR TITLE
Use backticks in pep508-rs

### DIFF
--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -2172,7 +2172,7 @@ impl std::fmt::Display for VersionParseError {
             } => {
                 write!(
                     f,
-                    "after parsing '{version}', found '{remaining}', \
+                    "after parsing `{version}`, found `{remaining}`, \
                      which is not part of a valid version",
                 )
             }

--- a/crates/pep508-rs/Readme.md
+++ b/crates/pep508-rs/Readme.md
@@ -73,6 +73,6 @@ from pep508_rs import Requirement, MarkerEnvironment
 env = MarkerEnvironment.current()
 Requirement("numpy; python_version >= '3.9.'").evaluate_markers(env, [])
 # This will log:
-# "Expected PEP 440 version to compare with python_version, found '3.9.', "
+# "Expected PEP 440 version to compare with python_version, found `3.9.`, "
 # "evaluating to false: Version `3.9.` doesn't match PEP 440 rules"
 ```

--- a/crates/pep508-rs/src/cursor.rs
+++ b/crates/pep508-rs/src/cursor.rs
@@ -125,7 +125,7 @@ impl<'a> Cursor<'a> {
             Some((_, value)) if value == expected => Ok(()),
             Some((pos, other)) => Err(Pep508Error {
                 message: Pep508ErrorSource::String(format!(
-                    "Expected '{expected}', found '{other}'"
+                    "Expected `{expected}`, found `{other}`"
                 )),
                 start: pos,
                 len: other.len_utf8(),

--- a/crates/pep508-rs/src/lib.rs
+++ b/crates/pep508-rs/src/lib.rs
@@ -604,7 +604,7 @@ fn parse_name<T: Pep508Url>(cursor: &mut Cursor) -> Result<PackageName, Pep508Er
             } else {
                 Err(Pep508Error {
                     message: Pep508ErrorSource::String(format!(
-                        "Expected package name starting with an alphanumeric character, found '{char}'"
+                        "Expected package name starting with an alphanumeric character, found `{char}`"
                     )),
                     start: index,
                     len: char.len_utf8(),
@@ -707,7 +707,7 @@ fn parse_extras_cursor<T: Pep508Url>(
             (Some((pos, ',')), true) => {
                 return Err(Pep508Error {
                     message: Pep508ErrorSource::String(
-                        "Expected either alphanumerical character (starting the extra name) or ']' (ending the extras section), found ','".to_string()
+                        "Expected either alphanumerical character (starting the extra name) or `]` (ending the extras section), found `,`".to_string()
                     ),
                     start: pos,
                     len: 1,
@@ -721,7 +721,7 @@ fn parse_extras_cursor<T: Pep508Url>(
             (Some((pos, other)), false) => {
                 return Err(Pep508Error {
                     message: Pep508ErrorSource::String(
-                        format!("Expected either ',' (separating extras) or ']' (ending the extras section), found '{other}'")
+                        format!("Expected either `,` (separating extras) or `]` (ending the extras section), found `{other}`")
                     ),
                     start: pos,
                     len: 1,
@@ -753,7 +753,7 @@ fn parse_extras_cursor<T: Pep508Url>(
             Some((pos, other)) => {
                 return Err(Pep508Error {
                     message: Pep508ErrorSource::String(format!(
-                        "Expected an alphanumeric character starting the extra name, found '{other}'"
+                        "Expected an alphanumeric character starting the extra name, found `{other}`"
                     )),
                     start: pos,
                     len: other.len_utf8(),
@@ -773,7 +773,7 @@ fn parse_extras_cursor<T: Pep508Url>(
             Some((pos, char)) if char != ',' && char != ']' && !char.is_whitespace() => {
                 return Err(Pep508Error {
                     message: Pep508ErrorSource::String(format!(
-                        "Invalid character in extras name, expected an alphanumeric character, '-', '_', '.', ',' or ']', found '{char}'"
+                        "Invalid character in extras name, expected an alphanumeric character, `-`, `_`, `.`, `,` or `]`, found `{char}`"
                     )),
                     start: pos,
                     len: char.len_utf8(),
@@ -1045,9 +1045,9 @@ fn parse_pep508_requirement<T: Pep508Url>(
             }
         }
         let message = if marker.is_none() {
-            format!(r#"Expected end of input or ';', found '{char}'"#)
+            format!(r#"Expected end of input or `;`, found `{char}`"#)
         } else {
-            format!(r#"Expected end of input, found '{char}'"#)
+            format!(r#"Expected end of input, found `{char}`"#)
         };
         return Err(Pep508Error {
             message: Pep508ErrorSource::String(message),
@@ -1154,7 +1154,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("_name"),
             @"
-            Expected package name starting with an alphanumeric character, found '_'
+            Expected package name starting with an alphanumeric character, found `_`
             _name
             ^"
         );
@@ -1309,7 +1309,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("black[ö]"),
             @"
-            Expected an alphanumeric character starting the extra name, found 'ö'
+            Expected an alphanumeric character starting the extra name, found `ö`
             black[ö]
                   ^"
         );
@@ -1320,7 +1320,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("black[_d]"),
             @"
-            Expected an alphanumeric character starting the extra name, found '_'
+            Expected an alphanumeric character starting the extra name, found `_`
             black[_d]
                   ^"
         );
@@ -1331,7 +1331,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("black[,]"),
             @"
-            Expected either alphanumerical character (starting the extra name) or ']' (ending the extras section), found ','
+            Expected either alphanumerical character (starting the extra name) or `]` (ending the extras section), found `,`
             black[,]
                   ^"
         );
@@ -1342,7 +1342,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("black[jüpyter]"),
             @"
-            Invalid character in extras name, expected an alphanumeric character, '-', '_', '.', ',' or ']', found 'ü'
+            Invalid character in extras name, expected an alphanumeric character, `-`, `_`, `.`, `,` or `]`, found `ü`
             black[jüpyter]
                    ^"
         );
@@ -1383,7 +1383,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("black[d,]"),
             @"
-            Expected an alphanumeric character starting the extra name, found ']'
+            Expected an alphanumeric character starting the extra name, found `]`
             black[d,]
                     ^"
         );
@@ -1489,9 +1489,10 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err(r"numpy; sys_platform"),
             @"
-                Expected a valid marker operator (such as '>=' or 'not in'), found ''
-                numpy; sys_platform
-                                   ^"
+            Expected a valid marker operator (such as `>=` or `not in`), found ``
+            numpy; sys_platform
+                               ^
+            "
         );
     }
 
@@ -1555,7 +1556,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err(r"==0.0"),
             @r"
-        Expected package name starting with an alphanumeric character, found '='
+        Expected package name starting with an alphanumeric character, found `=`
         ==0.0
         ^
         "
@@ -1590,7 +1591,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err(r"name[bar baz]"),
             @"
-            Expected either ',' (separating extras) or ']' (ending the extras section), found 'b'
+            Expected either `,` (separating extras) or `]` (ending the extras section), found `b`
             name[bar baz]
                      ^"
         );
@@ -1601,7 +1602,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err(r"name[bar, baz,]"),
             @"
-            Expected an alphanumeric character starting the extra name, found ']'
+            Expected an alphanumeric character starting the extra name, found `]`
             name[bar, baz,]
                           ^"
         );
@@ -1612,7 +1613,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err(r"name[bar, baz >= 1.0"),
             @"
-            Expected either ',' (separating extras) or ']' (ending the extras section), found '>'
+            Expected either `,` (separating extras) or `]` (ending the extras section), found `>`
             name[bar, baz >= 1.0
                           ^"
         );
@@ -1645,7 +1646,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err(r"name; invalid_name"),
             @"
-            Expected a quoted string or a valid marker name, found 'invalid_name'
+            Expected a quoted string or a valid marker name, found `invalid_name`
             name; invalid_name
                   ^^^^^^^^^^^^
             "
@@ -1657,7 +1658,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("name; '3.7' <= invalid_name"),
             @"
-            Expected a quoted string or a valid marker name, found 'invalid_name'
+            Expected a quoted string or a valid marker name, found `invalid_name`
             name; '3.7' <= invalid_name
                            ^^^^^^^^^^^^
             "
@@ -1669,7 +1670,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("name; '3.7' notin python_version"),
             @"
-            Expected a valid marker operator (such as '>=' or 'not in'), found 'notin'
+            Expected a valid marker operator (such as `>=` or `not in`), found `notin`
             name; '3.7' notin python_version
                         ^^^^^"
         );
@@ -1680,7 +1681,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("name; python_version == 3.10"),
             @"
-            Expected a quoted string or a valid marker name, found '3.10'
+            Expected a quoted string or a valid marker name, found `3.10`
             name; python_version == 3.10
                                     ^^^^
             "
@@ -1692,7 +1693,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("name; '3.6'inpython_version"),
             @"
-            Expected a valid marker operator (such as '>=' or 'not in'), found 'inpython_version'
+            Expected a valid marker operator (such as `>=` or `not in`), found `inpython_version`
             name; '3.6'inpython_version
                        ^^^^^^^^^^^^^^^^"
         );
@@ -1703,7 +1704,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("name; '3.7' not python_version"),
             @"
-            Expected 'i', found 'p'
+            Expected `i`, found `p`
             name; '3.7' not python_version
                             ^"
         );
@@ -1714,7 +1715,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("name; '3.7' ~ python_version"),
             @"
-            Expected a valid marker operator (such as '>=' or 'not in'), found '~'
+            Expected a valid marker operator (such as `>=` or `not in`), found `~`
             name; '3.7' ~ python_version
                         ^"
         );
@@ -1725,7 +1726,7 @@ mod tests {
         assert_snapshot!(
             parse_pep508_err("name==1.0.org1"),
             @r###"
-        after parsing '1.0', found '.org1', which is not part of a valid version
+        after parsing `1.0`, found `.org1`, which is not part of a valid version
         name==1.0.org1
             ^^^^^^^^^^
         "###
@@ -1771,7 +1772,7 @@ mod tests {
         assert_snapshot!(
             parse_unnamed_err("/foo-3.0.0-py3-none-any.whl[d,]"),
             @r###"
-        Expected an alphanumeric character starting the extra name, found ']'
+        Expected an alphanumeric character starting the extra name, found `]`
         /foo-3.0.0-py3-none-any.whl[d,]
                                       ^
         "###
@@ -1842,7 +1843,7 @@ mod tests {
             assert_eq!(url.fragment(), Some("hash=somehash"));
             assert!(
                 url.path().ends_with("/Users/ferris/wheel-0.42.0.whl"),
-                "Expected the path to end with '/Users/ferris/wheel-0.42.0.whl', found '{}'",
+                "Expected the path to end with `/Users/ferris/wheel-0.42.0.whl`, found `{}`",
                 url.path()
             );
         }

--- a/crates/pep508-rs/src/marker/parse.rs
+++ b/crates/pep508-rs/src/marker/parse.rs
@@ -43,7 +43,7 @@ fn parse_marker_operator<T: Pep508Url>(
             Some((pos, other)) => {
                 return Err(Pep508Error {
                     message: Pep508ErrorSource::String(format!(
-                        "Expected whitespace after 'not', found '{other}'"
+                        "Expected whitespace after `not`, found `{other}`"
                     )),
                     start: pos,
                     len: other.len_utf8(),
@@ -58,7 +58,7 @@ fn parse_marker_operator<T: Pep508Url>(
     }
     MarkerOperator::from_str(operator).map_err(|_| Pep508Error {
         message: Pep508ErrorSource::String(format!(
-            "Expected a valid marker operator (such as '>=' or 'not in'), found '{operator}'"
+            "Expected a valid marker operator (such as `>=` or `not in`), found `{operator}`"
         )),
         start,
         len,
@@ -103,7 +103,7 @@ pub(crate) fn parse_marker_value<T: Pep508Url>(
             let key = cursor.slice(start, len);
             MarkerValue::from_str(key).map_err(|_| Pep508Error {
                 message: Pep508ErrorSource::String(format!(
-                    "Expected a quoted string or a valid marker name, found '{key}'"
+                    "Expected a quoted string or a valid marker name, found `{key}`"
                 )),
                 start,
                 len,
@@ -343,8 +343,8 @@ fn parse_version_expr(
         reporter.report(
             MarkerWarningKind::Pep440Error,
             format!(
-                "Expected PEP 440 version operator to compare {key} with '{version}',
-                    found '{marker_operator}', will be ignored",
+                "Expected PEP 440 version operator to compare {key} with `{version}`,
+                    found `{marker_operator}`, will be ignored",
                 version = pattern.version()
             ),
         );
@@ -398,8 +398,8 @@ fn parse_inverted_version_expr(
         reporter.report(
             MarkerWarningKind::Pep440Error,
             format!(
-                "Expected PEP 440 version operator to compare {key} with '{version}',
-                    found '{marker_operator}', will be ignored"
+                "Expected PEP 440 version operator to compare {key} with `{version}`,
+                    found `{marker_operator}`, will be ignored"
             ),
         );
 

--- a/crates/pep508-rs/src/marker/tree.rs
+++ b/crates/pep508-rs/src/marker/tree.rs
@@ -1788,8 +1788,8 @@ mod test {
         testing_logger::validate(|captured_logs| {
             assert_eq!(
                 captured_logs[0].body,
-                "Expected PEP 440 version to compare with python_version, found '3.9.', \
-                 will evaluate to false: after parsing '3.9', found '.', which is \
+                "Expected PEP 440 version to compare with python_version, found `3.9.`, \
+                 will evaluate to false: after parsing `3.9`, found `.`, which is \
                  not part of a valid version"
             );
             assert_eq!(captured_logs[0].level, log::Level::Warn);

--- a/crates/pep508-rs/src/unnamed.rs
+++ b/crates/pep508-rs/src/unnamed.rs
@@ -188,9 +188,9 @@ fn parse_unnamed_requirement<Url: UnnamedRequirementUrl>(
             }
         }
         let message = if marker.is_none() {
-            format!(r#"Expected end of input or ';', found '{char}'"#)
+            format!(r#"Expected end of input or `;`, found `{char}`"#)
         } else {
-            format!(r#"Expected end of input, found '{char}'"#)
+            format!(r#"Expected end of input, found `{char}`"#)
         };
         return Err(Pep508Error {
             message: Pep508ErrorSource::String(message),

--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -154,7 +154,10 @@ pub struct RequirementsTxt {
 
 impl RequirementsTxt {
     /// See module level documentation
-    #[instrument(skip_all, fields(requirements_txt = requirements_txt.as_ref().as_os_str().to_str()))]
+    #[instrument(
+        skip_all,
+        fields(requirements_txt = requirements_txt.as_ref().as_os_str().to_str())
+    )]
     pub async fn parse(
         requirements_txt: impl AsRef<Path>,
         working_dir: impl AsRef<Path>,
@@ -622,7 +625,7 @@ fn eat_trailing_line(content: &str, s: &mut Scanner) -> Result<(), RequirementsT
         Some(other) => {
             let (line, column) = calculate_row_column(content, s.cursor());
             return Err(RequirementsTxtParserError::Parser {
-                message: format!("Expected comment or end-of-line, found '{other}'"),
+                message: format!("Expected comment or end-of-line, found `{other}`"),
                 line,
                 column,
             });
@@ -723,7 +726,7 @@ fn parse_hashes(content: &str, s: &mut Scanner) -> Result<Vec<String>, Requireme
         let (line, column) = calculate_row_column(content, s.cursor());
         return Err(RequirementsTxtParserError::Parser {
             message: format!(
-                "Expected '--hash', found '{:?}'",
+                "Expected `--hash`, found `{:?}`",
                 s.eat_while(|c: char| !c.is_whitespace())
             ),
             line,
@@ -1412,7 +1415,7 @@ mod test {
         }, {
             insta::assert_snapshot!(errors, @r###"
             Couldn't parse requirement in `<REQUIREMENTS_TXT>` at position 0
-            Expected an alphanumeric character starting the extra name, found 'ö'
+            Expected an alphanumeric character starting the extra name, found `ö`
             numpy[ö]==1.29
                   ^
             "###);
@@ -1542,7 +1545,7 @@ mod test {
         }, {
             insta::assert_snapshot!(errors, @r###"
             Couldn't parse requirement in `<REQUIREMENTS_TXT>` at position 3
-            Expected either alphanumerical character (starting the extra name) or ']' (ending the extras section), found ','
+            Expected either alphanumerical character (starting the extra name) or `]` (ending the extras section), found `,`
             black[,abcdef]
                   ^
             "###);

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -1187,7 +1187,7 @@ fn compile_python_invalid_version() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: invalid value '3.7.x' for '--python-version <PYTHON_VERSION>': Python version `3.7.x` could not be parsed: after parsing '3.7', found '.x', which is not part of a valid version
+    error: invalid value '3.7.x' for '--python-version <PYTHON_VERSION>': Python version `3.7.x` could not be parsed: after parsing `3.7`, found `.x`, which is not part of a valid version
 
     For more information, try '--help'.
     "###
@@ -3658,7 +3658,7 @@ fn error_missing_unnamed_env_var() -> Result<()> {
 
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.in` at position 0
-      Caused by: Expected package name starting with an alphanumeric character, found '$'
+      Caused by: Expected package name starting with an alphanumeric character, found `$`
     ${URL}
     ^
     "###
@@ -11881,7 +11881,7 @@ fn invalid_extra() -> Result<()> {
 
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.in` at position 0
-      Caused by: Expected an alphanumeric character starting the extra name, found '_'
+      Caused by: Expected an alphanumeric character starting the extra name, found `_`
     .[_anyio]
       ^
     "###);

--- a/crates/uv/tests/pip_list.rs
+++ b/crates/uv/tests/pip_list.rs
@@ -532,7 +532,7 @@ Version: 0.1-bulbasaur
 
     ----- stderr -----
     error: Failed to read metadata from: `[SITE_PACKAGES]/paramiko.egg-link`
-     Caused by: after parsing '0.1-b', found 'ulbasaur', which is not part of a valid version
+     Caused by: after parsing `0.1-b`, found `ulbasaur`, which is not part of a valid version
     "###
     );
 

--- a/crates/uv/tests/pip_uninstall.rs
+++ b/crates/uv/tests/pip_uninstall.rs
@@ -51,7 +51,7 @@ fn invalid_requirement() -> Result<()> {
 
     ----- stderr -----
     error: Failed to parse: `flask==1.0.x`
-      Caused by: after parsing '1.0', found '.x', which is not part of a valid version
+      Caused by: after parsing `1.0`, found `.x`, which is not part of a valid version
     flask==1.0.x
          ^^^^^^^
     "###);
@@ -99,7 +99,7 @@ fn invalid_requirements_txt_requirement() -> Result<()> {
 
     ----- stderr -----
     error: Couldn't parse requirement in `requirements.txt` at position 0
-      Caused by: after parsing '1.0', found '.x', which is not part of a valid version
+      Caused by: after parsing `1.0`, found `.x`, which is not part of a valid version
     flask==1.0.x
          ^^^^^^^
     "###);


### PR DESCRIPTION
In accordance with the style guide, use backticks in pep508-rs error messages.
