### PR TITLE
Add a declarative test framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,6 +4505,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-durations-export",
  "tracing-subscriber",

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -105,6 +105,7 @@ regex = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"], default-features = false }
 similar = { version = "2.6.0" }
 tempfile = { workspace = true }
+toml_edit = { workspace = true }
 zip = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/uv/scenarios/sync/add_unnamed.toml
+++ b/crates/uv/scenarios/sync/add_unnamed.toml
@@ -1,0 +1,77 @@
+[[step]]
+input."pyproject.toml" = """
+[project]
+name = "project"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+"""
+command = "add"
+args =  ["git+https://github.com/astral-test/uv-public-pypackage", "--tag=0.0.1"]
+output = """
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+Resolved 2 packages in [TIME]
+Prepared 2 packages in [TIME]
+Installed 2 packages in [TIME]
+ + project==0.1.0 (from file://[TEMP_DIR]/)
+ + uv-public-pypackage==0.1.0 (from git+https://github.com/astral-test/uv-public-pypackage@0dacfd662c64cb4ceb16e6cf65a157a8b715b979)
+"""
+snapshot."pyproject.toml" = '''
+[project]
+name = "project"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "uv-public-pypackage",
+]
+
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+
+[tool.uv.sources]
+uv-public-pypackage = { git = "https://github.com/astral-test/uv-public-pypackage", tag = "0.0.1" }
+'''
+snapshot."uv.lock" = '''
+version = 1
+requires-python = ">=3.12"
+
+[options]
+exclude-newer = "2024-03-25T00:00:00Z"
+
+[[package]]
+name = "project"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "uv-public-pypackage" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "uv-public-pypackage", git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.1" }]
+
+[[package]]
+name = "uv-public-pypackage"
+version = "0.1.0"
+source = { git = "https://github.com/astral-test/uv-public-pypackage?tag=0.0.1#0dacfd662c64cb4ceb16e6cf65a157a8b715b979" }
+'''
+
+[[step]]
+command = "sync"
+args = ["--frozen"]
+output = """
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+Audited 2 packages in [TIME]
+"""

--- a/crates/uv/scenarios/sync/convert_to_virtual.toml
+++ b/crates/uv/scenarios/sync/convert_to_virtual.toml
@@ -1,0 +1,101 @@
+[[step]]
+input."pyproject.toml" = """
+[project]
+name = "project"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["iniconfig"]
+
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+"""
+command = "sync"
+output = """
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+Resolved 2 packages in [TIME]
+Prepared 2 packages in [TIME]
+Installed 2 packages in [TIME]
+ + iniconfig==2.0.0
+ + project==0.1.0 (from file://[TEMP_DIR]/)
+"""
+snapshot."uv.lock" = '''
+version = 1
+requires-python = ">=3.12"
+
+[options]
+exclude-newer = "2024-03-25T00:00:00Z"
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
+name = "project"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "iniconfig" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "iniconfig" }]
+'''
+
+
+[[step]]
+# Remove the build system.
+input."pyproject.toml" = """
+[project]
+name = "project"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["iniconfig"]
+"""
+command = "sync"
+output = """
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+Resolved 2 packages in [TIME]
+Uninstalled 1 package in [TIME]
+ - project==0.1.0 (from file://[TEMP_DIR]/)
+"""
+snapshot."uv.lock" = '''
+version = 1
+requires-python = ">=3.12"
+
+[options]
+exclude-newer = "2024-03-25T00:00:00Z"
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
+name = "project"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "iniconfig" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "iniconfig" }]
+'''

