### PR TITLE
fix: replace std::fs::canonicalize with Simplified::simple_canonicaliz…

### DIFF
--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::path::{Component, Path, PathBuf, absolute};
+use std::path::{absolute, Component, Path, PathBuf};
 use std::sync::LazyLock;
 
 use either::Either;

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -13,7 +13,7 @@ pub static CWD: LazyLock<PathBuf> =
 pub static CANONICAL_CWD: LazyLock<PathBuf> = LazyLock::new(|| {
     std::env::current_dir()
         .expect("The current directory must exist")
-        .canonicalize()
+        .simple_canonicalize()
         .expect("The current directory must be canonicalized")
 });
 


### PR DESCRIPTION
## Summary
This PR addresses an issue on Windows where `std::fs::canonicalize` can fail or panic when resolving paths on mapped network drives. By replacing it with `Simplified::simple_canonicalize`, we aim to improve the robustness and cross-platform compatibility of path resolution.

### Changes
* Updated `CANONICAL_CWD` in `path.rs` to use `Simplified::simple_canonicalize` instead of `std::fs::canonicalize`.

### Why
* `std::fs::canonicalize` has known issues with resolving paths on mapped network drives on Windows, which can lead to panics or incorrect path resolution.
* `Simplified::simple_canonicalize` internally uses `dunce::canonicalize`, which handles these cases more gracefully, ensuring better stability and reliability.

## Test Plan
Since `simple_canonicalize` has already been tested in a prior PR, this change is expected to work without introducing any new issues. No additional tests are necessary beyond ensuring existing tests pass, which will confirm the correctness of the change.
