### PR TITLE
Avoid reading stale `.egg-info` from mutable sources

### DIFF
--- a/crates/distribution-types/src/buildable.rs
+++ b/crates/distribution-types/src/buildable.rs
@@ -56,6 +56,14 @@ impl BuildableSource<'_> {
             Self::Url(url) => url.is_editable(),
         }
     }
+
+    /// Return true if the source refers to a local source tree (i.e., a directory).
+    pub fn is_source_tree(&self) -> bool {
+        match self {
+            Self::Dist(dist) => matches!(dist, SourceDist::Directory(_)),
+            Self::Url(url) => matches!(url, SourceUrl::Directory(_)),
+        }
+    }
 }
 
 impl std::fmt::Display for BuildableSource<'_> {
@@ -93,6 +101,11 @@ impl<'a> SourceUrl<'a> {
             self,
             Self::Directory(DirectorySourceUrl { editable: true, .. })
         )
+    }
+
+    /// Return true if the source refers to a local file or directory.
+    pub fn is_local(&self) -> bool {
+        matches!(self, Self::Path(_) | Self::Directory(_))
     }
 }
 

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1529,6 +1529,12 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             Err(err) => return Err(err),
         }
 
+        // If the source distribution is a source tree, avoid reading `PKG-INFO` or `egg-info`,
+        // since they could be out-of-date.
+        if source.is_source_tree() {
+            return Ok(None);
+        }
+
         // Attempt to read static metadata from the `PKG-INFO` file.
         match read_pkg_info(source_root, subdirectory).await {
             Ok(metadata) => {


### PR DESCRIPTION
## Summary

In theory this problem already existed for `PKG-INFO`, but `egg-info` would be more common, I think, since it's built in the source tree.

Closes https://github.com/astral-sh/uv/issues/6712.
