### PR TITLE
Use type hints in code from `uv init`

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -471,7 +471,7 @@ impl InitProjectKind {
                 fs_err::write(
                     init_py,
                     indoc::formatdoc! {r#"
-                    def hello():
+                    def hello() -> None:
                         print("Hello from {name}!")
                     "#},
                 )?;

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -294,7 +294,7 @@ fn init_application_package() -> Result<()> {
     }, {
         assert_snapshot!(
             init, @r###"
-        def hello():
+        def hello() -> None:
             print("Hello from foo!")
         "###
         );

--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -230,7 +230,7 @@ example-packaged-app
 But the module defines a CLI function:
 
 ```python title="__init__.py"
-def hello():
+def hello() -> None:
     print("Hello from example-packaged-app!")
 ```
 


### PR DESCRIPTION
Let's promote type hints!

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
The generated script now annotates the return type of the dummy function `hello()`.

## Test Plan

<!-- How was it tested? -->
All existing tests have been synced with this update.
