### PR TITLE
document improvement: `settings.md/override-dependencies`

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -103,6 +103,10 @@ While constraints are _additive_, in that they're combined with the requirements
 constituent packages, overrides are _absolute_, in that they completely replace the
 requirements of any constituent packages.
 
+Including a package as an override will _not_ trigger installation of the package on its
+own; instead, the package must be requested elsewhere in the project's first-party or
+transitive dependencies.
+
 !!! note
     In `uv lock`, `uv sync`, and `uv run`, uv will only read `override-dependencies` from
     the `pyproject.toml` at the workspace root, and will ignore any declarations in other


### PR DESCRIPTION
## Summary
Improve the description of override-dependencies based on the statement in `concepts/resolution.md`: "As with constraints, overrides do not add a dependency on the package and only take effect if the package is requested in a direct or transitive dependency."

I tested it locally, `concepts/resolution.md` is correct. It would be better to also include this in the Reference Chapter of the docs.


