### PR TITLE
Use anchorlinks rather than permalinks

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -186,3 +186,12 @@ h3.cli-reference {
   font-size: 1.1em;
   margin: 0 0 0 0;
 }
+
+/* Styling for anchor link headers */
+.toclink {
+  color: unset !important;
+}
+
+.toclink:hover {
+  color: var(--md-accent-fg-color) !important;
+}

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -42,11 +42,12 @@ site_dir: site/uv
 markdown_extensions:
   - admonition
   - pymdownx.details
-  - toc:
-      permalink: "#"
   - pymdownx.snippets:
   - pymdownx.magiclink:
   - attr_list:
+  - toc:
+      anchorlink: true
+      anchorlink_class: "toclink"
   - md_in_html:
   - pymdownx.inlinehilite:
   - pymdownx.superfences:


### PR DESCRIPTION
## Summary

Unfortunately, the permalinks show up in the SERPs as part of the title:

![Screenshot 2024-09-22 at 3 08 54 PM](https://github.com/user-attachments/assets/6914af46-35bd-4d53-8a57-fbba21a0f7e9)

Instead, we'll just make the headers themselves links.

Before:
![Screenshot 2024-09-22 at 3 08 03 PM](https://github.com/user-attachments/assets/9e354fca-d319-4779-b38a-05daee530608)
![Screenshot 2024-09-22 at 3 08 06 PM](https://github.com/user-attachments/assets/954af6b5-35cd-4519-815f-24555b6ba086)

After:

![Screenshot 2024-09-22 at 3 08 19 PM](https://github.com/user-attachments/assets/90c84012-778d-440d-9028-2b40d86ad53c)
![Screenshot 2024-09-22 at 3 08 17 PM](https://github.com/user-attachments/assets/8add8f41-4030-4bbf-9acd-e6027e3f6cda)

I prefer what we had before visually, but the SEO hit is bad enough that I want to change it.
