### PR TITLE
Add support for system-level `uv.toml` configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5136,25 +5136,13 @@ dependencies = [
 name = "uv-settings"
 version = "0.0.1"
 dependencies = [
- "assert_cmd",
  "assert_fs",
- "base64 0.22.1",
- "byteorder",
  "clap",
  "dirs-sys",
- "etcetera",
- "filetime",
  "fs-err",
- "ignore",
  "indoc",
- "insta",
- "predicates",
- "regex",
- "reqwest",
  "schemars",
  "serde",
- "similar",
- "tempfile",
  "textwrap",
  "thiserror",
  "toml",
@@ -5174,7 +5162,6 @@ dependencies = [
  "uv-resolver",
  "uv-static",
  "uv-warnings",
- "zip",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5136,11 +5136,25 @@ dependencies = [
 name = "uv-settings"
 version = "0.0.1"
 dependencies = [
+ "assert_cmd",
+ "assert_fs",
+ "base64 0.22.1",
+ "byteorder",
  "clap",
  "dirs-sys",
+ "etcetera",
+ "filetime",
  "fs-err",
+ "ignore",
+ "indoc",
+ "insta",
+ "predicates",
+ "regex",
+ "reqwest",
  "schemars",
  "serde",
+ "similar",
+ "tempfile",
  "textwrap",
  "thiserror",
  "toml",
@@ -5160,6 +5174,7 @@ dependencies = [
  "uv-resolver",
  "uv-static",
  "uv-warnings",
+ "zip",
 ]
 
 [[package]]

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -46,18 +46,5 @@ url = { workspace = true }
 ignored = ["uv-options-metadata", "clap"]
 
 [dev-dependencies]
-assert_cmd = { version = "2.0.16" }
 assert_fs = { version = "1.1.2" }
-base64 = { version = "0.22.1" }
-byteorder = { version = "1.5.0" }
-etcetera = { workspace = true }
-filetime = { version = "0.2.25" }
-ignore = { version = "0.4.23" }
 indoc = { version = "2.0.5" }
-insta = { version = "1.40.0", features = ["filters", "json"] }
-predicates = { version = "3.1.2" }
-regex = { workspace = true }
-reqwest = { workspace = true, features = ["blocking"], default-features = false }
-similar = { version = "2.6.0" }
-tempfile = { workspace = true }
-zip = { workspace = true }

--- a/crates/uv-settings/Cargo.toml
+++ b/crates/uv-settings/Cargo.toml
@@ -44,3 +44,20 @@ url = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["uv-options-metadata", "clap"]
+
+[dev-dependencies]
+assert_cmd = { version = "2.0.16" }
+assert_fs = { version = "1.1.2" }
+base64 = { version = "0.22.1" }
+byteorder = { version = "1.5.0" }
+etcetera = { workspace = true }
+filetime = { version = "0.2.25" }
+ignore = { version = "0.4.23" }
+indoc = { version = "2.0.5" }
+insta = { version = "1.40.0", features = ["filters", "json"] }
+predicates = { version = "3.1.2" }
+regex = { workspace = true }
+reqwest = { workspace = true, features = ["blocking"], default-features = false }
+similar = { version = "2.6.0" }
+tempfile = { workspace = true }
+zip = { workspace = true }

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -62,12 +62,11 @@ impl FilesystemOptions {
     }
 
     pub fn system() -> Result<Option<Self>, Error> {
-        if let Some(file) = system_config_file() {
-            let options = read_file(&file)?;
-            Ok(Some(Self(options)))
-        } else {
-            Ok(None)
-        }
+        let Some(file) = system_config_file() else {
+            return Ok(None);
+        };
+        debug!("Found system configuration in: `{}`", file.display());
+        Ok(Some(Self(read_file(&file)?)))
     }
 
     /// Find the [`FilesystemOptions`] for the given path.

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -195,6 +195,7 @@ fn user_config_dir() -> Option<PathBuf> {
     }
 }
 
+#[cfg(not(windows))]
 fn locate_system_config_xdg(value: Option<&str>) -> Option<PathBuf> {
     // On Linux/MacOS systems, read the XDG_CONFIG_DIRS environment variable
 
@@ -220,7 +221,7 @@ fn system_config_file() -> Option<PathBuf> {
     // On Windows, use, e.g., C:\ProgramData
     #[cfg(windows)]
     {
-        Some(PathBuf::from("C:\\ProgramData\\uv\\uv.toml"))
+        return Some(PathBuf::from("C:\\ProgramData\\uv\\uv.toml"));
     }
 
     #[cfg(not(windows))]

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -258,12 +258,12 @@ pub enum Error {
 }
 
 #[cfg(test)]
+#[cfg(not(windows))]
 mod test {
     use crate::locate_system_config_xdg;
     use std::env;
     use std::path::Path;
 
-    #[cfg(not(windows))]
     #[test]
     fn test_locate_system_config_xdg() {
         // Construct the path to the uv.toml file in the tests/fixtures directory

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -63,13 +63,8 @@ impl FilesystemOptions {
 
     pub fn system() -> Result<Option<Self>, Error> {
         if let Some(file) = system_config_file() {
-            match read_file(&file) {
-                Ok(options) => {
-                    debug!("Found system configuration in: `{}`", file.display());
-                    Ok(Some(Self(options)))
-                }
-                Err(err) => Err(err),
-            }
+            let options = read_file(&file)?;
+            Ok(Some(Self(options)))
         } else {
             Ok(None)
         }
@@ -269,9 +264,10 @@ mod test {
     use std::env;
     use std::path::Path;
 
+    #[cfg(not(windows))]
     #[test]
     fn test_locate_system_config_xdg() {
-        // Construct the path to the uv.toml file in the tests/fixture directory
+        // Construct the path to the uv.toml file in the tests/fixtures directory
         let td = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests")
             .join("fixtures");

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -220,7 +220,7 @@ fn system_config_file() -> Option<PathBuf> {
     // On Windows, use, e.g., C:\ProgramData
     #[cfg(windows)]
     {
-        PathBuf::from("C:\\ProgramData\\uv\\uv.toml")
+        Some(PathBuf::from("C:\\ProgramData\\uv\\uv.toml"))
     }
 
     #[cfg(not(windows))]

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 use tracing::debug;
 
 use uv_fs::Simplified;
-#[cfg(not(windows))]
 use uv_static::EnvVars;
 use uv_warnings::warn_user;
 

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -222,7 +222,7 @@ fn system_config_file() -> Option<PathBuf> {
     {
         if let Ok(system_drive) = std::env::var(EnvVars::SYSTEMDRIVE) {
             let candidate = PathBuf::from(system_drive).join("ProgramData\\uv\\uv.toml");
-            return candidate.as_path().is_file().then(|| candidate);
+            return candidate.as_path().is_file().then_some(candidate);
         }
         None
     }

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -322,7 +322,7 @@ mod test {
         let expected = td.join("ProgramData\\uv\\uv.toml");
 
         // Previous value of %SYSTEMDRIVE% which should always exist
-        let sd = env::var(EnvVars::SYSTEMDRIVE).unwrap();
+        let sd = env::var(EnvVars::SYSTEMDRIVE).unwrap_or("C:".to_string());
 
         // This is typically only a drive (that is, letter and colon) but we
         // allow anything, including a path to the test fixtures...

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -216,29 +216,29 @@ fn locate_system_config_xdg(value: Option<&str>) -> Option<PathBuf> {
 ///
 /// Unix-like systems: This uses the `XDG_CONFIG_DIRS` environment variable in *nix systems.
 /// If the var is not present it will check /etc/xdg/uv/uv.toml and then /etc/uv/uv.toml.
-/// Windows: "C:\ProgramData\uv\uv.toml" is used.
+/// Windows: "%SYSTEMDRIVE%\ProgramData\uv\uv.toml" is used.
 fn system_config_file() -> Option<PathBuf> {
     // On Windows, use, e.g., C:\ProgramData
     #[cfg(windows)]
     {
-        return Some(PathBuf::from("C:\\ProgramData\\uv\\uv.toml"));
+        if let Ok(system_drive) = std::env::var(EnvVars::SYSTEMDRIVE) {
+            let candidate = PathBuf::from(system_drive).join("ProgramData\\uv\\uv.toml");
+            return candidate.as_path().is_file().then(|| candidate);
+        }
+        None
     }
 
     #[cfg(not(windows))]
     {
         if let Some(path) =
-            locate_system_config_xdg(std::env::var("XDG_CONFIG_DIRS").ok().as_deref())
+            locate_system_config_xdg(std::env::var(EnvVars::XDG_CONFIG_DIRS).ok().as_deref())
         {
             return Some(path);
         }
-        // Fallback to /etc/xdg/uv/uv.toml then /etc/uv/uv.toml if XDG_CONFIG_DIRS is not set or no
-        // valid path is found
-        for candidate in ["/etc/xdg/uv/uv.toml", "/etc/uv/uv.toml"] {
-            if Path::new(candidate).is_file() {
-                return Some(PathBuf::from(candidate));
-            }
-        }
-        None
+        // Fallback /etc/uv/uv.toml if XDG_CONFIG_DIRS is not set or no valid
+        // path is found
+        let candidate = Path::new("/etc/uv/uv.toml");
+        candidate.is_file().then(|| candidate.to_path_buf())
     }
 }
 
@@ -263,13 +263,19 @@ pub enum Error {
 }
 
 #[cfg(test)]
-#[cfg(not(windows))]
 mod test {
+    #[cfg(not(windows))]
     use crate::locate_system_config_xdg;
+    #[cfg(windows)]
+    use crate::system_config_file;
+    #[cfg(windows)]
+    use uv_static::EnvVars;
+
     use std::env;
     use std::path::Path;
 
     #[test]
+    #[cfg(not(windows))]
     fn test_locate_system_config_xdg() {
         // Construct the path to the uv.toml file in the tests/fixtures directory
         let td = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
@@ -307,5 +313,26 @@ mod test {
             .unwrap(),
             first_tf
         );
+    }
+
+    #[cfg(windows)]
+    fn test_windows_config() {
+        // Construct the path to the uv.toml file in the tests/fixtures directory
+        let td = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests\\fixtures");
+        let expected = td.join("ProgramData\\uv\\uv.toml");
+
+        // Previous value of %SYSTEMDRIVE% which should always exist
+        let sd = env::var(EnvVars::SYSTEMDRIVE).unwrap();
+
+        // This is typically only a drive (that is, letter and colon) but we
+        // allow anything, including a path to the test fixtures...
+        env::set_var(EnvVars::SYSTEMDRIVE, td.clone());
+        assert_eq!(system_config_file().unwrap(), expected);
+
+        // This does not have a ProgramData child, so contains no config.
+        env::set_var(EnvVars::SYSTEMDRIVE, td.parent().unwrap());
+        assert_eq!(system_config_file(), None);
+
+        env::set_var(EnvVars::SYSTEMDRIVE, sd);
     }
 }

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -337,7 +337,7 @@ mod test {
             .child("uv")
             .child("uv.toml")
             .write_str(indoc! {
-                    r#"
+                        r#"
             [pip]
             index-url = "https://test.pypi.org/simple"
         "#})?;

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -314,6 +314,7 @@ mod test {
         );
     }
 
+    #[test]
     #[cfg(windows)]
     fn test_windows_config() {
         // Construct the path to the uv.toml file in the tests/fixtures directory

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -202,7 +202,6 @@ fn locate_system_config_xdg(value: Option<&str>) -> Option<PathBuf> {
     let config_dirs = value.filter(|s| !s.is_empty()).unwrap_or(default);
 
     for dir in env::split_paths(config_dirs) {
-        println!("dir: {:?}", dir);
         let uv_toml_path = dir.join("uv").join("uv.toml");
         if uv_toml_path.is_file() {
             return Some(uv_toml_path);
@@ -336,8 +335,7 @@ mod test {
             .child("ProgramData")
             .child("uv")
             .child("uv.toml")
-            .write_str(indoc! {
-                        r#"
+            .write_str(indoc! { r#"
             [pip]
             index-url = "https://test.pypi.org/simple"
         "#})?;

--- a/crates/uv-settings/src/lib.rs
+++ b/crates/uv-settings/src/lib.rs
@@ -201,8 +201,8 @@ fn locate_system_config_xdg(value: Option<&str>) -> Option<PathBuf> {
     let default = "/etc/xdg";
     let config_dirs = value.filter(|s| !s.is_empty()).unwrap_or(default);
 
-    for dir in env::split_paths(config_dirs) {
-        let uv_toml_path = dir.join("uv").join("uv.toml");
+    for dir in config_dirs.split(':').take_while(|s| !s.is_empty()) {
+        let uv_toml_path = Path::new(dir).join("uv").join("uv.toml");
         if uv_toml_path.is_file() {
             return Some(uv_toml_path);
         }

--- a/crates/uv-settings/tests/fixtures/uv/uv.toml
+++ b/crates/uv-settings/tests/fixtures/uv/uv.toml
@@ -1,0 +1,2 @@
+[pip]
+index-url = "https://test.pypi.org/simple"

--- a/crates/uv-settings/tests/fixtures/uv/uv.toml
+++ b/crates/uv-settings/tests/fixtures/uv/uv.toml
@@ -1,2 +1,0 @@
-[pip]
-index-url = "https://test.pypi.org/simple"

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -203,7 +203,7 @@ impl EnvVars {
     pub const XDG_CONFIG_DIRS: &'static str = "XDG_CONFIG_DIRS";
 
     /// Path to system-level configuration directory on Windows systems.
-    pub const SYSTEMDRIVE: &'static str = "%SYSTEMDRIVE%";
+    pub const SYSTEMDRIVE: &'static str = "SYSTEMDRIVE";
 
     /// Path to user-level configuration directory on Unix systems.
     pub const XDG_CONFIG_HOME: &'static str = "XDG_CONFIG_HOME";

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -202,6 +202,9 @@ impl EnvVars {
     /// Path to system-level configuration directory on Unix systems.
     pub const XDG_CONFIG_DIRS: &'static str = "XDG_CONFIG_DIRS";
 
+    /// Path to system-level configuration directory on Windows systems.
+    pub const SYSTEMDRIVE: &'static str = "%SYSTEMDRIVE%";
+
     /// Path to user-level configuration directory on Unix systems.
     pub const XDG_CONFIG_HOME: &'static str = "XDG_CONFIG_HOME";
 

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -199,6 +199,9 @@ impl EnvVars {
     /// Used to set a temporary directory for some tests.
     pub const UV_INTERNAL__TEST_DIR: &'static str = "UV_INTERNAL__TEST_DIR";
 
+    /// Path to system-level configuration directory on Unix systems.
+    pub const XDG_CONFIG_DIRS: &'static str = "XDG_CONFIG_DIRS";
+
     /// Path to user-level configuration directory on Unix systems.
     pub const XDG_CONFIG_HOME: &'static str = "XDG_CONFIG_HOME";
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -117,17 +117,19 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         None
     } else if matches!(&*cli.command, Commands::Tool(_)) {
         // For commands that operate at the user-level, ignore local configuration.
-        FilesystemOptions::user()?
+        FilesystemOptions::system()?.combine(FilesystemOptions::user()?)
     } else if let Ok(workspace) =
         Workspace::discover(&project_dir, &DiscoveryOptions::default()).await
     {
         let project = FilesystemOptions::find(workspace.install_path())?;
+        let system = FilesystemOptions::system()?;
         let user = FilesystemOptions::user()?;
-        project.combine(user)
+        project.combine(system).combine(user)
     } else {
         let project = FilesystemOptions::find(&project_dir)?;
+        let system = FilesystemOptions::system()?;
         let user = FilesystemOptions::user()?;
-        project.combine(user)
+        project.combine(system).combine(user)
     };
 
     // Parse the external command, if necessary.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -129,7 +129,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         let project = FilesystemOptions::find(&project_dir)?;
         let system = FilesystemOptions::system()?;
         let user = FilesystemOptions::user()?;
-        project.combine(system).combine(user)
+        project.combine(user).combine(system)
     };
 
     // Parse the external command, if necessary.

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -117,14 +117,14 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
         None
     } else if matches!(&*cli.command, Commands::Tool(_)) {
         // For commands that operate at the user-level, ignore local configuration.
-        FilesystemOptions::system()?.combine(FilesystemOptions::user()?)
+        FilesystemOptions::user()?.combine(FilesystemOptions::system()?)
     } else if let Ok(workspace) =
         Workspace::discover(&project_dir, &DiscoveryOptions::default()).await
     {
         let project = FilesystemOptions::find(workspace.install_path())?;
         let system = FilesystemOptions::system()?;
         let user = FilesystemOptions::user()?;
-        project.combine(system).combine(user)
+        project.combine(user).combine(system)
     } else {
         let project = FilesystemOptions::find(&project_dir)?;
         let system = FilesystemOptions::system()?;

--- a/docs/configuration/files.md
+++ b/docs/configuration/files.md
@@ -9,7 +9,7 @@ in the nearest parent directory.
 
     For `tool` commands, which operate at the user level, local configuration
     files will be ignored. Instead, uv will exclusively read from user-level configuration
-    (e.g., `~/.config/uv/uv.toml`).
+    (e.g., `~/.config/uv/uv.toml`) and system-level configuration (e.g., `/etc/uv/uv.toml`).
 
 In workspaces, uv will begin its search at the workspace root, ignoring any configuration defined in
 workspace members. Since the workspace is locked as a single unit, configuration is shared across
@@ -40,13 +40,19 @@ index-url = "https://test.pypi.org/simple"
     `[tool.uv]` section in the accompanying `pyproject.toml` will be ignored.
 
 uv will also discover user-level configuration at `~/.config/uv/uv.toml` (or
-`$XDG_CONFIG_HOME/uv/uv.toml`) on macOS and Linux, or `%APPDATA%\uv\uv.toml` on Windows. User-level
-configuration must use the `uv.toml` format, rather than the `pyproject.toml` format, as a
-`pyproject.toml` is intended to define a Python _project_.
+`$XDG_CONFIG_HOME/uv/uv.toml`) on macOS and Linux, or `%APPDATA%\uv\uv.toml` on Windows; and
+system-level configuration at `/etc/uv/uv.toml` (or `$XDG_CONFIG_DIRS/uv/uv.toml`) on macOS and
+Linux, or `%SYSTEMDRIVE%\ProgramData\uv\uv.toml` on Windows.
 
-If both project- and user-level configuration are found, the settings will be merged, with the
-project-level configuration taking precedence. Specifically, if a string, number, or boolean is
-present in both tables, the project-level value will be used, and the user-level value will be
+User-and system-level configuration must use the `uv.toml` format, rather than the `pyproject.toml`
+format, as a `pyproject.toml` is intended to define a Python _project_.
+
+If project-, user-, and system-level configuration files are found, the settings will be merged,
+with project-level configuration taking precedence over the user-level configuration, and user-level
+configuration taking precedence over the system-level configuration.
+
+For example, if a string, number, or boolean is present in both the project- and user-level
+configuration tables, the project-level value will be used, and the user-level value will be
 ignored. If an array is present in both tables, the arrays will be concatenated, with the
 project-level settings appearing earlier in the merged array.
 

--- a/docs/configuration/files.md
+++ b/docs/configuration/files.md
@@ -49,7 +49,9 @@ format, as a `pyproject.toml` is intended to define a Python _project_.
 
 If project-, user-, and system-level configuration files are found, the settings will be merged,
 with project-level configuration taking precedence over the user-level configuration, and user-level
-configuration taking precedence over the system-level configuration.
+configuration taking precedence over the system-level configuration. (If multiple system-level
+configuration files are found, e.g., at both `/etc/uv/uv.toml` and `$XDG_CONFIG_DIRS/uv/uv.toml`,
+only the first-discovered file will be used, with XDG taking priority.)
 
 For example, if a string, number, or boolean is present in both the project- and user-level
 configuration tables, the project-level value will be used, and the user-level value will be


### PR DESCRIPTION
## Summary

Look for a system level uv.toml config file under `/etc/uv/uv.toml` or `C:\ProgramData`. 

This PR is to address #6742 and start a conversation. 

## Test Plan

This was tested locally manually on MacOS. I am happy to contribute tests once we settle on the approach. 

cc @thatch 
