### PR TITLE
Avoid selecting pre-releases for Python downloads without a version request

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -225,6 +225,7 @@ impl PythonDownloadRequest {
             .filter(move |download| self.satisfied_by_download(download))
     }
 
+    /// Whether this request is satisfied by the key of an existing installation.
     pub fn satisfied_by_key(&self, key: &PythonInstallationKey) -> bool {
         if let Some(arch) = &self.arch {
             if key.arch != *arch {
@@ -254,7 +255,14 @@ impl PythonDownloadRequest {
         true
     }
 
+    /// Whether this request is satisfied by a Python download.
+    ///
+    /// Note that unlike [`Self::satisfied_by_key`], this method will not match a pre-release
+    /// unless a version is included in the request.
     pub fn satisfied_by_download(&self, download: &ManagedPythonDownload) -> bool {
+        if self.version.is_none() && !download.key().prerelease.is_empty() {
+            return false;
+        }
         self.satisfied_by_key(download.key())
     }
 


### PR DESCRIPTION
Following #7263 the 3.13.0rc2 releases are at the top of the download list but we should not select them unless 3.13 is actually requested.

Prior to this, `uv python install` would install `3.13.0rc2`. 

```
❯ cargo run -- python install --no-config
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/uv python install --no-config`
Searching for Python installations
Installed Python 3.12.6 in 1.33s
 + cpython-3.12.6-macos-aarch64-none
```

```
❯ cargo run -- python install --no-config 3.13
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/uv python install --no-config 3.13`
Searching for Python versions matching: Python 3.13
Installed Python 3.13.0rc2 in 1.18s
 + cpython-3.13.0rc2-macos-aarch64-none
```
