### PR TITLE
docs: Incorrect workspace members keyword

### DIFF
--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -216,7 +216,7 @@ dependencies = [
 mollymawk = { workspace = true }
 
 [tool.uv.workspace]
-include = [
+members = [
   "packages/mollymawk"
 ]
 ```


### PR DESCRIPTION
## Summary

Small keyword fix. In the `concepts/dependencies` documentation, the workspace example listed members under an invalid `tool.uv.workspace.include` field.

This PR changes the key to [`tool.uv.workspace.members`](https://docs.astral.sh/uv/reference/settings/#workspace_members) instead.