### PR TITLE
Run `cargo upgrade`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
       - name: "Clippy"
         working-directory: ${{ github.workspace }}/crates/uv-trampoline
         if: matrix.target-arch == 'x86_64'
-        run: cargo xwin clippy --all-features --locked --target x86_64-pc-windows-msvc -- -D warnings
+        run: cargo xwin clippy --all-features --locked --target x86_64-pc-windows-msvc --tests -- -D warnings
         env:
           XWIN_ARCH: "x86_64"
           XWIN_CACHE_DIR: "${{ github.workspace }}/.xwin"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4140,9 +4140,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,34 +59,34 @@ uv-virtualenv = { path = "crates/uv-virtualenv" }
 uv-warnings = { path = "crates/uv-warnings" }
 uv-workspace = { path = "crates/uv-workspace" }
 
-anstream = { version = "0.6.13" }
-anyhow = { version = "1.0.80" }
-async-channel = { version = "2.2.0" }
-async-compression = { version = "0.4.6" }
-async-trait = { version = "0.1.78" }
+anstream = { version = "0.6.15" }
+anyhow = { version = "1.0.89" }
+async-channel = { version = "2.3.1" }
+async-compression = { version = "0.4.12" }
+async-trait = { version = "0.1.82" }
 async_http_range_reader = { version = "0.8.0" }
 async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "011b24604fa7bc223daaad7712c0694bac8f0a87", features = ["deflate", "tokio"] }
-axoupdater = { version = "0.7.0", default-features = false }
+axoupdater = { version = "0.7.2", default-features = false }
 backoff = { version = "0.4.0" }
-base64 = { version = "0.22.0" }
+base64 = { version = "0.22.1" }
 boxcar = { version = "0.2.5" }
 cachedir = { version = "0.3.1" }
-cargo-util = { version = "0.2.8" }
-clap = { version = "4.5.9" }
-clap_complete_command = { version = "0.6.0" }
-configparser = { version = "3.0.4" }
+cargo-util = { version = "0.2.14" }
+clap = { version = "4.5.17" }
+clap_complete_command = { version = "0.6.1" }
+configparser = { version = "3.1.0" }
 console = { version = "0.15.8", default-features = false }
 csv = { version = "1.3.0" }
-ctrlc = { version = "3.4.4" }
-dashmap = { version = "6.0.0" }
-data-encoding = { version = "2.5.0" }
+ctrlc = { version = "3.4.5" }
+dashmap = { version = "6.1.0" }
+data-encoding = { version = "2.6.0" }
 directories = { version = "5.0.1" }
 dirs-sys = { version = "0.4.1" }
-dunce = { version = "1.0.4" }
-either = { version = "1.12.0" }
+dunce = { version = "1.0.5" }
+either = { version = "1.13.0" }
 encoding_rs_io = { version = "0.1.7" }
 etcetera = { version = "0.8.0" }
-flate2 = { version = "1.0.28", default-features = false }
+flate2 = { version = "1.0.33", default-features = false }
 fs-err = { version = "2.11.0" }
 fs2 = { version = "0.4.3" }
 futures = { version = "0.3.30" }
@@ -97,74 +97,74 @@ hex = { version = "0.4.3" }
 home = { version = "0.5.9" }
 html-escape = { version = "0.2.13" }
 http = { version = "1.1.0" }
-indexmap = { version = "2.2.5" }
-indicatif = { version = "0.17.7" }
-indoc = { version = "2.0.4" }
+indexmap = { version = "2.5.0" }
+indicatif = { version = "0.17.8" }
+indoc = { version = "2.0.5" }
 itertools = { version = "0.13.0" }
-jiff = { version = "0.1.6", features = ["serde"] }
-junction = { version = "1.0.0" }
+jiff = { version = "0.1.13", features = ["serde"] }
+junction = { version = "1.2.0" }
 krata-tokio-tar = { version = "0.4.2" }
 mailparse = { version = "0.15.0" }
 md-5 = { version = "0.10.6" }
 memchr = { version = "2.7.4" }
 miette = { version = "7.2.0" }
 nanoid = { version = "0.4.0" }
-owo-colors = { version = "4.0.0" }
+owo-colors = { version = "4.1.0" }
 path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
-petgraph = { version = "0.6.4" }
-platform-info = { version = "2.0.2" }
+petgraph = { version = "0.6.5" }
+platform-info = { version = "2.0.3" }
 proc-macro2 = { version = "1.0.86" }
 pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "388685a8711092971930986644cfed152d1a1f6c" }
-pyo3 = { version = "0.21.0" }
+pyo3 = { version = "0.21.2" }
 pyo3-log = { version = "0.10.0" }
