### PR TITLE
Avoid selecting prerelease Python installations without opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1405,7 +1405,7 @@ jobs:
         run: echo $(which python3.13)
 
       - name: "Validate global Python install"
-        run: python3.13 scripts/check_system_python.py --uv ./uv
+        run: python3.13 scripts/check_system_python.py --uv ./uv --python 3.13
 
   system-test-conda:
     timeout-minutes: 10

--- a/docs/concepts/python-versions.md
+++ b/docs/concepts/python-versions.md
@@ -189,6 +189,17 @@ a system Python version, uv will use the first compatible version — not the ne
 If a Python version cannot be found on the system, uv will check for a compatible managed Python
 version download.
 
+### Python pre-releases
+
+Python pre-releases will not be selected by default. Python pre-releases will be used if there is no
+other available installation matching the request. For example, if only a pre-release version is
+available it will be used but otherwise a stable release version will be used. Similarly, if the
+path to a pre-release Python executable is provided then no other Python version matches the request
+and the pre-release version will be used.
+
+If a pre-release Python version is available and matches the request, uv will not download a stable
+Python version instead.
+
 ## Disabling automatic Python downloads
 
 By default, uv will automatically download Python versions when needed.


### PR DESCRIPTION
Similar to our semantics for packages with pre-release versions.

We will not use prerelease versions unless there are only prerelease versions available, a specific version is requested, 
or the prerelease version is found in a reasonable source (active environment, explicit path, etc. but not `PATH`).

For example, `uv python install 3.13 && uv run python --version` will no longer use `3.13.0rc2` unless that is the only Python version available, `--python 3.13` is used, or that's the Python version that is present in `.venv`.
