### PR TITLE
Feature/add file extension aliases 7365

### DIFF
--- a/crates/distribution-filename/src/extension.rs
+++ b/crates/distribution-filename/src/extension.rs
@@ -51,34 +51,6 @@ impl DistExtension {
     }
 }
 
-// impl SourceDistExtension {
-//     /// Extract the [`SourceDistExtension`] from a path.
-//     pub fn from_path(path: impl AsRef<Path>) -> Result<Self, ExtensionError> {
-//         /// Returns true if the path is a tar file (e.g., `.tar.gz`).
-//         fn is_tar(path: &Path) -> bool {
-//             path.file_stem().is_some_and(|stem| {
-//                 Path::new(stem)
-//                     .extension()
-//                     .is_some_and(|ext| ext.eq_ignore_ascii_case("tar"))
-//             })
-//         }
-
-//         let Some(extension) = path.as_ref().extension().and_then(|ext| ext.to_str()) else {
-//             return Err(ExtensionError::SourceDist);
-//         };
-
-//         match extension {
-//             "zip" => Ok(Self::Zip),
-//             "gz" if is_tar(path.as_ref()) => Ok(Self::TarGz),
-//             "tgz" => Ok(Self::TarGz),
-//             "bz2" if is_tar(path.as_ref()) => Ok(Self::TarBz2),
-//             "xz" if is_tar(path.as_ref()) => Ok(Self::TarXz),
-//             "zst" if is_tar(path.as_ref()) => Ok(Self::TarZst),
-//             _ => Err(ExtensionError::SourceDist),
-//         }
-//     }
-// }
-
 impl SourceDistExtension {
     /// Extract the [`SourceDistExtension`] from a path.
     pub fn from_path(path: impl AsRef<Path>) -> Result<Self, ExtensionError> {

--- a/crates/distribution-filename/src/extension.rs
+++ b/crates/distribution-filename/src/extension.rs
@@ -51,10 +51,38 @@ impl DistExtension {
     }
 }
 
+// impl SourceDistExtension {
+//     /// Extract the [`SourceDistExtension`] from a path.
+//     pub fn from_path(path: impl AsRef<Path>) -> Result<Self, ExtensionError> {
+//         /// Returns true if the path is a tar file (e.g., `.tar.gz`).
+//         fn is_tar(path: &Path) -> bool {
+//             path.file_stem().is_some_and(|stem| {
+//                 Path::new(stem)
+//                     .extension()
+//                     .is_some_and(|ext| ext.eq_ignore_ascii_case("tar"))
+//             })
+//         }
+
+//         let Some(extension) = path.as_ref().extension().and_then(|ext| ext.to_str()) else {
+//             return Err(ExtensionError::SourceDist);
+//         };
+
+//         match extension {
+//             "zip" => Ok(Self::Zip),
+//             "gz" if is_tar(path.as_ref()) => Ok(Self::TarGz),
+//             "tgz" => Ok(Self::TarGz),
+//             "bz2" if is_tar(path.as_ref()) => Ok(Self::TarBz2),
+//             "xz" if is_tar(path.as_ref()) => Ok(Self::TarXz),
+//             "zst" if is_tar(path.as_ref()) => Ok(Self::TarZst),
+//             _ => Err(ExtensionError::SourceDist),
+//         }
+//     }
+// }
+
 impl SourceDistExtension {
     /// Extract the [`SourceDistExtension`] from a path.
     pub fn from_path(path: impl AsRef<Path>) -> Result<Self, ExtensionError> {
-        /// Returns true if the path is a tar file (e.g., `.tar.gz`).
+        /// Returns true if the path is a tar file (e.g., `.tar.gz`, `.tar.xz`, etc.).
         fn is_tar(path: &Path) -> bool {
             path.file_stem().is_some_and(|stem| {
                 Path::new(stem)
@@ -68,16 +96,17 @@ impl SourceDistExtension {
         };
 
         match extension {
-            "zip" => Ok(Self::Zip),
+            "zip"=> Ok(Self::Zip),
             "gz" if is_tar(path.as_ref()) => Ok(Self::TarGz),
-            "tgz" => Ok(Self::TarGz),
-            "bz2" if is_tar(path.as_ref()) => Ok(Self::TarBz2),
-            "xz" if is_tar(path.as_ref()) => Ok(Self::TarXz),
+            "tgz" | "tar" => Ok(Self::TarGz), // `.tar` included here
+            "bz2" | "tbz" if is_tar(path.as_ref()) => Ok(Self::TarBz2),
+            "xz" | "txz" | "tlz" | "tar.lz" | "tar.lzma" if is_tar(path.as_ref()) => Ok(Self::TarXz),
             "zst" if is_tar(path.as_ref()) => Ok(Self::TarZst),
             _ => Err(ExtensionError::SourceDist),
         }
     }
 }
+
 
 impl Display for SourceDistExtension {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -93,8 +122,8 @@ impl Display for SourceDistExtension {
 
 #[derive(Error, Debug)]
 pub enum ExtensionError {
-    #[error("`.whl`, `.zip`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, or `.tar.zst`")]
+    #[error("`.whl`, `.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz`, `.tar.xz`, `.txz`, `.tar.lz`, `.tar.lzma`, or `.tar.zst`")]
     Dist,
-    #[error("`.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tar.xz`, or `.tar.zst`")]
+    #[error("`.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz`, `.tar.xz`, `.txz`, `.tar.lz`, `.tar.lzma`, or `.tar.zst`")]
     SourceDist,
 }

--- a/crates/distribution-filename/src/extension.rs
+++ b/crates/distribution-filename/src/extension.rs
@@ -27,12 +27,16 @@ pub enum DistExtension {
 )]
 #[archive(check_bytes)]
 #[archive_attr(derive(Debug))]
+
 pub enum SourceDistExtension {
     Zip,
     TarGz,
     TarBz2,
     TarXz,
+    Tar,
     TarZst,
+    TarLz,
+    TarLzma,
 }
 
 impl DistExtension {
@@ -54,7 +58,7 @@ impl DistExtension {
 impl SourceDistExtension {
     /// Extract the [`SourceDistExtension`] from a path.
     pub fn from_path(path: impl AsRef<Path>) -> Result<Self, ExtensionError> {
-        /// Returns true if the path is a tar file (e.g., `.tar.gz`, `.tar.xz`, etc.).
+        /// Returns true if the path is a tar file (e.g., `.tar`, `.tar.gz`, etc.).
         fn is_tar(path: &Path) -> bool {
             path.file_stem().is_some_and(|stem| {
                 Path::new(stem)
@@ -68,9 +72,10 @@ impl SourceDistExtension {
         };
 
         match extension {
-            "zip"=> Ok(Self::Zip),
+            "zip" => Ok(Self::Zip),
             "gz" if is_tar(path.as_ref()) => Ok(Self::TarGz),
-            "tgz" | "tar" => Ok(Self::TarGz), // `.tar` included here
+            "tgz" => Ok(Self::TarGz),
+            "tar" => Ok(Self::Tar),
             "bz2" | "tbz" if is_tar(path.as_ref()) => Ok(Self::TarBz2),
             "xz" | "txz" | "tlz" | "tar.lz" | "tar.lzma" if is_tar(path.as_ref()) => Ok(Self::TarXz),
             "zst" if is_tar(path.as_ref()) => Ok(Self::TarZst),
@@ -79,7 +84,6 @@ impl SourceDistExtension {
     }
 }
 
-
 impl Display for SourceDistExtension {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -87,7 +91,10 @@ impl Display for SourceDistExtension {
             Self::TarGz => f.write_str("tar.gz"),
             Self::TarBz2 => f.write_str("tar.bz2"),
             Self::TarXz => f.write_str("tar.xz"),
+            Self::Tar => f.write_str("tar"),
             Self::TarZst => f.write_str("tar.zst"),
+            Self::TarLz => f.write_str("tar.lz"),
+            Self::TarLzma => f.write_str("tar.lzma"),
         }
     }
 }
@@ -96,6 +103,7 @@ impl Display for SourceDistExtension {
 pub enum ExtensionError {
     #[error("`.whl`, `.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz`, `.tar.xz`, `.txz`, `.tar.lz`, `.tar.lzma`, or `.tar.zst`")]
     Dist,
-    #[error("`.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz`, `.tar.xz`, `.txz`, `.tar.lz`, `.tar.lzma`, or `.tar.zst`")]
+    #[error("`.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz`, `.tar.xz`, `.txz`, `.tar.lz`, `.tar.lzma`, `.tar`, or `.tar.zst`")]
     SourceDist,
 }
+

--- a/crates/uv/tests/build.rs
+++ b/crates/uv/tests/build.rs
@@ -816,7 +816,7 @@ fn wheel_from_sdist() -> Result<()> {
 
     ----- stderr -----
     Building wheel from source distribution...
-    error: `dist/project-0.1.0-py3-none-any.whl` is not a valid build source. Expected to receive a source directory, or a source distribution ending in one of: `.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz`, `.tar.xz`, `.txz`, `.tar.lz`, `.tar.lzma`, or `.tar.zst`.
+    error: `dist/project-0.1.0-py3-none-any.whl` is not a valid build source. Expected to receive a source directory, or a source distribution ending in one of: `.zip`, `.tar`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz`, `.tar.xz`, `.txz`, `.tar.lz`, `.tar.lzma`, or `.tar.zst`.
     "###);
 
     Ok(())

--- a/crates/uv/tests/build.rs
+++ b/crates/uv/tests/build.rs
@@ -816,7 +816,7 @@ fn wheel_from_sdist() -> Result<()> {
 
     ----- stderr -----
     Building wheel from source distribution...
-    error: `dist/project-0.1.0-py3-none-any.whl` is not a valid build source. Expected to receive a source directory, or a source distribution ending in one of: `.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tar.xz`, or `.tar.zst`.
+    error: `dist/project-0.1.0-py3-none-any.whl` is not a valid build source. Expected to receive a source directory, or a source distribution ending in one of: `.zip`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz`, `.tar.xz`, `.txz`, `.tar.lz`, `.tar.lzma`, or `.tar.zst`.
     "###);
 
     Ok(())

--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -303,11 +303,13 @@ distributions as gzip tarball (`.tar.gz`) archives. Prior to this specification,
 formats, which need to be supported for backward compatibility, were also allowed. uv supports
 reading and extracting archives in the following formats:
 
-- bzip2 tarball (`.tar.bz2`)
+- bzip2 tarball (`.tar.bz2`, `.tbz`)
 - gzip tarball (`.tar.gz`, `.tgz`)
-- xz tarball (`.tar.xz`)
+- xz tarball (`.tar.xz`, `.txz`)
 - zip (`.zip`)
 - zstd tarball (`.tar.zst`)
+- lzip tarball (`.tar.lz`)
+- lzma tarball (`.tar.lzma`)
 
 ## Learn more
 

--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -310,6 +310,7 @@ reading and extracting archives in the following formats:
 - zstd tarball (`.tar.zst`)
 - lzip tarball (`.tar.lz`)
 - lzma tarball (`.tar.lzma`)
+- uncompressed tarball (`.tar`)
 
 ## Learn more
 


### PR DESCRIPTION
## Summary
This pull request adds support for additional file extension aliases in the SourceDistExtension and ExtensionError enums. The newly supported file extensions include .tbz, .tgz, .txz, .tar.lz, .tar.lzma. These changes align the extensions supported by the SourceDistExtension with those used in Python packaging tools, enhancing compatibility with a broader range of source distribution formats.

closes #7201 

## Test Plan
should be added or updated to verify that the new extensions are correctly recognized as valid source distributions and that errors are correctly raised when unsupported extensions are provided.
