### PR TITLE
Update installation.md: Add x-cmd method to install uv

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -124,6 +124,14 @@ uv is available via [winget](https://winstall.app/apps/astral-sh.uv).
 $ winget install --id=astral-sh.uv  -e
 ```
 
+### X-CMD
+
+[x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.
+
+```console
+$ x env use uv
+```
+
 ### Docker
 
 uv provides a Docker image at


### PR DESCRIPTION
## Summary

Add x-cmd method to install uv

- Hi, we have implemented a lightweight [package manager using shell and awk](https://www.x-cmd.com/pkg/). It helps you download uv release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the uv installation.md?**[The installation method for the x command](https://www.x-cmd.com/start/) and [uv demo](https://www.x-cmd.com/pkg/uv)
  ```sh
  x env use uv
  ```
## Test Plan

Nothing.

