### PR TITLE
treat .tgz the same as .tar.gz

### DIFF
--- a/crates/distribution-filename/src/extension.rs
+++ b/crates/distribution-filename/src/extension.rs
@@ -70,6 +70,7 @@ impl SourceDistExtension {
         match extension {
             "zip" => Ok(Self::Zip),
             "gz" if is_tar(path.as_ref()) => Ok(Self::TarGz),
+            "tgz" => Ok(Self::TarGz),
             "bz2" if is_tar(path.as_ref()) => Ok(Self::TarBz2),
             "xz" if is_tar(path.as_ref()) => Ok(Self::TarXz),
             "zst" if is_tar(path.as_ref()) => Ok(Self::TarZst),
@@ -94,6 +95,6 @@ impl Display for SourceDistExtension {
 pub enum ExtensionError {
     #[error("`.whl`, `.zip`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, or `.tar.zst`")]
     Dist,
-    #[error("`.zip`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, or `.tar.zst`")]
+    #[error("`.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tar.xz`, or `.tar.zst`")]
     SourceDist,
 }

--- a/crates/uv/tests/build.rs
+++ b/crates/uv/tests/build.rs
@@ -816,7 +816,7 @@ fn wheel_from_sdist() -> Result<()> {
 
     ----- stderr -----
     Building wheel from source distribution...
-    error: `dist/project-0.1.0-py3-none-any.whl` is not a valid build source. Expected to receive a source directory, or a source distribution ending in one of: `.zip`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, or `.tar.zst`.
+    error: `dist/project-0.1.0-py3-none-any.whl` is not a valid build source. Expected to receive a source directory, or a source distribution ending in one of: `.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tar.xz`, or `.tar.zst`.
     "###);
 
     Ok(())

--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -303,7 +303,7 @@ archives. While less common, other formats are also supported when reading and e
 distributions:
 
 - bzip2 tarball (`.tar.bz2`)
-- gzip tarball (`.tar.gz`)
+- gzip tarball (`.tar.gz`, `.tgz`)
 - xz tarball (`.tar.xz`)
 - zip (`.zip`)
 - zstd tarball (`.tar.zst`)


### PR DESCRIPTION

## Summary

Fixes #7081 

Treats source distribution `.tgz` the same as `.tar.gz` plans

## Test Plan

Quick Version

```bash
cd $(mktemp -d)
uv init
uv add --dev build
.venv/bin/python -m build -s .
mv -v dist/*tar.gz dist/"$(basename dist/*.tar.gz .tar.gz)".tgz
uv pip install dist/*.tgz
```

Can add a proper test to the branch if requested
