### PR TITLE
Revert "Prune unzipped source distributions in `uv cache prune --ci` (#7446)"

### DIFF
--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -740,8 +740,7 @@ pub enum CacheBucket {
 impl CacheBucket {
     fn to_str(self) -> &'static str {
         match self {
-            // Note, next time we change the version we should change the name of this bucket to `source-dists-v0`
-            Self::SourceDistributions => "built-wheels-v3",
+            Self::SourceDistributions => "source-dists-v0",
             Self::FlatIndex => "flat-index-v0",
             Self::Git => "git-v0",
             Self::Interpreter => "interpreter-v2",

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -447,31 +447,12 @@ impl Cache {
                 Err(err) => return Err(err),
             }
 
+            // Remove any unzipped wheels (i.e., symlinks) from the built wheels cache.
             for entry in walkdir::WalkDir::new(self.bucket(CacheBucket::SourceDistributions)) {
                 let entry = entry?;
-
-                // If the directory contains a `metadata.msgpack`, then it's a built wheel revision.
-                if !entry.file_type().is_dir() {
-                    continue;
-                }
-
-                if !entry.path().join("metadata.msgpack").exists() {
-                    continue;
-                }
-
-                // Remove any symlinks and directories in the revision. The symlinks represent
-                // unzipped wheels, and the directories represent the source distribution archives.
-                for entry in fs_err::read_dir(entry.path())? {
-                    let entry = entry?;
-                    let path = entry.path();
-
-                    if path.is_dir() {
-                        debug!("Removing unzipped built wheel entry: {}", path.display());
-                        summary += rm_rf(path)?;
-                    } else if path.is_symlink() {
-                        debug!("Removing unzipped built wheel entry: {}", path.display());
-                        summary += rm_rf(path)?;
-                    }
+                if entry.file_type().is_symlink() {
+                    debug!("Removing unzipped wheel entry: {}", entry.path().display());
+                    summary += rm_rf(entry.path())?;
                 }
             }
         }

--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -321,7 +321,7 @@ fn prune_stale_revision() -> Result<()> {
     ----- stderr -----
     DEBUG uv [VERSION] ([COMMIT] DATE)
     Pruning cache at: [CACHE_DIR]/
-    DEBUG Removing dangling source revision: [CACHE_DIR]/built-wheels-v3/[ENTRY]
+    DEBUG Removing dangling source revision: [CACHE_DIR]/source-dists-v0/[ENTRY]
     DEBUG Removing dangling cache archive: [CACHE_DIR]/archive-v0/[ENTRY]
     Removed 8 files ([SIZE])
     "###);

--- a/crates/uv/tests/cache_prune.rs
+++ b/crates/uv/tests/cache_prune.rs
@@ -204,7 +204,7 @@ fn prune_unzipped() -> Result<()> {
 
     ----- stderr -----
     Pruning cache at: [CACHE_DIR]/
-    Removed 170 files ([SIZE])
+    Removed 162 files ([SIZE])
     "###);
 
     // Reinstalling the source distribution should not require re-downloading the source

--- a/docs/concepts/cache.md
+++ b/docs/concepts/cache.md
@@ -115,9 +115,9 @@ from source tends to be worthwhile, since the wheel building process can be expe
 for extension modules.
 
 To support this caching strategy, uv provides a `uv cache prune --ci` command, which removes all
-pre-built wheels and unzipped source distributions from the cache, but retains any wheels that were
-built from source. We recommend running `uv cache prune --ci` at the end of your continuous
-integration job to ensure maximum cache efficiency. For an example, see the
+pre-built wheels from the cache but retains any wheels that were built from source. We recommend
+running `uv cache prune --ci` at the end of your continuous integration job to ensure maximum cache
+efficiency. For an example, see the
 [GitHub integration guide](../guides/integration/github.md#caching).
 
 ## Cache directory


### PR DESCRIPTION
This reverts commit 9f7d9da449cab4119d07da3ecd2e3b868e092afd from PR #7446.

This is meant to be available as a quick fix if we can't otherwise find
a quick fix to the problem reported in #7485.

Fixes #7485
