### PR TITLE
Clarify locking and resolving without package name

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -528,8 +528,7 @@ async fn do_lock(
                     .collect(),
                 dev,
                 source_trees,
-                // Omit passing a single package name to accommodate for
-                // workspaces with multiple members.
+                // The root is always null in workspaces, it "depends on" the projects
                 None,
                 Some(workspace.packages().keys().cloned().collect()),
                 &extras,

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -528,6 +528,8 @@ async fn do_lock(
                     .collect(),
                 dev,
                 source_trees,
+                // Omit passing a single package name to accommodate for
+                // workspaces with multiple members.
                 None,
                 Some(workspace.packages().keys().cloned().collect()),
                 &extras,


### PR DESCRIPTION
This adds a guiding comment around an hardcoded no-value in the lock-and-resolve flow.

Ref: https://github.com/astral-sh/uv/pull/7488#issuecomment-2358385418