### PR TITLE
Clarify package priority order in pip compatibility guide

### DIFF
--- a/docs/pip/compatibility.md
+++ b/docs/pip/compatibility.md
@@ -478,8 +478,13 @@ consistent with
 
 ## Package priority
 
-There are usually many possible solutions given a set of requirements — a resolver must choose
-between the solutions. Unlike pip, uv's resolver uses the ordering provided of packages to determine
-the default priority. This means that uv's resolution can differ based on the order of the packages.
-For example, `uv pip install foo bar` would prioritize a newer version of `foo` over `bar`.
-Similarly, this applies to the ordering of requirements in input files to `uv pip compile`.
+There are usually many possible solutions given a set of requirements, and a resolver must choose
+between them. uv's resolver and pip's resolver have a different set of package priorities. While
+both resolvers use the user-provided order as one of their priorities, pip has additional
+[priorities](https://pip.pypa.io/en/stable/topics/more-dependency-resolution/#the-resolver-algorithm)
+that uv does not have. Hence, uv is more likely to be affected by a change in user order than pip
+is.
+
+For example, `uv pip install foo bar` prioritizes newer versions of `foo` over `bar` and could
+result in a different resolution than `uv pip install bar foo`. Similarly, this behavior applies to
+the ordering of requirements in input files for `uv pip compile`.


### PR DESCRIPTION
This is a minor documentation update to a recently added section "Package priority" in the pip compatibility guide. The aim of this PR is clear up two things which I think the current paragraph implies but I don't think are (always) true:

1. That pip doesn't use provided order to prioritize resolution
2. That uv relies solely on provided order to prioritize resolution

What is true, at least for now, is pip has more heuristics than uv to prioritize during resolution, and so I've tried to rework this to make it clear why changing the order might help uv come to a different resolution whereas for pip it might not make a difference.
