### PR TITLE
Drop Python version range enforcement from `PythonVersion::from_str`

### DIFF
--- a/crates/uv-python/src/python_version.rs
+++ b/crates/uv-python/src/python_version.rs
@@ -31,12 +31,6 @@ impl FromStr for PythonVersion {
         if version.epoch() != 0 {
             return Err(format!("Python version `{s}` has a non-zero epoch"));
         }
-        if version.version < Version::new([3, 7]) {
-            return Err(format!("Python version `{s}` must be >= 3.7"));
-        }
-        if version.version >= Version::new([4, 0]) {
-            return Err(format!("Python version `{s}` must be < 4.0"));
-        }
 
         Ok(Self(version))
     }


### PR DESCRIPTION
This caused some problems earlier, as it prevented us from _listing_ Python versions <3.7 which seems weird (see https://github.com/astral-sh/uv/pull/7131#issuecomment-2334929000)

I'm worried that without this the changes to installation key parsing in https://github.com/astral-sh/uv/pull/7263 would otherwise be too restrictive.

I think if we want to enforce these ranges, we should do so separately from the parse step.