### PR TITLE
`feat(7430)` - Add support to spawn python REPL with `uvx python` or `uvx python@<version>`

### DIFF
--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -198,6 +198,13 @@ pub(crate) async fn install(
 
             from_requirement
         }
+        // `python` or `python@3.13`
+        Target::Python | Target::FromPythonVersion(_) => {
+            bail!(
+                "`python` is not a valid tool name. Did you mean to install a Python interpreter?
+            If so, please use `uv python install` instead."
+            );
+        }
     };
 
     // If the user passed, e.g., `ruff@latest`, we need to mark it as upgradable.

--- a/crates/uv/tests/tool_run.rs
+++ b/crates/uv/tests/tool_run.rs
@@ -1130,3 +1130,87 @@ fn tool_run_latest() {
     ----- stderr -----
     "###);
 }
+
+#[test]
+fn tool_run_python_version_should_return_python_correct_python_version() {
+    let context = TestContext::new("3.12").with_filtered_counts();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Run `python`, which should use the installed version.
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("python")
+        .arg("--version")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Python 3.12.[X]
+
+    ----- stderr -----
+    Resolved in [TIME]
+    Audited in [TIME]
+    "###);
+}
+
+#[test]
+fn tool_run_python_should_exit_successfully() {
+    let context = TestContext::new("3.12").with_filtered_counts();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Run `python`, which should use the installed version.
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("python")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    
+    ----- stderr -----
+    Resolved in [TIME]
+    Audited in [TIME]
+    "###);
+}
+
+#[test]
+fn tool_run_python_should_return_error_if_interpreter_version_cannot_be_found() {
+    let context = TestContext::new("3.12").with_filtered_counts();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Run `python`, which should use the installed version.
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("python@3.12.99")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    
+    ----- stderr -----
+    error: No interpreter found for Python 3.12.[X] in virtual environments or system path
+    "###);
+}
+
+#[test]
+fn tool_run_python_should_return_error_if_requested_interpreter_version_is_invalid() {
+    let context = TestContext::new("3.12").with_filtered_counts();
+    let tool_dir = context.temp_dir.child("tools");
+    let bin_dir = context.temp_dir.child("bin");
+
+    // Run `python`, which should use the installed version.
+    uv_snapshot!(context.filters(), context.tool_run()
+        .arg("python@3.300")
+        .env("UV_TOOL_DIR", tool_dir.as_os_str())
+        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    
+    ----- stderr -----
+    error: Invalid version request: 3.300
+    "###);
+}

--- a/crates/uv/tests/tool_run.rs
+++ b/crates/uv/tests/tool_run.rs
@@ -1177,7 +1177,7 @@ fn tool_run_python_should_exit_successfully() {
             .arg("python")
             .env("UV_TOOL_DIR", tool_dir.as_os_str())
             .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
-            success: true
+    success: true
     exit_code: 0
     ----- stdout -----
     
@@ -1214,12 +1214,12 @@ fn tool_run_python_should_return_error_if_interpreter_version_cannot_be_found() 
             .arg("python@3.12.99")
             .env("UV_TOOL_DIR", tool_dir.as_os_str())
             .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
-             success: false
+    success: false
     exit_code: 2
     ----- stdout -----
     
     ----- stderr -----
-    error: No interpreter found for Python 3.12.[X] in virtual environments or system path or `py` launcher
+    error: No interpreter found for Python 3.12.[X] in virtual environments, system path, or `py` launcher
     "###);
     }
 }

