### PR TITLE
Adding support for `.pyc`  files in `uv run`

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -889,7 +889,7 @@ impl TryFrom<&ExternalCommand> for RunCommand {
             Ok(Self::Python(args.to_vec()))
         } else if target_path
             .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("py") || ext.eq_ignore_ascii_case("pyc"))
             && target_path.exists()
         {
             Ok(Self::PythonScript(target_path, args.to_vec()))


### PR DESCRIPTION
## Summary
- The change relates to #6635 is to include compiled python files (.pyc) in the uv run command.
- After this change `uv run foo.pyc` should spawn `python foo.pyc`.


## Test Plan
- There is a test that uses TestContext to compile and run a simple python file that prints "Hello World".
- I built the project locally and tried the same with a simple python file that I had compiled.


