### PR TITLE
Include the parent interpreter in Python discovery when `--system` is used

### DIFF
--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -1247,8 +1247,8 @@ mod tests {
         )??;
         assert_eq!(
             python.interpreter().python_full_version().to_string(),
-            "3.12.3",
-            "We should prefer the system interpreter"
+            "3.12.0",
+            "We should prefer the parent interpreter since it's not virtual"
         );
 
         // Test with `EnvironmentPreference::OnlyVirtual`


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/7417

Tested with this epic blurb

```
❯ uv pip install --python /Users/zb/.local/share/uv/python/cpython-3.13.0rc2-macos-aarch64-none/bin/python3 . --break-system-packages --reinstall
Resolved 1 package in 0.91ms
   Built uv @ file:///Users/zb/workspace/uv
Prepared 1 package in 2m 48s
Uninstalled 1 package in 1ms
Installed 1 package in 1ms
 - uv==0.4.10
 + uv==0.4.10 (from file:///Users/zb/workspace/uv)
❯ /Users/zb/.local/share/uv/python/cpython-3.13.0rc2-macos-aarch64-none/bin/python3 -m uv pip install --system -v httpx
DEBUG uv 0.4.10
DEBUG Searching for Python interpreter in system path
DEBUG Found `cpython-3.13.0rc2-macos-aarch64-none` at `/Users/zb/.local/share/uv/python/cpython-3.13.0rc2-macos-aarch64-none/bin/python3` (parent interpreter)
DEBUG Using Python 3.13.0rc2 environment at /Users/zb/.local/share/uv/python/cpython-3.13.0rc2-macos-aarch64-none/bin/python3
```