### PR TITLE
Remove some canonicalize calls

### DIFF
--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -108,8 +108,7 @@ impl<T: AsRef<Path>> Simplified for T {
         // current working directory, in case they differ.
         let path = path.strip_prefix(base.as_ref()).unwrap_or_else(|_| {
             path.strip_prefix(CWD.simplified()).unwrap_or_else(|_| {
-                path.strip_prefix(CANONICAL_CWD.simplified())
-                    .unwrap_or(path)
+                path
             })
         });
 
@@ -122,8 +121,7 @@ impl<T: AsRef<Path>> Simplified for T {
         // Attempt to strip the current working directory, then the canonicalized current working
         // directory, in case they differ.
         let path = path.strip_prefix(CWD.simplified()).unwrap_or_else(|_| {
-            path.strip_prefix(CANONICAL_CWD.simplified())
-                .unwrap_or(path)
+            path
         });
 
         // Use a portable representation for relative paths.

--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::path::{absolute, Component, Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::LazyLock;
 
 use either::Either;
@@ -8,14 +8,6 @@ use path_slash::PathExt;
 /// The current working directory.
 pub static CWD: LazyLock<PathBuf> =
     LazyLock::new(|| std::env::current_dir().expect("The current directory must exist"));
-
-/// The current working directory, canonicalized.
-pub static CANONICAL_CWD: LazyLock<PathBuf> = LazyLock::new(|| {
-    std::env::current_dir()
-        .expect("The current directory must exist")
-        .simple_canonicalize()
-        .expect("The current directory must be canonicalized")
-});
 
 pub trait Simplified {
     /// Simplify a [`Path`].
@@ -61,21 +53,7 @@ impl<T: AsRef<Path>> Simplified for T {
     }
 
     fn simple_canonicalize(&self) -> std::io::Result<PathBuf> {
-        match dunce::canonicalize(self.as_ref()) {
-            Ok(path) => Ok(path),
-            // On Windows, `dunce::canonicalize` can't canonicalize paths on network drives or RAM
-            // drives. In that case, fall back on `std::path::absolute`, but also verify that the
-            // path exists.
-            Err(e) if std::env::consts::OS != "windows" => Err(e),
-            _ => match absolute(self.as_ref()) {
-                Ok(path) if path.exists() => Ok(path),
-                Ok(_) => Err(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!("Path does not exist: {}", self.simplified_display()),
-                )),
-                Err(e) => Err(e),
-            },
-        }
+        dunce::canonicalize(self.as_ref())
     }
 
     fn user_display(&self) -> impl std::fmt::Display {
@@ -88,10 +66,7 @@ impl<T: AsRef<Path>> Simplified for T {
 
         // Attempt to strip the current working directory, then the canonicalized current working
         // directory, in case they differ.
-        let path = path.strip_prefix(CWD.simplified()).unwrap_or_else(|_| {
-            path.strip_prefix(CANONICAL_CWD.simplified())
-                .unwrap_or(path)
-        });
+        let path = path.strip_prefix(CWD.simplified()).unwrap_or(path);
 
         path.display()
     }
@@ -106,11 +81,9 @@ impl<T: AsRef<Path>> Simplified for T {
 
         // Attempt to strip the base, then the current working directory, then the canonicalized
         // current working directory, in case they differ.
-        let path = path.strip_prefix(base.as_ref()).unwrap_or_else(|_| {
-            path.strip_prefix(CWD.simplified()).unwrap_or_else(|_| {
-                path
-            })
-        });
+        let path = path
+            .strip_prefix(base.as_ref())
+            .unwrap_or_else(|_| path.strip_prefix(CWD.simplified()).unwrap_or(path));
 
         path.display()
     }
@@ -120,9 +93,7 @@ impl<T: AsRef<Path>> Simplified for T {
 
         // Attempt to strip the current working directory, then the canonicalized current working
         // directory, in case they differ.
-        let path = path.strip_prefix(CWD.simplified()).unwrap_or_else(|_| {
-            path
-        });
+        let path = path.strip_prefix(CWD.simplified()).unwrap_or(path);
 
         // Use a portable representation for relative paths.
         path.to_slash()

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -119,7 +119,7 @@ pub(crate) fn create(
         Err(err) => return Err(Error::Io(err)),
     }
 
-    let location = location.canonicalize()?;
+    let location = std::path::absolute(location)?;
 
     let bin_name = if cfg!(unix) {
         "bin"

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -47,10 +47,7 @@ pub(crate) async fn init(
 
     // Make sure a project does not already exist in the given directory.
     if path.join("pyproject.toml").exists() {
-        let path = path
-            .simple_canonicalize()
-            .unwrap_or_else(|_| path.simplified().to_path_buf());
-
+        let path = std::path::absolute(&path).unwrap_or_else(|_| path.simplified().to_path_buf());
         anyhow::bail!(
             "Project is already initialized in `{}`",
             path.display().cyan()
@@ -102,10 +99,8 @@ pub(crate) async fn init(
         }
         // Initialized a project in the given directory.
         Some(path) => {
-            let path = path
-                .simple_canonicalize()
-                .unwrap_or_else(|_| path.simplified().to_path_buf());
-
+            let path =
+                std::path::absolute(&path).unwrap_or_else(|_| path.simplified().to_path_buf());
             writeln!(
                 printer.stderr(),
                 "Initialized project `{}` at `{}`",


### PR DESCRIPTION
## Summary

A few of these should use `absolute` instead of `canonicalize`; and apparently we no longer need to strip the `CANONICAL_CWD` to get tests passing.
