### PR TITLE
Apply `--no-install` options when constructing resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4700,7 +4700,6 @@ dependencies = [
  "anyhow",
  "cache-key",
  "clap",
- "distribution-types",
  "either",
  "pep508_rs",
  "platform-tags",

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2536,11 +2536,6 @@ pub struct SyncArgs {
     #[arg(long, overrides_with("dev"))]
     pub no_dev: bool,
 
-    // /// Omit non-development dependencies.
-    // ///
-    // /// The project itself will also be omitted.
-    // #[arg(long, conflicts_with("no_dev"))]
-    // pub only_dev: bool,
     /// Do not remove extraneous packages present in the environment.
     ///
     /// When enabled, uv will make the minimum necessary changes to satisfy the requirements.

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2536,6 +2536,11 @@ pub struct SyncArgs {
     #[arg(long, overrides_with("dev"))]
     pub no_dev: bool,
 
+    // /// Omit non-development dependencies.
+    // ///
+    // /// The project itself will also be omitted.
+    // #[arg(long, conflicts_with("no_dev"))]
+    // pub only_dev: bool,
     /// Do not remove extraneous packages present in the environment.
     ///
     /// When enabled, uv will make the minimum necessary changes to satisfy the requirements.

--- a/crates/uv-configuration/Cargo.toml
+++ b/crates/uv-configuration/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 cache-key = { workspace = true }
-distribution-types = { workspace = true }
 pep508_rs = { workspace = true, features = ["schemars"] }
 platform-tags = { workspace = true }
 pypi-types = { workspace = true }

--- a/crates/uv-resolver/src/lock/requirements_txt.rs
+++ b/crates/uv-resolver/src/lock/requirements_txt.rs
@@ -134,7 +134,7 @@ impl<'lock> RequirementsTxtExport<'lock> {
         let mut nodes: Vec<Node> = petgraph
             .node_references()
             .filter(|(_index, package)| {
-                install_options.include_package(&package.id.name, root_name, lock.members())
+                install_options.include_package(&package.id.name, Some(root_name), lock.members())
             })
             .map(|(index, package)| Node {
                 package,

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -219,14 +219,18 @@ pub(super) async fn do_sync(
     let tags = venv.interpreter().tags()?;
 
     // Read the lockfile.
-    let resolution = lock.to_resolution(target, &markers, tags, extras, &dev, build_options)?;
+    let resolution = lock.to_resolution(
+        target,
+        &markers,
+        tags,
+        extras,
+        &dev,
+        build_options,
+        &install_options,
+    )?;
 
     // Always skip virtual projects, which shouldn't be built or installed.
     let resolution = apply_no_virtual_project(resolution);
-
-    // Filter resolution based on install-specific options.
-    let resolution =
-        install_options.filter_resolution(resolution, target.project_name(), lock.members());
 
     // Add all authenticated sources to the cache.
     for url in index_locations.urls() {


### PR DESCRIPTION
## Summary

We need to apply the `--no-install` filters earlier, such that we don't error if we only have a source distribution for a given package when `--no-build` is provided but that package is _omitted_.

Closes #7247.
