### PR TITLE
Prune unused source distributions from the cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,6 +4812,7 @@ dependencies = [
  "uv-types",
  "uv-warnings",
  "uv-workspace",
+ "walkdir",
  "zip",
 ]
 

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -18,7 +18,7 @@ use uv_normalize::PackageName;
 pub use crate::by_timestamp::CachedByTimestamp;
 #[cfg(feature = "clap")]
 pub use crate::cli::CacheArgs;
-use crate::removal::{rm_rf, Removal};
+pub use crate::removal::{rm_rf, Removal};
 pub use crate::timestamp::Timestamp;
 pub use crate::wheel::WheelCache;
 use crate::wheel::WheelCacheKind;
@@ -458,9 +458,7 @@ impl Cache {
             }
         }
 
-        // Third, remove any unused archives (by searching for archives that are not symlinked).
-        // TODO(charlie): Remove any unused source distributions. This requires introspecting the
-        // cache contents, e.g., reading and deserializing the manifests.
+        // Fourth, remove any unused archives (by searching for archives that are not symlinked).
         let mut references = FxHashSet::default();
 
         for bucket in CacheBucket::iter() {

--- a/crates/uv-cache/src/removal.rs
+++ b/crates/uv-cache/src/removal.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 /// Remove a file or directory and all its contents, returning a [`Removal`] with
 /// the number of files and directories removed, along with a total byte count.
-pub(crate) fn rm_rf(path: impl AsRef<Path>) -> io::Result<Removal> {
+pub fn rm_rf(path: impl AsRef<Path>) -> io::Result<Removal> {
     let mut removal = Removal::default();
     removal.rm_rf(path.as_ref())?;
     Ok(removal)

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }
 tracing = { workspace = true }
 url = { workspace = true }
+walkdir = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -44,6 +44,8 @@ pub enum Error {
     CacheDecode(#[from] rmp_serde::decode::Error),
     #[error("Failed to serialize cache entry")]
     CacheEncode(#[from] rmp_serde::encode::Error),
+    #[error("Failed to walk the distribution cache")]
+    CacheWalk(#[source] walkdir::Error),
 
     // Build error
     #[error(transparent)]

--- a/crates/uv-distribution/src/lib.rs
+++ b/crates/uv-distribution/src/lib.rs
@@ -4,6 +4,7 @@ pub use error::Error;
 pub use index::{BuiltWheelIndex, RegistryWheelIndex};
 pub use metadata::{ArchiveMetadata, LoweredRequirement, Metadata, RequiresDist};
 pub use reporter::Reporter;
+pub use source::prune;
 
 mod archive;
 mod distribution_database;

--- a/crates/uv-distribution/src/source/revision.rs
+++ b/crates/uv-distribution/src/source/revision.rs
@@ -63,6 +63,16 @@ impl RevisionId {
     fn new() -> Self {
         Self(nanoid::nanoid!())
     }
+
+    pub(crate) fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl AsRef<str> for RevisionId {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
 }
 
 impl AsRef<Path> for RevisionId {


### PR DESCRIPTION
## Summary

This has bothered me for a while and should be fairly impactful for users. It requires a weird implementation, since the distribution-building crate depends on the cache, and so the prune operation can't live in the cache, since it needs to access internals of the distribution-building crate.

Closes https://github.com/astral-sh/uv/issues/7096.
