### PR TITLE
Prefer compatible wheels in universal resolver

### DIFF
--- a/crates/bench/benches/uv.rs
+++ b/crates/bench/benches/uv.rs
@@ -100,7 +100,7 @@ mod resolver {
     use uv_python::Interpreter;
     use uv_resolver::{
         FlatIndex, InMemoryIndex, Manifest, OptionsBuilder, PythonRequirement, RequiresPython,
-        ResolutionGraph, Resolver, ResolverMarkers,
+        ResolutionGraph, Resolver, ResolverMarkers, TagPolicy,
     };
     use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
 
@@ -171,6 +171,8 @@ mod resolver {
             PythonRequirement::from_interpreter(interpreter)
         };
 
+        let tags = TagPolicy::Required(TAGS.clone());
+
         let build_context = BuildDispatch::new(
             client,
             &cache,
@@ -204,7 +206,7 @@ mod resolver {
             options,
             &python_requirement,
             markers,
-            Some(&TAGS),
+            &tags,
             &flat_index,
             &index,
             &hashes,

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -181,7 +181,7 @@ impl Interpreter {
     }
 
     /// Returns the [`Tags`] for this Python executable.
-    pub fn tags(&self) -> Result<&Tags, TagsError> {
+    pub fn tags(&self) -> Result<Tags, TagsError> {
         if self.tags.get().is_none() {
             let tags = Tags::from_env(
                 self.platform(),
@@ -193,7 +193,7 @@ impl Interpreter {
             )?;
             self.tags.set(tags).expect("tags should not be set");
         }
-        Ok(self.tags.get().expect("tags should be set"))
+        Ok(self.tags.get().expect("tags should be set").clone())
     }
 
     /// Returns `true` if the environment is a PEP 405-compliant virtual environment.

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -20,6 +20,7 @@ pub use resolver::{
     Reporter as ResolverReporter, Resolver, ResolverMarkers, ResolverProvider, VersionsResponse,
     WheelMetadataResult,
 };
+pub use tags::TagPolicy;
 pub use version_map::VersionMap;
 pub use yanks::AllowedYanks;
 
@@ -48,5 +49,6 @@ mod requires_python;
 mod resolution;
 mod resolution_mode;
 mod resolver;
+mod tags;
 mod version_map;
 mod yanks;

--- a/crates/uv-resolver/src/tags.rs
+++ b/crates/uv-resolver/src/tags.rs
@@ -1,0 +1,48 @@
+use platform_tags::Tags;
+
+#[derive(Debug, Clone)]
+pub enum TagPolicy {
+    /// Exclusively consider wheels that match the specified platform tags.
+    Required(Tags),
+    /// Prefer wheels that match the specified platform tags, but fall back to incompatible wheels
+    /// if  necessary.
+    Preferred(Tags),
+}
+
+impl TagPolicy {
+    /// Returns the platform tags to consider.
+    pub const fn tags(&self) -> &Tags {
+        match self {
+            TagPolicy::Required(tags) | TagPolicy::Preferred(tags) => tags,
+        }
+    }
+
+    #[must_use]
+    pub fn into_tags(self) -> Tags {
+        match self {
+            TagPolicy::Required(tags) | TagPolicy::Preferred(tags) => tags,
+        }
+    }
+
+    pub fn is_required(&self) -> bool {
+        matches!(self, TagPolicy::Required(_))
+    }
+}
+
+// #[derive(Debug, Copy, Clone)]
+// pub enum TagPolicy<'tags> {
+//     /// Exclusively consider wheels that match the specified platform tags.
+//     Required(&'tags Tags),
+//     /// Prefer wheels that match the specified platform tags, but fall back to incompatible wheels
+//     /// if  necessary.
+//     Preferred(&'tags Tags),
+// }
+//
+// impl<'tags> TagPolicy<'tags> {
+//     /// Returns the platform tags to consider.
+//     pub(crate) const fn tags(&self) -> &'tags Tags {
+//         match self {
+//             TagPolicy::Required(tags) | TagPolicy::Preferred(tags) => tags,
+//         }
+//     }
+// }

--- a/crates/uv/src/commands/build.rs
+++ b/crates/uv/src/commands/build.rs
@@ -22,7 +22,7 @@ use uv_python::{
     PythonPreference, PythonRequest, PythonVersionFile, VersionRequest,
 };
 use uv_requirements::RequirementsSource;
-use uv_resolver::{FlatIndex, RequiresPython};
+use uv_resolver::{FlatIndex, RequiresPython, TagPolicy};
 use uv_types::{BuildContext, BuildIsolation, HashStrategy};
 use uv_workspace::{DiscoveryOptions, Workspace};
 
@@ -283,9 +283,10 @@ async fn build_impl(
 
     // Resolve the flat indexes from `--find-links`.
     let flat_index = {
+        let tags = TagPolicy::Preferred(interpreter.tags()?);
         let client = FlatIndexClient::new(&client, cache);
         let entries = client.fetch(index_locations.flat_index()).await?;
-        FlatIndex::from_entries(entries, None, &hasher, build_options)
+        FlatIndex::from_entries(entries, &tags, &hasher, build_options)
     };
 
     // Initialize any shared state.

--- a/crates/uv/src/commands/pip/mod.rs
+++ b/crates/uv/src/commands/pip/mod.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use platform_tags::{Tags, TagsError};
 use pypi_types::ResolverMarkerEnvironment;
 use uv_configuration::TargetTriple;
@@ -36,37 +34,37 @@ pub(crate) fn resolution_markers(
     }
 }
 
-pub(crate) fn resolution_tags<'env>(
+pub(crate) fn resolution_tags(
     python_version: Option<&PythonVersion>,
     python_platform: Option<&TargetTriple>,
-    interpreter: &'env Interpreter,
-) -> Result<Cow<'env, Tags>, TagsError> {
+    interpreter: &Interpreter,
+) -> Result<Tags, TagsError> {
     Ok(match (python_platform, python_version.as_ref()) {
-        (Some(python_platform), Some(python_version)) => Cow::Owned(Tags::from_env(
+        (Some(python_platform), Some(python_version)) => Tags::from_env(
             &python_platform.platform(),
             (python_version.major(), python_version.minor()),
             interpreter.implementation_name(),
             interpreter.implementation_tuple(),
             interpreter.manylinux_compatible(),
             interpreter.gil_disabled(),
-        )?),
-        (Some(python_platform), None) => Cow::Owned(Tags::from_env(
+        )?,
+        (Some(python_platform), None) => Tags::from_env(
             &python_platform.platform(),
             interpreter.python_tuple(),
             interpreter.implementation_name(),
             interpreter.implementation_tuple(),
             interpreter.manylinux_compatible(),
             interpreter.gil_disabled(),
-        )?),
-        (None, Some(python_version)) => Cow::Owned(Tags::from_env(
+        )?,
+        (None, Some(python_version)) => Tags::from_env(
             interpreter.platform(),
             (python_version.major(), python_version.minor()),
             interpreter.implementation_name(),
             interpreter.implementation_tuple(),
             interpreter.manylinux_compatible(),
             interpreter.gil_disabled(),
-        )?),
-        (None, None) => Cow::Borrowed(interpreter.tags()?),
+        )?,
+        (None, None) => interpreter.tags()?,
     })
 }
 
@@ -75,33 +73,33 @@ pub(crate) fn resolution_environment(
     python_version: Option<PythonVersion>,
     python_platform: Option<TargetTriple>,
     interpreter: &Interpreter,
-) -> Result<(Cow<'_, Tags>, ResolverMarkerEnvironment), TagsError> {
+) -> Result<(Tags, ResolverMarkerEnvironment), TagsError> {
     let tags = match (python_platform, python_version.as_ref()) {
-        (Some(python_platform), Some(python_version)) => Cow::Owned(Tags::from_env(
+        (Some(python_platform), Some(python_version)) => Tags::from_env(
             &python_platform.platform(),
             (python_version.major(), python_version.minor()),
             interpreter.implementation_name(),
             interpreter.implementation_tuple(),
             interpreter.manylinux_compatible(),
             interpreter.gil_disabled(),
-        )?),
-        (Some(python_platform), None) => Cow::Owned(Tags::from_env(
+        )?,
+        (Some(python_platform), None) => Tags::from_env(
             &python_platform.platform(),
             interpreter.python_tuple(),
             interpreter.implementation_name(),
             interpreter.implementation_tuple(),
             interpreter.manylinux_compatible(),
             interpreter.gil_disabled(),
-        )?),
-        (None, Some(python_version)) => Cow::Owned(Tags::from_env(
+        )?,
+        (None, Some(python_version)) => Tags::from_env(
             interpreter.platform(),
             (python_version.major(), python_version.minor()),
             interpreter.implementation_name(),
             interpreter.implementation_tuple(),
             interpreter.manylinux_compatible(),
             interpreter.gil_disabled(),
-        )?),
-        (None, None) => Cow::Borrowed(interpreter.tags()?),
+        )?,
+        (None, None) => interpreter.tags()?,
     };
 
     // Apply the platform tags to the markers.

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -36,7 +36,7 @@ use uv_requirements::{
 };
 use uv_resolver::{
     DependencyMode, Exclusions, FlatIndex, InMemoryIndex, Manifest, Options, Preference,
-    Preferences, PythonRequirement, ResolutionGraph, Resolver, ResolverMarkers,
+    Preferences, PythonRequirement, ResolutionGraph, Resolver, ResolverMarkers, TagPolicy,
 };
 use uv_types::{HashStrategy, InFlight, InstalledPackagesProvider};
 use uv_warnings::warn_user;
@@ -100,7 +100,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
     hasher: &HashStrategy,
     reinstall: &Reinstall,
     upgrade: &Upgrade,
-    tags: Option<&Tags>,
+    tags: &TagPolicy,
     markers: ResolverMarkers,
     python_requirement: PythonRequirement,
     client: &RegistryClient,

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -25,7 +25,7 @@ use uv_python::{
     EnvironmentPreference, PythonDownloads, PythonInstallation, PythonPreference, PythonRequest,
     PythonVersionFile, VersionRequest,
 };
-use uv_resolver::{ExcludeNewer, FlatIndex, RequiresPython};
+use uv_resolver::{ExcludeNewer, FlatIndex, RequiresPython, TagPolicy};
 use uv_shell::Shell;
 use uv_types::{BuildContext, BuildIsolation, HashStrategy};
 use uv_warnings::warn_user_once;
@@ -291,7 +291,7 @@ async fn venv_impl(
                 .map_err(VenvError::FlatIndex)?;
             FlatIndex::from_entries(
                 entries,
-                Some(tags),
+                &TagPolicy::Required(tags),
                 &HashStrategy::None,
                 &BuildOptions::new(NoBinary::None, NoBuild::All),
             )


### PR DESCRIPTION
## Summary

I need input on whether this is a good change. In the universal resolver, we currently choose an arbitrary wheel when extracting package metadata. A downside here is that if we need to download the entire wheel, we might end up downloading a _second_ (compatible) wheel when we go to install. So, e.g., you could end up downloading two PyTorch wheels, one during resolution, and one during installation (if your registry doesn't support range requests -- otherwise, we don't download during resolution anyway).

The idea here is to respect platform tags when deciding which wheel to use (but _not_ error if we can't find a compatible wheel).

The major downside here is that resolution could actually vary depending on the platform you're on, if a package has inconsistent metadata across wheels, since we'll look at different wheels for metadata on Windows vs. on Linux, for example.

I'm inclined _not_ to do this, since it breaks the nice property that resolution is entirely machine-independent. But it's weird to download two wheels like that.

Closes https://github.com/astral-sh/uv/issues/5921.
