### PR TITLE
Strip fragments from direct source URLs in lockfile

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2280,14 +2280,14 @@ impl Source {
 
     fn from_direct_built_dist(direct_dist: &DirectUrlBuiltDist) -> Source {
         Source::Direct(
-            UrlString::from(&direct_dist.url),
+            normalize_url(direct_dist.url.to_url()),
             DirectSource { subdirectory: None },
         )
     }
 
     fn from_direct_source_dist(direct_dist: &DirectUrlSourceDist) -> Source {
         Source::Direct(
-            UrlString::from(&direct_dist.url),
+            normalize_url(direct_dist.url.to_url()),
             DirectSource {
                 subdirectory: direct_dist
                     .subdirectory


### PR DESCRIPTION
## Summary

In resolving https://github.com/astral-sh/uv/issues/7059, I noticed that we left the fragment on the `source = { url = "..." }`.
