### PR TITLE
Remove `FileLocation::Path` variant

### DIFF
--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -1019,7 +1019,6 @@ impl Identifier for FileLocation {
                 DistributionId::RelativeUrl(base.to_string(), url.to_string())
             }
             Self::AbsoluteUrl(url) => DistributionId::AbsoluteUrl(url.to_string()),
-            Self::Path(path) => path.distribution_id(),
         }
     }
 
@@ -1029,7 +1028,6 @@ impl Identifier for FileLocation {
                 ResourceId::RelativeUrl(base.to_string(), url.to_string())
             }
             Self::AbsoluteUrl(url) => ResourceId::AbsoluteUrl(url.to_string()),
-            Self::Path(path) => path.resource_id(),
         }
     }
 }

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -6,7 +6,7 @@ use tracing::{debug, info_span, warn, Instrument};
 use url::Url;
 
 use distribution_filename::DistFilename;
-use distribution_types::{File, FileLocation, FlatIndexLocation, IndexUrl};
+use distribution_types::{File, FileLocation, FlatIndexLocation, IndexUrl, UrlString};
 use uv_cache::{Cache, CacheBucket};
 
 use crate::cached_client::{CacheControl, CachedClientError};
@@ -254,6 +254,9 @@ impl<'a> FlatIndexClient<'a> {
                 continue;
             };
 
+            // SAFETY: The index path is itself constructed from a URL.
+            let url = Url::from_file_path(entry.path()).unwrap();
+
             let file = File {
                 dist_info_metadata: false,
                 filename: filename.to_string(),
@@ -261,7 +264,7 @@ impl<'a> FlatIndexClient<'a> {
                 requires_python: None,
                 size: None,
                 upload_time_utc_ms: None,
-                url: FileLocation::Path(entry.path().clone()),
+                url: FileLocation::AbsoluteUrl(UrlString::from(url)),
                 yanked: None,
             };
 

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -427,7 +427,6 @@ impl RegistryClient {
                             WheelLocation::Url(url)
                         }
                     }
-                    FileLocation::Path(path) => WheelLocation::Path(path.clone()),
                 };
 
                 match location {

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -151,16 +151,6 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
                         pypi_types::base_url_join_relative(base, url)?
                     }
                     FileLocation::AbsoluteUrl(url) => url.to_url(),
-                    FileLocation::Path(path) => {
-                        let cache_entry = self.build_context.cache().entry(
-                            CacheBucket::Wheels,
-                            WheelCache::Index(&wheel.index).wheel_dir(wheel.name().as_ref()),
-                            wheel.filename.stem(),
-                        );
-                        return self
-                            .load_wheel(path, &wheel.filename, cache_entry, dist, hashes)
-                            .await;
-                    }
                 };
 
                 // Create a cache entry for the wheel.

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -100,24 +100,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                         pypi_types::base_url_join_relative(base, url)?
                     }
                     FileLocation::AbsoluteUrl(url) => url.to_url(),
-                    FileLocation::Path(path) => {
-                        let url = Url::from_file_path(path)
-                            .map_err(|()| Error::RelativePath(path.clone()))?;
-                        return self
-                            .archive(
-                                source,
-                                &PathSourceUrl {
-                                    url: &url,
-                                    path: Cow::Borrowed(path),
-                                    ext: dist.ext,
-                                },
-                                &cache_shard,
-                                tags,
-                                hashes,
-                            )
-                            .boxed_local()
-                            .await;
-                    }
                 };
 
                 // If the URL is a file URL, use the local path directly.
@@ -277,23 +259,6 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                         pypi_types::base_url_join_relative(base, url)?
                     }
                     FileLocation::AbsoluteUrl(url) => url.to_url(),
-                    FileLocation::Path(path) => {
-                        let url = Url::from_file_path(path)
-                            .map_err(|()| Error::RelativePath(path.clone()))?;
-                        return self
-                            .archive_metadata(
-                                source,
-                                &PathSourceUrl {
-                                    url: &url,
-                                    path: Cow::Borrowed(path),
-                                    ext: dist.ext,
-                                },
-                                &cache_shard,
-                                hashes,
-                            )
-                            .boxed_local()
-                            .await;
-                    }
                 };
 
                 // If the URL is a file URL, use the local path directly.

--- a/crates/uv-resolver/src/lock.rs
+++ b/crates/uv-resolver/src/lock.rs
@@ -2856,7 +2856,7 @@ impl<'de> serde::Deserialize<'de> for Hash {
 fn normalize_file_location(location: &FileLocation) -> Result<UrlString, ToUrlError> {
     match location {
         FileLocation::AbsoluteUrl(ref absolute) => Ok(absolute.as_base_url()),
-        _ => Ok(normalize_url(location.to_url()?)),
+        FileLocation::RelativeUrl(_, _) => Ok(normalize_url(location.to_url()?)),
     }
 }
 


### PR DESCRIPTION
## Summary

This is redundant now that we support `file://` URLs.
