### PR TITLE
Remove the first empty line for `uv tree --package foo`

### DIFF
--- a/crates/uv-resolver/src/lock/tree.rs
+++ b/crates/uv-resolver/src/lock/tree.rs
@@ -319,11 +319,7 @@ impl<'env> TreeDisplay<'env> {
             }
         } else {
             let by_package: FxHashMap<_, _> = self.roots.iter().map(|id| (&id.name, id)).collect();
-            let mut first = true;
             for package in &self.packages {
-                if std::mem::take(&mut first) {
-                    lines.push(String::new());
-                }
                 if let Some(id) = by_package.get(package) {
                     path.clear();
                     lines.extend(self.visit(Node::Root(id), &mut visited, &mut path));


### PR DESCRIPTION
## Summary

When using `uv tree --package foo`, an extra empty line appears at the beginning, which seems unnecessary since `uv tree` without the package option doesn’t have this. It’s possible that the intention was to add separation between packages, i.e. the correct implementation shoule be:

```rust
if !std::mem::take(&mut first) {
    lines.push(String::new());
}
```

Even if corrected, this extra spacing might be redundant as `uv tree` doesn’t include these empty lines between packages by default.

```console
$ uv init project
$ cd project
$ uv init foo
$ uv tree
Using CPython 3.12.5
Resolved 2 packages in 1ms
foo v0.1.0
project v0.1.0

$ uv tree --package project
Using CPython 3.12.5
Resolved 2 packages in 1ms

project v0.1.0
```
