### PR TITLE
Use astral-sh/setup-uv action

### DIFF
--- a/.github/workflows/sync-python-releases.yml
+++ b/.github/workflows/sync-python-releases.yml
@@ -17,7 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: hynek/setup-cached-uv@v2
+      - uses: astral-sh/setup-uv@main
+        with:
+          version: "latest"
+          enable-cache: true
       - name: Sync Python Releases
         run: |
           uv run -- fetch-download-metadata.py


### PR DESCRIPTION
## Summary

Use the now official `astral-sh/setup-uv` action in `sync-python-release.yml` workflow.