### PR TITLE
Support pre-releases in Python version requests - `command --python <major.minor.pre-release>`

### DIFF
--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -1415,20 +1415,6 @@ impl std::fmt::Display for Prerelease {
     }
 }
 
-impl FromStr for Prerelease {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let version = Version::from_str(s).map_err(|err| err.to_string())?;
-        match version.pre() {
-            Some(pre) => Ok(pre),
-            None => Err(format!(
-                "unable to parse pre-release version from the given input: {s}"
-            )),
-        }
-    }
-}
-
 /// A part of the [local version identifier](<https://peps.python.org/pep-0440/#local-version-identifiers>)
 ///
 /// Local versions are a mess:

--- a/crates/pep440-rs/src/version.rs
+++ b/crates/pep440-rs/src/version.rs
@@ -1415,6 +1415,20 @@ impl std::fmt::Display for Prerelease {
     }
 }
 
+impl FromStr for Prerelease {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let version = Version::from_str(s).map_err(|err| err.to_string())?;
+        match version.pre() {
+            Some(pre) => Ok(pre),
+            None => Err(format!(
+                "unable to parse pre-release version from the given input: {s}"
+            )),
+        }
+    }
+}
+
 /// A part of the [local version identifier](<https://peps.python.org/pep-0440/#local-version-identifiers>)
 ///
 /// Local versions are a mess:

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1920,7 +1920,7 @@ mod tests {
     use std::{path::PathBuf, str::FromStr};
 
     use assert_fs::{prelude::*, TempDir};
-    use pep440_rs::Prerelease;
+    use pep440_rs::{Prerelease, PrereleaseKind};
     use test_log::test;
 
     use crate::{
@@ -2221,15 +2221,36 @@ mod tests {
         );
         assert_eq!(
             VersionRequest::from_str("3.13a1").unwrap(),
-            VersionRequest::MajorMinorPrerelease(3, 13, Prerelease::from_str("3.13a1").unwrap())
+            VersionRequest::MajorMinorPrerelease(
+                3,
+                13,
+                Prerelease {
+                    kind: PrereleaseKind::Alpha,
+                    number: 1
+                }
+            )
         );
         assert_eq!(
             VersionRequest::from_str("3.13.0b2").unwrap(),
-            VersionRequest::MajorMinorPrerelease(3, 13, Prerelease::from_str("3.13.0b2").unwrap())
+            VersionRequest::MajorMinorPrerelease(
+                3,
+                13,
+                Prerelease {
+                    kind: PrereleaseKind::Beta,
+                    number: 2
+                }
+            )
         );
         assert_eq!(
             VersionRequest::from_str("3.13.0rc3").unwrap(),
-            VersionRequest::MajorMinorPrerelease(3, 13, Prerelease::from_str("3.13.0rc3").unwrap())
+            VersionRequest::MajorMinorPrerelease(
+                3,
+                13,
+                Prerelease {
+                    kind: PrereleaseKind::Rc,
+                    number: 3
+                }
+            )
         );
         assert!(
             // Test for overflow

--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1554,10 +1554,10 @@ impl VersionRequest {
                     ));
                 }
             }
-            Self::MajorMinorPrerelease(major, minor, _) => {
+            Self::MajorMinorPrerelease(major, minor, prerelease) => {
                 if (*major, *minor) < (3, 7) {
                     return Err(format!(
-                        "Python <3.7 is not supported but {major}.{minor} was requested."
+                        "Python <3.7 is not supported but {major}.{minor}{prerelease} was requested."
                     ));
                 }
             }


### PR DESCRIPTION
## Summary

This PR adds support to include Python pre-releases when requesting versions. 
Check out the docs for commands that support the `Python` option: 
```text
--python, -p python
The Python interpreter to use for the virtual environment.
```
At least the following scenarios are supported:
```bash
3.13.0a1
3.13b2
3.13rc4
313rc1
```

## Test Plan

I added a basic unit test to `uv/crates/uv-python/src/discovery.rs`. I could have added more, but I have not discovered any relevant places.

CI passes

Note: I was unable to execute the entire test set locally. There were at least some timeout issues (some tests took over 60 seconds). 

========== output ===========
beta version
```bash
cargo run -- venv --python 3.13.0b3                                                                                                           ░▒▓ 94% 󰁹
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/uv venv --python 3.13.0b3`
Using Python 3.13.0b3 interpreter at: /home/mikko/.pyenv/versions/3.13.0b3/bin/python3
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
````
release candidate
```bash
 cargo run -- venv --python 3.13.0rc2                                                                                                          ░▒▓ 94% 󰁹
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.83s
     Running `target/debug/uv venv --python 3.13.0rc2`
Using Python 3.13.0rc2 interpreter at: /home/mikko/.pyenv/versions/3.13.0rc2/bin/python3
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
```

```bash
cargo run -- venv --python 313rc2                                                                                                             ░▒▓ 94% 󰁹
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.31s
     Running `target/debug/uv venv --python 313rc2`
Using Python 3.13.0rc2 interpreter at: /home/mikko/.pyenv/versions/3.13.0rc2/bin/python3
Creating virtualenv at: .venv
Activate with: source .venv/bin/activate
```

