### PR TITLE
Don't create Python bytecode files during interpreter discovery

### DIFF
--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -616,7 +616,8 @@ impl InterpreterInfo {
             tempdir.path().escape_for_python()
         );
         let output = Command::new(interpreter)
-            .arg("-I")
+            .arg("-I") // Isolated mode.
+            .arg("-B") // Don't write bytecode.
             .arg("-c")
             .arg(script)
             .output()


### PR DESCRIPTION
## Summary

As @konstin noted, `python -I` ignores `PYTHONDONTWRITEBYTECODE`, so `--no-compile-bytecode` may end up with bytecode spilled onto the disk nevertheless.

This should fix that by way of adding [`-B`](https://docs.python.org/3.12/using/cmdline.html#cmdoption-B).

## Test Plan

None so far. I can add proper tests if required, if this is deemed a good idea :)

Closes #7696.