### PR TITLE
uv python install: Detect hard-float support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,21 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,18 +570,6 @@ checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
 dependencies = [
  "base64 0.22.1",
  "encoding_rs",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "num-traits",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1642,29 +1615,6 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core 0.52.0",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2733,7 +2683,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
  "bitflags 2.6.0",
- "chrono",
  "flate2",
  "hex",
  "lazy_static",
@@ -2748,7 +2697,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
  "bitflags 2.6.0",
- "chrono",
  "hex",
 ]
 
@@ -5666,15 +5614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +585,18 @@ checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
 dependencies = [
  "base64 0.22.1",
  "encoding_rs",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1615,6 +1642,29 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core 0.52.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2674,6 +2724,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.6.0",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.6.0",
+ "chrono",
+ "hex",
 ]
 
 [[package]]
@@ -5061,6 +5137,7 @@ dependencies = [
  "pep440_rs",
  "pep508_rs",
  "platform-tags",
+ "procfs",
  "pypi-types",
  "regex",
  "reqwest",
@@ -5589,6 +5666,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 petgraph = { version = "0.6.5" }
 platform-info = { version = "2.0.3" }
-procfs = { version = "0.16.0" }
+procfs = { version = "0.16.0" , default-features = false, features = ["flate2"] }
 proc-macro2 = { version = "1.0.86" }
 pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "388685a8711092971930986644cfed152d1a1f6c" }
 pyo3 = { version = "0.21.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 petgraph = { version = "0.6.5" }
 platform-info = { version = "2.0.3" }
+procfs = { version = "0.16.0" }
 proc-macro2 = { version = "1.0.86" }
 pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "388685a8711092971930986644cfed152d1a1f6c" }
 pyo3 = { version = "0.21.2" }

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -36,7 +36,6 @@ futures = { workspace = true }
 goblin = { workspace = true }
 itertools = { workspace = true }
 owo-colors = { workspace = true }
-procfs = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
@@ -57,6 +56,9 @@ which = { workspace = true }
 [target.'cfg(any(unix, target_os = "wasi", target_os = "redox"))'.dependencies]
 rustix = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = { workspace = true }
+
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true }
 winsafe = { workspace = true }
@@ -70,4 +72,6 @@ indoc = { version = "2.0.5" }
 itertools = { version = "0.13.0" }
 temp-env = { version = "0.3.6" }
 tempfile = { version = "3.12.0" }
-test-log = { version = "0.2.16", features = ["trace"], default-features = false }
+test-log = { version = "0.2.16", features = [
+    "trace"
+], default-features = false }

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -36,6 +36,7 @@ futures = { workspace = true }
 goblin = { workspace = true }
 itertools = { workspace = true }
 owo-colors = { workspace = true }
+procfs = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }

--- a/crates/uv-python/Cargo.toml
+++ b/crates/uv-python/Cargo.toml
@@ -72,6 +72,4 @@ indoc = { version = "2.0.5" }
 itertools = { version = "0.13.0" }
 temp-env = { version = "0.3.6" }
 tempfile = { version = "3.12.0" }
-test-log = { version = "0.2.16", features = [
-    "trace"
-], default-features = false }
+test-log = { version = "0.2.16", features = ["trace"], default-features = false }

--- a/crates/uv-python/src/cpuinfo.rs
+++ b/crates/uv-python/src/cpuinfo.rs
@@ -4,21 +4,34 @@ use anyhow::Error;
 #[cfg(target_os = "linux")]
 use procfs::{CpuInfo, Current};
 
+/// Detects whether the hardware supports floating-point operations using ARM's Vector Floating Point (VFP) hardware.
+///
+/// This function is relevant specifically for ARM architectures, where the presence of the "vfp" flag in `/proc/cpuinfo`
+/// indicates that the CPU supports hardware floating-point operations.
+/// This helps determine whether the system is using the `gnueabihf` (hard-float) ABI or `gnueabi` (soft-float) ABI.
+///
+/// More information on this can be found in the [Debian ARM Hard Float Port documentation](https://wiki.debian.org/ArmHardFloatPort#VFP).
 #[cfg(target_os = "linux")]
 pub(crate) fn detect_hardware_floating_point_support() -> Result<bool, Error> {
     let cpu_info = CpuInfo::current()?;
+
+    // Iterate through each core and check if the "vfp" flag is present,
+    // indicating hardware floating-point support.
     for num in 0..cpu_info.num_cores() {
         if let Some(flags) = cpu_info.flags(num) {
             if flags.contains(&"vfp") {
-                return Ok(true);
+                return Ok(true); // Hardware floating-point (gnueabihf) detected.
             }
         }
     }
-    Ok(false)
+
+    Ok(false) // Default to soft-float (gnueabi) if no "vfp" flag is found
 }
 
