### PR TITLE
ci(docker)!: adjust entrypoint and cmd for inherited images

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -198,7 +198,8 @@ jobs:
           FROM ${BASE_IMAGE}
           COPY --from=${{ env.UV_BASE_IMG }}:latest /uv /usr/local/bin/uv
           COPY --from=${{ env.UV_BASE_IMG }}:latest /uvx /usr/local/bin/uvx
-          ENTRYPOINT ["/usr/local/bin/uv"]
+          ENTRYPOINT []
+          CMD ["/usr/local/bin/uv"]
           EOF
 
           # Initialize a variable to store all tag docker metadata patterns


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/7030

This removes our custom `ENTRYPOINT` just for the additional docker tags, and makes it empty (to avoid possible upstream surprises if any) and moves running uv to `CMD` for consistency.

This approach is probably the in-between solution from the discussion in https://github.com/astral-sh/uv/issues/7030#issuecomment-2329443719 and would work for everyone's use cases.

## Test Plan

Tested release workflow in https://github.com/samypr100/uv/actions/runs/10711049920

The default CMD still gives a nice default.

```shell
> docker run ghcr.io/samypr100/uv:0.4.5-alpine
An extremely fast Python package manager.

Usage: uv [OPTIONS] <COMMAND>

Commands:
  run      Run a command or script
  init     Create a new project
  add      Add dependencies to the project
  remove   Remove dependencies from the project
  sync     Update the project's environment
  lock     Update the project's lockfile
  export   Export the project's lockfile to an alternate format
  tree     Display the project's dependency tree
  tool     Run and install commands provided by Python packages
  python   Manage Python versions and installations
  pip      Manage Python packages with a pip-compatible interface
  venv     Create a virtual environment
  build    Build Python packages into source distributions and wheels
  cache    Manage uv's cache
  version  Display uv's version
  help     Display documentation for a command
```
