### PR TITLE
chore: run `cargo dev generate-all` on CI and locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,10 @@ jobs:
               - "!**/*.md"
               - "!bin/**"
               - "!assets/**"
-              # Generated markdown files are checked during test runs
+              # Generated markdown and JSON files are checked during test runs
               - "docs/reference/cli.md"
               - "docs/reference/settings.md"
+              - "uv.schema.json"
   cargo-fmt:
     timeout-minutes: 10
     name: "cargo fmt"
@@ -137,6 +138,20 @@ jobs:
         env:
           XWIN_ARCH: "x86_64"
           XWIN_CACHE_DIR: "${{ github.workspace}}/.xwin"
+
+  cargo-dev-generate-all:
+    timeout-minutes: 10
+    needs: determine_changes
+    if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
+    runs-on: ubuntu-latest
+    name: "cargo dev generate-all"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: "Generate all"
+        run: cargo dev generate-all --mode check
 
   cargo-shear:
     timeout-minutes: 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,16 @@ repos:
         types: [rust]
         pass_filenames: false # This makes it a lot faster
 
+  - repo: local
+    hooks:
+      - id: cargo-dev-generate-all
+        name: cargo dev generate-all
+        entry: cargo dev generate-all
+        language: system
+        types: [rust]
+        pass_filenames: false
+        files: ^crates/(uv-cli|uv-settings)/
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -438,9 +438,7 @@ uv init [OPTIONS] [PATH]
 
 </dd><dt><code>--no-readme</code></dt><dd><p>Do not create a <code>README.md</code> file</p>
 
-</dd><dt><code>--no-workspace</code></dt><dd><p>Avoid discovering a workspace.</p>
-
-<p>Instead, create a standalone project.</p>
+</dd><dt><code>--no-workspace</code></dt><dd><p>Avoid discovering a workspace and create a standalone project.</p>
 
 <p>By default, uv searches for workspaces in the current directory or any parent directory.</p>
 


### PR DESCRIPTION
## Summary

Noticed that running `cargo dev generate-all` on `main` produced changes and saw that that the command is not run on the CI nor as a pre-commit hook.

Not sure if having the command running as a pre-commit hook is something we want, so I can remove it if you prefer. I find that nice to have as it's probably easy to forget to run it, especially for new contributors (and it will only run if there are changes in `uv_cli` or `uv_settings` crates).

## Test Plan

- Added `cargo dev generate-all --mode check` on the CI, which produced [this failing job](https://github.com/astral-sh/uv/actions/runs/10648055597/job/29516699393)
- Ran `cargo dev generate-all` locally and committed the changes, which produced [this succeeding job](https://github.com/astral-sh/uv/actions/runs/10648076910/job/29516744942)