### PR TITLE
Require opt-in to use alternative Python implementations

### DIFF
--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -281,12 +281,18 @@ impl PythonDownloadRequest {
         self.satisfied_by_key(download.key())
     }
 
+    /// Whether this download request opts-in to pre-release Python versions.
     pub fn allows_prereleases(&self) -> bool {
         self.prereleases.unwrap_or_else(|| {
             self.version
                 .as_ref()
                 .is_some_and(VersionRequest::allows_prereleases)
         })
+    }
+
+    /// Whether this download request opts-in to alternative Python implementations.
+    pub fn allows_alternative_implementations(&self) -> bool {
+        self.implementation.is_some()
     }
 
     pub fn satisfied_by_interpreter(&self, interpreter: &Interpreter) -> bool {

--- a/crates/uv-python/src/implementation.rs
+++ b/crates/uv-python/src/implementation.rs
@@ -52,8 +52,8 @@ impl LenientImplementationName {
 }
 
 impl From<&ImplementationName> for &'static str {
-    fn from(v: &ImplementationName) -> &'static str {
-        match v {
+    fn from(value: &ImplementationName) -> &'static str {
+        match value {
             ImplementationName::CPython => "cpython",
             ImplementationName::PyPy => "pypy",
             ImplementationName::GraalPy => "graalpy",
@@ -61,9 +61,15 @@ impl From<&ImplementationName> for &'static str {
     }
 }
 
+impl From<ImplementationName> for &'static str {
+    fn from(value: ImplementationName) -> &'static str {
+        (&value).into()
+    }
+}
+
 impl<'a> From<&'a LenientImplementationName> for &'a str {
-    fn from(v: &'a LenientImplementationName) -> &'a str {
-        match v {
+    fn from(value: &'a LenientImplementationName) -> &'a str {
+        match value {
             LenientImplementationName::Known(implementation) => implementation.into(),
             LenientImplementationName::Unknown(name) => name,
         }

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -16,7 +16,8 @@ use crate::implementation::LenientImplementationName;
 use crate::managed::{ManagedPythonInstallation, ManagedPythonInstallations};
 use crate::platform::{Arch, Libc, Os};
 use crate::{
-    downloads, Error, Interpreter, PythonDownloads, PythonPreference, PythonSource, PythonVersion,
+    downloads, Error, ImplementationName, Interpreter, PythonDownloads, PythonPreference,
+    PythonSource, PythonVersion,
 };
 
 /// A Python interpreter and accompanying tools.
@@ -174,6 +175,16 @@ impl PythonInstallation {
     /// Return the [`LenientImplementationName`] of the Python installation as reported by its interpreter.
     pub fn implementation(&self) -> LenientImplementationName {
         LenientImplementationName::from(self.interpreter.implementation_name())
+    }
+
+    /// Whether this is a CPython installation.
+    ///
+    /// Returns false if it is an alternative implementation, e.g., PyPy.
+    pub(crate) fn is_alternative_implementation(&self) -> bool {
+        !matches!(
+            self.implementation(),
+            LenientImplementationName::Known(ImplementationName::CPython)
+        )
     }
 
     /// Return the [`Arch`] of the Python installation as reported by its interpreter.

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -25,7 +25,9 @@ use uv_fs::{write_atomic_sync, PythonExt, Simplified};
 use crate::implementation::LenientImplementationName;
 use crate::platform::{Arch, Libc, Os};
 use crate::pointer_size::PointerSize;
-use crate::{Prefix, PythonInstallationKey, PythonVersion, Target, VirtualEnvironment};
+use crate::{
+    Prefix, PythonInstallationKey, PythonVersion, Target, VersionRequest, VirtualEnvironment,
+};
 
 /// A Python executable and its associated platform markers.
 #[derive(Debug, Clone)]
@@ -493,6 +495,21 @@ impl Interpreter {
         } else {
             (version.major(), version.minor()) == self.python_tuple()
         }
+    }
+
+    /// Whether or not this Python interpreter is from a default Python executable name, like
+    /// `python`, `python3`, or `python.exe`.
+    pub(crate) fn has_default_executable_name(&self) -> bool {
+        let Some(file_name) = self.sys_executable().file_name() else {
+            return false;
+        };
+        let Some(name) = file_name.to_str() else {
+            return false;
+        };
+        VersionRequest::Default
+            .executable_names(None)
+            .into_iter()
+            .any(|default_name| name == default_name.to_string())
     }
 }
 

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -1793,7 +1793,7 @@ mod tests {
         })?;
         assert!(
             matches!(result, Err(PythonNotFound { .. })),
-            "We should not the pypy interpreter if not named `python` or requested; got {result:?}"
+            "We should not find the pypy interpreter if not named `python` or requested; got {result:?}"
         );
 
         // But we should find it


### PR DESCRIPTION
Closes #7118 

This only really affects managed interpreters, as we exclude alternative Python implementations from the search path during the `VersionRequest::executable_names` part of discovery. 