### PR TITLE
ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ profile.json
 
 # MkDocs
 /site
+
+# macOS
+**/.DS_Store


### PR DESCRIPTION
Just ignoring macOS generated files. 

Would respectfully accept that would might not be merged.