### PR TITLE
fix: correct inline suggestion for requirements.txt

### DIFF
--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -915,7 +915,7 @@ impl Display for RequirementsTxtParserError {
                 write!(f, "Unsupported editable requirement")
             }
             Self::MissingRequirementPrefix(given) => {
-                write!(f, "Requirement `{given}` looks like a requirements file but was passed as a package name. Did you mean `-r {given}`?")
+                write!(f, "Requirement `{given}` looks like a requirements file but was passed as a package name. Did you mean `--with-requirements {given}`?")
             }
             Self::NoBinary { specifier, .. } => {
                 write!(f, "Invalid specifier for `--no-binary`: {specifier}")
@@ -1035,7 +1035,7 @@ impl Display for RequirementsTxtFileError {
             RequirementsTxtParserError::MissingRequirementPrefix(given) => {
                 write!(
                     f,
-                    "Requirement `{given}` in `{}` looks like a requirements file but was passed as a package name. Did you mean `-r {given}`?",
+                    "Requirement `{given}` in `{}` looks like a requirements file but was passed as a package name. Did you mean `--with-requirements {given}`?",
                     self.file.user_display(),
                 )
             }
@@ -1658,7 +1658,7 @@ mod test {
         insta::with_settings!({
             filters => filters
         }, {
-            insta::assert_snapshot!(errors, @"Requirement `file.txt` in `<REQUIREMENTS_TXT>` looks like a requirements file but was passed as a package name. Did you mean `-r file.txt`?");
+            insta::assert_snapshot!(errors, @"Requirement `file.txt` in `<REQUIREMENTS_TXT>` looks like a requirements file but was passed as a package name. Did you mean `--with-requirements file.txt`?");
         });
 
         Ok(())

--- a/crates/uv-requirements/src/sources.rs
+++ b/crates/uv-requirements/src/sources.rs
@@ -94,7 +94,7 @@ impl RequirementsSource {
             let term = Term::stderr();
             if term.is_term() {
                 let prompt = format!(
-                    "`{name}` looks like a local requirements file but was passed as a package name. Did you mean `-r {name}`?"
+                    "`{name}` looks like a local requirements file but was passed as a package name. Did you mean `--with-requirements {name}`?"
                 );
                 let confirmation = confirm::confirm(&prompt, &term, true).unwrap();
                 if confirmation {
@@ -111,7 +111,7 @@ impl RequirementsSource {
             let term = Term::stderr();
             if term.is_term() {
                 let prompt = format!(
-                    "`{name}` looks like a local metadata file but was passed as a package name. Did you mean `-r {name}`?"
+                    "`{name}` looks like a local metadata file but was passed as a package name. Did you mean `--with-requirements {name}`?"
                 );
                 let confirmation = confirm::confirm(&prompt, &term, true).unwrap();
                 if confirmation {


### PR DESCRIPTION
Fixed #6845

## Summary

Passing a requiremenst.txt file via `--with` to uvx is wrong and there's a helpful inline suggestion to use xxxx instead.

The suggestion was wrong, suggested `-r` while the correct flag is `--with-requirements`.

## Test Plan

- create a simple requirements.txt
- [opt] run `cargo run -- --help` to work around #6847
- run `cargo run --bin uvx -- --with test-requirements.txt tox` or similar

## Full Disclosure

The "wrong" text was present in 4 lines of code and 1 assert, and so I've changes all 5 places.

I have no clue if all 5 places should have been changed. Maybe only some?

Please review 🙇🏻 