### PR TITLE
chore(renovate): enable `regex` manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
   semanticCommits: "disabled",
   separateMajorMinor: false,
   prHourlyLimit: 10,
-  enabledManagers: ["github-actions", "pre-commit", "cargo"],
+  enabledManagers: ["github-actions", "pre-commit", "cargo", "regex"],
   cargo: {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy
     rangeStrategy: "update-lockfile",


### PR DESCRIPTION
## Summary

Investigated https://github.com/astral-sh/uv/pull/7807#issuecomment-2384080360, and the reason why the PR mentioned in the comment did not work in the end is because we only opt-in for specific managers in Renovate configuration. By enabling [regex](https://docs.renovatebot.com/modules/manager/regex/) manager, we should now get proper updates to documentation references.

## Test Plan

Tested enabling specific managers (including `regex` one) in https://github.com/mkniewallner/mkv-playground/pull/18, and Renovate was still able to detect regex dependencies.