### PR TITLE
uv/tests: filter out link mode warning in one test

### DIFF
--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -179,6 +179,21 @@ impl TestContext {
         }
         self
     }
+
+    /// Adds a filter that specifically ignores the link mode warning.
+    ///
+    /// This occurs in some cases and can be used on an ad hoc basis to squash
+    /// the warning in the snapshots. This is useful because the warning does
+    /// not consistently appear. It is dependent on the environment. (For
+    /// example, sometimes it's dependent on whether `/tmp` and `~/.local` live
+    /// on the same file system.)
+    #[inline]
+    pub fn with_filtered_link_mode_warning(mut self) -> Self {
+        let pattern = "warning: Failed to hardlink files; .*\n.*\n.*\n";
+        self.filters.push((pattern.to_string(), String::new()));
+        self
+    }
+
     /// Discover the path to the XDG state directory. We use this, rather than the OS-specific
     /// temporary directory, because on macOS (and Windows on GitHub Actions), they involve
     /// symlinks. (On macOS, the temporary directory is, like `/var/...`, which resolves to

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -5834,7 +5834,18 @@ fn lock_dev_transitive() -> Result<()> {
 /// Avoid persisting registry credentials in `uv.lock`.
 #[test]
 fn lock_redact_https() -> Result<()> {
-    let context = TestContext::new("3.12");
+    // This test in particular seems to prompt a link mode warning
+    // that occurs when hardlinking fails. In particular, in this test,
+    // uv tries to hardlink between `/tmp` and `~/.local`, which on my
+    // system fails because `/tmp` is a different file system (a ramdisk).
+    // So we filter this warning out so that our snapshot tests pass on
+    // systems where this warning pops up.
+    //
+    // This is caused by using `--no-cache` in some of the commands below,
+    // which in turns means we don't use the test context cache location.
+    // We should probably add a way to configure the `--no-cache` temporary
+    // directory location during testing.
+    let context = TestContext::new("3.12").with_filtered_link_mode_warning();
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(


### PR DESCRIPTION
In the `lock_redact_https` test specifically, it prompts a link mode
warning from `uv` on my system. Debugging seems to suggest it is
provoked by attempting to hardlink between `/tmp` and `~/.local`. Since
these are on different file systems for me (with `/tmp` being a
ramdisk), it provokes the warning, and this turn spoils the snapshot
when running tests locally.

This PR adds a test specific filter rule to fix this.
