### PR TITLE
Fix grammatical error in CLI docs

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2780,7 +2780,7 @@ pub struct AddArgs {
     /// Add the dependency to the specified Python script, rather than to a project.
     ///
     /// If provided, uv will add the dependency to the script's inline metadata
-    /// table, in adhere with PEP 723. If no such inline metadata table is present,
+    /// table, in adherence with PEP 723. If no such inline metadata table is present,
     /// a new one will be created and added to the script. When executed via `uv run`,
     /// uv will create a temporary environment for the script with all inline
     /// dependencies installed.
@@ -2849,7 +2849,7 @@ pub struct RemoveArgs {
     /// Remove the dependency from the specified Python script, rather than from a project.
     ///
     /// If provided, uv will remove the dependency from the script's inline metadata
-    /// table, in adhere with PEP 723.
+    /// table, in adherence with PEP 723.
     #[arg(long)]
     pub script: Option<PathBuf>,
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -812,7 +812,7 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 
 </dd><dt><code>--script</code> <i>script</i></dt><dd><p>Add the dependency to the specified Python script, rather than to a project.</p>
 
-<p>If provided, uv will add the dependency to the script&#8217;s inline metadata table, in adhere with PEP 723. If no such inline metadata table is present, a new one will be created and added to the script. When executed via <code>uv run</code>, uv will create a temporary environment for the script with all inline dependencies installed.</p>
+<p>If provided, uv will add the dependency to the script&#8217;s inline metadata table, in adherence with PEP 723. If no such inline metadata table is present, a new one will be created and added to the script. When executed via <code>uv run</code>, uv will create a temporary environment for the script with all inline dependencies installed.</p>
 
 </dd><dt><code>--tag</code> <i>tag</i></dt><dd><p>Tag to use when adding a dependency from Git</p>
 
@@ -1100,7 +1100,7 @@ uv remove [OPTIONS] <PACKAGES>...
 </ul>
 </dd><dt><code>--script</code> <i>script</i></dt><dd><p>Remove the dependency from the specified Python script, rather than from a project.</p>
 
-<p>If provided, uv will remove the dependency from the script&#8217;s inline metadata table, in adhere with PEP 723.</p>
+<p>If provided, uv will remove the dependency from the script&#8217;s inline metadata table, in adherence with PEP 723.</p>
 
 </dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 


### PR DESCRIPTION
Fixing a grammatical error in the CLI docs, namely `in adhere with` -> `in adherence with`.