### PR TITLE
Fix documentation typos for `uv build --build-constraint` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Enhancements
 
-- Accept `--build-constraints` in `uv build` ([#7085](https://github.com/astral-sh/uv/pull/7085))
+- Accept `--build-constraint` in `uv build` ([#7085](https://github.com/astral-sh/uv/pull/7085))
 - Add `--require-hashes` and `--verify-hashes` to `uv build` ([#7094](https://github.com/astral-sh/uv/pull/7094))
 - Add `--show-version-specifiers` to `uv tool list` ([#7050](https://github.com/astral-sh/uv/pull/7050))
 - Respect hashes in constraints files ([#7093](https://github.com/astral-sh/uv/pull/7093))

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -1991,7 +1991,7 @@ pub struct BuildArgs {
     /// Require a matching hash for each build requirement.
     ///
     /// Hash-checking mode is all or nothing. If enabled, _all_ build requirements must be provided
-    /// with a corresponding hash or set of hashes via the `--build-constraints` argument.
+    /// with a corresponding hash or set of hashes via the `--build-constraint` argument.
     /// Additionally, if enabled, _all_ requirements must either be pinned to exact versions
     /// (e.g., `==1.0.0`), or be specified via direct URL.
     ///

--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -585,7 +585,7 @@ You can limit `uv build` to building a source distribution with `uv build --sdis
 distribution with `uv build --wheel`, or build both distributions from source with
 `uv build --sdist --wheel`.
 
-`uv build` accepts `--build-constraints`, which can be used to constrain the versions of any build
+`uv build` accepts `--build-constraint`, which can be used to constrain the versions of any build
 requirements during the build process. When coupled with `--require-hashes`, uv will enforce that
 the requirement used to build the project match specific, known hashes, for reproducibility.
 
@@ -599,7 +599,7 @@ Running the following would build the project with the specified version of `set
 that the downloaded `setuptools` distribution matches the specified hash:
 
 ```console
-$ uv build --build-constraints constraints.txt --require-hashes
+$ uv build --build-constraint constraints.txt --require-hashes
 ```
 
 ## Build isolation

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6450,7 +6450,7 @@ uv build [OPTIONS] [SRC]
 
 </dd><dt><code>--require-hashes</code></dt><dd><p>Require a matching hash for each build requirement.</p>
 
-<p>Hash-checking mode is all or nothing. If enabled, <em>all</em> build requirements must be provided with a corresponding hash or set of hashes via the <code>--build-constraints</code> argument. Additionally, if enabled, <em>all</em> requirements must either be pinned to exact versions (e.g., <code>==1.0.0</code>), or be specified via direct URL.</p>
+<p>Hash-checking mode is all or nothing. If enabled, <em>all</em> build requirements must be provided with a corresponding hash or set of hashes via the <code>--build-constraint</code> argument. Additionally, if enabled, <em>all</em> requirements must either be pinned to exact versions (e.g., <code>==1.0.0</code>), or be specified via direct URL.</p>
 
 <p>Hash-checking mode introduces a number of additional constraints:</p>
 


### PR DESCRIPTION
Summary

This pull request fixes a typo in the --build-constraints flag, which should be singular (--build-constraint). This update ensures consistency across the documentation and prevents potential confusion for users.

Closes #7315

## Test Plan
The change was verified by reviewing the relevant documentation files where the flag is referenced. No functional code changes were made, so no additional testing is required beyond confirming the documentation update.

## Tested
The change was tested by visually inspecting the updated documentation to confirm that the typo has been corrected
