### PR TITLE
generate-shell-completion: generate `uvx` shell completions for the fish shell

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4240,4 +4240,12 @@ pub fn generate_shell_completion(
     buffer: &mut dyn std::io::Write,
 ) {
     shell.generate(&mut Cli::command(), buffer);
+    // `uvx` completion
+    #[allow(clippy::single_match)] // Hopefully, this will be implemented for other shells as well
+    match shell {
+        clap_complete_command::Shell::Fish => {
+            writeln!(buffer, r#"complete -c uvx --wraps "uv tool run""#).ok();
+        }
+        _ => {}
+    };
 }

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use anyhow::{anyhow, Result};
 use clap::builder::styling::{AnsiColor, Effects, Style};
 use clap::builder::Styles;
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 use distribution_types::{FlatIndexLocation, IndexUrl};
 use pep508_rs::Requirement;
 use pypi_types::VerbatimParsedUrl;
@@ -4233,4 +4233,11 @@ pub struct DisplayTreeArgs {
     /// Show the reverse dependencies for the given package. This flag will invert the tree and display the packages that depend on the given package.
     #[arg(long, alias = "reverse")]
     pub invert: bool,
+}
+
+pub fn generate_shell_completion(
+    shell: &clap_complete_command::Shell,
+    buffer: &mut dyn std::io::Write,
+) {
+    shell.generate(&mut Cli::command(), buffer);
 }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -6,7 +6,7 @@ use std::process::ExitCode;
 use anstream::eprintln;
 use anyhow::Result;
 use clap::error::{ContextKind, ContextValue};
-use clap::{CommandFactory, Parser};
+use clap::Parser;
 use owo_colors::OwoColorize;
 use settings::PipTreeSettings;
 use tracing::{debug, instrument};
@@ -773,7 +773,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
             Ok(ExitStatus::Success)
         }
         Commands::GenerateShellCompletion(args) => {
-            args.shell.generate(&mut Cli::command(), &mut stdout());
+            uv_cli::generate_shell_completion(&args.shell, &mut stdout());
             Ok(ExitStatus::Success)
         }
         Commands::Tool(ToolNamespace {


### PR DESCRIPTION
Cc: #7258

## Summary

`uv generate-shell-completion fish` will automatically include completion for `uvx`.

Hopefully, others will contribute something similar to other shells.

## Test Plan

I ran

     cargo run -- generate-shell-completion fish |source

in `fish` and checked `uvx --f<TAB>` expands to the correct options. You can also do `uvx -<TAB>`.