### PR TITLE
Avoid erroneous version warning for .dist-info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4963,12 +4963,10 @@ dependencies = [
  "distribution-filename",
  "fs-err",
  "futures",
- "pep440_rs",
  "pypi-types",
  "thiserror",
  "tokio",
  "tokio-util",
- "tracing",
  "uv-normalize",
  "zip",
 ]

--- a/crates/uv-metadata/Cargo.toml
+++ b/crates/uv-metadata/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace = true
 
 [dependencies]
 distribution-filename = { workspace = true }
-pep440_rs = { workspace = true }
 pypi-types = { workspace = true }
 uv-normalize = { workspace = true }
 
@@ -21,7 +20,6 @@ futures = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
-tracing = { workspace = true }
 zip = { workspace = true }
 
 [lints]


### PR DESCRIPTION
## Summary

Since https://github.com/astral-sh/uv/pull/7208, this is now _always_ firing, for every directory, because the version gets normalized (e.g., `1.2.3` gets normalized to `1-2-3`, which never matches the parsed version). pip doesn't warn here, I guess we won't either, because I can't figure out a robust way to do this... We need to get the non-normalized remainder after stripping the normalized package name, but we strip the normalized package name from the normalized string, so we only have a normalized remainder.
