### PR TITLE
Respect `pyproject.toml` credentials from user-provided requirements

### DIFF
--- a/crates/uv-git/src/credentials.rs
+++ b/crates/uv-git/src/credentials.rs
@@ -1,8 +1,14 @@
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
-
 use cache_key::RepositoryUrl;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, RwLock};
+use tracing::trace;
+use url::Url;
 use uv_auth::Credentials;
+
+/// Global authentication cache for a uv invocation.
+///
+/// This is used to share Git credentials within a single process.
+pub static GIT_STORE: LazyLock<GitStore> = LazyLock::new(GitStore::default);
 
 /// A store for Git credentials.
 #[derive(Debug, Default)]
@@ -17,5 +23,18 @@ impl GitStore {
     /// Get the [`Credentials`] for the given URL, if they exist.
     pub fn get(&self, url: &RepositoryUrl) -> Option<Arc<Credentials>> {
         self.0.read().unwrap().get(url).cloned()
+    }
+}
+
+/// Populate the global authentication store with credentials on a Git URL, if there are any.
+///
+/// Returns `true` if the store was updated.
+pub fn store_credentials_from_url(url: &Url) -> bool {
+    if let Some(credentials) = Credentials::from_url(url) {
+        trace!("Caching credentials for {url}");
+        GIT_STORE.insert(RepositoryUrl::new(url), credentials);
+        true
+    } else {
+        false
     }
 }

--- a/crates/uv-git/src/lib.rs
+++ b/crates/uv-git/src/lib.rs
@@ -1,8 +1,6 @@
-use std::sync::LazyLock;
-
 use url::Url;
 
