### PR TITLE
ci(windows): Introduce setup-dev-drive.ps1, maximize dev drive usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
     name: "cargo test | windows"
     steps:
       - name: Create Dev Drive using ReFS
-        run: .github/workflows/setup-dev-drive.ps1
+        run: .\.github\workflows\setup-dev-drive.ps1
 
       - uses: actions/checkout@v4
 
@@ -497,7 +497,7 @@ jobs:
     name: "build binary | windows"
     steps:
       - name: Create Dev Drive using ReFS
-        run: .github/workflows/setup-dev-drive.ps1
+        run: .\.github\workflows\setup-dev-drive.ps1
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,22 +241,14 @@ jobs:
     name: "cargo test | windows"
     steps:
       - name: Create Dev Drive using ReFS
-        run: |
-          $Volume = New-VHD -Path C:/uv_dev_drive.vhdx -SizeBytes 20GB |
-                    Mount-VHD -Passthru |
-                    Initialize-Disk -Passthru |
-                    New-Partition -AssignDriveLetter -UseMaximumSize |
-                    Format-Volume -FileSystem ReFS -Confirm:$false -Force
-          Write-Output $Volume
-          Write-Output "DEV_DRIVE=$($Volume.DriveLetter):" >> $env:GITHUB_ENV
-          Write-Output "TEMP=$($Volume.DriveLetter):\uv-tmp" >> $env:GITHUB_ENV
+        run: .github/workflows/setup-dev-drive.ps1
 
       - uses: actions/checkout@v4
 
       # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
       - name: Copy Git Repo to Dev Drive
         run: |
-          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.DEV_DRIVE }}/uv" -Recurse
+          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
 
       # We do not test with Python patch versions on Windows
       # so we can use `setup-python` instead of our bootstrapping code
@@ -272,39 +264,25 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: ${{ env.DEV_DRIVE }}/uv
-        env:
-          CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-          RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
+          workspaces: ${{ env.UV_WORKSPACE }}
 
       - name: "Install Rust toolchain"
-        working-directory: ${{ env.DEV_DRIVE }}/uv
-        env:
-          CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-          RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
+        working-directory: ${{ env.UV_WORKSPACE }}
         run: rustup show
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
-        env:
-          CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-          RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
 
       - name: "Cargo test"
-        working-directory: ${{ env.DEV_DRIVE }}/uv
-        env:
-          CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-          RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
+        working-directory: ${{ env.UV_WORKSPACE }}
         run: |
           cargo nextest run --no-default-features --features python,pypi --workspace --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 
       - name: "Smoke test"
-        working-directory: ${{ env.DEV_DRIVE }}/uv
+        working-directory: ${{ env.UV_WORKSPACE }}
         env:
-          CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-          RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
           # Avoid debug build stack overflows.
           UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
         run: |
@@ -519,44 +497,28 @@ jobs:
     name: "build binary | windows"
     steps:
       - name: Create Dev Drive using ReFS
-        run: |
-          $Volume = New-VHD -Path C:/uv_dev_drive.vhdx -SizeBytes 10GB |
-                    Mount-VHD -Passthru |
-                    Initialize-Disk -Passthru |
-                    New-Partition -AssignDriveLetter -UseMaximumSize |
-                    Format-Volume -FileSystem ReFS -Confirm:$false -Force
-          Write-Output $Volume
-          Write-Output "DEV_DRIVE=$($Volume.DriveLetter):" >> $env:GITHUB_ENV
-          Write-Output "TEMP=$($Volume.DriveLetter):\uv-tmp" >> $env:GITHUB_ENV
+        run: .github/workflows/setup-dev-drive.ps1
 
       - uses: actions/checkout@v4
 
       # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
       - name: Copy Git Repo to Dev Drive
         run: |
-          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.DEV_DRIVE }}/uv" -Recurse
-
-      - uses: rui314/setup-mold@v1
+          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
 
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: ${{ env.DEV_DRIVE }}/uv
-        env:
-          CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-          RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
+          workspaces: ${{ env.UV_WORKSPACE }}
 
       - name: "Build"
-        working-directory: ${{ env.DEV_DRIVE }}/uv
-        env:
-          CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
-          RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
+        working-directory: ${{ env.UV_WORKSPACE }}
         run: cargo build
 
       - name: "Upload binary"
         uses: actions/upload-artifact@v4
         with:
           name: uv-windows-${{ github.sha }}
-          path: ${{ env.DEV_DRIVE }}/uv/target/debug/uv.exe
+          path: ${{ env.UV_WORKSPACE }}/target/debug/uv.exe
           retention-days: 1
 
   ecosystem-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,7 @@ jobs:
                     Format-Volume -FileSystem ReFS -Confirm:$false -Force
           Write-Output $Volume
           Write-Output "DEV_DRIVE=$($Volume.DriveLetter):" >> $env:GITHUB_ENV
+          Write-Output "TEMP=$($Volume.DriveLetter):\uv-tmp" >> $env:GITHUB_ENV
 
       - uses: actions/checkout@v4
 
@@ -296,7 +297,6 @@ jobs:
         env:
           CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
           RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
-          TEMP: ${{ env.DEV_DRIVE }}/tmp-uv
         run: |
           cargo nextest run --no-default-features --features python,pypi --workspace --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 
@@ -527,6 +527,7 @@ jobs:
                     Format-Volume -FileSystem ReFS -Confirm:$false -Force
           Write-Output $Volume
           Write-Output "DEV_DRIVE=$($Volume.DriveLetter):" >> $env:GITHUB_ENV
