### PR TITLE
Improve messages for empty solves and installs

### DIFF
--- a/crates/uv/src/commands/pip/loggers.rs
+++ b/crates/uv/src/commands/pip/loggers.rs
@@ -43,17 +43,25 @@ pub(crate) struct DefaultInstallLogger;
 
 impl InstallLogger for DefaultInstallLogger {
     fn on_audit(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result {
-        let s = if count == 1 { "" } else { "s" };
-        writeln!(
-            printer.stderr(),
-            "{}",
-            format!(
-                "Audited {} {}",
-                format!("{count} package{s}").bold(),
-                format!("in {}", elapsed(start.elapsed())).dimmed()
+        if count == 0 {
+            writeln!(
+                printer.stderr(),
+                "{}",
+                format!("Audited in {}", elapsed(start.elapsed())).dimmed()
             )
-            .dimmed()
-        )
+        } else {
+            let s = if count == 1 { "" } else { "s" };
+            writeln!(
+                printer.stderr(),
+                "{}",
+                format!(
+                    "Audited {} {}",
+                    format!("{count} package{s}").bold(),
+                    format!("in {}", elapsed(start.elapsed())).dimmed()
+                )
+                .dimmed()
+            )
+        }
     }
 
     fn on_prepare(&self, count: usize, start: std::time::Instant, printer: Printer) -> fmt::Result {
@@ -404,17 +412,25 @@ impl ResolveLogger for DefaultResolveLogger {
         start: std::time::Instant,
         printer: Printer,
     ) -> fmt::Result {
-        let s = if count == 1 { "" } else { "s" };
-        writeln!(
-            printer.stderr(),
-            "{}",
-            format!(
-                "Resolved {} {}",
-                format!("{count} package{s}").bold(),
-                format!("in {}", elapsed(start.elapsed())).dimmed()
+        if count == 0 {
+            writeln!(
+                printer.stderr(),
+                "{}",
+                format!("Resolved in {}", elapsed(start.elapsed())).dimmed()
             )
-            .dimmed()
-        )
+        } else {
+            let s = if count == 1 { "" } else { "s" };
+            writeln!(
+                printer.stderr(),
+                "{}",
+                format!(
+                    "Resolved {} {}",
+                    format!("{count} package{s}").bold(),
+                    format!("in {}", elapsed(start.elapsed())).dimmed()
+                )
+                .dimmed()
+            )
+        }
     }
 }
 

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -9209,7 +9209,7 @@ fn lock_remove_member_virtual() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 0 packages in [TIME]
+    Resolved in [TIME]
     error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided. To update the lockfile, run `uv lock`.
     "###);
 
@@ -9220,7 +9220,7 @@ fn lock_remove_member_virtual() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 0 packages in [TIME]
+    Resolved in [TIME]
     Removed anyio v4.3.0
     Removed idna v3.6
     Removed leaf v0.1.0

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -136,7 +136,7 @@ fn missing_venv() -> Result<()> {
 
     ----- stderr -----
     warning: Requirements file requirements.in does not contain any dependencies
-    Resolved 0 packages in [TIME]
+    Resolved in [TIME]
     "###
     );
 
@@ -320,7 +320,7 @@ fn compile_constraints_inline() -> Result<()> {
     #    uv pip compile --cache-dir [CACHE_DIR] requirements.in
 
     ----- stderr -----
-    Resolved 0 packages in [TIME]
+    Resolved in [TIME]
     "###
     );
 
@@ -5475,7 +5475,7 @@ fn matching_index_urls_requirements_txt() -> Result<()> {
     #    uv pip compile --cache-dir [CACHE_DIR] requirements.in --constraint constraints.in
 
     ----- stderr -----
-    Resolved 0 packages in [TIME]
+    Resolved in [TIME]
     "###
     );
 
@@ -10074,7 +10074,7 @@ fn emit_marker_expression_conditional() -> Result<()> {
     #    sys_platform == 'linux'
 
     ----- stderr -----
-    Resolved 0 packages in [TIME]
+    Resolved in [TIME]
     "###);
 
     Ok(())
@@ -11644,7 +11644,7 @@ fn dynamic_pyproject_toml() -> Result<()> {
     #    uv pip compile --cache-dir [CACHE_DIR] pyproject.toml
 
     ----- stderr -----
-    Resolved 0 packages in [TIME]
+    Resolved in [TIME]
     "###);
 
     Ok(())

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -54,7 +54,7 @@ fn empty_requirements_txt() -> Result<()> {
 
     ----- stderr -----
     warning: Requirements file requirements.txt does not contain any dependencies
-    Audited 0 packages in [TIME]
+    Audited in [TIME]
     "###
     );
 

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -359,8 +359,8 @@ fn pip_sync_empty() -> Result<()> {
 
     ----- stderr -----
     warning: Requirements file requirements.txt does not contain any dependencies
-    Resolved 0 packages in [TIME]
-    Audited 0 packages in [TIME]
+    Resolved in [TIME]
+    Audited in [TIME]
     "###
     );
 
@@ -383,7 +383,7 @@ fn pip_sync_empty() -> Result<()> {
 
     ----- stderr -----
     warning: Requirements file requirements.txt does not contain any dependencies
-    Resolved 0 packages in [TIME]
+    Resolved in [TIME]
     Uninstalled 1 package in [TIME]
      - iniconfig==2.0.0
     "###

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -178,8 +178,8 @@ fn empty() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 0 packages in [TIME]
-    Audited 0 packages in [TIME]
+    Resolved in [TIME]
+    Audited in [TIME]
     "###);
 
     assert!(context.temp_dir.child("uv.lock").exists());
@@ -191,8 +191,8 @@ fn empty() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 0 packages in [TIME]
-    Audited 0 packages in [TIME]
+    Resolved in [TIME]
+    Audited in [TIME]
     "###);
 
     Ok(())


### PR DESCRIPTION
## Summary

Tries to improve the following:

```
❯ cargo run sync
   Compiling uv-cli v0.0.1 (/Users/crmarsh/workspace/uv/crates/uv-cli)
   Compiling uv v0.3.3 (/Users/crmarsh/workspace/uv/crates/uv)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.81s
     Running `/Users/crmarsh/workspace/uv/target/debug/uv sync`
Using Python 3.12.1
Creating virtualenv at: .venv
Resolved in 7ms
Audited environment in 0.05ms
```

In this case we don't actually have any dependencies -- should we just omit `Resolved in...` and perhaps even the audited line?
