### PR TITLE
Ignore pre-release segments when discovering via `requires-python`

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1441,7 +1441,10 @@ impl VersionRequest {
                     interpreter.python_patch(),
                 ) == (*major, *minor, *patch)
             }
-            Self::Range(specifiers) => specifiers.contains(interpreter.python_version()),
+            Self::Range(specifiers) => {
+                let version = interpreter.python_version().only_release();
+                specifiers.contains(&version)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`3.13.0b0` should be allowed by `>=3.13`.

Closes #6798.
