### PR TITLE
Fix PPC64 page size in binary builds.

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -431,8 +431,12 @@ jobs:
         platform:
           - target: powerpc64le-unknown-linux-gnu
             arch: ppc64le
+            # see https://github.com/astral-sh/uv/issues/6528
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: powerpc64-unknown-linux-gnu
             arch: ppc64
+            # see https://github.com/astral-sh/uv/issues/6528
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
 
     steps:
       - uses: actions/checkout@v4
@@ -576,6 +580,8 @@ jobs:
             arch: armv7
           - target: powerpc64le-unknown-linux-musl
             arch: ppc64le
+            # see https://github.com/astral-sh/uv/issues/6528
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
             toolchain: nightly
       fail-fast: false
 


### PR DESCRIPTION
## Summary

Add maturin build flag to set 64kb page size on PPC64 and PPC64LE architectures. Not aware of modern systems that use 4kb pages.

Resolves #6528

## Test Plan

ppc64le gnu dynamic-linked and musl static-linked binary builds were tested successfully on an IBM Power9 system running RHEL 8.8. I do not have access to other types of PPC64 systems for testing.
