### PR TITLE
Ignore errors in workspace discovery with `--no-project`

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use owo_colors::OwoColorize;
 use pep440_rs::Version;
 use pep508_rs::PackageName;
-use tracing::debug;
+use tracing::{debug, warn};
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity};
 use uv_fs::{absolutize_path, Simplified, CWD};
@@ -14,7 +14,6 @@ use uv_python::{
     VersionRequest,
 };
 use uv_resolver::RequiresPython;
-use uv_warnings::warn_user_once;
 use uv_workspace::pyproject_mut::{DependencyTarget, PyProjectTomlMut};
 use uv_workspace::{check_nested_workspaces, DiscoveryOptions, Workspace, WorkspaceError};
 
@@ -184,16 +183,14 @@ async fn init_project(
             Err(WorkspaceError::MissingPyprojectToml | WorkspaceError::NonWorkspace(_)) => {
                 // If the user runs with `--no-workspace` and we can't find a workspace, warn.
                 if no_workspace {
-                    warn_user_once!("`--no-workspace` was provided, but no workspace was found");
+                    warn!("`--no-workspace` was provided, but no workspace was found");
                 }
                 None
             }
             Err(err) => {
                 // If the user runs with `--no-workspace`, ignore the error.
                 if no_workspace {
-                    warn_user_once!(
-                        "Ignoring workspace discovery error due to `--no-workspace`: {err}"
-                    );
+                    warn!("Ignoring workspace discovery error due to `--no-workspace`: {err}");
                     None
                 } else {
                     return Err(err.into());

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -700,7 +700,6 @@ fn init_no_workspace() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Ignoring workspace discovery error due to `--no-workspace`: No `project` table found in: `[TEMP_DIR]/`
     Initialized project `bar`
     "###);
 
@@ -728,7 +727,6 @@ fn init_no_workspace_warning() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: `--no-workspace` was provided, but no workspace was found
     Initialized project `project`
     "###);
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/6550.
