### PR TITLE
Display the target virtual environment path if non-default

### DIFF
--- a/crates/uv/src/commands/pip/check.rs
+++ b/crates/uv/src/commands/pip/check.rs
@@ -3,14 +3,13 @@ use std::time::Instant;
 
 use anyhow::Result;
 use owo_colors::OwoColorize;
-use tracing::debug;
 
 use uv_cache::Cache;
 use uv_distribution_types::{Diagnostic, InstalledDist};
-use uv_fs::Simplified;
 use uv_installer::{SitePackages, SitePackagesDiagnostic};
 use uv_python::{EnvironmentPreference, PythonEnvironment, PythonRequest};
 
+use crate::commands::pip::operations::report_target_environment;
 use crate::commands::{elapsed, ExitStatus};
 use crate::printer::Printer;
 
@@ -30,11 +29,7 @@ pub(crate) fn pip_check(
         cache,
     )?;
 
-    debug!(
-        "Using Python {} environment at {}",
-        environment.interpreter().python_version(),
-        environment.python_executable().user_display().cyan()
-    );
+    report_target_environment(&environment, cache, printer)?;
 
     // Build the installed index.
     let site_packages = SitePackages::from_environment(&environment)?;

--- a/crates/uv/src/commands/pip/freeze.rs
+++ b/crates/uv/src/commands/pip/freeze.rs
@@ -3,14 +3,13 @@ use std::fmt::Write;
 use anyhow::Result;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
-use tracing::debug;
 
 use uv_cache::Cache;
 use uv_distribution_types::{Diagnostic, InstalledDist, Name};
-use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_python::{EnvironmentPreference, PythonEnvironment, PythonRequest};
 
+use crate::commands::pip::operations::report_target_environment;
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
@@ -30,11 +29,7 @@ pub(crate) fn pip_freeze(
         cache,
     )?;
 
-    debug!(
-        "Using Python {} environment at {}",
-        environment.interpreter().python_version(),
-        environment.python_executable().user_display().cyan()
-    );
+    report_target_environment(&environment, cache, printer)?;
 
     // Build the installed index.
     let site_packages = SitePackages::from_environment(&environment)?;

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -33,6 +33,7 @@ use uv_resolver::{
 use uv_types::{BuildIsolation, HashStrategy};
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger, InstallLogger};
+use crate::commands::pip::operations::report_target_environment;
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::{operations, resolution_markers, resolution_tags};
 use crate::commands::{diagnostics, ExitStatus, SharedState};
@@ -147,11 +148,7 @@ pub(crate) async fn pip_install(
         &cache,
     )?;
 
