### PR TITLE
packaged app: use executable named for the project and main function

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -460,7 +460,7 @@ impl InitProjectKind {
         if package {
             // Since it'll be packaged, we can add a `[project.scripts]` entry
             pyproject.push('\n');
-            pyproject.push_str(&pyproject_project_scripts(name, "hello", "hello"));
+            pyproject.push_str(&pyproject_project_scripts(name, name.as_str(), "main"));
 
             // Add a build system
             pyproject.push('\n');
@@ -479,7 +479,7 @@ impl InitProjectKind {
                 fs_err::write(
                     init_py,
                     indoc::formatdoc! {r#"
-                    def hello() -> None:
+                    def main() -> None:
                         print("Hello from {name}!")
                     "#},
                 )?;

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -279,7 +279,7 @@ fn init_application_package() -> Result<()> {
         dependencies = []
 
         [project.scripts]
-        hello = "foo:hello"
+        foo = "foo:main"
 
         [build-system]
         requires = ["hatchling"]
@@ -294,13 +294,13 @@ fn init_application_package() -> Result<()> {
     }, {
         assert_snapshot!(
             init, @r###"
-        def hello() -> None:
+        def main() -> None:
             print("Hello from foo!")
         "###
         );
     });
 
-    uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("hello"), @r###"
+    uv_snapshot!(context.filters(), context.run().current_dir(&child).arg("foo"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1423,7 +1423,7 @@ fn init_virtual_project() -> Result<()> {
         dependencies = []
 
         [project.scripts]
-        hello = "foo:hello"
+        foo = "foo:main"
 
         [build-system]
         requires = ["hatchling"]
@@ -1457,7 +1457,7 @@ fn init_virtual_project() -> Result<()> {
         dependencies = []
 
         [project.scripts]
-        hello = "foo:hello"
+        foo = "foo:main"
 
         [build-system]
         requires = ["hatchling"]
@@ -1552,7 +1552,7 @@ fn init_nested_virtual_workspace() -> Result<()> {
         dependencies = []
 
         [project.scripts]
-        hello = "foo:hello"
+        foo = "foo:main"
 
         [build-system]
         requires = ["hatchling"]

--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -231,7 +231,7 @@ example-packaged-app
 But the module defines a CLI function:
 
 ```python title="__init__.py"
-def hello() -> None:
+def main() -> None:
     print("Hello from example-packaged-app!")
 ```
 
@@ -247,7 +247,7 @@ requires-python = ">=3.11"
 dependencies = []
 
 [project.scripts]
-hello = "example_packaged_app:hello"
+example-packaged-app = "example_packaged_app:main"
 
 [build-system]
 requires = ["hatchling"]
@@ -257,7 +257,7 @@ build-backend = "hatchling.build"
 Which can be executed with `uv run`:
 
 ```console
-$ uv run hello
+$ uv run example-packaged-app
 Hello from example-packaged-app!
 ```
 


### PR DESCRIPTION
## Summary

Create a function main as the default for a packaged app. Configure the default executable as:

`example-packaged-app = "example_packaged_app:main"`

Which is often what you want - the executable has the same name as the app.
The purpose is to more often hit what the user wants, so they don't have
to even rename the command to start developing.

## Test Plan

- existing tests are updated
