### PR TITLE
Add `--package` support to `uv build`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1955,6 +1955,15 @@ pub struct BuildArgs {
     #[arg(value_parser = parse_file_path)]
     pub src: Option<PathBuf>,
 
+    /// Build a specific package in the workspace.
+    ///
+    /// The workspace will be discovered from the provided source directory, or the current
+    /// directory if no source directory is provided.
+    ///
+    /// If the workspace member does not exist, uv will exit with an error.
+    #[arg(long)]
+    pub package: Option<PackageName>,
+
     /// The output directory to which distributions should be written.
     ///
     /// Defaults to the `dist` subdirectory within the source directory, or the

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -672,6 +672,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
 
             commands::build(
                 args.src,
+                args.package,
                 args.out_dir,
                 args.sdist,
                 args.wheel,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1616,6 +1616,7 @@ impl PipCheckSettings {
 #[derive(Debug, Clone)]
 pub(crate) struct BuildSettings {
     pub(crate) src: Option<PathBuf>,
+    pub(crate) package: Option<PackageName>,
     pub(crate) out_dir: Option<PathBuf>,
     pub(crate) sdist: bool,
     pub(crate) wheel: bool,
@@ -1630,6 +1631,7 @@ impl BuildSettings {
         let BuildArgs {
             src,
             out_dir,
+            package,
             sdist,
             wheel,
             python,
@@ -1640,6 +1642,7 @@ impl BuildSettings {
 
         Self {
             src,
+            package,
             out_dir,
             sdist,
             wheel,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6374,6 +6374,12 @@ uv build [OPTIONS] [SRC]
 
 <p>Defaults to the <code>dist</code> subdirectory within the source directory, or the directory containing the source distribution archive.</p>
 
+</dd><dt><code>--package</code> <i>package</i></dt><dd><p>Build a specific package in the workspace.</p>
+
+<p>The workspace will be discovered from the provided source directory, or the current directory if no source directory is provided.</p>
+
+<p>If the workspace member does not exist, uv will exit with an error.</p>
+
 </dd><dt><code>--prerelease</code> <i>prerelease</i></dt><dd><p>The strategy to use when considering pre-release versions.</p>
 
 <p>By default, uv will accept pre-releases for packages that <em>only</em> publish pre-releases, along with first-party requirements that contain an explicit pre-release marker in the declared specifiers (<code>if-necessary-or-explicit</code>).</p>


### PR DESCRIPTION
## Summary

This PR adds `--package` support to `uv build`, such that you can use `--package` from anywhere in a workspace to build any member.

If a source directory is provided, we use that as the workspace root.

If a file is provided, we error.

For now, `uv build` only builds the current package, making it semantically identical to `uv sync`.