### PR TITLE
Add new `PythonRequest::Any` and `VersionRequest::Any` variants

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -173,7 +173,7 @@ impl PythonDownloadRequest {
                     .with_version(version.clone()),
             ),
             PythonRequest::Key(request) => Some(request.clone()),
-            PythonRequest::Default => Some(Self::default()),
+            PythonRequest::Default | PythonRequest::Any => Some(Self::default()),
             // We can't download a managed installation for these request kinds
             PythonRequest::Directory(_)
             | PythonRequest::ExecutableName(_)

--- a/crates/uv-python/src/environment.rs
+++ b/crates/uv-python/src/environment.rs
@@ -80,7 +80,7 @@ impl fmt::Display for EnvironmentNotFound {
             EnvironmentPreference::OnlyVirtual => SearchType::Virtual,
         };
 
-        if matches!(self.request, PythonRequest::Default) {
+        if matches!(self.request, PythonRequest::Default | PythonRequest::Any) {
             write!(f, "No {search_type} found")?;
         } else {
             write!(f, "No {search_type} found for {}", self.request)?;

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -305,7 +305,7 @@ impl ManagedPythonInstallation {
     pub fn satisfies(&self, request: &PythonRequest) -> bool {
         match request {
             PythonRequest::File(path) => self.executable() == *path,
-            PythonRequest::Default => true,
+            PythonRequest::Default | PythonRequest::Any => true,
             PythonRequest::Directory(path) => self.path() == *path,
             PythonRequest::ExecutableName(name) => self
                 .executable()

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -66,7 +66,7 @@ pub(crate) async fn list(
     };
 
     let installed = find_python_installations(
-        &PythonRequest::Default,
+        &PythonRequest::Any,
         EnvironmentPreference::OnlySystem,
         python_preference,
         cache,


### PR DESCRIPTION
Follow-up to https://github.com/astral-sh/uv/pull/7514 and #7526 adding the `Any` variants again with slightly different semantics (i.e., they allow pre-releases)

We'll be able to use this in https://github.com/astral-sh/uv/pull/7508 to avoid querying a bunch of alternative interpreters unnecessarily in the non-list case.