### PR TITLE
Use the larger x64 macOS runner for release builds

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -64,7 +64,7 @@ jobs:
 
   macos-x86_64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: macos-12
+    runs-on: macos-12-large
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/6766