### PR TITLE
fix: typo in alternative-indexes.md docs

### DIFF
--- a/docs/guides/integration/alternative-indexes.md
+++ b/docs/guides/integration/alternative-indexes.md
@@ -6,7 +6,7 @@ some initial setup.
 
 !!! important
 
-    Please read the dcocumentation on [using multiple indexes](../../pip/compatibility.md#packages-that-exist-on-multiple-indexes)
+    Please read the documentation on [using multiple indexes](../../pip/compatibility.md#packages-that-exist-on-multiple-indexes)
     in uv — the default behavior is different from pip to prevent dependency confusion attacks, but
     this means that uv may not find the versions of a package as you'd expect.
 


### PR DESCRIPTION

## Summary

Small typo on the guide for alternative index

## Test Plan

I rerun the documentation to see the typo gone.