### PR TITLE
 Replace incorrect ``--source`` and ``--binary`` flags with correct ``--sdist`` and ``--wheel`` flags in ``uv build``

### DIFF
--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -581,9 +581,9 @@ You can build the project in a different directory by providing a path to `uv bu
 `uv build` will first build a source distribution, and then build a binary distribution (wheel) from
 that source distribution.
 
-You can limit `uv build` to building a source distribution with `uv build --source`, a binary
-distribution with `uv build --binary`, or build both distributions from source with
-`uv build --source --binary`.
+You can limit `uv build` to building a source distribution with `uv build --sdist`, a binary
+distribution with `uv build --wheel`, or build both distributions from source with
+`uv build --sdist --wheel`.
 
 `uv build` accepts `--build-constraints`, which can be used to constrain the versions of any build
 requirements during the build process. When coupled with `--require-hashes`, uv will enforce that


### PR DESCRIPTION

## Summary
 Replace incorrect ``--source`` and ``--binary`` flags with correct ``--sdist`` and ``--wheel`` flags in uv build.
 
![image](https://github.com/user-attachments/assets/f72a9c73-bfce-441b-8756-d0cb22afcd7d)

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan
Run the server locally
![image](https://github.com/user-attachments/assets/f702f19f-96b8-4338-bd1b-e2fb35f5697a)

<!-- How was it tested? -->
