### PR TITLE
feat(self-update): show old version in update message

### DIFF
--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -74,14 +74,24 @@ pub(crate) async fn self_update(printer: Printer) -> Result<ExitStatus> {
     // available version of uv.
     match updater.run().await {
         Ok(Some(result)) => {
+            let version_information = if result.old_version.is_some() {
+                format!(
+                    "from {} to {}",
+                    format!("v{}", result.old_version.unwrap()).bold().white(),
+                    format!("v{}", result.new_version).bold().white(),
+                )
+            } else {
+                format!("to {}", format!("v{}", result.new_version).bold().white())
+            };
+
             writeln!(
                 printer.stderr(),
                 "{}",
                 format_args!(
-                    "{}{} Upgraded uv to {}! {}",
+                    "{}{} Upgraded uv {}! {}",
                     "success".green().bold(),
                     ":".bold(),
-                    format!("v{}", result.new_version).bold().white(),
+                    version_information,
                     format!(
                         "https://github.com/astral-sh/uv/releases/tag/{}",
                         result.new_version_tag

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -74,10 +74,10 @@ pub(crate) async fn self_update(printer: Printer) -> Result<ExitStatus> {
     // available version of uv.
     match updater.run().await {
         Ok(Some(result)) => {
-            let version_information = if result.old_version.is_some() {
+            let version_information = if let Some(old_version) = result.old_version {
                 format!(
                     "from {} to {}",
-                    format!("v{}", result.old_version.unwrap()).bold().white(),
+                    format!("v{old_version}").bold().white(),
                     format!("v{}", result.new_version).bold().white(),
                 )
             } else {


### PR DESCRIPTION
## Summary

Indicate the previous version from which uv was upgraded when running `uv self update`. Thought that it could be useful in some situations to have a trace of the previous version that was installed.

## Test Plan

Did not find a way to test this, since this heavily relies on being able to use the installation script and the ability to publish artifacts for a specific tag.