### PR TITLE
Revert changes to pyproject.toml when sync fails duing `uv add`

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -597,7 +597,7 @@ pub(crate) async fn add(
     // Initialize any shared state.
     let state = SharedState::default();
 
-    match project::sync::do_sync(
+    if let Err(err) = project::sync::do_sync(
         &project,
         &venv,
         &lock,
@@ -615,14 +615,11 @@ pub(crate) async fn add(
     )
     .await
     {
-        Err(err) => {
-            // Revert the changes to the `pyproject.toml`, if necessary.
-            if modified {
-                fs_err::write(project.root().join("pyproject.toml"), existing)?;
-            }
-            return Err(err.into());
+        // Revert the changes to the `pyproject.toml`, if necessary.
+        if modified {
+            fs_err::write(project.root().join("pyproject.toml"), existing)?;
         }
-        _ => (),
+        return Err(err.into());
     }
 
     Ok(ExitStatus::Success)

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -615,12 +615,13 @@ pub(crate) async fn add(
     )
     .await
     {
-        Err(_) => {
+        Err(err) => {
             // Revert the changes to the `pyproject.toml`, if necessary.
             if modified {
                 fs_err::write(project.root().join("pyproject.toml"), existing)?;
             }
-            return Ok(ExitStatus::Failure);
+            eprint!("{err:?}");
+            return Err(err.into());
         }
         _ => (),
     }

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -597,7 +597,7 @@ pub(crate) async fn add(
     // Initialize any shared state.
     let state = SharedState::default();
 
-    project::sync::do_sync(
+    match project::sync::do_sync(
         &project,
         &venv,
         &lock,
@@ -613,7 +613,17 @@ pub(crate) async fn add(
         cache,
         printer,
     )
-    .await?;
+    .await
+    {
+        Err(_) => {
+            // Revert the changes to the `pyproject.toml`, if necessary.
+            if modified {
+                fs_err::write(project.root().join("pyproject.toml"), existing)?;
+            }
+            return Ok(ExitStatus::Failure);
+        }
+        _ => (),
+    }
 
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -620,7 +620,6 @@ pub(crate) async fn add(
             if modified {
                 fs_err::write(project.root().join("pyproject.toml"), existing)?;
             }
-            eprint!("{err:?}");
             return Err(err.into());
         }
         _ => (),

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -3888,8 +3888,11 @@ fn fail_to_add_revert_project() -> Result<()> {
         dependencies = []
     "#})?;
 
-    // Adding `anyio` should include a lower-bound.
-    uv_snapshot!(context.filters(), context.add(&["pytorch==1.0.2"]), @r###"
+    // Adding `pytorch==1.0.2` should produce an error
+    let filters = std::iter::once((r"exit code: 1", "exit status: 1"))
+        .chain(context.filters())
+        .collect::<Vec<_>>();
+    uv_snapshot!(filters, context.add(&["pytorch==1.0.2"]), @r###"
     success: false
     exit_code: 2
     ----- stdout -----

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -3896,28 +3896,7 @@ fn fail_to_add_revert_project() -> Result<()> {
 
     ----- stderr -----
     Resolved 2 packages in [TIME]
-    Operation(Anyhow(Failed to prepare distributions
-
-    Caused by:
-        0: Failed to fetch wheel: pytorch==1.0.2
-        1: Build backend failed to build wheel through `build_wheel()` with exit status: 1
-           --- stdout:
-           
-           --- stderr:
-           Traceback (most recent call last):
-             File "<string>", line 11, in <module>
-             File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 410, in build_wheel
-               return self._build_with_temp_dir(
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-             File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 395, in _build_with_temp_dir
-               self.run_setup()
-             File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 487, in run_setup
-               super().run_setup(setup_script=setup_script)
-             File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 311, in run_setup
-               exec(code, locals())
-             File "<string>", line 15, in <module>
-           Exception: You tried to install "pytorch". The package named for PyTorch is "torch"
-           ---))error: Failed to prepare distributions
+    error: Failed to prepare distributions
       Caused by: Failed to fetch wheel: pytorch==1.0.2
       Caused by: Build backend failed to build wheel through `build_wheel()` with exit status: 1
     --- stdout:


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This is a attempt at fixing https://github.com/astral-sh/uv/issues/6486. It reverts changes made to `pyproject.toml` when sync fails during `uv add`. This solution felt a little heavy handed and could probably be improved but it is what happens when locking fails during `uv add` so I thought it would be a good start.

## Test Plan

<!-- How was it tested? -->

I have added a test case for this to `tests/edit.rs`. It uses `pytorch==1.0.2` to achieve the desired failure.