### PR TITLE
Revert "Env variables for python downloads"

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -115,30 +115,16 @@ pub struct GlobalArgs {
         global = true,
         long,
         help_heading = "Python options",
-        display_order = 700,
-        env = "UV_PYTHON_PREFERENCE"
+        display_order = 700
     )]
     pub python_preference: Option<PythonPreference>,
 
     /// Allow automatically downloading Python when required.
-    #[arg(
-        global = true,
-        long,
-        help_heading = "Python options",
-        hide = true,
-        value_parser = clap::builder::BoolishValueParser::new(),
-        env = "UV_ALLOW_PYTHON_DOWNLOADS"
-    )]
+    #[arg(global = true, long, help_heading = "Python options", hide = true)]
     pub allow_python_downloads: bool,
 
     /// Disable automatic downloads of Python.
-    #[arg(
-        global = true,
-        long,
-        help_heading = "Python options",
-        value_parser = clap::builder::BoolishValueParser::new(),
-        env = "UV_NO_PYTHON_DOWNLOADS"
-    )]
+    #[arg(global = true, long, help_heading = "Python options")]
     pub no_python_downloads: bool,
 
     /// Deprecated version of [`Self::python_downloads`].

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -39,10 +39,10 @@ fn help() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
-              [possible values: only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [possible values:
+              only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
+              Disable automatic downloads of Python
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -101,10 +101,10 @@ fn help_flag() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
-              [possible values: only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [possible values:
+              only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
+              Disable automatic downloads of Python
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -162,10 +162,10 @@ fn help_short_flag() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
-              [possible values: only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [possible values:
+              only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
+              Disable automatic downloads of Python
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -274,8 +274,6 @@ fn help_subcommand() {
               By default, uv prefers using Python versions it manages. However, it will use system
               Python installations if a uv-managed Python is not installed. This option allows
               prioritizing or ignoring system Python installations.
-              
-              [env: UV_PYTHON_PREFERENCE=]
 
               Possible values:
               - only-managed: Only use managed Python installations; never use system Python
@@ -287,8 +285,6 @@ fn help_subcommand() {
 
           --no-python-downloads
               Disable automatic downloads of Python
-              
-              [env: UV_NO_PYTHON_DOWNLOADS=]
 
     Global options:
       -q, --quiet
@@ -425,8 +421,6 @@ fn help_subsubcommand() {
               By default, uv prefers using Python versions it manages. However, it will use system
               Python installations if a uv-managed Python is not installed. This option allows
               prioritizing or ignoring system Python installations.
-              
-              [env: UV_PYTHON_PREFERENCE=]
 
               Possible values:
               - only-managed: Only use managed Python installations; never use system Python
@@ -438,8 +432,6 @@ fn help_subsubcommand() {
 
           --no-python-downloads
               Disable automatic downloads of Python
-              
-              [env: UV_NO_PYTHON_DOWNLOADS=]
 
     Global options:
       -q, --quiet
@@ -539,10 +531,10 @@ fn help_flag_subcommand() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
-              [possible values: only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [possible values:
+              only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
+              Disable automatic downloads of Python
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -591,10 +583,10 @@ fn help_flag_subsubcommand() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
-              [possible values: only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [possible values:
+              only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
+              Disable automatic downloads of Python
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -723,10 +715,10 @@ fn help_with_global_option() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
-              [possible values: only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [possible values:
+              only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
+              Disable automatic downloads of Python
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -822,10 +814,10 @@ fn help_with_no_pager() {
 
     Python options:
           --python-preference <PYTHON_PREFERENCE>
-              Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
-              [possible values: only-managed, managed, system, only-system]
+              Whether to prefer uv-managed or system Python installations [possible values:
+              only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python [env: UV_NO_PYTHON_DOWNLOADS=]
+              Disable automatic downloads of Python
 
     Global options:
       -q, --quiet                      Do not print any output

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -69,10 +69,6 @@ In addition, uv respects the following environment variables:
   packages.
 - `UV_TOOL_DIR`: Used to specify the directory where uv will store managed tools.
 - `UV_TOOL_BIN_DIR`: Used to specify the "bin" directory where uv will install tool executables.
-- `UV_NO_PYTHON_DOWNLOADS`: Disable automatic downloads of Python.
-- `UV_ALLOW_PYTHON_DOWNLOADS`: Allow automatically downloading Python when required.
-- `UV_PYTHON_PREFERENCE`: Whether to prefer using Python installations that are already present on
-  the system, or those that are downloaded and installed by uv.
 - `UV_PYTHON_INSTALL_DIR`: Used to specify the directory where uv will store managed Python
   installations.
 - `UV_PYTHON_INSTALL_MIRROR`: Managed Python installations are downloaded from


### PR DESCRIPTION
This reverts commit bbd9adaa407c9b036d2f1ff7ea553afecb5ec627 from #6416 — the Python download variable is not aligned with the setting.
