### PR TITLE
Allow setting a target version for `uv self update`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -418,8 +418,15 @@ pub struct SelfNamespace {
 #[derive(Subcommand)]
 #[cfg(feature = "self-update")]
 pub enum SelfCommand {
-    /// Update uv to the latest version.
-    Update,
+    /// Update uv.
+    Update(SelfUpdateArgs),
+}
+
+#[derive(Args, Debug)]
+#[cfg(feature = "self-update")]
+pub struct SelfUpdateArgs {
+    /// If not specified, the latest version is used. Otherwise, updates to the specified version.
+    pub target_version: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -425,7 +425,7 @@ pub enum SelfCommand {
 #[derive(Args, Debug)]
 #[cfg(feature = "self-update")]
 pub struct SelfUpdateArgs {
-    /// If not specified, the latest version is used. Otherwise, updates to the specified version.
+    /// Update to the specified version. If not provided, uv will update to the latest version.
     pub target_version: Option<String>,
 }
 

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use anyhow::Result;
-use axoupdater::{AxoUpdater, AxoupdateError};
+use axoupdater::{AxoUpdater, AxoupdateError, UpdateRequest};
 use owo_colors::OwoColorize;
 use tracing::debug;
 
@@ -11,7 +11,7 @@ use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Attempt to update the uv binary.
-pub(crate) async fn self_update(printer: Printer) -> Result<ExitStatus> {
+pub(crate) async fn self_update(version: Option<String>, printer: Printer) -> Result<ExitStatus> {
     let mut updater = AxoUpdater::new_for("uv");
     updater.disable_installer_output();
 
@@ -69,6 +69,14 @@ pub(crate) async fn self_update(printer: Printer) -> Result<ExitStatus> {
             ":".bold()
         )
     )?;
+
+    let update_request = if let Some(version) = version {
+        UpdateRequest::SpecificTag(version)
+    } else {
+        UpdateRequest::Latest
+    };
+
+    updater.configure_version_specifier(update_request);
 
     // Run the updater. This involves a network request, since we need to determine the latest
     // available version of uv.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -18,7 +18,7 @@ use uv_cli::{
 };
 use uv_cli::{PythonCommand, PythonNamespace, ToolCommand, ToolNamespace};
 #[cfg(feature = "self-update")]
-use uv_cli::{SelfCommand, SelfNamespace};
+use uv_cli::{SelfCommand, SelfNamespace, SelfUpdateArgs};
 use uv_fs::CWD;
 use uv_requirements::RequirementsSource;
 use uv_scripts::Pep723Script;
@@ -766,8 +766,8 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         }
         #[cfg(feature = "self-update")]
         Commands::Self_(SelfNamespace {
-            command: SelfCommand::Update,
-        }) => commands::self_update(printer).await,
+            command: SelfCommand::Update(SelfUpdateArgs { target_version }),
+        }) => commands::self_update(target_version, printer).await,
         Commands::Version { output_format } => {
             commands::version(output_format, &mut stdout())?;
             Ok(ExitStatus::Success)


### PR DESCRIPTION
## Summary

Resolves #6642 

## Test Plan

```console
❯ cargo build --bin uv --features self-update
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.78s
❯ cp target/debug/uv ~/.cargo/bin
❯ uv self update 0.3.4
info: Checking for updates...
success: Upgraded uv from v0.4.8 to v0.3.4! https://github.com/astral-sh/uv/releases/tag/0.3.4
❯ uv --version
uv 0.3.4 (39f3cd2a9 2024-08-26)
❯ cp target/debug/uv ~/.cargo/bin
❯ uv self update
info: Checking for updates...
success: Upgraded uv from v0.3.4 to v0.4.8! https://github.com/astral-sh/uv/releases/tag/0.4.8
❯ uv --version
uv 0.4.8 (956cadd1a 2024-09-09)
```