### PR TITLE
Ignore `UV_CACHE_DIR` in `help` tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,5 +16,8 @@ indent_size = 4
 [*.snap]
 trim_trailing_whitespace = false
 
+[crates/uv/tests/help.rs]
+trim_trailing_whitespace = false
+
 [*.md]
 max_line_length = 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,11 +173,12 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup show
 
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+          enable-cache: true
       - name: "Install required Python versions"
-        run: |
-          # astral-sh/setup-uv sets `UV_CACHE_DIR` which disrupts the help message check
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv python install
+        run: uv python install
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
@@ -221,11 +222,12 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup show
 
+      - uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+          enable-cache: true
       - name: "Install required Python versions"
-        run: |
-          # astral-sh/setup-uv sets `UV_CACHE_DIR` which disrupts the help message check
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv python install
+        run: uv python install
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,10 +174,10 @@ jobs:
         run: rustup show
 
       - name: "Install required Python versions"
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: "latest"
-          enable-cache: true
+        run: |
+          # astral-sh/setup-uv sets `UV_CACHE_DIR` which disrupts the help message check
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv python install
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
@@ -222,10 +222,10 @@ jobs:
         run: rustup show
 
       - name: "Install required Python versions"
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: "latest"
-          enable-cache: true
+        run: |
+          # astral-sh/setup-uv sets `UV_CACHE_DIR` which disrupts the help message check
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv python install
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,10 +174,10 @@ jobs:
         run: rustup show
 
       - name: "Install required Python versions"
-        run: |
-          # astral-sh/setup-uv sets `UV_CACHE_DIR` which disrupts the help message check
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv python install
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+          enable-cache: true
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
@@ -222,10 +222,10 @@ jobs:
         run: rustup show
 
       - name: "Install required Python versions"
-        run: |
-          # astral-sh/setup-uv sets `UV_CACHE_DIR` which disrupts the help message check
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv python install
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+          enable-cache: true
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -198,7 +198,7 @@ impl TestContext {
     #[must_use]
     pub fn with_ignore_cache_dir(mut self) -> Self {
         self.filters.push((
-            r"\[env: UV_CACHE_DIR=.+\]".to_string(),
+            r"\[env:[\n\s]* UV_CACHE_DIR=.+\]".to_string(),
             "[env: UV_CACHE_DIR=]".to_string(),
         ));
         self

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -201,10 +201,8 @@ impl TestContext {
             r"\[env:[\n\s]* UV_CACHE_DIR=.+\]".to_string(),
             "[env: UV_CACHE_DIR=]".to_string(),
         ));
-        self.filters.push((
-            r"--cache-dir <CACHE_DIR> ".to_string(),
-            "".to_string(),
-        ));
+        self.filters
+            .push((r"--cache-dir <CACHE_DIR> ".to_string(), String::new()));
         self
     }
 

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -407,7 +407,10 @@ impl TestContext {
 
     /// Ignore `UV_CACHE_DIR` env variable in tests.
     pub fn ignore_cache_dir(&mut self) {
-        self.filters.push((r"\[env: UV_CACHE_DIR=.+\]".to_string(), "[env: UV_CACHE_DIR=]".to_string()));
+        self.filters.push((
+            r"\[env: UV_CACHE_DIR=.+\]".to_string(),
+            "[env: UV_CACHE_DIR=]".to_string(),
+        ));
     }
 
     /// Create a uv command for testing.

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -201,8 +201,10 @@ impl TestContext {
             r"\[env:[\n\s]* UV_CACHE_DIR=.+\]".to_string(),
             "[env: UV_CACHE_DIR=]".to_string(),
         ));
+        // When `--cache-dir` is followed with other options,
+        // remove it from the text. Since its presence is inconsistent.
         self.filters
-            .push((r"--cache-dir <CACHE_DIR> ".to_string(), String::new()));
+            .push((r"--cache-dir <CACHE_DIR> <".to_string(), "<".to_string()));
         self
     }
 

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -405,6 +405,11 @@ impl TestContext {
         }
     }
 
