### PR TITLE
Avoid using debug representation for git source urls

### DIFF
--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -73,7 +73,7 @@ impl GitSource {
             // If we have a locked revision, and we have a preexisting database
             // which has that revision, then no update needs to happen.
             (Some(rev), Some(db)) if db.contains(rev.into()) => {
-                debug!("Using existing git source `{:?}`", self.git.repository);
+                debug!("Using existing git source `{}`", self.git.repository);
                 (db, rev, None)
             }
 
@@ -82,7 +82,7 @@ impl GitSource {
             // situation that we have a locked revision but the database
             // doesn't have it.
             (locked_rev, db) => {
-                debug!("Updating git source `{:?}`", self.git.repository);
+                debug!("Updating git source `{}`", self.git.repository);
 
                 // Report the checkout operation to the reporter.
                 let task = self.reporter.as_ref().map(|reporter| {

--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -73,7 +73,7 @@ impl GitSource {
             // If we have a locked revision, and we have a preexisting database
             // which has that revision, then no update needs to happen.
             (Some(rev), Some(db)) if db.contains(rev.into()) => {
-                debug!("Using existing git source `{}`", self.git.repository);
+                debug!("Using existing Git source `{}`", self.git.repository);
                 (db, rev, None)
             }
 
@@ -82,7 +82,7 @@ impl GitSource {
             // situation that we have a locked revision but the database
             // doesn't have it.
             (locked_rev, db) => {
-                debug!("Updating git source `{}`", self.git.repository);
+                debug!("Updating Git source `{}`", self.git.repository);
 
                 // Report the checkout operation to the reporter.
                 let task = self.reporter.as_ref().map(|reporter| {


### PR DESCRIPTION
e.g.

> DEBUG Using existing Git source `https://github.com/StarfishStorage/python-swiftclient.git`

instead of

> DEBUG Using existing git source `Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("github.com")), port: None, path: "/StarfishStorage/gunicorn.git", query: None, fragment: None }`