### PR TITLE
Improve project handling in `uv venv`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -322,6 +322,10 @@ pub enum Commands {
     /// By default, creates a virtual environment named `.venv` in the working
     /// directory. An alternative path may be provided positionally.
     ///
+    /// If in a project, the default environment name can be changed with
+    /// the `UV_PROJECT_ENVIRONMENT` environment variable; this only applies
+    /// when run from the project root directory.
+    ///
     /// If a virtual environment exists at the target path, it will be removed
     /// and a new, empty virtual environment will be created.
     ///
@@ -1961,6 +1965,14 @@ pub struct VenvArgs {
     #[arg(long, overrides_with("system"), hide = true)]
     pub no_system: bool,
 
+    /// Avoid discovering a project or workspace.
+    ///
+    /// By default, uv searches for projects in the current directory or any parent directory to
+    /// determine the default path of the virtual environment and check for Python version
+    /// constraints, if any.
+    #[arg(long, alias = "no-workspace")]
+    pub no_project: bool,
+
     /// Install seed packages (one or more of: `pip`, `setuptools`, and `wheel`) into the virtual environment.
     ///
     /// Note `setuptools` and `wheel` are not included in Python 3.12+ environments.
@@ -1980,8 +1992,11 @@ pub struct VenvArgs {
     pub allow_existing: bool,
 
     /// The path to the virtual environment to create.
-    #[arg(default_value = ".venv")]
-    pub name: PathBuf,
+    ///
+    /// Default to `.venv` in the working directory.
+    ///
+    /// Relative paths are resolved relative to the working directory.
+    pub path: Option<PathBuf>,
 
     /// Provide an alternative prompt prefix for the virtual environment.
     ///

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1,7 +1,6 @@
 use std::ffi::OsString;
 use std::fmt::Write;
 use std::io::stdout;
-use std::path::PathBuf;
 use std::process::ExitCode;
 
 use anstream::eprintln;
@@ -680,7 +679,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
 
             // Since we use ".venv" as the default name, we use "." as the default prompt.
             let prompt = args.prompt.or_else(|| {
-                if args.name == PathBuf::from(".venv") {
+                if args.path.is_none() {
                     Some(".".to_string())
                 } else {
                     None
@@ -688,7 +687,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             });
 
             commands::venv(
-                &args.name,
+                args.path,
                 args.settings.python.as_deref(),
                 globals.python_preference,
                 globals.python_downloads,
@@ -706,6 +705,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 globals.concurrency,
                 globals.native_tls,
                 cli.no_config,
+                args.no_project,
                 &cache,
                 printer,
                 args.relocatable,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1614,10 +1614,11 @@ impl PipCheckSettings {
 pub(crate) struct VenvSettings {
     pub(crate) seed: bool,
     pub(crate) allow_existing: bool,
-    pub(crate) name: PathBuf,
+    pub(crate) path: Option<PathBuf>,
     pub(crate) prompt: Option<String>,
     pub(crate) system_site_packages: bool,
     pub(crate) relocatable: bool,
+    pub(crate) no_project: bool,
     pub(crate) settings: PipSettings,
 }
 
@@ -1630,7 +1631,7 @@ impl VenvSettings {
             no_system,
             seed,
             allow_existing,
-            name,
+            path,
             prompt,
             system_site_packages,
             relocatable,
@@ -1639,6 +1640,7 @@ impl VenvSettings {
             keyring_provider,
             allow_insecure_host,
             exclude_newer,
+            no_project,
             link_mode,
             compat_args: _,
         } = args;
@@ -1646,9 +1648,10 @@ impl VenvSettings {
         Self {
             seed,
             allow_existing,
-            name,
+            path,
             prompt,
             system_site_packages,
+            no_project,
             relocatable,
             settings: PipSettings::combine(
                 PipOptions {

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -335,8 +335,8 @@ impl TestContext {
 
         // Make virtual environment activation cross-platform and shell-agnostic
         filters.push((
-            r"Activate with: (?:.*)\\Scripts\\activate".to_string(),
-            "Activate with: source .venv/bin/activate".to_string(),
+            r"Activate with: (.*)\\Scripts\\activate".to_string(),
+            "Activate with: source $1/bin/activate".to_string(),
         ));
         filters.push((
             r"Activate with: source .venv/bin/activate(?:\.\w+)".to_string(),

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5956,6 +5956,8 @@ Create a virtual environment.
 
 By default, creates a virtual environment named `.venv` in the working directory. An alternative path may be provided positionally.
 
+If in a project, the default environment name can be changed with the `UV_PROJECT_ENVIRONMENT` environment variable; this only applies when run from the project root directory.
+
 If a virtual environment exists at the target path, it will be removed and a new, empty virtual environment will be created.
 
 When using uv, the virtual environment does not need to be activated. uv will find a virtual environment (named `.venv`) in the working directory or any parent directories.
@@ -5963,12 +5965,16 @@ When using uv, the virtual environment does not need to be activated. uv will fi
 <h3 class="cli-reference">Usage</h3>
 
 ```
-uv venv [OPTIONS] [NAME]
+uv venv [OPTIONS] [PATH]
 ```
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt><code>NAME</code></dt><dd><p>The path to the virtual environment to create</p>
+<dl class="cli-reference"><dt><code>PATH</code></dt><dd><p>The path to the virtual environment to create.</p>
+
+<p>Default to <code>.venv</code> in the working directory.</p>
+
+<p>Relative paths are resolved relative to the working directory.</p>
 
 </dd></dl>
 
@@ -6104,6 +6110,10 @@ uv venv [OPTIONS] [NAME]
 </dd><dt><code>--no-progress</code></dt><dd><p>Hide all progress outputs.</p>
 
 <p>For example, spinners or progress bars.</p>
+
+</dd><dt><code>--no-project</code></dt><dd><p>Avoid discovering a project or workspace.</p>
+
+<p>By default, uv searches for projects in the current directory or any parent directory to determine the default path of the virtual environment and check for Python version constraints, if any.</p>
 
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 


### PR DESCRIPTION
- Respect `UV_PROJECT_ENVIRONMENT` when in project root
- Add `--no-project` and `--no-workspace` to opt-out of above and `requires-python` detection
- Rename `[NAME]` to `[PATH]` in CLI