--- a/crates/uv/tests/common/declarative.rs
+++ b/crates/uv/tests/common/declarative.rs
@@ -1,0 +1,205 @@
+#![allow(clippy::print_stderr)]
+
+use crate::common::{run_and_format, TestContext};
+use anyhow::Context;
+use rustc_hash::FxHashMap;
+use serde::Deserialize;
+use std::env;
+use std::path::Path;
+use std::process::Command;
+use toml_edit::DocumentMut;
+use uv_fs::Simplified;
+
+#[derive(Debug, Deserialize)]
+pub struct DeclarativeTest {
+    /// Default: 3.12
+    python_version: Option<String>,
+    step: Vec<DeclarativeStep>,
+}
+
+impl DeclarativeTest {
+    /// Run a declarative test scenario.
+    pub fn run(scenario_name: &str) {
+        let update = env::var("INSTA_UPDATE").as_deref() == Ok("always");
+        let scenario_path = Path::new("scenarios").join(scenario_name);
+        run_scenario(scenario_name, update, &scenario_path);
+    }
+}
+
+/// A toml serialized test scenario.
+///
+/// A toml test has steps, which can have the following component:
+/// * Inputs, a filename to content mapping.
+/// * Command, a command to which the default options are attached, and an output field that
+///   snapshots that command's output.
+/// * Outputs, a filename to content mapping of snapshots.
+///
+/// By defaults, the test fails if the snapshots mismatch. Set the `INSTA_UPDATE` environment
+/// variable to `always` (e.g., `INSTA_UPDATE=always cargo nextest run`) to update the snapshots.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum DeclarativeCommand {
+    PipCompile,
+    PipSync,
+    PipShow,
+    PipFreeze,
+    PipCheck,
+    PipList,
+    Venv,
+    PipInstall,
+    PipUninstall,
+    PipTree,
+    Help,
+    Init,
+    Sync,
+    Lock,
+    Export,
+    Build,
+    Publish,
+    PythonFind,
+    PythonPin,
+    PythonDir,
+    Run,
+    ToolRun,
+    ToolUpgrade,
+    ToolInstall,
+    ToolList,
+    ToolDir,
+    ToolUninstall,
+    Add,
+    Remove,
+    Tree,
+    Clean,
+    Prune,
+}
+
+impl DeclarativeCommand {
+    fn to_command(&self, context: &TestContext) -> Command {
+        match self {
+            Self::PipCompile => context.pip_compile(),
+            Self::PipSync => context.pip_sync(),
+            Self::PipShow => context.pip_show(),
+            Self::PipFreeze => context.pip_freeze(),
+            Self::PipCheck => context.pip_check(),
+            Self::PipList => context.pip_list(),
+            Self::Venv => context.venv(),
+            Self::PipInstall => context.pip_install(),
+            Self::PipUninstall => context.pip_uninstall(),
+            Self::PipTree => context.pip_tree(),
+            Self::Help => context.help(),
+            Self::Init => context.init(),
+            Self::Sync => context.sync(),
+            Self::Lock => context.lock(),
+            Self::Export => context.export(),
+            Self::Build => context.build(),
+            Self::Publish => context.publish(),
+            Self::PythonFind => context.python_find(),
+            Self::PythonPin => context.python_pin(),
+            Self::PythonDir => context.python_dir(),
+            Self::Run => context.run(),
+            Self::ToolRun => context.tool_run(),
+            Self::ToolUpgrade => context.tool_upgrade(),
+            Self::ToolInstall => context.tool_install(),
+            Self::ToolList => context.tool_list(),
+            Self::ToolDir => context.tool_dir(),
+            Self::ToolUninstall => context.tool_uninstall(),
+            Self::Add => context.add(),
+            Self::Remove => context.remove(),
+            Self::Tree => context.tree(),
+            Self::Clean => context.clean(),
+            Self::Prune => context.prune(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DeclarativeStep {
+    #[serde(default)]
+    input: FxHashMap<String, String>,
+    command: DeclarativeCommand,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env_remove: Vec<String>,
+    output: Option<String>,
+    #[serde(default)]
+    snapshot: FxHashMap<String, String>,
+}
+
+fn run_scenario(scenario_name: &str, update: bool, scenario_path: &Path) {
+    let snapshot_serialized = fs_err::read_to_string(scenario_path).unwrap();
+    // Structured, for the main routine
+    let scenario: DeclarativeTest = toml::from_str(&snapshot_serialized).unwrap();
+    // Formatted, for snapshot updates
+    let mut doc = snapshot_serialized.parse::<DocumentMut>().unwrap();
+
+    let context = TestContext::new(scenario.python_version.as_deref().unwrap_or("3.12"));
+
+    for (step_id, step) in scenario.step.iter().enumerate() {
+        // Write the input files
+        for (path, content) in &step.input {
+            fs_err::write(context.temp_dir.join(path), content).unwrap();
+        }
+
+        // Run the command
+        let mut command = step.command.to_command(&context);
+        for arg in &step.args {
+            command.arg(arg);
+        }
+        for env_remove in &step.env_remove {
+            command.env_remove(env_remove);
+        }
+        let (actual, _) = run_and_format(
+            &mut command,
+            context.filters(),
+            &format!("Step {}: {:?}", step_id + 1, step.command),
+            None,
+        );
+        if let Some(expected) = &step.output {
+            if update {
+                if actual.trim() != expected.trim() {
+                    eprintln!(
+                        "Updating snapshot for {scenario_name} step {} output",
+                        step_id + 1
+                    );
+                    doc["step"][step_id]["output"] = toml_edit::value(actual);
+                    fs_err::write(scenario_path, doc.to_string()).unwrap();
+                }
+            } else {
+                assert_eq!(
+                    actual.trim(),
+                    expected.trim(),
+                    "Output mismatch for step {}: {:?}",
+                    step_id + 1,
+                    step.command
+                );
+            }
+        }
+
+        // Check the output file
+        for (path, expected) in &step.snapshot {
+            let actual = fs_err::read_to_string(context.temp_dir.join(path))
+                .with_context(|| format!("Missing expected output file: `{}`", path.user_display()))
+                .unwrap();
+            if update {
+                if actual.trim() != expected.trim() {
+                    eprintln!(
+                        "Updating snapshot for {scenario_name} step {} snapshot {path}",
+                        step_id + 1
+                    );
+                    doc["step"][step_id]["snapshot"][path] = toml_edit::value(actual);
+                    fs_err::write(scenario_path, doc.to_string()).unwrap();
+                }
+            } else {
+                assert_eq!(
+                    actual.trim(),
+                    expected.trim(),
+                    "Snapshot mismatch for step {}: {:?}",
+                    step_id + 1,
+                    step.command
+                );
+            }
+        }
+    }
+}

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -1,13 +1,10 @@
 // The `unreachable_pub` is to silence false positives in RustRover.
 #![allow(dead_code, unreachable_pub)]
 
-use std::borrow::BorrowMut;
-use std::env;
-use std::ffi::OsString;
-use std::iter::Iterator;
-use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus, Output};
-use std::str::FromStr;
+mod declarative;
+
+#[allow(unused_imports)] // False positive in clippy
+pub use declarative::DeclarativeTest;
 
 use assert_cmd::assert::{Assert, OutputAssertExt};
 use assert_fs::assert::PathAssert;
@@ -18,7 +15,13 @@ use indoc::formatdoc;
 use itertools::Itertools;
 use predicates::prelude::predicate;
 use regex::Regex;
-
+use std::borrow::BorrowMut;
+use std::env;
+use std::ffi::OsString;
+use std::iter::Iterator;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus, Output};
+use std::str::FromStr;
 use uv_cache::Cache;
 use uv_fs::Simplified;
 use uv_python::managed::ManagedPythonInstallations;

--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -5,6 +5,7 @@ use assert_cmd::prelude::*;
 use assert_fs::{fixture::ChildPath, prelude::*};
 use insta::assert_snapshot;
 
+use crate::common::DeclarativeTest;
 use common::{uv_snapshot, venv_bin_path, TestContext};
 use predicates::prelude::predicate;
 use tempfile::tempdir_in;
@@ -1349,134 +1350,8 @@ fn no_install_project_no_build() -> Result<()> {
 
 /// Convert from a package to a virtual project.
 #[test]
-fn convert_to_virtual() -> Result<()> {
-    let context = TestContext::new("3.12");
-
-    let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(
-        r#"
-        [project]
-        name = "project"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = ["iniconfig"]
-
-        [build-system]
-        requires = ["setuptools>=42"]
-        build-backend = "setuptools.build_meta"
-        "#,
-    )?;
-
-    // Running `uv sync` should install the project itself.
-    uv_snapshot!(context.filters(), context.sync(), @r###"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    Resolved 2 packages in [TIME]
-    Prepared 2 packages in [TIME]
-    Installed 2 packages in [TIME]
-     + iniconfig==2.0.0
-     + project==0.1.0 (from file://[TEMP_DIR]/)
-    "###);
-
-    let lock = context.read("uv.lock");
-
-    insta::with_settings!({
-        filters => context.filters(),
-    }, {
-        assert_snapshot!(
-            lock, @r###"
-        version = 1
-        requires-python = ">=3.12"
-
-        [options]
-        exclude-newer = "2024-03-25T00:00:00Z"
-
-        [[package]]
-        name = "iniconfig"
-        version = "2.0.0"
-        source = { registry = "https://pypi.org/simple" }
-        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
-        wheels = [
-            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
-        ]
-
-        [[package]]
-        name = "project"
-        version = "0.1.0"
-        source = { editable = "." }
-        dependencies = [
-            { name = "iniconfig" },
-        ]
-
-        [package.metadata]
-        requires-dist = [{ name = "iniconfig" }]
-        "###
-        );
-    });
-
-    // Remove the build system.
-    pyproject_toml.write_str(
-        r#"
-        [project]
-        name = "project"
-        version = "0.1.0"
-        requires-python = ">=3.12"
-        dependencies = ["iniconfig"]
-        "#,
-    )?;
-
-    // Running `uv sync` should remove the project itself.
-    uv_snapshot!(context.filters(), context.sync(), @r###"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-
-    ----- stderr -----
-    Resolved 2 packages in [TIME]
-    Uninstalled 1 package in [TIME]
-     - project==0.1.0 (from file://[TEMP_DIR]/)
-    "###);
-
-    let lock = context.read("uv.lock");
-
-    insta::with_settings!({
-        filters => context.filters(),
-    }, {
-        assert_snapshot!(
-            lock, @r###"
-        version = 1
-        requires-python = ">=3.12"
-
-        [options]
-        exclude-newer = "2024-03-25T00:00:00Z"
-
-        [[package]]
-        name = "iniconfig"
-        version = "2.0.0"
-        source = { registry = "https://pypi.org/simple" }
-        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
-        wheels = [
-            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
-        ]
-
-        [[package]]
-        name = "project"
-        version = "0.1.0"
-        source = { virtual = "." }
-        dependencies = [
-            { name = "iniconfig" },
-        ]
-
-        [package.metadata]
-        requires-dist = [{ name = "iniconfig" }]
-        "###
-        );
-    });
-
-    Ok(())
+fn convert_to_virtual() {
+    DeclarativeTest::run("sync/convert_to_virtual.toml");
 }
 
 /// Convert from a virtual project to a package.


### PR DESCRIPTION
While reviewing the index PRs, the tests all followed the same structure; they weren't so much test logic as a sequence of writing files, a test context command and snapshotting output and files.

Instead of defining them in code, we can write them as toml scenarios:

```toml
[[step]]
input."pyproject.toml" = """
[...]
"""
command = "add"
args =  ["git+https://github.com/astral-test/uv-public-pypackage", "--tag=0.0.1"]
output = """
[...]
"""
snapshot."pyproject.toml" = '''
[...]
'''
snapshot."uv.lock" = '''
[...]
'''
```

The tests now have a shared schema and can be written without code. We can change the tests without recompiling and massively reduce the code size in the `uv` crate (previously, each time you would apply snapshot changes you would have to wait for a recompile). The tests become easier to maintain (toml can be edited by Python should need be) and by decoupling the test declaration from code we can add improve the test runner more easily. I don't expect all tests to be migrated, there's actual custom code in a number of tests.

**Migration Strategy** Procedural and declarative tests can coexist in the same file, there is no breaking change involved. If we want to migrate existing test, we can move the existing testing to more concise abstractions using the `TestContext` with rust refactoring, then using regex to migrate many simple procedural tests.


The PR migrates two tests as an example. I would suggest merging the framework and starting to write new tests in it, extending it as needed. Once we feel sufficiently confident and the need, we can migrate older tests, too.