### PR TITLE
Add example of reading script from stdin using echo

### DIFF
--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -63,6 +63,14 @@ print("hello world!")
 EOF
 ```
 
+or
+
+```bash
+echo '
+print("hello world!")
+' | uv run -
+```
+
 Note that if you use `uv run` in a _project_, i.e. a directory with a `pyproject.toml`, it will
 install the current project before running the script. If your script does not depend on the
 project, use the `--no-project` flag to skip this:

--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -57,18 +57,16 @@ hello world!
 
 Additionally, your script can be read directly from stdin:
 
+```console
+$ echo 'print("hello world!")' | uv run -
+```
+
+Or, if your shell supports [here-documents](https://en.wikipedia.org/wiki/Here_document):
+
 ```bash
 uv run - <<EOF
 print("hello world!")
 EOF
-```
-
-or
-
-```bash
-echo '
-print("hello world!")
-' | uv run -
 ```
 
 Note that if you use `uv run` in a _project_, i.e. a directory with a `pyproject.toml`, it will


### PR DESCRIPTION
As a non-shell-wizard, I was unfamiliar with the `EOF` syntax used in the existing example (just above the one I added). I thought including an example where the output of `echo` is piped to `uv run` might be more accessible. As a bonus, it should work across more shells: the `EOF` example doesn't work in fish because fish [doesn't support heredocs](https://fishshell.com/docs/current/fish_for_bash_users.html#heredocs), while the `echo` example does.

Feel free to ignore if unwanted.
