### PR TITLE
Avoid stripping root for user path display

### DIFF
--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -65,6 +65,11 @@ impl<T: AsRef<Path>> Simplified for T {
     fn user_display(&self) -> impl std::fmt::Display {
         let path = dunce::simplified(self.as_ref());
 
+        // If current working directory is root, display the path as-is.
+        if CWD.ancestors().nth(1).is_none() {
+            return path.display();
+        }
+
         // Attempt to strip the current working directory, then the canonicalized current working
         // directory, in case they differ.
         let path = path.strip_prefix(CWD.simplified()).unwrap_or_else(|_| {
@@ -77,6 +82,11 @@ impl<T: AsRef<Path>> Simplified for T {
 
     fn user_display_from(&self, base: impl AsRef<Path>) -> impl std::fmt::Display {
         let path = dunce::simplified(self.as_ref());
+
+        // If current working directory is root, display the path as-is.
+        if CWD.ancestors().nth(1).is_none() {
+            return path.display();
+        }
 
         // Attempt to strip the base, then the current working directory, then the canonicalized
         // current working directory, in case they differ.


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/6840.

## Test Plan

```
❯ ~/workspace/uv/target/debug/uv pip list --verbose
DEBUG uv 0.4.0
DEBUG Searching for Python interpreter in system path
DEBUG Found `cpython-3.12.3-macos-aarch64-none` at `/Users/crmarsh/.local/share/rtx/installs/python/3.12.3/bin/python3` (search path)
DEBUG Using Python 3.12.3 environment at /Users/crmarsh/.local/share/rtx/installs/python/3.12.3/bin/python3
```
