### PR TITLE
Add timeouts to all of the CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
               - "docs/reference/cli.md"
               - "docs/reference/settings.md"
   cargo-fmt:
+    timeout-minutes: 10
     name: "cargo fmt"
     runs-on: ubuntu-latest
     steps:
@@ -68,6 +69,7 @@ jobs:
         run: python scripts/transform_readme.py --target pypi
 
   python-lint:
+    timeout-minutes: 10
     name: "Python lint"
     runs-on: ubuntu-latest
     steps:
@@ -87,6 +89,7 @@ jobs:
         run: pipx run --python 3.12 mypy
 
   cargo-clippy:
+    timeout-minutes: 10
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
@@ -102,6 +105,7 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
   cargo-clippy-xwin:
+    timeout-minutes: 10
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
@@ -132,6 +136,7 @@ jobs:
           XWIN_CACHE_DIR: "${{ github.workspace}}/.xwin"
 
   cargo-shear:
+    timeout-minutes: 10
     name: "cargo shear"
     runs-on: ubuntu-latest
     steps:
@@ -145,6 +150,7 @@ jobs:
   # See: https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-ubuntu-and-windows-larger-runners
 
   cargo-test-linux:
+    timeout-minutes: 10
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on:
@@ -184,6 +190,7 @@ jobs:
           $uv pip install ruff
 
   cargo-test-macos:
+    timeout-minutes: 10
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on:
@@ -223,6 +230,7 @@ jobs:
           $uv pip install ruff
 
   cargo-test-windows:
+    timeout-minutes: 15
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on:
@@ -303,6 +311,7 @@ jobs:
 
   # Separate jobs for the nightly crate
   windows-trampoline-check:
+    timeout-minutes: 10
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
@@ -361,6 +370,7 @@ jobs:
 
   # Separate jobs for the nightly crate
   windows-trampoline-test:
+    timeout-minutes: 10
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on: windows-latest
@@ -397,9 +407,9 @@ jobs:
       - uses: crate-ci/typos@master
 
   docs:
+    timeout-minutes: 10
     name: "mkdocs"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     env:
       MKDOCS_INSIDERS_SSH_KEY_EXISTS: ${{ secrets.MKDOCS_INSIDERS_SSH_KEY != '' }}
     steps:
@@ -424,6 +434,7 @@ jobs:
         run: mkdocs build --strict -f mkdocs.insiders.yml
 
   build-binary-linux:
+    timeout-minutes: 10
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on:
@@ -451,6 +462,7 @@ jobs:
           retention-days: 1
 
   build-binary-macos-aarch64:
+    timeout-minutes: 10
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on:
@@ -473,6 +485,7 @@ jobs:
           retention-days: 1
 
   build-binary-macos-x86_64:
+    timeout-minutes: 10
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on:
@@ -496,6 +509,7 @@ jobs:
 
   build-binary-windows:
     needs: determine_changes
+    timeout-minutes: 10
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
     runs-on:
       labels: windows-latest-large
@@ -542,6 +556,7 @@ jobs:
           retention-days: 1
 
   ecosystem-test:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "ecosystem test | ${{ matrix.repo }}"
     runs-on: ubuntu-latest
@@ -578,6 +593,7 @@ jobs:
           ./${{ matrix.command }}
 
   integration-test-conda:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "integration test | conda on ubuntu"
     runs-on: ubuntu-latest
@@ -608,6 +624,7 @@ jobs:
           ./uv pip install anyio
 
   integration-test-pypy-linux:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "integration test | pypy on ubuntu"
     runs-on: ubuntu-latest
@@ -671,6 +688,7 @@ jobs:
           ./uv pip install anyio
 
   integration-test-pypy-windows:
+    timeout-minutes: 10
     needs: build-binary-windows
     name: "integration test | pypy on windows"
     runs-on: windows-latest
@@ -733,6 +751,7 @@ jobs:
           .\uv.exe pip install anyio
 
   integration-test-graalpy-linux:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "integration test | graalpy on ubuntu"
     runs-on: ubuntu-latest
@@ -802,6 +821,7 @@ jobs:
           ./uv pip install anyio
 
   integration-test-graalpy-windows:
+    timeout-minutes: 10
     needs: build-binary-windows
     name: "integration test | graalpy on windows"
     runs-on: windows-latest
@@ -864,6 +884,7 @@ jobs:
           .\uv.exe pip install anyio
 
   integration-test-github-actions:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "integration test | github actions"
     runs-on: ubuntu-latest
@@ -897,6 +918,7 @@ jobs:
           ./uv pip install anyio --reinstall
 
   cache-test-ubuntu:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "check cache | ubuntu"
     runs-on: ubuntu-latest
@@ -922,6 +944,7 @@ jobs:
         run: python scripts/check_cache_compat.py --uv-current ./uv --uv-previous ./uv-x86_64-unknown-linux-gnu/uv
 
   cache-test-macos-aarch64:
+    timeout-minutes: 10
     needs: build-binary-macos-aarch64
     name: "check cache | macos aarch64"
     runs-on: macos-14
@@ -943,6 +966,7 @@ jobs:
         run: python scripts/check_cache_compat.py --uv-current ./uv --uv-previous ./uv-aarch64-apple-darwin/uv
 
   system-test-debian:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "check system | python on debian"
     runs-on: ubuntu-latest
