### PR TITLE
[WIP] Add a `--suffix` option to `uv tool install`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3156,6 +3156,10 @@ pub struct ToolInstallArgs {
         help_heading = "Python options"
     )]
     pub python: Option<String>,
+
+    /// The suffix to install the package and executables with
+    #[arg(long, help_heading = "Installer options")]
+    pub suffix: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -56,11 +56,21 @@ pub enum Error {
     Serialization(#[from] toml_edit::ser::Error),
 }
 
-/// A Package identitifier
+/// A Tool name
+///
+/// TODO: This representation works for installing, but could be problematic for upgrading and uninstalling
+/// Consider changing it to either a single String (with the resolved name), or an enum with variants for different identifiers
 #[derive(Debug, Clone)]
 pub struct ToolName {
     pub name: PackageName,
     pub suffix: Option<String>,
+}
+
+impl fmt::Display for ToolName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // TODO Decide how Tools are displayed
+        write!(f, "{}", self.name)
+    }
 }
 
 /// A collection of uv-managed tools installed on the current system.
@@ -165,8 +175,7 @@ impl InstalledTools {
         let path = self.tool_dir(name).join("uv-receipt.toml");
 
         debug!(
-            "Adding metadata entry for tool `{}` at {}",
-            name.name,
+            "Adding metadata entry for tool `{name}` at {}",
             path.user_display()
         );
 
@@ -191,8 +200,7 @@ impl InstalledTools {
         let environment_path = self.tool_dir(name);
 
         debug!(
-            "Deleting environment for tool `{}` at {}",
-            name.name,
+            "Deleting environment for tool `{name}` at {}",
             environment_path.user_display()
         );
 
@@ -217,8 +225,7 @@ impl InstalledTools {
         match PythonEnvironment::from_root(&environment_path, cache) {
             Ok(venv) => {
                 debug!(
-                    "Using existing environment for tool `{}`: {}",
-                    name.name,
+                    "Using existing environment for tool `{name}`: {}",
                     environment_path.user_display()
                 );
                 Ok(Some(venv))
@@ -251,8 +258,7 @@ impl InstalledTools {
         match fs_err::remove_dir_all(&environment_path) {
             Ok(()) => {
                 debug!(
-                    "Removed existing environment for tool `{}`: {}",
-                    name.name,
+                    "Removed existing environment for tool `{name}`: {}",
                     environment_path.user_display()
                 );
             }
@@ -261,8 +267,7 @@ impl InstalledTools {
         }
 
         debug!(
-            "Creating environment for tool `{}`: {}",
-            name.name,
+            "Creating environment for tool `{name}`: {}",
             environment_path.user_display()
         );
 

--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -58,7 +58,7 @@ pub enum Error {
 
 /// A Package identitifier
 #[derive(Debug, Clone)]
-pub struct PackageId {
+pub struct ToolName {
     pub name: PackageName,
     pub suffix: Option<String>,
 }
@@ -94,7 +94,7 @@ impl InstalledTools {
     }
 
     /// Return the expected directory for a tool with the given [`PackageName`].
-    pub fn tool_dir(&self, name: &PackageId) -> PathBuf {
+    pub fn tool_dir(&self, name: &ToolName) -> PathBuf {
         if let Some(suffix) = &name.suffix {
             self.root.join(name.name.to_string() + suffix)
         } else {
@@ -141,7 +141,7 @@ impl InstalledTools {
     /// error.
     ///
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
-    pub fn get_tool_receipt(&self, name: &PackageId) -> Result<Option<Tool>, Error> {
+    pub fn get_tool_receipt(&self, name: &ToolName) -> Result<Option<Tool>, Error> {
         let path = self.tool_dir(name).join("uv-receipt.toml");
         match ToolReceipt::from_path(&path) {
             Ok(tool_receipt) => Ok(Some(tool_receipt.tool)),
@@ -160,7 +160,7 @@ impl InstalledTools {
     /// Any existing receipt will be replaced.
     ///
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
-    pub fn add_tool_receipt(&self, name: &PackageId, tool: Tool) -> Result<(), Error> {
+    pub fn add_tool_receipt(&self, name: &ToolName, tool: Tool) -> Result<(), Error> {
         let tool_receipt = ToolReceipt::from(tool);
         let path = self.tool_dir(name).join("uv-receipt.toml");
 
@@ -187,7 +187,7 @@ impl InstalledTools {
     /// # Errors
     ///
     /// If no such environment exists for the tool.
-    pub fn remove_environment(&self, name: &PackageId) -> Result<(), Error> {
+    pub fn remove_environment(&self, name: &ToolName) -> Result<(), Error> {
         let environment_path = self.tool_dir(name);
 
         debug!(
@@ -209,7 +209,7 @@ impl InstalledTools {
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
     pub fn get_environment(
         &self,
-        name: &PackageId,
+        name: &ToolName,
         cache: &Cache,
     ) -> Result<Option<PythonEnvironment>, Error> {
         let environment_path = self.tool_dir(name);
@@ -242,7 +242,7 @@ impl InstalledTools {
     /// Note it is generally incorrect to use this without [`Self::acquire_lock`].
     pub fn create_environment(
         &self,
-        name: &PackageId,
+        name: &ToolName,
         interpreter: Interpreter,
     ) -> Result<PythonEnvironment, Error> {
         let environment_path = self.tool_dir(name);
@@ -287,7 +287,7 @@ impl InstalledTools {
     }
 
     /// Return the [`Version`] of an installed tool.
-    pub fn version(&self, name: &PackageId, cache: &Cache) -> Result<Version, Error> {
+    pub fn version(&self, name: &ToolName, cache: &Cache) -> Result<Version, Error> {
         let environment_path = self.tool_dir(name);
         let environment = PythonEnvironment::from_root(&environment_path, cache)?;
         let site_packages = SitePackages::from_environment(&environment)

--- a/crates/uv/src/commands/tool/common.rs
+++ b/crates/uv/src/commands/tool/common.rs
@@ -17,7 +17,7 @@ use uv_python::PythonEnvironment;
 use uv_settings::ToolOptions;
 use uv_shell::Shell;
 use uv_tool::{
-    entrypoint_paths, find_executable_directory, InstalledTools, PackageId, Tool, ToolEntrypoint,
+    entrypoint_paths, find_executable_directory, InstalledTools, Tool, ToolEntrypoint, ToolName,
 };
 use uv_warnings::warn_user;
 
@@ -81,7 +81,7 @@ pub(crate) fn install_executables(
         bail!("Expected at least one requirement")
     };
 
-    let pkg = PackageId {
+    let pkg = ToolName {
         name: name.clone(),
         suffix: suffix.clone(),
     };

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -17,7 +17,7 @@ use uv_python::{
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 use uv_settings::{ResolverInstallerOptions, ToolOptions};
-use uv_tool::{InstalledTools, PackageId};
+use uv_tool::{InstalledTools, ToolName};
 use uv_warnings::warn_user;
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
@@ -242,7 +242,7 @@ pub(crate) async fn install(
     let installed_tools = InstalledTools::from_settings()?.init()?;
     let _lock = installed_tools.lock().await?;
 
-    let pkg = PackageId {
+    let pkg = ToolName {
         name: from.name.clone(),
         suffix: suffix.clone(),
     };

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -6,7 +6,7 @@ use owo_colors::OwoColorize;
 
 use uv_cache::Cache;
 use uv_fs::Simplified;
-use uv_tool::{InstalledTools, PackageId};
+use uv_tool::{InstalledTools, ToolName};
 use uv_warnings::warn_user;
 
 use crate::commands::ExitStatus;
@@ -46,7 +46,7 @@ pub(crate) async fn list(
             );
             continue;
         };
-        let pkg = PackageId {
+        let pkg = ToolName {
             name: name.clone(),
             suffix: None, // TODO Add suffix option
         };

--- a/crates/uv/src/commands/tool/list.rs
+++ b/crates/uv/src/commands/tool/list.rs
@@ -6,7 +6,7 @@ use owo_colors::OwoColorize;
 
 use uv_cache::Cache;
 use uv_fs::Simplified;
-use uv_tool::InstalledTools;
+use uv_tool::{InstalledTools, PackageId};
 use uv_warnings::warn_user;
 
 use crate::commands::ExitStatus;
@@ -46,9 +46,13 @@ pub(crate) async fn list(
             );
             continue;
         };
+        let pkg = PackageId {
+            name: name.clone(),
+            suffix: None, // TODO Add suffix option
+        };
 
         // Output tool name and version
-        let version = match installed_tools.version(&name, cache) {
+        let version = match installed_tools.version(&pkg, cache) {
             Ok(version) => version,
             Err(e) => {
                 writeln!(printer.stderr(), "{e}")?;
@@ -74,7 +78,7 @@ pub(crate) async fn list(
                 printer.stdout(),
                 "{} ({})",
                 format!("{name} v{version}{version_specifier}").bold(),
-                installed_tools.tool_dir(&name).simplified_display().cyan(),
+                installed_tools.tool_dir(&pkg).simplified_display().cyan(),
             )?;
         } else {
             writeln!(

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -25,6 +25,7 @@ use uv_python::{
     PythonPreference, PythonRequest,
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
+use uv_tool::PackageId;
 use uv_tool::{entrypoint_paths, InstalledTools};
 use uv_warnings::warn_user;
 
@@ -436,9 +437,14 @@ async fn get_or_create_environment(
         let installed_tools = InstalledTools::from_settings()?.init()?;
         let _lock = installed_tools.lock().await?;
 
+        let pkg = PackageId {
+            name: from.name.clone(),
+            suffix: None, // TODO add suffix support
+        };
+
         let existing_environment =
             installed_tools
-                .get_environment(&from.name, cache)?
+                .get_environment(&pkg, cache)?
                 .filter(|environment| {
                     python_request.as_ref().map_or(true, |python_request| {
                         python_request.satisfied(environment.interpreter(), cache)

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -25,7 +25,7 @@ use uv_python::{
     PythonPreference, PythonRequest,
 };
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
-use uv_tool::PackageId;
+use uv_tool::ToolName;
 use uv_tool::{entrypoint_paths, InstalledTools};
 use uv_warnings::warn_user;
 
@@ -437,7 +437,7 @@ async fn get_or_create_environment(
         let installed_tools = InstalledTools::from_settings()?.init()?;
         let _lock = installed_tools.lock().await?;
 
-        let pkg = PackageId {
+        let pkg = ToolName {
             name: from.name.clone(),
             suffix: None, // TODO add suffix support
         };

--- a/crates/uv/src/commands/tool/uninstall.rs
+++ b/crates/uv/src/commands/tool/uninstall.rs
@@ -7,7 +7,7 @@ use tracing::debug;
 
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
-use uv_tool::{InstalledTools, PackageId, Tool, ToolEntrypoint};
+use uv_tool::{InstalledTools, Tool, ToolEntrypoint, ToolName};
 
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
@@ -100,7 +100,7 @@ async fn do_uninstall(
         for (name, receipt) in installed_tools.tools()? {
             let Ok(receipt) = receipt else {
                 // If the tool is not installed properly, attempt to remove the environment anyway.
-                let pkg = PackageId {
+                let pkg = ToolName {
                     name: name.clone(),
                     suffix: None, // TODO add support for suffix
                 };
@@ -129,7 +129,7 @@ async fn do_uninstall(
     } else {
         let mut entrypoints = vec![];
         for name in names {
-            let pkg = PackageId {
+            let pkg = ToolName {
                 name: name.clone(),
                 suffix: None, // TODO add support for suffix
             };
@@ -188,7 +188,7 @@ async fn uninstall_tool(
     tools: &InstalledTools,
 ) -> Result<Vec<ToolEntrypoint>> {
     // Remove the tool itself.
-    let pkg = PackageId {
+    let pkg = ToolName {
         name: name.clone(),
         suffix: None, // TODO add support for suffix
     };

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -10,7 +10,7 @@ use uv_configuration::Concurrency;
 use uv_normalize::PackageName;
 use uv_requirements::RequirementsSpecification;
 use uv_settings::{Combine, ResolverInstallerOptions, ToolOptions};
-use uv_tool::{InstalledTools, PackageId};
+use uv_tool::{InstalledTools, ToolName};
 
 use crate::commands::pip::loggers::{SummaryResolveLogger, UpgradeInstallLogger};
 use crate::commands::project::{update_environment, EnvironmentUpdate};
@@ -59,7 +59,7 @@ pub(crate) async fn upgrade(
         debug!("Upgrading tool: `{name}`");
 
         // Ensure the tool is installed.
-        let pkg = PackageId {
+        let pkg = ToolName {
             name: name.clone(),
             suffix: None, // TODO add support for suffix
         };
@@ -87,7 +87,7 @@ pub(crate) async fn upgrade(
             }
         };
 
-        let pkg = PackageId {
+        let pkg = ToolName {
             name: name.clone(),
             suffix: None, // TODO add support for suffix
         };

--- a/crates/uv/src/commands/tool/upgrade.rs
+++ b/crates/uv/src/commands/tool/upgrade.rs
@@ -10,7 +10,7 @@ use uv_configuration::Concurrency;
 use uv_normalize::PackageName;
 use uv_requirements::RequirementsSpecification;
 use uv_settings::{Combine, ResolverInstallerOptions, ToolOptions};
-use uv_tool::InstalledTools;
+use uv_tool::{InstalledTools, PackageId};
 
 use crate::commands::pip::loggers::{SummaryResolveLogger, UpgradeInstallLogger};
 use crate::commands::project::{update_environment, EnvironmentUpdate};
@@ -59,7 +59,11 @@ pub(crate) async fn upgrade(
         debug!("Upgrading tool: `{name}`");
 
         // Ensure the tool is installed.
-        let existing_tool_receipt = match installed_tools.get_tool_receipt(&name) {
+        let pkg = PackageId {
+            name: name.clone(),
+            suffix: None, // TODO add support for suffix
+        };
+        let existing_tool_receipt = match installed_tools.get_tool_receipt(&pkg) {
             Ok(Some(receipt)) => receipt,
             Ok(None) => {
                 let install_command = format!("uv tool install {name}");
@@ -83,7 +87,11 @@ pub(crate) async fn upgrade(
             }
         };
 
-        let existing_environment = match installed_tools.get_environment(&name, cache) {
+        let pkg = PackageId {
+            name: name.clone(),
+            suffix: None, // TODO add support for suffix
+        };
+        let existing_environment = match installed_tools.get_environment(&pkg, cache) {
             Ok(Some(environment)) => environment,
             Ok(None) => {
                 let install_command = format!("uv tool install {name}");
@@ -149,6 +157,7 @@ pub(crate) async fn upgrade(
             // existing executables.
             remove_entrypoints(&existing_tool_receipt);
 
+            let suffix = None; // TODO add support for suffix
             install_executables(
                 &environment,
                 &name,
@@ -158,6 +167,7 @@ pub(crate) async fn upgrade(
                 existing_tool_receipt.python().to_owned(),
                 requirements.to_vec(),
                 printer,
+                &suffix, /* TODO suffix upgrade */
             )?;
         }
     }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -852,6 +852,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.force,
                 args.options,
                 args.settings,
+                args.suffix,
                 globals.python_preference,
                 globals.python_downloads,
                 globals.connectivity,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -364,6 +364,7 @@ pub(crate) struct ToolInstallSettings {
     pub(crate) settings: ResolverInstallerSettings,
     pub(crate) force: bool,
     pub(crate) editable: bool,
+    pub(crate) suffix: Option<String>,
 }
 
 impl ToolInstallSettings {
@@ -381,6 +382,7 @@ impl ToolInstallSettings {
             build,
             refresh,
             python,
+            suffix,
         } = args;
 
         let options = resolver_installer_options(installer, build).combine(
@@ -406,6 +408,7 @@ impl ToolInstallSettings {
             refresh: Refresh::from(refresh),
             options,
             settings,
+            suffix,
         }
     }
 }

--- a/crates/uv/tests/show_settings.rs
+++ b/crates/uv/tests/show_settings.rs
@@ -2565,6 +2565,7 @@ fn resolve_tool() -> anyhow::Result<()> {
         },
         force: false,
         editable: false,
+        suffix: None,
     }
 
     ----- stderr -----

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -174,6 +174,182 @@ fn tool_install() {
     });
 }
 
+/// Test installing a tool twice  with `uv tool install --suffix`
+/// and different suffixes
+#[test]
+fn tool_install_suffix() {
+    let context = TestContext::new("3.12")
+        .with_filtered_counts()
+        .with_filtered_exe_suffix();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Install `black`
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("black")
+        .arg("--suffix")
+        .arg("_beta")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str())
+        .env("PATH", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Prepared [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
+    Installed 2 executables: black, blackd
+    "###);
+
+    tool_dir
+        .child("black_beta")
+        .assert(predicate::path::is_dir());
+    tool_dir
+        .child("black_beta")
+        .child("uv-receipt.toml")
+        .assert(predicate::path::exists());
+
+    let executable = bin_dir.child(format!("black_beta{}", std::env::consts::EXE_SUFFIX));
+    executable.assert(predicate::path::exists());
+    assert!(executable.exists());
+
+    // On Windows, we can't snapshot an executable file.
+    #[cfg(not(windows))]
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        // Should run black in the virtual environment
+        assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
+        #![TEMP_DIR]/tools/black_beta/bin/python
+        # -*- coding: utf-8 -*-
+        import re
+        import sys
+        from black import patched_main
+        if __name__ == "__main__":
+            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            sys.exit(patched_main())
+        "###);
+
+    });
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        // We should have a tool receipt
+        assert_snapshot!(fs_err::read_to_string(tool_dir.join("black_beta").join("uv-receipt.toml")).unwrap(), @r###"
+        [tool]
+        requirements = [{ name = "black" }]
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black_beta" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd_beta" },
+        ]
+
+        [tool.options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+        "###);
+    });
+
+    uv_snapshot!(context.filters(), Command::new("black_beta").arg("--version").env("PATH", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    black_beta, 24.3.0 (compiled: yes)
+    Python (CPython) 3.12.[X]
+
+    ----- stderr -----
+    "###);
+
+    // Install `black` alfa
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("black")
+        .arg("--suffix")
+        .arg("_alfa")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str())
+        .env("PATH", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
+    Installed 2 executables: black, blackd
+    "###);
+
+    tool_dir
+        .child("black_alfa")
+        .assert(predicate::path::is_dir());
+    tool_dir
+        .child("black_alfa")
+        .child("uv-receipt.toml")
+        .assert(predicate::path::exists());
+
+    let executable = bin_dir.child(format!("black_alfa{}", std::env::consts::EXE_SUFFIX));
+    executable.assert(predicate::path::exists());
+    assert!(executable.exists());
+
+    // On Windows, we can't snapshot an executable file.
+    #[cfg(not(windows))]
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        // Should run black in the virtual environment
+        assert_snapshot!(fs_err::read_to_string(executable).unwrap(), @r###"
+        #![TEMP_DIR]/tools/black_alfa/bin/python
+        # -*- coding: utf-8 -*-
+        import re
+        import sys
+        from black import patched_main
+        if __name__ == "__main__":
+            sys.argv[0] = re.sub(r"(-script\.pyw|\.exe)?$", "", sys.argv[0])
+            sys.exit(patched_main())
+        "###);
+
+    });
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        // We should have a tool receipt
+        assert_snapshot!(fs_err::read_to_string(tool_dir.join("black_alfa").join("uv-receipt.toml")).unwrap(), @r###"
+        [tool]
+        requirements = [{ name = "black" }]
+        entrypoints = [
+            { name = "black", install-path = "[TEMP_DIR]/bin/black_alfa" },
+            { name = "blackd", install-path = "[TEMP_DIR]/bin/blackd_alfa" },
+        ]
+
+        [tool.options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+        "###);
+    });
+
+    uv_snapshot!(context.filters(), Command::new("black_alfa").arg("--version").env("PATH", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    black_alfa, 24.3.0 (compiled: yes)
+    Python (CPython) 3.12.[X]
+
+    ----- stderr -----
+    "###);
+}
+
 #[test]
 fn tool_install_suggest_other_packages_with_executable() {
     let context = TestContext::new("3.12").with_filtered_exe_suffix();

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2811,6 +2811,8 @@ uv tool install [OPTIONS] <PACKAGE>
 
 <li><code>lowest-direct</code>:  Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies</li>
 </ul>
+</dd><dt><code>--suffix</code> <i>suffix</i></dt><dd><p>The suffix to install the package and executables with</p>
+
 </dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
 </dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Ongoing attempt to close #6365 

So far:
- Added the CLI argument and general setting
- Modified the tools enviroments and receipts to work with a suffix
  - Right now the design stores tools in the directory `{name}{suffix}`
- Made the `uv tool install` command thread and process suffixes

TODO:
- Add support for `upgrade`, `uninstall`
- Normalize suffixes (right now they're taken verbatim and not according the rules specified in the RFC #3560)
- Modify the representation of `ToolName` after discussions
- Improve testing
  - Colliding tools (Packagea `A` and `A_B` can collide if `A` is installed with suffix `_B`)
  - Preliminary discussions point towards requiring uniqueness of `{package name}{suffix}` as an id, we need to test that

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

For now, tests that the same package can be installed with different suffixes

<!-- How was it tested? -->
