### PR TITLE
Add `--app` and `--lib` options to `uv init`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2101,12 +2101,46 @@ pub struct InitArgs {
 
     /// Create a virtual project, rather than a package.
     ///
-    /// A virtual project is a project that is not intended to be built as a Python package,
-    /// such as a project that only contains scripts or other application code.
-    ///
-    /// Virtual projects themselves are not installed into the Python environment.
-    #[arg(long)]
+    /// This option is deprecated and will be removed in a future release.
+    #[arg(long, hide = true, conflicts_with = "package")]
     pub r#virtual: bool,
+
+    /// Set up the project to be built as a Python package.
+    ///
+    /// Defines a `[build-system]` for the project.
+    ///
+    /// This is the default behavior when using `--lib`.
+    ///
+    /// When using `--app`, this will include a `[project.scripts]` entrypoint and use a `src/`
+    /// project structure.
+    #[arg(long, overrides_with = "no_package")]
+    pub r#package: bool,
+
+    /// Do not set up the project to be built as a Python package.
+    ///
+    /// Does not include a `[build-system]` for the project.
+    ///
+    /// This is the default behavior when using `--app`.
+    #[arg(long, overrides_with = "package", conflicts_with = "lib")]
+    pub r#no_package: bool,
+
+    /// Create a project for an application.
+    ///
+    /// This is the default behavior if `--lib` is not requested.
+    ///
+    /// This project kind is for web servers, scripts, and command-line interfaces.
+    ///
+    /// By default, an application is not intended to be built and distributed as a Python package.
+    /// The `--package` option can be used to create an application that is distributable, e.g., if
+    /// you want to distribute a command-line interface via PyPI.
+    #[arg(long, alias = "application", conflicts_with = "lib")]
+    pub r#app: bool,
+
+    /// Create a project for a library.
+    ///
+    /// A library is a project that is intended to be built and distributed as a Python package.
+    #[arg(long, alias = "library", conflicts_with = "app")]
+    pub r#lib: bool,
 
     /// Do not create a `README.md` file.
     #[arg(long)]

--- a/crates/uv/src/commands/mod.rs
+++ b/crates/uv/src/commands/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use pip::sync::pip_sync;
 pub(crate) use pip::tree::pip_tree;
 pub(crate) use pip::uninstall::pip_uninstall;
 pub(crate) use project::add::add;
-pub(crate) use project::init::init;
+pub(crate) use project::init::{init, InitProjectKind};
 pub(crate) use project::lock::lock;
 pub(crate) use project::remove::remove;
 pub(crate) use project::run::{run, RunCommand};

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1025,7 +1025,8 @@ async fn run_project(
             commands::init(
                 args.path,
                 args.name,
-                args.r#virtual,
+                args.package,
+                args.kind,
                 args.no_readme,
                 args.python,
                 args.no_workspace,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -372,7 +372,15 @@ uv init [OPTIONS] [PATH]
 
 <h3 class="cli-reference">Options</h3>
 
-<dl class="cli-reference"><dt><code>--cache-dir</code> <i>cache-dir</i></dt><dd><p>Path to the cache directory.</p>
+<dl class="cli-reference"><dt><code>--app</code></dt><dd><p>Create a project for an application.</p>
+
+<p>This is the default behavior if <code>--lib</code> is not requested.</p>
+
+<p>This project kind is for web servers, scripts, and command-line interfaces.</p>
+
+<p>By default, an application is not intended to be built and distributed as a Python package. The <code>--package</code> option can be used to create an application that is distributable, e.g., if you want to distribute a command-line interface via PyPI.</p>
+
+</dd><dt><code>--cache-dir</code> <i>cache-dir</i></dt><dd><p>Path to the cache directory.</p>
 
 <p>Defaults to <code>$HOME/Library/Caches/uv</code> on macOS, <code>$XDG_CACHE_HOME/uv</code> or <code>$HOME/.cache/uv</code> on Linux, and <code>%LOCALAPPDATA%\uv\cache</code> on Windows.</p>
 
@@ -394,6 +402,10 @@ uv init [OPTIONS] [PATH]
 
 </dd><dt><code>--help</code>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 
+</dd><dt><code>--lib</code></dt><dd><p>Create a project for a library.</p>
+
+<p>A library is a project that is intended to be built and distributed as a Python package.</p>
+
 </dd><dt><code>--name</code> <i>name</i></dt><dd><p>The name of the project.</p>
 
 <p>Defaults to the name of the directory.</p>
@@ -409,6 +421,12 @@ uv init [OPTIONS] [PATH]
 </dd><dt><code>--no-config</code></dt><dd><p>Avoid discovering configuration files (<code>pyproject.toml</code>, <code>uv.toml</code>).</p>
 
 <p>Normally, configuration files are discovered in the current directory, parent directories, or user configuration directories.</p>
+
+</dd><dt><code>--no-package</code></dt><dd><p>Do not set up the project to be built as a Python package.</p>
+
+<p>Does not include a <code>[build-system]</code> for the project.</p>
+
+<p>This is the default behavior when using <code>--app</code>.</p>
 
 </dd><dt><code>--no-progress</code></dt><dd><p>Hide all progress outputs.</p>
 
@@ -427,6 +445,14 @@ uv init [OPTIONS] [PATH]
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
 <p>When disabled, uv will only use locally cached data and locally available files.</p>
+
+</dd><dt><code>--package</code></dt><dd><p>Set up the project to be built as a Python package.</p>
+
+<p>Defines a <code>[build-system]</code> for the project.</p>
+
+<p>This is the default behavior when using <code>--lib</code>.</p>
+
+<p>When using <code>--app</code>, this will include a <code>[project.scripts]</code> entrypoint and use a <code>src/</code> project structure.</p>
 
 </dd><dt><code>--python</code>, <code>-p</code> <i>python</i></dt><dd><p>The Python interpreter to use to determine the minimum supported Python version.</p>
 
@@ -454,12 +480,6 @@ uv init [OPTIONS] [PATH]
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>
 
 </dd><dt><code>--version</code>, <code>-V</code></dt><dd><p>Display the uv version</p>
-
-</dd><dt><code>--virtual</code></dt><dd><p>Create a virtual project, rather than a package.</p>
-
-<p>A virtual project is a project that is not intended to be built as a Python package, such as a project that only contains scripts or other application code.</p>
-
-<p>Virtual projects themselves are not installed into the Python environment.</p>
 
 </dd></dl>
 


### PR DESCRIPTION
Changes the `uv init` experience with a focus on working for more use-cases out of the box.

- Adds `--app` and `--lib` options to control the created project style
- Changes the default from a library with `src/` and a build backend (`--lib`) to an application that is not packaged (`--app`)
- Hides the `--virtual` option and replaces it with `--package` and `--no-package`
- `--no-package` is not allowed with `--lib` right now, but it could be in the future once we understand a use-case
- Creates a runnable project
   - Applications have a `hello.py` file which you can run with `uv run hello.py`
   - Packaged applications, e.g., `uv init --app --package` create a package and script entrypoint, which you can run with `uv run hello`
   - Libraries provide a demo API function, e.g., `uv run python -c "import name; print(name.hello())"` — this is unchanged

Closes #6471 