### PR TITLE
Add detailed errors for `tool.uv.sources` deserialization failures

### DIFF
--- a/crates/uv-distribution/src/metadata/lowering.rs
+++ b/crates/uv-distribution/src/metadata/lowering.rs
@@ -209,10 +209,6 @@ impl LoweredRequirement {
                             };
                             (source, marker)
                         }
-                        Source::CatchAll { .. } => {
-                            // Emit a dedicated error message, which is an improvement over Serde's default error.
-                            return Err(LoweringError::InvalidEntry);
-                        }
                     };
 
                     marker.and(requirement.marker.clone());
@@ -325,11 +321,6 @@ impl LoweredRequirement {
                         Source::Workspace { .. } => {
                             return Err(LoweringError::WorkspaceMember);
                         }
-                        Source::CatchAll { .. } => {
-                            // Emit a dedicated error message, which is an improvement over Serde's default
-                            // error.
-                            return Err(LoweringError::InvalidEntry);
-                        }
                     };
 
                     marker.and(requirement.marker.clone());
@@ -364,8 +355,6 @@ pub enum LoweringError {
     UndeclaredWorkspacePackage,
     #[error("Can only specify one of: `rev`, `tag`, or `branch`")]
     MoreThanOneGitRef,
-    #[error("Unable to combine options in `tool.uv.sources`")]
-    InvalidEntry,
     #[error("Workspace members are not allowed in non-workspace contexts")]
     WorkspaceMember,
     #[error(transparent)]

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -245,7 +245,6 @@ mod test {
         8 | tqdm = true
           |        ^^^^
         invalid type: boolean `true`, expected an array or map
-
         "###);
     }
 
@@ -263,8 +262,12 @@ mod test {
         "#};
 
         assert_snapshot!(format_err(input).await, @r###"
-        error: Failed to parse entry for: `tqdm`
-          Caused by: Can only specify one of: `rev`, `tag`, or `branch`
+        error: TOML parse error at line 8, column 8
+          |
+        8 | tqdm = { git = "https://github.com/tqdm/tqdm", rev = "baaaaaab", tag = "v1.0.0" }
+          |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        expected at most one of `rev`, `tag`, or `branch`
+
         "###);
     }
 
@@ -281,14 +284,12 @@ mod test {
             tqdm = { git = "https://github.com/tqdm/tqdm", ref = "baaaaaab" }
         "#};
 
-        // TODO(konsti): This should tell you the set of valid fields
         assert_snapshot!(format_err(input).await, @r###"
         error: TOML parse error at line 8, column 8
           |
         8 | tqdm = { git = "https://github.com/tqdm/tqdm", ref = "baaaaaab" }
           |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        data did not match any variant of untagged enum Source
-
+        unknown field `ref`, expected one of `git`, `subdirectory`, `rev`, `tag`, `branch`, `url`, `path`, `editable`, `index`, `workspace`, `marker`
         "###);
     }
 
@@ -305,14 +306,12 @@ mod test {
             tqdm = { path = "tqdm", index = "torch" }
         "#};
 
-        // TODO(konsti): This should tell you the set of valid fields
         assert_snapshot!(format_err(input).await, @r###"
         error: TOML parse error at line 8, column 8
           |
         8 | tqdm = { path = "tqdm", index = "torch" }
           |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        data did not match any variant of untagged enum Source
-
+        cannot specify both `path` and `index`
         "###);
     }
 
@@ -349,7 +348,6 @@ mod test {
           |                ^
         invalid string
         expected `"`, `'`
-
         "###);
     }
 
@@ -371,8 +369,10 @@ mod test {
           |
         8 | tqdm = { url = "§invalid#+#*Ä" }
           |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        data did not match any variant of untagged enum Source
+        invalid value: string "§invalid#+#*Ä", expected relative URL without a base
 
+
+        in `url`
         "###);
     }
 

--- a/uv.schema.json
+++ b/uv.schema.json
@@ -1356,66 +1356,6 @@
             }
           },
           "additionalProperties": false
-        },
-        {
-          "description": "A catch-all variant used to emit precise error messages when deserializing.",
-          "type": "object",
-          "required": [
-            "git",
-            "index",
-            "path",
-            "url",
-            "workspace"
-          ],
-          "properties": {
-            "branch": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "git": {
-              "type": "string"
-            },
-            "index": {
-              "type": "string"
-            },
-            "marker": {
-              "$ref": "#/definitions/MarkerTree"
-            },
-            "path": {
-              "$ref": "#/definitions/String"
-            },
-            "rev": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "subdirectory": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/String"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "tag": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "url": {
-              "type": "string"
-            },
-            "workspace": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
         }
       ]
     },


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/7817.
