### PR TITLE
Fix Docker integration docs for intermediate layers

### DIFF
--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -347,6 +347,8 @@ ADD . /app
 
 # Sync the project
 RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen
 ```
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The Docker integration docs were missing to mount the `uv.lock` and `pyproject.toml` which are required also for the second layer that runs `uv sync --locked`.

It also failed to mention that if your `pyproject.toml` references a readme file, that it must be mounted as well.
