### PR TITLE
Remove unused `thiserror` variants in resolver

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -36,12 +36,6 @@ pub enum ResolveError {
     #[error("Attempted to wait on an unregistered task: `{_0}`")]
     UnregisteredTask(String),
 
-    #[error("Package metadata name `{metadata}` does not match given name `{given}`")]
-    NameMismatch {
-        given: PackageName,
-        metadata: PackageName,
-    },
-
     #[error(transparent)]
     PubGrubSpecifier(#[from] PubGrubSpecifierError),
 
@@ -60,9 +54,6 @@ pub enum ResolveError {
 
     #[error("Package `{0}` attempted to resolve via URL: {1}. URL dependencies must be expressed as direct requirements or constraints. Consider adding `{0} @ {1}` to your dependencies or constraints file.")]
     DisallowedUrl(PackageName, String),
-
-    #[error("There are conflicting editable requirements for package `{0}`:\n- {1}\n- {2}")]
-    ConflictingEditables(PackageName, String, String),
 
     #[error(transparent)]
     DistributionType(#[from] distribution_types::Error),
@@ -89,14 +80,6 @@ pub enum ResolveError {
     #[error(transparent)]
     NoSolution(#[from] NoSolutionError),
 
-    #[error("{package} {version} depends on itself")]
-    SelfDependency {
-        /// Package whose dependencies we want.
-        package: Box<PubGrubPackage>,
-        /// Version of the package for which we want the dependencies.
-        version: Box<Version>,
-    },
-
     #[error("Attempted to construct an invalid version specifier")]
     InvalidVersion(#[from] pep440_rs::VersionSpecifierBuildError),
 
@@ -106,9 +89,8 @@ pub enum ResolveError {
     #[error("found conflicting distribution in resolution: {0}")]
     ConflictingDistribution(ConflictingDistributionError),
 
-    /// Something unexpected happened.
-    #[error("{0}")]
-    Failure(String),
+    #[error("Package `{0}` is unavailable")]
+    PackageUnavailable(PackageName),
 }
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for ResolveError {

--- a/crates/uv-resolver/src/pubgrub/package.rs
+++ b/crates/uv-resolver/src/pubgrub/package.rs
@@ -8,7 +8,7 @@ use crate::python_requirement::PythonRequirement;
 
 /// [`Arc`] wrapper around [`PubGrubPackageInner`] to make cloning (inside PubGrub) cheap.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct PubGrubPackage(Arc<PubGrubPackageInner>);
+pub(crate) struct PubGrubPackage(Arc<PubGrubPackageInner>);
 
 impl Deref for PubGrubPackage {
     type Target = PubGrubPackageInner;
@@ -38,7 +38,7 @@ impl From<PubGrubPackageInner> for PubGrubPackage {
 ///    package (e.g., `black[colorama]`), and mark it as a dependency of the real package (e.g.,
 ///    `black`). We then discard the virtual packages at the end of the resolution process.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub enum PubGrubPackageInner {
+pub(crate) enum PubGrubPackageInner {
     /// The root package, which is used to start the resolution process.
     Root(Option<PackageName>),
     /// A Python version.
@@ -167,7 +167,7 @@ impl PubGrubPackage {
     }
 
     /// Returns `true` if this PubGrub package is a proxy package.
-    pub fn is_proxy(&self) -> bool {
+    pub(crate) fn is_proxy(&self) -> bool {
         matches!(
             &**self,
             PubGrubPackageInner::Extra { .. }
@@ -219,7 +219,7 @@ impl PubGrubPackage {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Hash, Ord)]
-pub enum PubGrubPython {
+pub(crate) enum PubGrubPython {
     /// The Python version installed in the current environment.
     Installed,
     /// The Python version for which dependencies are being resolved.

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1216,9 +1216,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         false,
                         "Dependencies were requested for a package that is not available"
                     );
-                    return Err(ResolveError::Failure(format!(
-                        "The package is unavailable: {name}"
-                    )));
+                    return Err(ResolveError::PackageUnavailable(name.clone()));
                 }
 
                 // Wait for the metadata to be available.


### PR DESCRIPTION
## Summary

While looking at something else, I noticed that these are not used.
