### PR TITLE
Bind to the host to allow connections in FastAPI Docker example

### DIFF
--- a/docs/guides/integration/fastapi.md
+++ b/docs/guides/integration/fastapi.md
@@ -130,7 +130,7 @@ WORKDIR /app
 RUN uv sync --frozen --no-cache
 
 # Run the application.
-CMD ["/app/.venv/bin/fastapi", "run", "app/main.py", "--port", "80"]
+CMD ["/app/.venv/bin/fastapi", "run", "app/main.py", "--port", "80", "--host", "0.0.0.0"]
 ```
 
 For more on using uv with Docker, see the [Docker guide](./docker.md).


### PR DESCRIPTION
This wouldn't allow connections as written