### PR TITLE
Add support for configuring `python-downloads` with `UV_PYTHON_DOWNLOADS`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -120,11 +120,13 @@ pub struct GlobalArgs {
     )]
     pub python_preference: Option<PythonPreference>,
 
-    /// Allow automatically downloading Python when required.
+    #[allow(clippy::doc_markdown)]
+    /// Allow automatically downloading Python when required. [env: "UV_PYTHON_DOWNLOADS=auto"]
     #[arg(global = true, long, help_heading = "Python options", hide = true)]
     pub allow_python_downloads: bool,
 
-    /// Disable automatic downloads of Python.
+    #[allow(clippy::doc_markdown)]
+    /// Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]
     #[arg(global = true, long, help_heading = "Python options")]
     pub no_python_downloads: bool,
 

--- a/crates/uv-dev/src/generate_cli_reference.rs
+++ b/crates/uv-dev/src/generate_cli_reference.rs
@@ -20,6 +20,11 @@ const REPLACEMENTS: &[(&str, &str)] = &[
         "<code>uv help python</code>",
         "<a href=\"#uv-python\">uv python</a>",
     ),
+    // Drop the manually included `env` section for `--no-python-downloads`
+    // TODO(zanieb): In general, we should show all of the environment variables in the reference
+    // but this one is non-standard so it's the only one included right now. When we tackle the rest
+    // we can fix the formatting.
+    (" [env: &quot;UV<em>PYTHON</em>DOWNLOADS=never&quot;]", ""),
 ];
 
 const SHOW_HIDDEN_COMMANDS: &[&str] = &["generate-shell-completion"];

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -89,6 +89,19 @@ pub enum PythonDownloads {
     Never,
 }
 
