### PR TITLE
Allow dependency metadata entries for direct URL requirements

### DIFF
--- a/crates/uv-distribution-types/src/dependency_metadata.rs
+++ b/crates/uv-distribution-types/src/dependency_metadata.rs
@@ -1,5 +1,6 @@
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
 use uv_normalize::{ExtraName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_pep508::Requirement;
@@ -20,22 +21,57 @@ impl DependencyMetadata {
     }
 
     /// Retrieve a [`StaticMetadata`] entry by [`PackageName`] and [`Version`].
-    pub fn get(&self, package: &PackageName, version: &Version) -> Option<ResolutionMetadata> {
+    pub fn get(
+        &self,
+        package: &PackageName,
+        version: Option<&Version>,
+    ) -> Option<ResolutionMetadata> {
         let versions = self.0.get(package)?;
 
-        // Search for an exact, then a global match.
-        let metadata = versions
-            .iter()
-            .find(|v| v.version.as_ref() == Some(version))
-            .or_else(|| versions.iter().find(|v| v.version.is_none()))?;
-
-        Some(ResolutionMetadata {
-            name: metadata.name.clone(),
-            version: version.clone(),
-            requires_dist: metadata.requires_dist.clone(),
-            requires_python: metadata.requires_python.clone(),
-            provides_extras: metadata.provides_extras.clone(),
-        })
+        if let Some(version) = version {
+            // If a specific version was requested, search for an exact match, then a global match.
+            let metadata = versions
+                .iter()
+                .find(|v| v.version.as_ref() == Some(version))
+                .inspect(|_| {
+                    debug!("Found dependency metadata entry for `{package}=={version}`",);
+                })
+                .or_else(|| versions.iter().find(|v| v.version.is_none()))
+                .inspect(|_| {
+                    debug!("Found global metadata entry for `{package}`",);
+                });
+            let Some(metadata) = metadata else {
+                warn!("No dependency metadata entry found for `{package}=={version}`");
+                return None;
+            };
+            debug!("Found dependency metadata entry for `{package}=={version}`",);
+            Some(ResolutionMetadata {
+                name: metadata.name.clone(),
+                version: version.clone(),
+                requires_dist: metadata.requires_dist.clone(),
+                requires_python: metadata.requires_python.clone(),
+                provides_extras: metadata.provides_extras.clone(),
+            })
+        } else {
+            // If no version was requested (i.e., it's a direct URL dependency), allow a single
+            // versioned match.
+            let [metadata] = versions.as_slice() else {
+                warn!("Multiple dependency metadata entries found for `{package}`");
+                return None;
+            };
+            let Some(version) = metadata.version.clone() else {
+                warn!("No version found in dependency metadata entry for `{package}`");
+                return None;
+            };
+            debug!("Found dependency metadata entry for `{package}` (assuming: `{version}`)");
+            Some(ResolutionMetadata {
+                name: metadata.name.clone(),
+                version,
+                requires_dist: metadata.requires_dist.clone(),
+                requires_python: metadata.requires_python.clone(),
+                provides_extras: metadata.provides_extras.clone(),
+            })
+        }
     }
 
     /// Retrieve all [`StaticMetadata`] entries.

--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -590,7 +590,7 @@ pub(crate) fn fetch(
     }
 }
 
-/// Attempts to use `git` CLI installed on the system to fetch a repository,.
+/// Attempts to use `git` CLI installed on the system to fetch a repository.
 fn fetch_with_cli(
     repo: &mut GitRepository,
     url: &str,

--- a/crates/uv-git/src/source.rs
+++ b/crates/uv-git/src/source.rs
@@ -51,6 +51,68 @@ impl GitSource {
         }
     }
 
+    /// Resolve a Git source to a specific revision.
+    #[instrument(skip(self), fields(repository = %self.git.repository, rev = ?self.git.precise))]
+    pub fn resolve(self) -> Result<GitSha> {
+        // Compute the canonical URL for the repository.
+        let canonical = RepositoryUrl::new(&self.git.repository);
+
+        // The path to the repo, within the Git database.
+        let ident = cache_digest(&canonical);
+        let db_path = self.cache.join("db").join(&ident);
+
+        // Authenticate the URL, if necessary.
+        let remote = if let Some(credentials) = GIT_STORE.get(&canonical) {
+            Cow::Owned(credentials.apply(self.git.repository.clone()))
+        } else {
+            Cow::Borrowed(&self.git.repository)
+        };
+
+        let remote = GitRemote::new(&remote);
+        let (db, actual_rev, task) = match (self.git.precise, remote.db_at(&db_path).ok()) {
+            // If we have a locked revision, and we have a preexisting database
+            // which has that revision, then no update needs to happen.
+            (Some(rev), Some(db)) if db.contains(rev.into()) => {
+                debug!("Using existing Git source `{}`", self.git.repository);
+                (db, rev, None)
+            }
+
+            // ... otherwise we use this state to update the git database. Note
+            // that we still check for being offline here, for example in the
+            // situation that we have a locked revision but the database
+            // doesn't have it.
+            (locked_rev, db) => {
+                debug!("Updating Git source `{}`", self.git.repository);
+
+                // Report the checkout operation to the reporter.
+                let task = self.reporter.as_ref().map(|reporter| {
+                    reporter.on_checkout_start(remote.url(), self.git.reference.as_rev())
+                });
+
+                let (db, actual_rev) = remote.checkout(
+                    &db_path,
+                    db,
+                    &self.git.reference,
+                    locked_rev.map(GitOid::from),
+                    &self.client,
+                )?;
+
+                (db, GitSha::from(actual_rev), task)
+            }
+        };
+
+        let short_id = db.to_short_id(actual_rev.into())?;
+
+        // Report the checkout operation to the reporter.
+        if let Some(task) = task {
+            if let Some(reporter) = self.reporter.as_ref() {
+                reporter.on_checkout_complete(remote.url(), short_id.as_str(), task);
+            }
+        }
+
+        Ok(actual_rev)
+    }
+
     /// Fetch the underlying Git repository at the given revision.
     #[instrument(skip(self), fields(repository = %self.git.repository, rev = ?self.git.precise))]
     pub fn fetch(self) -> Result<Fetch> {

--- a/crates/uv-resolver/src/redirect.rs
+++ b/crates/uv-resolver/src/redirect.rs
@@ -1,5 +1,4 @@
 use url::Url;
-
 use uv_git::{GitReference, GitResolver};
 use uv_pep508::VerbatimUrl;
 use uv_pypi_types::{ParsedGitUrl, ParsedUrl, VerbatimParsedUrl};
@@ -17,9 +16,8 @@ pub(crate) fn url_to_precise(url: VerbatimParsedUrl, git: &GitResolver) -> Verba
     let Some(new_git_url) = git.precise(git_url.clone()) else {
         debug_assert!(
             matches!(git_url.reference(), GitReference::FullCommit(_)),
-            "Unseen Git URL: {}, {:?}",
+            "Unseen Git URL: {}, {git_url:?}",
             url.verbatim,
-            git_url
         );
         return url;
     };

--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -855,3 +855,9 @@ You could run the following sequence of commands to sync `flash-attn`:
 $ uv sync --extra build
 $ uv sync --extra build --extra compile
 ```
+
+!!! note
+
+    The `version` field in `tool.uv.dependency-metadata` is optional for registry-based
+    dependencies (when omitted, uv will assume the metadata applies to all versions of the package),
+    but _required_ for direct URL dependencies (like Git dependencies).

--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -313,6 +313,12 @@ package's metadata is incorrect or incomplete, or when a package is not availabl
 index. While dependency overrides allow overriding the allowed versions of a package globally,
 metadata overrides allow overriding the declared metadata of a _specific package_.
 
+!!! note
+
+    The `version` field in `tool.uv.dependency-metadata` is optional for registry-based
+    dependencies (when omitted, uv will assume the metadata applies to all versions of the package),
+    but _required_ for direct URL dependencies (like Git dependencies).
+
 Entries in the `tool.uv.dependency-metadata` table follow the
 [Metadata 2.3](https://packaging.python.org/en/latest/specifications/core-metadata/) specification,
 though only `name`, `version`, `requires-dist`, `requires-python`, and `provides-extra` are read by


### PR DESCRIPTION
## Summary

This is part of making https://github.com/astral-sh/uv/issues/7299#issuecomment-2385286341 better. You can now use `tool.uv.dependency-metadata` for direct URL requirements. Unfortunately, you _must_ include a version, since we need one to perform resolution.
