### PR TITLE
Ignore `.python-version` files in `uv venv` with `--no-config`

### DIFF
--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -57,6 +57,7 @@ pub(crate) async fn venv(
     exclude_newer: Option<ExcludeNewer>,
     concurrency: Concurrency,
     native_tls: bool,
+    no_config: bool,
     cache: &Cache,
     printer: Printer,
     relocatable: bool,
@@ -78,6 +79,7 @@ pub(crate) async fn venv(
         exclude_newer,
         concurrency,
         native_tls,
+        no_config,
         cache,
         printer,
         relocatable,
@@ -130,6 +132,7 @@ async fn venv_impl(
     exclude_newer: Option<ExcludeNewer>,
     concurrency: Concurrency,
     native_tls: bool,
+    no_config: bool,
     cache: &Cache,
     printer: Printer,
     relocatable: bool,
@@ -145,8 +148,7 @@ async fn venv_impl(
 
     // (2) Request from `.python-version`
     if interpreter_request.is_none() {
-        // TODO(zanieb): Support `--no-config` here
-        interpreter_request = PythonVersionFile::discover(&*CWD, false, false)
+        interpreter_request = PythonVersionFile::discover(&*CWD, no_config, false)
             .await
             .into_diagnostic()?
             .and_then(PythonVersionFile::into_version);

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -681,6 +681,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.settings.exclude_newer,
                 globals.concurrency,
                 globals.native_tls,
+                cli.no_config,
                 &cache,
                 printer,
                 args.relocatable,


### PR DESCRIPTION
Dupe of  #6373 — merged into the wrong branch by accident.