### PR TITLE
Use a single buffer for hints on resolver errors

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Formatter;
 use std::sync::Arc;
 
+use indexmap::IndexSet;
 use pubgrub::{DefaultStringReporter, DerivationTree, Derived, External, Range, Reporter};
 use rustc_hash::FxHashMap;
 
@@ -248,7 +249,8 @@ impl std::fmt::Display for NoSolutionError {
         write!(f, "{report}")?;
 
         // Include any additional hints.
-        for hint in formatter.hints(
+        let mut additional_hints = IndexSet::default();
+        formatter.generate_hints(
             &self.error,
             &self.selector,
             &self.index_locations,
@@ -256,7 +258,9 @@ impl std::fmt::Display for NoSolutionError {
             &self.incomplete_packages,
             &self.fork_urls,
             &self.markers,
-        ) {
+            &mut additional_hints,
+        );
+        for hint in additional_hints {
             write!(f, "\n\n{hint}")?;
         }
 


### PR DESCRIPTION
This changes the structure of the hints generator in the resolver when encountering solution errors, so that it re-uses a single output buffer owned by the caller.
It avoids repeated allocations of a temporary buffer within each recursive function call.