### PR TITLE
Fix basic authentication tests to reflect proxy changes

### DIFF
--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -4058,14 +4058,14 @@ fn install_package_basic_auth_from_keyring_wrong_password() {
         .env("KEYRING_TEST_CREDENTIALS", r#"{"pypi-proxy.fly.dev": {"public": "foobar"}}"#)
         .env("PATH", venv_bin_path(&context.venv)), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Request for public@https://pypi-proxy.fly.dev/basic-auth/simple/anyio/
     Request for public@pypi-proxy.fly.dev
-    error: Failed to download `anyio==4.3.0`
-      Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl.metadata)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because anyio was not found in the package registry and you require anyio, we can conclude that your requirements are unsatisfiable.
     "###
     );
 }
@@ -4099,14 +4099,14 @@ fn install_package_basic_auth_from_keyring_wrong_username() {
         .env("KEYRING_TEST_CREDENTIALS", r#"{"pypi-proxy.fly.dev": {"other": "heron"}}"#)
         .env("PATH", venv_bin_path(&context.venv)), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Request for public@https://pypi-proxy.fly.dev/basic-auth/simple/anyio/
     Request for public@pypi-proxy.fly.dev
-    error: Failed to download `anyio==4.3.0`
-      Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl.metadata)
+      × No solution found when resolving dependencies:
+      ╰─▶ Because anyio was not found in the package registry and you require anyio, we can conclude that your requirements are unsatisfiable.
     "###
     );
 }


### PR DESCRIPTION
Updates the snapshot for the deployment from https://github.com/astral-sh/pypi-proxy/pull/9 — for a while now, we've only been failing on file requests not registry requests because the proxy auth was setup wrong.