### PR TITLE
Revert `pyproject.toml` modifications on Ctrl-C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4463,6 +4463,7 @@ dependencies = [
  "byteorder",
  "cache-key",
  "clap",
+ "ctrlc",
  "distribution-types",
  "etcetera",
  "filetime",

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -48,6 +48,7 @@ anstream = { workspace = true }
 anyhow = { workspace = true }
 axoupdater = { workspace = true, features = ["github_releases", "tokio"], optional = true }
 clap = { workspace = true, features = ["derive", "string", "wrap_help"] }
+ctrlc = { workspace = true }
 flate2 = { workspace = true, default-features = false }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }


### PR DESCRIPTION
## Summary

Not perfect, but an improvement at least for an interactive experience.

Closes #6818.
