### PR TITLE
chore(ci): bump macos-12 intel runner to macos-13 intel runner

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -64,7 +64,7 @@ jobs:
 
   macos-x86_64:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
-    runs-on: macos-12-large
+    runs-on: macos-13-large
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1366,7 +1366,7 @@ jobs:
     timeout-minutes: 10
     needs: build-binary-macos-x86_64
     name: "check system | python on macos x86_64"
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/6972

This is not breaking since `MACOSX_DEPLOYMENT_TARGET` will stay the same (currently defaulting to 10.12) so a `uv-x.y.z-py3-none-macosx_10_12_x86_64.whl` will still be built
