### PR TITLE
docs: add missing `console` highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 
 Use a specific Python version in the current directory:
 
-```
+```console
 $ uv python pin pypy@3.11
 Pinned `.python-version` to `pypy@3.11`
 ```
@@ -190,7 +190,7 @@ Updated `example.py`
 
 Then, run the script in an isolated virtual environment:
 
-```
+```console
 $ uv run example.py
 Reading inline script metadata from: example.py
 Installed 5 packages in 12ms

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -73,13 +73,13 @@ Once a tool is installed with `uv tool install`, `uvx` will use the installed ve
 
 For example, after installing an older version of Ruff:
 
-```
+```console
 $ uv tool install ruff==0.5.0
 ```
 
 The version of `ruff` and `uvx ruff` is the same:
 
-```
+```console
 $ ruff --version
 ruff 0.5.0
 $ uvx ruff --version

--- a/docs/guides/install-python.md
+++ b/docs/guides/install-python.md
@@ -62,7 +62,7 @@ $ uv python install 3.11 3.12
 
 To install an alternative Python implementation, e.g. PyPy:
 
-```
+```console
 $ uv python install pypy@3.12
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -155,7 +155,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 
 Use a specific Python version in the current directory:
 
-```
+```console
 $ uv python pin pypy@3.11
 Pinned `.python-version` to `pypy@3.11`
 ```
@@ -177,7 +177,7 @@ Updated `example.py`
 
 Then, run the script in an isolated virtual environment:
 
-```
+```console
 $ uv run example.py
 Reading inline script metadata from: example.py
 Installed 5 packages in 12ms


### PR DESCRIPTION
## Summary

Spotted a few missing `console` highlights in the documentation.