### PR TITLE
Add `UV_NO_SYNC` environment variable

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2528,7 +2528,7 @@ pub struct RunArgs {
     ///
     /// Implies `--frozen`, as the project dependencies will be ignored (i.e., the lockfile will not
     /// be updated, since the environment will not be synced regardless).
-    #[arg(long, conflicts_with = "frozen")]
+    #[arg(long, env = "UV_NO_SYNC", value_parser = clap::builder::BoolishValueParser::new(), conflicts_with = "frozen")]
     pub no_sync: bool,
 
     /// Assert that the `uv.lock` will remain unchanged.
@@ -2844,7 +2844,7 @@ pub struct AddArgs {
     pub extra: Option<Vec<ExtraName>>,
 
     /// Avoid syncing the virtual environment.
-    #[arg(long, conflicts_with = "frozen")]
+    #[arg(long, env = "UV_NO_SYNC", value_parser = clap::builder::BoolishValueParser::new(), conflicts_with = "frozen")]
     pub no_sync: bool,
 
     /// Assert that the `uv.lock` will remain unchanged.
@@ -2913,7 +2913,7 @@ pub struct RemoveArgs {
     pub optional: Option<ExtraName>,
 
     /// Avoid syncing the virtual environment after re-locking the project.
-    #[arg(long, conflicts_with = "frozen")]
+    #[arg(long, env = "UV_NO_SYNC", value_parser = clap::builder::BoolishValueParser::new(), conflicts_with = "frozen")]
     pub no_sync: bool,
 
     /// Assert that the `uv.lock` will remain unchanged.

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -71,6 +71,8 @@ uv accepts the following command-line arguments as environment variables:
   set, uv will use this username for publishing.
 - `UV_PUBLISH_PASSWORD`: Equivalent to the `--password` command-line argument in `uv publish`. If
   set, uv will use this password for publishing.
+- `UV_NO_SYNC`: Equivalent to the `--no-sync` command-line argument. If set, uv will skip updating
+  the environment.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -279,6 +279,7 @@ uv run [OPTIONS] <COMMAND>
 
 <p>Implies <code>--frozen</code>, as the project dependencies will be ignored (i.e., the lockfile will not be updated, since the environment will not be synced regardless).</p>
 
+<p>May also be set with the <code>UV_NO_SYNC</code> environment variable.</p>
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
 <p>When disabled, uv will only use locally cached data and locally available files.</p>
@@ -792,6 +793,7 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 
 </dd><dt><code>--no-sync</code></dt><dd><p>Avoid syncing the virtual environment</p>
 
+<p>May also be set with the <code>UV_NO_SYNC</code> environment variable.</p>
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
 <p>When disabled, uv will only use locally cached data and locally available files.</p>
@@ -1108,6 +1110,7 @@ uv remove [OPTIONS] <PACKAGES>...
 
 </dd><dt><code>--no-sync</code></dt><dd><p>Avoid syncing the virtual environment after re-locking the project</p>
 
+<p>May also be set with the <code>UV_NO_SYNC</code> environment variable.</p>
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
 <p>When disabled, uv will only use locally cached data and locally available files.</p>


### PR DESCRIPTION
## Summary

I have a workflow where I want use `uv` as a dependency solver only, and manage my environments with external tooling (Nix).

## Test Plan

Manually tested. Automated testing seems excessive for such a trivial change.

## Problems

It's still not as useful as I'd like it to be.
`uv` uncondtionally creates a virtual environment, something I would expect that `--no-sync` should disable.
This looks a bit more tricky to achieve and I'm not sure about how to best structure it.