### PR TITLE
Pin rich==13.7.1 for --exclude-newer in tests

### DIFF
--- a/scripts/uv-run-remote-script-test.py
+++ b/scripts/uv-run-remote-script-test.py
@@ -2,7 +2,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#   "rich==13.8.1",
+#   "rich==13.7.1",
 # ]
 # ///
 import sys


### PR DESCRIPTION
Fixes broken test in #6375

Tested here with:

```sh
cargo run run --exclude-newer=2024-03-25T00:00:00Z scripts/uv-run-remote-script-test.py CI
```
