### PR TITLE
Add `uv build --no-build-logs` to silence the build backend logs

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2033,7 +2033,7 @@ pub struct BuildArgs {
     pub build_logs: bool,
 
     /// Hide logs from the build backend.
-    #[arg(long, overrides_with("build_logs"))]
+    #[arg(long, overrides_with("build_logs"), hide = true)]
     pub no_build_logs: bool,
 
     /// Constrain build dependencies using the given requirements files when building

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2029,12 +2029,12 @@ pub struct BuildArgs {
     #[arg(long)]
     pub wheel: bool,
 
-    #[arg(long, overrides_with("no_backend_output"), hide = true)]
-    pub backend_output: bool,
+    #[arg(long, overrides_with("no_build_logs"), hide = true)]
+    pub build_logs: bool,
 
-    /// Hide output from the build backend.
-    #[arg(long, overrides_with("backend_output"))]
-    pub no_backend_output: bool,
+    /// Hide logs from the build backend.
+    #[arg(long, overrides_with("build_logs"))]
+    pub no_build_logs: bool,
 
     /// Constrain build dependencies using the given requirements files when building
     /// distributions.

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2029,6 +2029,13 @@ pub struct BuildArgs {
     #[arg(long)]
     pub wheel: bool,
 
+    #[arg(long, overrides_with("no_backend_output"), hide = true)]
+    pub backend_output: bool,
+
+    /// Hide output from the build backend.
+    #[arg(long, overrides_with("backend_output"))]
+    pub no_backend_output: bool,
+
     /// Constrain build dependencies using the given requirements files when building
     /// distributions.
     ///

--- a/crates/uv/src/commands/build.rs
+++ b/crates/uv/src/commands/build.rs
@@ -38,7 +38,7 @@ pub(crate) async fn build(
     output_dir: Option<PathBuf>,
     sdist: bool,
     wheel: bool,
-    backend_output: bool,
+    build_logs: bool,
     build_constraints: Vec<RequirementsSource>,
     hash_checking: Option<HashCheckingMode>,
     python: Option<String>,
@@ -59,7 +59,7 @@ pub(crate) async fn build(
         output_dir.as_deref(),
         sdist,
         wheel,
-        backend_output,
+        build_logs,
         &build_constraints,
         hash_checking,
         python.as_deref(),
@@ -111,7 +111,7 @@ async fn build_impl(
     output_dir: Option<&Path>,
     sdist: bool,
     wheel: bool,
-    backend_output: bool,
+    build_logs: bool,
     build_constraints: &[RequirementsSource],
     hash_checking: Option<HashCheckingMode>,
     python_request: Option<&str>,
@@ -373,7 +373,7 @@ async fn build_impl(
 
     let build_output = match printer {
         Printer::Default | Printer::NoProgress | Printer::Verbose => {
-            if backend_output {
+            if build_logs {
                 BuildOutput::Stderr
             } else {
                 BuildOutput::Quiet

--- a/crates/uv/src/commands/build.rs
+++ b/crates/uv/src/commands/build.rs
@@ -38,6 +38,7 @@ pub(crate) async fn build(
     output_dir: Option<PathBuf>,
     sdist: bool,
     wheel: bool,
+    backend_output: bool,
     build_constraints: Vec<RequirementsSource>,
     hash_checking: Option<HashCheckingMode>,
     python: Option<String>,
@@ -58,6 +59,7 @@ pub(crate) async fn build(
         output_dir.as_deref(),
         sdist,
         wheel,
+        backend_output,
         &build_constraints,
         hash_checking,
         python.as_deref(),
@@ -109,6 +111,7 @@ async fn build_impl(
     output_dir: Option<&Path>,
     sdist: bool,
     wheel: bool,
+    backend_output: bool,
     build_constraints: &[RequirementsSource],
     hash_checking: Option<HashCheckingMode>,
     python_request: Option<&str>,
@@ -369,7 +372,13 @@ async fn build_impl(
     let dist = None;
 
     let build_output = match printer {
-        Printer::Default | Printer::NoProgress | Printer::Verbose => BuildOutput::Stderr,
+        Printer::Default | Printer::NoProgress | Printer::Verbose => {
+            if backend_output {
+                BuildOutput::Stderr
+            } else {
+                BuildOutput::Quiet
+            }
+        }
         Printer::Quiet => BuildOutput::Quiet,
     };
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -702,6 +702,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.out_dir,
                 args.sdist,
                 args.wheel,
+                args.backend_output,
                 build_constraints,
                 args.hash_checking,
                 args.python,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -702,7 +702,7 @@ async fn run(cli: Cli) -> Result<ExitStatus> {
                 args.out_dir,
                 args.sdist,
                 args.wheel,
-                args.backend_output,
+                args.build_logs,
                 build_constraints,
                 args.hash_checking,
                 args.python,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1666,7 +1666,7 @@ pub(crate) struct BuildSettings {
     pub(crate) out_dir: Option<PathBuf>,
     pub(crate) sdist: bool,
     pub(crate) wheel: bool,
-    pub(crate) backend_output: bool,
+    pub(crate) build_logs: bool,
     pub(crate) build_constraint: Vec<PathBuf>,
     pub(crate) hash_checking: Option<HashCheckingMode>,
     pub(crate) python: Option<String>,
@@ -1688,8 +1688,8 @@ impl BuildSettings {
             no_require_hashes,
             verify_hashes,
             no_verify_hashes,
-            backend_output,
-            no_backend_output,
+            build_logs,
+            no_build_logs,
             python,
             build,
             refresh,
@@ -1702,7 +1702,7 @@ impl BuildSettings {
             out_dir,
             sdist,
             wheel,
-            backend_output: flag(backend_output, no_backend_output).unwrap_or(true),
+            build_logs: flag(build_logs, no_build_logs).unwrap_or(true),
             build_constraint: build_constraint
                 .into_iter()
                 .filter_map(Maybe::into_option)

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1666,6 +1666,7 @@ pub(crate) struct BuildSettings {
     pub(crate) out_dir: Option<PathBuf>,
     pub(crate) sdist: bool,
     pub(crate) wheel: bool,
+    pub(crate) backend_output: bool,
     pub(crate) build_constraint: Vec<PathBuf>,
     pub(crate) hash_checking: Option<HashCheckingMode>,
     pub(crate) python: Option<String>,
@@ -1687,6 +1688,8 @@ impl BuildSettings {
             no_require_hashes,
             verify_hashes,
             no_verify_hashes,
+            backend_output,
+            no_backend_output,
             python,
             build,
             refresh,
@@ -1699,6 +1702,7 @@ impl BuildSettings {
             out_dir,
             sdist,
             wheel,
+            backend_output: flag(backend_output, no_backend_output).unwrap_or(true),
             build_constraint: build_constraint
                 .into_iter()
                 .filter_map(Maybe::into_option)

--- a/crates/uv/tests/build.rs
+++ b/crates/uv/tests/build.rs
@@ -1523,7 +1523,7 @@ fn build_quiet() -> Result<()> {
 }
 
 #[test]
-fn build_no_backend_output() -> Result<()> {
+fn build_no_build_logs() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let project = context.temp_dir.child("project");
@@ -1546,7 +1546,7 @@ fn build_no_backend_output() -> Result<()> {
     project.child("src").child("__init__.py").touch()?;
     project.child("README").touch()?;
 
-    uv_snapshot!(&context.filters(), context.build().arg("project").arg("--no-backend-output"), @r###"
+    uv_snapshot!(&context.filters(), context.build().arg("project").arg("--no-build-logs"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/uv/tests/build.rs
+++ b/crates/uv/tests/build.rs
@@ -1521,3 +1521,41 @@ fn build_quiet() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn build_no_backend_output() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let project = context.temp_dir.child("project");
+
+    let pyproject_toml = project.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["anyio==3.7.0"]
+
+        [build-system]
+        requires = ["setuptools>=42"]
+        build-backend = "setuptools.build_meta"
+        "#,
+    )?;
+
+    project.child("src").child("__init__.py").touch()?;
+    project.child("README").touch()?;
+
+    uv_snapshot!(&context.filters(), context.build().arg("project").arg("--no-backend-output"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Building source distribution...
+    Building wheel from source distribution...
+    Successfully built project/dist/project-0.1.0.tar.gz and project/dist/project-0.1.0-py3-none-any.whl
+    "###);
+
+    Ok(())
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6897,8 +6897,6 @@ uv build [OPTIONS] [SRC]
 
 <p>Assumes that the packages&#8217; build dependencies specified by PEP 518 are already installed.</p>
 
-</dd><dt><code>--no-build-logs</code></dt><dd><p>Hide output from the build backend</p>
-
 </dd><dt><code>--no-build-package</code> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 
 </dd><dt><code>--no-cache</code>, <code>-n</code></dt><dd><p>Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation</p>

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6878,6 +6878,8 @@ uv build [OPTIONS] [SRC]
 <p>However, in some cases, you may want to use the platform&#8217;s native certificate store, especially if you&#8217;re relying on a corporate trust root (e.g., for a mandatory proxy) that&#8217;s included in your system&#8217;s certificate store.</p>
 
 <p>May also be set with the <code>UV_NATIVE_TLS</code> environment variable.</p>
+</dd><dt><code>--no-backend-output</code></dt><dd><p>Hide output from the build backend</p>
+
 </dd><dt><code>--no-binary</code></dt><dd><p>Don&#8217;t install pre-built wheels.</p>
 
 <p>The given packages will be built and installed from source. The resolver will still use pre-built wheels to extract package metadata, if available.</p>

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6878,8 +6878,6 @@ uv build [OPTIONS] [SRC]
 <p>However, in some cases, you may want to use the platform&#8217;s native certificate store, especially if you&#8217;re relying on a corporate trust root (e.g., for a mandatory proxy) that&#8217;s included in your system&#8217;s certificate store.</p>
 
 <p>May also be set with the <code>UV_NATIVE_TLS</code> environment variable.</p>
-</dd><dt><code>--no-backend-output</code></dt><dd><p>Hide output from the build backend</p>
-
 </dd><dt><code>--no-binary</code></dt><dd><p>Don&#8217;t install pre-built wheels.</p>
 
 <p>The given packages will be built and installed from source. The resolver will still use pre-built wheels to extract package metadata, if available.</p>
@@ -6898,6 +6896,8 @@ uv build [OPTIONS] [SRC]
 </dd><dt><code>--no-build-isolation-package</code> <i>no-build-isolation-package</i></dt><dd><p>Disable isolation when building source distributions for a specific package.</p>
 
 <p>Assumes that the packages&#8217; build dependencies specified by PEP 518 are already installed.</p>
+
+</dd><dt><code>--no-build-logs</code></dt><dd><p>Hide output from the build backend</p>
 
 </dd><dt><code>--no-build-package</code> <i>no-build-package</i></dt><dd><p>Don&#8217;t build source distributions for a specific package</p>
 


### PR DESCRIPTION
Extends https://github.com/astral-sh/uv/pull/7674

The build backend can be pretty verbose, it seems nice to be able to turn that off?