### PR TITLE
installation.md: update shell syntax for setting env vars

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -60,7 +60,7 @@ Request a specific version by including it in the URL:
     disable this behavior, set `INSTALLER_NO_MODIFY_PATH=1`. For example:
 
     ```
-    INSTALLER_NO_MODIFY_PATH=1 bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
+    curl -LsSf https://astral.sh/uv/install.sh | env INSTALLER_NO_MODIFY_PATH=1 sh
     ```
 
 ### PyPI


### PR DESCRIPTION
I find this more readable; it also no longer requires bash (thought just replacing `bash` with `sh` would achieve that much).

Strictly speaking, `env` is not necessary on most shells, but I find it makes things clearer.

## Test Plan

Ran the command locally, did not try compiling the docs.



----------

Aside, loosely related (and hopefully helpful) suggestions:

I'm hoping you will also explain in the docs how to install to `~/.local/bin`, with the same goal as https://github.com/astral-sh/uv/pull/6839. Using environment variables for that is fine.

Another minor FR I'd have is to mention these environment variables in the help message of the installer script, especially if you want to encourage people to use them.

Thank you for working on the installation script! It helps me feel more comfortable about eventually asking that people install `uv` to compile docs on my project, hopefully helping people who don't have a Python environment already installed.
