### PR TITLE
Revert "Remove duplicate warning for settings discovery errors (#7384)"

### DIFF
--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -1,10 +1,10 @@
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use tracing::{debug, warn};
+use tracing::debug;
 
 use uv_fs::Simplified;
-use uv_warnings::owo_colors::OwoColorize;
+use uv_warnings::warn_user;
 
 pub use crate::combine::*;
 pub use crate::settings::*;
@@ -74,7 +74,7 @@ impl FilesystemOptions {
                 }
                 Err(Error::PyprojectToml(file, err)) => {
                     // If we see an invalid `pyproject.toml`, warn but continue.
-                    warn!(
+                    warn_user!(
                         "Failed to parse `{}` during settings discovery:\n{}",
                         file.cyan(),
                         textwrap::indent(&err.to_string(), "  ")
@@ -107,7 +107,7 @@ impl FilesystemOptions {
                     .and_then(|content| toml::from_str::<PyProjectToml>(&content).ok())
                 {
                     if pyproject.tool.is_some_and(|tool| tool.uv.is_some()) {
-                        warn!(
+                        warn_user!(
                             "Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The `[tool.uv]` section will be ignored in favor of the `uv.toml` file."
                         );
                     }

--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -13005,6 +13005,13 @@ fn lock_duplicate_sources() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    warning: Failed to parse `pyproject.toml` during settings discovery:
+      TOML parse error at line 9, column 9
+        |
+      9 |         python-multipart = { url = "https://files.pythonhosted.org/packages/c0/3e/9fbfd74e7f5b54f653f7ca99d44ceb56e718846920162165061c4c22b71a/python_multipart-0.0.8-py3-none-any.whl" }
+        |         ^
+      duplicate key `python-multipart` in table `tool.uv.sources`
+
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 9, column 9
       |

--- a/crates/uv/tests/pip_compile.rs
+++ b/crates/uv/tests/pip_compile.rs
@@ -3285,6 +3285,15 @@ fn override_dependency_from_workspace_invalid_syntax() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    warning: Failed to parse `pyproject.toml` during settings discovery:
+      TOML parse error at line 9, column 29
+        |
+      9 |     override-dependencies = [
+        |                             ^
+      no such comparison operator "=", must be one of ~= == != <= >= < > ===
+      werkzeug=2.3.0
+              ^^^^^^
+
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 9, column 29
       |

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -92,6 +92,13 @@ fn invalid_pyproject_toml_syntax() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    warning: Failed to parse `pyproject.toml` during settings discovery:
+      TOML parse error at line 1, column 5
+        |
+      1 | 123 - 456
+        |     ^
+      expected `.`, `=`
+
     error: Failed to parse: `pyproject.toml`
       Caused by: TOML parse error at line 1, column 5
       |

--- a/crates/uv/tests/show_settings.rs
+++ b/crates/uv/tests/show_settings.rs
@@ -2950,6 +2950,7 @@ fn resolve_both() -> anyhow::Result<()> {
     }
 
     ----- stderr -----
+    warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`. The `[tool.uv]` section will be ignored in favor of the `uv.toml` file.
     "###
     );
 

--- a/crates/uv/tests/venv.rs
+++ b/crates/uv/tests/venv.rs
@@ -495,6 +495,13 @@ fn create_venv_warns_user_on_requires_python_discovery_error() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    warning: Failed to parse `pyproject.toml` during settings discovery:
+      TOML parse error at line 1, column 9
+        |
+      1 | invalid toml
+        |         ^
+      expected `.`, `=`
+
     warning: Failed to parse: `pyproject.toml`
     Using Python 3.12.[X] interpreter at: [PYTHON-3.12]
     Creating virtual environment at: .venv


### PR DESCRIPTION
## Summary

This reverts commit 3060fd22c00c3f5ca96374747600c8b4bab6a896.

These are now _never_ shown to users, because `tracing` isn't set up at that point. I'm going to try and improve the solution more holistically, but this is better than the status quo.

Closes https://github.com/astral-sh/uv/issues/7573.
