### PR TITLE
Support locks path deps with path deps

### DIFF
--- a/crates/bench/benches/uv.rs
+++ b/crates/bench/benches/uv.rs
@@ -206,7 +206,7 @@ mod resolver {
             &hashes,
             &build_context,
             installed_packages,
-            DistributionDatabase::new(client, &build_context, concurrency.downloads),
+            DistributionDatabase::new(client, &build_context, None, concurrency.downloads),
         )?;
 
         Ok(resolver.resolve().await?)

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -155,7 +155,13 @@ impl<'a> BuildContext for BuildDispatch<'a> {
             &HashStrategy::None,
             self,
             EmptyInstalledPackages,
-            DistributionDatabase::new(self.client, self, self.concurrency.downloads),
+            DistributionDatabase::new(
+                self.client,
+                self,
+                // Not needed, there's no `uv.lock`.
+                None,
+                self.concurrency.downloads,
+            ),
         )?;
         let graph = resolver.resolve().await.with_context(|| {
             format!(
@@ -238,7 +244,13 @@ impl<'a> BuildContext for BuildDispatch<'a> {
                 tags,
                 &HashStrategy::None,
                 self.build_options,
-                DistributionDatabase::new(self.client, self, self.concurrency.downloads),
+                DistributionDatabase::new(
+                    self.client,
+                    self,
+                    // Not needed, there's no `uv.lock`.
+                    None,
+                    self.concurrency.downloads,
+                ),
             );
 
             debug!(

--- a/crates/uv-distribution/src/metadata/mod.rs
+++ b/crates/uv-distribution/src/metadata/mod.rs
@@ -60,6 +60,7 @@ impl Metadata {
         metadata: Metadata23,
         install_path: &Path,
         lock_path: &Path,
+        main_workspace_root: Option<&Path>,
         sources: SourceStrategy,
     ) -> Result<Self, MetadataError> {
         // Lower the requirements.
@@ -76,6 +77,7 @@ impl Metadata {
             },
             install_path,
             lock_path,
+            main_workspace_root,
             sources,
         )
         .await?;

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -38,6 +38,7 @@ impl RequiresDist {
         metadata: pypi_types::RequiresDist,
         install_path: &Path,
         lock_path: &Path,
+        main_workspace_root: Option<&Path>,
         sources: SourceStrategy,
     ) -> Result<Self, MetadataError> {
         match sources {
@@ -54,7 +55,7 @@ impl RequiresDist {
                     return Ok(Self::from_metadata23(metadata));
                 };
 
-                Self::from_project_workspace(metadata, &project_workspace)
+                Self::from_project_workspace(metadata, &project_workspace, main_workspace_root)
             }
             SourceStrategy::Disabled => Ok(Self::from_metadata23(metadata)),
         }
@@ -63,6 +64,7 @@ impl RequiresDist {
     fn from_project_workspace(
         metadata: pypi_types::RequiresDist,
         project_workspace: &ProjectWorkspace,
+        main_workspace_root: Option<&Path>,
     ) -> Result<Self, MetadataError> {
         // Collect any `tool.uv.sources` and `tool.uv.dev_dependencies` from `pyproject.toml`.
         let empty = BTreeMap::default();
@@ -94,6 +96,7 @@ impl RequiresDist {
                         project_workspace.project_root(),
                         sources,
                         project_workspace.workspace(),
+                        main_workspace_root,
                     )
                     .map(LoweredRequirement::into_inner)
                     .map_err(|err| MetadataError::LoweringError(requirement_name.clone(), err))
@@ -117,6 +120,7 @@ impl RequiresDist {
                     project_workspace.project_root(),
                     sources,
                     project_workspace.workspace(),
+                    main_workspace_root,
                 )
                 .map(LoweredRequirement::into_inner)
                 .map_err(|err| MetadataError::LoweringError(requirement_name.clone(), err))
@@ -177,6 +181,7 @@ mod test {
         Ok(RequiresDist::from_project_workspace(
             requires_dist,
             &project_workspace,
+            None,
         )?)
     }
 

--- a/crates/uv-requirements/src/source_tree.rs
+++ b/crates/uv-requirements/src/source_tree.rs
@@ -161,7 +161,11 @@ impl<'a, Context: BuildContext> SourceTreeResolver<'a, Context> {
         })?;
 
         // If the path is a `pyproject.toml`, attempt to extract the requirements statically.
-        if let Ok(metadata) = self.database.requires_dist(source_tree).await {
+        if let Ok(metadata) = self
+            .database
+            .requires_dist(source_tree, self.database.main_workspace_root())
+            .await
+        {
             return Ok(metadata);
         }
 

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -310,6 +310,10 @@ pub(crate) async fn pip_compile(
         BuildIsolation::SharedPackage(&environment, &no_build_isolation_package)
     };
 
+    // Currently no effect (only used for `uv.lock`), but there's no reason not to preserve this
+    // information.
+    let main_workspace_root = output_file.and_then(|file| file.parent());
+
     let build_dispatch = BuildDispatch::new(
         &client,
         &cache,
@@ -346,6 +350,7 @@ pub(crate) async fn pip_compile(
         dev,
         source_trees,
         project,
+        main_workspace_root,
         None,
         &extras,
         preferences,

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -336,6 +336,8 @@ pub(crate) async fn pip_install(
         dev,
         source_trees,
         project,
+        // Not needed, there's no `uv.lock`.
+        None,
         None,
         extras,
         preferences,
@@ -372,6 +374,8 @@ pub(crate) async fn pip_install(
         site_packages,
         Modifications::Sufficient,
         &reinstall,
+        // Not needed, there's no `uv.lock`.
+        None,
         &build_options,
         link_mode,
         compile,

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use owo_colors::OwoColorize;
 use std::collections::{BTreeSet, HashSet};
 use std::fmt::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::debug;
 
 use distribution_types::{
@@ -92,6 +92,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
     dev: Vec<GroupName>,
     source_trees: Vec<PathBuf>,
     mut project: Option<PackageName>,
+    main_workspace_root: Option<&Path>,
     workspace_members: Option<BTreeSet<PackageName>>,
     extras: &ExtrasSpecification,
     preferences: Vec<Preference>,
@@ -120,7 +121,12 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
             requirements,
             hasher,
             index,
-            DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
+            DistributionDatabase::new(
+                client,
+                build_dispatch,
+                main_workspace_root,
+                concurrency.downloads,
+            ),
         )
         .with_reporter(ResolverReporter::from(printer))
         .resolve()
@@ -133,7 +139,12 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 extras,
                 hasher,
                 index,
-                DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
+                DistributionDatabase::new(
+                    client,
+                    build_dispatch,
+                    main_workspace_root,
+                    concurrency.downloads,
+                ),
             )
             .with_reporter(ResolverReporter::from(printer))
             .resolve()
@@ -186,7 +197,12 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
         overrides,
         hasher,
         index,
-        DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
+        DistributionDatabase::new(
+            client,
+            build_dispatch,
+            main_workspace_root,
+            concurrency.downloads,
+        ),
     )
     .with_reporter(ResolverReporter::from(printer))
     .resolve()
@@ -211,7 +227,12 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
                 &dev,
                 hasher,
                 index,
-                DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
+                DistributionDatabase::new(
+                    client,
+                    build_dispatch,
+                    main_workspace_root,
+                    concurrency.downloads,
+                ),
             )
             .with_reporter(ResolverReporter::from(printer))
             .resolve(&markers)
@@ -257,7 +278,12 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
             hasher,
             build_dispatch,
             installed_packages,
-            DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
+            DistributionDatabase::new(
+                client,
+                build_dispatch,
+                main_workspace_root,
+                concurrency.downloads,
+            ),
         )?
         .with_reporter(reporter);
 
@@ -344,6 +370,7 @@ pub(crate) async fn install(
     site_packages: SitePackages,
     modifications: Modifications,
     reinstall: &Reinstall,
+    main_workspace_root: Option<&Path>,
     build_options: &BuildOptions,
     link_mode: LinkMode,
     compile: bool,
@@ -426,7 +453,12 @@ pub(crate) async fn install(
             tags,
             hasher,
             build_options,
-            DistributionDatabase::new(client, build_dispatch, concurrency.downloads),
+            DistributionDatabase::new(
+                client,
+                build_dispatch,
+                main_workspace_root,
+                concurrency.downloads,
+            ),
         )
         .with_reporter(PrepareReporter::from(printer).with_length(remote.len() as u64));
 

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -284,6 +284,8 @@ pub(crate) async fn pip_sync(
         dev,
         source_trees,
         project,
+        // No effect (only used for `uv.lock`).
+        None,
         None,
         &extras,
         preferences,
@@ -320,6 +322,8 @@ pub(crate) async fn pip_sync(
         site_packages,
         Modifications::Exact,
         &reinstall,
+        // Not needed, there's no `uv.lock`.
+        None,
         &build_options,
         link_mode,
         compile,

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -309,7 +309,12 @@ pub(crate) async fn add(
         requirements,
         &hasher,
         &state.index,
-        DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads),
+        DistributionDatabase::new(
+            &client,
+            &build_dispatch,
+            Some(target.workspace_root()),
+            concurrency.downloads,
+        ),
     )
     .with_reporter(ResolverReporter::from(printer))
     .resolve()
@@ -670,6 +675,13 @@ impl Target {
         match self {
             Self::Script(_, interpreter) => interpreter,
             Self::Project(_, venv) => venv.interpreter(),
+        }
+    }
+
+    fn workspace_root(&self) -> &Path {
+        match self {
+            Target::Script(script, _) => &script.path,
+            Target::Project(project, _) => project.root(),
         }
     }
 }

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use tracing::debug;
 
 use cache_key::{cache_digest, hash_digest};
@@ -31,6 +32,7 @@ impl CachedEnvironment {
         spec: RequirementsSpecification,
         interpreter: Interpreter,
         settings: &ResolverInstallerSettings,
+        main_workspace_root: Option<&Path>,
         state: &SharedState,
         resolve: Box<dyn ResolveLogger>,
         install: Box<dyn InstallLogger>,
@@ -60,6 +62,7 @@ impl CachedEnvironment {
         let graph = resolve_environment(
             &interpreter,
             spec,
+            main_workspace_root,
             settings.as_ref().into(),
             state,
             resolve,

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -400,7 +400,13 @@ async fn do_lock(
         concurrency,
     );
 
-    let database = DistributionDatabase::new(&client, &build_dispatch, concurrency.downloads);
+    let database = DistributionDatabase::new(
+        &client,
+        &build_dispatch,
+        // We want to compute paths relative to `uv.lock`, so we need its absolute location.
+        Some(workspace.install_path()),
+        concurrency.downloads,
+    );
 
     // If any of the resolution-determining settings changed, invalidate the lock.
     let existing_lock = if let Some(existing_lock) = existing_lock {
@@ -496,6 +502,8 @@ async fn do_lock(
                 dev,
                 source_trees,
                 None,
+                // We want to compute paths relative to `uv.lock`, so we need its absolute location.
+                Some(workspace.install_path()),
                 Some(workspace.packages().keys().cloned().collect()),
                 &extras,
                 preferences,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -254,6 +254,7 @@ pub(super) async fn do_sync(
         site_packages,
         modifications,
         reinstall,
+        Some(project.root()),
         build_options,
         link_mode,
         compile_bytecode,

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -273,6 +273,8 @@ pub(crate) async fn install(
             environment,
             spec,
             &settings,
+            // Tools don't have a workspace, they should use absolute paths.
+            None,
             &state,
             Box::new(DefaultResolveLogger),
             Box::new(DefaultInstallLogger),
@@ -298,6 +300,8 @@ pub(crate) async fn install(
         let resolution = resolve_environment(
             &interpreter,
             spec,
+            // Tools don't have a workspace, they should use absolute paths.
+            None,
             settings.as_ref().into(),
             &state,
             Box::new(DefaultResolveLogger),

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -539,6 +539,8 @@ async fn get_or_create_environment(
         spec,
         interpreter,
         settings,
+        // Tools don't have a workspace, they should use absolute paths.
+        None,
         &state,
         if show_resolution {
             Box::new(DefaultResolveLogger)

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -128,6 +128,8 @@ pub(crate) async fn upgrade(
             existing_environment,
             spec,
             &settings,
+            // Tools don't have a workspace, they should use absolute paths.
+            None,
             &state,
             Box::new(SummaryResolveLogger),
             Box::new(UpgradeInstallLogger::new(name.clone())),

--- a/crates/uv/tests/branching_urls.rs
+++ b/crates/uv/tests/branching_urls.rs
@@ -276,14 +276,14 @@ fn root_package_splits_transitive_too() -> Result<()> {
 
     [package.metadata]
     requires-dist = [
-        { name = "b1", marker = "python_full_version < '3.12'", directory = "../b1" },
-        { name = "b2", marker = "python_full_version >= '3.12'", directory = "../b2" },
+        { name = "b1", marker = "python_full_version < '3.12'", directory = "b1" },
+        { name = "b2", marker = "python_full_version >= '3.12'", directory = "b2" },
     ]
 
     [[package]]
     name = "b1"
     version = "0.1.0"
-    source = { directory = "../b1" }
+    source = { directory = "b1" }
     dependencies = [
         { name = "iniconfig", version = "1.1.1", source = { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl" }, marker = "python_full_version < '3.12'" },
     ]
@@ -294,7 +294,7 @@ fn root_package_splits_transitive_too() -> Result<()> {
     [[package]]
     name = "b2"
     version = "0.1.0"
-    source = { directory = "../b2" }
+    source = { directory = "b2" }
     dependencies = [
         { name = "iniconfig", version = "2.0.0", source = { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl" }, marker = "python_full_version >= '3.12'" },
     ]
@@ -804,12 +804,12 @@ fn dont_pre_visit_url_packages() -> Result<()> {
     ]
 
     [package.metadata]
-    requires-dist = [{ name = "c", directory = "../c" }]
+    requires-dist = [{ name = "c", directory = "c" }]
 
     [[package]]
     name = "c"
     version = "0.1.0"
-    source = { directory = "../c" }
+    source = { directory = "c" }
     "###);
 
     Ok(())

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -1506,3 +1506,64 @@ fn workspace_member_name_shadows_dependencies() -> Result<()> {
 
     Ok(())
 }
+
+/// Test that path dependencies with path dependencies resolve paths correctly across workspaces.
+///
+/// Each package is its own workspace. We put the other projects into a separate directory `libs` so
+/// the paths don't line up by accident.
+#[test]
+fn test_path_hopping() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    // Build the main project ...
+    let deps = indoc! {r#"
+        dependencies = ["foo"]
+
+        [tool.uv.sources]
+        foo = { path = "../libs/foo", editable = true }
+
+    "#};
+    let main_project_dir = context.temp_dir.join("project");
+    make_project(&main_project_dir, "project", deps)?;
+
+    // ... that depends on foo ...
+    let deps = indoc! {r#"
+        dependencies = ["bar"]
+
+        [tool.uv.sources]
+        bar = { path = "../../libs/bar", editable = true }
+    "#};
+    make_project(&context.temp_dir.join("libs").join("foo"), "foo", deps)?;
+
+    // ... that depends on bar, a stub project.
+    make_project(&context.temp_dir.join("libs").join("bar"), "bar", "")?;
+
+    uv_snapshot!(context.filters(), context.lock().arg("--preview").current_dir(&main_project_dir), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
+    Resolved 3 packages in [TIME]
+    "###
+    );
+
+    let lock: SourceLock =
+        toml::from_str(&fs_err::read_to_string(main_project_dir.join("uv.lock"))?)?;
+    assert_json_snapshot!(lock.sources(), @r###"
+    {
+      "bar": {
+        "editable": "../libs/bar"
+      },
+      "foo": {
+        "editable": "../libs/foo"
+      },
+      "project": {
+        "editable": "."
+      }
+    }
+    "###);
+
+    Ok(())
+}


### PR DESCRIPTION
Pass the location of `uv.lock`, the base of our relative lockfile paths, around when locking in project mode. This fixes previous incorrect paths that were using the root of the other workspace as reference for the relative path.

Fixes #6371.
