### PR TITLE
uv-resolver: add error checking for conflicting distributions

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -19,6 +19,7 @@ use crate::pubgrub::{
     PubGrubPackage, PubGrubPackageInner, PubGrubReportFormatter, PubGrubSpecifierError,
 };
 use crate::python_requirement::PythonRequirement;
+use crate::resolution::ConflictingDistributionError;
 use crate::resolver::{IncompletePackage, ResolverMarkers, UnavailablePackage, UnavailableReason};
 
 #[derive(Debug, thiserror::Error)]
@@ -101,6 +102,9 @@ pub enum ResolveError {
 
     #[error("In `--require-hashes` mode, all requirements must be pinned upfront with `==`, but found: `{0}`")]
     UnhashedPackage(PackageName),
+
+    #[error("found conflicting distribution in resolution: {0}")]
+    ConflictingDistribution(ConflictingDistributionError),
 
     /// Something unexpected happened.
     #[error("{0}")]

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -13,7 +13,9 @@ pub use prerelease::PrereleaseMode;
 pub use pubgrub::{PubGrubSpecifier, PubGrubSpecifierError};
 pub use python_requirement::PythonRequirement;
 pub use requires_python::{RequiresPython, RequiresPythonError, RequiresPythonRange};
-pub use resolution::{AnnotationStyle, DisplayResolutionGraph, ResolutionGraph};
+pub use resolution::{
+    AnnotationStyle, ConflictingDistributionError, DisplayResolutionGraph, ResolutionGraph,
+};
 pub use resolution_mode::ResolutionMode;
 pub use resolver::{
     BuildId, DefaultResolverProvider, InMemoryIndex, MetadataResponse, PackageVersionsResult,

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -428,7 +428,7 @@ impl Lock {
                 }
             }
         }
-        Ok(Self {
+        let lock = Self {
             version,
             fork_markers,
             supported_environments,
@@ -437,7 +437,8 @@ impl Lock {
             packages,
             by_id,
             manifest,
-        })
+        };
+        Ok(lock)
     }
 
     /// Record the requirements that were used to generate this lock.
@@ -1464,38 +1465,6 @@ impl TryFrom<LockWire> for Lock {
             supported_environments,
             fork_markers,
         )?;
-
-        /*
-        // TODO: Use the below in tests to validate we don't produce a
-        // trivially incorrect lock file.
-        let mut name_to_markers: BTreeMap<&PackageName, Vec<(&Version, &MarkerTree)>> =
-            BTreeMap::new();
-        for package in &lock.packages {
-            for dep in &package.dependencies {
-                name_to_markers
-                    .entry(&dep.package_id.name)
-                    .or_default()
-                    .push((&dep.package_id.version, &dep.marker));
-            }
-        }
-        for (name, marker_trees) in name_to_markers {
-            for (i, (version1, marker1)) in marker_trees.iter().enumerate() {
-                for (version2, marker2) in &marker_trees[i + 1..] {
-                    if version1 == version2 {
-                        continue;
-                    }
-                    if !marker1.is_disjoint(marker2) {
-                        assert!(
-                            false,
-                            "[{marker1:?}] (for version {version1}) is not disjoint with \
-                             [{marker2:?}] (for version {version2}) \
-                             for package `{name}`",
-                        );
-                    }
-                }
-            }
-        }
-        */
 
         Ok(lock)
     }

--- a/crates/uv-resolver/src/resolution/mod.rs
+++ b/crates/uv-resolver/src/resolution/mod.rs
@@ -11,8 +11,8 @@ use uv_distribution::Metadata;
 use uv_normalize::{ExtraName, GroupName, PackageName};
 
 pub use crate::resolution::display::{AnnotationStyle, DisplayResolutionGraph};
-pub use crate::resolution::graph::ResolutionGraph;
 pub(crate) use crate::resolution::graph::ResolutionGraphNode;
+pub use crate::resolution::graph::{ConflictingDistributionError, ResolutionGraph};
 pub(crate) use crate::resolution::requirements_txt::RequirementsTxtDist;
 
 mod display;
@@ -31,6 +31,11 @@ pub(crate) struct AnnotatedDist {
     pub(crate) dev: Option<GroupName>,
     pub(crate) hashes: Vec<HashDigest>,
     pub(crate) metadata: Option<Metadata>,
+    /// The "full" marker for this distribution. It precisely describes all
+    /// marker environments for which this distribution _can_ be installed.
+    /// That is, when doing a traversal over all of the distributions in a
+    /// resolution, this marker corresponds to the disjunction of all paths to
+    /// this distribution in the resolution graph.
     pub(crate) marker: MarkerTree,
 }
 


### PR DESCRIPTION
This PR adds some additional sanity checking on resolution graphs to
ensure we can never install different versions of the same package into
the same environment.

I used code similar to this to provoke bugs in the resolver before the
release, but it never made it into `main`. Here, we add the error
checking to the creation of `ResolutionGraph`, since this is where it's
most convenient to access the "full" markers of each distribution.

We only report an error when `debug_assertions` are enabled to avoid
rendering `uv` *completely* unusuable if a bug were to occur in a
production binary. For example, maybe a conflict is detected in a marker
environment that isn't actually used. While not ideal, `uv` is still
usable for any other marker environment.

Closes #5598
