### PR TITLE
Fix retrieval of credentials for URLs from cache

### DIFF
--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -17,7 +17,7 @@ pub struct Credentials {
     password: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash, Default)]
 pub(crate) struct Username(Option<String>);
 
 impl Username {

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -161,6 +161,13 @@ impl Middleware for AuthMiddleware {
                 // Do not insert already-cached credentials
                 None
             } else if let Some(credentials) = self
+                .cache()
+                .get_url(request.url(), &credentials.to_username())
+            {
+                request = credentials.authenticate(request);
+                // Do not insert already-cached credentials
+                None
+            } else if let Some(credentials) = self
                 .fetch_credentials(Some(&credentials), request.url())
                 .await
             {


### PR DESCRIPTION
While working on https://github.com/astral-sh/uv/pull/6389 I discovered we never checked `cache.get_url` here, which is wrong — though I don't think it had much effect in practice since the realm would typically match first. The main problem is that when we call `get_url` later we hard-code the username to `None` because we assume we checked up here with the username if present. 