### PR TITLE
Set private classifier for non-package application

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -593,7 +593,7 @@ impl InitProjectKind {
         package: bool,
     ) -> Result<()> {
         // Create the `pyproject.toml`
-        let mut pyproject = pyproject_project(name, requires_python, no_readme);
+        let mut pyproject = pyproject_project(name, requires_python, package, no_readme);
 
         // Include additional project configuration for packaged applications
         if package {
@@ -678,7 +678,7 @@ impl InitProjectKind {
         }
 
         // Create the `pyproject.toml`
-        let mut pyproject = pyproject_project(name, requires_python, no_readme);
+        let mut pyproject = pyproject_project(name, requires_python, true, no_readme);
 
         // Always include a build system if the project is packaged.
         pyproject.push('\n');
@@ -732,6 +732,7 @@ impl InitProjectKind {
 fn pyproject_project(
     name: &PackageName,
     requires_python: &RequiresPython,
+    package: bool,
     no_readme: bool,
 ) -> String {
     indoc::formatdoc! {r#"
@@ -739,11 +740,12 @@ fn pyproject_project(
         name = "{name}"
         version = "0.1.0"
         description = "Add your description here"{readme}
-        requires-python = "{requires_python}"
+        requires-python = "{requires_python}"{classifiers}
         dependencies = []
     "#,
         readme = if no_readme { "" } else { "\nreadme = \"README.md\"" },
         requires_python = requires_python.specifiers(),
+        classifiers = if package { "" } else { "\nclassifiers = [ \"Private :: Do Not Upload\" ]" },
     }
 }
 

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -40,6 +40,7 @@ fn init() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = ">=3.12"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -101,6 +102,7 @@ fn init_application() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = ">=3.12"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -172,6 +174,7 @@ fn init_application_hello_exists() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = ">=3.12"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -223,6 +226,7 @@ fn init_application_other_python_exists() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = ">=3.12"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -702,6 +706,7 @@ fn init_no_readme() -> Result<()> {
         version = "0.1.0"
         description = "Add your description here"
         requires-python = ">=3.12"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -737,6 +742,7 @@ fn init_no_pin_python() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = ">=3.12"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -839,6 +845,7 @@ fn init_application_current_dir() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = ">=3.12"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -1456,6 +1463,7 @@ fn init_no_workspace_warning() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = ">=3.12"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -1530,6 +1538,7 @@ fn init_project_inside_project() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = ">=3.12"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -1902,6 +1911,7 @@ fn init_requires_python_workspace() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = ">=3.10"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -1960,6 +1970,7 @@ fn init_requires_python_version() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = ">=3.8"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -2019,6 +2030,7 @@ fn init_requires_python_specifiers() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = "==3.8.*"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );
@@ -2127,6 +2139,7 @@ fn init_failure() -> Result<()> {
         description = "Add your description here"
         readme = "README.md"
         requires-python = ">=3.12"
+        classifiers = [ "Private :: Do Not Upload" ]
         dependencies = []
         "###
         );


### PR DESCRIPTION
## Summary

For non-package applications (mostly private projects), set classifier to `Private :: Do Not Upload` to prevent it from being uploaded to PyPI by accident.

