### PR TITLE
Fix code block title in Gitlab integration docs

### DIFF
--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -5,7 +5,7 @@
 Astral provides [Docker images](docker.md#available-images) with uv preinstalled.
 Select a variant that is suitable for your workflow.
 
-```yaml title="gitlab-ci.yml
+```yaml title="gitlab-ci.yml"
 variables:
   UV_VERSION: 0.4
   PYTHON_VERSION: 3.12


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/64b8d1cc-6dd7-4cd0-9e4a-aee992ec87fc)

A bit sad that mkdocs/mkdocs-material doesn't error on these kind of issues. I'm wondering if a linter tool, similar to [sphinx-lint](https://github.com/sphinx-contrib/sphinx-lint) exists for mkdocs :thinking: 