### PR TITLE
Ignore activate venv in tests

### DIFF
--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -419,13 +419,15 @@ impl TestContext {
     /// * Don't wrap text output based on the terminal we're in, the test output doesn't get printed
     ///   but snapshotted to a string.
     /// * Use a fake `HOME` to avoid accidentally changing the developer's machine.
-    /// * Hide other Python python with `UV_PYTHON_INSTALL_DIR` and installed interpreters with
-    ///   `UV_TEST_PYTHON_PATH`.
+    /// * Hide other Pythons with `UV_PYTHON_INSTALL_DIR` and installed interpreters with
+    ///   `UV_TEST_PYTHON_PATH` and an active venv (if applicable) by removing `VIRTUAL_ENV`.
     /// * Increase the stack size to avoid stack overflows on windows due to large async functions.
     pub fn add_shared_args(&self, command: &mut Command, activate_venv: bool) {
         command
             .arg("--cache-dir")
             .arg(self.cache_dir.path())
+            // When running the tests in a venv, ignore that venv, otherwise we'll capture warnings.
+            .env_remove("VIRTUAL_ENV")
             .env("UV_NO_WRAP", "1")
             .env("HOME", self.home_dir.as_os_str())
             .env("UV_PYTHON_INSTALL_DIR", "")


### PR DESCRIPTION
Fix a regression in running tests from #6864 that would cause test failures due to added "does not match the project environment path `.venv` and will be ignored" warning when running the tests inside an active venv,
