### PR TITLE
Move uvx shell completion to uvx --generate-shell-completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,13 @@ jobs:
           $uv venv
           $uv pip install ruff
 
+      - name: "Smoke test completion"
+        run: |
+          uv="./target/debug/uv"
+          uvx="./target/debug/uvx"
+          eval "$($uv generate-shell-completion bash)"
+          eval "$($uvx --generate-shell-completion bash)"
+
   cargo-test-macos:
     timeout-minutes: 10
     needs: determine_changes
@@ -304,6 +311,18 @@ jobs:
           Set-Alias -Name uv -Value ./target/debug/uv
           uv venv
           uv pip install ruff
+
+      - name: "Smoke test completion"
+        working-directory: ${{ env.UV_WORKSPACE }}
+        shell: powershell
+        env:
+          # Avoid debug build stack overflows.
+          UV_STACK_SIZE: 2000000
+        run: |
+          Set-Alias -Name uv -Value ./target/debug/uv
+          Set-Alias -Name uvx -Value ./target/debug/uvx
+          (& uv generate-shell-completion powershell) | Out-String | Invoke-Expression
+          (& uvx --generate-shell-completion powershell) | Out-String | Invoke-Expression
 
   # Separate jobs for the nightly crate
   windows-trampoline-check:

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3247,6 +3247,9 @@ pub struct ToolRunArgs {
     /// By default, environment modifications are omitted, but enabled under `--verbose`.
     #[arg(long, env = "UV_SHOW_RESOLUTION", value_parser = clap::builder::BoolishValueParser::new(), hide = true)]
     pub show_resolution: bool,
+
+    #[arg(long, hide = true)]
+    pub generate_shell_completion: Option<clap_complete_command::Shell>,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -319,6 +319,7 @@ impl ToolRunSettings {
             build,
             refresh,
             python,
+            generate_shell_completion: _,
         } = args;
 
         // If `--upgrade` was passed explicitly, warn.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -186,6 +186,24 @@ To enable shell autocompletion for uv commands, run one of the following:
     Add-Content -Path $PROFILE -Value '(& uv generate-shell-completion powershell) | Out-String | Invoke-Expression'
     ```
 
+To enable shell autocompletion for uvx, run one of the following:
+
+=== "Linux and macOS"
+
+    ```bash
+    # Determine your shell (e.g., with `echo $SHELL`), then run one of:
+    echo 'eval "$(uvx --generate-shell-completion bash)"' >> ~/.bashrc
+    echo 'eval "$(uvx --generate-shell-completion zsh)"' >> ~/.zshrc
+    echo 'uvx --generate-shell-completion fish | source' >> ~/.config/fish/config.fish
+    echo 'eval (uvx --generate-shell-completion elvish | slurp)' >> ~/.elvish/rc.elv
+    ```
+
+=== "Windows"
+
+    ```powershell
+    Add-Content -Path $PROFILE -Value '(& uvx --generate-shell-completion powershell) | Out-String | Invoke-Expression'
+    ```
+
 Then restart the shell or source the shell config file.
 
 ## Uninstallation


### PR DESCRIPTION
## Summary

Because a problem was found with Powershell and combining the generated completion scripts for uv and uvx, let's try separating uv and uvx command completion scripts.

The generated powershell script template can be seen in clap_complete source, and it starts with `using` directives, which makes it impossible (apparently) to concatenate two of those script outputs.

As a side effect, this is available under `uv tool run --generate-shell-completion` too.

Fixes #7482

## Test Plan

- `eval "$(cargo run --bin uvx -- --generate-shell-completion bash)"`
- Test Powershell