+impl FromStr for PythonDownloads {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "auto" | "automatic" | "true" | "1" => Ok(PythonDownloads::Automatic),
+            "manual" => Ok(PythonDownloads::Manual),
+            "never" | "false" | "0" => Ok(PythonDownloads::Never),
+            _ => Err(format!("Invalid value for `python-download`: '{s}'")),
+        }
+    }
+}
+
 impl From<bool> for PythonDownloads {
     fn from(value: bool) -> Self {
         if value {

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -117,6 +117,7 @@ impl GlobalSettings {
                 .unwrap_or_else(PythonPreference::default_from_env),
             python_downloads: flag(args.allow_python_downloads, args.no_python_downloads)
                 .map(PythonDownloads::from)
+                .combine(env(env::UV_PYTHON_DOWNLOADS))
                 .combine(workspace.and_then(|workspace| workspace.globals.python_downloads))
                 .unwrap_or_default(),
             no_progress: args.no_progress,
@@ -2174,6 +2175,11 @@ mod env {
 
     pub(super) const CONCURRENT_INSTALLS: (&str, &str) =
         ("UV_CONCURRENT_INSTALLS", "a non-zero integer");
+
+    pub(super) const UV_PYTHON_DOWNLOADS: (&str, &str) = (
+        "UV_PYTHON_DOWNLOADS",
+        "one of 'auto', 'true', 'manual', 'never', or 'false'",
+    );
 }
 
 /// Attempt to load and parse an environment variable with the given name.

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -42,7 +42,7 @@ fn help() {
               Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
               [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -104,7 +104,7 @@ fn help_flag() {
               Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
               [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -165,7 +165,7 @@ fn help_short_flag() {
               Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
               [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -281,7 +281,7 @@ fn help_subcommand() {
                 installations
 
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]
 
     Global options:
       -q, --quiet
@@ -430,7 +430,7 @@ fn help_subsubcommand() {
                 installations
 
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]
 
     Global options:
       -q, --quiet
@@ -533,7 +533,7 @@ fn help_flag_subcommand() {
               Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
               [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -585,7 +585,7 @@ fn help_flag_subsubcommand() {
               Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
               [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -717,7 +717,7 @@ fn help_with_global_option() {
               Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
               [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]
 
     Global options:
       -q, --quiet                      Do not print any output
@@ -816,7 +816,7 @@ fn help_with_no_pager() {
               Whether to prefer uv-managed or system Python installations [env: UV_PYTHON_PREFERENCE=]
               [possible values: only-managed, managed, system, only-system]
           --no-python-downloads
-              Disable automatic downloads of Python
+              Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]
 
     Global options:
       -q, --quiet                      Do not print any output

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -58,6 +58,9 @@ uv accepts the following command-line arguments as environment variables:
   exclude distributions published after the specified date.
 - `UV_PYTHON_PREFERENCE`: Equivalent to the `--python-preference` command-line argument. Whether uv
   should prefer system or managed Python versions.
+- `UV_PYTHON_DOWNLOADS`: Equivalent to the
+  [`python-downloads`](../reference/settings.md#python-downloads) setting and, when disabled, the
+  `--no-python-downloads` option. Whether uv should allow Python downloads.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -235,7 +235,7 @@ uv run [OPTIONS] <COMMAND>
 
 <p>If a virtual environment is active or found in a current or parent directory, it will be used as if there was no project or workspace.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -406,7 +406,7 @@ uv init [OPTIONS] [PATH]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-readme</code></dt><dd><p>Do not create a <code>README.md</code> file</p>
 
@@ -634,7 +634,7 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -908,7 +908,7 @@ uv remove [OPTIONS] <PACKAGES>...
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -1174,7 +1174,7 @@ uv sync [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -1412,7 +1412,7 @@ uv lock [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -1645,7 +1645,7 @@ uv tree [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -1966,7 +1966,7 @@ uv tool run [OPTIONS] [COMMAND]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -2206,7 +2206,7 @@ uv tool install [OPTIONS] <PACKAGE>
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -2444,7 +2444,7 @@ uv tool upgrade [OPTIONS] <NAME>
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -2639,7 +2639,7 @@ uv tool uninstall [OPTIONS] <NAME>
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -2726,7 +2726,7 @@ uv tool update-shell [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -2831,7 +2831,7 @@ uv tool dir [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -2992,7 +2992,7 @@ uv python list [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -3097,7 +3097,7 @@ uv python install [OPTIONS] [TARGETS]...
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -3198,7 +3198,7 @@ uv python find [OPTIONS] [REQUEST]
 
 <p>Otherwise, when no request is provided, the Python requirement of a project in the current directory or parent directories will be used.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -3293,7 +3293,7 @@ uv python pin [OPTIONS] [REQUEST]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-workspace</code></dt><dd><p>Avoid validating the Python pin is compatible with the workspace.</p>
 
@@ -3388,7 +3388,7 @@ uv python dir [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -3479,7 +3479,7 @@ uv python uninstall [OPTIONS] <TARGETS>...
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -3740,7 +3740,7 @@ uv pip compile [OPTIONS] <SRC_FILE>...
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -4067,7 +4067,7 @@ uv pip sync [OPTIONS] <SRC_FILE>...
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -4374,7 +4374,7 @@ uv pip install [OPTIONS] <PACKAGE|--requirement <REQUIREMENT>|--editable <EDITAB
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
 
@@ -4621,7 +4621,7 @@ uv pip uninstall [OPTIONS] <PACKAGE|--requirement <REQUIREMENT>>
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -4722,7 +4722,7 @@ uv pip freeze [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -4835,7 +4835,7 @@ uv pip list [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -4936,7 +4936,7 @@ uv pip show [OPTIONS] [PACKAGE]...
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -5038,7 +5038,7 @@ uv pip tree [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-system</code></dt><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -5139,7 +5139,7 @@ uv pip check [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -5317,7 +5317,7 @@ uv venv [OPTIONS] [NAME]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -5452,7 +5452,7 @@ uv cache clean [OPTIONS] [PACKAGE]...
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -5539,7 +5539,7 @@ uv cache prune [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -5628,7 +5628,7 @@ uv cache dir [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -5709,7 +5709,7 @@ uv version [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
@@ -5814,7 +5814,7 @@ uv help [OPTIONS] [COMMAND]...
 
 <p>For example, spinners or progress bars.</p>
 
-</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python</p>
+</dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 


### PR DESCRIPTION
Part of https://github.com/astral-sh/uv/issues/6406

Replaces #6416 