### PR TITLE
Do not error if the `CACHEDIR.TAG` file exists but cannot be written to

### DIFF
--- a/crates/uv-fs/src/cachedir.rs
+++ b/crates/uv-fs/src/cachedir.rs
@@ -32,9 +32,13 @@ pub fn add_tag<P: AsRef<path::Path>>(directory: P) -> io::Result<()> {
 /// Will return an error if The tag file doesn't exist and can't be created for any reason
 /// (the `directory` doesn't exist, permission error, can't write to the file etc.).
 pub fn ensure_tag<P: AsRef<path::Path>>(directory: P) -> io::Result<()> {
-    match add_tag(directory) {
+    match add_tag(&directory) {
         Err(e) => match e.kind() {
             io::ErrorKind::AlreadyExists => Ok(()),
+            // If it exists, but we can't write to it for some reason don't fail
+            io::ErrorKind::PermissionDenied if directory.as_ref().join("CACHEDIR.TAG").exists() => {
+                Ok(())
+            }
             _ => Err(e),
         },
         other => other,


### PR DESCRIPTION
Attempting to address the error in https://github.com/astral-sh/uv/issues/7434 — it seems overkill to fail if the file exists but isn't writable.