### PR TITLE
Avoid using editable tag in lockfile for non-package dependencies

### DIFF
--- a/crates/distribution-types/src/cached.rs
+++ b/crates/distribution-types/src/cached.rs
@@ -34,6 +34,7 @@ pub struct CachedDirectUrlDist {
     pub url: VerbatimUrl,
     pub path: PathBuf,
     pub editable: bool,
+    pub r#virtual: bool,
     pub hashes: Vec<HashDigest>,
 }
 
@@ -57,6 +58,7 @@ impl CachedDist {
                 hashes,
                 path,
                 editable: false,
+                r#virtual: false,
             }),
             Dist::Built(BuiltDist::Path(dist)) => Self::Url(CachedDirectUrlDist {
                 filename,
@@ -64,6 +66,7 @@ impl CachedDist {
                 hashes,
                 path,
                 editable: false,
+                r#virtual: false,
             }),
             Dist::Source(SourceDist::Registry(_dist)) => Self::Registry(CachedRegistryDist {
                 filename,
@@ -76,6 +79,7 @@ impl CachedDist {
                 hashes,
                 path,
                 editable: false,
+                r#virtual: false,
             }),
             Dist::Source(SourceDist::Git(dist)) => Self::Url(CachedDirectUrlDist {
                 filename,
@@ -83,6 +87,7 @@ impl CachedDist {
                 hashes,
                 path,
                 editable: false,
+                r#virtual: false,
             }),
             Dist::Source(SourceDist::Path(dist)) => Self::Url(CachedDirectUrlDist {
                 filename,
@@ -90,6 +95,7 @@ impl CachedDist {
                 hashes,
                 path,
                 editable: false,
+                r#virtual: false,
             }),
             Dist::Source(SourceDist::Directory(dist)) => Self::Url(CachedDirectUrlDist {
                 filename,
@@ -97,6 +103,7 @@ impl CachedDist {
                 hashes,
                 path,
                 editable: dist.editable,
+                r#virtual: dist.r#virtual,
             }),
         }
     }
@@ -124,6 +131,7 @@ impl CachedDist {
                         url: dist.url.raw().clone(),
                         install_path: path,
                         editable: dist.editable,
+                        r#virtual: dist.r#virtual,
                     })))
                 } else {
                     Ok(Some(ParsedUrl::try_from(dist.url.to_url())?))
@@ -161,6 +169,7 @@ impl CachedDirectUrlDist {
             hashes,
             path,
             editable: false,
+            r#virtual: false,
         }
     }
 }

--- a/crates/distribution-types/src/lib.rs
+++ b/crates/distribution-types/src/lib.rs
@@ -309,6 +309,8 @@ pub struct DirectorySourceDist {
     pub install_path: PathBuf,
     /// Whether the package should be installed in editable mode.
     pub editable: bool,
+    /// Whether the package should be built and installed.
+    pub r#virtual: bool,
     /// The URL as it was provided by the user.
     pub url: VerbatimUrl,
 }
@@ -404,6 +406,7 @@ impl Dist {
         url: VerbatimUrl,
         install_path: &Path,
         editable: bool,
+        r#virtual: bool,
     ) -> Result<Dist, Error> {
         // Convert to an absolute path.
         let install_path = path::absolute(install_path)?;
@@ -421,6 +424,7 @@ impl Dist {
             name,
             install_path,
             editable,
+            r#virtual,
             url,
         })))
     }
