### PR TITLE
Fix to miss string termination in PowerShell commands for shell autocompletion docs.

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -120,7 +120,7 @@ To enable shell autocompletion for uv commands, run one of the following:
 === "Windows"
 
     ```powershell
-    Add-Content -Path $PROFILE -Value '(& uv generate-shell-completion powershell) | Out-String | Invoke-Expression
+    Add-Content -Path $PROFILE -Value '(& uv generate-shell-completion powershell) | Out-String | Invoke-Expression'
     ```
 
 Then restart the shell or source the shell config file.


### PR DESCRIPTION

## Summary
 Missing string termination in PowerShell commands for shell autocompletion docs.
 Incomplete command:
 
![image](https://github.com/user-attachments/assets/c96a93a3-f70c-4496-be54-34ab72f01a3f)



## Test Plan
Run docs server locally
![image](https://github.com/user-attachments/assets/fe861be4-6e44-441b-b924-ae832a72be16)
