### PR TITLE
Use consistent PyPI cache bucket

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1863,7 +1863,7 @@ impl Package {
                     url: FileLocation::AbsoluteUrl(file_url.clone()),
                     yanked: None,
                 });
-                let index = IndexUrl::Url(VerbatimUrl::from_url(url.to_url()));
+                let index = IndexUrl::from(VerbatimUrl::from_url(url.to_url()));
 
                 let reg_dist = RegistrySourceDist {
                     name: self.id.name.clone(),
@@ -1905,7 +1905,7 @@ impl Package {
                     url: FileLocation::AbsoluteUrl(UrlString::from(file_url)),
                     yanked: None,
                 });
-                let index = IndexUrl::Path(
+                let index = IndexUrl::from(
                     VerbatimUrl::from_absolute_path(workspace_root.join(path))
                         .map_err(LockErrorKind::RegistryVerbatimUrl)?,
                 );
@@ -3284,7 +3284,7 @@ impl Wheel {
                     url: FileLocation::AbsoluteUrl(file_url.clone()),
                     yanked: None,
                 });
-                let index = IndexUrl::Url(VerbatimUrl::from_url(index_url.to_url()));
+                let index = IndexUrl::from(VerbatimUrl::from_url(index_url.to_url()));
                 Ok(RegistryBuiltWheel {
                     filename,
                     file,
@@ -3314,7 +3314,7 @@ impl Wheel {
                     url: FileLocation::AbsoluteUrl(UrlString::from(file_url)),
                     yanked: None,
                 });
-                let index = IndexUrl::Path(
+                let index = IndexUrl::from(
                     VerbatimUrl::from_absolute_path(root.join(index_path))
                         .map_err(LockErrorKind::RegistryVerbatimUrl)?,
                 );

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -108,7 +108,7 @@ fn run_with_python_version() -> Result<()> {
     Removed virtual environment at: .venv
     Creating virtualenv at: .venv
     Resolved 5 packages in [TIME]
-    Prepared 3 packages in [TIME]
+    Prepared 1 package in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.6.0
      + foo==1.0.0 (from file://[TEMP_DIR]/)
@@ -1186,7 +1186,6 @@ fn run_requirements_txt() -> Result<()> {
     Resolved 6 packages in [TIME]
     Audited 4 packages in [TIME]
     Resolved 2 packages in [TIME]
-    Prepared 1 package in [TIME]
     Installed 2 packages in [TIME]
      + iniconfig==2.0.0
      + sniffio==1.3.1
@@ -1484,7 +1483,6 @@ fn run_isolated_python_version() -> Result<()> {
 
     ----- stderr -----
     Resolved 6 packages in [TIME]
-    Prepared 5 packages in [TIME]
     Installed 6 packages in [TIME]
      + anyio==4.3.0
      + exceptiongroup==1.2.0
@@ -1508,7 +1506,6 @@ fn run_isolated_python_version() -> Result<()> {
 
     ----- stderr -----
     Resolved 6 packages in [TIME]
-    Prepared 3 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==4.3.0
      + foo==1.0.0 (from file://[TEMP_DIR]/)

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -1007,7 +1007,6 @@ fn sync_dev() -> Result<()> {
 
     ----- stderr -----
     Resolved 5 packages in [TIME]
-    Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]
      + anyio==4.3.0
      + idna==3.6
@@ -1191,7 +1190,6 @@ fn no_install_workspace() -> Result<()> {
     ----- stderr -----
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: .venv
-    Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
      + anyio==3.7.0
      + idna==3.6
@@ -1656,7 +1654,6 @@ fn sync_custom_environment_path() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: foo
     Resolved 2 packages in [TIME]
-    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###);
@@ -1682,7 +1679,6 @@ fn sync_custom_environment_path() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: foobar/.venv
     Resolved 2 packages in [TIME]
-    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###);
@@ -1708,7 +1704,6 @@ fn sync_custom_environment_path() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: bar
     Resolved 2 packages in [TIME]
-    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###);
@@ -1730,7 +1725,6 @@ fn sync_custom_environment_path() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: [OTHER_TEMPDIR]/.venv
     Resolved 2 packages in [TIME]
-    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###);
@@ -1811,7 +1805,6 @@ fn sync_workspace_custom_environment_path() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: foo
     Resolved 3 packages in [TIME]
-    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###);
@@ -1968,7 +1961,6 @@ fn sync_virtual_env_warning() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: foo
     Resolved 2 packages in [TIME]
-    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###);
@@ -1984,7 +1976,6 @@ fn sync_virtual_env_warning() -> Result<()> {
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtualenv at: bar
     Resolved 2 packages in [TIME]
-    Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
      + iniconfig==2.0.0
     "###);

--- a/crates/uv/tests/workspace.rs
+++ b/crates/uv/tests/workspace.rs
@@ -601,7 +601,6 @@ fn test_uv_run_isolate() -> Result<()> {
 
     ----- stderr -----
     Resolved 8 packages in [TIME]
-    Prepared 3 packages in [TIME]
     Installed 5 packages in [TIME]
      + anyio==4.3.0
      + bird-feeder==1.0.0 (from file://[TEMP_DIR]/albatross-root-workspace/packages/bird-feeder)


### PR DESCRIPTION
## Summary

All the registry wheels were getting cached under `index/b2a7eb67d4c26b82` rather than `pypi`, because we used `IndexUrl::Url` rather than `IndexUrl::from`.