@@ -458,6 +462,7 @@ impl Dist {
                 url.verbatim,
                 &directory.install_path,
                 directory.editable,
+                directory.r#virtual,
             ),
             ParsedUrl::Git(git) => {
                 Self::from_git_url(name, url.verbatim, git.url, git.subdirectory)

--- a/crates/distribution-types/src/resolution.rs
+++ b/crates/distribution-types/src/resolution.rs
@@ -220,6 +220,7 @@ impl From<&ResolvedDist> for Requirement {
                     install_path: sdist.install_path.clone(),
                     url: sdist.url.clone(),
                     editable: sdist.editable,
+                    r#virtual: sdist.r#virtual,
                 },
             },
             ResolvedDist::Installed(dist) => RequirementSource::Registry {

--- a/crates/pypi-types/src/parsed_url.rs
+++ b/crates/pypi-types/src/parsed_url.rs
@@ -72,6 +72,7 @@ impl UnnamedRequirementUrl for VerbatimParsedUrl {
                 url: verbatim.to_url(),
                 install_path: verbatim.as_path()?,
                 editable: false,
+                r#virtual: false,
             })
         } else {
             ParsedUrl::Path(ParsedPathUrl {
@@ -101,6 +102,7 @@ impl UnnamedRequirementUrl for VerbatimParsedUrl {
                 url: verbatim.to_url(),
                 install_path: verbatim.as_path()?,
                 editable: false,
+                r#virtual: false,
             })
         } else {
             ParsedUrl::Path(ParsedPathUrl {
@@ -208,15 +210,17 @@ pub struct ParsedDirectoryUrl {
     /// The absolute path to the distribution which we use for installing.
     pub install_path: PathBuf,
     pub editable: bool,
+    pub r#virtual: bool,
 }
 
 impl ParsedDirectoryUrl {
     /// Construct a [`ParsedDirectoryUrl`] from a path requirement source.
-    pub fn from_source(install_path: PathBuf, editable: bool, url: Url) -> Self {
+    pub fn from_source(install_path: PathBuf, editable: bool, r#virtual: bool, url: Url) -> Self {
         Self {
             url,
             install_path,
             editable,
+            r#virtual,
         }
     }
 }
@@ -370,6 +374,7 @@ impl TryFrom<Url> for ParsedUrl {
                     url,
                     install_path: path.clone(),
                     editable: false,
+                    r#virtual: false,
                 }))
             } else {
                 Ok(Self::Path(ParsedPathUrl {

--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -1861,6 +1861,7 @@ mod test {
                                             },
                                             install_path: "/foo/bar",
                                             editable: true,
+                                            virtual: false,
                                         },
                                     ),
                                     verbatim: VerbatimUrl {

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-bare-url.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-bare-url.txt.snap
@@ -23,6 +23,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/scripts/packages/black_editable",
                                 editable: false,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -72,6 +73,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/scripts/packages/black_editable",
                                 editable: false,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -125,6 +127,7 @@ RequirementsTxt {
                                 },
                                 install_path: "/scripts/packages/black_editable",
                                 editable: false,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-editable.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-editable.txt.snap
@@ -25,6 +25,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -81,6 +82,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -137,6 +139,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -193,6 +196,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -249,6 +253,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -298,6 +303,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable[d",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-bare-url.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-bare-url.txt.snap
@@ -23,6 +23,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/scripts/packages/black_editable",
                                 editable: false,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -72,6 +73,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/scripts/packages/black_editable",
                                 editable: false,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -125,6 +127,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/scripts/packages/black_editable",
                                 editable: false,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-editable.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-editable.txt.snap
@@ -25,6 +25,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -81,6 +82,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -137,6 +139,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -193,6 +196,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -249,6 +253,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {
@@ -298,6 +303,7 @@ RequirementsTxt {
                                 },
                                 install_path: "<REQUIREMENTS_DIR>/editable[d",
                                 editable: true,
+                                virtual: false,
                             },
                         ),
                         verbatim: VerbatimUrl {

--- a/crates/uv-distribution/src/index/cached_wheel.rs
+++ b/crates/uv-distribution/src/index/cached_wheel.rs
@@ -55,6 +55,7 @@ impl CachedWheel {
             url,
             path: self.entry.into_path_buf(),
             editable: false,
+            r#virtual: false,
             hashes: self.hashes,
         }
     }
@@ -66,6 +67,19 @@ impl CachedWheel {
             url,
             path: self.entry.into_path_buf(),
             editable: true,
+            r#virtual: false,
+            hashes: self.hashes,
+        }
+    }
+
+    /// Convert a [`CachedWheel`] into an editable [`CachedDirectUrlDist`].
+    pub fn into_virtual(self, url: VerbatimUrl) -> CachedDirectUrlDist {
+        CachedDirectUrlDist {
+            filename: self.filename,
+            url,
+            path: self.entry.into_path_buf(),
+            editable: false,
+            r#virtual: true,
             hashes: self.hashes,
         }
     }

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -264,6 +264,7 @@ impl<'a> Planner<'a> {
                 }
 
                 RequirementSource::Directory {
+                    r#virtual,
                     url,
                     editable,
                     install_path,
@@ -284,6 +285,7 @@ impl<'a> Planner<'a> {
                         url: url.clone(),
                         install_path,
                         editable: *editable,
+                        r#virtual: *r#virtual,
                     };
 
                     // Find the most-compatible wheel from the cache, since we don't know

--- a/crates/uv-installer/src/satisfies.rs
+++ b/crates/uv-installer/src/satisfies.rs
@@ -197,6 +197,7 @@ impl RequirementSatisfaction {
             RequirementSource::Directory {
                 install_path: requested_path,
                 editable: requested_editable,
+                r#virtual: _,
                 url: _,
             } => {
                 let InstalledDist::Url(InstalledDirectUrlDist { direct_url, .. }) = &distribution

--- a/crates/uv-requirements/src/lookahead.rs
+++ b/crates/uv-requirements/src/lookahead.rs
@@ -288,6 +288,7 @@ fn required_dist(requirement: &Requirement) -> Result<Option<Dist>, distribution
         } => Dist::from_file_url(requirement.name.clone(), url.clone(), install_path, *ext)?,
         RequirementSource::Directory {
             install_path,
+            r#virtual,
             url,
             editable,
         } => Dist::from_directory_url(
@@ -295,6 +296,7 @@ fn required_dist(requirement: &Requirement) -> Result<Option<Dist>, distribution
             url.clone(),
             install_path,
             *editable,
+            *r#virtual,
         )?,
     }))
 }

--- a/crates/uv-resolver/src/pubgrub/dependencies.rs
+++ b/crates/uv-resolver/src/pubgrub/dependencies.rs
@@ -145,12 +145,14 @@ impl PubGrubRequirement {
             }
             RequirementSource::Directory {
                 editable,
+                r#virtual,
                 url,
                 install_path,
             } => {
                 let parsed_url = ParsedUrl::Directory(ParsedDirectoryUrl::from_source(
                     install_path.clone(),
                     *editable,
+                    *r#virtual,
                     url.to_url(),
                 ));
                 (url, parsed_url)

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -281,10 +281,20 @@ impl Workspace {
                 name: project.name.clone(),
                 extras,
                 marker: MarkerTree::TRUE,
-                source: RequirementSource::Directory {
-                    install_path: member.root.clone(),
-                    editable: true,
-                    url,
+                source: if member.pyproject_toml.is_package() {
+                    RequirementSource::Directory {
+                        install_path: member.root.clone(),
+                        editable: true,
+                        r#virtual: false,
+                        url,
+                    }
+                } else {
+                    RequirementSource::Directory {
+                        install_path: member.root.clone(),
+                        editable: false,
+                        r#virtual: true,
+                        url,
+                    }
                 },
                 origin: None,
             })

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -3853,6 +3853,10 @@ fn lock_python_version_marker_complement() -> Result<()> {
             "typing-extensions ; python_full_version > '3.10'",
             "typing-extensions ; python_full_version <= '3.10'",
         ]
+
+        [build-system]
+        requires = ["setuptools>=42", "wheel"]
+        build-backend = "setuptools.build_meta"
         "#,
     )?;
 
@@ -5206,6 +5210,10 @@ fn lock_same_version_multiple_urls() -> Result<()> {
           "dependency @ {} ; sys_platform == 'darwin'",
           "dependency @ {} ; sys_platform != 'darwin'",
         ]
+
+        [build-system]
+        requires = ["setuptools>=42", "wheel"]
+        build-backend = "setuptools.build_meta"
         "#,
         Url::from_file_path(context.temp_dir.join("v1")).unwrap(),
         Url::from_file_path(context.temp_dir.join("v2")).unwrap(),
@@ -7754,6 +7762,10 @@ fn lock_editable() -> Result<()> {
         name = "library"
         version = "0.1.0"
         dependencies = []
+
+        [build-system]
+        requires = ["setuptools>=42", "wheel"]
+        build-backend = "setuptools.build_meta"
     "#})?;
     library.child("src/__init__.py").touch()?;
 
@@ -8817,7 +8829,7 @@ fn lock_remove_member() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         "###
         );
     });