+    /// Ignore `UV_CACHE_DIR` env variable in tests.
+    pub fn ignore_cache_dir(&mut self) {
+        self.filters.push((r"\[env: UV_CACHE_DIR=.+\]".to_string(), "[env: UV_CACHE_DIR=]".to_string()));
+    }
+
     /// Create a uv command for testing.
     pub fn command(&self) -> Command {
         let mut command = Command::new(get_bin());

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -194,6 +194,16 @@ impl TestContext {
         self
     }
 
+    /// Ignore `UV_CACHE_DIR` env variable in tests.
+    #[must_use]
+    pub fn with_ignore_cache_dir(mut self) -> Self {
+        self.filters.push((
+            r"\[env: UV_CACHE_DIR=.+\]".to_string(),
+            "[env: UV_CACHE_DIR=]".to_string(),
+        ));
+        self
+    }
+
     /// Discover the path to the XDG state directory. We use this, rather than the OS-specific
     /// temporary directory, because on macOS (and Windows on GitHub Actions), they involve
     /// symlinks. (On macOS, the temporary directory is, like `/var/...`, which resolves to
@@ -403,14 +413,6 @@ impl TestContext {
             filters,
             _root: root,
         }
-    }
-
-    /// Ignore `UV_CACHE_DIR` env variable in tests.
-    pub fn ignore_cache_dir(&mut self) {
-        self.filters.push((
-            r"\[env: UV_CACHE_DIR=.+\]".to_string(),
-            "[env: UV_CACHE_DIR=]".to_string(),
-        ));
     }
 
     /// Create a uv command for testing.

--- a/crates/uv/tests/common/mod.rs
+++ b/crates/uv/tests/common/mod.rs
@@ -201,6 +201,10 @@ impl TestContext {
             r"\[env:[\n\s]* UV_CACHE_DIR=.+\]".to_string(),
             "[env: UV_CACHE_DIR=]".to_string(),
         ));