+          Write-Output "TEMP=$($Volume.DriveLetter):\uv-tmp" >> $env:GITHUB_ENV
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,11 +240,10 @@ jobs:
       labels: "windows-latest-xlarge"
     name: "cargo test | windows"
     steps:
-      - name: Create Dev Drive using ReFS
-        shell: pwsh
-        run: .github/workflows/setup-dev-drive.ps1
-
       - uses: actions/checkout@v4
+
+      - name: Create Dev Drive using ReFS
+        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
 
       # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
       - name: Copy Git Repo to Dev Drive
@@ -497,11 +496,10 @@ jobs:
       labels: windows-latest-large
     name: "build binary | windows"
     steps:
-      - name: Create Dev Drive using ReFS
-        shell: pwsh
-        run: .github/workflows/setup-dev-drive.ps1
-
       - uses: actions/checkout@v4
+
+      - name: Create Dev Drive using ReFS
+        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
 
       # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
       - name: Copy Git Repo to Dev Drive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,8 @@ jobs:
     name: "cargo test | windows"
     steps:
       - name: Create Dev Drive using ReFS
-        run: .\.github\workflows\setup-dev-drive.ps1
+        shell: pwsh
+        run: .github/workflows/setup-dev-drive.ps1
 
       - uses: actions/checkout@v4
 
@@ -497,7 +498,8 @@ jobs:
     name: "build binary | windows"
     steps:
       - name: Create Dev Drive using ReFS
-        run: .\.github\workflows\setup-dev-drive.ps1
+        shell: pwsh
+        run: .github/workflows/setup-dev-drive.ps1
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
         env:
           CARGO_HOME: ${{ env.DEV_DRIVE }}/.cargo
           RUSTUP_HOME: ${{ env.DEV_DRIVE }}/.rustup
-          UV_INTERNAL__TEST_DIR: ${{ env.DEV_DRIVE }}/tmp-uv
+          TEMP: ${{ env.DEV_DRIVE }}/tmp-uv
         run: |
           cargo nextest run --no-default-features --features python,pypi --workspace --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -14,6 +14,7 @@ $Tmp = "$($Drive)/uv-tmp"
 
 Write-Output `
 	"DEV_DRIVE=$($Drive)" `
+	"TMP=$($Tmp)" `
 	"TEMP=$($Tmp)" `
 	"UV_INTERNAL__TEST_DIR=$($Tmp)" `
 	"RUSTUP_HOME=$($Drive)/.rustup" `

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -1,0 +1,23 @@
+# This creates a 20GB dev drive, and exports all required environment
+# variables so that rustup, uv and others all use the dev drive as much
+# as possible.
+$Volume = New-VHD -Path C:/uv_dev_drive.vhdx -SizeBytes 20GB |
+					Mount-VHD -Passthru |
+					Initialize-Disk -Passthru |
+					New-Partition -AssignDriveLetter -UseMaximumSize |
+					Format-Volume -FileSystem ReFS -Confirm:$false -Force
+
+Write-Output $Volume
+
+$Drive = "$($Volume.DriveLetter):"
+$Tmp = "$($Drive)/uv-tmp"
+
+Write-Output `
+	"DEV_DRIVE=$($Drive)" `
+	"TEMP=$($Tmp)" `
+	"UV_INTERNAL__TEST_DIR=$($Tmp)" `
+	"RUSTUP_HOME=$($Drive)/.rustup" `
+	"CARGO_HOME=$($Drive)/.cargo" `
+	"UV_WORKSPACE=$($Drive)/uv" `
+	>> $env:GITHUB_ENV
+

--- a/crates/distribution-types/src/installed.rs
+++ b/crates/distribution-types/src/installed.rs
@@ -90,6 +90,7 @@ impl InstalledDist {
 
             let name = PackageName::from_str(name)?;
             let version = Version::from_str(version).map_err(|err| anyhow!(err))?;
+
             return if let Some(direct_url) = Self::direct_url(path)? {
                 match Url::try_from(&direct_url) {
                     Ok(url) => Ok(Some(Self::Url(InstalledDirectUrlDist {

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -135,14 +135,7 @@ impl Cache {
 
     /// Create a temporary cache directory.
     pub fn temp() -> Result<Self, io::Error> {
-        let temp_dir =
-            if let Ok(test_dir) = std::env::var("UV_INTERNAL__TEST_DIR").map(PathBuf::from) {
-                let uv_cache_dir = test_dir.join("uv-cache");
-                let _ = fs_err::create_dir_all(&uv_cache_dir);
-                tempfile::tempdir_in(uv_cache_dir)?
-            } else {
-                tempfile::tempdir()?
-            };
+        let temp_dir = tempfile::tempdir()?
         Ok(Self {
             root: temp_dir.path().to_path_buf(),
             refresh: Refresh::None(Timestamp::now()),

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -135,7 +135,7 @@ impl Cache {
 
     /// Create a temporary cache directory.
     pub fn temp() -> Result<Self, io::Error> {
-        let temp_dir = tempfile::tempdir()?
+        let temp_dir = tempfile::tempdir()?;
         Ok(Self {
             root: temp_dir.path().to_path_buf(),
             refresh: Refresh::None(Timestamp::now()),


### PR DESCRIPTION
As suggested by @samypr100 on #6680:
https://github.com/astral-sh/uv/pull/6680#issuecomment-2313607984

## Summary

Instead of using `UV_INTERNAL__TEST_DIR`, it simply exports `TEMP` when running Windows jobs.

## Test Plan

I'm going to run this manually under ProcMon on my Windows machine and see where uv writes temp files, hopefully to the dev drive and not `%(LOCAL)APPDATA%` or something.

I'm going to commit a dummy code change and look at build time changes in CI.