### PR TITLE
Update documentation to setup-uv@v3

### DIFF
--- a/docs/guides/integration/github.md
+++ b/docs/guides/integration/github.md
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v3
 ```
 
 It is considered best practice to pin to a specific uv version, e.g., with:
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v3
         with:
           # Install a specific version of uv.
           version: "0.4.17"
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v3
 
       - name: Set up Python
         run: uv python install
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v3
 
       - name: "Set up Python"
         uses: actions/setup-python@v5
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v3
 
       - name: "Set up Python"
         uses: actions/setup-python@v5
@@ -165,7 +165,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v3
 
       - name: Set up Python
         run: uv python install
@@ -193,7 +193,7 @@ persisting the cache:
 
 ```yaml title="example.yml"
 - name: Enable caching
-  uses: astral-sh/setup-uv@v2
+  uses: astral-sh/setup-uv@v3
   with:
     enable-cache: true
 ```
@@ -202,7 +202,7 @@ You can configure the action to use a custom cache directory on the runner:
 
 ```yaml title="example.yml"
 - name: Define a custom uv cache path
-  uses: astral-sh/setup-uv@v2
+  uses: astral-sh/setup-uv@v3
   with:
     enable-cache: true
     cache-local-path: "/path/to/cache"
@@ -212,7 +212,7 @@ Or invalidate it when the lockfile changes:
 
 ```yaml title="example.yml"
 - name: Define a cache dependency glob
-  uses: astral-sh/setup-uv@v2
+  uses: astral-sh/setup-uv@v3
   with:
     enable-cache: true
     cache-dependency-glob: "uv.lock"
@@ -222,7 +222,7 @@ Or when any requirements file changes:
 
 ```yaml title="example.yml"
 - name: Define a cache dependency glob
-  uses: astral-sh/setup-uv@v2
+  uses: astral-sh/setup-uv@v3
   with:
     enable-cache: true
     cache-dependency-glob: "requirements**.txt"


### PR DESCRIPTION
## Summary

Update the documentation from using setup-uv@v2 for GitHub Actions to use setup-uv@v3 instead.