### PR TITLE
Fix handling of `sys.base_prefix` collision in interpreter identity check during tool installs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4482,6 +4482,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rustc-hash",
+ "same-file",
  "serde",
  "serde_json",
  "similar",

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -66,6 +66,7 @@ owo-colors = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 rustc-hash = { workspace = true }
+same-file = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/7586

Extends https://github.com/astral-sh/uv/pull/7593 (thanks @lucab!)