### PR TITLE
Show verbose output during system install in test

### DIFF
--- a/scripts/check_system_python.py
+++ b/scripts/check_system_python.py
@@ -68,7 +68,8 @@ if __name__ == "__main__":
         # Install the package (`pylint`).
         logging.info("Installing the package `pylint`.")
         subprocess.run(
-            [uv, "pip", "install", "pylint", "--system"] + allow_externally_managed,
+            [uv, "pip", "install", "pylint", "--system", "--verbose"]
+            + allow_externally_managed,
             cwd=temp_dir,
             check=True,
         )


### PR DESCRIPTION
We do this for the other installs and it is helpful for debugging

This is missing in https://github.com/astral-sh/uv/actions/runs/10817725906/job/30011855241?pr=7300