### PR TITLE
Use path file instead of `sitecustomize.py`

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -612,9 +612,11 @@ pub(crate) async fn run(
         })
     };
 
-    // If we're running in an ephemeral environment, add a `sitecustomize.py` to enable loading of
+    // If we're running in an ephemeral environment, add a path file to enable loading of
     // the base environment's site packages. Setting `PYTHONPATH` is insufficient, as it doesn't
     // resolve `.pth` files in the base environment.
+    // And `sitecustomize.py` would be an alternative but it can be shadowed by an existing such
+    // module in the python installation.
     if let Some(ephemeral_env) = ephemeral_env.as_ref() {
         let ephemeral_site_packages = ephemeral_env
             .site_packages()
@@ -626,7 +628,7 @@ pub(crate) async fn run(
             .ok_or_else(|| anyhow!("Base environment has no site packages directory"))?;
 
         fs_err::write(
-            ephemeral_site_packages.join("sitecustomize.py"),
+            ephemeral_site_packages.join("_uv_ephemeral_overlay.pth"),
             format!(
                 "import site; site.addsitedir(\"{}\")",
                 base_site_packages.escape_for_python()


### PR DESCRIPTION
## Summary

Use a path file (`.pth`) instead of `sitecustomize.py` for configuring path in emphemeral virtualenvs, overlaying the ephemeral venv on top of the base `.venv`.

`sitecustomize.py` is a module in the python installation and as such a unique resource - homebrew pythons on macos already install such a file and thus uv's `sitecustomize.py`, placed in the ephemeral env, did not have any effect.

I don't find any documentation explicitly saying that addsitedir is valid in `.pth` files but from trial it seems to be - and there is the precedent of the existing _virtualenv.pth _virtualenv.py pair that do nontrivial operations.

## Test Plan

- Testing on ephemeral venv, resolving to base venv including editable install in base: done (py3.7, 3.12)
- Testing on homebrew python/macos: done (py3.11)
- tests: run_editable

Fixes #7152