### PR TITLE
Allow spaces in path requirements

### DIFF
--- a/crates/requirements-txt/src/lib.rs
+++ b/crates/requirements-txt/src/lib.rs
@@ -1325,6 +1325,7 @@ mod test {
 
     #[cfg(unix)]
     #[test_case(Path::new("semicolon.txt"))]
+    #[test_case(Path::new("hash.txt"))]
     #[tokio::test]
     async fn parse_err(path: &Path) {
         let working_dir = workspace_test_data_dir().join("requirements-txt");

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-bare-url.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-bare-url.txt.snap
@@ -158,6 +158,156 @@ RequirementsTxt {
             ),
             hashes: [],
         },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Directory(
+                            ParsedDirectoryUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                install_path: "<REQUIREMENTS_DIR>/scripts/packages/black editable",
+                                editable: false,
+                                virtual: false,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./scripts/packages/black editable",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: true,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/bare-url.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Directory(
+                            ParsedDirectoryUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                install_path: "<REQUIREMENTS_DIR>/scripts/packages/black editable",
+                                editable: false,
+                                virtual: false,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./scripts/packages/black editable",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: python_full_version >= '3.9',
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/bare-url.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Directory(
+                            ParsedDirectoryUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                install_path: "<REQUIREMENTS_DIR>/scripts/packages/black editable",
+                                editable: false,
+                                virtual: false,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./scripts/packages/black editable",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: true,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/bare-url.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
     ],
     constraints: [],
     editables: [],

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-hash.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-unix-hash.txt.snap
@@ -3,17 +3,17 @@ source: crates/requirements-txt/src/lib.rs
 expression: actual
 ---
 RequirementsTxtFileError {
-    file: "<REQUIREMENTS_DIR>/semicolon.txt",
+    file: "<REQUIREMENTS_DIR>/hash.txt",
     error: Pep508 {
         source: Pep508Error {
             message: String(
-                "Missing space before ';', the end of the URL is ambiguous",
+                "Missing space before '#', the end of the URL is ambiguous",
             ),
             start: 10,
             len: 1,
-            input: "./editable; python_version >= \"3.9\" and os_name == \"posix\"",
+            input: "./editable# comment",
         },
-        start: 50,
-        end: 108,
+        start: 49,
+        end: 68,
     },
 }

--- a/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-bare-url.txt.snap
+++ b/crates/requirements-txt/src/snapshots/requirements_txt__test__parse-windows-bare-url.txt.snap
@@ -158,6 +158,156 @@ RequirementsTxt {
             ),
             hashes: [],
         },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Directory(
+                            ParsedDirectoryUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "/<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                install_path: "<REQUIREMENTS_DIR>/scripts/packages/black editable",
+                                editable: false,
+                                virtual: false,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./scripts/packages/black editable",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: true,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/bare-url.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Directory(
+                            ParsedDirectoryUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "/<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                install_path: "<REQUIREMENTS_DIR>/scripts/packages/black editable",
+                                editable: false,
+                                virtual: false,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./scripts/packages/black editable",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: python_full_version >= '3.9',
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/bare-url.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Directory(
+                            ParsedDirectoryUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "/<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                install_path: "<REQUIREMENTS_DIR>/scripts/packages/black editable",
+                                editable: false,
+                                virtual: false,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/<REQUIREMENTS_DIR>/scripts/packages/black%20editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./scripts/packages/black editable",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: true,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/bare-url.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
     ],
     constraints: [],
     editables: [],

--- a/crates/requirements-txt/test-data/requirements-txt/bare-url.txt
+++ b/crates/requirements-txt/test-data/requirements-txt/bare-url.txt
@@ -1,3 +1,6 @@
 ./scripts/packages/black_editable
 ./scripts/packages/black_editable[dev]
 file:///scripts/packages/black_editable
+./scripts/packages/black editable
+./scripts/packages/black editable ; python_version >= "3.9"
+./scripts/packages/black editable # comment

--- a/crates/requirements-txt/test-data/requirements-txt/hash.txt
+++ b/crates/requirements-txt/test-data/requirements-txt/hash.txt
@@ -1,0 +1,2 @@
+# Disallowed (missing whitespace before hash)
+-e ./editable# comment


### PR DESCRIPTION
## Summary

This PR modifies our parsing to allow spaces in URLs. I don't know if this is a correct change... But we now parse URLs until we see:

- A newline.
- A semicolon (marker) or hash (comment), _preceded_ by a space. We parse the URL until the last
  non-whitespace character (inclusive).
- A semicolon (marker) or hash (comment) _followed_ by a space. We treat this as an error, since
  the end of the URL is ambiguous (e.g., `https://foo.com; marker`) would be a URL that ends in `;`).

Closes https://github.com/astral-sh/uv/issues/6032.
