### PR TITLE
Always run both public and private documentation checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,18 +409,18 @@ jobs:
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_KEY }}
-      - name: "Install Insiders dependencies"
+
+      - name: "Install dependencies (public)"
+        run: pip install -r docs/requirements.txt
+      - name: "Build docs (public)"
+        run: mkdocs build --strict -f mkdocs.public.yml
+
+      - name: "Install dependencies (insiders)"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
         run: pip install -r docs/requirements-insiders.txt
-      - name: "Install dependencies"
-        if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS != 'true' }}
-        run: pip install -r docs/requirements.txt
-      - name: "Build Insiders docs"
+      - name: "Build docs (insiders)"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
         run: mkdocs build --strict -f mkdocs.insiders.yml
-      - name: "Build docs"
-        if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS != 'true' }}
-        run: mkdocs build --strict -f mkdocs.public.yml
 
   build-binary-linux:
     needs: determine_changes


### PR DESCRIPTION
Avoiding failures like https://github.com/astral-sh/uv/pull/6705

Context in https://github.com/astral-sh/uv/pull/6099

## Test plan

Even though I opened the pull request, the public build was still tested.