### PR TITLE
Set `VIRTUAL_ENV` for `uv run` invocations

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -629,6 +629,11 @@ pub(crate) async fn run(
     )?;
     process.env("PATH", new_path);
 
+    // Ensure `VIRTUAL_ENV` is set.
+    if interpreter.is_virtualenv() {
+        process.env("VIRTUAL_ENV", interpreter.sys_prefix().as_os_str());
+    };
+
     // Spawn and wait for completion
     // Standard input, output, and error streams are all inherited
     // TODO(zanieb): Throw a nicer error message if the command is not found


### PR DESCRIPTION
If we don't do this, and `uv run` invokes something like `uv run --isolated uv pip install foo` uv won't mutate the isolated environment, it'll mutate whatever outer environment it finds.