### PR TITLE
Remove duplicate code from `mkdocs` template file

### DIFF
--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -48,8 +48,6 @@ markdown_extensions:
   - pymdownx.magiclink:
   - attr_list:
   - md_in_html:
-  - pymdownx.highlight:
-      anchor_linenums: true
   - pymdownx.inlinehilite:
   - pymdownx.superfences:
   - markdown.extensions.attr_list:


### PR DESCRIPTION
This PR remove a duplicated code from `mkdocs` template

Fix: #6756 