-    debug!(
-        "Using Python {} environment at {}",
-        environment.interpreter().python_version(),
-        environment.python_executable().user_display().cyan()
-    );
+    report_target_environment(&environment, &cache, printer)?;
 
     // Apply any `--target` or `--prefix` directories.
     let environment = if let Some(target) = target {

--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
 use serde::Serialize;
-use tracing::debug;
 use unicode_width::UnicodeWidthStr;
 
 use uv_cache::Cache;
@@ -17,6 +16,7 @@ use uv_normalize::PackageName;
 use uv_python::PythonRequest;
 use uv_python::{EnvironmentPreference, PythonEnvironment};
 
+use crate::commands::pip::operations::report_target_environment;
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
@@ -39,11 +39,7 @@ pub(crate) fn pip_list(
         cache,
     )?;
 
-    debug!(
-        "Using Python {} environment at {}",
-        environment.interpreter().python_version(),
-        environment.python_executable().user_display().cyan()
-    );
+    report_target_environment(&environment, cache, printer)?;
 
     // Build the installed index.
     let site_packages = SitePackages::from_environment(&environment)?;

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -551,7 +551,7 @@ pub(crate) fn report_target_environment(
         env.root().user_display()
     );
 
-    let Ok(target) = env.root().canonicalize() else {
+    let Ok(target) = std::path::absolute(env.root()) else {
         debug!("{}", message);
         return Ok(());
     };
@@ -571,7 +571,7 @@ pub(crate) fn report_target_environment(
     }
 
     // Do not report a default environment path
-    if let Ok(default) = PathBuf::from(".venv").canonicalize() {
+    if let Ok(default) = std::path::absolute(PathBuf::from(".venv")) {
         if target == default {
             debug!("{}", message);
             return Ok(());

--- a/crates/uv/src/commands/pip/show.rs
+++ b/crates/uv/src/commands/pip/show.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use itertools::{Either, Itertools};
 use owo_colors::OwoColorize;
 use rustc_hash::FxHashMap;
-use tracing::debug;
 
 use uv_cache::Cache;
 use uv_distribution_types::{Diagnostic, Name};
@@ -13,6 +12,7 @@ use uv_installer::SitePackages;
 use uv_normalize::PackageName;
 use uv_python::{EnvironmentPreference, PythonEnvironment, PythonRequest};
 
+use crate::commands::pip::operations::report_target_environment;
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
@@ -45,11 +45,7 @@ pub(crate) fn pip_show(
         cache,
     )?;
 
-    debug!(
-        "Using Python {} environment at {}",
-        environment.interpreter().python_version(),
-        environment.python_executable().user_display().cyan()
-    );
+    report_target_environment(&environment, cache, printer)?;
 
     // Build the installed index.
     let site_packages = SitePackages::from_environment(&environment)?;

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -29,6 +29,7 @@ use uv_resolver::{
 use uv_types::{BuildIsolation, HashStrategy};
 
 use crate::commands::pip::loggers::{DefaultInstallLogger, DefaultResolveLogger};
+use crate::commands::pip::operations::report_target_environment;
 use crate::commands::pip::operations::Modifications;
 use crate::commands::pip::{operations, resolution_markers, resolution_tags};
 use crate::commands::{diagnostics, ExitStatus, SharedState};
@@ -131,11 +132,7 @@ pub(crate) async fn pip_sync(
         &cache,
     )?;
 
-    debug!(
-        "Using Python {} environment at {}",
-        environment.interpreter().python_version(),
-        environment.python_executable().user_display().cyan()
-    );
+    report_target_environment(&environment, &cache, printer)?;
 
     // Apply any `--target` or `--prefix` directories.
     let environment = if let Some(target) = target {

--- a/crates/uv/src/commands/pip/tree.rs
+++ b/crates/uv/src/commands/pip/tree.rs
@@ -4,19 +4,16 @@ use anyhow::Result;
 use indexmap::IndexMap;
 use owo_colors::OwoColorize;
 use rustc_hash::{FxHashMap, FxHashSet};
-use tracing::debug;
 
 use uv_cache::Cache;
 use uv_distribution::Metadata;
 use uv_distribution_types::{Diagnostic, Name};
-use uv_fs::Simplified;
 use uv_installer::SitePackages;
 use uv_normalize::PackageName;
 use uv_pypi_types::{RequirementSource, ResolverMarkerEnvironment};
-use uv_python::EnvironmentPreference;
-use uv_python::PythonEnvironment;
-use uv_python::PythonRequest;
+use uv_python::{EnvironmentPreference, PythonEnvironment, PythonRequest};
 
+use crate::commands::pip::operations::report_target_environment;
 use crate::commands::ExitStatus;
 use crate::printer::Printer;
 
@@ -42,11 +39,7 @@ pub(crate) fn pip_tree(
         cache,
     )?;
 
-    debug!(
-        "Using Python {} environment at {}",
-        environment.interpreter().python_version(),
-        environment.python_executable().user_display().cyan()
-    );
+    report_target_environment(&environment, cache, printer)?;
 
     // Read packages from the virtual environment.
     let site_packages = SitePackages::from_environment(&environment)?;

--- a/crates/uv/src/commands/pip/uninstall.rs
+++ b/crates/uv/src/commands/pip/uninstall.rs
@@ -18,6 +18,7 @@ use uv_python::PythonRequest;
 use uv_python::{Prefix, PythonEnvironment, Target};
 use uv_requirements::{RequirementsSource, RequirementsSpecification};
 
+use crate::commands::pip::operations::report_target_environment;
 use crate::commands::{elapsed, ExitStatus};
 use crate::printer::Printer;
 
@@ -57,11 +58,7 @@ pub(crate) async fn pip_uninstall(
         &cache,
     )?;
 
-    debug!(
-        "Using Python {} environment at {}",
-        environment.interpreter().python_version(),
-        environment.python_executable().user_display().cyan(),
-    );
+    report_target_environment(&environment, &cache, printer)?;
 
     // Apply any `--target` or `--prefix` directories.
     let environment = if let Some(target) = target {

--- a/crates/uv/tests/export.rs
+++ b/crates/uv/tests/export.rs
@@ -537,6 +537,7 @@ fn relative_path() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 3 packages in [TIME]
     Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]

--- a/crates/uv/tests/pip_install.rs
+++ b/crates/uv/tests/pip_install.rs
@@ -1124,6 +1124,7 @@ fn install_editable_bare_cli() {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -1150,6 +1151,7 @@ fn install_editable_bare_requirements_txt() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -3265,6 +3267,7 @@ requires-python = ">=3.8"
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -3284,6 +3287,7 @@ requires-python = ">=3.8"
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Audited 1 package in [TIME]
     "###
     );
@@ -3309,6 +3313,7 @@ requires-python = ">=3.8"
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 4 packages in [TIME]
     Prepared 2 packages in [TIME]
     Uninstalled 2 packages in [TIME]
@@ -3356,6 +3361,7 @@ fn invalidate_path_on_cache_key() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -3375,6 +3381,7 @@ fn invalidate_path_on_cache_key() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Audited 1 package in [TIME]
     "###
     );
@@ -3391,6 +3398,7 @@ fn invalidate_path_on_cache_key() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 4 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -3411,6 +3419,7 @@ fn invalidate_path_on_cache_key() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 4 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -3441,6 +3450,7 @@ fn invalidate_path_on_cache_key() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Audited 1 package in [TIME]
     "###
     );
@@ -3473,6 +3483,7 @@ fn invalidate_path_on_cache_key() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 4 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -3493,6 +3504,7 @@ fn invalidate_path_on_cache_key() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 4 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -3548,6 +3560,7 @@ fn invalidate_path_on_commit() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 4 packages in [TIME]
     Prepared 4 packages in [TIME]
     Installed 4 packages in [TIME]
@@ -3567,6 +3580,7 @@ fn invalidate_path_on_commit() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Audited 1 package in [TIME]
     "###
     );
@@ -3589,6 +3603,7 @@ fn invalidate_path_on_commit() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 4 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
@@ -4688,6 +4703,7 @@ fn deptry_gitignore() {
     ----- stdout -----
 
     ----- stderr -----
+    Using Python 3.12.[X] environment at [VENV]/
     Resolved 3 packages in [TIME]
     Prepared 3 packages in [TIME]
     Installed 3 packages in [TIME]


### PR DESCRIPTION
Supersedes https://github.com/astral-sh/uv/pull/4835

Closes https://github.com/astral-sh/uv/issues/2155

e.g.

```
❯ cargo run -q -- pip install --python ../../example httpx
Using Python 3.12.1 environment at /Users/zb/example
Resolved 7 packages in 561ms
Prepared 4 packages in 62ms
Installed 4 packages in 13ms
 + certifi==2024.8.30
 + h11==0.14.0
 + httpcore==1.0.5
 + httpx==0.27.2

❯ cargo run -q -- pip install httpx
Resolved 7 packages in 17ms
Installed 4 packages in 10ms
 + certifi==2024.8.30
 + h11==0.14.0
 + httpcore==1.0.5
 + httpx==0.27.2
```