### PR TITLE
Document environment variable that disables printing of virtual environment name in prompt

### DIFF
--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -117,6 +117,8 @@ In addition, uv respects the following environment variables:
 - `VIRTUAL_ENV`: Used to detect an activated virtual environment.
 - `CONDA_PREFIX`: Used to detect an activated Conda environment.
 - `PROMPT`: Used to detect the use of the Windows Command Prompt (as opposed to PowerShell).
+- `VIRTUAL_ENV_DISABLE_PROMPT`: If set to `1` before a virtual environment is activated, then the
+  virtual environment name will not be prepended to the terminal prompt.
 - `NU_VERSION`: Used to detect the use of NuShell.
 - `FISH_VERSION`: Used to detect the use of the Fish shell.
 - `BASH_VERSION`: Used to detect the use of the Bash shell.


### PR DESCRIPTION
This PR adds a line to `docs/configuration/environment.md` that documents `VIRTUAL_ENV_DISABLE_PROMPT`.  If set to `1` when the virtual environment is activated, then the virtual environment name will not be prepended to a terminal prompt.

So far I've tested this in bash, but from the various activation scripts, it looks like it is respected for a variety of shells.

Maintainers should please feel free to edit this PR directly. Thank you!