### PR TITLE
Allow unused mut in graph resolution conflicts

### DIFF
--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -246,6 +246,8 @@ impl ResolutionGraph {
             options,
             fork_markers,
         };
+
+        #[allow(unused_mut, reason = "Used in debug_assertions below")]
         let mut conflicting = graph.find_conflicting_distributions();
         if !conflicting.is_empty() {
             tracing::warn!(


### PR DESCRIPTION
## Summary

When running:
`cargo install --git https://github.com/astral-sh/uv uv` I got the following warning:
```
warning: variable does not need to be mutable
   --> crates/uv-resolver/src/resolution/graph.rs:249:13
    |
249 |         let mut conflicting = graph.find_conflicting_distributions();
    |             ----^^^^^^^^^^^
    |             |
    |             help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default
```

This change just allows the mut, since it's used in a #[cfg(debug_assertions)] below

## Test Plan

Given the change should not make it into the compiled artifact, don't think much in the way of testing is warranted, but please 
correct me if I'm wrong.