### PR TITLE
Prune unzipped source distributions in `uv cache prune --ci`

### DIFF
--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -204,7 +204,7 @@ fn prune_unzipped() -> Result<()> {
 
     ----- stderr -----
     Pruning cache at: [CACHE_DIR]/
-    Removed 162 files ([SIZE])
+    Removed 170 files ([SIZE])
     "###);
 
     // Reinstalling the source distribution should not require re-downloading the source

--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -115,9 +115,9 @@ from source tends to be worthwhile, since the wheel building process can be expe
 for extension modules.
 
 To support this caching strategy, uv provides a `uv cache prune --ci` command, which removes all
-pre-built wheels from the cache but retains any wheels that were built from source. We recommend
-running `uv cache prune --ci` at the end of your continuous integration job to ensure maximum cache
-efficiency. For an example, see the
+pre-built wheels and unzipped source distributions from the cache, but retains any wheels that were
+built from source. We recommend running `uv cache prune --ci` at the end of your continuous
+integration job to ensure maximum cache efficiency. For an example, see the
 [GitHub integration guide](../guides/integration/github.md#caching).
 
 ## Cache directory


### PR DESCRIPTION
## Summary

It's very unlikely that retaining these is beneficial, since you tend to partition the cache by platform anyway.

Closes https://github.com/astral-sh/uv/issues/7394.
