### PR TITLE
Make headers title case for backward compatibility

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -191,6 +191,7 @@ impl<'a> BaseClientBuilder<'a> {
     ) -> Client {
         // Configure the builder.
         let client_builder = ClientBuilder::new()
+            .http1_title_case_headers()
             .user_agent(user_agent)
             .pool_max_idle_per_host(20)
             .read_timeout(std::time::Duration::from_secs(timeout))


### PR DESCRIPTION
## Summary
Http headers are supposed to be case-insensitive (RFC 2616), but there are some implementations that don't normalize them.
I noticed it while migrating to `uv`, calls to an internal registry failed. A man in the middle server helped me to find that `pip` uses Title-Case while `uv pip` uses lowercase.

## Test Plan

I tested `uv` with the same server and now it works fine.
