### PR TITLE
Avoid panic with missing temporary directory

### DIFF
--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::io;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -145,14 +146,16 @@ impl<'a> RegistryClientBuilder<'a> {
     }
 }
 
-impl<'a> From<BaseClientBuilder<'a>> for RegistryClientBuilder<'a> {
-    fn from(value: BaseClientBuilder<'a>) -> Self {
-        Self {
+impl<'a> TryFrom<BaseClientBuilder<'a>> for RegistryClientBuilder<'a> {
+    type Error = io::Error;
+
+    fn try_from(value: BaseClientBuilder<'a>) -> Result<Self, Self::Error> {
+        Ok(Self {
             index_urls: IndexUrls::default(),
             index_strategy: IndexStrategy::default(),
-            cache: Cache::temp().unwrap(),
+            cache: Cache::temp()?,
             base_client_builder: value,
-        }
+        })
     }
 }
 

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -277,7 +277,7 @@ pub(crate) async fn pip_compile(
     }
 
     // Initialize the registry client.
-    let client = RegistryClientBuilder::from(client_builder)
+    let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
         .index_urls(index_locations.index_urls())
         .index_strategy(index_strategy)

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -270,7 +270,7 @@ pub(crate) async fn pip_install(
     }
 
     // Initialize the registry client.
-    let client = RegistryClientBuilder::from(client_builder)
+    let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
         .index_urls(index_locations.index_urls())
         .index_strategy(index_strategy)

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -220,7 +220,7 @@ pub(crate) async fn pip_sync(
     }
 
     // Initialize the registry client.
-    let client = RegistryClientBuilder::from(client_builder)
+    let client = RegistryClientBuilder::try_from(client_builder)?
         .cache(cache.clone())
         .index_urls(index_locations.index_urls())
         .index_strategy(index_strategy)

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -257,7 +257,7 @@ pub(crate) async fn add(
     }
 
     // Initialize the registry client.
-    let client = RegistryClientBuilder::from(client_builder)
+    let client = RegistryClientBuilder::try_from(client_builder)?
         .index_urls(settings.index_locations.index_urls())
         .index_strategy(settings.index_strategy)
         .markers(&markers)

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -249,7 +249,8 @@ async fn venv_impl(
         }
 
         // Instantiate a client.
-        let client = RegistryClientBuilder::from(client_builder)
+        let client = RegistryClientBuilder::try_from(client_builder)
+            .into_diagnostic()?
             .cache(cache.clone())
             .index_urls(index_locations.index_urls())
             .index_strategy(index_strategy)


### PR DESCRIPTION
Forward an error for missing temp directories:

```
$ env TMPDIR=.tmp uv-debug pip install httpx
  error: No such file or directory (os error 2) at path "/home/konsti/projects/uv/.tmp/.tmpgIBhhh"
```

Fixes #6878