### PR TITLE
Use `globwalk` for `cache-keys` matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,7 +4610,7 @@ name = "uv-cache-info"
 version = "0.0.1"
 dependencies = [
  "fs-err",
- "glob",
+ "globwalk",
  "schemars",
  "serde",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ fs-err = { version = "2.11.0" }
 fs2 = { version = "0.4.3" }
 futures = { version = "0.3.30" }
 glob = { version = "0.3.1" }
+globwalk = { version = "0.9.1" }
 goblin = { version = "0.8.2", default-features = false, features = ["std", "elf32", "elf64", "endian_fd"] }
 hex = { version = "0.4.3" }
 home = { version = "0.5.9" }

--- a/crates/uv-cache-info/Cargo.toml
+++ b/crates/uv-cache-info/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-glob = { workspace = true }
+globwalk = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -46,6 +46,8 @@ pub enum Error {
     CacheEncode(#[from] rmp_serde::encode::Error),
     #[error("Failed to walk the distribution cache")]
     CacheWalk(#[source] walkdir::Error),
+    #[error(transparent)]
+    CacheInfo(#[from] uv_cache_info::CacheInfoError),
 
     // Build error
     #[error(transparent)]

--- a/crates/uv-distribution/src/index/built_wheel_index.rs
+++ b/crates/uv-distribution/src/index/built_wheel_index.rs
@@ -132,8 +132,7 @@ impl<'a> BuiltWheelIndex<'a> {
         };
 
         // If the distribution is stale, omit it from the index.
-        let cache_info =
-            CacheInfo::from_directory(&source_dist.install_path).map_err(Error::CacheRead)?;
+        let cache_info = CacheInfo::from_directory(&source_dist.install_path)?;
 
         if cache_info != *pointer.cache_info() {
             return Ok(None);

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1112,8 +1112,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
         }
 
         // Determine the last-modified time of the source distribution.
-        let cache_info =
-            CacheInfo::from_directory(&resource.install_path).map_err(Error::CacheRead)?;
+        let cache_info = CacheInfo::from_directory(&resource.install_path)?;
 
         // Read the existing metadata from the cache.
         let entry = cache_shard.entry(LOCAL_REVISION);


### PR DESCRIPTION
## Summary

This should be more efficient as we can do a single traversal.

Closes https://github.com/astral-sh/uv/issues/7321.
