### PR TITLE
Add --script option to uv init

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2313,14 +2313,35 @@ pub struct InitArgs {
     /// By default, an application is not intended to be built and distributed as a Python package.
     /// The `--package` option can be used to create an application that is distributable, e.g., if
     /// you want to distribute a command-line interface via PyPI.
-    #[arg(long, alias = "application", conflicts_with = "lib")]
+    #[arg(
+        long,
+        alias = "application",
+        conflicts_with = "lib",
+        conflicts_with = "script"
+    )]
     pub r#app: bool,
 
     /// Create a project for a library.
     ///
     /// A library is a project that is intended to be built and distributed as a Python package.
-    #[arg(long, alias = "library", conflicts_with = "app")]
+    #[arg(
+        long,
+        alias = "library",
+        conflicts_with = "app",
+        conflicts_with = "script"
+    )]
     pub r#lib: bool,
+
+    /// Create a script with inline metadata.
+    ///
+    /// A Python script is a file intended for standalone execution with or without dependencies.
+    #[arg(
+        long,
+        conflicts_with = "app",
+        conflicts_with = "lib",
+        conflicts_with = "package"
+    )]
+    pub r#script: bool,
 
     /// Do not create a `README.md` file.
     #[arg(long)]

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -585,7 +585,7 @@ impl InitProjectKind {
         python_request: Option<&PythonRequest>,
         no_readme: bool,
     ) -> Result<()> {
-        // Create the `pyproject.toml`
+        // Create the embedded `pyproject.toml`
         let pyproject = pyproject_script(name, requires_python, no_readme);
 
         // Create the script

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -174,17 +174,19 @@ impl InitSettings {
             no_package,
             app,
             lib,
+            script,
             no_readme,
             no_pin_python,
             no_workspace,
             python,
         } = args;
 
-        let kind = match (app, lib) {
-            (true, false) => InitProjectKind::Application,
-            (false, true) => InitProjectKind::Library,
-            (false, false) => InitProjectKind::default(),
-            (true, true) => unreachable!("`app` and `lib` are mutually exclusive"),
+        let kind = match (app, lib, script) {
+            (true, false, false) => InitProjectKind::Application,
+            (false, true, false) => InitProjectKind::Library,
+            (false, false, true) => InitProjectKind::Script,
+            (false, false, false) => InitProjectKind::default(),
+            _ => unreachable!("`app`, `lib` and `script` are mutually exclusive"),
         };
 
         let package = flag(package || r#virtual, no_package).unwrap_or(kind.packaged_by_default());

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -478,7 +478,6 @@ fn init_script() -> Result<()> {
     Initialized project `myapp-py` at `[TEMP_DIR]/foo/myapp.py`
     "###);
 
-
     let myapp = fs_err::read_to_string(myapp_py)?;
     insta::with_settings!({
         filters => context.filters(),
@@ -522,7 +521,6 @@ fn init_script() -> Result<()> {
 
     Ok(())
 }
-
 
 /// Ensure that `uv init` initializes the cache.
 #[test]

--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -127,11 +127,20 @@ Multiple dependencies can be requested by repeating with `--with` option.
 Note that if `uv run` is used in a _project_, these dependencies will be included _in addition_ to
 the project's dependencies. To opt-out of this behavior, use the `--no-project` flag.
 
-## Declaring script dependencies
+## Creating a python script
 
 Python recently added a standard format for
 [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata).
-This allows the dependencies for a script to be declared in the script itself.
+It allows for selecting python versions and defining dependencies. Use `uv init --script` to initialize
+scripts with the inline metadata:
+
+```console
+$ uv init --script example.py --python 3.12
+```
+
+## Declaring script dependencies
+
+The inline metadata format allows the dependencies for a script to be declared in the script itself.
 
 uv supports adding and updating inline script metadata for you. Use `uv add --script` to declare the
 dependencies for the script:

--- a/docs/guides/scripts.md
+++ b/docs/guides/scripts.md
@@ -131,8 +131,8 @@ the project's dependencies. To opt-out of this behavior, use the `--no-project` 
 
 Python recently added a standard format for
 [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata).
-It allows for selecting python versions and defining dependencies. Use `uv init --script` to initialize
-scripts with the inline metadata:
+It allows for selecting python versions and defining dependencies. Use `uv init --script` to
+initialize scripts with the inline metadata:
 
 ```console
 $ uv init --script example.py --python 3.12

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -510,6 +510,10 @@ uv init [OPTIONS] [PATH]
 </ul>
 </dd><dt><code>--quiet</code>, <code>-q</code></dt><dd><p>Do not print any output</p>
 
+</dd><dt><code>--script</code></dt><dd><p>Create a script with inline metadata.</p>
+
+<p>A Python script is a file intended for standalone execution with or without dependencies.</p>
+
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This is a partial implementation of #7402 
Since there was no discussion yet, I didn't get much further than adding the command line option and writing the .py file

Feel free to use this PR (or not). I am unsure if I will have time to finish it.

There is one opinionated bit which is the readme "type" which is [part of the pep 723 spec](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#specification) but you may want to think about it before introducing any such thing

Missing: 
 - The PackageName converts dots into dashes. I did not check how to fix it. You will see it when you run the command as the hello will show foo-py instead of foo.py
 - Add to the docs to teach people how to create scripts [here](https://docs.astral.sh/uv/guides/scripts/)
 - Combine python_request and requires_python as there is no standalone .python-version file
 - possibly add a shebang and make the file executable 
 - Test cases

## Test Plan

<!-- How was it tested? -->
uv init --script foo.py
