### PR TITLE
expose `FlatDistributions` struct in public API

### DIFF
--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -2,7 +2,7 @@ pub use dependency_mode::DependencyMode;
 pub use error::{NoSolutionError, NoSolutionHeader, ResolveError};
 pub use exclude_newer::ExcludeNewer;
 pub use exclusions::Exclusions;
-pub use flat_index::FlatIndex;
+pub use flat_index::{FlatDistributions, FlatIndex};
 pub use lock::{
     Lock, LockError, RequirementsTxtExport, ResolverManifest, SatisfiesResult, TreeDisplay,
 };


### PR DESCRIPTION
Would it be okay to expose this struct? We currently use our own ResolveProvider, and it would be nice to use the `FlatDistributions` for easy `VersionMap` creation.

Thanks!
