### PR TITLE
Display skipped managed interpreters during Python discovery

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -294,10 +294,16 @@ fn python_executables_from_installed<'a>(
                 Ok(installations
                     .into_iter()
                     .filter(move |installation| {
-                        version.is_none()
+                        if version.is_none()
                             || version.is_some_and(|version| {
                                 version.matches_version(&installation.version())
                             })
+                        {
+                            true
+                        } else {
+                            debug!("Skipping incompatible managed installation `{installation}`");
+                            false
+                        }
                     })
                     .inspect(|installation| debug!("Found managed installation `{installation}`"))
                     .map(|installation| (PythonSource::Managed, installation.executable())))


### PR DESCRIPTION
e.g.

```
❯ cargo run -- python find 3.11rc2 -v
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/uv python find 3.11rc2 -v`
DEBUG uv 0.4.15
DEBUG Searching for Python 3.11rc2 in managed installations or system path
DEBUG Found `cpython-3.12.1-macos-aarch64-none` at `/Users/zb/workspace/uv/.venv/bin/python3` (active virtual environment)
DEBUG Found `cpython-3.12.1-macos-aarch64-none` at `/Users/zb/workspace/uv/.venv/bin/python3` (virtual environment)
DEBUG Searching for managed installations at `/Users/zb/.local/share/uv/python`
DEBUG Skipping incompatible managed installation `cpython-3.13.0rc2-macos-aarch64-none`
DEBUG Skipping incompatible managed installation `cpython-3.12.1-macos-aarch64-none`
DEBUG Skipping incompatible managed installation `cpython-3.11.7-macos-aarch64-none`
DEBUG Skipping incompatible managed installation `cpython-3.10.13-macos-aarch64-none`
DEBUG Skipping incompatible managed installation `cpython-3.9.18-macos-aarch64-none`
DEBUG Skipping incompatible managed installation `cpython-3.8.18-macos-aarch64-none`
DEBUG Skipping incompatible managed installation `cpython-3.8.12-macos-aarch64-none`
DEBUG Skipping incompatible managed installation `pypy-3.9.19-macos-aarch64-none`
DEBUG Found `cpython-3.12.1-macos-aarch64-none` at `/Users/zb/workspace/uv/.venv/bin/python` (search path)
DEBUG Found `cpython-3.12.1-macos-aarch64-none` at `/Users/zb/workspace/uv/.venv/bin/python3` (search path)
DEBUG Found `cpython-3.12.6-macos-aarch64-none` at `/opt/homebrew/bin/python3` (search path)
DEBUG Found `cpython-3.11.10-macos-aarch64-none` at `/opt/homebrew/bin/python3.11` (search path)
DEBUG Found `cpython-3.9.6-macos-aarch64-none` at `/usr/bin/python3` (search path)
error: No interpreter found for Python 3.11rc2 in virtual environments, managed installations, or system path
```