### PR TITLE
Support `uv build --wheel` from source distributions

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -341,14 +341,20 @@ pub enum Commands {
     Venv(VenvArgs),
     /// Build Python packages into source distributions and wheels.
     ///
-    /// By default, `uv build` will build a source distribution ("sdist")
-    /// from the source directory, and a binary distribution ("wheel") from
-    /// the source distribution.
+    /// `uv build` accepts a path to a directory or source distribution,
+    /// which defaults to the current working directory.
+    ///
+    /// By default, if passed a directory, `uv build` will build a source
+    /// distribution ("sdist") from the source directory, and a binary
+    /// distribution ("wheel") from  the source distribution.
     ///
     /// `uv build --sdist` can be used to build only the source distribution,
     /// `uv build --wheel` can be used to build only the binary distribution,
     /// and `uv build --sdist --wheel` can be used to build both distributions
     /// from source.
+    ///
+    /// If passed a source distribution, `uv build --wheel` will build a wheel
+    /// from  the source distribution.
     #[command(
         after_help = "Use `uv help build` for more details.",
         after_long_help = ""
@@ -1942,15 +1948,17 @@ pub struct PipTreeArgs {
 #[derive(Args)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct BuildArgs {
-    /// The directory from which distributions should be built.
+    /// The directory from which distributions should be built, or a source
+    /// distribution archive to build into a wheel.
     ///
     /// Defaults to the current working directory.
     #[arg(value_parser = parse_file_path)]
-    pub src_dir: Option<PathBuf>,
+    pub src: Option<PathBuf>,
 
     /// The output directory to which distributions should be written.
     ///
-    /// Defaults to the `dist` subdirectory within the source directory.
+    /// Defaults to the `dist` subdirectory within the source directory, or the
+    /// directory containing the source distribution archive.
     #[arg(long, short, value_parser = parse_file_path)]
     pub out_dir: Option<PathBuf>,
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -671,7 +671,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             );
 
             commands::build(
-                args.src_dir,
+                args.src,
                 args.out_dir,
                 args.sdist,
                 args.wheel,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1615,7 +1615,7 @@ impl PipCheckSettings {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub(crate) struct BuildSettings {
-    pub(crate) src_dir: Option<PathBuf>,
+    pub(crate) src: Option<PathBuf>,
     pub(crate) out_dir: Option<PathBuf>,
     pub(crate) sdist: bool,
     pub(crate) wheel: bool,
@@ -1628,7 +1628,7 @@ impl BuildSettings {
     /// Resolve the [`BuildSettings`] from the CLI and filesystem configuration.
     pub(crate) fn resolve(args: BuildArgs, filesystem: Option<FilesystemOptions>) -> Self {
         let BuildArgs {
-            src_dir,
+            src,
             out_dir,
             sdist,
             wheel,
@@ -1639,7 +1639,7 @@ impl BuildSettings {
         } = args;
 
         Self {
-            src_dir,
+            src,
             out_dir,
             sdist,
             wheel,

--- a/crates/uv/tests/build.rs
+++ b/crates/uv/tests/build.rs
@@ -40,6 +40,17 @@ fn build() -> Result<()> {
     Successfully built project/dist/project-0.1.0.tar.gz and project/dist/project-0.1.0-py3-none-any.whl
     "###);
 
+    project
+        .child("dist")
+        .child("project-0.1.0.tar.gz")
+        .assert(predicate::path::is_file());
+    project
+        .child("dist")
+        .child("project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::is_file());
+
+    fs_err::remove_dir_all(project.child("dist"))?;
+
     // Build the current working directory.
     uv_snapshot!(context.filters(), context.build().current_dir(project.path()), @r###"
     success: true
@@ -49,6 +60,17 @@ fn build() -> Result<()> {
     ----- stderr -----
     Successfully built dist/project-0.1.0.tar.gz and dist/project-0.1.0-py3-none-any.whl
     "###);
+
+    project
+        .child("dist")
+        .child("project-0.1.0.tar.gz")
+        .assert(predicate::path::is_file());
+    project
+        .child("dist")
+        .child("project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::is_file());
+
+    fs_err::remove_dir_all(project.child("dist"))?;
 
     // Error if there's nothing to build.
     uv_snapshot!(context.filters(), context.build(), @r###"
@@ -115,6 +137,15 @@ fn sdist() -> Result<()> {
     Successfully built dist/project-0.1.0.tar.gz
     "###);
 
+    project
+        .child("dist")
+        .child("project-0.1.0.tar.gz")
+        .assert(predicate::path::is_file());
+    project
+        .child("dist")
+        .child("project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::missing());
+
     Ok(())
 }
 
@@ -151,6 +182,15 @@ fn wheel() -> Result<()> {
     Successfully built dist/project-0.1.0-py3-none-any.whl
     "###);
 
+    project
+        .child("dist")
+        .child("project-0.1.0.tar.gz")
+        .assert(predicate::path::missing());
+    project
+        .child("dist")
+        .child("project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::is_file());
+
     Ok(())
 }
 
@@ -185,6 +225,109 @@ fn sdist_wheel() -> Result<()> {
 
     ----- stderr -----
     Successfully built dist/project-0.1.0.tar.gz and dist/project-0.1.0-py3-none-any.whl
+    "###);
+
+    project
+        .child("dist")
+        .child("project-0.1.0.tar.gz")
+        .assert(predicate::path::is_file());
+    project
+        .child("dist")
+        .child("project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::is_file());
+
+    Ok(())
+}
+
+#[test]
+fn wheel_from_sdist() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let project = context.temp_dir.child("project");
+
+    let pyproject_toml = project.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==3.7.0"]
+
+        [build-system]
+        requires = ["setuptools>=42"]
+        build-backend = "setuptools.build_meta"
+        "#,
+    )?;
+
+    project.child("src").child("__init__.py").touch()?;
+
+    // Build the sdist.
+    uv_snapshot!(context.filters(), context.build().arg("--sdist").current_dir(&project), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Successfully built dist/project-0.1.0.tar.gz
+    "###);
+
+    project
+        .child("dist")
+        .child("project-0.1.0.tar.gz")
+        .assert(predicate::path::is_file());
+    project
+        .child("dist")
+        .child("project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::missing());
+
+    // Error if `--wheel` is not specified.
+    uv_snapshot!(context.filters(), context.build().arg("./dist/project-0.1.0.tar.gz").current_dir(&project), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Pass `--wheel` explicitly to build a wheel from a source distribution
+    "###);
+
+    // Error if `--sdist` is specified.
+    uv_snapshot!(context.filters(), context.build().arg("./dist/project-0.1.0.tar.gz").arg("--sdist").current_dir(&project), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Building an `--sdist` from a source distribution is not supported
+    "###);
+
+    // Build the wheel from the sdist.
+    uv_snapshot!(context.filters(), context.build().arg("./dist/project-0.1.0.tar.gz").arg("--wheel").current_dir(&project), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Successfully built dist/project-0.1.0-py3-none-any.whl
+    "###);
+
+    project
+        .child("dist")
+        .child("project-0.1.0.tar.gz")
+        .assert(predicate::path::is_file());
+    project
+        .child("dist")
+        .child("project-0.1.0-py3-none-any.whl")
+        .assert(predicate::path::is_file());
+
+    // Passing a wheel is an error.
+    uv_snapshot!(context.filters(), context.build().arg("./dist/project-0.1.0-py3-none-any.whl").arg("--wheel").current_dir(&project), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: `dist/project-0.1.0-py3-none-any.whl` is not a valid build source. Expected to receive a source directory, or a source distribution ending in one of: `.zip`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, or `.tar.zst`.
     "###);
 
     Ok(())

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6190,19 +6190,23 @@ uv venv [OPTIONS] [PATH]
 
 Build Python packages into source distributions and wheels.
 
-By default, `uv build` will build a source distribution ("sdist") from the source directory, and a binary distribution ("wheel") from the source distribution.
+`uv build` accepts a path to a directory or source distribution, which defaults to the current working directory.
+
+By default, if passed a directory, `uv build` will build a source distribution ("sdist") from the source directory, and a binary distribution ("wheel") from  the source distribution.
 
 `uv build --sdist` can be used to build only the source distribution, `uv build --wheel` can be used to build only the binary distribution, and `uv build --sdist --wheel` can be used to build both distributions from source.
+
+If passed a source distribution, `uv build --wheel` will build a wheel from  the source distribution.
 
 <h3 class="cli-reference">Usage</h3>
 
 ```
-uv build [OPTIONS] [SRC_DIR]
+uv build [OPTIONS] [SRC]
 ```
 
 <h3 class="cli-reference">Arguments</h3>
 
-<dl class="cli-reference"><dt><code>SRC_DIR</code></dt><dd><p>The directory from which distributions should be built.</p>
+<dl class="cli-reference"><dt><code>SRC</code></dt><dd><p>The directory from which distributions should be built, or a source distribution archive to build into a wheel.</p>
 
 <p>Defaults to the current working directory.</p>
 
@@ -6368,7 +6372,7 @@ uv build [OPTIONS] [SRC_DIR]
 
 </dd><dt><code>--out-dir</code>, <code>-o</code> <i>out-dir</i></dt><dd><p>The output directory to which distributions should be written.</p>
 
-<p>Defaults to the <code>dist</code> subdirectory within the source directory.</p>
+<p>Defaults to the <code>dist</code> subdirectory within the source directory, or the directory containing the source distribution archive.</p>
 
 </dd><dt><code>--prerelease</code> <i>prerelease</i></dt><dd><p>The strategy to use when considering pre-release versions.</p>
 


### PR DESCRIPTION
## Summary

This PR allows users to run `uv build --wheel ./path/to/source.tar.gz` to build a wheel from a source distribution. This is also the default behavior if you run `uv build ./path/to/source.tar.gz`. If you pass `--sdist`, we error.