### PR TITLE
Display alternative Python implementations in `uv python list`

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -946,11 +946,14 @@ pub(crate) fn find_python_installation(
 
         // If it's an alternative implementation, and alternative implementations aren't allowed
         // skip it
+        let allows_alternative_implementation = request.allows_alternative_implementations()
+            || installation.source.allows_alternative_implementations()
+            || (installation.uses_default_executable_name()
+                && installation.source == PythonSource::SearchPath);
         if !matches!(
             installation.implementation(),
             LenientImplementationName::Known(ImplementationName::CPython),
-        ) && !request.allows_alternative_implementations()
-            && !installation.source.allows_alternative_implementations()
+        ) && !allows_alternative_implementation
         {
             debug!("Skipping alternative implementation {}", installation.key());
             continue;
@@ -1217,10 +1220,7 @@ impl PythonRequest {
         for implementation in
             ImplementationName::long_names().chain(ImplementationName::short_names())
         {
-            if let Some(remainder) = value
-                .to_ascii_lowercase()
-                .strip_prefix(Into::<&str>::into(*implementation))
-            {
+            if let Some(remainder) = value.to_ascii_lowercase().strip_prefix(implementation) {
                 // e.g. `pypy`
                 if remainder.is_empty() {
                     return Self::Implementation(
@@ -1395,7 +1395,8 @@ impl PythonRequest {
 
     pub(crate) fn allows_alternative_implementations(&self) -> bool {
         match self {
-            Self::Any => false,
+            Self::Default => false,
+            Self::Any => true,
             Self::Version(_) => false,
             Self::Directory(_) | Self::File(_) | Self::ExecutableName(_) => true,
             Self::Implementation(_) => true,

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -285,6 +285,10 @@ impl PythonDownloadRequest {
         })
     }
 
+    pub fn allows_alternative_implementations(&self) -> bool {
+        self.implementation.is_some()
+    }
+
     pub fn satisfied_by_interpreter(&self, interpreter: &Interpreter) -> bool {
         if let Some(version) = self.version() {
             if !version.matches_interpreter(interpreter) {

--- a/crates/uv-python/src/implementation.rs
+++ b/crates/uv-python/src/implementation.rs
@@ -61,6 +61,12 @@ impl From<&ImplementationName> for &'static str {
     }
 }
 
+impl From<ImplementationName> for &'static str {
+    fn from(v: ImplementationName) -> &'static str {
+        (&v).into()
+    }
+}
+
 impl<'a> From<&'a LenientImplementationName> for &'a str {
     fn from(v: &'a LenientImplementationName) -> &'a str {
         match v {

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -17,6 +17,7 @@ use crate::managed::{ManagedPythonInstallation, ManagedPythonInstallations};
 use crate::platform::{Arch, Libc, Os};
 use crate::{
     downloads, Error, Interpreter, PythonDownloads, PythonPreference, PythonSource, PythonVersion,
+    VersionRequest,
 };
 
 /// A Python interpreter and accompanying tools.
@@ -198,6 +199,21 @@ impl PythonInstallation {
 
     pub fn into_interpreter(self) -> Interpreter {
         self.interpreter
+    }
+
+    /// Whether or not this Python installation uses a default Python name, like `python`,
+    /// `python3`, or `python.exe`.
+    pub(crate) fn uses_default_executable_name(&self) -> bool {
+        let Some(file_name) = self.interpreter.sys_executable().file_name() else {
+            return false;
+        };
+        let Some(name) = file_name.to_str() else {
+            return false;
+        };
+        VersionRequest::Default
+            .executable_names(None)
+            .into_iter()
+            .any(|default_name| name == default_name.to_string())
     }
 }
 


### PR DESCRIPTION
Closes #7286

We now show externally-managed alternative Python implementations

```
❯ ./target/debug/uv python list --only-installed
cpython-3.13.0rc2-macos-aarch64-none    /Users/zb/.local/share/uv/python/cpython-3.13.0rc2-macos-aarch64-none/bin/python3 -> python3.13
cpython-3.12.6-macos-aarch64-none       /opt/homebrew/opt/python@3.12/bin/python3.12 -> ../Frameworks/Python.framework/Versions/3.12/bin/python3.12
cpython-3.12.6-macos-aarch64-none       /Users/zb/.local/share/uv/python/cpython-3.12.6-macos-aarch64-none/bin/python3 -> python3.12
cpython-3.11.10-macos-aarch64-none      /opt/homebrew/opt/python@3.11/bin/python3.11 -> ../Frameworks/Python.framework/Versions/3.11/bin/python3.11
cpython-3.11.10-macos-aarch64-none      /Users/zb/.local/share/uv/python/cpython-3.11.10-macos-aarch64-none/bin/python3 -> python3.11
cpython-3.11.5-macos-aarch64-none       /Users/zb/.local/share/uv/python/cpython-3.11.5-macos-aarch64-none/bin/python3 -> python3.11
cpython-3.9.6-macos-aarch64-none        /Library/Developer/CommandLineTools/usr/bin/python3 -> ../../Library/Frameworks/Python3.framework/Versions/3.9/bin/python3
pypy-3.10.14-macos-aarch64-none         /opt/homebrew/bin/pypy3 -> ../Cellar/pypy3.10/7.3.17/bin/pypy3
pypy-3.10.14-macos-aarch64-none         /Users/zb/.local/share/uv/python/pypy-3.10.14-macos-aarch64-none/bin/python3 -> pypy3.10
```

Previously, this required the implementation to use the `python` executable name. The problem here is that we weren't looking at these executables at all unless the alternative implementation was requested.