### PR TITLE
pep508: add graph debug representation for `MarkerTree`

### DIFF
--- a/crates/pep508-rs/src/marker/mod.rs
+++ b/crates/pep508-rs/src/marker/mod.rs
@@ -18,9 +18,9 @@ mod tree;
 pub use environment::{MarkerEnvironment, MarkerEnvironmentBuilder};
 pub use tree::{
     ContainsMarkerTree, ExtraMarkerTree, ExtraOperator, InMarkerTree, MarkerExpression,
-    MarkerOperator, MarkerTree, MarkerTreeContents, MarkerTreeKind, MarkerValue, MarkerValueExtra,
-    MarkerValueString, MarkerValueVersion, MarkerWarningKind, StringMarkerTree, StringVersion,
-    VersionMarkerTree,
+    MarkerOperator, MarkerTree, MarkerTreeContents, MarkerTreeDebugGraph, MarkerTreeKind,
+    MarkerValue, MarkerValueExtra, MarkerValueString, MarkerValueVersion, MarkerWarningKind,
+    StringMarkerTree, StringVersion, VersionMarkerTree,
 };
 
 /// `serde` helpers for [`MarkerTree`].

--- a/crates/pep508-rs/src/marker/simplify.rs
+++ b/crates/pep508-rs/src/marker/simplify.rs
@@ -279,7 +279,7 @@ fn simplify(dnf: &mut Vec<Vec<MarkerExpression>>) {
 }
 
 /// Merge any edges that lead to identical subtrees into a single range.
-fn collect_edges<'a, T>(
+pub(crate) fn collect_edges<'a, T>(
     map: impl ExactSizeIterator<Item = (&'a Range<T>, MarkerTree)>,
 ) -> IndexMap<MarkerTree, Range<T>, FxBuildHasher>
 where


### PR DESCRIPTION
This PR revives #6129, but is less bold:

* It doesn't rename anything. (I think the rename is probably right
  though.)
* It doesn't change the _default_ `Debug` impl. Instead, it offers this
  as a new `MarkerTree::debug_graph` method.

I found this pretty useful for debugging since it gives a display format
that is more faithful to the internal representation of a `MarkerTree`.
So I think it's worth having around. But making it available in `Debug`
is perhaps a bridge too far since it isn't as familiar as the typical
PEP 508 representation and isn't as succinct.

I did consider printing this when using `{:#?}` (i.e., the "alternate"
debug representation), but too many things use that (like `insta` I
think) to make it practical.

Closes #6129
