### PR TITLE
Docs: Add Installation note for PowerShell 7.X

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,6 +17,7 @@ $ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
 !!! tip
+
     For PowerShell 7.X replace `powershell` with `pwsh`. [See Microsoft Docs for differences](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/differences-from-windows-powershell)
 
 By default, uv is installed to `~/.cargo/bin`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -16,6 +16,9 @@ $ curl -LsSf https://astral.sh/uv/install.sh | sh
 $ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
+!!! tip
+    For PowerShell 7.X replace `powershell` with `pwsh`. [See Microsoft Docs for differences](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/differences-from-windows-powershell)
+
 By default, uv is installed to `~/.cargo/bin`.
 
 !!! tip


### PR DESCRIPTION
## Summary

If using PowerShell Core (7.X) on Windows the user would get an execution policy error even if set to RemoteSigned as the actual script would execute within Windows PowerShell. 

## Test Plan

Tested locally. Docs only. 