-quote = { version = "1.0.36" }
-rayon = { version = "1.8.0" }
-reflink-copy = { version = "0.1.15" }
-regex = { version = "1.10.2" }
-reqwest = { version = "0.12.3", default-features = false, features = ["json", "gzip", "stream", "rustls-tls", "rustls-tls-native-roots"] }
+quote = { version = "1.0.37" }
+rayon = { version = "1.10.0" }
+reflink-copy = { version = "0.1.19" }
+regex = { version = "1.10.6" }
+reqwest = { version = "0.12.7", default-features = false, features = ["json", "gzip", "stream", "rustls-tls", "rustls-tls-native-roots"] }
 reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913" }
 reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913" }
-rkyv = { version = "0.7.43", features = ["strict", "validation"] }
-rmp-serde = { version = "1.1.2" }
+rkyv = { version = "0.7.45", features = ["strict", "validation"] }
+rmp-serde = { version = "1.3.0" }
 rust-netrc = { version = "0.1.1" }
 rustc-hash = { version = "2.0.0" }
-rustix = { version = "0.38.34", default-features = false, features = ["fs", "std"] }
+rustix = { version = "0.38.37", default-features = false, features = ["fs", "std"] }
 same-file = { version = "1.0.6" }
-schemars = { version = "0.8.16", features = ["url"] }
+schemars = { version = "0.8.21", features = ["url"] }
 seahash = { version = "4.1.0" }
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = { version = "1.0.114" }
+serde = { version = "1.0.210", features = ["derive"] }
+serde_json = { version = "1.0.128" }
 sha2 = { version = "0.10.8" }
 smallvec = { version = "1.13.2" }
-syn = { version = "2.0.66" }
+syn = { version = "2.0.77" }
 sys-info = { version = "0.9.1" }
-target-lexicon = { version = "0.12.14" }
-tempfile = { version = "3.9.0" }
+target-lexicon = { version = "0.12.16" }
+tempfile = { version = "3.12.0" }
 textwrap = { version = "0.16.1" }
-thiserror = { version = "1.0.56" }
+thiserror = { version = "1.0.63" }
 tl = { git = "https://github.com/charliermarsh/tl.git", rev = "6e25b2ee2513d75385101a8ff9f591ef51f314ec" }
-tokio = { version = "1.35.1", features = ["fs", "io-util", "macros", "process", "signal", "sync"] }
-tokio-stream = { version = "0.1.14" }
-tokio-util = { version = "0.7.10", features = ["compat"] }
-toml = { version = "0.8.12" }
-toml_edit = { version = "0.22.13", features = ["serde"] }
+tokio = { version = "1.40.0", features = ["fs", "io-util", "macros", "process", "signal", "sync"] }
+tokio-stream = { version = "0.1.16" }
+tokio-util = { version = "0.7.12", features = ["compat"] }
+toml = { version = "0.8.19" }
+toml_edit = { version = "0.22.21", features = ["serde"] }
 tracing = { version = "0.1.40" }
 tracing-durations-export = { version = "0.3.0", features = ["plot"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "registry"] }
 tracing-tree = { version = "0.4.0" }
-unicode-width = { version = "0.1.11" }
+unicode-width = { version = "0.1.13" }
 unscanny = { version = "0.1.0" }
-url = { version = "2.5.0" }
+url = { version = "2.5.2" }
 urlencoding = { version = "2.1.3" }
 walkdir = { version = "2.5.0" }
-which = { version = "6.0.0", features = ["regex"] }
+which = { version = "6.0.3", features = ["regex"] }
 windows-registry = { version = "0.2.0" }
 windows-result = { version = "0.2.0" }
 windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Ioctl", "Win32_System_IO"] }
 winreg = { version = "0.52.0" }
 winsafe = { version = "0.0.22", features = ["kernel"] }
-wiremock = { version = "0.6.0" }
+wiremock = { version = "0.6.2" }
 xz2 = { version = "0.1.7" }
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -46,7 +46,7 @@ uv-resolver = { workspace = true }
 uv-types = { workspace = true }
 
 anyhow = { workspace = true }
-codspeed-criterion-compat = { version = "2.7.1", default-features = false, optional = true }
+codspeed-criterion-compat = { version = "2.7.2", default-features = false, optional = true }
 criterion = { version = "0.5.1", default-features = false, features = ["async_tokio"] }
 jiff = { workspace = true }
 tokio = { workspace = true }

