### PR TITLE
docs(dependency-bots): mention PEP 723 + some improvements

### DIFF
--- a/docs/guides/integration/dependency-bots.md
+++ b/docs/guides/integration/dependency-bots.md
@@ -1,8 +1,21 @@
 # Dependency bots
 
+It is considered best practice to regularly update dependencies, to avoid being exposed to
+vulnerabilities, limit incompatibilities between dependencies, and avoid complex upgrades when
+upgrading from a too old version. A variety of tools can help staying up-to-date by creating
+automated pull requests. Several of them support uv, or have work underway to support it.
+
 ## Renovate
 
 uv is supported by [Renovate](https://github.com/renovatebot/renovate).
+
+!!! note
+
+    Updating `uv pip compile` outputs such as `requirements.txt` is not yet supported. Progress can
+    be tracked
+    at [renovatebot/renovate#30909](https://github.com/renovatebot/renovate/issues/30909).
+
+### `uv.lock` output
 
 Renovate uses the presence of a `uv.lock` file to determine that uv is used for managing
 dependencies, and will suggest upgrades to
@@ -16,7 +29,7 @@ dependencies) by enabling the
 [`lockFileMaintenance`](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance)
 option:
 
-```json5 title="renovate.json5"
+```jsx title="renovate.json5"
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   lockFileMaintenance: {
@@ -25,12 +38,32 @@ option:
 }
 ```
 
-!!! note
+### Inline script metadata
 
-    `uv pip compile` outputs such as `requirements.txt` are not yet supported by Renovate.
-    Progress can be tracked at [renovatebot/renovate#30909](https://github.com/renovatebot/renovate/issues/30909).
+Renovate supports updating dependencies defined using
+[script inline metadata](../scripts.md/#declaring-script-dependencies).
+
+Since it cannot automatically detect which Python files use script inline metadata, their locations
+need to be explicitly defined using
+[`fileMatch`](https://docs.renovatebot.com/configuration-options/#filematch), like so:
+
+```jsx title="renovate.json5"
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  pep723: {
+    fileMatch: [
+      "scripts/generate_docs\\.py",
+      "scripts/run_server\\.py",
+    ],
+  },
+}
+```
 
 ## Dependabot
 
-Support for uv is not yet available. Progress can be tracked at
-[dependabot/dependabot-core#10039](https://github.com/dependabot/dependabot-core/issues/10039).
+Support for uv is not yet available. Progress can be tracked at:
+
+- [dependabot/dependabot-core#10478](https://github.com/dependabot/dependabot-core/issues/10478) for
+  `uv.lock` output
+- [dependabot/dependabot-core#10039](https://github.com/dependabot/dependabot-core/issues/10039) for
+  `uv pip compile` outputs


### PR DESCRIPTION
## Summary

Renovate recently gained support for updating dependencies defined using PEP 723 (https://github.com/renovatebot/renovate/pull/31266). Since uv supports this format, I thought it could be nice to mention support for it in the integrations documentation as well. I took the occasion to make the page a bit more structured as well.

## Test Plan

Ran Renovate on https://github.com/mkniewallner/renovate-pep723, which created https://github.com/mkniewallner/renovate-pep723/pull/2 that updates a dependency defined using PEP 723. But I'll re-run some tests again once the changes are released on Renovate cloud GitHub app just in case.