### PR TITLE
Fix handling of != intersections in `requires-python`

### DIFF
--- a/crates/uv/tests/sync.rs
+++ b/crates/uv/tests/sync.rs
@@ -378,7 +378,7 @@ fn mixed_requires_python() -> Result<()> {
 
     ----- stderr -----
     Using CPython 3.8.[X] interpreter at: [PYTHON-3.8]
-    error: The requested interpreter resolved to Python 3.8.[X], which is incompatible with the project's Python requirement: `>=3.12`. However, a workspace member (`bird-feeder`) supports Python >=3.8. To install the workspace member on its own, navigate to `packages/bird-feeder`, then run `uv venv --python 3.8.[X]` followed by `uv pip install -e .`.
+    error: The requested interpreter resolved to Python 3.8.[X], which is incompatible with the project's Python requirement: `>=3.8, >=3.12`. However, a workspace member (`bird-feeder`) supports Python >=3.8. To install the workspace member on its own, navigate to `packages/bird-feeder`, then run `uv venv --python 3.8.[X]` followed by `uv pip install -e .`.
     "###);
 
     Ok(())


### PR DESCRIPTION
## Summary

The issue here is that, if you user has a `requires-python` like `>= 3.7, != 3.8.5`, this gets expanded to the following bounds:

- `[3.7, 3.8.5)`
- `(3.8.5, ...`

We then convert this to the specific `>= 3.7, < 3.8.5, > 3.8.5`. But the commas in that expression are conjunctions... So it's impossible to satisfy? No version is both `< 3.8.5` and `> 3.8.5`.

Instead, we now preserve the input `requires-python` and just concatenate the terms, only using PubGrub to compute the _bounds_.

Closes https://github.com/astral-sh/uv/issues/7862.
