### PR TITLE
Don't build uv-dev by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-dev = "run --package uv-dev"
+dev = "run --package uv-dev --features dev"
 
 # statically link the C runtime so the executable does not depend on
 # that shared/dynamic library.

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -67,6 +67,13 @@ mimalloc = { version = "0.1.39" }
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
 tikv-jemallocator = { version = "0.6.0" }
 
+[[bin]]
+name = "uv-dev"
+# We don't want to build the dev CLI by default, so we skip it by requiring an off-by-default feature
+required-features = ["dev"]
+
 [features]
 default = []
+# Actually build the dev CLI.
+dev = []
 render = ["poloto", "resvg", "tagu"]


### PR DESCRIPTION
Most times we compile with `cargo build`, we don't actually need `uv-dev`. By making `uv-dev` dependent on a new `dev` feature, it doesn't get built by default anymore, but only when passing `--features dev`.

Hopefully a small improvement for compile times or at least system load.