--- a/crates/distribution-filename/Cargo.toml
+++ b/crates/distribution-filename/Cargo.toml
@@ -23,4 +23,4 @@ thiserror = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.36.1" }
+insta = { version = "1.40.0" }

--- a/crates/install-wheel-rs/Cargo.toml
+++ b/crates/install-wheel-rs/Cargo.toml
@@ -51,6 +51,6 @@ walkdir = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]
-anyhow = { version = "1.0.80" }
-assert_fs = { version = "1.1.1" }
-indoc = { version = "2.0.4" }
+anyhow = { version = "1.0.89" }
+assert_fs = { version = "1.1.2" }
+indoc = { version = "2.0.5" }

--- a/crates/pep440-rs/Cargo.toml
+++ b/crates/pep440-rs/Cargo.toml
@@ -27,7 +27,7 @@ unicode-width = { workspace = true }
 unscanny = { workspace = true }
 
 [dev-dependencies]
-indoc = { version = "2.0.4" }
+indoc = { version = "2.0.5" }
 
 [features]
 # Match the API of the published crate, for compatibility.

--- a/crates/pep508-rs/Cargo.toml
+++ b/crates/pep508-rs/Cargo.toml
@@ -42,9 +42,9 @@ uv-normalize = { workspace = true }
 uv-pubgrub = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.36.1" }
-log = { version = "0.4.21" }
-serde_json = { version = "1.0.114" }
+insta = { version = "1.40.0" }
+log = { version = "0.4.22" }
+serde_json = { version = "1.0.128" }
 testing_logger = { version = "0.1.1" }
 
 [features]

--- a/crates/platform-tags/Cargo.toml
+++ b/crates/platform-tags/Cargo.toml
@@ -18,4 +18,4 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.36.1" }
+insta = { version = "1.40.0" }

--- a/crates/requirements-txt/Cargo.toml
+++ b/crates/requirements-txt/Cargo.toml
@@ -35,11 +35,11 @@ url = { workspace = true }
 http = ["reqwest", "reqwest-middleware"]
 
 [dev-dependencies]
-anyhow = { version = "1.0.80" }
-assert_fs = { version = "1.1.1" }
-indoc = { version = "2.0.4" }
-insta = { version = "1.36.1", features = ["filters"] }
+anyhow = { version = "1.0.89" }
+assert_fs = { version = "1.1.2" }
+indoc = { version = "2.0.5" }
+insta = { version = "1.40.0", features = ["filters"] }
 itertools = { version = "0.13.0" }
-tempfile = { version = "3.9.0" }
+tempfile = { version = "3.12.0" }
 test-case = { version = "3.3.1" }
-tokio = { version = "1.35.1" }
+tokio = { version = "1.40.0" }

--- a/crates/uv-auth/Cargo.toml
+++ b/crates/uv-auth/Cargo.toml
@@ -26,5 +26,5 @@ urlencoding = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 wiremock = { workspace = true }
-insta = { version = "1.36.1" }
-test-log = { version = "0.2.15", features = ["trace"], default-features = false }
+insta = { version = "1.40.0" }
+test-log = { version = "0.2.16", features = ["trace"], default-features = false }

--- a/crates/uv-build/Cargo.toml
+++ b/crates/uv-build/Cargo.toml
@@ -40,4 +40,4 @@ tracing = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.36.1" }
+insta = { version = "1.40.0" }

--- a/crates/uv-cli/Cargo.toml
+++ b/crates/uv-cli/Cargo.toml
@@ -35,7 +35,7 @@ serde = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.36.1", features = ["filters", "json"] }
+insta = { version = "1.40.0", features = ["filters", "json"] }
 
 [features]
 default = []

--- a/crates/uv-client/Cargo.toml
+++ b/crates/uv-client/Cargo.toml
@@ -51,8 +51,8 @@ urlencoding = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-http-body-util = { version = "0.1.0" }
-hyper = { version = "1.2.0", features = ["server", "http1"] }
-hyper-util = { version = "0.1.3", features = ["tokio"] }
-insta = { version = "1.36.1", features = ["filters", "json", "redactions"] }
+http-body-util = { version = "0.1.2" }
+hyper = { version = "1.4.1", features = ["server", "http1"] }
+hyper-util = { version = "0.1.8", features = ["tokio"] }
+insta = { version = "1.40.0", features = ["filters", "json", "redactions"] }
 tokio = { workspace = true }

--- a/crates/uv-dev/Cargo.toml
+++ b/crates/uv-dev/Cargo.toml
@@ -40,7 +40,7 @@ itertools = { workspace = true }
 markdown = { version = "0.3.0" }
 owo-colors = { workspace = true }
 poloto = { version = "19.1.2", optional = true }