-use crate::credentials::GitStore;
+pub use crate::credentials::{store_credentials_from_url, GIT_STORE};
 pub use crate::git::GitReference;
 pub use crate::resolver::{
     GitResolver, GitResolverError, RepositoryReference, ResolvedRepositoryReference,
@@ -15,11 +13,6 @@ mod git;
 mod resolver;
 mod sha;
 mod source;
-
-/// Global authentication cache for a uv invocation.
-///
-/// This is used to share Git credentials within a single process.
-pub static GIT_STORE: LazyLock<GitStore> = LazyLock::new(GitStore::default);
 
 /// A URL reference to a Git repository.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Hash, Ord)]

--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -120,6 +120,8 @@ pub struct Project {
     pub version: Option<Version>,
     /// The Python versions this project is compatible with.
     pub requires_python: Option<VersionSpecifiers>,
+    /// The dependencies of the project.
+    pub dependencies: Option<Vec<String>>,
     /// The optional dependencies of the project.
     pub optional_dependencies: Option<BTreeMap<ExtraName, Vec<String>>>,
 

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -531,6 +531,22 @@ impl Workspace {
         &self.sources
     }
 
+    /// Returns an iterator over all sources in the workspace.
+    pub fn iter_sources(&self) -> impl Iterator<Item = &Source> {
+        self.packages
+            .values()
+            .filter_map(|member| {
+                member.pyproject_toml().tool.as_ref().and_then(|tool| {
+                    tool.uv
+                        .as_ref()
+                        .and_then(|uv| uv.sources.as_ref())
+                        .map(ToolUvSources::inner)
+                        .map(|sources| sources.values())
+                })
+            })
+            .flatten()
+    }
+
     /// The `pyproject.toml` of the workspace.
     pub fn pyproject_toml(&self) -> &PyProjectToml {
         &self.pyproject_toml
@@ -1608,6 +1624,9 @@ mod tests {
                   "name": "bird-feeder",
                   "version": "1.0.0",
                   "requires-python": ">=3.12",
+                  "dependencies": [
+                    "anyio>=4.3.0,<5"
+                  ],
                   "optional-dependencies": null
                 },
                 "pyproject_toml": "[PYPROJECT_TOML]"
@@ -1619,6 +1638,9 @@ mod tests {
                 "name": "bird-feeder",
                 "version": "1.0.0",
                 "requires-python": ">=3.12",
+                "dependencies": [
+                  "anyio>=4.3.0,<5"
+                ],
                 "optional-dependencies": null
               },
               "tool": null
@@ -1653,6 +1675,9 @@ mod tests {
                       "name": "bird-feeder",
                       "version": "1.0.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "anyio>=4.3.0,<5"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -1664,6 +1689,9 @@ mod tests {
                     "name": "bird-feeder",
                     "version": "1.0.0",
                     "requires-python": ">=3.12",
+                    "dependencies": [
+                      "anyio>=4.3.0,<5"
+                    ],
                     "optional-dependencies": null
                   },
                   "tool": null
@@ -1697,6 +1725,10 @@ mod tests {
                       "name": "albatross",
                       "version": "0.1.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "bird-feeder",
+                        "tqdm>=4,<5"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -1707,6 +1739,10 @@ mod tests {
                       "name": "bird-feeder",
                       "version": "1.0.0",
                       "requires-python": ">=3.8",
+                      "dependencies": [
+                        "anyio>=4.3.0,<5",
+                        "seeds"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -1717,6 +1753,9 @@ mod tests {
                       "name": "seeds",
                       "version": "1.0.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "idna==3.6"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -1732,6 +1771,10 @@ mod tests {
                     "name": "albatross",
                     "version": "0.1.0",
                     "requires-python": ">=3.12",
+                    "dependencies": [
+                      "bird-feeder",
+                      "tqdm>=4,<5"
+                    ],
                     "optional-dependencies": null
                   },
                   "tool": {
@@ -1786,6 +1829,10 @@ mod tests {
                       "name": "albatross",
                       "version": "0.1.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "bird-feeder",
+                        "tqdm>=4,<5"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -1796,6 +1843,10 @@ mod tests {
                       "name": "bird-feeder",
                       "version": "1.0.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "anyio>=4.3.0,<5",
+                        "seeds"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -1806,6 +1857,9 @@ mod tests {
                       "name": "seeds",
                       "version": "1.0.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "idna==3.6"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -1861,6 +1915,9 @@ mod tests {
                       "name": "albatross",
                       "version": "0.1.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "tqdm>=4,<5"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -1872,6 +1929,9 @@ mod tests {
                     "name": "albatross",
                     "version": "0.1.0",
                     "requires-python": ">=3.12",
+                    "dependencies": [
+                      "tqdm>=4,<5"
+                    ],
                     "optional-dependencies": null
                   },
                   "tool": null
@@ -1973,6 +2033,9 @@ mod tests {
                       "name": "albatross",
                       "version": "0.1.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "tqdm>=4,<5"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -1983,6 +2046,9 @@ mod tests {
                       "name": "seeds",
                       "version": "1.0.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "idna==3.6"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -1994,6 +2060,9 @@ mod tests {
                     "name": "albatross",
                     "version": "0.1.0",
                     "requires-python": ">=3.12",
+                    "dependencies": [
+                      "tqdm>=4,<5"
+                    ],
                     "optional-dependencies": null
                   },
                   "tool": {
@@ -2062,6 +2131,9 @@ mod tests {
                       "name": "albatross",
                       "version": "0.1.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "tqdm>=4,<5"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -2072,6 +2144,9 @@ mod tests {
                       "name": "seeds",
                       "version": "1.0.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "idna==3.6"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -2083,6 +2158,9 @@ mod tests {
                     "name": "albatross",
                     "version": "0.1.0",
                     "requires-python": ">=3.12",
+                    "dependencies": [
+                      "tqdm>=4,<5"
+                    ],
                     "optional-dependencies": null
                   },
                   "tool": {
@@ -2152,6 +2230,9 @@ mod tests {
                       "name": "albatross",
                       "version": "0.1.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "tqdm>=4,<5"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -2162,6 +2243,9 @@ mod tests {
                       "name": "bird-feeder",
                       "version": "1.0.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "anyio>=4.3.0,<5"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -2172,6 +2256,9 @@ mod tests {
                       "name": "seeds",
                       "version": "1.0.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "idna==3.6"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -2183,6 +2270,9 @@ mod tests {
                     "name": "albatross",
                     "version": "0.1.0",
                     "requires-python": ">=3.12",
+                    "dependencies": [
+                      "tqdm>=4,<5"
+                    ],
                     "optional-dependencies": null
                   },
                   "tool": {
@@ -2252,6 +2342,9 @@ mod tests {
                       "name": "albatross",
                       "version": "0.1.0",
                       "requires-python": ">=3.12",
+                      "dependencies": [
+                        "tqdm>=4,<5"
+                      ],
                       "optional-dependencies": null
                     },
                     "pyproject_toml": "[PYPROJECT_TOML]"
@@ -2263,6 +2356,9 @@ mod tests {
                     "name": "albatross",
                     "version": "0.1.0",
                     "requires-python": ">=3.12",
+                    "dependencies": [
+                      "tqdm>=4,<5"
+                    ],
                     "optional-dependencies": null
                   },
                   "tool": {

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -442,7 +442,7 @@ impl TestContext {
         if cfg!(all(windows, debug_assertions)) {
             // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
             // default windows stack of 1MB
-            command.env("UV_STACK_SIZE", (2 * 1024 * 1024).to_string());
+            command.env("UV_STACK_SIZE", (4 * 1024 * 1024).to_string());
         }
     }
 
@@ -533,7 +533,7 @@ impl TestContext {
         if cfg!(all(windows, debug_assertions)) {
             // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
             // default windows stack of 1MB
-            command.env("UV_STACK_SIZE", (2 * 1024 * 1024).to_string());
+            command.env("UV_STACK_SIZE", (4 * 1024 * 1024).to_string());
         }
 
         command

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -686,7 +686,7 @@ build-backend = "poetry.core.masonry.api"
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to extract static metadata from `pyproject.toml`
+    error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 13, column 1
        |
     13 | [project.dependencies]


### PR DESCRIPTION
## Summary

When syncing a lockfile, we need to respect credentials defined in the `pyproject.toml`, even if they won't be used for resolution. Unfortunately, this includes credentials in `tool.uv.sources`, `tool.uv.dev-dependencies`, `project.dependencies`, and `project.optional-dependencies`.

Closes https://github.com/astral-sh/uv/issues/7453.
