### PR TITLE
chore(renovate): update GitHub Actions major versions in docs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,6 +64,18 @@
       enabled: false,
     },
   ],
+  customManagers: [
+    // Update major GitHub actions references in documentation.
+    {
+      customType: "regex",
+      fileMatch: ["^docs/.*\\.md$"],
+      matchStrings: [
+        "\\suses: (?<depName>[\\w-]+/[\\w-]+)(?<path>/.*)?@(?<currentValue>.+?)\\s",
+      ],
+      datasourceTemplate: "github-tags",
+      versioningTemplate: "regex:^v(?<major>\\d+)$",
+    },
+  ],
   vulnerabilityAlerts: {
     commitMessageSuffix: "",
     labels: ["internal", "security"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,6 +26,14 @@
       enabled: false,
     },
     {
+      // Create dedicated branches to update references to dependencies in the documentation.
+      matchPaths: ["docs/**/*.md"],
+      commitMessageTopic: "references to {{{depName}}}",
+      semanticCommitType: "docs",
+      semanticCommitScope: null,
+      additionalBranchPrefix: "docs-",
+    },
+    {
       // Group upload/download artifact updates, the versions are dependent
       groupName: "Artifact GitHub Actions dependencies",
       matchManagers: ["github-actions"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,7 +28,7 @@
     {
       // Create dedicated branches to update references to dependencies in the documentation.
       matchPaths: ["docs/**/*.md"],
-      commitMessageTopic: "references to {{{depName}}}",
+      commitMessageTopic: "documentation references to {{{depName}}}",
       semanticCommitType: "docs",
       semanticCommitScope: null,
       additionalBranchPrefix: "docs-",


### PR DESCRIPTION
## Summary

Originally wanted to update the reference to `astral-sh/setup-uv` in https://docs.astral.sh/uv/guides/integration/github/, but thought it could be nice to automate those updates through Renovate. The custom manager will look for any major version GitHub Action reference in any Markdown file in `docs` directory, and raise a PR to update it.

Possible improvements:
- We could separate those updates from updating the actions updates for uv's own GitHub Actions workflow, which would end up raising 2 different PRs instead of grouping them (example of the current behaviour without this improvement in https://github.com/mkniewallner/mkv-playground/pull/4 where we update the doc reference at the same time as a real dependency usage in a workflow).
- ~Should the PRs be raised immediately, to handle the update as soon as possible, instead of waiting for the regular weekly Monday schedule? This would ensure that `astral-sh/setup-uv` references are handled as early as possible.~ done in https://github.com/astral-sh/uv/pull/7584/commits/6af7f4575071091b337a9fd3f24bc4459923f2a2

## Test Plan

I've tested that with https://github.com/mkniewallner/mkv-playground/blob/00ddfb69003843ad57d05f9ef036e655aaf765d7/renovate.json5 and https://github.com/mkniewallner/mkv-playground/blob/00ddfb69003843ad57d05f9ef036e655aaf765d7/docs/integeration/foo.md, where Renovate raised 2 PRs:
- https://github.com/mkniewallner/mkv-playground/pull/13
- https://github.com/mkniewallner/mkv-playground/pull/4