### PR TITLE
Avoid warning about bad Python interpreter links for empty project environment directories

### DIFF
--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -78,6 +78,9 @@ pub enum Error {
 
     #[error(transparent)]
     MissingEnvironment(#[from] environment::EnvironmentNotFound),
+
+    #[error(transparent)]
+    InvalidEnvironment(#[from] environment::InvalidEnvironment),
 }
 
 // The mock interpreters are not valid on Windows so we don't have unit test coverage there

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -1747,9 +1747,7 @@ fn sync_custom_environment_path() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Ignoring existing virtual environment linked to non-existent Python interpreter: foo/[BIN]/python
-    Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
-    error: Project virtual environment directory `[TEMP_DIR]/foo` cannot be used because it has existing, non-virtual environment content
+    error: Project virtual environment directory `[TEMP_DIR]/foo` cannot be used because it is not a virtual environment and is non-empty
     "###);
 
     // But if it's just an incompatible virtual environment...


### PR DESCRIPTION
Someone reported this a while back (will try to find the issue), and I ran into it working on #7522 