### PR TITLE
Fix typo `aaarch64->aarch64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1417,7 +1417,7 @@ and `uv tool run` ([#4404](https://github.com/astral-sh/uv/pull/4404))
 
 - Add `--workspace` option to `uv add` ([#4362](https://github.com/astral-sh/uv/pull/4362))
 - Ignore query errors during `uv toolchain list` ([#4382](https://github.com/astral-sh/uv/pull/4382))
-- Respect `.python-version` files and fetch manged toolchains in uv project
+- Respect `.python-version` files and fetch managed toolchains in uv project
 commands ([#4361](https://github.com/astral-sh/uv/pull/4361))
 - Respect `.python-version` in `uv venv --preview` ([#4360](https://github.com/astral-sh/uv/pull/4360))
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -995,7 +995,7 @@ pub struct PipCompileArgs {
     ///
     /// Represented as a "target triple", a string that describes the target platform in terms of
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
-    /// `aaarch64-apple-darwin`.
+    /// `aarch64-apple-darwin`.
     #[arg(long)]
     pub python_platform: Option<TargetTriple>,
 
@@ -1278,7 +1278,7 @@ pub struct PipSyncArgs {
     ///
     /// Represented as a "target triple", a string that describes the target platform in terms of
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
-    /// `aaarch64-apple-darwin`.
+    /// `aarch64-apple-darwin`.
     ///
     /// WARNING: When specified, uv will select wheels that are compatible with the _target_
     /// platform; as a result, the installed distributions may not be compatible with the _current_
@@ -1553,7 +1553,7 @@ pub struct PipInstallArgs {
     ///
     /// Represented as a "target triple", a string that describes the target platform in terms of
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
-    /// `aaarch64-apple-darwin`.
+    /// `aarch64-apple-darwin`.
     ///
     /// WARNING: When specified, uv will select wheels that are compatible with the _target_
     /// platform; as a result, the installed distributions may not be compatible with the _current_
@@ -2899,7 +2899,7 @@ pub struct TreeArgs {
     ///
     /// Represented as a "target triple", a string that describes the target
     /// platform in terms of its CPU, vendor, and operating system name, like
-    /// `x86_64-unknown-linux-gnu` or `aaarch64-apple-darwin`.
+    /// `x86_64-unknown-linux-gnu` or `aarch64-apple-darwin`.
     #[arg(long, conflicts_with = "universal")]
     pub python_platform: Option<TargetTriple>,
 

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -1012,7 +1012,7 @@ pub struct PipOptions {
     ///
     /// Represented as a "target triple", a string that describes the target platform in terms of
     /// its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
-    /// `aaarch64-apple-darwin`.
+    /// `aarch64-apple-darwin`.
     #[option(
         default = "None",
         value_type = "str",

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -8247,7 +8247,7 @@ fn universal_unnecessary_python() -> Result<()> {
 /// on the marker environment. This is usually fine, except in this case,
 /// `torchvision` has an unconditional dependency on `torch`, and this resulted
 /// in the markers being dropped. As a result, we'd previously write a
-/// `requirements.txt` file that unconditionally dependended on two different
+/// `requirements.txt` file that unconditionally depended on two different
 /// versions of `torch`.
 ///
 /// See: <https://github.com/astral-sh/uv/issues/5086>

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -744,7 +744,7 @@ fn sync_build_isolation_extra() -> Result<()> {
 /// Avoid using incompatible versions for build dependencies that are also part of the resolved
 /// environment. This is a very subtle issue, but: when locking, we don't enforce platform
 /// compatibility. So, if we reuse the resolver state to install, and the install itself has to
-/// preform a resolution (e.g., for the build dependencies of a source distribution), that
+/// perform a resolution (e.g., for the build dependencies of a source distribution), that
 /// resolution may choose incompatible versions.
 ///
 /// The key property here is that there's a shared package between the build dependencies and the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2182,7 +2182,7 @@ uv tree [OPTIONS]
 
 <p>For example, pass <code>--platform windows</code> to display the dependencies that would be included when installing on Windows.</p>
 
-<p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aaarch64-apple-darwin</code>.</p>
+<p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
 
 <p>Possible values:</p>
 
@@ -4469,7 +4469,7 @@ uv pip compile [OPTIONS] <SRC_FILE>...
 
 </dd><dt><code>--python-platform</code> <i>python-platform</i></dt><dd><p>The platform for which requirements should be resolved.</p>
 
-<p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aaarch64-apple-darwin</code>.</p>
+<p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
 
 <p>Possible values:</p>
 
@@ -4791,7 +4791,7 @@ uv pip sync [OPTIONS] <SRC_FILE>...
 <p>May also be set with the <code>UV_PYTHON</code> environment variable.</p>
 </dd><dt><code>--python-platform</code> <i>python-platform</i></dt><dd><p>The platform for which requirements should be installed.</p>
 
-<p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aaarch64-apple-darwin</code>.</p>
+<p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
 
 <p>WARNING: When specified, uv will select wheels that are compatible with the <em>target</em> platform; as a result, the installed distributions may not be compatible with the <em>current</em> platform. Conversely, any distributions that are built from source may be incompatible with the <em>target</em> platform, as they will be built for the <em>current</em> platform. The <code>--python-platform</code> option is intended for advanced use cases.</p>
 
@@ -5153,7 +5153,7 @@ uv pip install [OPTIONS] <PACKAGE|--requirement <REQUIREMENT>|--editable <EDITAB
 <p>May also be set with the <code>UV_PYTHON</code> environment variable.</p>
 </dd><dt><code>--python-platform</code> <i>python-platform</i></dt><dd><p>The platform for which requirements should be installed.</p>
 
-<p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aaarch64-apple-darwin</code>.</p>
+<p>Represented as a &quot;target triple&quot;, a string that describes the target platform in terms of its CPU, vendor, and operating system name, like <code>x86_64-unknown-linux-gnu</code> or <code>aarch64-apple-darwin</code>.</p>
 
 <p>WARNING: When specified, uv will select wheels that are compatible with the <em>target</em> platform; as a result, the installed distributions may not be compatible with the <em>current</em> platform. Conversely, any distributions that are built from source may be incompatible with the <em>target</em> platform, as they will be built for the <em>current</em> platform. The <code>--python-platform</code> option is intended for advanced use cases.</p>
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -2361,7 +2361,7 @@ The platform for which requirements should be resolved.
 
 Represented as a "target triple", a string that describes the target platform in terms of
 its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or
-`aaarch64-apple-darwin`.
+`aarch64-apple-darwin`.
 
 **Default value**: `None`
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -894,7 +894,7 @@
           ]
         },
         "python-platform": {
-          "description": "The platform for which requirements should be resolved.\n\nRepresented as a \"target triple\", a string that describes the target platform in terms of its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or `aaarch64-apple-darwin`.",
+          "description": "The platform for which requirements should be resolved.\n\nRepresented as a \"target triple\", a string that describes the target platform in terms of its CPU, vendor, and operating system name, like `x86_64-unknown-linux-gnu` or `aarch64-apple-darwin`.",
           "anyOf": [
             {
               "$ref": "#/definitions/TargetTriple"


### PR DESCRIPTION
copy pasted `--python-platform aaarch64-unknown-linux-gnu` [from the docs](https://docs.astral.sh/uv/reference/cli/#uv-pip-compile) and got

> error: invalid value 'aaarch64-unknown-linux-gnu' for '--python-platform <PYTHON_PLATFORM>'
>   [possible values: windows, linux, macos, x86_64-pc-windows-msvc, i686-pc-windows-msvc, x86_64-unknown-linux-gnu, aarch64-apple-darwin, x86_64-apple-darwin, aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, x86_64-unknown-linux-musl, x86_64-manylinux_2_17, x86_64-manylinux_2_28, x86_64-manylinux_2_31, aarch64-manylinux_2_17, aarch64-manylinux_2_28, aarch64-manylinux_2_31]
> 
>   tip: a similar value exists: 'aarch64-unknown-linux-gnu'