### PR TITLE
docs: Add PyTorch installation guide

### DIFF
--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -12,13 +12,32 @@ please refer to [Getting Help](../../getting-started/help.md).
 
 !!! tip "TL;DR"
 
-    * If want PyTorch on macOS, just run `uv add torch`/`uv pip install torch`.
-    * If want PyTorch on Windows *with CPU support*, just run `uv add torch`/`uv pip install torch`.
-    * If want to install PyTorch on Linux with CPU support, add `--extra-index-url=https://download.pytorch.org/whl/cpu` to the `uv add`/`uv pip install` command.
-    * For Windows and Linux:
-        1. If you need CUDA 11.8, add `--extra-index-url=https://download.pytorch.org/whl/cu118` to the `uv add`/`uv pip install` command.
-        2. If you need CUDA 12.1, add `--extra-index-url=https://download.pytorch.org/whl/cu121` to the `uv add`/`uv pip install` command.
-        3. If you need CUDA 12.4, add `--extra-index-url=https://download.pytorch.org/whl/cu124` to the `uv add`/`uv pip install` command.
+    As of 09/2024:
+
+    * Use `uv add torch` or `uv pip install torch` for:
+        * on macOS (CPU only)
+        * on Linux (CUDA 12.1 only)
+        * on Windows (CPU only)
+    * Use `uv add --extra-index-url=https://download.pytorch.org/whl/cpu torch` or `uv pip install --extra-index-url=https://download.pytorch.org/whl/cpu torch` for:
+        * on Linux (CPU only)
+    * `uv add --extra-index-url=https://download.pytorch.org/whl/cu118 torch` or `uv pip install --extra-index-url=https://download.pytorch.org/whl/cu118 torch` will work:
+        * on Windows and Linux (CUDA 11.8 only)
+    * `uv add --extra-index-url=https://download.pytorch.org/whl/cu121 torch` or `uv pip install --extra-index-url=https://download.pytorch.org/whl/cu121 torch` will work:
+        * on Windows (CUDA 12.1 only)
+    * `uv add --extra-index-url=https://download.pytorch.org/whl/cu124 torch` or `uv pip install --extra-index-url=https://download.pytorch.org/whl/cu124 torch` will work:
+        * on Windows (CUDA 12.4 only)
+        * on Linux (CUDA 12.4 only)
+
+
+!!! info "Why `--extra-index-url`?"
+
+    uv `--extra-index-url` behaves differently than `pip --extra-index-url`. See more [here](https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes).
+
+!!! warning "About lockfile cross-compatibility"
+
+    Currently, uv does not support pinning a package to a specific index (though progress is tracked [here](https://github.com/astral-sh/uv/issues/171)).
+    In case of PyTorch, this means that the lockfile might not be cross-compatible between different platforms. For example: suppose a Windows user runs `uv add torch` and then a Linux user
+    runs `uv sync` to synchronise the lockfile. The Windows user will get CPU-only PyTorch, while the Linux user will get CUDA 12.1 PyTorch.
 
 ## On macOS
 
@@ -54,12 +73,14 @@ uv pip install --extra-index-url=https://download.pytorch.org/whl/cu118 torch
 
 ### CUDA 12.1 Support
 
+Currently, wheels on PyPI for PyTorch on Linux come with CUDA 12.1.
+
 ```sh
 # in a project
-uv add --extra-index-url=https://download.pytorch.org/whl/cu121 torch
+uv add torch
 
 # make sure there is a virtual environment in the directory
-uv pip install --extra-index-url=https://download.pytorch.org/whl/cu121 torch
+uv pip install torch
 ```
 
 ### CUDA 12.4 Support

--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -164,4 +164,4 @@ This will install PyTorch 2.5.0 on macOS, and PyTorch 2.5.0+cu124 on Linux and W
 
 !!! warning "PyTorch on Intel Macs"
 
-    Note that the last version to support Intel Macs is PyTorch 2.3.0. In other words, if you try to install PyTorch 2.4.0 or more on an Intel Mac, you will get an error.
+    Note that the last minor version to support Intel Macs is PyTorch 2.2. In other words, if you try to install PyTorch 2.3.0 or more on an Intel Mac, you will get an error. Alternatively, you can install PyTorch with conda

--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -31,13 +31,15 @@ please refer to [Getting Help](../../getting-started/help.md).
 
 !!! info "Why `--extra-index-url`?"
 
-    uv `--extra-index-url` behaves differently than `pip --extra-index-url`. See more [here](https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes).
+    uv `--extra-index-url` behaves slightly differently from `pip --extra-index-url`. See more [here](https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes).
 
 !!! warning "About lockfile cross-compatibility"
 
-    Currently, uv does not support pinning a package to a specific index (though progress is tracked [here](https://github.com/astral-sh/uv/issues/171)).
-    In case of PyTorch, this means that the lockfile might not be cross-compatible between different platforms. For example: suppose a Windows user runs `uv add torch` and then a Linux user
-    runs `uv sync` to synchronise the lockfile. The Windows user will get CPU-only PyTorch, while the Linux user will get CUDA 12.1 PyTorch.
+    Currently, uv does not support pinning a package to a specific index (though progress is tracked [here](https://github.com/astral-sh/uv/issues/171)). As a result,
+    the lockfiles are not guaranteed to be cross-compatible between different platforms. For example: suppose a Windows user runs `uv add torch` and then a Linux user runs
+    `uv sync` to synchronise the lockfile. The Windows user will get CPU-only PyTorch, while the Linux user will get CUDA 12.1 PyTorch.
+
+    If you specify the `[tool.uv.sources]` section in your `pyproject.toml`, users from different platform might not be able to solve for the package dependencies.
 
 ## On macOS
 

--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -1,0 +1,199 @@
+# Installing pytorch with uv
+
+[PyTorch](https://pytorch.org/) is a popular open-source deep-learning learning library that can run
+both on CPUs and GPUs. For this reason, PyTorch can be notoriously cumbersome to install, especially
+on Linux/Windows.
+
+[PyTorch website](https://pytorch.org/get-started/locally/) offers a simple tool to determine what
+`pip` command you should run to install PyTorch. This guide should help you do the same with `uv`.
+If the following instructions fail, you might want to check the original source for any difference,
+and open an issue to report the discrepancy. In this case, or if you run into any other issue,
+please refer to [Getting Help](../../getting-started/help.md).
+
+!!! tip "TL;DR"
+
+    * If want PyTorch on macOS, just run `uv add torch`/`uv pip install torch`.
+    * If want PyTorch on Windows *with CPU support*, just run `uv add torch`/`uv pip install torch`.
+    * If want to install PyTorch on Linux with CPU support, add `--extra-index-url=https://download.pytorch.org/whl/cpu` to the `uv add`/`uv pip install` command.
+    * For Windows and Linux:
+        1. If you need CUDA 11.8, add `--extra-index-url=https://download.pytorch.org/whl/cu118` to the `uv add`/`uv pip install` command.
+        2. If you need CUDA 12.1, add `--extra-index-url=https://download.pytorch.org/whl/cu121` to the `uv add`/`uv pip install` command.
+        3. If you need CUDA 12.4, add `--extra-index-url=https://download.pytorch.org/whl/cu124` to the `uv add`/`uv pip install` command.
+
+## On macOS
+
+Since CUDA is not available on macOS, you should just run:
+
+```sh
+# in a project
+uv add torch
+
+# make sure there is a virtual environment in the directory
+uv pip install torch
+```
+
+## On Linux
+
+### CPU Only
+
+```sh
+uv add --extra-index-url=https://download.pytorch.org/whl/cpu torch
+
+uv pip install --extra-index-url=https://download.pytorch.org/whl/cpu torch
+```
+
+Alternatively, add the following to the `pyproject.toml` file:
+
+```toml
+[project]
+dependencies = [
+    "torch",
+]
+
+[tool.uv.sources]
+torch = { url = "https://download.pytorch.org/whl/cpu" }
+```
+
+### CUDA 11.8 Support
+
+```sh
+# in a project
+uv add --extra-index-url=https://download.pytorch.org/whl/cu118 torch
+
+# make sure there is a virtual environment in the directory
+uv pip install --extra-index-url=https://download.pytorch.org/whl/cu118 torch
+```
+
+Alternatively, add the following to the `pyproject.toml` file:
+
+```toml
+[project]
+dependencies = [
+    "torch",
+]
+
+[tool.uv.sources]
+torch = { url = "https://download.pytorch.org/whl/cu118" }
+```
+
+### CUDA 12.1 Support
+
+```sh
+# in a project
+uv add --extra-index-url=https://download.pytorch.org/whl/cu121 torch
+
+# make sure there is a virtual environment in the directory
+uv pip install --extra-index-url=https://download.pytorch.org/whl/cu121 torch
+```
+
+Alternatively, add the following to the `pyproject.toml` file:
+
+```toml
+[project]
+dependencies = [
+    "torch",
+]
+
+[tool.uv.sources]
+torch = { url = "https://download.pytorch.org/whl/cu121" }
+```
+
+### CUDA 12.4 Support
+
+```sh
+# in a project
+uv add --extra-index-url=https://download.pytorch.org/whl/cu124 torch
+
+# make sure there is a virtual environment in the directory
+uv pip install --extra-index-url=https://download.pytorch.org/whl/cu124 torch
+```
+
+Alternatively, add the following to the `pyproject.toml` file:
+
+```toml
+[project]
+dependencies = [
+    "torch",
+]
+
+[tool.uv.sources]
+torch = { url = "https://download.pytorch.org/whl/cu124" }
+```
+
+## On Windows
+
+### CPU Only
+
+```sh
+# in a project
+uv add torch
+
+# make sure there is a virtual environment in the directory
+uv pip install torch
+```
+
+### CUDA 11.8 Support
+
+```sh
+# in a project
+uv add --extra-index-url=https://download.pytorch.org/whl/cu118 torch
+
+# make sure there is a virtual environment in the directory
+uv pip install --extra-index-url=https://download.pytorch.org/whl/cu118 torch
+```
+
+Alternatively, add the following to the `pyproject.toml` file:
+
+```toml
+[project]
+dependencies = [
+    "torch",
+]
+
+[tool.uv.sources]
+torch = { url = "https://download.pytorch.org/whl/cu118" }
+```
+
+### CUDA 12.1 Support
+
+```sh
+# in a project
+uv add --extra-index-url=https://download.pytorch.org/whl/cu121 torch
+
+# make sure there is a virtual environment in the directory
+uv pip install --extra-index-url=https://download.pytorch.org/whl/cu121 torch
+```
+
+Alternatively, add the following to the `pyproject.toml` file:
+
+```toml
+[project]
+dependencies = [
+    "torch",
+]
+
+[tool.uv.sources]
+torch = { url = "https://download.pytorch.org/whl/cu121" }
+```
+
+### CUDA 12.4 Support
+
+```sh
+# in a project
+uv add --extra-index-url=https://download.pytorch.org/whl/cu124 torch
+
+# make sure there is a virtual environment in the directory
+uv pip install --extra-index-url=https://download.pytorch.org/whl/cu124 torch
+```
+
+Alternatively, add the following to the `pyproject.toml` file:
+
+```toml
+[project]
+dependencies = [
+    "torch",
+]
+
+[tool.uv.sources]
+torch = { url = "https://download.pytorch.org/whl/cu124" }
+```

--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -42,18 +42,6 @@ uv add --extra-index-url=https://download.pytorch.org/whl/cpu torch
 uv pip install --extra-index-url=https://download.pytorch.org/whl/cpu torch
 ```
 
-Alternatively, add the following to the `pyproject.toml` file:
-
-```toml
-[project]
-dependencies = [
-    "torch",
-]
-
-[tool.uv.sources]
-torch = { url = "https://download.pytorch.org/whl/cpu" }
-```
-
 ### CUDA 11.8 Support
 
 ```sh
@@ -62,18 +50,6 @@ uv add --extra-index-url=https://download.pytorch.org/whl/cu118 torch
 
 # make sure there is a virtual environment in the directory
 uv pip install --extra-index-url=https://download.pytorch.org/whl/cu118 torch
-```
-
-Alternatively, add the following to the `pyproject.toml` file:
-
-```toml
-[project]
-dependencies = [
-    "torch",
-]
-
-[tool.uv.sources]
-torch = { url = "https://download.pytorch.org/whl/cu118" }
 ```
 
 ### CUDA 12.1 Support
@@ -86,18 +62,6 @@ uv add --extra-index-url=https://download.pytorch.org/whl/cu121 torch
 uv pip install --extra-index-url=https://download.pytorch.org/whl/cu121 torch
 ```
 
-Alternatively, add the following to the `pyproject.toml` file:
-
-```toml
-[project]
-dependencies = [
-    "torch",
-]
-
-[tool.uv.sources]
-torch = { url = "https://download.pytorch.org/whl/cu121" }
-```
-
 ### CUDA 12.4 Support
 
 ```sh
@@ -106,18 +70,6 @@ uv add --extra-index-url=https://download.pytorch.org/whl/cu124 torch
 
 # make sure there is a virtual environment in the directory
 uv pip install --extra-index-url=https://download.pytorch.org/whl/cu124 torch
-```
-
-Alternatively, add the following to the `pyproject.toml` file:
-
-```toml
-[project]
-dependencies = [
-    "torch",
-]
-
-[tool.uv.sources]
-torch = { url = "https://download.pytorch.org/whl/cu124" }
 ```
 
 ## On Windows
@@ -142,18 +94,6 @@ uv add --extra-index-url=https://download.pytorch.org/whl/cu118 torch
 uv pip install --extra-index-url=https://download.pytorch.org/whl/cu118 torch
 ```
 
-Alternatively, add the following to the `pyproject.toml` file:
-
-```toml
-[project]
-dependencies = [
-    "torch",
-]
-
-[tool.uv.sources]
-torch = { url = "https://download.pytorch.org/whl/cu118" }
-```
-
 ### CUDA 12.1 Support
 
 ```sh
@@ -164,18 +104,6 @@ uv add --extra-index-url=https://download.pytorch.org/whl/cu121 torch
 uv pip install --extra-index-url=https://download.pytorch.org/whl/cu121 torch
 ```
 
-Alternatively, add the following to the `pyproject.toml` file:
-
-```toml
-[project]
-dependencies = [
-    "torch",
-]
-
-[tool.uv.sources]
-torch = { url = "https://download.pytorch.org/whl/cu121" }
-```
-
 ### CUDA 12.4 Support
 
 ```sh
@@ -184,16 +112,4 @@ uv add --extra-index-url=https://download.pytorch.org/whl/cu124 torch
 
 # make sure there is a virtual environment in the directory
 uv pip install --extra-index-url=https://download.pytorch.org/whl/cu124 torch
-```
-
-Alternatively, add the following to the `pyproject.toml` file:
-
-```toml
-[project]
-dependencies = [
-    "torch",
-]
-
-[tool.uv.sources]
-torch = { url = "https://download.pytorch.org/whl/cu124" }
 ```

--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -161,3 +161,7 @@ dependencies = [
 ```
 
 This will install PyTorch 2.5.0 on macOS, and PyTorch 2.5.0+cu124 on Linux and Windows.
+
+!!! warning "PyTorch on Intel Macs"
+
+    Note that the last version to support Intel Macs is PyTorch 2.3.0. In other words, if you try to install PyTorch 2.4.0 or more on an Intel Mac, you will get an error.

--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -1,6 +1,10 @@
 # Installing PyTorch with uv
 
-[PyTorch](https://pytorch.org/) is a popular open-source deep learning framework that has first-class support for acceleration via GPUs. Installation, however, can be complex, as you won't find all the wheels for PyTorch on PyPI and you have to manage this through external indexes. This guide aims to help you set up a `pyproject.toml` file using `uv` [indexes features](../../configuration/indexes.md).
+[PyTorch](https://pytorch.org/) is a popular open-source deep learning framework that has
+first-class support for acceleration via GPUs. Installation, however, can be complex, as you won't
+find all the wheels for PyTorch on PyPI and you have to manage this through external indexes. This
+guide aims to help you set up a `pyproject.toml` file using `uv`
+[indexes features](../../configuration/indexes.md).
 
 !!! info "Available PyTorch indexes"
 
@@ -16,8 +20,11 @@
     * https://download.pytorch.org/whl/cpu
     * https://download.pytorch.org/whl/rocm6.2 (AMD GPUs, only available on Linux)
 
-
-The [PyTorch website](https://pytorch.org/get-started/locally/) offers a simple interface to determine what `pip` command you should run to install PyTorch. This guide should help you do the same with `uv`. If the following instructions fail, you might want to check the link for any difference, and open an issue to report the discrepancy. In this case, or if you run into any other issue, please refer to [Getting Help](../../getting-started/help.md).
+The [PyTorch website](https://pytorch.org/get-started/locally/) offers a simple interface to
+determine what `pip` command you should run to install PyTorch. This guide should help you do the
+same with `uv`. If the following instructions fail, you might want to check the link for any
+difference, and open an issue to report the discrepancy. In this case, or if you run into any other
+issue, please refer to [Getting Help](../../getting-started/help.md).
 
 ## Initialise a project
 
@@ -31,10 +38,10 @@ uv init
 
     Make sure to use a Python version that is supported by PyTorch. You can find the compatibility matrix [here](https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix).
 
-
 ## Add PyTorch indexes
 
-Open the `pyproject.toml` file, and create a custom index matching the channel you want to use (CPU, NVIDIA or AMD), to instruct `uv` where to find the PyTorch wheels.
+Open the `pyproject.toml` file, and create a custom index matching the channel you want to use (CPU,
+NVIDIA or AMD), to instruct `uv` where to find the PyTorch wheels.
 
 === "CPU-only"
 
@@ -81,11 +88,16 @@ Open the `pyproject.toml` file, and create a custom index matching the channel y
     explicit = true
     ```
 
-Note the `explicit` option: this prevents packages from being installed from that index unless explicitly pinned to it (see the step below). This means that only PyTorch will be installed from this index, while all other packages will be looked up on PyPI (the default index).
+Note the `explicit` option: this prevents packages from being installed from that index unless
+explicitly pinned to it (see the step below). This means that only PyTorch will be installed from
+this index, while all other packages will be looked up on PyPI (the default index).
 
 ## Pin PyTorch to the custom index
 
-Now you need to pin specific PyTorch versions to the appropriate indexes. The `tool.uv.sources` table in the `pyproject.toml` is a mapping that matches a package to a list of indexes inside of which to look. Note that you need to create a new entry for every library you want to install. In other words, if your project depends on both PyTorch and torchvision, you need to do as follows:
+Now you need to pin specific PyTorch versions to the appropriate indexes. The `tool.uv.sources`
+table in the `pyproject.toml` is a mapping that matches a package to a list of indexes inside of
+which to look. Note that you need to create a new entry for every library you want to install. In
+other words, if your project depends on both PyTorch and torchvision, you need to do as follows:
 
 === "CPU-only"
 
@@ -159,7 +171,8 @@ Now you need to pin specific PyTorch versions to the appropriate indexes. The `t
 
 ## Add PyTorch to your dependencies
 
-Finally, we can add PyTorch to the `project.dependencies` section of the `pyproject.toml`. To install PyTorch and torchvision, run:
+Finally, we can add PyTorch to the `project.dependencies` section of the `pyproject.toml`. To
+install PyTorch and torchvision, run:
 
 ```sh
 uv add torch torchvision
@@ -177,7 +190,8 @@ dependencies = [
 ]
 ```
 
-This will install PyTorch 2.5.0 and torchvision 0.19 on macOS, and PyTorch 2.5.0+cu124 with torchvision 0.20.0+cu124 on Linux and Windows.
+This will install PyTorch 2.5.0 and torchvision 0.19 on macOS, and PyTorch 2.5.0+cu124 with
+torchvision 0.20.0+cu124 on Linux and Windows.
 
 !!! warning "PyTorch on Intel Macs"
 

--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -1,6 +1,6 @@
 # Installing PyTorch with uv
 
-[PyTorch](https://pytorch.org/) is a popular open-source deep-learning learning framework that has first-class support for acceleration via GPUs. Installation, however, can be complex, as you won't find all the wheels for PyTorch on PyPI and you have to manage this through external indexes. This guide aims to help you set up a `pyproject.toml` file using `uv` [indexes features](../../configuration/indexes.md).
+[PyTorch](https://pytorch.org/) is a popular open-source deep learning framework that has first-class support for acceleration via GPUs. Installation, however, can be complex, as you won't find all the wheels for PyTorch on PyPI and you have to manage this through external indexes. This guide aims to help you set up a `pyproject.toml` file using `uv` [indexes features](../../configuration/indexes.md).
 
 !!! info "Available PyTorch indexes"
 

--- a/docs/guides/integration/pytorch.md
+++ b/docs/guides/integration/pytorch.md
@@ -34,13 +34,13 @@ uv init
 
 ## Add PyTorch indexes
 
-Open the `pyproject.toml` file, and create a custom index matching the CUDA version you have available to instruct `uv` where to find the PyTorch wheels.
+Open the `pyproject.toml` file, and create a custom index matching the channel you want to use (CPU, NVIDIA or AMD), to instruct `uv` where to find the PyTorch wheels.
 
 === "CPU-only"
 
     ```toml
     [[tool.uv.index]]
-    name = "torch-cpu"
+    name = "pytorch-cpu"
     url = "https://download.pytorch.org/whl/cpu"
     explicit = true
     ```
@@ -49,7 +49,7 @@ Open the `pyproject.toml` file, and create a custom index matching the CUDA vers
 
     ```toml
     [[tool.uv.index]]
-    name = "torch-cu118"
+    name = "pytorch-cu118"
     url = "https://download.pytorch.org/whl/cu118"
     explicit = true
     ```
@@ -58,7 +58,7 @@ Open the `pyproject.toml` file, and create a custom index matching the CUDA vers
 
     ```toml
     [[tool.uv.index]]
-    name = "torch-cu121"
+    name = "pytorch-cu121"
     url = "https://download.pytorch.org/whl/cu121"
     explicit = true
     ```
@@ -67,7 +67,7 @@ Open the `pyproject.toml` file, and create a custom index matching the CUDA vers
 
     ```toml
     [[tool.uv.index]]
-    name = "torch-cu124"
+    name = "pytorch-cu124"
     url = "https://download.pytorch.org/whl/cu124"
     explicit = true
     ```
@@ -76,16 +76,16 @@ Open the `pyproject.toml` file, and create a custom index matching the CUDA vers
 
     ```toml
     [[tool.uv.index]]
-    name = "torch-rocm"
+    name = "pytorch-rocm"
     url = "https://download.pytorch.org/whl/rocm6.2"
     explicit = true
     ```
 
-Note that we also specify the `explicit` option: this prevents packages from being installed from that index unless explicitly pinned to it (see the step below). This means that only PyTorch will be installed from this index, while all other packages will be looked up on PyPI.
+Note the `explicit` option: this prevents packages from being installed from that index unless explicitly pinned to it (see the step below). This means that only PyTorch will be installed from this index, while all other packages will be looked up on PyPI (the default index).
 
 ## Pin PyTorch to the custom index
 
-Now we need to pin specific PyTorch versions to the appropriate indexes. We do this by adding/editing the `sources` section in the `pyproject.toml`.
+Now you need to pin specific PyTorch versions to the appropriate indexes. The `tool.uv.sources` table in the `pyproject.toml` is a mapping that matches a package to a list of indexes inside of which to look. Note that you need to create a new entry for every library you want to install. In other words, if your project depends on both PyTorch and torchvision, you need to do as follows:
 
 === "CPU-only"
 
@@ -94,7 +94,10 @@ Now we need to pin specific PyTorch versions to the appropriate indexes. We do t
     ```toml
     [tool.uv.sources]
     torch = [
-      { index = "torch-cpu", marker = "platform_system != 'Darwin'"},
+      { index = "pytorch-cpu", marker = "platform_system != 'Darwin'"},
+    ]
+    torchvision = [
+      { index = "pytorch-cpu", marker = "platform_system != 'Darwin'"},
     ]
     ```
 
@@ -105,7 +108,10 @@ Now we need to pin specific PyTorch versions to the appropriate indexes. We do t
     ```toml
     [tool.uv.sources]
     torch = [
-      { index = "torch-cu118", marker = "platform_system != 'Darwin'"},
+      { index = "pytorch-cu118", marker = "platform_system != 'Darwin'"},
+    ]
+    torchvision = [
+      { index = "pytorch-cu118", marker = "platform_system != 'Darwin'"},
     ]
     ```
 
@@ -116,7 +122,10 @@ Now we need to pin specific PyTorch versions to the appropriate indexes. We do t
     ```toml
     [tool.uv.sources]
     torch = [
-      { index = "torch-cu121", marker = "platform_system != 'Darwin'"},
+      { index = "pytorch-cu121", marker = "platform_system != 'Darwin'"},
+    ]
+    torchvision = [
+      { index = "pytorch-cu121", marker = "platform_system != 'Darwin'"},
     ]
     ```
 
@@ -127,7 +136,10 @@ Now we need to pin specific PyTorch versions to the appropriate indexes. We do t
     ```toml
     [tool.uv.sources]
     torch = [
-      { index = "torch-cu124", marker = "platform_system != 'Darwin'"},
+      { index = "pytorch-cu124", marker = "platform_system != 'Darwin'"},
+    ]
+    torchvision = [
+      { index = "pytorch-cu124", marker = "platform_system != 'Darwin'"},
     ]
     ```
 
@@ -138,16 +150,19 @@ Now we need to pin specific PyTorch versions to the appropriate indexes. We do t
     ```toml
     [tool.uv.sources]
     torch = [
-      { index = "torch-rocm", marker = "platform_system == 'Linux'"},
+      { index = "pytorch-rocm", marker = "platform_system == 'Linux'"},
+    ]
+    torchvision = [
+      { index = "pytorch-rocm", marker = "platform_system == 'Linux'"},
     ]
     ```
 
 ## Add PyTorch to your dependencies
 
-Finally, we can add PyTorch to the `project.dependencies` section of the `pyproject.toml`. You can do this by hand, or using `uv`:
+Finally, we can add PyTorch to the `project.dependencies` section of the `pyproject.toml`. To install PyTorch and torchvision, run:
 
 ```sh
-uv add torch
+uv add torch torchvision
 ```
 
 However, if you want to be more explicit, you could also:
@@ -157,10 +172,12 @@ However, if you want to be more explicit, you could also:
 dependencies = [
   "torch==2.5.0 ; platform_system == 'Darwin'",
   "torch==2.5.0+cu124 ; platform_system != 'Darwin'",
+  "torchvision==0.20.0 ; platform_system == 'Darwin'",
+  "torchvision==0.20.0+cu124 ; platform_system != 'Darwin'",
 ]
 ```
 
-This will install PyTorch 2.5.0 on macOS, and PyTorch 2.5.0+cu124 on Linux and Windows.
+This will install PyTorch 2.5.0 and torchvision 0.19 on macOS, and PyTorch 2.5.0+cu124 with torchvision 0.20.0+cu124 on Linux and Windows.
 
 !!! warning "PyTorch on Intel Macs"
 

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -115,6 +115,7 @@ nav:
       - GitLab CI/CD: guides/integration/gitlab.md
       - Pre-commit: guides/integration/pre-commit.md
       - FastAPI: guides/integration/fastapi.md
+      - PyTorch: guides/integration/pytorch.md
       - Alternative indexes: guides/integration/alternative-indexes.md
       - Dependency bots: guides/integration/dependency-bots.md
   - The pip interface:


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

Hello there! First real docs PR for uv.

1. I expect this will be rewritten a gazillion times to have a consistent tone with the rest of the docs, despite me trying to stick to it as best as I could. Feel free to edit!
2. I went super on the verbose mode, while also providing a callout with a TLDR on top. Scrap anything you feel it's redundant!
3. I placed the guide under `integrations` since Charlie added the FastAPI integration there.

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Addresses #5945

## Test Plan

<!-- How was it tested? -->
I just looked at the docs on the dev server of mkdocs if it looked nice.

**I could not test the commands that I wrote work** outside of macOS. If someone among contributors has a Windows/Linux laptop, it should be enough, even for the GPU-supported versions: I expect the installation will just break once torch checks for CUDA (perhaps even at runtime).