### PR TITLE
uv-tool/install: ignore existing environments on interpreter mismatch

### DIFF
--- a/crates/uv-tool/src/lib.rs
+++ b/crates/uv-tool/src/lib.rs
@@ -204,7 +204,7 @@ impl InstalledTools {
         match PythonEnvironment::from_root(&environment_path, cache) {
             Ok(venv) => {
                 debug!(
-                    "Using existing environment for tool `{name}`: {}",
+                    "Found existing environment for tool `{name}`: {}",
                     environment_path.user_display()
                 );
                 Ok(Some(venv))

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -7,7 +7,7 @@ use owo_colors::OwoColorize;
 use pep440_rs::{VersionSpecifier, VersionSpecifiers};
 use pep508_rs::MarkerTree;
 use pypi_types::{Requirement, RequirementSource};
-use tracing::debug;
+use tracing::trace;
 use uv_cache::{Cache, Refresh};
 use uv_cache_info::Timestamp;
 use uv_client::{BaseClientBuilder, Connectivity};
@@ -283,8 +283,8 @@ pub(crate) async fn install(
                 let old_base_prefix = environment.interpreter().sys_base_prefix();
                 let selected_base_prefix = interpreter.sys_base_prefix();
                 if old_base_prefix == selected_base_prefix {
-                    debug!(
-                        "Found existing interpreter for tool `{}`: {}",
+                    trace!(
+                        "Existing interpreter matches the requested interpreter for `{}`: {}",
                         from.name,
                         environment.interpreter().sys_executable().display()
                     );
@@ -292,7 +292,7 @@ pub(crate) async fn install(
                 } else {
                     let _ = writeln!(
                         printer.stderr(),
-                        "Ignored existing environment for `{from}` due to stale Python interpreter",
+                        "Ignoring existing environment for `{from}`: the requested Python interpreter does not match the environment interpreter",
                         from = from.name.cyan(),
                     );
                     false

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -2138,7 +2138,7 @@ fn tool_install_python_params() {
     ----- stdout -----
 
     ----- stderr -----
-    Ignored existing environment for `black` due to stale Python interpreter
+    Ignoring existing environment for `black`: the requested Python interpreter does not match the environment interpreter
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -2184,7 +2184,7 @@ fn tool_install_python_params() {
     ----- stdout -----
 
     ----- stderr -----
-    Ignored existing environment for `black` due to stale Python interpreter
+    Ignoring existing environment for `black`: the requested Python interpreter does not match the environment interpreter
     Resolved [N] packages in [TIME]
     Installed [N] packages in [TIME]
      + black==24.3.0

--- a/crates/uv/tests/tool_install.rs
+++ b/crates/uv/tests/tool_install.rs
@@ -2072,9 +2072,10 @@ fn tool_install_upgrade() {
     });
 }
 
-/// Test reinstalling tools with varying `--python` requests.
+/// Test reinstalling tools with varying `--python` and
+/// `--python-preference` parameters.
 #[test]
-fn tool_install_python_request() {
+fn tool_install_python_params() {
     let context = TestContext::new_with_versions(&["3.11", "3.12"])
         .with_filtered_counts()
         .with_filtered_exe_suffix();
@@ -2122,10 +2123,12 @@ fn tool_install_python_request() {
     `black` is already installed
     "###);
 
-    // Install with Python 3.11 (incompatible).
+    // Install with system Python 3.11 (different version, incompatible).
     uv_snapshot!(context.filters(), context.tool_install()
         .arg("-p")
         .arg("3.11")
+        .arg("--python-preference")
+        .arg("only-system")
         .arg("black")
         .env("UV_TOOL_DIR", tool_dir.as_os_str())
         .env("XDG_BIN_HOME", bin_dir.as_os_str())
@@ -2135,7 +2138,7 @@ fn tool_install_python_request() {
     ----- stdout -----
 
     ----- stderr -----
-    Existing environment for `black` does not satisfy the requested Python interpreter
+    Ignored existing environment for `black` due to stale Python interpreter
     Resolved [N] packages in [TIME]
     Prepared [N] packages in [TIME]
     Installed [N] packages in [TIME]
@@ -2146,6 +2149,69 @@ fn tool_install_python_request() {
      + pathspec==0.12.1
      + platformdirs==4.2.0
     Installed 2 executables: black, blackd
+    "###);
+
+    // Install with system Python 3.11 (compatible).
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("-p")
+        .arg("3.11")
+        .arg("--python-preference")
+        .arg("only-system")
+        .arg("black")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str())
+        .env("PATH", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    `black` is already installed
+    "###);
+
+    // Install with managed Python 3.11 (different source, incompatible).
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("-p")
+        .arg("3.11")
+        .arg("--python-preference")
+        .arg("only-managed")
+        .arg("black")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str())
+        .env("PATH", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Ignored existing environment for `black` due to stale Python interpreter
+    Resolved [N] packages in [TIME]
+    Installed [N] packages in [TIME]
+     + black==24.3.0
+     + click==8.1.7
+     + mypy-extensions==1.0.0
+     + packaging==24.0
+     + pathspec==0.12.1
+     + platformdirs==4.2.0
+    Installed 2 executables: black, blackd
+    "###);
+
+    // Install with managed Python 3.11 (compatible).
+    uv_snapshot!(context.filters(), context.tool_install()
+        .arg("-p")
+        .arg("3.11")
+        .arg("--python-preference")
+        .arg("only-managed")
+        .arg("black")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str())
+        .env("PATH", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    `black` is already installed
     "###);
 }
 


### PR DESCRIPTION
This changes `uv tool install` behavior with regards to re-using existing environments.
In particular, this replaces the existing version-matching logic with a tighter one, enforcing
a same-interpreter match.
This allows to properly switch between system and managed interpreter, at the cost of
more eagerly invalidating existing environments every time there is an interpreter change.

Closes: https://github.com/astral-sh/uv/issues/7320