### PR TITLE
Check `python/uv/` folder with `mypy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,10 @@ version_files = [
 
 [tool.mypy]
 ignore_missing_imports = true
-files = "crates/uv-python/*.py"
+files = [
+  "crates/uv-python/*.py",
+  "python/uv/*.py",
+]
 
 [tool.uv]
 managed = false

--- a/python/uv/_build_backend.py
+++ b/python/uv/_build_backend.py
@@ -37,13 +37,13 @@ def call(args: "list[str]", config_settings: "dict | None" = None) -> str:
     if result.returncode != 0:
         sys.exit(result.returncode)
     # If there was extra stdout, forward it (there should not be extra stdout)
-    sdtout = result.stdout.decode("utf-8").strip().splitlines(keepends=True)
-    sys.stdout.writelines(sdtout[:-1])
+    stdout = result.stdout.decode("utf-8").strip().splitlines(keepends=True)
+    sys.stdout.writelines(stdout[:-1])
     # Fail explicitly instead of an irrelevant stacktrace
-    if not sdtout:
+    if not stdout:
         print("uv subprocess did not return a filename on stdout", file=sys.stderr)
         sys.exit(1)
-    return sdtout[-1].strip()
+    return stdout[-1].strip()
 
 
 def build_sdist(sdist_directory: str, config_settings: "dict | None" = None):

--- a/python/uv/_build_backend.py
+++ b/python/uv/_build_backend.py
@@ -37,13 +37,13 @@ def call(args: "list[str]", config_settings: "dict | None" = None) -> str:
     if result.returncode != 0:
         sys.exit(result.returncode)
     # If there was extra stdout, forward it (there should not be extra stdout)
-    result = result.stdout.decode("utf-8").strip().splitlines(keepends=True)
-    sys.stdout.writelines(result[:-1])
+    sdtout = result.stdout.decode("utf-8").strip().splitlines(keepends=True)
+    sys.stdout.writelines(sdtout[:-1])
     # Fail explicitly instead of an irrelevant stacktrace
-    if not result:
+    if not sdtout:
         print("uv subprocess did not return a filename on stdout", file=sys.stderr)
         sys.exit(1)
-    return result[-1].strip()
+    return sdtout[-1].strip()
 
 
 def build_sdist(sdist_directory: str, config_settings: "dict | None" = None):


### PR DESCRIPTION
It used to report:

```
» mypy 
python/uv/_build_backend.py:40: error: Incompatible types in assignment (expression has type "list[str]", variable has type "CompletedProcess[bytes]")  [assignment]
python/uv/_build_backend.py:41: error: Value of type "CompletedProcess[bytes]" is not indexable  [index]
python/uv/_build_backend.py:46: error: Value of type "CompletedProcess[bytes]" is not indexable  [index]
Found 3 errors in 1 file (checked 6 source files)
```

So, I had to fix this problem by renaming the `result` var.