### PR TITLE
Fix `uv tree --invert` for platform dependencies

### DIFF
--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -27,7 +27,7 @@ pub struct TreeDisplay<'env> {
     /// Prune the given packages from the display of the dependency tree.
     prune: Vec<PackageName>,
     /// Display only the specified packages.
-    package: Vec<PackageName>,
+    packages: Vec<PackageName>,
     /// Whether to de-duplicate the displayed dependencies.
     no_dedupe: bool,
 }
@@ -39,11 +39,12 @@ impl<'env> TreeDisplay<'env> {
         markers: Option<&'env ResolverMarkerEnvironment>,
         depth: usize,
         prune: Vec<PackageName>,
-        package: Vec<PackageName>,
+        packages: Vec<PackageName>,
         no_dedupe: bool,
         invert: bool,
     ) -> Self {
         let mut non_roots = FxHashSet::default();
+        let mut skipped = FxHashSet::default();
 
         // Index all the dependencies. We could read these from the `Lock` directly, but we have to
         // support `--invert`, so we might as well build them up in either case.
@@ -51,16 +52,27 @@ impl<'env> TreeDisplay<'env> {
         let mut optional_dependencies: FxHashMap<_, FxHashMap<_, Vec<_>>> = FxHashMap::default();
         let mut dev_dependencies: FxHashMap<_, FxHashMap<_, Vec<_>>> = FxHashMap::default();
 
-        for packages in &lock.packages {
-            for dependency in &packages.dependencies {
+        for package in &lock.packages {
+            for dependency in &package.dependencies {
+                // Skip dependencies that don't apply to the current environment.
+                if let Some(environment_markers) = markers {
+                    if !dependency
+                        .complexified_marker
+                        .evaluate(environment_markers, &[])
+                    {
+                        skipped.insert(dependency.package_id.clone());
+                        continue;
+                    }
+                }
+
                 let parent = if invert {
                     &dependency.package_id
                 } else {
-                    &packages.id
+                    &package.id
                 };
                 let child = if invert {
                     Cow::Owned(Dependency {
-                        package_id: packages.id.clone(),
+                        package_id: package.id.clone(),
                         extra: dependency.extra.clone(),
                         simplified_marker: dependency.simplified_marker.clone(),
                         complexified_marker: dependency.complexified_marker.clone(),
@@ -71,29 +83,30 @@ impl<'env> TreeDisplay<'env> {
 
                 non_roots.insert(child.package_id.clone());
 
-                // Skip dependencies that don't apply to the current environment.
-                if let Some(environment_markers) = markers {
-                    if !dependency
-                        .complexified_marker
-                        .evaluate(environment_markers, &[])
-                    {
-                        continue;
-                    }
-                }
-
                 dependencies.entry(parent).or_default().push(child);
             }
 
-            for (extra, dependencies) in &packages.optional_dependencies {
+            for (extra, dependencies) in &package.optional_dependencies {
                 for dependency in dependencies {
+                    // Skip dependencies that don't apply to the current environment.
+                    if let Some(environment_markers) = markers {
+                        if !dependency
+                            .complexified_marker
+                            .evaluate(environment_markers, &[])
+                        {
+                            skipped.insert(dependency.package_id.clone());
+                            continue;
+                        }
+                    }
+
                     let parent = if invert {
                         &dependency.package_id
                     } else {
-                        &packages.id
+                        &package.id
                     };
                     let child = if invert {
                         Cow::Owned(Dependency {
-                            package_id: packages.id.clone(),
+                            package_id: package.id.clone(),
                             extra: dependency.extra.clone(),
                             simplified_marker: dependency.simplified_marker.clone(),
                             complexified_marker: dependency.complexified_marker.clone(),
@@ -103,16 +116,6 @@ impl<'env> TreeDisplay<'env> {
                     };
 
                     non_roots.insert(child.package_id.clone());
-
-                    // Skip dependencies that don't apply to the current environment.
-                    if let Some(environment_markers) = markers {
-                        if !dependency
-                            .complexified_marker
-                            .evaluate(environment_markers, &[])
-                        {
-                            continue;
-                        }
-                    }
 
                     optional_dependencies
                         .entry(parent)
@@ -123,16 +126,27 @@ impl<'env> TreeDisplay<'env> {
                 }
             }
 
-            for (group, dependencies) in &packages.dev_dependencies {
+            for (group, dependencies) in &package.dev_dependencies {
                 for dependency in dependencies {
+                    // Skip dependencies that don't apply to the current environment.
+                    if let Some(environment_markers) = markers {
+                        if !dependency
+                            .complexified_marker
+                            .evaluate(environment_markers, &[])
+                        {
+                            skipped.insert(dependency.package_id.clone());
+                            continue;
+                        }
+                    }
+
                     let parent = if invert {
                         &dependency.package_id
                     } else {
-                        &packages.id
+                        &package.id
                     };
                     let child = if invert {
                         Cow::Owned(Dependency {
-                            package_id: packages.id.clone(),
+                            package_id: package.id.clone(),
                             extra: dependency.extra.clone(),
                             simplified_marker: dependency.simplified_marker.clone(),
                             complexified_marker: dependency.complexified_marker.clone(),
@@ -142,16 +156,6 @@ impl<'env> TreeDisplay<'env> {
                     };
 
                     non_roots.insert(child.package_id.clone());
-
-                    // Skip dependencies that don't apply to the current environment.
-                    if let Some(environment_markers) = markers {
-                        if !dependency
-                            .complexified_marker
-                            .evaluate(environment_markers, &[])
-                        {
-                            continue;
-                        }
-                    }
 
                     dev_dependencies
                         .entry(parent)
@@ -168,7 +172,7 @@ impl<'env> TreeDisplay<'env> {
             .packages
             .iter()
             .map(|dist| &dist.id)
-            .filter(|id| !non_roots.contains(*id))
+            .filter(|id| !non_roots.contains(*id) && !skipped.contains(*id))
             .collect::<Vec<_>>();
 
         Self {
@@ -178,7 +182,7 @@ impl<'env> TreeDisplay<'env> {
             dev_dependencies,
             depth,
             prune,
-            package,
+            packages,
             no_dedupe,
         }
     }
@@ -309,7 +313,7 @@ impl<'env> TreeDisplay<'env> {
         let mut path = Vec::new();
         let mut lines = Vec::new();
 
-        if self.package.is_empty() {
+        if self.packages.is_empty() {
             for id in &self.roots {
                 path.clear();
                 lines.extend(self.visit(Node::Root(id), &mut visited, &mut path));
@@ -317,7 +321,7 @@ impl<'env> TreeDisplay<'env> {
         } else {
             let by_package: FxHashMap<_, _> = self.roots.iter().map(|id| (&id.name, id)).collect();
             let mut first = true;
-            for package in &self.package {
+            for package in &self.packages {
                 if std::mem::take(&mut first) {
                     lines.push(String::new());
                 }

--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -44,7 +44,6 @@ impl<'env> TreeDisplay<'env> {
         invert: bool,
     ) -> Self {
         let mut non_roots = FxHashSet::default();
-        let mut skipped = FxHashSet::default();
 
         // Index all the dependencies. We could read these from the `Lock` directly, but we have to
         // support `--invert`, so we might as well build them up in either case.
@@ -60,7 +59,7 @@ impl<'env> TreeDisplay<'env> {
                         .complexified_marker
                         .evaluate(environment_markers, &[])
                     {
-                        skipped.insert(dependency.package_id.clone());
+                        non_roots.insert(dependency.package_id.clone());
                         continue;
                     }
                 }
@@ -94,7 +93,7 @@ impl<'env> TreeDisplay<'env> {
                             .complexified_marker
                             .evaluate(environment_markers, &[])
                         {
-                            skipped.insert(dependency.package_id.clone());
+                            non_roots.insert(dependency.package_id.clone());
                             continue;
                         }
                     }
@@ -134,7 +133,7 @@ impl<'env> TreeDisplay<'env> {
                             .complexified_marker
                             .evaluate(environment_markers, &[])
                         {
-                            skipped.insert(dependency.package_id.clone());
+                            non_roots.insert(dependency.package_id.clone());
                             continue;
                         }
                     }
@@ -172,7 +171,7 @@ impl<'env> TreeDisplay<'env> {
             .packages
             .iter()
             .map(|dist| &dist.id)
-            .filter(|id| !non_roots.contains(*id) && !skipped.contains(*id))
+            .filter(|id| !non_roots.contains(*id))
             .collect::<Vec<_>>();
 
         Self {


### PR DESCRIPTION
## Summary

`click` has one dependency of `colorama` only on Windows, `uv tree --invert` should not include `colorama` on non-Windows platforms, but currently:

```console
$ uv init
$ uv add click
$ uv tree --invert --python-platform macos
colorama v0.4.6
```

it should:
```console
$ uv tree --invert --python-platform macos
click v8.1.7
    └── project v0.1.0
```
