### PR TITLE
Include pre-release Python versions in `uv python list`

### DIFF
--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -50,7 +50,9 @@ pub(crate) async fn list(
                     None
                 }
             }
-        };
+        }
+        // Include pre-release versions
+        .map(|request| request.with_prereleases(true));
 
         let downloads = download_request
             .as_ref()

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -75,6 +75,8 @@ async fn do_uninstall(
                 anyhow::anyhow!("Cannot uninstall managed Python for request: {request}")
             })
         })
+        // Always include pre-releases in uninstalls
+        .map(|result| result.map(|request| request.with_prereleases(true)))
         .collect::<Result<Vec<_>>>()?;
 
     let installed_installations: Vec<_> = installations.find_all()?.collect();


### PR DESCRIPTION
Follows https://github.com/astral-sh/uv/pull/7278

Closes https://github.com/astral-sh/uv/issues/7280

`uv python list` should show installed pre-release versions, even though we don't select them by default (as defined by #7300 and https://github.com/astral-sh/uv/pull/7278)