### PR TITLE
Rename `PythonRequest::Any` -> `PythonRequest::Default`

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -173,7 +173,7 @@ impl PythonDownloadRequest {
                     .with_version(version.clone()),
             ),
             PythonRequest::Key(request) => Some(request.clone()),
-            PythonRequest::Any => Some(Self::default()),
+            PythonRequest::Default => Some(Self::default()),
             // We can't download a managed installation for these request kinds
             PythonRequest::Directory(_)
             | PythonRequest::ExecutableName(_)

--- a/crates/uv-python/src/environment.rs
+++ b/crates/uv-python/src/environment.rs
@@ -80,7 +80,7 @@ impl fmt::Display for EnvironmentNotFound {
             EnvironmentPreference::OnlyVirtual => SearchType::Virtual,
         };
 
-        if matches!(self.request, PythonRequest::Any) {
+        if matches!(self.request, PythonRequest::Default) {
             write!(f, "No {search_type} found")?;
         } else {
             write!(f, "No {search_type} found for {}", self.request)?;

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -87,7 +87,7 @@ impl PythonInstallation {
         cache: &Cache,
         reporter: Option<&dyn Reporter>,
     ) -> Result<Self, Error> {
-        let request = request.unwrap_or_else(|| &PythonRequest::Any);
+        let request = request.unwrap_or_else(|| &PythonRequest::Default);
 
         // Search for the installation
         match Self::find(request, environments, preference, cache) {

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -416,7 +416,7 @@ mod tests {
         context.search_path = Some(vec![]);
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -430,7 +430,7 @@ mod tests {
         context.search_path = None;
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -454,7 +454,7 @@ mod tests {
 
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -478,7 +478,7 @@ mod tests {
 
         let interpreter = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -538,7 +538,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -569,7 +569,7 @@ mod tests {
 
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -605,7 +605,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::default(),
                 &context.cache,
@@ -636,7 +636,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -657,7 +657,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -682,7 +682,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlySystem,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -707,7 +707,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -970,7 +970,7 @@ mod tests {
         let python =
             context.run_with_vars(&[("VIRTUAL_ENV", Some(venv.as_os_str()))], || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -995,7 +995,7 @@ mod tests {
         let python =
             context.run_with_vars(&[("VIRTUAL_ENV", Some(venv.as_os_str()))], || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1020,7 +1020,7 @@ mod tests {
             context.run_with_vars(&[("CONDA_PREFIX", Some(condaenv.as_os_str()))], || {
                 // Note this python is not treated as a system interpreter
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::OnlyVirtual,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1050,7 +1050,7 @@ mod tests {
             ],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1069,7 +1069,7 @@ mod tests {
         let python =
             context.run_with_vars(&[("CONDA_PREFIX", Some(condaenv.as_os_str()))], || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1094,7 +1094,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1111,7 +1111,7 @@ mod tests {
         context.add_python_versions(&["3.12.1", "3.12.2"])?;
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1139,7 +1139,7 @@ mod tests {
         let python =
             context.run_with_vars(&[("VIRTUAL_ENV", Some(venv.as_os_str()))], || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1172,7 +1172,7 @@ mod tests {
             &[("UV_INTERNAL__PARENT_INTERPRETER", Some(parent.as_os_str()))],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1196,7 +1196,7 @@ mod tests {
             ],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1217,7 +1217,7 @@ mod tests {
             ],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::ExplicitSystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1238,7 +1238,7 @@ mod tests {
             ],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::OnlySystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1259,7 +1259,7 @@ mod tests {
             ],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::OnlyVirtual,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1292,7 +1292,7 @@ mod tests {
             &[("UV_INTERNAL__PARENT_INTERPRETER", Some(parent.as_os_str()))],
             || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::Any,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1319,7 +1319,7 @@ mod tests {
         let python =
             context.run_with_vars(&[("VIRTUAL_ENV", Some(venv.as_os_str()))], || {
                 find_python_installation(
-                    &PythonRequest::Any,
+                    &PythonRequest::Default,
                     EnvironmentPreference::OnlySystem,
                     PythonPreference::OnlySystem,
                     &context.cache,
@@ -1371,7 +1371,7 @@ mod tests {
 
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::OnlyVirtual,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1422,7 +1422,7 @@ mod tests {
 
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1767,7 +1767,7 @@ mod tests {
         context.add_python_interpreters(&[(true, ImplementationName::PyPy, "pypy", "3.10.0")])?;
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1783,7 +1783,7 @@ mod tests {
         context.add_python_interpreters(&[(true, ImplementationName::PyPy, "python", "3.10.1")])?;
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -1836,7 +1836,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -2110,7 +2110,7 @@ mod tests {
         )])?;
         let result = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -2131,7 +2131,7 @@ mod tests {
         )])?;
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,
@@ -2184,7 +2184,7 @@ mod tests {
 
         let python = context.run(|| {
             find_python_installation(
-                &PythonRequest::Any,
+                &PythonRequest::Default,
                 EnvironmentPreference::Any,
                 PythonPreference::OnlySystem,
                 &context.cache,

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -305,7 +305,7 @@ impl ManagedPythonInstallation {
     pub fn satisfies(&self, request: &PythonRequest) -> bool {
         match request {
             PythonRequest::File(path) => self.executable() == *path,
-            PythonRequest::Any => true,
+            PythonRequest::Default => true,
             PythonRequest::Directory(path) => self.path() == *path,
             PythonRequest::ExecutableName(name) => self
                 .executable()

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -139,7 +139,7 @@ pub(crate) async fn add(
                 request
             } else {
                 // (3) Assume any Python version
-                PythonRequest::Any
+                PythonRequest::Default
             };
 
             let interpreter = PythonInstallation::find_or_download(

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -41,7 +41,7 @@ pub(crate) async fn install(
         PythonVersionFile::discover(&*CWD, no_config, true)
             .await?
             .map(uv_python::PythonVersionFile::into_versions)
-            .unwrap_or_else(|| vec![PythonRequest::Any])
+            .unwrap_or_else(|| vec![PythonRequest::Default])
     } else {
         targets
             .iter()
@@ -62,7 +62,7 @@ pub(crate) async fn install(
     let mut unfilled_requests = Vec::new();
     let mut uninstalled = Vec::new();
     for (request, download_request) in requests.iter().zip(download_requests) {
-        if matches!(requests.as_slice(), [PythonRequest::Any]) {
+        if matches!(requests.as_slice(), [PythonRequest::Default]) {
             writeln!(printer.stderr(), "Searching for Python installations")?;
         } else {
             writeln!(
@@ -75,7 +75,7 @@ pub(crate) async fn install(
             .iter()
             .find(|installation| download_request.satisfied_by_key(installation.key()))
         {
-            if matches!(request, PythonRequest::Any) {
+            if matches!(request, PythonRequest::Default) {
                 writeln!(printer.stderr(), "Found: {}", installation.key().green())?;
             } else {
                 writeln!(
@@ -96,7 +96,7 @@ pub(crate) async fn install(
     }
 
     if unfilled_requests.is_empty() {
-        if matches!(requests.as_slice(), [PythonRequest::Any]) {
+        if matches!(requests.as_slice(), [PythonRequest::Default]) {
             writeln!(
                 printer.stderr(),
                 "Python is already available. Use `uv python install <request>` to install a specific version.",

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -66,7 +66,7 @@ pub(crate) async fn list(
     };
 
     let installed = find_python_installations(
-        &PythonRequest::Any,
+        &PythonRequest::Default,
         EnvironmentPreference::OnlySystem,
         python_preference,
         cache,

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -59,7 +59,7 @@ async fn do_uninstall(
     let start = std::time::Instant::now();
 
     let requests = if all {
-        vec![PythonRequest::Any]
+        vec![PythonRequest::Default]
     } else {
         let targets = targets.into_iter().collect::<BTreeSet<_>>();
         targets
@@ -82,7 +82,7 @@ async fn do_uninstall(
     let installed_installations: Vec<_> = installations.find_all()?.collect();
     let mut matching_installations = BTreeSet::default();
     for (request, download_request) in requests.iter().zip(download_requests) {
-        if matches!(requests.as_slice(), [PythonRequest::Any]) {
+        if matches!(requests.as_slice(), [PythonRequest::Default]) {
             writeln!(printer.stderr(), "Searching for Python installations")?;
         } else {
             writeln!(
@@ -100,7 +100,7 @@ async fn do_uninstall(
             matching_installations.insert(installation.clone());
         }
         if !found {
-            if matches!(requests.as_slice(), [PythonRequest::Any]) {
+            if matches!(requests.as_slice(), [PythonRequest::Default]) {
                 writeln!(printer.stderr(), "No Python installations found")?;
                 return Ok(ExitStatus::Failure);
             }


### PR DESCRIPTION
As we support more complex Python discovery behaviors such as:

- #7431 
- #7335 
- #7300 

`Any` is no longer accurate, we actually are looking for a reasonable default Python version to use which may exclude the first one we find. Separately, we need the idea of `Any` to improve behavior when listing versions (e.g., #7286) where we do actually want to match _any_ Python version. As a first step, we'll rename `Any` to `Default`. Then, we'll introduce a new `Any` that actually behaves as we'd expect.
