### PR TITLE
Heal cache entries with missing source distributions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4795,6 +4795,7 @@ dependencies = [
  "indoc",
  "insta",
  "nanoid",
+ "owo-colors",
  "pep440_rs",
  "pep508_rs",
  "platform-tags",

--- a/crates/uv-cache/src/lib.rs
+++ b/crates/uv-cache/src/lib.rs
@@ -45,6 +45,11 @@ impl CacheEntry {
         Self(path.into())
     }
 
+    /// Return the cache entry's parent directory.
+    pub fn shard(&self) -> CacheShard {
+        CacheShard(self.dir().to_path_buf())
+    }
+
     /// Convert the [`CacheEntry`] into a [`PathBuf`].
     #[inline]
     pub fn into_path_buf(self) -> PathBuf {

--- a/crates/uv-distribution/Cargo.toml
+++ b/crates/uv-distribution/Cargo.toml
@@ -37,6 +37,7 @@ anyhow = { workspace = true }
 fs-err = { workspace = true }
 futures = { workspace = true }
 nanoid = { workspace = true }
+owo-colors = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }

--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use owo_colors::OwoColorize;
 use tokio::task::JoinError;
 use url::Url;
 use zip::result::ZipError;
@@ -93,6 +94,8 @@ pub enum Error {
     MetadataLowering(#[from] MetadataError),
     #[error("Distribution not found at: {0}")]
     NotFound(Url),
+    #[error("Attempted to re-extract the source distribution for `{0}`, but the hashes didn't match. Run `{}` to clear the cache.", "uv cache clean".green())]
+    CacheHeal(String),
 
     /// A generic request middleware error happened while making a request.
     /// Refer to the error message for more details.


### PR DESCRIPTION
## Summary

`uv cache prune --ci` will remove the source distribution directory. If we then need to build a _different_ wheel (e.g., you're building a package that has Python minor version-specific wheels), we fail, because we expect the source to be there.

Now, if the source is missing, we re-download it. It would be slightly easier to just _ignore_ that revision, but that would mean we'd also lose the already-built wheels -- so if you ran against many Python versions, we'd continuously lose the cached data.

Closes https://github.com/astral-sh/uv/issues/7543.

## Test Plan

We can add tests, but they _need_ to build non-pure Python wheels, which tends to be expensive...

For reference:

```console
$ cargo run venv --python 3.12
$ cargo run pip install mercurial==6.8.1 --verbose
$ cargo run cache prune --ci
$ cargo run venv --python 3.11
$ cargo run pip install mercurial==6.8.1 --verbose
```

I also did this with a local `.tar.gz` that I downloaded from PyPI.