### PR TITLE
Support globs as cache keys in `tool.uv.cache-keys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4609,6 +4609,7 @@ name = "uv-cache-info"
 version = "0.0.1"
 dependencies = [
  "fs-err",
+ "glob",
  "schemars",
  "serde",
  "thiserror",

--- a/crates/uv-cache-info/Cargo.toml
+++ b/crates/uv-cache-info/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
+glob = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/crates/uv-settings/src/settings.rs
+++ b/crates/uv-settings/src/settings.rs
@@ -58,13 +58,20 @@ pub struct Options {
     /// to ensure that the project is rebuilt whenever the `requirements.txt` file is modified (in
     /// addition to watching the `pyproject.toml`).
     ///
+    /// Globs are supported, following the syntax of the [`glob`](https://docs.rs/glob/0.3.1/glob/struct.Pattern.html)
+    /// crate. For example, to invalidate the cache whenever a `.toml` file in the project directory
+    /// or any of its subdirectories is modified, you can specify `cache-keys = [{ file = "**/*.toml" }]`.
+    /// Note that the use of globs can be expensive, as uv may need to walk the filesystem to
+    /// determine whether any files have changed.
+    ///
     /// Cache keys can also include version control information. For example, if a project uses
     /// `setuptools_scm` to read its version from a Git tag, you can specify `cache-keys = [{ git = true }, { file = "pyproject.toml" }]`
     /// to include the current Git commit hash in the cache key (in addition to the
     /// `pyproject.toml`).
     ///
     /// Cache keys only affect the project defined by the `pyproject.toml` in which they're
-    /// specified (as opposed to, e.g., affecting all members in a workspace).
+    /// specified (as opposed to, e.g., affecting all members in a workspace), and all paths and
+    /// globs are interpreted as relative to the project directory.
     #[option(
         default = r#"[{ file = "pyproject.toml" }, { file = "setup.py" }, { file = "setup.cfg" }]"#,
         value_type = "list[dict]",

--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -52,6 +52,21 @@ the following to the project's `pyproject.toml`:
 cache-keys = [{ file = "requirements.txt" }]
 ```
 
