### PR TITLE
Docker: put uv and uvx in a single layer

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -196,8 +196,7 @@ jobs:
           # Generate Dockerfile content
           cat <<EOF > Dockerfile
           FROM ${BASE_IMAGE}
-          COPY --from=${{ env.UV_BASE_IMG }}:latest /uv /usr/local/bin/uv
-          COPY --from=${{ env.UV_BASE_IMG }}:latest /uvx /usr/local/bin/uvx
+          COPY --from=${{ env.UV_BASE_IMG }}:latest /uv /uvx /usr/local/bin/
           ENTRYPOINT []
           CMD ["/usr/local/bin/uv"]
           EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ RUN cp target/$(cat rust_target.txt)/release/uv /uv \
 # RUN strip --strip-all /uv
 
 FROM scratch
-COPY --from=build /uv /uv
-COPY --from=build /uvx /uvx
+COPY --from=build /uv /uvx /
 WORKDIR /io
 ENTRYPOINT ["/uv"]


### PR DESCRIPTION
## Summary

Copy both `uv` and `uvx` into place in a single Dockerfile command. [`COPY` supports multiple sources when the destination is a directory.](https://docs.docker.com/engine/reference/builder/#copy)

As it is, e.g. `ghcr.io/astral-sh/uv:0.4.16-python3.12-bookworm-slim` has this (screenshot from [Dive](https://github.com/wagoodman/dive)):

<img width="377" alt="Screenshot 2024-09-26 at 10 11 24" src="https://github.com/user-attachments/assets/1ca6a0d5-95fd-4210-9a4f-0afa2300b63f">

and less layers is a Good Thing.

## Test Plan

I hope the CI pipeline will take care of testing – I couldn't get the Docker build to finish on my machine right away (SIGKILL, so out of memory, I guess 😄)