### PR TITLE
Provide resolution hints in case of possible local name conflicts

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -258,6 +258,7 @@ impl std::fmt::Display for NoSolutionError {
             &self.incomplete_packages,
             &self.fork_urls,
             &self.markers,
+            &self.workspace_members,
             &mut additional_hints,
         );
         for hint in additional_hints {

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -4834,7 +4834,7 @@ fn add_shadowed_name() -> Result<()> {
       × No solution found when resolving dependencies:
       ╰─▶ Because dagster-webserver==1.6.13 depends on your project and your project depends on dagster-webserver==1.6.13, we can conclude that your project's requirements are unsatisfiable.
 
-          hint: The package `dagster-webserver` depends on `dagster` which is shadowed by your project. Consider changing the name of the project.
+          hint: The package `dagster-webserver` depends on the package `dagster` but the name is shadowed by your project. Consider changing the name of the project.
       help: If this is intentional, run `uv add --frozen` to skip the lock and sync steps.
     "###);
 
@@ -4859,7 +4859,7 @@ fn add_shadowed_name() -> Result<()> {
           depend on your project.
           And because dagster-webserver==1.6.13 depends on your project and your project depends on dagster-webserver>=1.6.11,<1.7.0, we can conclude that your project's requirements are unsatisfiable.
 
-          hint: The package `dagster-webserver` depends on `dagster` which is shadowed by your project. Consider changing the name of the project.
+          hint: The package `dagster-webserver` depends on the package `dagster` but the name is shadowed by your project. Consider changing the name of the project.
       help: If this is intentional, run `uv add --frozen` to skip the lock and sync steps.
     "###);
 

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -4812,7 +4812,7 @@ fn update_offset() -> Result<()> {
 /// Check hint for <https://github.com/astral-sh/uv/issues/7329>
 /// if there is a broken cyclic dependency on a local package.
 #[test]
-fn add_error_local_cycle() -> Result<()> {
+fn add_shadowed_name() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
@@ -4834,7 +4834,7 @@ fn add_error_local_cycle() -> Result<()> {
       × No solution found when resolving dependencies:
       ╰─▶ Because dagster-webserver==1.6.13 depends on your project and your project depends on dagster-webserver==1.6.13, we can conclude that your project's requirements are unsatisfiable.
 
-          hint: Resolution failed on a dependency ('dagster') which has the same name as your local package ('dagster'). Consider checking your project for possible name conflicts with packages in the index.
+          hint: The package `dagster-webserver` depends on `dagster` which is shadowed by your project. Consider changing the name of the project.
       help: If this is intentional, run `uv add --frozen` to skip the lock and sync steps.
     "###);
 
@@ -4859,7 +4859,7 @@ fn add_error_local_cycle() -> Result<()> {
           depend on your project.
           And because dagster-webserver==1.6.13 depends on your project and your project depends on dagster-webserver>=1.6.11,<1.7.0, we can conclude that your project's requirements are unsatisfiable.
 
-          hint: Resolution failed on a dependency ('dagster') which has the same name as your local package ('dagster'). Consider checking your project for possible name conflicts with packages in the index.
+          hint: The package `dagster-webserver` depends on `dagster` which is shadowed by your project. Consider changing the name of the project.
       help: If this is intentional, run `uv add --frozen` to skip the lock and sync steps.
     "###);
 

--- a/crates/uv/tests/edit.rs
+++ b/crates/uv/tests/edit.rs
@@ -4822,35 +4822,46 @@ fn add_error_local_cycle() -> Result<()> {
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = []
-
-        [build-system]
-        requires = ["setuptools>=42"]
-        build-backend = "setuptools.build_meta"
     "#})?;
 
-    uv_snapshot!(context.filters(), context.add().arg("dagster-webserver==1.8.7"), @r###"
+    // Pinned constrained, check for a direct dependency loop.
+    uv_snapshot!(context.filters(), context.add().arg("dagster-webserver==1.6.13"), @r###"
     success: false
     exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because there is no version of dagster-webserver==1.8.7 and your project depends on dagster-webserver==1.8.7, we can conclude that your project's requirements are unsatisfiable.
+      ╰─▶ Because dagster-webserver==1.6.13 depends on your project and your project depends on dagster-webserver==1.6.13, we can conclude that your project's requirements are unsatisfiable.
 
           hint: Resolution failed on a dependency ('dagster') which has the same name as your local package ('dagster'). Consider checking your project for possible name conflicts with packages in the index.
       help: If this is intentional, run `uv add --frozen` to skip the lock and sync steps.
     "###);
 
-    uv_snapshot!(context.filters(), context.add().arg("xyz").arg("--frozen"), @r###"
-    success: true
-    exit_code: 0
+    // Constraint with several available versions, check for an indirect dependency loop.
+    uv_snapshot!(context.filters(), context.add().arg("dagster-webserver>=1.6.11,<1.7.0"), @r###"
+    success: false
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    "###);
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only the following versions of dagster-webserver are available:
+              dagster-webserver<=1.6.13
+              dagster-webserver>1.7.0
+          and dagster-webserver==1.6.11 depends on your project, we can conclude that all of:
+              dagster-webserver>=1.6.11,<1.6.12
+              dagster-webserver>1.6.13,<1.7.0
+          depend on your project.
+          And because dagster-webserver==1.6.12 depends on your project, we can conclude that all of:
+              dagster-webserver>=1.6.11,<1.6.13
+              dagster-webserver>1.6.13,<1.7.0
+          depend on your project.
+          And because dagster-webserver==1.6.13 depends on your project and your project depends on dagster-webserver>=1.6.11,<1.7.0, we can conclude that your project's requirements are unsatisfiable.
 
-    let lock = context.temp_dir.join("uv.lock");
-    assert!(!lock.exists());
+          hint: Resolution failed on a dependency ('dagster') which has the same name as your local package ('dagster'). Consider checking your project for possible name conflicts with packages in the index.
+      help: If this is intentional, run `uv add --frozen` to skip the lock and sync steps.
+    "###);
 
     Ok(())
 }


### PR DESCRIPTION
This enhances the hints generator in the resolver with some heuristic to detect and warn in case of failures due to version mismatches on a local package. Those may be the symptom of name conflict/shadowing with a transitive dependency.

Closes: https://github.com/astral-sh/uv/issues/7329
