### PR TITLE
Avoid reusing state across tool upgrades

### DIFF
--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -31,9 +31,6 @@ pub(crate) async fn upgrade(
 
     printer: Printer,
 ) -> Result<ExitStatus> {
-    // Initialize any shared state.
-    let state = SharedState::default();
-
     let installed_tools = InstalledTools::from_settings()?.init()?;
     let _lock = installed_tools.acquire_lock()?;
 
@@ -118,6 +115,9 @@ pub(crate) async fn upgrade(
         // Resolve the requirements.
         let requirements = existing_tool_receipt.requirements();
         let spec = RequirementsSpecification::from_requirements(requirements.to_vec());
+
+        // Initialize any shared state.
+        let state = SharedState::default();
 
         // TODO(zanieb): Build the environment in the cache directory then copy into the tool
         // directory.


### PR DESCRIPTION
## Summary

Because tool upgrades can use different Python versions, we can't share state across them.

Closes https://github.com/astral-sh/uv/issues/6659.
