### PR TITLE
Add `--no-project` alias for `uv python pin --no-workspace`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3060,13 +3060,13 @@ pub struct PythonPinArgs {
     #[arg(long, overrides_with("no_resolved"), hide = true)]
     pub no_resolved: bool,
 
-    /// Avoid validating the Python pin is compatible with the workspace.
+    /// Avoid validating the Python pin is compatible with the project or workspace.
     ///
-    /// By default, a workspace is discovered in the current directory or any parent
-    /// directory. If a workspace is found, the Python pin is validated against
-    /// the workspace's `requires-python` constraint.
-    #[arg(long)]
-    pub no_workspace: bool,
+    /// By default, a project or workspace is discovered in the current directory or any parent
+    /// directory. If a workspace is found, the Python pin is validated against the workspace's
+    /// `requires-python` constraint.
+    #[arg(long, alias = "no-workspace")]
+    pub no_project: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/python/pin.rs
+++ b/crates/uv/src/commands/python/pin.rs
@@ -22,11 +22,11 @@ pub(crate) async fn pin(
     request: Option<String>,
     resolved: bool,
     python_preference: PythonPreference,
-    no_workspace: bool,
+    no_project: bool,
     cache: &Cache,
     printer: Printer,
 ) -> Result<ExitStatus> {
-    let virtual_project = if no_workspace {
+    let virtual_project = if no_project {
         None
     } else {
         match VirtualProject::discover(&CWD, &DiscoveryOptions::default()).await {

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -944,7 +944,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.request,
                 args.resolved,
                 globals.python_preference,
-                args.no_workspace,
+                args.no_project,
                 &cache,
                 printer,
             )

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -590,7 +590,7 @@ impl PythonFindSettings {
 pub(crate) struct PythonPinSettings {
     pub(crate) request: Option<String>,
     pub(crate) resolved: bool,
-    pub(crate) no_workspace: bool,
+    pub(crate) no_project: bool,
 }
 
 impl PythonPinSettings {
@@ -601,13 +601,13 @@ impl PythonPinSettings {
             request,
             no_resolved,
             resolved,
-            no_workspace,
+            no_project,
         } = args;
 
         Self {
             request,
             resolved: flag(resolved, no_resolved).unwrap_or(false),
-            no_workspace,
+            no_project,
         }
     }
 }

--- a/crates/uv/tests/python_pin.rs
+++ b/crates/uv/tests/python_pin.rs
@@ -264,17 +264,38 @@ fn python_pin_compatible_with_requires_python() -> anyhow::Result<()> {
     error: The requested Python version `cpython@3.10` is incompatible with the project `requires-python` value of `>=3.11`.
     "###);
 
+    // Request an incompatible version with project discovery turned off
+    uv_snapshot!(context.filters(), context.python_pin().arg("cpython@3.10").arg("--no-project"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Pinned `.python-version` to `cpython@3.10`
+
+    ----- stderr -----
+    "###);
+
+    // And, as an alias, workspace discovery
+    uv_snapshot!(context.filters(), context.python_pin().arg("cpython@3.10").arg("--no-workspace"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Pinned `.python-version` to `cpython@3.10`
+
+    ----- stderr -----
+    "###);
+
     // Request a complex version range that resolves to an incompatible version
     uv_snapshot!(context.filters(), context.python_pin().arg(">3.8,<3.11"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    Pinned `.python-version` to `>3.8, <3.11`
+    Updated `.python-version` from `cpython@3.10` -> `>3.8, <3.11`
 
     ----- stderr -----
     warning: The requested Python version `>3.8, <3.11` resolves to `3.10.[X]` which  is incompatible with the project `requires-python` value of `>=3.11`.
     "###);
 
+    // Request a version that is compatible
     uv_snapshot!(context.filters(), context.python_pin().arg("3.11"), @r###"
     success: true
     exit_code: 0

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3293,11 +3293,11 @@ uv python pin [OPTIONS] [REQUEST]
 
 <p>For example, spinners or progress bars.</p>
 
+</dd><dt><code>--no-project</code></dt><dd><p>Avoid validating the Python pin is compatible with the project or workspace.</p>
+
+<p>By default, a project or workspace is discovered in the current directory or any parent directory. If a workspace is found, the Python pin is validated against the workspace&#8217;s <code>requires-python</code> constraint.</p>
+
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
-
-</dd><dt><code>--no-workspace</code></dt><dd><p>Avoid validating the Python pin is compatible with the workspace.</p>
-
-<p>By default, a workspace is discovered in the current directory or any parent directory. If a workspace is found, the Python pin is validated against the workspace&#8217;s <code>requires-python</code> constraint.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 


### PR DESCRIPTION
This matches the other interfaces and seems like an oversight.