### PR TITLE
Extract METADATA reading into a crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4661,7 +4661,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "insta",
- "install-wheel-rs",
  "itertools 0.13.0",
  "jiff",
  "pep440_rs",
@@ -4687,6 +4686,7 @@ dependencies = [
  "uv-cache",
  "uv-configuration",
  "uv-fs",
+ "uv-metadata",
  "uv-normalize",
  "uv-version",
  "uv-warnings",
@@ -4793,7 +4793,6 @@ dependencies = [
  "futures",
  "indoc",
  "insta",
- "install-wheel-rs",
  "nanoid",
  "pep440_rs",
  "pep508_rs",
@@ -4817,6 +4816,7 @@ dependencies = [
  "uv-extract",
  "uv-fs",
  "uv-git",
+ "uv-metadata",
  "uv-normalize",
  "uv-types",
  "uv-warnings",
@@ -4936,6 +4936,24 @@ dependencies = [
  "quote",
  "syn 2.0.76",
  "textwrap",
+]
+
+[[package]]
+name = "uv-metadata"
+version = "0.1.0"
+dependencies = [
+ "async_zip",
+ "distribution-filename",
+ "fs-err",
+ "futures",
+ "pep440_rs",
+ "pypi-types",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uv-normalize",
+ "zip",
 ]
 
 [[package]]
@@ -5065,7 +5083,6 @@ dependencies = [
  "futures",
  "indexmap",
  "insta",
- "install-wheel-rs",
  "itertools 0.13.0",
  "jiff",
  "once-map",
@@ -5095,6 +5112,7 @@ dependencies = [
  "uv-distribution",
  "uv-fs",
  "uv-git",
+ "uv-metadata",
  "uv-normalize",
  "uv-pubgrub",
  "uv-python",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,13 @@ uv-fs = { path = "crates/uv-fs" }
 uv-git = { path = "crates/uv-git" }
 uv-installer = { path = "crates/uv-installer" }
 uv-macros = { path = "crates/uv-macros" }
+uv-metadata = { path = "crates/uv-metadata" }
 uv-normalize = { path = "crates/uv-normalize" }
 uv-options-metadata = { path = "crates/uv-options-metadata" }
+uv-pubgrub = { path = "crates/uv-pubgrub" }
 uv-python = { path = "crates/uv-python" }
 uv-requirements = { path = "crates/uv-requirements" }
 uv-resolver = { path = "crates/uv-resolver" }
-uv-pubgrub = { path = "crates/uv-pubgrub" }
 uv-scripts = { path = "crates/uv-scripts" }
 uv-settings = { path = "crates/uv-settings" }
 uv-shell = { path = "crates/uv-shell" }
@@ -64,7 +65,7 @@ async-channel = { version = "2.2.0" }
 async-compression = { version = "0.4.6" }
 async-trait = { version = "0.1.78" }
 async_http_range_reader = { version = "0.8.0" }
-async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "011b24604fa7bc223daaad7712c0694bac8f0a87", features = ["deflate"] }
+async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "011b24604fa7bc223daaad7712c0694bac8f0a87", features = ["deflate", "tokio"] }
 axoupdater = { version = "0.7.0", default-features = false }
 backoff = { version = "0.4.0" }
 base64 = { version = "0.22.0" }

--- a/crates/install-wheel-rs/src/lib.rs
+++ b/crates/install-wheel-rs/src/lib.rs
@@ -16,7 +16,6 @@ use uv_normalize::PackageName;
 pub use wheel::{parse_wheel_file, read_record_file, LibKind};
 
 pub mod linker;
-pub mod metadata;
 mod record;
 mod script;
 mod uninstall;
@@ -82,24 +81,10 @@ pub enum Error {
     Pep440,
     #[error("Invalid direct_url.json")]
     DirectUrlJson(#[from] serde_json::Error),
-    #[error("No .dist-info directory found")]
-    MissingDistInfo,
     #[error("Cannot uninstall package; `RECORD` file not found at: {}", _0.user_display())]
     MissingRecord(PathBuf),
     #[error("Cannot uninstall package; `top_level.txt` file not found at: {}", _0.user_display())]
     MissingTopLevel(PathBuf),
-    #[error("Multiple .dist-info directories found: {0}")]
-    MultipleDistInfo(String),
-    #[error(
-        "The .dist-info directory {0} does not consist of the normalized package name and version"
-    )]
-    MissingDistInfoSegments(String),
-    #[error("The .dist-info directory {0} does not start with the normalized package name: {1}")]
-    MissingDistInfoPackageName(String, String),
-    #[error("The .dist-info directory {0} does not start with the normalized version: {1}")]
-    MissingDistInfoVersion(String, String),
-    #[error("The .dist-info directory name contains invalid characters")]
-    InvalidDistInfoPrefix,
     #[error("Invalid wheel size")]
     InvalidSize,
     #[error("Invalid package name")]

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -10,7 +10,6 @@ workspace = true
 cache-key = { workspace = true }
 distribution-filename = { workspace = true }
 distribution-types = { workspace = true }
-install-wheel-rs = { workspace = true }
 pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
 platform-tags = { workspace = true }
@@ -19,6 +18,7 @@ uv-auth = { workspace = true }
 uv-cache = { workspace = true }
 uv-configuration = { workspace = true }
 uv-fs = { workspace = true, features = ["tokio"] }
+uv-metadata = { workspace = true }
 uv-normalize = { workspace = true }
 uv-version = { workspace = true }
 uv-warnings = { workspace = true }
@@ -26,7 +26,7 @@ uv-warnings = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 async_http_range_reader = { workspace = true }
-async_zip = { workspace = true, features = ["tokio"] }
+async_zip = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 html-escape = { workspace = true }

--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -148,8 +148,8 @@ pub enum ErrorKind {
     #[error("Expected an index URL, but received non-base URL: {0}")]
     CannotBeABase(Url),
 
-    #[error(transparent)]
-    DistInfo(#[from] install_wheel_rs::Error),
+    #[error("Failed to read metadata: `{0}`")]
+    Metadata(String, #[source] uv_metadata::Error),
 
     #[error("{0} isn't available locally, but making network requests to registries was banned")]
     NoIndex(String),

--- a/crates/uv-client/src/remote_metadata.rs
+++ b/crates/uv-client/src/remote_metadata.rs
@@ -1,11 +1,10 @@
+use crate::{Error, ErrorKind};
 use async_http_range_reader::AsyncHttpRangeReader;
+use distribution_filename::WheelFilename;
 use futures::io::BufReader;
 use tokio_util::compat::TokioAsyncReadCompatExt;
-
-use distribution_filename::WheelFilename;
-use install_wheel_rs::metadata::find_archive_dist_info;
-
-use crate::{Error, ErrorKind};
+use url::Url;
+use uv_metadata::find_archive_dist_info;
 
 /// Read the `.dist-info/METADATA` file from a async remote zip reader, so we avoid downloading the
 /// entire wheel just for the one file.
@@ -50,6 +49,7 @@ use crate::{Error, ErrorKind};
 /// rest of the crate.
 pub(crate) async fn wheel_metadata_from_remote_zip(
     filename: &WheelFilename,
+    debug_name: &Url,
     reader: &mut AsyncHttpRangeReader,
 ) -> Result<String, Error> {
     // Make sure we have the back part of the stream.
@@ -75,7 +75,7 @@ pub(crate) async fn wheel_metadata_from_remote_zip(
             .enumerate()
             .filter_map(|(idx, e)| Some(((idx, e), e.filename().as_str().ok()?))),
     )
-    .map_err(ErrorKind::DistInfo)?;
+    .map_err(|err| ErrorKind::Metadata(debug_name.to_string(), err))?;
 
     let offset = metadata_entry.header_offset();
     let size = metadata_entry.compressed_size()

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [dependencies]
 distribution-filename = { workspace = true }
 distribution-types = { workspace = true }
-install-wheel-rs = { workspace = true }
 pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
 platform-tags = { workspace = true }
@@ -27,6 +26,7 @@ uv-configuration = { workspace = true }
 uv-extract = { workspace = true }
 uv-fs = { workspace = true, features = ["tokio"] }
 uv-git = { workspace = true }
+uv-metadata = { workspace = true }
 uv-normalize = { workspace = true }
 uv-types = { workspace = true }
 uv-warnings = { workspace = true }

--- a/crates/uv-distribution/src/download.rs
+++ b/crates/uv-distribution/src/download.rs
@@ -4,6 +4,8 @@ use crate::Error;
 use distribution_filename::WheelFilename;
 use distribution_types::{CachedDist, Dist, Hashed};
 use pypi_types::{HashDigest, Metadata23};
+use uv_metadata::read_flat_wheel_metadata;
+
 use uv_cache_info::CacheInfo;
 
 /// A locally available wheel.
@@ -41,6 +43,7 @@ impl LocalWheel {
     /// Read the [`Metadata23`] from a wheel.
     pub fn metadata(&self) -> Result<Metadata23, Error> {
         read_flat_wheel_metadata(&self.filename, &self.archive)
+            .map_err(|err| Error::WheelMetadata(self.archive.clone(), Box::new(err)))
     }
 }
 
@@ -67,14 +70,4 @@ impl std::fmt::Display for LocalWheel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.remote())
     }
-}
-
-/// Read the [`Metadata23`] from an unzipped wheel.
-fn read_flat_wheel_metadata(
-    filename: &WheelFilename,
-    wheel: impl AsRef<Path>,
-) -> Result<Metadata23, Error> {
-    let dist_info = install_wheel_rs::metadata::find_flat_dist_info(filename, &wheel)?;
-    let metadata = install_wheel_rs::metadata::read_dist_info_metadata(&dist_info, &wheel)?;
-    Ok(Metadata23::parse_metadata(&metadata)?)
 }

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -63,8 +63,8 @@ pub enum Error {
     VersionMismatch { given: Version, metadata: Version },
     #[error("Failed to parse metadata from built wheel")]
     Metadata(#[from] pypi_types::MetadataError),
-    #[error("Failed to read `dist-info` metadata from built wheel")]
-    DistInfo(#[from] install_wheel_rs::Error),
+    #[error("Failed to read metadata: `{}`", _0.user_display())]
+    WheelMetadata(PathBuf, #[source] Box<uv_metadata::Error>),
     #[error("Failed to read zip archive from built wheel")]
     Zip(#[from] ZipError),
     #[error("Source distribution directory contains neither readable `pyproject.toml` nor `setup.py`: `{}`", _0.user_display())]

--- a/crates/uv-extract/Cargo.toml
+++ b/crates/uv-extract/Cargo.toml
@@ -17,7 +17,7 @@ distribution-filename = { workspace = true }
 pypi-types = { workspace = true }
 
 async-compression = { workspace = true, features = ["bzip2", "gzip", "zstd", "xz"] }
-async_zip = { workspace = true, features = ["tokio"] }
+async_zip = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
 md-5 = { workspace = true }

--- a/crates/uv-metadata/Cargo.toml
+++ b/crates/uv-metadata/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "uv-metadata"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+distribution-filename = { workspace = true }
+pep440_rs = { workspace = true }
+pypi-types = { workspace = true }
+uv-normalize = { workspace = true }
+
+async_zip = { workspace = true }
+fs-err = { workspace = true }
+futures = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+zip = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 cache-key = { workspace = true }
 distribution-filename = { workspace = true }
 distribution-types = { workspace = true }
-install-wheel-rs = { workspace = true }
 once-map = { workspace = true }
 pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
@@ -28,6 +27,7 @@ uv-configuration = { workspace = true }
 uv-distribution = { workspace = true }
 uv-fs = { workspace = true, features = ["serde"] }
 uv-git = { workspace = true }
+uv-metadata = { workspace = true }
 uv-normalize = { workspace = true }
 uv-pubgrub = { workspace = true }
 uv-python = { workspace = true }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -899,7 +899,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 );
                 return Ok(None);
             }
-            MetadataResponse::InvalidStructure { source: _, err } => {
+            MetadataResponse::InvalidStructure(err) => {
                 self.unavailable_packages.insert(
                     name.clone(),
                     UnavailablePackage::InvalidStructure(err.to_string()),
@@ -1272,8 +1272,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             UnavailableVersion::InconsistentMetadata,
                         ));
                     }
-                    MetadataResponse::InvalidStructure { source: _, err } => {
-                        warn!("Unable to extract metadata for {source}: {err}");
+                    MetadataResponse::InvalidStructure(err) => {
+                        warn!("Unable to extract metadata for {name}: {err}");
                         self.incomplete_packages
                             .entry(name.clone())
                             .or_default()
@@ -1668,7 +1668,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         MetadataResponse::InvalidMetadata(err) => {
                             warn!("Unable to extract metadata for {dist}: {err}");
                         }
-                        MetadataResponse::InvalidStructure { err, source: _ } => {
+                        MetadataResponse::InvalidStructure(err) => {
                             warn!("Unable to extract metadata for {dist}: {err}");
                         }
                         _ => {}
@@ -1686,7 +1686,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         MetadataResponse::InvalidMetadata(err) => {
                             warn!("Unable to extract metadata for {dist}: {err}");
                         }
-                        MetadataResponse::InvalidStructure { source: _, err } => {
+                        MetadataResponse::InvalidStructure(err) => {
                             warn!("Unable to extract metadata for {dist}: {err}");
                         }
                         _ => {}

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -899,7 +899,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                 );
                 return Ok(None);
             }
-            MetadataResponse::InvalidStructure(err) => {
+            MetadataResponse::InvalidStructure { source: _, err } => {
                 self.unavailable_packages.insert(
                     name.clone(),
                     UnavailablePackage::InvalidStructure(err.to_string()),
@@ -1272,8 +1272,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                             UnavailableVersion::InconsistentMetadata,
                         ));
                     }
-                    MetadataResponse::InvalidStructure(err) => {
-                        warn!("Unable to extract metadata for {name}: {err}");
+                    MetadataResponse::InvalidStructure { source: _, err } => {
+                        warn!("Unable to extract metadata for {source}: {err}");
                         self.incomplete_packages
                             .entry(name.clone())
                             .or_default()
@@ -1668,7 +1668,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         MetadataResponse::InvalidMetadata(err) => {
                             warn!("Unable to extract metadata for {dist}: {err}");
                         }
-                        MetadataResponse::InvalidStructure(err) => {
+                        MetadataResponse::InvalidStructure { err, source: _ } => {
                             warn!("Unable to extract metadata for {dist}: {err}");
                         }
                         _ => {}
@@ -1686,7 +1686,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         MetadataResponse::InvalidMetadata(err) => {
                             warn!("Unable to extract metadata for {dist}: {err}");
                         }
-                        MetadataResponse::InvalidStructure(err) => {
+                        MetadataResponse::InvalidStructure { source: _, err } => {
                             warn!("Unable to extract metadata for {dist}: {err}");
                         }
                         _ => {}

--- a/crates/uv-resolver/src/resolver/provider.rs
+++ b/crates/uv-resolver/src/resolver/provider.rs
@@ -39,10 +39,7 @@ pub enum MetadataResponse {
     /// The wheel metadata was found, but the metadata was inconsistent.
     InconsistentMetadata(Box<uv_distribution::Error>),
     /// The wheel has an invalid structure.
-    InvalidStructure {
-        source: String,
-        err: Box<uv_metadata::Error>,
-    },
+    InvalidStructure(Box<uv_metadata::Error>),
     /// The wheel metadata was not found in the cache and the network is not available.
     Offline,
 }
@@ -188,10 +185,7 @@ impl<'a, Context: BuildContext> ResolverProvider for DefaultResolverProvider<'a,
                         Ok(MetadataResponse::InvalidMetadata(err))
                     }
                     uv_client::ErrorKind::Metadata(_, err) => {
-                        Ok(MetadataResponse::InvalidStructure {
-                            source: dist.to_string(),
-                            err: Box::new(err),
-                        })
+                        Ok(MetadataResponse::InvalidStructure(Box::new(err)))
                     }
                     kind => Err(uv_client::Error::from(kind).into()),
                 },
@@ -204,11 +198,8 @@ impl<'a, Context: BuildContext> ResolverProvider for DefaultResolverProvider<'a,
                 uv_distribution::Error::Metadata(err) => {
                     Ok(MetadataResponse::InvalidMetadata(Box::new(err)))
                 }
-                uv_distribution::Error::WheelMetadata(source, err) => {
-                    Ok(MetadataResponse::InvalidStructure {
-                        source: source.to_string_lossy().to_string(),
-                        err,
-                    })
+                uv_distribution::Error::WheelMetadata(_, err) => {
+                    Ok(MetadataResponse::InvalidStructure(err))
                 }
                 err => Err(err),
             },

--- a/crates/uv/tests/pip_sync.rs
+++ b/crates/uv/tests/pip_sync.rs
@@ -2615,13 +2615,15 @@ fn incompatible_wheel() -> Result<()> {
         .arg("requirements.txt")
         .arg("--strict"), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to read `foo @ file://[TEMP_DIR]/foo-1.2.3-not-compatible-wheel.whl`
-      Caused by: Failed to unzip wheel: foo-1.2.3-not-compatible-wheel.whl
-      Caused by: unable to locate the end of central directory record
+      × No solution found when resolving dependencies:
+      ╰─▶ Because foo has an invalid package format and you require foo, we can conclude that your requirements are unsatisfiable.
+
+          hint: The structure of foo was invalid:
+            Failed to read from zip file
     "###
     );
 


### PR DESCRIPTION
This is preparatory work for the upload functionality, which needs to read the METADATA file and attach its parsed contents to the POST request: We move finding the `.dist-info` from `install-wheel-rs` and `uv-client` to a new `uv-metadata` crate, so it can be shared with the publish crate.

I don't properly know if its the right place since the upload code isn't ready, but i'm PR-ing it now because it already had merge conflicts.