### PR TITLE
Improve legibility of build failure errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4267,6 +4267,7 @@ dependencies = [
  "indoc",
  "insta",
  "itertools 0.13.0",
+ "owo-colors",
  "regex",
  "rustc-hash",
  "serde",

--- a/crates/uv-build-frontend/Cargo.toml
+++ b/crates/uv-build-frontend/Cargo.toml
@@ -29,6 +29,7 @@ anyhow = { workspace = true }
 fs-err = { workspace = true }
 indoc = { workspace = true }
 itertools = { workspace = true }
+owo-colors = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

We now...

- Only show `stdout` and/or `stderr` if they're non-empty.
- Use a colorful header for the start of each section
- Highlight the step that failed

## Test Plan

![Screenshot 2024-10-01 at 8 18 42 PM](https://github.com/user-attachments/assets/c3dadf6d-11be-468d-940c-a0a29c4a88f0)
