### PR TITLE
docs: made `uvx` note more explict

### DIFF
--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -46,7 +46,7 @@ Tools are installed into temporary, isolated environments when using `uvx`.
     If you are running a tool in a [_project_](../concepts/projects.md) and the tool requires that your project is installed,
     e.g., when using `pytest` or `mypy`, you'll want to use [`uv run`](./projects.md#running-commands) instead of `uvx`.
     Otherwise, the tool will be run in a virtual environment that is isolated from your project.
-    However you can still use `uvx`, but it's not recommended.
+    However, if your project has a flat structure, `uvx` can still be effective without requiring the project to be installed.
 
 ## Commands with different package names
 

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -46,6 +46,7 @@ Tools are installed into temporary, isolated environments when using `uvx`.
     If you are running a tool in a [_project_](../concepts/projects.md) and the tool requires that your project is installed,
     e.g., when using `pytest` or `mypy`, you'll want to use [`uv run`](./projects.md#running-commands) instead of `uvx`.
     Otherwise, the tool will be run in a virtual environment that is isolated from your project.
+    However you can still use `uvx`, but it's not recommened.
 
 ## Commands with different package names
 

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -46,7 +46,7 @@ Tools are installed into temporary, isolated environments when using `uvx`.
     If you are running a tool in a [_project_](../concepts/projects.md) and the tool requires that your project is installed,
     e.g., when using `pytest` or `mypy`, you'll want to use [`uv run`](./projects.md#running-commands) instead of `uvx`.
     Otherwise, the tool will be run in a virtual environment that is isolated from your project.
-    However you can still use `uvx`, but it's not recommened.
+    However you can still use `uvx`, but it's not recommeneded.
 
 ## Commands with different package names
 

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -43,7 +43,7 @@ Tools are installed into temporary, isolated environments when using `uvx`.
 
 !!! note
 
-    If you are running a tool in a [_project_](../concepts/projects.md) and the tool requires that 
+    If you are running a tool in a [_project_](../concepts/projects.md) and the tool requires that
     your project is installed, e.g., when using `pytest` or `mypy`, you'll want to use
     [`uv run`](./projects.md#running-commands) instead of `uvx`. Otherwise, the tool will be run in
     a virtual environment that is isolated from your project.

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -43,10 +43,15 @@ Tools are installed into temporary, isolated environments when using `uvx`.
 
 !!! note
 
-    If you are running a tool in a [_project_](../concepts/projects.md) and the tool requires that your project is installed,
-    e.g., when using `pytest` or `mypy`, you'll want to use [`uv run`](./projects.md#running-commands) instead of `uvx`.
-    Otherwise, the tool will be run in a virtual environment that is isolated from your project.
-    However, if your project has a flat structure, `uvx` can still be effective without requiring the project to be installed.
+    If you are running a tool in a [_project_](../concepts/projects.md) and the tool requires that 
+    your project is installed, e.g., when using `pytest` or `mypy`, you'll want to use
+    [`uv run`](./projects.md#running-commands) instead of `uvx`. Otherwise, the tool will be run in
+    a virtual environment that is isolated from your project.
+
+    If your project has a flat structure, e.g., instead of using a `src` directory for modules,
+    the project itself does not need to be installed and `uvx` is fine. In this case, using
+    `uv run` is only beneficial if you want to pin the version of the tool in the project's
+    dependencies.
 
 ## Commands with different package names
 

--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -46,7 +46,7 @@ Tools are installed into temporary, isolated environments when using `uvx`.
     If you are running a tool in a [_project_](../concepts/projects.md) and the tool requires that your project is installed,
     e.g., when using `pytest` or `mypy`, you'll want to use [`uv run`](./projects.md#running-commands) instead of `uvx`.
     Otherwise, the tool will be run in a virtual environment that is isolated from your project.
-    However you can still use `uvx`, but it's not recommeneded.
+    However you can still use `uvx`, but it's not recommended.
 
 ## Commands with different package names
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I used `uvx` to test my code using `pytest` it was just before the documentation and it worked pretty fine. But when I saw the docs I was confused as it says:

> If you are running a tool in a project and the tool requires that your project is installed, e.g., when using `pytest` or `mypy`, you'll want to use `uv` run instead of `uvx`. Otherwise, the tool will be run in a virtual environment that is isolated from your project.

So to make it simple if you don't recommend using `uvx` in this situation then here is the pull request, and if not just close this pull request. I said that I don't have to open an issue to discuss this as it's so simple.

## Test Plan

None
