### PR TITLE
feat(cli): add `--token` option to `self update` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4464,6 +4464,7 @@ dependencies = [
  "flate2",
  "fs-err",
  "futures",
+ "http",
  "ignore",
  "indexmap",
  "indicatif",

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -427,6 +427,10 @@ pub enum SelfCommand {
 pub struct SelfUpdateArgs {
     /// Update to the specified version. If not provided, uv will update to the latest version.
     pub target_version: Option<String>,
+
+    /// Specify a github token for authentication during the update process.
+    #[arg(long, env = "UV_GITHUB_TOKEN")]
+    pub token: Option<String>,
 }
 
 #[derive(Args)]

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -428,7 +428,8 @@ pub struct SelfUpdateArgs {
     /// Update to the specified version. If not provided, uv will update to the latest version.
     pub target_version: Option<String>,
 
-    /// Specify a github token for authentication during the update process.
+    /// A GitHub token for authentication.
+    /// A token is not required but can be used to reduce the chance of encountering rate limits.
     #[arg(long, env = "UV_GITHUB_TOKEN")]
     pub token: Option<String>,
 }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -55,6 +55,7 @@ ctrlc = { workspace = true }
 flate2 = { workspace = true, default-features = false }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
+http = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true }
 indoc = { workspace = true }

--- a/crates/uv/src/commands/self_update.rs
+++ b/crates/uv/src/commands/self_update.rs
@@ -11,9 +11,17 @@ use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
 /// Attempt to update the uv binary.
-pub(crate) async fn self_update(version: Option<String>, printer: Printer) -> Result<ExitStatus> {
+pub(crate) async fn self_update(
+    version: Option<String>,
+    token: Option<String>,
+    printer: Printer,
+) -> Result<ExitStatus> {
     let mut updater = AxoUpdater::new_for("uv");
     updater.disable_installer_output();
+
+    if let Some(token) = token {
+        updater.set_github_token(&token);
+    }
 
     // Load the "install receipt" for the current binary. If the receipt is not found, then
     // uv was likely installed via a package manager.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -766,8 +766,12 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
         }
         #[cfg(feature = "self-update")]
         Commands::Self_(SelfNamespace {
-            command: SelfCommand::Update(SelfUpdateArgs { target_version }),
-        }) => commands::self_update(target_version, printer).await,
+            command:
+                SelfCommand::Update(SelfUpdateArgs {
+                    target_version,
+                    token,
+                }),
+        }) => commands::self_update(target_version, token, printer).await,
         Commands::Version { output_format } => {
             commands::version(output_format, &mut stdout())?;
             Ok(ExitStatus::Success)


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

It often reaches the GitHub API rate limit and shows error like `error: HTTP status client error (403 Forbidden) for url (https://api.github.com/repos/astral-sh/uv/releases)` when running `uv self update`.

To bypass this rate limit issue, allow user to pass a GitHub token via `--token` or `UV_GITHUB_TOKEN` env.

## Test Plan

<!-- How was it tested? -->
