### PR TITLE
Add test coverage for Python version discovery with prereleases

### DIFF
--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -1850,6 +1850,58 @@ mod tests {
     }
 
     #[test]
+    fn find_python_all_minors_prerelease() -> Result<()> {
+        let mut context = TestContext::new()?;
+        context.add_python_interpreters(&[
+            (true, ImplementationName::CPython, "python", "3.10.0"),
+            (true, ImplementationName::CPython, "python3", "3.10.0"),
+            (true, ImplementationName::CPython, "python3.11", "3.11.0b0"),
+        ])?;
+
+        let python = context.run(|| {
+            find_python_installation(
+                &PythonRequest::parse(">= 3.11"),
+                EnvironmentPreference::Any,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        })??;
+        assert_eq!(
+            python.interpreter().python_full_version().to_string(),
+            "3.11.0b0",
+            "We should find the 3.11 prerelease even though >=3.11 would normally exclude prereleases"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn find_python_all_minors_prerelease_next() -> Result<()> {
+        let mut context = TestContext::new()?;
+        context.add_python_interpreters(&[
+            (true, ImplementationName::CPython, "python", "3.10.0"),
+            (true, ImplementationName::CPython, "python3", "3.10.0"),
+            (true, ImplementationName::CPython, "python3.12", "3.12.0b0"),
+        ])?;
+
+        let python = context.run(|| {
+            find_python_installation(
+                &PythonRequest::parse(">= 3.11"),
+                EnvironmentPreference::Any,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        })??;
+        assert_eq!(
+            python.interpreter().python_full_version().to_string(),
+            "3.12.0b0",
+            "We should find the 3.12 prerelease"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn find_python_pypy_prefers_executable_with_implementation_name() -> Result<()> {
         let mut context = TestContext::new()?;
 


### PR DESCRIPTION
Coverage for https://github.com/astral-sh/uv/pull/6813 — reverting that commit causes the 3.11.0b0 test case to fail.