### PR TITLE
Avoid fatal error when searching for egg-info with missing directory

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -1899,6 +1899,9 @@ async fn read_egg_info(
     let egg_info = match find_egg_info(directory.as_ref()) {
         Ok(Some(path)) => path,
         Ok(None) => return Err(Error::MissingEggInfo),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(Error::MissingEggInfo)
+        }
         Err(err) => return Err(Error::CacheRead(err)),
     };
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/7485.

## Test Plan

```
$ cargo run cache clean
$ cargo run venv
$ cargo run pip install django-allauth==0.51.0
$ cargo run venv
$ cargo run pip install django-allauth==0.51.0
```