-pretty_assertions = { version = "1.4.0" }
+pretty_assertions = { version = "1.4.1" }
 resvg = { version = "0.29.0", optional = true }
 schemars = { workspace = true }
 serde = { workspace = true }
@@ -54,7 +54,7 @@ tracing-subscriber = { workspace = true }
 walkdir = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mimalloc = { version = "0.1.39" }
+mimalloc = { version = "0.1.43" }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
 tikv-jemallocator = { version = "0.6.0" }

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -53,4 +53,4 @@ zip = { workspace = true }
 
 [dev-dependencies]
 indoc = { version = "2.0.5" }
-insta = { version = "1.39.0", features = ["filters", "json", "redactions"] }
+insta = { version = "1.40.0", features = ["filters", "json", "redactions"] }

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -63,10 +63,10 @@ windows-registry = { workspace = true }
 windows-result = { workspace = true }
 
 [dev-dependencies]
-anyhow = { version = "1.0.80" }
-assert_fs = { version = "1.1.1" }
-indoc = { version = "2.0.4" }
+anyhow = { version = "1.0.89" }
+assert_fs = { version = "1.1.2" }
+indoc = { version = "2.0.5" }
 itertools = { version = "0.13.0" }
 temp-env = { version = "0.3.6" }
-tempfile = { version = "3.9.0" }
-test-log = { version = "0.2.15", features = ["trace"], default-features = false }
+tempfile = { version = "3.12.0" }
+test-log = { version = "0.2.16", features = ["trace"], default-features = false }

--- a/crates/uv-resolver/Cargo.toml
+++ b/crates/uv-resolver/Cargo.toml
@@ -61,5 +61,5 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-insta = { version = "1.36.1" }
+insta = { version = "1.40.0" }
 toml = { workspace = true }

--- a/crates/uv-trampoline/Cargo.lock
+++ b/crates/uv-trampoline/Cargo.lock
@@ -18,53 +18,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
 name = "anstyle"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
-dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "anyhow"
@@ -110,17 +67,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "getrandom",
- "instant",
- "rand",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,25 +90,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "cachedir"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4703f3937077db8fa35bee3c8789343c1aec2585f0146f09d658d4ccc0e8d873"
-dependencies = [
- "tempfile",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "crc32fast"
@@ -229,24 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cd446c890d6bed1d8b53acef5f240069ebef91d6fae7c5f52efe61fe8b5eae"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "encoding_rs_io"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
-dependencies = [
- "encoding_rs",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,27 +192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -352,31 +244,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "junction"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16"
-dependencies = [
- "scopeguard",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,33 +281,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "owo-colors"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
-
-[[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
 
 [[package]]
 name = "predicates"
@@ -488,36 +328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,12 +343,6 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
-
-[[package]]
-name = "rustc-hash"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustix"
@@ -561,12 +365,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -650,37 +448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "ufmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,37 +481,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uv-fs"
-version = "0.0.1"
-dependencies = [
- "backoff",
- "cachedir",
- "dunce",
- "either",
- "encoding_rs_io",
- "fs-err",
- "fs2",
- "junction",
- "path-slash",
- "tempfile",
- "tracing",
- "urlencoding",
- "uv-warnings",
-]
-
-[[package]]
 name = "uv-trampoline"
 version = "0.1.0"
 dependencies = [
@@ -757,19 +493,9 @@ dependencies = [
  "thiserror",
  "ufmt",
  "ufmt-write",
- "uv-fs",
  "which",
  "windows",
  "zip",
-]
-
-[[package]]
-name = "uv-warnings"
-version = "0.0.1"
-dependencies = [
- "anstream",
- "owo-colors",
- "rustc-hash",
 ]
 
 [[package]]
@@ -792,12 +518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
 name = "which"
 version = "6.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,22 +530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,12 +537,6 @@ checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -991,27 +689,6 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
 
 [[package]]
 name = "zip"

--- a/crates/uv-trampoline/Cargo.lock
+++ b/crates/uv-trampoline/Cargo.lock
@@ -53,7 +53,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -63,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -332,7 +332,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -368,12 +368,12 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "junction"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9c415a9b7b1e86cd5738f39d34c9e78c765da7fb1756dbd7d31b3b0d2e7afa"
+checksum = "72bbdfd737a243da3dfc1f99ee8d6e166480f17ab4ac84d7c34aacd73fc7bd16"
 dependencies = [
  "scopeguard",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -417,9 +417,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "owo-colors"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "path-slash"
@@ -435,9 +435,12 @@ checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "predicates"
@@ -547,7 +550,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -609,14 +612,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -827,7 +831,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -910,6 +914,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +991,27 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
 
 [[package]]
 name = "zip"

--- a/crates/uv-trampoline/Cargo.toml
+++ b/crates/uv-trampoline/Cargo.toml
@@ -55,6 +55,5 @@ assert_cmd = { version = "2.0.14" }
 assert_fs = { version = "1.1.1" }
 fs-err = { version = "2.11.0" }
 thiserror = { version = "1.0.56" }
-uv-fs = { path = "../uv-fs" }
 which = { version = "6.0.0" }
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }

--- a/crates/uv-trampoline/tests/harness.rs
+++ b/crates/uv-trampoline/tests/harness.rs
@@ -12,8 +12,6 @@ use which::which;
 use zip::write::FileOptions;
 use zip::ZipWriter;
 
-use uv_fs::Simplified;
-
 const LAUNCHER_MAGIC_NUMBER: [u8; 4] = [b'U', b'V', b'U', b'V'];
 
 #[cfg(all(windows, target_arch = "x86"))]
@@ -104,7 +102,7 @@ if __name__ == "__main__":
 /// See: <https://github.com/pypa/pip/blob/0ad4c94be74cc24874c6feb5bb3c2152c398a18e/src/pip/_vendor/distlib/scripts.py#L136-L165>
 fn format_shebang(executable: impl AsRef<Path>) -> String {
     // Convert the executable to a simplified path.
-    let executable = executable.as_ref().simplified_display().to_string();
+    let executable = executable.as_ref().display().to_string();
     format!("#!{executable}")
 }
 
@@ -173,7 +171,7 @@ fn windows_script_launcher(
     }
 
     let python = python_executable.as_ref();
-    let python_path = python.simplified_display().to_string();
+    let python_path = python.display().to_string();
 
     let mut launcher: Vec<u8> = Vec::with_capacity(launcher_bin.len() + payload.len());
     launcher.extend_from_slice(launcher_bin);
@@ -211,7 +209,7 @@ fn generate_console_launcher() -> Result<()> {
 
     println!(
         "Wrote Console Launcher in {}",
-        console_bin_path.path().simplified_display()
+        console_bin_path.path().display()
     );
 
     let stdout_predicate = "Hello from uv-trampoline-console.exe\r\n";
@@ -260,10 +258,7 @@ fn generate_gui_launcher() -> Result<()> {
     // Create Launcher
     File::create(gui_bin_path.path())?.write_all(gui_launcher.as_ref())?;
 
-    println!(
-        "Wrote GUI Launcher in {}",
-        gui_bin_path.path().simplified_display()
-    );
+    println!("Wrote GUI Launcher in {}", gui_bin_path.path().display());
 
     // Test GUI Launcher
     // NOTICE: This will spawn a GUI and will wait until you close the window.

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -40,8 +40,8 @@ itertools = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-assert_fs = { version = "1.1.0" }
-insta = { version = "1.39.0", features = ["filters", "json", "redactions"] }
+assert_fs = { version = "1.1.2" }
+insta = { version = "1.40.0", features = ["filters", "json", "redactions"] }
 regex = { workspace = true }
 tempfile = { workspace = true }
 

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -83,22 +83,22 @@ which = { workspace = true }
 zip = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mimalloc = { version = "0.1.39" }
+mimalloc = { version = "0.1.43" }
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "openbsd"), any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "powerpc64")))'.dependencies]
 tikv-jemallocator = { version = "0.6.0" }
 
 [dev-dependencies]
-assert_cmd = { version = "2.0.14" }
-assert_fs = { version = "1.1.0" }
-base64 = { version = "0.22.0" }
+assert_cmd = { version = "2.0.16" }
+assert_fs = { version = "1.1.2" }
+base64 = { version = "0.22.1" }
 byteorder = { version = "1.5.0" }
 etcetera = { workspace = true }
-filetime = { version = "0.2.23" }
-ignore = { version = "0.4.22" }
-indoc = { version = "2.0.4" }
-insta = { version = "1.36.1", features = ["filters", "json"] }
-predicates = { version = "3.0.4" }
+filetime = { version = "0.2.25" }
+ignore = { version = "0.4.23" }
+indoc = { version = "2.0.5" }
+insta = { version = "1.40.0", features = ["filters", "json"] }
+predicates = { version = "3.1.2" }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"], default-features = false }
 similar = { version = "2.6.0" }


### PR DESCRIPTION
## Summary

`cargo upgrade` just updates the listed versions in the TOML files. There's no change to the `Cargo.lock` other than a minor bump to `toml-edit`.
