### PR TITLE
Use a single lint task in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: rustup component add rustfmt
 
       - name: "Install uv"
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+        uses: astral-sh/setup-uv@v3
 
       - name: "rustfmt"
         run: cargo fmt --all --check
@@ -173,10 +173,11 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup show
 
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v3
+
       - name: "Install required Python versions"
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv python install
+        run: uv python install
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
@@ -213,10 +214,11 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup show
 
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v3
+
       - name: "Install required Python versions"
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv python install
+        run: uv python install
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
               - "docs/reference/cli.md"
               - "docs/reference/settings.md"
               - "uv.schema.json"
-  cargo-fmt:
+  lint:
     timeout-minutes: 10
-    name: "cargo fmt"
+    name: "lint"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +57,9 @@ jobs:
 
       - name: "Install Rustfmt"
         run: rustup component add rustfmt
+
+      - name: "Install uv"
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
       - name: "rustfmt"
         run: cargo fmt --all --check
@@ -69,27 +72,13 @@ jobs:
       - name: "README check"
         run: python scripts/transform_readme.py --target pypi
 
-  python-lint:
-    timeout-minutes: 10
-    name: "Python lint"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
-      - name: "Install uv"
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-
-      - name: "Format"
+      - name: "Python format"
         run: uvx ruff format --diff .
 
-      - name: "Lint"
+      - name: "Python lint"
         run: uvx ruff check .
 
-      - name: "Type check"
+      - name: "Python type check"
         run: uvx mypy
 
   cargo-clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,11 +173,11 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup show
 
-      - name: "Install uv"
-        uses: astral-sh/setup-uv@v3
-
       - name: "Install required Python versions"
-        run: uv python install
+        run: |
+          # astral-sh/setup-uv sets `UV_CACHE_DIR` which disrupts the help message check
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv python install
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
@@ -214,11 +214,11 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup show
 
-      - name: "Install uv"
-        uses: astral-sh/setup-uv@v3
-
       - name: "Install required Python versions"
-        run: uv python install
+        run: |
+          # astral-sh/setup-uv sets `UV_CACHE_DIR` which disrupts the help message check
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv python install
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
We initially had two jobs for fast lints, one for Python and one for Rust (rustfmt). We now have fast lints for more (Rust, Python, {json5,yaml,yml}, Markdown, Readme). Instead of arbitrarily splitting the new cases between Python or Rust and reporting e.g. Prettier failures as Rust problems, we run them in a single job that's still <1min on a regular runner. This also reduces our large test matrix by one job.

Note: Before merging, we need to change the required checks configuration in the settings.