### PR TITLE
Use file stem when parsing cached wheel names

### DIFF
--- a/crates/uv-distribution/src/index/cached_wheel.rs
+++ b/crates/uv-distribution/src/index/cached_wheel.rs
@@ -97,7 +97,7 @@ impl CachedWheel {
         let path = path.as_ref();
 
         // Determine the wheel filename.
-        let filename = path.file_name()?.to_str()?;
+        let filename = path.file_stem()?.to_str()?;
         let filename = WheelFilename::from_stem(filename).ok()?;
 
         // Read the pointer.
@@ -121,7 +121,7 @@ impl CachedWheel {
         let path = path.as_ref();
 
         // Determine the wheel filename.
-        let filename = path.file_name()?.to_str()?;
+        let filename = path.file_stem()?.to_str()?;
         let filename = WheelFilename::from_stem(filename).ok()?;
 
         // Read the pointer.


### PR DESCRIPTION
## Summary

I noticed that we were including `http` (the file extension) in the platform tags when reading from the cache:

![Screenshot 2024-09-28 at 9 40 15 PM](https://github.com/user-attachments/assets/d80ed351-1257-42b5-8292-0b11a50c767d)

Probably harmless, but wrong.