@@ -11349,7 +11361,7 @@ fn lock_explicit_virtual_project() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "black" },
         ]
@@ -11421,7 +11433,7 @@ fn lock_explicit_virtual_project() -> Result<()> {
     Ok(())
 }
 
-/// Lock a project that is implicitly virtual (by way of omitting `build-system`0>
+/// Lock a project that is implicitly virtual (by way of omitting `build-system`).
 #[test]
 fn lock_implicit_virtual_project() -> Result<()> {
     let context = TestContext::new("3.12");
@@ -11566,7 +11578,7 @@ fn lock_implicit_virtual_project() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "black" },
         ]
@@ -11632,6 +11644,167 @@ fn lock_implicit_virtual_project() -> Result<()> {
      + packaging==24.0
      + pathspec==0.12.1
      + platformdirs==4.2.0
+     + sniffio==1.3.1
+    "###);
+
+    Ok(())
+}
+
+/// Lock a project that has a path dependency that is implicitly virtual (by way of omitting
+/// `build-system`).
+#[test]
+fn lock_implicit_virtual_path() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio >3", "child"]
+
+        [tool.uv.sources]
+        child = { path = "./child" }
+        "#,
+    )?;
+
+    let child = context.temp_dir.child("child");
+    child.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig >1"]
+        "#,
+    )?;
+
+    uv_snapshot!(context.filters(), context.lock(), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    "###);
+
+    let lock = fs_err::read_to_string(context.temp_dir.join("uv.lock")).unwrap();
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r###"
+        version = 1
+        requires-python = ">=3.12"
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "anyio"
+        version = "4.3.0"
+        source = { registry = "https://pypi.org/simple" }
+        dependencies = [
+            { name = "idna" },
+            { name = "sniffio" },
+        ]
+        sdist = { url = "https://files.pythonhosted.org/packages/db/4d/3970183622f0330d3c23d9b8a5f52e365e50381fd484d08e3285104333d3/anyio-4.3.0.tar.gz", hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6", size = 159642 }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl", hash = "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8", size = 85584 },
+        ]
+
+        [[package]]
+        name = "child"
+        version = "0.1.0"
+        source = { virtual = "child" }
+        dependencies = [
+            { name = "iniconfig" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "iniconfig", specifier = ">1" }]
+
+        [[package]]
+        name = "idna"
+        version = "3.6"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca", size = 175426 }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f", size = 61567 },
+        ]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "anyio" },
+            { name = "child" },
+        ]
+
+        [package.metadata]
+        requires-dist = [
+            { name = "anyio", specifier = ">3" },
+            { name = "child", virtual = "child" },
+        ]
+
+        [[package]]
+        name = "sniffio"
+        version = "1.3.1"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+        ]
+        "###
+        );
+    });
+
+    // Re-run with `--locked`.
+    uv_snapshot!(context.filters(), context.lock().arg("--locked"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    "###);
+
+    // Re-run with `--offline`. We shouldn't need a network connection to validate an
+    // already-correct lockfile with immutable metadata.
+    uv_snapshot!(context.filters(), context.lock().arg("--locked").arg("--offline").arg("--no-cache"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 6 packages in [TIME]
+    "###);
+
+    // Install from the lockfile. The virtual project should _not_ be installed.
+    uv_snapshot!(context.filters(), context.sync().arg("--frozen"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Prepared 4 packages in [TIME]
+    Installed 4 packages in [TIME]
+     + anyio==4.3.0
+     + idna==3.6
+     + iniconfig==2.0.0
      + sniffio==1.3.1
     "###);
 

--- a/crates/uv/tests/lock_scenarios.rs
+++ b/crates/uv/tests/lock_scenarios.rs
@@ -103,7 +103,7 @@ fn fork_allows_non_conflicting_non_overlapping_dependencies() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
         ]
@@ -215,7 +215,7 @@ fn fork_allows_non_conflicting_repeated_dependencies() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a" },
         ]
@@ -334,7 +334,7 @@ fn fork_basic() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'darwin'" },
             { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'linux'" },
@@ -667,7 +667,7 @@ fn fork_filter_sibling_dependencies() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", version = "4.3.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'darwin'" },
             { name = "package-a", version = "4.4.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'linux'" },
@@ -789,7 +789,7 @@ fn fork_upgrade() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-foo" },
         ]
@@ -938,7 +938,7 @@ fn fork_incomplete_markers() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "python_full_version < '3.10'" },
             { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "python_full_version >= '3.11'" },
@@ -1074,7 +1074,7 @@ fn fork_marker_accrue() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", marker = "implementation_name == 'cpython'" },
             { name = "package-b", marker = "implementation_name == 'pypy'" },
@@ -1317,7 +1317,7 @@ fn fork_marker_inherit_combined_allowed() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'darwin'" },
             { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'linux'" },
@@ -1485,7 +1485,7 @@ fn fork_marker_inherit_combined_disallowed() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'darwin'" },
             { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'linux'" },
@@ -1654,7 +1654,7 @@ fn fork_marker_inherit_combined() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'darwin'" },
             { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'linux'" },
@@ -1796,7 +1796,7 @@ fn fork_marker_inherit_isolated() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'darwin'" },
             { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'linux'" },
@@ -1956,7 +1956,7 @@ fn fork_marker_inherit_transitive() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'darwin'" },
             { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'linux'" },
@@ -2088,7 +2088,7 @@ fn fork_marker_inherit() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'darwin'" },
             { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'linux'" },
@@ -2247,7 +2247,7 @@ fn fork_marker_limited_inherit() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'darwin'" },
             { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'linux'" },
@@ -2390,7 +2390,7 @@ fn fork_marker_selection() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a" },
             { name = "package-b", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'darwin'" },
@@ -2557,7 +2557,7 @@ fn fork_marker_track() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a" },
             { name = "package-b", version = "2.7", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'darwin'" },
@@ -2692,7 +2692,7 @@ fn fork_non_fork_marker_transitive() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a" },
             { name = "package-b" },
@@ -2972,7 +2972,7 @@ fn fork_overlapping_markers_basic() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a" },
         ]
@@ -3216,7 +3216,7 @@ fn preferences_dependent_forking_bistable() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-cleaver" },
         ]
@@ -3635,7 +3635,7 @@ fn preferences_dependent_forking_tristable() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-bar", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform != 'linux'" },
             { name = "package-bar", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'linux'" },
@@ -3836,7 +3836,7 @@ fn preferences_dependent_forking() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-bar", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform != 'linux'" },
             { name = "package-bar", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'linux'" },
@@ -4021,7 +4021,7 @@ fn fork_remaining_universe_partitioning() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", version = "1.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'illumos'" },
             { name = "package-a", version = "2.0.0", source = { registry = "https://astral-sh.github.io/packse/PACKSE_VERSION/simple-html/" }, marker = "sys_platform == 'windows'" },
@@ -4112,7 +4112,7 @@ fn fork_requires_python_full_prerelease() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
 
         [package.metadata]
         requires-dist = [{ name = "package-a", marker = "python_full_version == '3.9'", specifier = "==1.0.0" }]
@@ -4196,7 +4196,7 @@ fn fork_requires_python_full() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
 
         [package.metadata]
         requires-dist = [{ name = "package-a", marker = "python_full_version == '3.9'", specifier = "==1.0.0" }]
@@ -4293,7 +4293,7 @@ fn fork_requires_python_patch_overlap() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
         dependencies = [
             { name = "package-a", marker = "python_full_version < '3.11'" },
         ]
@@ -4377,7 +4377,7 @@ fn fork_requires_python() -> Result<()> {
         [[package]]
         name = "project"
         version = "0.1.0"
-        source = { editable = "." }
+        source = { virtual = "." }
 
         [package.metadata]
         requires-dist = [{ name = "package-a", marker = "python_full_version == '3.9.*'", specifier = "==1.0.0" }]

--- a/crates/uv/tests/snapshots/workflow__jax_instability-2.snap
+++ b/crates/uv/tests/snapshots/workflow__jax_instability-2.snap
@@ -162,7 +162,7 @@ wheels = [
 [[package]]
 name = "uv-lock-instability"
 version = "0.1.0"
-source = { editable = "." }
+source = { virtual = "." }
 dependencies = [
     { name = "jax" },
 ]

--- a/crates/uv/tests/workflow.rs
+++ b/crates/uv/tests/workflow.rs
@@ -466,7 +466,7 @@ fn jax_instability() -> Result<()> {
         +[[package]]
          name = "uv-lock-instability"
          version = "0.1.0"
-         source = { editable = "." }
+         source = { virtual = "." }
          dependencies = [
              { name = "jax" },
         +    { name = "tzdata" },
@@ -519,7 +519,7 @@ fn jax_instability() -> Result<()> {
         -[[package]]
          name = "uv-lock-instability"
          version = "0.1.0"
-         source = { editable = "." }
+         source = { virtual = "." }
          dependencies = [
              { name = "jax" },
         -    { name = "tzdata" },


### PR DESCRIPTION
## Summary

Use a dedicated source type for non-package requirements. Also enables us to support non-package `path` dependencies _and_ removes the need to have the member `pyproject.toml` files available when we sync _and_ makes it explicit which dependencies are virtual vs. not (as evidenced by the snapshot changes). All good things!
