### PR TITLE
(doc) Fix wrong examples for locking

### DIFF
--- a/docs/pip/compile.md
+++ b/docs/pip/compile.md
@@ -49,13 +49,13 @@ $ echo "ruff" | uv pip compile -
 To lock with optional dependencies enabled, e.g., the "foo" extra:
 
 ```console
-$ uv pip install -r pyproject.toml --extra foo
+$ uv pip compile pyproject.toml --extra foo
 ```
 
 To lock with all optional dependencies enabled:
 
 ```console
-$ uv pip install -r pyproject.toml --all-extras
+$ uv pip compile pyproject.toml --all-extras
 ```
 
 Note extras are not supported with the `requirements.in` format.


### PR DESCRIPTION
## Summary

The examples for compile with optional dependencies use `uv pip install` instead of `uv pip compile` (probably a copy-paste error)

## Test Plan
N/A  This is a minor doc issue. The result is directly rendered.