### PR TITLE
Display the Python version in malformed installation key traces

### DIFF
--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -335,7 +335,7 @@ impl FromStr for PythonInstallationKey {
         let version = PythonVersion::from_str(version).map_err(|err| {
             PythonInstallationKeyError::ParseError(
                 key.to_string(),
-                format!("invalid Python version: {err}"),
+                format!("invalid Python version `{version}`: {err}"),
             )
         })?;
 


### PR DESCRIPTION
e.g., the existing message is bad?

```
WARN Ignoring malformed managed Python entry:
    Failed to parse Python installation key `cpython-3.13.0rc2-macos-aarch64-none`: invalid Python version: invalid digit found in string