### PR TITLE
Take unowned request in `PythonInstallation::find_or_download`

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -138,7 +138,7 @@ pub(crate) async fn add(
             };
 
             let interpreter = PythonInstallation::find_or_download(
-                Some(python_request),
+                Some(&python_request),
                 EnvironmentPreference::Any,
                 python_preference,
                 python_downloads,
@@ -175,7 +175,7 @@ pub(crate) async fn add(
         };
 
         let interpreter = PythonInstallation::find_or_download(
-            python_request,
+            python_request.as_ref(),
             EnvironmentPreference::Any,
             python_preference,
             python_downloads,

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -204,7 +204,7 @@ async fn init_project(
                     .connectivity(connectivity)
                     .native_tls(native_tls);
                 let interpreter = PythonInstallation::find_or_download(
-                    Some(request),
+                    Some(&request),
                     EnvironmentPreference::Any,
                     python_preference,
                     python_downloads,
@@ -231,7 +231,7 @@ async fn init_project(
             .connectivity(connectivity)
             .native_tls(native_tls);
         let interpreter = PythonInstallation::find_or_download(
-            Some(request),
+            Some(&request),
             EnvironmentPreference::Any,
             python_preference,
             python_downloads,

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -261,7 +261,7 @@ impl FoundInterpreter {
 
         // Locate the Python interpreter to use in the environment
         let python = PythonInstallation::find_or_download(
-            python_request,
+            python_request.as_ref(),
             EnvironmentPreference::OnlySystem,
             python_preference,
             python_downloads,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -123,7 +123,7 @@ pub(crate) async fn run(
             .native_tls(native_tls);
 
         let interpreter = PythonInstallation::find_or_download(
-            python_request,
+            python_request.as_ref(),
             EnvironmentPreference::Any,
             python_preference,
             python_downloads,
@@ -351,7 +351,7 @@ pub(crate) async fn run(
                     .await?;
 
                     PythonInstallation::find_or_download(
-                        python_request,
+                        python_request.as_ref(),
                         EnvironmentPreference::Any,
                         python_preference,
                         python_downloads,
@@ -464,7 +464,7 @@ pub(crate) async fn run(
                 };
 
                 let python = PythonInstallation::find_or_download(
-                    python_request,
+                    python_request.as_ref(),
                     // No opt-in is required for system environments, since we are not mutating it.
                     EnvironmentPreference::Any,
                     python_preference,

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -61,7 +61,7 @@ pub(crate) async fn install(
     // Pre-emptively identify a Python interpreter. We need an interpreter to resolve any unnamed
     // requirements, even if we end up using a different interpreter for the tool install itself.
     let interpreter = PythonInstallation::find_or_download(
-        python_request.clone(),
+        python_request.as_ref(),
         EnvironmentPreference::OnlySystem,
         python_preference,
         python_downloads,

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -324,7 +324,7 @@ async fn get_or_create_environment(
 
     // Discover an interpreter.
     let interpreter = PythonInstallation::find_or_download(
-        python_request.clone(),
+        python_request.as_ref(),
         EnvironmentPreference::OnlySystem,
         python_preference,
         python_downloads,

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -183,7 +183,7 @@ async fn venv_impl(
 
     // Locate the Python interpreter to use in the environment
     let python = PythonInstallation::find_or_download(
-        interpreter_request,
+        interpreter_request.as_ref(),
         EnvironmentPreference::OnlySystem,
         python_preference,
         python_downloads,


### PR DESCRIPTION
## Summary

It only needs a reference anyway, so we can avoid cloning.