### PR TITLE
Retain empty extras on workspace members

### DIFF
--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -273,17 +273,7 @@ impl Workspace {
                 .as_ref()
                 .map(|optional_dependencies| {
                     // It's a `BTreeMap` so the keys are sorted.
-                    optional_dependencies
-                        .iter()
-                        .filter_map(|(name, dependencies)| {
-                            if dependencies.is_empty() {
-                                None
-                            } else {
-                                Some(name)
-                            }
-                        })
-                        .cloned()
-                        .collect::<Vec<_>>()
+                    optional_dependencies.keys().cloned().collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
 


### PR DESCRIPTION
## Summary

I'm not sure why we drop these but it seems incorrect.
