### PR TITLE
Determine if pre-release Python downloads should be allowed using the version specifiers

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -278,7 +278,11 @@ impl PythonDownloadRequest {
     }
 
     pub fn allows_prereleases(&self) -> bool {
-        self.prereleases.unwrap_or_else(|| self.version.is_some())
+        self.prereleases.unwrap_or_else(|| {
+            self.version
+                .as_ref()
+                .is_some_and(VersionRequest::allows_prereleases)
+        })
     }
 
     pub fn satisfied_by_interpreter(&self, interpreter: &Interpreter) -> bool {


### PR DESCRIPTION
Closes #7637

```
❯ uv python install '>=3.11'
Installed Python 3.12.6 in 1.70s
 + cpython-3.12.6-macos-aarch64-none

❯ uv python install 3.13
Installed Python 3.13.0rc2 in 1.89s
 + cpython-3.13.0rc2-macos-aarch64-none

❯ uv python uninstall --all
Searching for Python installations
Uninstalled 2 versions in 94ms
 - cpython-3.12.6-macos-aarch64-none
 - cpython-3.13.0rc2-macos-aarch64-none

❯ uv python install '>=3.11a1'
Installed Python 3.13.0rc2 in 1.89s
 + cpython-3.13.0rc2-macos-aarch64-none
```