### PR TITLE
docs(configuration): clarify `uv.toml` precedence

### DIFF
--- a/docs/configuration/files.md
+++ b/docs/configuration/files.md
@@ -35,9 +35,9 @@ index-url = "https://test.pypi.org/simple"
 
 !!! note
 
-    `uv.toml` files take precedence over `pyproject.toml` ones, so if both `uv.toml` and
-    `pyproject.toml` files are used in a directory, configuration will be read from `uv.toml`, and
-    `[tool.uv]` section in `pyproject.toml` will be ignored.
+    `uv.toml` files take precedence over `pyproject.toml` files, so if both `uv.toml` and
+    `pyproject.toml` files are present in a directory, configuration will be read from `uv.toml`, and
+    `[tool.uv]` section in the accompanying `pyproject.toml` will be ignored.
 
 uv will also discover user-level configuration at `~/.config/uv/uv.toml` (or
 `$XDG_CONFIG_HOME/uv/uv.toml`) on macOS and Linux, or `%APPDATA%\uv\uv.toml` on Windows. User-level

--- a/docs/configuration/files.md
+++ b/docs/configuration/files.md
@@ -33,6 +33,12 @@ uv will also search for `uv.toml` files, which follow an identical structure, bu
 index-url = "https://test.pypi.org/simple"
 ```
 
+!!! note
+
+    `uv.toml` files take precedence over `pyproject.toml` ones, so if both `uv.toml` and
+    `pyproject.toml` files are used in a directory, configuration will be read from `uv.toml`, and
+    `[tool.uv]` section in `pyproject.toml` will be ignored.
+
 uv will also discover user-level configuration at `~/.config/uv/uv.toml` (or
 `$XDG_CONFIG_HOME/uv/uv.toml`) on macOS and Linux, or `%APPDATA%\uv\uv.toml` on Windows. User-level
 configuration must use the `uv.toml` format, rather than the `pyproject.toml` format, as a


### PR DESCRIPTION
## Summary

Add a note in the documentation to clarify that `uv.toml` files take precedence over `[tool.uv]` section in `pyproject.toml`, based on the warning shown in the CLI:

```console
$ uv version
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The `[tool.uv]` section will be ignored in favor of the `uv.toml` file.
uv 0.4.2 (Homebrew 2024-09-01)
```