### PR TITLE
Fix test case for `lock_redact_git`

### DIFF
--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -6111,7 +6111,7 @@ fn lock_redact_git() -> Result<()> {
     "###);
 
     // Install from the lockfile.
-    uv_snapshot!(&filters, context.sync().arg("--frozen"), @r###"
+    uv_snapshot!(&filters, context.sync().arg("--frozen").arg("--reinstall").arg("--no-cache"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----


### PR DESCRIPTION
These kinds of tests need to reinstall and disable the cache to actually test if credentials are propagated correctly.