+        self.filters.push((
+            r"--cache-dir <CACHE_DIR> ".to_string(),
+            "".to_string(),
+        ));
         self
     }
 

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -4,7 +4,8 @@ mod common;
 
 #[test]
 fn help() {
-    let context = TestContext::new_with_versions(&[]);
+    let mut context = TestContext::new_with_versions(&[]);
+    context.ignore_cache_dir();
 
     // The `uv help` command should show the long help message
     uv_snapshot!(context.filters(), context.help(), @r###"
@@ -74,7 +75,9 @@ fn help() {
 
 #[test]
 fn help_flag() {
-    let context = TestContext::new_with_versions(&[]);
+    let mut context = TestContext::new_with_versions(&[]);
+    context.ignore_cache_dir();
+
     uv_snapshot!(context.filters(), context.command().arg("--help"), @r###"
     success: true
     exit_code: 0
@@ -140,7 +143,9 @@ fn help_flag() {
 
 #[test]
 fn help_short_flag() {
-    let context = TestContext::new_with_versions(&[]);
+    let mut context = TestContext::new_with_versions(&[]);
+    context.ignore_cache_dir();
+
     uv_snapshot!(context.filters(), context.command().arg("-h"), @r###"
     success: true
     exit_code: 0
@@ -206,7 +211,8 @@ fn help_short_flag() {
 
 #[test]
 fn help_subcommand() {
-    let context = TestContext::new_with_versions(&[]);
+    let mut context = TestContext::new_with_versions(&[]);
+    context.ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.help().arg("python"), @r###"
     success: true
@@ -394,7 +400,8 @@ fn help_subcommand() {
 
 #[test]
 fn help_subsubcommand() {
-    let context = TestContext::new_with_versions(&[]);
+    let mut context = TestContext::new_with_versions(&[]);
+    context.ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.help().arg("python").arg("install"), @r###"
     success: true
@@ -562,7 +569,8 @@ fn help_subsubcommand() {
 
 #[test]
 fn help_flag_subcommand() {
-    let context = TestContext::new_with_versions(&[]);
+    let mut context = TestContext::new_with_versions(&[]);
+    context.ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.command().arg("python").arg("--help"), @r###"
     success: true
@@ -618,7 +626,8 @@ fn help_flag_subcommand() {
 
 #[test]
 fn help_flag_subsubcommand() {
-    let context = TestContext::new_with_versions(&[]);
+    let mut context = TestContext::new_with_versions(&[]);
+    context.ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.command().arg("python").arg("install").arg("--help"), @r###"
     success: true
@@ -747,7 +756,8 @@ fn help_unknown_subsubcommand() {
 
 #[test]
 fn help_with_global_option() {
-    let context = TestContext::new_with_versions(&[]);
+    let mut context = TestContext::new_with_versions(&[]);
+    context.ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.help().arg("--no-cache"), @r###"
     success: true
@@ -849,7 +859,8 @@ fn help_with_version() {
 
 #[test]
 fn help_with_no_pager() {
-    let context = TestContext::new_with_versions(&[]);
+    let mut context = TestContext::new_with_versions(&[]);
+    context.ignore_cache_dir();
 
     // We can't really test whether the --no-pager option works with a snapshot test.
     // It's still nice to have a test for the option to confirm the option exists.

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -4,7 +4,7 @@ mod common;
 
 #[test]
 fn help() {
-    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
+    let context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     // The `uv help` command should show the long help message
     uv_snapshot!(context.filters(), context.help(), @r###"
@@ -74,7 +74,7 @@ fn help() {
 
 #[test]
 fn help_flag() {
-    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
+    let context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.command().arg("--help"), @r###"
     success: true
@@ -141,7 +141,7 @@ fn help_flag() {
 
 #[test]
 fn help_short_flag() {
-    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
+    let context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.command().arg("-h"), @r###"
     success: true
@@ -208,7 +208,7 @@ fn help_short_flag() {
 
 #[test]
 fn help_subcommand() {
-    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
+    let context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.help().arg("python"), @r###"
     success: true
@@ -396,7 +396,7 @@ fn help_subcommand() {
 
 #[test]
 fn help_subsubcommand() {
-    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
+    let context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.help().arg("python").arg("install"), @r###"
     success: true
@@ -564,7 +564,7 @@ fn help_subsubcommand() {
 
 #[test]
 fn help_flag_subcommand() {
-    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
+    let context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.command().arg("python").arg("--help"), @r###"
     success: true
@@ -620,7 +620,7 @@ fn help_flag_subcommand() {
 
 #[test]
 fn help_flag_subsubcommand() {
-    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
+    let context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.command().arg("python").arg("install").arg("--help"), @r###"
     success: true
@@ -749,7 +749,7 @@ fn help_unknown_subsubcommand() {
 
 #[test]
 fn help_with_global_option() {
-    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
+    let context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.help().arg("--no-cache"), @r###"
     success: true
@@ -851,7 +851,7 @@ fn help_with_version() {
 
 #[test]
 fn help_with_no_pager() {
-    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
+    let context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     // We can't really test whether the --no-pager option works with a snapshot test.
     // It's still nice to have a test for the option to confirm the option exists.

--- a/crates/uv/tests/help.rs
+++ b/crates/uv/tests/help.rs
@@ -4,8 +4,7 @@ mod common;
 
 #[test]
 fn help() {
-    let mut context = TestContext::new_with_versions(&[]);
-    context.ignore_cache_dir();
+    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     // The `uv help` command should show the long help message
     uv_snapshot!(context.filters(), context.help(), @r###"
@@ -75,8 +74,7 @@ fn help() {
 
 #[test]
 fn help_flag() {
-    let mut context = TestContext::new_with_versions(&[]);
-    context.ignore_cache_dir();
+    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.command().arg("--help"), @r###"
     success: true
@@ -143,8 +141,7 @@ fn help_flag() {
 
 #[test]
 fn help_short_flag() {
-    let mut context = TestContext::new_with_versions(&[]);
-    context.ignore_cache_dir();
+    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.command().arg("-h"), @r###"
     success: true
@@ -211,8 +208,7 @@ fn help_short_flag() {
 
 #[test]
 fn help_subcommand() {
-    let mut context = TestContext::new_with_versions(&[]);
-    context.ignore_cache_dir();
+    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.help().arg("python"), @r###"
     success: true
@@ -400,8 +396,7 @@ fn help_subcommand() {
 
 #[test]
 fn help_subsubcommand() {
-    let mut context = TestContext::new_with_versions(&[]);
-    context.ignore_cache_dir();
+    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.help().arg("python").arg("install"), @r###"
     success: true
@@ -569,8 +564,7 @@ fn help_subsubcommand() {
 
 #[test]
 fn help_flag_subcommand() {
-    let mut context = TestContext::new_with_versions(&[]);
-    context.ignore_cache_dir();
+    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.command().arg("python").arg("--help"), @r###"
     success: true
@@ -626,8 +620,7 @@ fn help_flag_subcommand() {
 
 #[test]
 fn help_flag_subsubcommand() {
-    let mut context = TestContext::new_with_versions(&[]);
-    context.ignore_cache_dir();
+    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.command().arg("python").arg("install").arg("--help"), @r###"
     success: true
@@ -756,8 +749,7 @@ fn help_unknown_subsubcommand() {
 
 #[test]
 fn help_with_global_option() {
-    let mut context = TestContext::new_with_versions(&[]);
-    context.ignore_cache_dir();
+    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.help().arg("--no-cache"), @r###"
     success: true
@@ -859,8 +851,7 @@ fn help_with_version() {
 
 #[test]
 fn help_with_no_pager() {
-    let mut context = TestContext::new_with_versions(&[]);
-    context.ignore_cache_dir();
+    let mut context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     // We can't really test whether the --no-pager option works with a snapshot test.
     // It's still nice to have a test for the option to confirm the option exists.

--- a/crates/uv/tests/pip_uninstall.rs
+++ b/crates/uv/tests/pip_uninstall.rs
@@ -13,12 +13,9 @@ mod common;
 
 #[test]
 fn no_arguments() -> Result<()> {
-    let temp_dir = assert_fs::TempDir::new()?;
+    let context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
-    uv_snapshot!(Command::new(get_bin())
-        .arg("pip")
-        .arg("uninstall")
-        .current_dir(&temp_dir), @r###"
+    uv_snapshot!(context.filters(), context.pip_uninstall(), @r###"
     success: false
     exit_code: 2
     ----- stdout -----

--- a/crates/uv/tests/pip_uninstall.rs
+++ b/crates/uv/tests/pip_uninstall.rs
@@ -12,7 +12,7 @@ use crate::common::{get_bin, venv_to_interpreter, TestContext};
 mod common;
 
 #[test]
-fn no_arguments() -> Result<()> {
+fn no_arguments() {
     let context = TestContext::new_with_versions(&[]).with_ignore_cache_dir();
 
     uv_snapshot!(context.filters(), context.pip_uninstall(), @r###"
@@ -29,8 +29,6 @@ fn no_arguments() -> Result<()> {
     For more information, try '--help'.
     "###
     );
-
-    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I added a new function to push an extra filter to ignore `\[env: UV_CACHE_DIR=.+\]` line and replace it with an empty value.

I also changed `.editorconfig` file, because you actually need empty lines with spaces. Other option: I can add a default filter to ignore empty lines with spaces and replace them with just empty lines.

Plus, I added `setup-uv` action instead of `curl -LsSf https://astral.sh/uv/install.sh | sh`, not sure if that is planned right now, though!

Closes https://github.com/astral-sh/uv/issues/7542

## Test Plan

I executed this locally, it works!

```
» UV_CACHE_DIR=/tmp cargo nextest run --no-fail-fast help                   
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.22s
------------
 Nextest run ID f8ee686c-2fb9-49da-a657-aeeaf4dbb534 with nextest profile: default
    Starting 13 tests across 89 binaries (1693 tests skipped)
        PASS [   1.289s] uv::help help_flag_subsubcommand
        PASS [   1.295s] uv::help help_with_help
        PASS [   1.301s] uv::help help_flag_subcommand
        PASS [   1.317s] uv::help help_short_flag
        PASS [   1.326s] uv::help help_flag
        PASS [   1.331s] uv::help help_with_no_pager
        PASS [   1.333s] uv::help help_subcommand
        PASS [   1.334s] uv::help help
        PASS [   1.334s] uv::help help_unknown_subsubcommand
        PASS [   1.346s] uv::help help_subsubcommand
        PASS [   1.351s] uv::help help_with_global_option
        PASS [   1.380s] uv::help help_unknown_subcommand
        PASS [   0.132s] uv::help help_with_version
------------
     Summary [   1.422s] 13 tests run: 13 passed, 1693 skipped
                                       
```
