### PR TITLE
bump quinn-proto crate to 0.11.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,9 +2825,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
+checksum = "ea0a9b3a42929fad8a7c3de7f86ce0814cfa893328157672680e9fb1145549c5"
 dependencies = [
  "bytes",
  "rand",


### PR DESCRIPTION
addresses the following security advisory: https://github.com/quinn-rs/quinn/security/advisories/GHSA-vr26-jcq5-fjj8