### PR TITLE
Env variables for python downloads

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -115,16 +115,30 @@ pub struct GlobalArgs {
         global = true,
         long,
         help_heading = "Python options",
-        display_order = 700
+        display_order = 700,
+        env = "UV_PYTHON_PREFERENCE"
     )]
     pub python_preference: Option<PythonPreference>,
 
     /// Allow automatically downloading Python when required.
-    #[arg(global = true, long, help_heading = "Python options", hide = true)]
+    #[arg(
+        global = true,
+        long,
+        help_heading = "Python options",
+        hide = true,
+        value_parser = clap::builder::BoolishValueParser::new(),
+        env = "UV_ALLOW_PYTHON_DOWNLOADS"
+    )]
     pub allow_python_downloads: bool,
 
     /// Disable automatic downloads of Python.
-    #[arg(global = true, long, help_heading = "Python options")]
+    #[arg(
+        global = true,
+        long,
+        help_heading = "Python options",
+        value_parser = clap::builder::BoolishValueParser::new(),
+        env = "UV_NO_PYTHON_DOWNLOADS"
+    )]
     pub no_python_downloads: bool,
 
     /// Deprecated version of [`Self::python_downloads`].

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -39,10 +39,10 @@ fn help() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [possible values:
-              only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
+              [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -101,10 +101,10 @@ fn help_flag() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [possible values:
-              only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
+              [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -162,10 +162,10 @@ fn help_short_flag() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [possible values:
-              only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
+              [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -274,6 +274,8 @@ fn help_subcommand() {
               By default, uv prefers using Python versions it manages. However, it will use system
               Python installations if a uv-managed Python is not installed. This option allows
               prioritizing or ignoring system Python installations.
+              
+              [env: UV_PYTHON_PREFERENCE=]
 
               Possible values:
               - only-managed: Only use managed Python installations; never use system Python
@@ -285,6 +287,8 @@ fn help_subcommand() {
 
           --no-python-downloads
               Disable automatic downloads of Python
+              
+              [env: UV_NO_PYTHON_DOWNLOADS=]
 
     Global options:
       -q, --quiet
@@ -421,6 +425,8 @@ fn help_subsubcommand() {
               By default, uv prefers using Python versions it manages. However, it will use system
               Python installations if a uv-managed Python is not installed. This option allows
               prioritizing or ignoring system Python installations.
+              
+              [env: UV_PYTHON_PREFERENCE=]
 
               Possible values:
               - only-managed: Only use managed Python installations; never use system Python
@@ -432,6 +438,8 @@ fn help_subsubcommand() {
 
           --no-python-downloads
               Disable automatic downloads of Python
+              
+              [env: UV_NO_PYTHON_DOWNLOADS=]
 
     Global options:
       -q, --quiet
@@ -531,10 +539,10 @@ fn help_flag_subcommand() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [possible values:
-              only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
+              [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -583,10 +591,10 @@ fn help_flag_subsubcommand() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [possible values:
-              only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
+              [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -715,10 +723,10 @@ fn help_with_global_option() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [possible values:
-              only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
+              [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -814,10 +822,10 @@ fn help_with_no_pager() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [possible values:
-              only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
+              [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
 
     Global options:
       -q, --quiet                      Do not print any output

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -69,6 +69,10 @@ In addition, uv respects the following environment variables:
   packages.
 - `UV_TOOL_DIR`: Used to specify the directory where uv will store managed tools.
 - `UV_TOOL_BIN_DIR`: Used to specify the "bin" directory where uv will install tool executables.
+- `UV_NO_PYTHON_DOWNLOADS`: Disable automatic downloads of Python.
+- `UV_ALLOW_PYTHON_DOWNLOADS`: Allow automatically downloading Python when required.
+- `UV_PYTHON_PREFERENCE`: Whether to prefer using Python installations that are already present on
+  the system, or those that are downloaded and installed by uv.
 - `UV_PYTHON_INSTALL_DIR`: Used to specify the directory where uv will store managed Python
   installations.
 - `UV_PYTHON_INSTALL_MIRROR`: Managed Python installations are downloaded from


### PR DESCRIPTION
## Summary

Resolves #6406

## Test Plan

```
❯ UV_PYTHON_PREFERENCE=only-managed cargo run -q -- sync --show-settings | rg python_preference
    python_preference: OnlyManaged,
❯ UV_PYTHON_PREFERENCE=system cargo run -q -- sync --show-settings | rg python_preference
    python_preference: System,
❯ UV_NO_PYTHON_DOWNLOADS=1 cargo run -q -- sync --show-settings | rg python_downloads
    python_downloads: Never,
❯ UV_ALLOW_PYTHON_DOWNLOADS=1 cargo run -q -- sync --show-settings | rg python_downloads
    python_downloads: Automatic,
```