+/// For non-Linux systems or architectures, the function will return `false` as hardware floating-point detection
+/// is not applicable outside of Linux ARM architectures.
 #[cfg(not(target_os = "linux"))]
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn detect_hardware_floating_point_support() -> Result<bool, Error> {
-    Ok(false)
+    Ok(false) // Non-Linux or non-ARM systems: hardware floating-point detection is not applicable
 }

--- a/crates/uv-python/src/cpuinfo.rs
+++ b/crates/uv-python/src/cpuinfo.rs
@@ -1,0 +1,16 @@
+//! Fetches CPU information.
+
+use anyhow::Error;
+use procfs::{CpuInfo, Current};
+
+pub(crate) fn detect_hardware_floating_point_support() -> Result<bool, Error> {
+    let cpu_info = CpuInfo::current()?;
+    for num in 0..cpu_info.num_cores() {
+        if let Some(flags) = cpu_info.flags(num) {
+            if flags.contains(&"vfp") {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}

--- a/crates/uv-python/src/cpuinfo.rs
+++ b/crates/uv-python/src/cpuinfo.rs
@@ -1,8 +1,10 @@
 //! Fetches CPU information.
 
 use anyhow::Error;
+#[cfg(target_os = "linux")]
 use procfs::{CpuInfo, Current};
 
+#[cfg(target_os = "linux")]
 pub(crate) fn detect_hardware_floating_point_support() -> Result<bool, Error> {
     let cpu_info = CpuInfo::current()?;
     for num in 0..cpu_info.num_cores() {
@@ -12,5 +14,11 @@ pub(crate) fn detect_hardware_floating_point_support() -> Result<bool, Error> {
             }
         }
     }
+    Ok(false)
+}
+
+#[cfg(not(target_os = "linux"))]
+#[allow(clippy::unnecessary_wraps)]
+pub(crate) fn detect_hardware_floating_point_support() -> Result<bool, Error> {
     Ok(false)
 }

--- a/crates/uv-python/src/lib.rs
+++ b/crates/uv-python/src/lib.rs
@@ -18,6 +18,7 @@ pub use crate::version_files::{
 };
 pub use crate::virtualenv::{Error as VirtualEnvError, PyVenvConfiguration, VirtualEnvironment};
 
+mod cpuinfo;
 mod discovery;
 pub mod downloads;
 mod environment;

--- a/crates/uv-python/src/platform.rs
+++ b/crates/uv-python/src/platform.rs
@@ -1,3 +1,4 @@
+use crate::cpuinfo::detect_hardware_floating_point_support;
 use crate::libc::{detect_linux_libc, LibcDetectionError, LibcVersion};
 use std::fmt::Display;
 use std::ops::Deref;
@@ -30,7 +31,15 @@ impl Libc {
     pub(crate) fn from_env() -> Result<Self, LibcDetectionError> {
         match std::env::consts::OS {
             "linux" => Ok(Self::Some(match detect_linux_libc()? {
-                LibcVersion::Manylinux { .. } => target_lexicon::Environment::Gnu,
+                LibcVersion::Manylinux { .. } => match std::env::consts::ARCH {
+                    // download-metadata.json only includes armv7.
+                    "arm" | "armv7" => match detect_hardware_floating_point_support() {
+                        Ok(true) => target_lexicon::Environment::Gnueabihf,
+                        Ok(false) => target_lexicon::Environment::Gnueabi,
+                        Err(_) => target_lexicon::Environment::Gnu,
+                    },
+                    _ => target_lexicon::Environment::Gnu,
+                },
                 LibcVersion::Musllinux { .. } => target_lexicon::Environment::Musl,
             })),
             "windows" | "macos" => Ok(Self::None),

--- a/crates/uv-python/src/platform.rs
+++ b/crates/uv-python/src/platform.rs
@@ -32,6 +32,8 @@ impl Libc {
         match std::env::consts::OS {
             "linux" => Ok(Self::Some(match detect_linux_libc()? {
                 LibcVersion::Manylinux { .. } => match std::env::consts::ARCH {
+                    // Checks if the CPU supports hardware floating-point operations.
+                    // Depending on the result, it selects either the `gnueabihf` (hard-float) or `gnueabi` (soft-float) environment.
                     // download-metadata.json only includes armv7.
                     "arm" | "armv7" => match detect_hardware_floating_point_support() {
                         Ok(true) => target_lexicon::Environment::Gnueabihf,


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

## Summary

This pull request fixes [#6873](https://github.com/astral-sh/uv/issues/6873) by implementing
a mechanism to detect whether the ARM architecture supports the VFP (Vector Floating Point) hardware,
which is critical for selecting the appropriate `libc` variant.

The detection is based on reading the flags from `/proc/cpuinfo`.
Specifically, if the `vfp` flag is present, the system will use the `gnueabihf` (hard-float ABI) variant;
if not, it will default to `gnueabi` (soft-float ABI).

For additional context, see the [Debian documentation on the ARM Hard Float Port](https://wiki.debian.org/ArmHardFloatPort#VFP).

## Test Plan

- [ ] Verify that the correct `libc` variant is selected on an ARM system with and without VFP support.
