### PR TITLE
Ignore all errors in `pyproject.toml` files when `--no-project` is used in `uv run`

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -267,7 +267,13 @@ pub(crate) async fn run(
                 Ok(project) => Some(project),
                 Err(WorkspaceError::MissingPyprojectToml) => None,
                 Err(WorkspaceError::NonWorkspace(_)) => None,
-                Err(err) => return Err(err.into()),
+                Err(err) => {
+                    if no_project {
+                        None
+                    } else {
+                        return Err(err.into());
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/6550
