### PR TITLE
Include sys.path of ephemeral env in PYTHONPATH

### DIFF
--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -733,7 +733,7 @@ pub(crate) async fn run(
                     ephemeral_env
                         .interpreter()
                         .sys_path()
-                        .into_iter()
+                        .iter()
                         .map(|path| path.display().to_string())
                         .collect::<Vec<_>>()
                         .join(if cfg!(windows) { ";" } else { ":" }),

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -725,6 +725,9 @@ pub(crate) async fn run(
         ephemeral_env
             .as_ref()
             .map(|ephemeral_env| {
+                // Ensure the sys.path of the ephemeral env is included in
+                // the process's env, in case we're executing an external
+                // command which resolves to the project environment (i.e. `jupyter`)
                 process.env(
                     "PYTHONPATH",
                     ephemeral_env

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -724,7 +724,19 @@ pub(crate) async fn run(
     let new_path = std::env::join_paths(
         ephemeral_env
             .as_ref()
-            .map(PythonEnvironment::scripts)
+            .map(|ephemeral_env| {
+                process.env(
+                    "PYTHONPATH",
+                    ephemeral_env
+                        .interpreter()
+                        .sys_path()
+                        .into_iter()
+                        .map(|path| path.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(if cfg!(windows) { ";" } else { ":" }),
+                );
+                PythonEnvironment::scripts(ephemeral_env)
+            })
             .into_iter()
             .chain(std::iter::once(base_interpreter.scripts()))
             .map(PathBuf::from)


### PR DESCRIPTION
This PR ensures that the sys.path of an ephemeral environment is included in the PYTHONPATH of spawned processes (useful in the case of executing external commands). This addresses issue #7647.

I tested this with the repro in the issue, i.e.:

```
uv init
uv add jupyter
uv run --with pydantic jupyter lab
```

An automated test is trickier — Jupyter doesn't have an interface for executing commands non-interactively (closest thing is ```jupyter console```, which spawns a repl). Its runtime (ipython) does accept a ```-c``` flag, but the issue doesn't manifest when using ipython — as such,  a test wouldn't be effective. Open to thoughts on more rigorous test plans, I might be missing something!