### PR TITLE
Fix table of contents sizing

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -155,7 +155,7 @@ See https://github.com/astral-sh/uv/issues/5130 */
 }
 
 /* Increase the size of the index nav item to match the sections */
-.md-nav__item:first-child {
+.md-nav--primary .md-nav__item:first-child {
   font-size: 17.5px;
   font-weight: normal;
 }


### PR DESCRIPTION
Now
<img width="864" alt="Screenshot 2024-09-27 at 10 57 40 PM" src="https://github.com/user-attachments/assets/84c99d34-9b5a-4522-a2b4-0ef3c9cdda49">
Previously
<img width="864" alt="Screenshot 2024-09-27 at 10 57 46 PM" src="https://github.com/user-attachments/assets/d7ff7401-ece5-4b49-813e-cd4e58d6cf19">
