### PR TITLE
Respect lockfile preferences for `--with` requirements

### DIFF
--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -1,18 +1,18 @@
 use tracing::debug;
 
+use crate::commands::pip::loggers::{InstallLogger, ResolveLogger};
+use crate::commands::project::{
+    resolve_environment, sync_environment, EnvironmentSpecification, ProjectError,
+};
+use crate::commands::SharedState;
+use crate::printer::Printer;
+use crate::settings::ResolverInstallerSettings;
 use cache_key::{cache_digest, hash_digest};
 use distribution_types::Resolution;
 use uv_cache::{Cache, CacheBucket};
 use uv_client::Connectivity;
 use uv_configuration::Concurrency;
 use uv_python::{Interpreter, PythonEnvironment};
-use uv_requirements::RequirementsSpecification;
-
-use crate::commands::pip::loggers::{InstallLogger, ResolveLogger};
-use crate::commands::project::{resolve_environment, sync_environment, ProjectError};
-use crate::commands::SharedState;
-use crate::printer::Printer;
-use crate::settings::ResolverInstallerSettings;
 
 /// A [`PythonEnvironment`] stored in the cache.
 #[derive(Debug)]
@@ -28,7 +28,7 @@ impl CachedEnvironment {
     /// Get or create an [`CachedEnvironment`] based on a given set of requirements and a base
     /// interpreter.
     pub(crate) async fn get_or_create(
-        spec: RequirementsSpecification,
+        spec: EnvironmentSpecification<'_>,
         interpreter: Interpreter,
         settings: &ResolverInstallerSettings,
         state: &SharedState,
@@ -58,8 +58,8 @@ impl CachedEnvironment {
 
         // Resolve the requirements with the interpreter.
         let graph = resolve_environment(
-            &interpreter,
             spec,
+            &interpreter,
             settings.as_ref().into(),
             state,
             resolve,

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -858,7 +858,7 @@ async fn commit(lock: &Lock, workspace: &Workspace) -> Result<(), ProjectError> 
 /// Read the lockfile from the workspace.
 ///
 /// Returns `Ok(None)` if the lockfile does not exist.
-async fn read(workspace: &Workspace) -> Result<Option<Lock>, ProjectError> {
+pub(crate) async fn read(workspace: &Workspace) -> Result<Option<Lock>, ProjectError> {
     match fs_err::tokio::read_to_string(&workspace.install_path().join("uv.lock")).await {
         Ok(encoded) => match toml::from_str(&encoded) {
             Ok(lock) => Ok(Some(lock)),

--- a/crates/uv/src/commands/tool/install.rs
+++ b/crates/uv/src/commands/tool/install.rs
@@ -25,6 +25,7 @@ use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
 
 use crate::commands::project::{
     resolve_environment, resolve_names, sync_environment, update_environment,
+    EnvironmentSpecification,
 };
 use crate::commands::tool::common::remove_entrypoints;
 use crate::commands::tool::Target;
@@ -384,8 +385,8 @@ pub(crate) async fn install(
         // If we're creating a new environment, ensure that we can resolve the requirements prior
         // to removing any existing tools.
         let resolution = resolve_environment(
+            EnvironmentSpecification::from(spec),
             &interpreter,
-            spec,
             settings.as_ref().into(),
             &state,
             Box::new(DefaultResolveLogger),

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -33,7 +33,7 @@ use crate::commands::pip::loggers::{
     DefaultInstallLogger, DefaultResolveLogger, SummaryInstallLogger, SummaryResolveLogger,
 };
 use crate::commands::pip::operations;
-use crate::commands::project::{resolve_names, ProjectError};
+use crate::commands::project::{resolve_names, EnvironmentSpecification, ProjectError};
 use crate::commands::reporters::PythonDownloadReporter;
 use crate::commands::tool::Target;
 use crate::commands::{
@@ -488,7 +488,7 @@ async fn get_or_create_environment(
     // TODO(zanieb): Determine if we should layer on top of the project environment if it is present.
 
     let environment = CachedEnvironment::get_or_create(
-        spec,
+        EnvironmentSpecification::from(spec),
         interpreter,
         settings,
         &state,


### PR DESCRIPTION
## Summary

This is a long-time TODO to respect versions from the base environment when resolving `--with` requirements.

Closes https://github.com/astral-sh/uv/issues/7416
