### PR TITLE
Add Python 3.13 system test for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1356,7 +1356,7 @@ jobs:
   system-test-pyenv:
     timeout-minutes: 10
     needs: build-binary-linux
-    name: "check system | python via pyenv"
+    name: "check system | python3.9 via pyenv"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -1379,6 +1379,33 @@ jobs:
 
       - name: "Validate global Python install"
         run: python3.9 scripts/check_system_python.py --uv ./uv
+
+  system-test-linux-313:
+    timeout-minutes: 10
+    needs: build-binary-linux
+    name: "check system | python3.13"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+          allow-prereleases: true
+
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-linux-${{ github.sha }}
+
+      - name: "Prepare binary"
+        run: chmod +x ./uv
+
+      - name: "Print Python path"
+        run: echo $(which python3.13)
+
+      - name: "Validate global Python install"
+        run: python3.13 scripts/check_system_python.py --uv ./uv
 
   system-test-conda:
     timeout-minutes: 10


### PR DESCRIPTION
Previously we only had coverage on Windows

e.g. for more test coverage in cases like https://github.com/astral-sh/uv/pull/7300#discussion_r1755343870

I picked Linux over macOS because the 3.13 prereleases are not available via HomeBrew?