### PR TITLE
Remove build system from FastAPI guide

### DIFF
--- a/docs/guides/integration/fastapi.md
+++ b/docs/guides/integration/fastapi.md
@@ -58,10 +58,6 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]",
 ]
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
 ```
 
 From there, you can run the FastAPI application with:


### PR DESCRIPTION
Matches https://github.com/astral-sh/uv-fastapi-example/pull/2