### PR TITLE
Lock and resolve with project name where available

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -528,7 +528,11 @@ async fn do_lock(
                     .collect(),
                 dev,
                 source_trees,
-                None,
+                workspace
+                    .pyproject_toml()
+                    .project
+                    .as_ref()
+                    .map(|proj| proj.name.clone()),
                 Some(workspace.packages().keys().cloned().collect()),
                 &extras,
                 preferences,


### PR DESCRIPTION
This populates the project package name (if available) for lock-and-resolve operations.
