### PR TITLE
Docs: Spell out the names of the Docker images for easier copy-paste

### DIFF
--- a/docs/guides/integration/docker.md
+++ b/docs/guides/integration/docker.md
@@ -20,43 +20,46 @@ $ docker run ghcr.io/astral-sh/uv --help
 
 uv provides a distroless Docker image including the `uv` binary. The following tags are published:
 
-- `uv:latest`
-- `uv:{major}.{minor}.{patch}`, e.g., `uv:0.4.16`
-- `uv:{major}.{minor}`, e.g., `uv:0.4` (the latest patch version)
+- `ghcr.io/astral-sh/uv:latest`
+- `ghcr.io/astral-sh/uv:{major}.{minor}.{patch}`, e.g., `ghcr.io/astral-sh/uv:0.4.16`
+- `ghcr.io/astral-sh/uv:{major}.{minor}`, e.g., `ghcr.io/astral-sh/uv:0.4` (the latest patch
+  version)
 
 In addition, uv publishes the following images:
 
 <!-- prettier-ignore -->
 - Based on `alpine:3.20`:
-    - `uv:alpine`
-    - `uv:alpine3.20`
+    - `ghcr.io/astral-sh/uv:alpine`
+    - `ghcr.io/astral-sh/uv:alpine3.20`
 - Based on `debian:bookworm-slim`:
-    - `uv:debian-slim`
-    - `uv:bookworm-slim`
+    - `ghcr.io/astral-sh/uv:debian-slim`
+    - `ghcr.io/astral-sh/uv:bookworm-slim`
 - Based on `buildpack-deps:bookworm`:
-    - `uv:debian`
-    - `uv:bookworm`
+    - `ghcr.io/astral-sh/uv:debian`
+    - `ghcr.io/astral-sh/uv:bookworm`
 - Based on `python3.x-alpine`:
-    - `uv:python3.12-alpine`
-    - `uv:python3.11-alpine`
-    - `uv:python3.10-alpine`
-    - `uv:python3.9-alpine`
-    - `uv:python3.8-alpine`
+    - `ghcr.io/astral-sh/uv:python3.12-alpine`
+    - `ghcr.io/astral-sh/uv:python3.11-alpine`
+    - `ghcr.io/astral-sh/uv:python3.10-alpine`
+    - `ghcr.io/astral-sh/uv:python3.9-alpine`
+    - `ghcr.io/astral-sh/uv:python3.8-alpine`
 - Based on `python3.x-bookworm`:
-    - `uv:python3.12-bookworm`
-    - `uv:python3.11-bookworm`
-    - `uv:python3.10-bookworm`
-    - `uv:python3.9-bookworm`
-    - `uv:python3.8-bookworm`
+    - `ghcr.io/astral-sh/uv:python3.12-bookworm`
+    - `ghcr.io/astral-sh/uv:python3.11-bookworm`
+    - `ghcr.io/astral-sh/uv:python3.10-bookworm`
+    - `ghcr.io/astral-sh/uv:python3.9-bookworm`
+    - `ghcr.io/astral-sh/uv:python3.8-bookworm`
 - Based on `python3.x-slim-bookworm`:
-    - `uv:python3.12-bookworm-slim`
-    - `uv:python3.11-bookworm-slim`
-    - `uv:python3.10-bookworm-slim`
-    - `uv:python3.9-bookworm-slim`
-    - `uv:python3.8-bookworm-slim`
+    - `ghcr.io/astral-sh/uv:python3.12-bookworm-slim`
+    - `ghcr.io/astral-sh/uv:python3.11-bookworm-slim`
+    - `ghcr.io/astral-sh/uv:python3.10-bookworm-slim`
+    - `ghcr.io/astral-sh/uv:python3.9-bookworm-slim`
+    - `ghcr.io/astral-sh/uv:python3.8-bookworm-slim`
+<!-- prettier-ignore-end -->
 
 As with the distroless image, each image is published with uv version tags as
-`uv:{major}.{minor}.{patch}-{base}` and `uv:{major}.{minor}-{base}`, e.g., `uv:0.4.16-alpine`.
+`ghcr.io/astral-sh/uv:{major}.{minor}.{patch}-{base}` and
+`ghcr.io/astral-sh/uv:{major}.{minor}-{base}`, e.g., `ghcr.io/astral-sh/uv:0.4.16-alpine`.
 
 For more details, see the [GitHub Container](https://github.com/astral-sh/uv/pkgs/container/uv)
 page.


### PR DESCRIPTION
## Summary

It was all too easy to just copy the non-qualified name of the Docker images and wonder why they couldn't be found – well, because they're on `ghcr.io`, and you need to read the prose before the list to figure that out.


## Test Plan

No plan.