### PR TITLE
Fix typos in docs, error messages and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1628,7 +1628,7 @@ in `pip compile` ([#3804](https://github.com/astral-sh/uv/pull/3804))
 
 ### Bug fixes
 
-- Do not treat interpereters discovered via `CONDA_PREFIX` as system
+- Do not treat interpreters discovered via `CONDA_PREFIX` as system
 interpreters ([#3771](https://github.com/astral-sh/uv/pull/3771))
 
 ## 0.2.1
@@ -1969,7 +1969,7 @@ handling ([#3210](https://github.com/astral-sh/uv/pull/3210))
 
 ### Bug fixes
 
-- Avoid removing quites from requirements markers ([#3214](https://github.com/astral-sh/uv/pull/3214))
+- Avoid removing quotes from requirements markers ([#3214](https://github.com/astral-sh/uv/pull/3214))
 - Avoid adding extras when expanding constraints ([#3232](https://github.com/astral-sh/uv/pull/3232))
 - Reinstall package when editable label is removed ([#3219](https://github.com/astral-sh/uv/pull/3219))
 
@@ -1977,7 +1977,7 @@ handling ([#3210](https://github.com/astral-sh/uv/pull/3210))
 
 - Add `RAYON_NUM_THREADS` to environment variable docs ([#3223](https://github.com/astral-sh/uv/pull/3223))
 - Document support for HTTP proxy variables ([#3247](https://github.com/astral-sh/uv/pull/3247))
-- Fix documentation for `--python-platfor`m ([#3220](https://github.com/astral-sh/uv/pull/3220))
+- Fix documentation for `--python-platform` ([#3220](https://github.com/astral-sh/uv/pull/3220))
 
 ## 0.1.37
 
@@ -2204,7 +2204,7 @@ opt-in (`--index-strategy unsafe-any-match`) ([#2815](https://github.com/astral-
 - Detect Fish via `FISH_VERSION` ([#2781](https://github.com/astral-sh/uv/pull/2781))
 - Exclude installed distributions with multiple versions from consideration in the
 resolver ([#2779](https://github.com/astral-sh/uv/pull/2779))
-- Resolve non-determistic behavior in preferences due to site-packages
+- Resolve non-deterministic behavior in preferences due to site-packages
 ordering ([#2780](https://github.com/astral-sh/uv/pull/2780))
 - Use canonical URL to key redirect map ([#2764](https://github.com/astral-sh/uv/pull/2764))
 - Use distribution database and index for all pre-resolution phases ([#2766](https://github.com/astral-sh/uv/pull/2766))

--- a/crates/uv-auth/src/middleware.rs
+++ b/crates/uv-auth/src/middleware.rs
@@ -205,7 +205,7 @@ impl Middleware for AuthMiddleware {
         // Clone the request so we can retry it on authentication failure
         let mut retry_request = request.try_clone().ok_or_else(|| {
             Error::Middleware(anyhow!(
-                "Request object is not clonable. Are you passing a streaming body?".to_string()
+                "Request object is not cloneable. Are you passing a streaming body?".to_string()
             ))
         })?;
 

--- a/crates/uv-client/src/cached_client.rs
+++ b/crates/uv-client/src/cached_client.rs
@@ -34,7 +34,7 @@ pub trait Cacheable: Sized {
     /// This associated type permits customizing what the "output" type of
     /// deserialization is. It can be identical to `Self`.
     ///
-    /// Typical use of this is for wrapper types used to proviate blanket trait
+    /// Typical use of this is for wrapper types used to provide blanket trait
     /// impls without hitting overlapping impl problems.
     type Target;
 

--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -123,7 +123,7 @@ actually need to make an HTTP request).
 # Additional reading
 
 * Short introduction to `Cache-Control`: <https://csswizardry.com/2019/03/cache-control-for-civilians/>
-* Caching best practcies: <https://jakearchibald.com/2016/caching-best-practices/>
+* Caching best practices: <https://jakearchibald.com/2016/caching-best-practices/>
 * Overview of HTTP caching: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching>
 * MDN docs for `Cache-Control`: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control>
 * The 1997 RFC for HTTP 1.1: <https://www.rfc-editor.org/rfc/rfc2068#section-13>
@@ -734,7 +734,7 @@ impl ArchivedCachePolicy {
         let age = self.age(now).as_secs();
 
         // Per RFC 8246, the `immutable` directive means that a reload from an
-        // end user should not result in a revlalidation request. Indeed, the
+        // end user should not result in a revalidation request. Indeed, the
         // `immutable` directive seems to imply that clients should never talk
         // to the origin server until the cached response is stale with respect
         // to its freshness lifetime (as set by the server).

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -897,7 +897,7 @@ pub fn find_best_python_installation(
 ) -> Result<FindPythonResult, Error> {
     debug!("Starting Python discovery for {}", request);
 
-    // First, check for an exact match (or the first available version if no Python versfion was provided)
+    // First, check for an exact match (or the first available version if no Python version was provided)
     debug!("Looking for exact match for request {request}");
     let result = find_python_installation(request, environments, preference, cache)?;
     if let Ok(ref installation) = result {

--- a/crates/uv-python/src/py_launcher.rs
+++ b/crates/uv-python/src/py_launcher.rs
@@ -15,7 +15,7 @@ pub(crate) struct WindowsPython {
     pub(crate) version: Option<PythonVersion>,
 }
 
-/// Àdding `windows_registry::Value::into_string()`.
+/// Adding `windows_registry::Value::into_string()`.
 fn value_to_string(value: Value) -> Option<String> {
     match value {
         Value::String(string) => Some(string),

--- a/crates/uv-resolver/src/pubgrub/report.rs
+++ b/crates/uv-resolver/src/pubgrub/report.rs
@@ -86,7 +86,7 @@ impl ReportFormatter<PubGrubPackage, Range<Version>, UnavailableReason>
                     let range =
                         // Note that sometimes we do not have a range of available versions, e.g.,
                         // when a package is from a non-registry source. In that case, we cannot
-                        // perform further simplicifaction of the range.
+                        // perform further simplification of the range.
                         if let Some(available_versions) = package.name().and_then(|name| self.available_versions.get(name)) {
                             update_availability_range(&complement, available_versions)
                         } else {

--- a/crates/uv-virtualenv/src/activator/activate.nu
+++ b/crates/uv-virtualenv/src/activator/activate.nu
@@ -38,7 +38,7 @@ export-env {
         } | all {|i| $i == true}
     }
 
-    # Emulates a `test -z`, but btter as it handles e.g 'false'
+    # Emulates a `test -z`, but better as it handles e.g 'false'
     def is-env-true [name: string] {
       if (has-env $name) {
         # Try to parse 'true', '0', '1', and fail if not convertible

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -595,7 +595,7 @@ fn report_dry_run(
         )?;
     }
 
-    // TDOO(charlie): DRY this up with `report_modifications`. The types don't quite line up.
+    // TODO(charlie): DRY this up with `report_modifications`. The types don't quite line up.
     for event in reinstalls
         .into_iter()
         .chain(extraneous.into_iter())

--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -61,7 +61,7 @@ Markers allow attaching an expression to requirements that indicate when the dep
 used. For example `bar; python_version<"3.9"` can be used to only require `bar` on Python 3.8 and
 older.
 
-Markers are used to adjust a package's dependencies dependending on the current environment or
+Markers are used to adjust a package's dependencies depending on the current environment or
 platform. For example, markers can be used to change dependencies based on the operating system, the
 CPU architecture, the Python version, the Python implementation, and more.
 

--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -212,7 +212,7 @@ services:
     # ...
 
     develop:
-      # Create a `watch` configuration to update the appl
+      # Create a `watch` configuration to update the app
       #
       watch:
         # Sync the working directory with the `/app` directory in the container

--- a/docs/pip/compatibility.md
+++ b/docs/pip/compatibility.md
@@ -412,7 +412,7 @@ issues to convey your interest.
 ## Registry authentication
 
 uv does not support `pip`'s `auto` or `import` options for `--keyring-provider`. At present, only
-the `subproces` option is supported.
+the `subprocess` option is supported.
 
 Unlike `pip`, uv does not enable keyring authentication by default.
 

--- a/docs/pip/compile.md
+++ b/docs/pip/compile.md
@@ -135,7 +135,7 @@ While constraints are _additive_, in that they're combined with the requirements
 packages, overrides are _absolute_, in that they completely replace the requirements of the
 constituent packages.
 
-Overrides are most often used to remove upper bounds from a transtive dependency. For example, if
+Overrides are most often used to remove upper bounds from a transitive dependency. For example, if
 `a` requires `c>=1.0,<2.0` and `b` requires `c>=2.0` and the current project requires `a` and `b`
 then the dependencies cannot be resolved.
 


### PR DESCRIPTION
What started off as spotting/fixing a user facing docs typo turned into a bit of a yak shave with my local spell-checker, as part of [upstreaming](https://github.com/crate-ci/typos/issues/1090#issuecomment-2323281389) improvements to `crate-ci/typos` (which [by design](https://github.com/crate-ci/typos?tab=readme-ov-file#why-was--not-corrected) uses a known-typos strategy rather than a purely dictionary based approach).