--- a/crates/uv/tests/tool_run.rs
+++ b/crates/uv/tests/tool_run.rs
@@ -1137,7 +1137,6 @@ fn tool_run_python_version_should_return_python_correct_python_version() {
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
-    // Run `python`, which should use the installed version.
     uv_snapshot!(context.filters(), context.tool_run()
         .arg("python")
         .arg("--version")
@@ -1160,11 +1159,11 @@ fn tool_run_python_should_exit_successfully() {
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
-    // Run `python`, which should use the installed version.
-    uv_snapshot!(context.filters(), context.tool_run()
-        .arg("python")
-        .env("UV_TOOL_DIR", tool_dir.as_os_str())
-        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    if cfg!(target_os = "linux") {
+        uv_snapshot!(context.filters(), context.tool_run()
+            .arg("python")
+            .env("UV_TOOL_DIR", tool_dir.as_os_str())
+            .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1173,6 +1172,23 @@ fn tool_run_python_should_exit_successfully() {
     Resolved in [TIME]
     Audited in [TIME]
     "###);
+    } else if cfg!(target_os = "windows") {
+        uv_snapshot!(context.filters(), context.tool_run()
+            .arg("python")
+            .env("UV_TOOL_DIR", tool_dir.as_os_str())
+            .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+            success: true
+    exit_code: 0
+    ----- stdout -----
+    
+    ----- stderr -----
+    Resolved in [TIME]
+    Audited in [TIME]
+    Python 3.12.[X] (tags/v3.12.[X]:a4a2d2b, Sep  6 2024, 20:11:23) [MSC v.1940 64 bit (AMD64)] on win32
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>>
+    "###);
+    }
 }
 
 #[test]
@@ -1181,11 +1197,11 @@ fn tool_run_python_should_return_error_if_interpreter_version_cannot_be_found() 
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
-    // Run `python`, which should use the installed version.
-    uv_snapshot!(context.filters(), context.tool_run()
-        .arg("python@3.12.99")
-        .env("UV_TOOL_DIR", tool_dir.as_os_str())
-        .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+    if cfg!(target_os = "linux") {
+        uv_snapshot!(context.filters(), context.tool_run()
+            .arg("python@3.12.99")
+            .env("UV_TOOL_DIR", tool_dir.as_os_str())
+            .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -1193,6 +1209,19 @@ fn tool_run_python_should_return_error_if_interpreter_version_cannot_be_found() 
     ----- stderr -----
     error: No interpreter found for Python 3.12.[X] in virtual environments or system path
     "###);
+    } else if cfg!(target_os = "windows") {
+        uv_snapshot!(context.filters(), context.tool_run()
+            .arg("python@3.12.99")
+            .env("UV_TOOL_DIR", tool_dir.as_os_str())
+            .env("XDG_BIN_HOME", bin_dir.as_os_str()), @r###"
+             success: false
+    exit_code: 2
+    ----- stdout -----
+    
+    ----- stderr -----
+    error: No interpreter found for Python 3.12.[X] in virtual environments or system path or `py` launcher
+    "###);
+    }
 }
 
 #[test]
@@ -1201,7 +1230,6 @@ fn tool_run_python_should_return_error_if_requested_interpreter_version_is_inval
     let tool_dir = context.temp_dir.child("tools");
     let bin_dir = context.temp_dir.child("bin");
 
-    // Run `python`, which should use the installed version.
     uv_snapshot!(context.filters(), context.tool_run()
         .arg("python@3.300")
         .env("UV_TOOL_DIR", tool_dir.as_os_str())


### PR DESCRIPTION
## Summary

This PR adds support to spawn Python REPL with the following commands:
```bash
uvx python # or
uvx python@3.12.9 # or
uvx python@3.13.rc2
```

## Test Plan

I added a few snapshot tests to the `crates/uv/tests/tool_run.rs.` 

CI passes

### Manual Tests
```bash
cargo run -- tool run python                                                                                                                                  ░▒▓ 99% 󰁹
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.42s
     Running `target/debug/uv tool run python`
Python 3.12.1 (main, Jan  8 2024, 05:57:25) [Clang 17.0.6 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
````

```bash
cargo run -- tool run python@3.9.20                                                                                                                           ░▒▓ 99% 󰁹
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/uv tool run 'python@3.9.20'`
Python 3.9.20 (main, Sep  9 2024, 22:13:21)
[Clang 18.1.8 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
```

```bash
cargo run -- tool run python@3.13.0rc2                                                                                                                        ░▒▓ 99% 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/uv tool run 'python@3.13.0rc2'`
Python 3.13.0rc2 (main, Sep  9 2024, 22:13:26) [Clang 18.1.8 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
```
```bash
cargo run -- tool run python@3.13.0b3                                                                                                                         ░▒▓ 99% 
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.41s
     Running `target/debug/uv tool run 'python@3.13.0b3'`
Python 3.13.0b3 (main, Sep 12 2024, 19:13:56) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
```

## Remarks/Questions

- `uvx python@latest` does not work, and I'm unsure how to handle this. Is this a valid alternative?
- `uvx python` launches REPL from system env? Is that correct? Or should it take the default interpreter from the virtual environment?
- [uv tool run](https://docs.astral.sh/uv/reference/cli/#uv-tool-run) has many options when running `uvx python`. E.g. `--python`?
- Do you think we should document this change somewhere? If so, what would be the correct place?


Related to issue #7430
