### PR TITLE
Compute resolver hints using the final reduced derivation tree

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -251,7 +251,7 @@ impl std::fmt::Display for NoSolutionError {
         // Include any additional hints.
         let mut additional_hints = IndexSet::default();
         formatter.generate_hints(
-            &self.error,
+            &tree,
             &self.selector,
             &self.index_locations,
             &self.unavailable_packages,


### PR DESCRIPTION
This switches the no-solution formatter to use the final derivation tree (simplified and reduced) when generating hints.
