### PR TITLE
Avoid iteration for singleton selections

### DIFF
--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -329,6 +329,12 @@ impl Version {
         self.is_pre() || self.is_dev()
     }
 
+    /// Whether this is a stable version (i.e., _not_ an alpha/beta/rc or dev version)
+    #[inline]
+    pub fn is_stable(&self) -> bool {
+        !self.is_pre() && !self.is_dev()
+    }
+
     /// Whether this is an alpha/beta/rc version
     #[inline]
     pub fn is_pre(&self) -> bool {

--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -75,7 +75,7 @@ impl CandidateSelector {
     pub(crate) fn select<'a, InstalledPackages: InstalledPackagesProvider>(
         &'a self,
         package_name: &'a PackageName,
-        range: &'a Range<Version>,
+        range: &Range<Version>,
         version_maps: &'a [VersionMap],
         preferences: &'a Preferences,
         installed_packages: &'a InstalledPackages,
@@ -315,10 +315,10 @@ impl CandidateSelector {
     pub(crate) fn select_no_preference<'a>(
         &'a self,
         package_name: &'a PackageName,
-        range: &'a Range<Version>,
+        range: &Range<Version>,
         version_maps: &'a [VersionMap],
         markers: &ResolverMarkers,
-    ) -> Option<Candidate<'a>> {
+    ) -> Option<Candidate> {
         trace!(
             "Selecting candidate for {package_name} with range {range} with {} remote versions",
             version_maps.iter().map(VersionMap::len).sum::<usize>(),
@@ -435,7 +435,7 @@ impl CandidateSelector {
                             let Some(dist) = maybe_dist.prioritized_dist() else {
                                 continue;
                             };
-                            trace!(
+                            tracing::trace!(
                                 "found candidate for package {:?} with range {:?} \
                                  after {} steps: {:?} version",
                                 package_name,
@@ -481,7 +481,7 @@ impl CandidateSelector {
                     let Some(dist) = maybe_dist.prioritized_dist() else {
                         continue;
                     };
-                    trace!(
+                    tracing::trace!(
                         "found candidate for package {:?} with range {:?} \
                          after {} steps: {:?} version",
                         package_name,

--- a/crates/uv-resolver/src/resolver/batch_prefetch.rs
+++ b/crates/uv-resolver/src/resolver/batch_prefetch.rs
@@ -87,23 +87,13 @@ impl BatchPrefetcher {
         };
         let mut prefetch_count = 0;
         for _ in 0..total_prefetch {
-            let range = match &phase {
-                BatchPrefetchStrategy::Compatible { compatible, .. } => compatible.clone(),
-                BatchPrefetchStrategy::InOrder { previous } => {
-                    if selector.use_highest_version(name) {
-                        Range::strictly_lower_than(previous.clone())
-                    } else {
-                        Range::strictly_higher_than(previous.clone())
-                    }
-                }
-            };
             let candidate = match phase {
                 BatchPrefetchStrategy::Compatible {
                     compatible,
                     previous,
                 } => {
                     if let Some(candidate) =
-                        selector.select_no_preference(name, &range, version_map, markers)
+                        selector.select_no_preference(name, &compatible, version_map, markers)
                     {
                         let compatible = compatible.intersection(
                             &Range::singleton(candidate.version().clone()).complement(),
@@ -116,13 +106,16 @@ impl BatchPrefetcher {
                     } else {
                         // We exhausted the compatible version, switch to ignoring the existing
                         // constraints on the package and instead going through versions in order.
-                        phase = BatchPrefetchStrategy::InOrder {
-                            previous: previous.clone(),
-                        };
+                        phase = BatchPrefetchStrategy::InOrder { previous };
                         continue;
                     }
                 }
-                BatchPrefetchStrategy::InOrder { previous: _ } => {
+                BatchPrefetchStrategy::InOrder { previous } => {
+                    let range = if selector.use_highest_version(name) {
+                        Range::strictly_lower_than(previous)
+                    } else {
+                        Range::strictly_higher_than(previous)
+                    };
                     if let Some(candidate) =
                         selector.select_no_preference(name, &range, version_map, markers)
                     {

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1955,7 +1955,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         available_versions
                             .entry(name.clone())
                             .or_insert_with(BTreeSet::new)
-                            .extend(version_map.iter().map(|(version, _)| version.clone()));
+                            .extend(version_map.versions().cloned());
                     }
                 }
             }

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -148,6 +148,7 @@ impl VersionMap {
         &self,
         range: &Range<Version>,
     ) -> impl DoubleEndedIterator<Item = (&Version, VersionMapDistHandle)> + ExactSizeIterator {
+        // Performance optimization: If we only have a single version, return that version directly.
         if let Some(version) = range.as_singleton() {
             either::Either::Left(match self.inner {
                 VersionMapInner::Eager(ref map) => {

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -24,6 +24,7 @@ use crate::{yanks::AllowedYanks, ExcludeNewer, RequiresPython};
 /// A map from versions to distributions.
 #[derive(Debug)]
 pub struct VersionMap {
+    /// The inner representation of the version map.
     inner: VersionMapInner,
 }
 
@@ -50,6 +51,7 @@ impl VersionMap {
         flat_index: Option<FlatDistributions>,
         build_options: &BuildOptions,
     ) -> Self {
+        let mut stable = false;
         let mut map = BTreeMap::new();
         // Create stubs for each entry in simple metadata. The full conversion
         // from a `VersionFiles` to a PrioritizedDist for each version
@@ -59,6 +61,7 @@ impl VersionMap {
                 .version
                 .deserialize(&mut SharedDeserializeMap::new())
                 .expect("archived version always deserializes");
+            stable |= version.is_stable();
             map.insert(
                 version,
                 LazyPrioritizedDist::OnlySimple(SimplePrioritizedDist {
@@ -70,6 +73,7 @@ impl VersionMap {
         // If a set of flat distributions have been given, we need to add those
         // to our map of entries as well.
         for (version, prioritized_dist) in flat_index.into_iter().flatten() {
+            stable |= version.is_stable();
             match map.entry(version) {
                 Entry::Vacant(e) => {
                     e.insert(LazyPrioritizedDist::OnlyFlat(prioritized_dist));
@@ -95,6 +99,7 @@ impl VersionMap {
         Self {
             inner: VersionMapInner::Lazy(VersionMapLazy {
                 map,
+                stable,
                 simple_metadata,
                 no_binary: build_options.no_binary_package(package_name),
                 no_build: build_options.no_build_package(package_name),
@@ -125,7 +130,7 @@ impl VersionMap {
         version: &Version,
     ) -> Option<(&Version, &PrioritizedDist)> {
         match self.inner {
-            VersionMapInner::Eager(ref map) => map.get_key_value(version),
+            VersionMapInner::Eager(ref eager) => eager.map.get_key_value(version),
             VersionMapInner::Lazy(ref lazy) => lazy.get_with_version(version),
         }
     }
@@ -133,7 +138,7 @@ impl VersionMap {
     /// Return an iterator over the versions in this map.
     pub(crate) fn versions(&self) -> impl Iterator<Item = &Version> {
         match &self.inner {
-            VersionMapInner::Eager(map) => either::Either::Left(map.keys()),
+            VersionMapInner::Eager(eager) => either::Either::Left(eager.map.keys()),
             VersionMapInner::Lazy(lazy) => either::Either::Right(lazy.map.keys()),
         }
     }
@@ -151,8 +156,8 @@ impl VersionMap {
         // Performance optimization: If we only have a single version, return that version directly.
         if let Some(version) = range.as_singleton() {
             either::Either::Left(match self.inner {
-                VersionMapInner::Eager(ref map) => {
-                    either::Either::Left(map.get_key_value(version).into_iter().map(
+                VersionMapInner::Eager(ref eager) => {
+                    either::Either::Left(eager.map.get_key_value(version).into_iter().map(
                         move |(version, dist)| {
                             let version_map_dist = VersionMapDistHandle {
                                 inner: VersionMapDistHandleInner::Eager(dist),
@@ -174,8 +179,8 @@ impl VersionMap {
             })
         } else {
             either::Either::Right(match self.inner {
-                VersionMapInner::Eager(ref map) => {
-                    either::Either::Left(map.iter().map(|(version, dist)| {
+                VersionMapInner::Eager(ref eager) => {
+                    either::Either::Left(eager.map.iter().map(|(version, dist)| {
                         let version_map_dist = VersionMapDistHandle {
                             inner: VersionMapDistHandleInner::Eager(dist),
                         };
@@ -197,7 +202,9 @@ impl VersionMap {
     /// Return the [`Hashes`] for the given version, if any.
     pub(crate) fn hashes(&self, version: &Version) -> Option<Vec<HashDigest>> {
         match self.inner {
-            VersionMapInner::Eager(ref map) => map.get(version).map(|file| file.hashes().to_vec()),
+            VersionMapInner::Eager(ref eager) => {
+                eager.map.get(version).map(|file| file.hashes().to_vec())
+            }
             VersionMapInner::Lazy(ref lazy) => lazy.get(version).map(|file| file.hashes().to_vec()),
         }
     }
@@ -208,33 +215,26 @@ impl VersionMap {
     /// usable in the current environment.
     pub(crate) fn len(&self) -> usize {
         match self.inner {
-            VersionMapInner::Eager(ref map) => map.len(),
+            VersionMapInner::Eager(VersionMapEager { ref map, .. }) => map.len(),
             VersionMapInner::Lazy(VersionMapLazy { ref map, .. }) => map.len(),
         }
     }
-}
 
-impl Default for VersionMap {
-    /// Create an empty version map.
-    fn default() -> Self {
-        Self {
-            inner: VersionMapInner::Eager(BTreeMap::default()),
+    /// Returns `true` if the map contains at least one stable (non-pre-release) version.
+    pub(crate) fn stable(&self) -> bool {
+        match self.inner {
+            VersionMapInner::Eager(ref map) => map.stable,
+            VersionMapInner::Lazy(ref map) => map.stable,
         }
     }
 }
 
 impl From<FlatDistributions> for VersionMap {
     fn from(flat_index: FlatDistributions) -> Self {
+        let stable = flat_index.iter().any(|(version, _)| version.is_stable());
+        let map = flat_index.into();
         Self {
-            inner: VersionMapInner::Eager(flat_index.into()),
-        }
-    }
-}
-
-impl From<BTreeMap<Version, PrioritizedDist>> for VersionMap {
-    fn from(value: BTreeMap<Version, PrioritizedDist>) -> Self {
-        Self {
-            inner: VersionMapInner::Eager(value),
+            inner: VersionMapInner::Eager(VersionMapEager { map, stable }),
         }
     }
 }
@@ -280,13 +280,22 @@ enum VersionMapInner {
     ///
     /// This usually happens when one needs a `VersionMap` from a
     /// `FlatDistributions`.
-    Eager(BTreeMap<Version, PrioritizedDist>),
+    Eager(VersionMapEager),
     /// Some distributions might be fully materialized (i.e., by initializing
     /// a `VersionMap` with a `FlatDistributions`), but some distributions
     /// might still be in their "raw" `SimpleMetadata` format. In this case, a
     /// `PrioritizedDist` isn't actually created in memory until the
     /// specific version has been requested.
     Lazy(VersionMapLazy),
+}
+
+/// A map from versions to distributions that are fully materialized in memory.
+#[derive(Debug)]
+struct VersionMapEager {
+    /// A map from version to distribution.
+    map: BTreeMap<Version, PrioritizedDist>,
+    /// Whether the version map contains at least one stable (non-pre-release) version.
+    stable: bool,
 }
 
 /// A map that lazily materializes some prioritized distributions upon access.
@@ -301,6 +310,8 @@ enum VersionMapInner {
 struct VersionMapLazy {
     /// A map from version to possibly-initialized distribution.
     map: BTreeMap<Version, LazyPrioritizedDist>,
+    /// Whether the version map contains at least one stable (non-pre-release) version.
+    stable: bool,
     /// The raw simple metadata from which `PrioritizedDist`s should
     /// be constructed.
     simple_metadata: OwnedArchive<SimpleMetadata>,


### PR DESCRIPTION
## Summary

If we have a singleton `Range`, we don't need to iterate over the map of available ranges; instead, we can just get the singleton directly.

Closes #6131.