@@ -968,6 +992,7 @@ jobs:
         run: python3.11 scripts/check_system_python.py --uv ./uv --externally-managed
 
   system-test-fedora:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "check system | python on fedora"
     runs-on: ubuntu-latest
@@ -993,6 +1018,7 @@ jobs:
         run: python3 scripts/check_system_python.py --uv ./uv
 
   system-test-ubuntu:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "check system | python on ubuntu"
     runs-on: ubuntu-latest
@@ -1018,11 +1044,11 @@ jobs:
         run: python scripts/check_system_python.py --uv ./uv
 
   system-test-opensuse:
+    timeout-minutes: 5
     needs: build-binary-linux
     name: "check system | python on opensuse"
     runs-on: ubuntu-latest
     container: opensuse/tumbleweed
-    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
@@ -1054,6 +1080,7 @@ jobs:
   # rockylinux mimics centos but with added maintenance stability
   # and avoids issues with centos stream uptime concerns
   system-test-rocky-linux:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "check system | python on rocky linux ${{ matrix.rocky-version }}"
     runs-on: ubuntu-latest
@@ -1090,6 +1117,7 @@ jobs:
         run: python3 scripts/check_system_python.py --uv ./uv
 
   system-test-pypy:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "check system | pypy on ubuntu"
     runs-on: ubuntu-latest
@@ -1115,6 +1143,7 @@ jobs:
         run: pypy scripts/check_system_python.py --uv ./uv
 
   system-test-pyston:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "check system | pyston"
     runs-on: ubuntu-latest
@@ -1137,6 +1166,7 @@ jobs:
         run: pyston scripts/check_system_python.py --uv ./uv
 
   system-test-alpine:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "check system | alpine"
     runs-on: ubuntu-latest
@@ -1162,6 +1192,7 @@ jobs:
         run: python3 scripts/check_system_python.py --uv ./uv --externally-managed
 
   system-test-macos-aarch64:
+    timeout-minutes: 10
     needs: build-binary-macos-aarch64
     name: "check system | python on macos aarch64"
     runs-on: macos-14
@@ -1185,6 +1216,7 @@ jobs:
         run: python3 scripts/check_system_python.py --uv ./uv --externally-managed
 
   system-test-macos-aarch64-homebrew:
+    timeout-minutes: 10
     needs: build-binary-macos-aarch64
     name: "check system | homebrew python on macos aarch64"
     runs-on: macos-14
@@ -1209,6 +1241,7 @@ jobs:
         run: python3 scripts/check_system_python.py --uv ./uv --externally-managed
 
   system-test-macos-x86_64:
+    timeout-minutes: 10
     needs: build-binary-macos-x86_64
     name: "check system | python on macos x86_64"
     runs-on: macos-12
@@ -1234,6 +1267,7 @@ jobs:
         run: python3 scripts/check_system_python.py --uv ./uv
 
   system-test-windows-python-310:
+    timeout-minutes: 10
     needs: build-binary-windows
     name: "check system | python3.10 on windows"
     runs-on: windows-latest
@@ -1259,6 +1293,7 @@ jobs:
         run: py -3.10 ./scripts/check_system_python.py --uv ./uv.exe
 
   system-test-windows-x86-python-310:
+    timeout-minutes: 10
     needs: build-binary-windows
     name: "check system | python3.10 on windows x86"
     runs-on: windows-latest
@@ -1285,6 +1320,7 @@ jobs:
         run: python ./scripts/check_system_python.py --uv ./uv.exe
 
   system-test-windows-python-313:
+    timeout-minutes: 10
     needs: build-binary-windows
     name: "check system | python3.13 on windows"
     runs-on: windows-latest
@@ -1312,6 +1348,7 @@ jobs:
         run: py -3.13 ./scripts/check_system_python.py --uv ./uv.exe
 
   system-test-choco:
+    timeout-minutes: 10
     needs: build-binary-windows
     name: "check system | python3.12 via chocolatey"
     runs-on: windows-latest
@@ -1336,6 +1373,7 @@ jobs:
         run: py -3.9 ./scripts/check_system_python.py --uv ./uv.exe
 
   system-test-pyenv:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "check system | python via pyenv"
     runs-on: ubuntu-latest
@@ -1362,6 +1400,7 @@ jobs:
         run: python3.9 scripts/check_system_python.py --uv ./uv
 
   system-test-conda:
+    timeout-minutes: 10
     needs:
       [build-binary-windows, build-binary-macos-aarch64, build-binary-linux]
     name: check system | conda${{ matrix.python-version }} on ${{ matrix.os }}
@@ -1413,6 +1452,7 @@ jobs:
         run: python ./scripts/check_system_python.py --uv ./uv
 
   system-test-amazonlinux:
+    timeout-minutes: 10
     needs: build-binary-linux
     name: "check system | amazonlinux"
     runs-on: ubuntu-latest
@@ -1441,6 +1481,7 @@ jobs:
         run: python3 scripts/check_system_python.py --uv ./uv
 
   system-test-windows-embedded-python-310:
+    timeout-minutes: 10
     needs: build-binary-windows
     name: "check system | embedded python3.10 on windows"
     runs-on: windows-latest


### PR DESCRIPTION
Noticed https://github.com/astral-sh/uv/actions/runs/10601946253/job/29382920849?pr=6767 hung. This seems like best practice.