+Globs are supported, following the syntax of the
+[`glob`](https://docs.rs/glob/0.3.1/glob/struct.Pattern.html) crate. For example, to invalidate the
+cache whenever a `.toml` file in the project directory or any of its subdirectories is modified, use
+the following:
+
+```toml title="pyproject.toml"
+[tool.uv]
+cache-keys = [{ file = "**/*.toml" }]
+```
+
+!!! note
+
+    The use of globs can be expensive, as uv may need to walk the filesystem to determine whether any files have changed.
+    This may, in turn, requiring traversal of large or deeply nested directories.
+
 As an escape hatch, if a project uses `dynamic` metadata that isn't covered by `tool.uv.cache-keys`,
 you can instruct uv to _always_ rebuild and reinstall it by adding the project to the
 `tool.uv.reinstall-package` list:

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -76,13 +76,20 @@ As an example: if a project uses dynamic metadata to read its dependencies from 
 to ensure that the project is rebuilt whenever the `requirements.txt` file is modified (in
 addition to watching the `pyproject.toml`).
 
+Globs are supported, following the syntax of the [`glob`](https://docs.rs/glob/0.3.1/glob/struct.Pattern.html)
+crate. For example, to invalidate the cache whenever a `.toml` file in the project directory
+or any of its subdirectories is modified, you can specify `cache-keys = [{ file = "**/*.toml" }]`.
+Note that the use of globs can be expensive, as uv may need to walk the filesystem to
+determine whether any files have changed.
+
 Cache keys can also include version control information. For example, if a project uses
 `setuptools_scm` to read its version from a Git tag, you can specify `cache-keys = [{ git = true }, { file = "pyproject.toml" }]`
 to include the current Git commit hash in the cache key (in addition to the
 `pyproject.toml`).
 
 Cache keys only affect the project defined by the `pyproject.toml` in which they're
-specified (as opposed to, e.g., affecting all members in a workspace).
+specified (as opposed to, e.g., affecting all members in a workspace), and all paths and
+globs are interpreted as relative to the project directory.
 
 **Default value**: `[{ file = "pyproject.toml" }, { file = "setup.py" }, { file = "setup.cfg" }]`
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -22,7 +22,7 @@
       ]
     },
     "cache-keys": {
-      "description": "The keys to consider when caching builds for the project.\n\nCache keys enable you to specify the files or directories that should trigger a rebuild when modified. By default, uv will rebuild a project whenever the `pyproject.toml`, `setup.py`, or `setup.cfg` files in the project directory are modified, i.e.:\n\n```toml cache-keys = [{ file = \"pyproject.toml\" }, { file = \"setup.py\" }, { file = \"setup.cfg\" }] ```\n\nAs an example: if a project uses dynamic metadata to read its dependencies from a `requirements.txt` file, you can specify `cache-keys = [{ file = \"requirements.txt\" }, { file = \"pyproject.toml\" }]` to ensure that the project is rebuilt whenever the `requirements.txt` file is modified (in addition to watching the `pyproject.toml`).\n\nCache keys can also include version control information. For example, if a project uses `setuptools_scm` to read its version from a Git tag, you can specify `cache-keys = [{ git = true }, { file = \"pyproject.toml\" }]` to include the current Git commit hash in the cache key (in addition to the `pyproject.toml`).\n\nCache keys only affect the project defined by the `pyproject.toml` in which they're specified (as opposed to, e.g., affecting all members in a workspace).",
+      "description": "The keys to consider when caching builds for the project.\n\nCache keys enable you to specify the files or directories that should trigger a rebuild when modified. By default, uv will rebuild a project whenever the `pyproject.toml`, `setup.py`, or `setup.cfg` files in the project directory are modified, i.e.:\n\n```toml cache-keys = [{ file = \"pyproject.toml\" }, { file = \"setup.py\" }, { file = \"setup.cfg\" }] ```\n\nAs an example: if a project uses dynamic metadata to read its dependencies from a `requirements.txt` file, you can specify `cache-keys = [{ file = \"requirements.txt\" }, { file = \"pyproject.toml\" }]` to ensure that the project is rebuilt whenever the `requirements.txt` file is modified (in addition to watching the `pyproject.toml`).\n\nGlobs are supported, following the syntax of the [`glob`](https://docs.rs/glob/0.3.1/glob/struct.Pattern.html) crate. For example, to invalidate the cache whenever a `.toml` file in the project directory or any of its subdirectories is modified, you can specify `cache-keys = [{ file = \"**/*.toml\" }]`. Note that the use of globs can be expensive, as uv may need to walk the filesystem to determine whether any files have changed.\n\nCache keys can also include version control information. For example, if a project uses `setuptools_scm` to read its version from a Git tag, you can specify `cache-keys = [{ git = true }, { file = \"pyproject.toml\" }]` to include the current Git commit hash in the cache key (in addition to the `pyproject.toml`).\n\nCache keys only affect the project defined by the `pyproject.toml` in which they're specified (as opposed to, e.g., affecting all members in a workspace), and all paths and globs are interpreted as relative to the project directory.",
       "writeOnly": true,
       "type": [
         "array",
@@ -432,11 +432,11 @@
     "CacheKey": {
       "anyOf": [
         {
-          "description": "Ex) `\"Cargo.lock\"`",
+          "description": "Ex) `\"Cargo.lock\"` or `\"**/*.toml\"`",
           "type": "string"
         },
         {
-          "description": "Ex) `{ file = \"Cargo.lock\" }`",
+          "description": "Ex) `{ file = \"Cargo.lock\" }` or `{ file = \"**/*.toml\" }`",
           "type": "object",
           "required": [
             "file"


### PR DESCRIPTION
## Summary

This has been asked for a few times. There are risks that these checks could be slow, but they're buyer-beware.

Closes https://github.com/astral-sh/uv/issues/7246.
