### PR TITLE
Avoid writing invalid PEP 723 scripts on `tool.uv.sources`

### DIFF
--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -347,13 +347,12 @@ fn serialize_metadata(metadata: &str) -> String {
     output.push('\n');
 
     for line in metadata.lines() {
-        if line.is_empty() {
-            output.push('\n');
-        } else {
-            output.push_str("# ");
+        output.push('#');
+        if !line.is_empty() {
+            output.push(' ');
             output.push_str(line);
-            output.push('\n');
         }
+        output.push('\n');
     }
 
     output.push_str("# ///");

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -1,6 +1,7 @@
 #![cfg(all(feature = "python", feature = "pypi"))]
 
 use anyhow::Result;
+use assert_cmd::assert::OutputAssertExt;
 use assert_fs::prelude::*;
 use indoc::indoc;
 use insta::assert_snapshot;
@@ -3918,16 +3919,12 @@ fn add_git_to_script() -> Result<()> {
         # /// script
         # requires-python = ">=3.11"
         # dependencies = [
-        #   "rich",
+        #   "anyio",
         # ]
         # ///
 
-        import requests
-        from rich.pretty import pprint
-
-        resp = requests.get("https://peps.python.org/api/peps.json")
-        data = resp.json()
-        pprint([(k, v["title"]) for k, v in data.items()][:10])
+        import anyio
+        import uv_public_pypackage
     "#})?;
 
     uv_snapshot!(context.filters(), context
@@ -3953,23 +3950,23 @@ fn add_git_to_script() -> Result<()> {
         # /// script
         # requires-python = ">=3.11"
         # dependencies = [
-        #   "rich",
+        #   "anyio",
         #   "uv-public-pypackage",
         # ]
-
+        #
         # [tool.uv.sources]
         # uv-public-pypackage = { git = "https://github.com/astral-test/uv-public-pypackage", tag = "0.0.1" }
         # ///
 
-        import requests
-        from rich.pretty import pprint
-
-        resp = requests.get("https://peps.python.org/api/peps.json")
-        data = resp.json()
-        pprint([(k, v["title"]) for k, v in data.items()][:10])
+        import anyio
+        import uv_public_pypackage
         "###
         );
     });
+
+    // Ensure that the script runs without error.
+    context.run().arg("script.py").assert().success();
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

We were writing empty lines between the dependencies and the `tool.uv.sources` table, which led to the `/// script` tag being unclosed and thus not recognized.

Closes https://github.com/astral-sh/uv/issues/6700.
