### PR TITLE
Avoid extra newlines in debug logging for source builds

### DIFF
--- a/crates/uv-build/src/lib.rs
+++ b/crates/uv-build/src/lib.rs
@@ -258,10 +258,10 @@ impl Write for Printer {
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
         match self {
             Self::Stderr => {
-                anstream::eprint!("{s}");
+                anstream::eprintln!("{s}");
             }
             Self::Debug => {
-                debug!("{}", s);
+                debug!("{s}");
             }
         }
         Ok(())
@@ -1106,7 +1106,7 @@ impl PythonRunner {
             loop {
                 match reader.next_line().await? {
                     Some(line) => {
-                        let _ = writeln!(printer, "{line}");
+                        let _ = write!(printer, "{line}");
                         buffer.push(line);
                     }
                     None => return Ok(()),


### PR DESCRIPTION
## Summary

@henryiii brought this up and I noticed it too:

![Screenshot 2024-09-06 at 4 09 32 PM](https://github.com/user-attachments/assets/a2849a0e-0515-4856-a9fe-14c713ed9b75)

## Test Plan

`uv build`:

![Screenshot 2024-09-07 at 2 08 39 PM](https://github.com/user-attachments/assets/841db9b7-1fd1-4964-aa57-58b479a255ff)

`uv pip install -e . --verbose`:

![Screenshot 2024-09-07 at 2 08 52 PM](https://github.com/user-attachments/assets/30b2817a-d4a3-4437-b47d-2bc037f5afa4)
