### PR TITLE
Read and write `.python-version` in the workspace root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5329,6 +5329,7 @@ dependencies = [
  "uv-macros",
  "uv-normalize",
  "uv-options-metadata",
+ "uv-python",
  "uv-warnings",
 ]
 

--- a/crates/uv-python/src/version_files.rs
+++ b/crates/uv-python/src/version_files.rs
@@ -114,6 +114,11 @@ impl PythonVersionFile {
         self.versions.iter()
     }
 
+    /// Check if the file contains the given version request.
+    pub fn contains(&self, request: &PythonRequest) -> bool {
+        self.versions.contains(request)
+    }
+
     /// Cast to a list of all versions declared in the file.
     pub fn into_versions(self) -> Vec<PythonRequest> {
         self.versions

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -20,6 +20,7 @@ uv-fs = { workspace = true, features = ["tokio", "schemars"] }
 uv-git = { workspace = true }
 uv-macros = { workspace = true }
 uv-normalize = { workspace = true }
+uv-python = { workspace = true }
 uv-warnings = { workspace = true }
 uv-options-metadata = { workspace = true }
 

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -1908,8 +1908,12 @@ fn init_requires_python_workspace() -> Result<()> {
     });
 
     // `.python-version` should be written in the workspace root.
-    child.child(".python-version").assert(predicate::path::missing());
-    child.child(".python-versions").assert(predicate::path::missing());
+    child
+        .child(".python-version")
+        .assert(predicate::path::missing());
+    child
+        .child(".python-versions")
+        .assert(predicate::path::missing());
 
     let python_version = fs_err::read_to_string(context.temp_dir.join(".python-version"))?;
     insta::with_settings!({
@@ -1970,8 +1974,12 @@ fn init_requires_python_version() -> Result<()> {
     });
 
     // `.python-version` should be written in the workspace root.
-    child.child(".python-version").assert(predicate::path::missing());
-    child.child(".python-versions").assert(predicate::path::missing());
+    child
+        .child(".python-version")
+        .assert(predicate::path::missing());
+    child
+        .child(".python-versions")
+        .assert(predicate::path::missing());
 
     let python_version = fs_err::read_to_string(context.temp_dir.join(".python-version"))?;
     insta::with_settings!({
@@ -2033,8 +2041,12 @@ fn init_requires_python_specifiers() -> Result<()> {
     });
 
     // `.python-version` should be written in the workspace root.
-    child.child(".python-version").assert(predicate::path::missing());
-    child.child(".python-versions").assert(predicate::path::missing());
+    child
+        .child(".python-version")
+        .assert(predicate::path::missing());
+    child
+        .child(".python-versions")
+        .assert(predicate::path::missing());
 
     let python_version = fs_err::read_to_string(context.temp_dir.join(".python-version"))?;
     insta::with_settings!({

--- a/crates/uv/tests/init.rs
+++ b/crates/uv/tests/init.rs
@@ -1879,8 +1879,8 @@ fn init_requires_python_workspace() -> Result<()> {
         "#,
     })?;
 
-    let child = context.temp_dir.join("foo");
-    uv_snapshot!(context.filters(), context.init().current_dir(&context.temp_dir).arg(&child), @r###"
+    let child = context.temp_dir.child("foo");
+    uv_snapshot!(context.filters(), context.init().current_dir(&context.temp_dir).arg(&*child), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1907,7 +1907,11 @@ fn init_requires_python_workspace() -> Result<()> {
         );
     });
 
-    let python_version = fs_err::read_to_string(child.join(".python-version"))?;
+    // `.python-version` should be written in the workspace root.
+    child.child(".python-version").assert(predicate::path::missing());
+    child.child(".python-versions").assert(predicate::path::missing());
+
+    let python_version = fs_err::read_to_string(context.temp_dir.join(".python-version"))?;
     insta::with_settings!({
         filters => context.filters(),
     }, {
@@ -1937,8 +1941,8 @@ fn init_requires_python_version() -> Result<()> {
         "#,
     })?;
 
-    let child = context.temp_dir.join("foo");
-    uv_snapshot!(context.filters(), context.init().current_dir(&context.temp_dir).arg(&child).arg("--python").arg("3.8"), @r###"
+    let child = context.temp_dir.child("foo");
+    uv_snapshot!(context.filters(), context.init().current_dir(&context.temp_dir).arg(&*child).arg("--python").arg("3.8"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1965,7 +1969,11 @@ fn init_requires_python_version() -> Result<()> {
         );
     });
 
-    let python_version = fs_err::read_to_string(child.join(".python-version"))?;
+    // `.python-version` should be written in the workspace root.
+    child.child(".python-version").assert(predicate::path::missing());
+    child.child(".python-versions").assert(predicate::path::missing());
+
+    let python_version = fs_err::read_to_string(context.temp_dir.join(".python-version"))?;
     insta::with_settings!({
         filters => context.filters(),
     }, {
@@ -1996,8 +2004,8 @@ fn init_requires_python_specifiers() -> Result<()> {
         "#,
     })?;
 
-    let child = context.temp_dir.join("foo");
-    uv_snapshot!(context.filters(), context.init().current_dir(&context.temp_dir).arg(&child).arg("--python").arg("==3.8.*"), @r###"
+    let child = context.temp_dir.child("foo");
+    uv_snapshot!(context.filters(), context.init().current_dir(&context.temp_dir).arg(&*child).arg("--python").arg("==3.8.*"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2024,7 +2032,11 @@ fn init_requires_python_specifiers() -> Result<()> {
         );
     });
 
-    let python_version = fs_err::read_to_string(child.join(".python-version"))?;
+    // `.python-version` should be written in the workspace root.
+    child.child(".python-version").assert(predicate::path::missing());
+    child.child(".python-versions").assert(predicate::path::missing());
+
+    let python_version = fs_err::read_to_string(context.temp_dir.join(".python-version"))?;
     insta::with_settings!({
         filters => context.filters(),
     }, {


### PR DESCRIPTION
## Summary

This PR modifies `uv init` and `uv python pin` to read and write the Python version file from the discovered workspace root, instead of the current working directory.

It also includes some behavioral changes (noted in the self-review comments). The previous behavior seemed erroneous, but if it wasn't, please instruct me to revert these changes.

Resolves #7806