### PR TITLE
Update docs on `.python-version` file

### DIFF
--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -106,6 +106,7 @@ Applications are the default target for `uv init`, but can also be specified wit
 $ uv init --app example-app
 $ tree example-app
 example-app
+├── .python-version
 ├── README.md
 ├── hello.py
 └── pyproject.toml
@@ -155,6 +156,7 @@ Libraries can be created by using the `--lib` flag:
 $ uv init --lib example-lib
 $ tree example-lib
 example-lib
+├── .python-version
 ├── README.md
 ├── pyproject.toml
 └── src
@@ -217,6 +219,7 @@ The project structure looks the same as a library:
 $ uv init --app --package example-packaged-app
 $ tree example-packaged-app
 example-packaged-app
+├── .python-version
 ├── README.md
 ├── pyproject.toml
 └── src

--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -96,8 +96,8 @@ are used for requesting local interpreters such as a file path.
 By default `uv python install` will verify that a managed Python version is installed or install the
 latest version.
 
-However, when a project contains a `.python-version` file, which specifies the default Python
-version to be used, uv will install the Python version listed in the file.
+However, a project may include a `.python-version` file specifying a default Python version. If
+present, uv will install the Python version listed in the file.
 
 Alternatively, a project that requires multiple Python versions may also define a `.python-versions`
 file. If present, uv will install all of the Python versions listed in the file. This file takes

--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -96,8 +96,8 @@ are used for requesting local interpreters such as a file path.
 By default `uv python install` will verify that a managed Python version is installed or install the
 latest version.
 
-However, a project may define a `.python-version` file specifying the default Python version to be
-used. If present, uv will install the Python version listed in the file.
+However, when a project contains a `.python-version` file, which specifies the default Python
+version to be used, uv will install the Python version listed in the file.
 
 Alternatively, a project that requires multiple Python versions may also define a `.python-versions`
 file. If present, uv will install all of the Python versions listed in the file. This file takes

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -23,6 +23,7 @@ uv will create the following files:
 
 ```text
 .
+├── .python-version
 ├── README.md
 ├── hello.py
 └── pyproject.toml
@@ -50,6 +51,7 @@ A complete listing would look like:
 │   ├── bin
 │   ├── lib
 │   └── pyvenv.cfg
+├── .python-version
 ├── README.md
 ├── hello.py
 ├── pyproject.toml
@@ -80,6 +82,11 @@ description or license. You can edit this file manually, or use commands like `u
 
 You'll also use this file to specify uv [configuration options](../configuration/files.md) in a
 [`[tool.uv]`](../reference/settings.md) section.
+
+### `.python-version`
+
+The `.python-version` file contains the default Python version that the project should use.
+This file tells uv which Python version to use when creating the project's virtual environment.
 
 ### `.venv`
 

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -85,8 +85,8 @@ You'll also use this file to specify uv [configuration options](../configuration
 
 ### `.python-version`
 
-The `.python-version` file contains the default Python version that the project should use.
-This file tells uv which Python version to use when creating the project's virtual environment.
+The `.python-version` file contains the project's default Python version. This file tells uv which
+Python version to use when creating the project's virtual environment.
 
 ### `.venv`
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/7027

* When displaying the file structure of a uv-managed project show the `.python-version` file which is now created by default.
* Mention the purpose of the `.python-version` file in `Guides/Working on projects/Project structure`
* In `Concepts/Python versions/Project python versions`, changed sentence about `.python-version` file to reflect the fact it is included by default so is likely to be present.
