### PR TITLE
Organize downloads by prioritizing the platform, then the architecture.

### DIFF
--- a/crates/uv-python/download-metadata.json
+++ b/crates/uv-python/download-metadata.json
@@ -11,6 +11,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "685ef71882f16eabab0bc838094727978370f0ad95c29f7f5c244ffa31316aeb"
   },
+  "cpython-3.13.0rc3-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "0f5f9fcf82093c428b80c552165544439f4adcdbe5129ecf721d619e532e9b5e"
+  },
   "cpython-3.13.0rc3-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -47,18 +59,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "b7180d5ea5fda2f397d04e2e6e11a2a7e0d732542bf54c484afb81d087a7b927"
   },
-  "cpython-3.13.0rc3-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "873905b3e5e8cba700126e8d6ed28ad3aef0dd102f730f8ca196018477dd2da6"
-  },
   "cpython-3.13.0rc3-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -82,18 +82,6 @@
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "2769182e58b0dddec15222bfeecbd4b12fde61c38f23a90aa942514f3545fb9b"
-  },
-  "cpython-3.13.0rc3-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "0f5f9fcf82093c428b80c552165544439f4adcdbe5129ecf721d619e532e9b5e"
   },
   "cpython-3.13.0rc3-linux-x86_64-gnu": {
     "name": "cpython",
@@ -119,6 +107,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "4df6b7665c735a728d72e6f49034f1a6b7d9a54b0fbc472dc2ca525eb3dd513f"
   },
+  "cpython-3.13.0rc3-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "873905b3e5e8cba700126e8d6ed28ad3aef0dd102f730f8ca196018477dd2da6"
+  },
   "cpython-3.13.0rc3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -142,6 +142,18 @@
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "9e17f9fcc314a5dd489089a7502a525c4dd08af862f9cf33b52161a752f2a5b7"
+  },
+  "cpython-3.13.0rc2-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "971668ac7f3168efc4d2b589e9d36247ab8ca9f9525c56c8aa7bfd374060105b"
   },
   "cpython-3.13.0rc2-linux-aarch64-gnu": {
     "name": "cpython",
@@ -179,18 +191,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "0db2d263bdbb3af1e8dc0677fa44a5cda992ba989551346ccbbfd50a86135c3d"
   },
-  "cpython-3.13.0rc2-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "759f600b27a6a0ef2638cb02e8bbcc6de726dd1c896759f78da3e412f6c992e9"
-  },
   "cpython-3.13.0rc2-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -214,18 +214,6 @@
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "50a2080e30d1504e76e5471e46830f0b4974c66b538ed8ec7df416975133ff89"
-  },
-  "cpython-3.13.0rc2-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "971668ac7f3168efc4d2b589e9d36247ab8ca9f9525c56c8aa7bfd374060105b"
   },
   "cpython-3.13.0rc2-linux-x86_64-gnu": {
     "name": "cpython",
@@ -251,6 +239,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "6f09aa5ba6aab8bf21955dbc3d6bab19125130ef0ebe29242b0e5ac1eebb3161"
   },
+  "cpython-3.13.0rc2-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "759f600b27a6a0ef2638cb02e8bbcc6de726dd1c896759f78da3e412f6c992e9"
+  },
   "cpython-3.13.0rc2-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -274,6 +274,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "473c8745464e2b20477bb4faa2e0de51b6fadae68ecd79ca7951df2d15c1b214"
+  },
+  "cpython-3.12.7-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "acc9294db71a23be6ca947b039b1fc5be40638d2ab212034dba37abe4df9f53b"
   },
   "cpython-3.12.7-linux-aarch64-gnu": {
     "name": "cpython",
@@ -311,18 +323,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "8d5e9053d89932734e77c312ba60f100413a19d54d377927424aebb0b0bfbad8"
   },
-  "cpython-3.12.7-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "e55a74a174295a5fc32b0c3da07ef100bf27a99b381ed4e60f8bf981459eb63f"
-  },
   "cpython-3.12.7-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -346,18 +346,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "dde181a2d7bcad9239b47d2e416f2fa0b0022052955227ab980ef6ca84a400c4"
-  },
-  "cpython-3.12.7-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "acc9294db71a23be6ca947b039b1fc5be40638d2ab212034dba37abe4df9f53b"
   },
   "cpython-3.12.7-linux-x86_64-gnu": {
     "name": "cpython",
@@ -383,6 +371,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "a531873f3c382520e9f773ac3c84227e46ceb482b35a3d8703b4fab229096315"
   },
+  "cpython-3.12.7-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "e55a74a174295a5fc32b0c3da07ef100bf27a99b381ed4e60f8bf981459eb63f"
+  },
   "cpython-3.12.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -406,6 +406,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "0419bafa4444a5aa0c554197bce0679e7cc0f28edc7ee8cfbe0ccea860bdb904"
+  },
+  "cpython-3.12.6-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "b10d19eb5548a3b3b0a5e6f9109834d7ecfc139bc15754f81a94d39eaa5bdd26"
   },
   "cpython-3.12.6-linux-aarch64-gnu": {
     "name": "cpython",
@@ -443,18 +455,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "31a043c40e1dbb528404ff6e1fcad25638d54dfab2d379c3989d47ec24e6938b"
   },
-  "cpython-3.12.6-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "d87275e613632ab738528fe20a94a7193e824e91ba7f1e7845e7fcfc1f114900"
-  },
   "cpython-3.12.6-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -478,18 +478,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "89be19666ecb7cdbbfd596e462d690a78a380f1fe5c2967b25a1779b0cec9339"
-  },
-  "cpython-3.12.6-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "b10d19eb5548a3b3b0a5e6f9109834d7ecfc139bc15754f81a94d39eaa5bdd26"
   },
   "cpython-3.12.6-linux-x86_64-gnu": {
     "name": "cpython",
@@ -515,6 +503,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "661e2a4b03d6eccbb5b15f5bd2869fbdd39132513394d758287e46115e48d4ef"
   },
+  "cpython-3.12.6-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "d87275e613632ab738528fe20a94a7193e824e91ba7f1e7845e7fcfc1f114900"
+  },
   "cpython-3.12.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -538,6 +538,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "90715cdab075e5a2680acf2695572d165b6269bdb5d1942ab577491478aea55f"
+  },
+  "cpython-3.12.5-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "49a9f7ad41d62e0ece9e664ca5ae95f022e7b68eef48e8a6f11620ec9247c686"
   },
   "cpython-3.12.5-linux-aarch64-gnu": {
     "name": "cpython",
@@ -575,18 +587,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "a9992b30d7b3ecb558cd12fde919e3e2836f161f8f777afea31140d5fff6362e"
   },
-  "cpython-3.12.5-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "b1009d46b87330c099d02411ca5e9e333f13305c5abdbe20810a7c467cedb051"
-  },
   "cpython-3.12.5-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -610,18 +610,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "2b6ea3a5242de99574191ee42df864756eca6d7cb1dbd4cd7ab2850ba8b828f8"
-  },
-  "cpython-3.12.5-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "49a9f7ad41d62e0ece9e664ca5ae95f022e7b68eef48e8a6f11620ec9247c686"
   },
   "cpython-3.12.5-linux-x86_64-gnu": {
     "name": "cpython",
@@ -647,6 +635,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "e61b1274e1195f227cb30ba5d89ea32d743796d992adcaffad4819e4b0405d24"
   },
+  "cpython-3.12.5-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "b1009d46b87330c099d02411ca5e9e333f13305c5abdbe20810a7c467cedb051"
+  },
   "cpython-3.12.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -670,6 +670,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "ef6948e836f531bd7a58ffbe602803ff1c83c65f99d1da19be369ea61f136c93"
+  },
+  "cpython-3.12.4-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "9d68cbdd12d1d6f98d35cc76add232c12db75c6b7f49733bffc88e7b1c025a79"
   },
   "cpython-3.12.4-linux-aarch64-gnu": {
     "name": "cpython",
@@ -707,18 +719,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "4281764e69339a138e30211b9923d74036d07c7a56c6aacc6dbdb2802a575f51"
   },
-  "cpython-3.12.4-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "ff0fab24f38c22130e45b90b7ec10dc4ce9677b545d9fb9109a72d2ffbab7b02"
-  },
   "cpython-3.12.4-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -742,18 +742,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "b2fd015ab3689e024de6fbb34a4942acdb54c2184d1963e22829aafa1d81ba2c"
-  },
-  "cpython-3.12.4-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "9d68cbdd12d1d6f98d35cc76add232c12db75c6b7f49733bffc88e7b1c025a79"
   },
   "cpython-3.12.4-linux-x86_64-gnu": {
     "name": "cpython",
@@ -779,6 +767,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "de4983ffa610ff2c3b9bcb62882366f017d94bf11b194c1fce17ad9e502acce6"
   },
+  "cpython-3.12.4-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "ff0fab24f38c22130e45b90b7ec10dc4ce9677b545d9fb9109a72d2ffbab7b02"
+  },
   "cpython-3.12.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -802,6 +802,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "ccc40e5af329ef2af81350db2a88bbd6c17b56676e82d62048c15d548401519e"
+  },
+  "cpython-3.12.3-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8"
   },
   "cpython-3.12.3-linux-aarch64-gnu": {
     "name": "cpython",
@@ -839,18 +851,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabihf-install_only.tar.gz",
     "sha256": "635080827bed4616dc271545677837203098e5b55e7195d803e1dca7da24fc0c"
   },
-  "cpython-3.12.3-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-i686-pc-windows-msvc-install_only.tar.gz",
-    "sha256": "bd723ad1aa05551627715a428660250f0e74db0f1421b03f399235772057ef55"
-  },
   "cpython-3.12.3-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -874,18 +874,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "872fc321363b8cdd826fd2cb1adfd1ceb813bc1281f9d410c1c2c4e177e8df86"
-  },
-  "cpython-3.12.3-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8"
   },
   "cpython-3.12.3-linux-x86_64-gnu": {
     "name": "cpython",
@@ -911,6 +899,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "eb70814dc254f02714c77305de01b8ed2250c146320e22d0ed14b39021f89a8a"
   },
+  "cpython-3.12.3-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-i686-pc-windows-msvc-install_only.tar.gz",
+    "sha256": "bd723ad1aa05551627715a428660250f0e74db0f1421b03f399235772057ef55"
+  },
   "cpython-3.12.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -935,6 +935,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "01c064c00013b0175c7858b159989819ead53f4746d40580b5b0b35b6e80fba6"
   },
+  "cpython-3.12.2-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "a53a6670a202c96fec0b8c55ccc780ea3af5307eb89268d5b41a9775b109c094"
+  },
   "cpython-3.12.2-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -946,18 +958,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e52550379e7c4ac27a87de832d172658bc04150e4e27d4e858e6d8cbb96fd709"
-  },
-  "cpython-3.12.2-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "1e919365f3e04eb111283f7a45d32eac2f327287ab7bf46720d5629e144cbff9"
   },
   "cpython-3.12.2-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -983,18 +983,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "ecd6b0285e5eef94deb784b588b4b425a15a43ae671bf206556659dc141a9825"
   },
-  "cpython-3.12.2-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "a53a6670a202c96fec0b8c55ccc780ea3af5307eb89268d5b41a9775b109c094"
-  },
   "cpython-3.12.2-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1018,6 +1006,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "b428b4151c70b85339ac2659e5f69f7e47142d34a506e05ecd095efe2e3dec81"
+  },
+  "cpython-3.12.2-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "1e919365f3e04eb111283f7a45d32eac2f327287ab7bf46720d5629e144cbff9"
   },
   "cpython-3.12.2-windows-x86_64-none": {
     "name": "cpython",
@@ -1043,6 +1043,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "f93f8375ca6ac0a35d58ff007043cbd3a88d9609113f1cb59cf7c8d215f064af"
   },
+  "cpython-3.12.1-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "eca96158c1568dedd9a0b3425375637a83764d1fa74446438293089a8bfac1f8"
+  },
   "cpython-3.12.1-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1054,18 +1066,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "236533ef20e665007a111c2f36efb59c87ae195ad7dca223b6dc03fb07064f0b"
-  },
-  "cpython-3.12.1-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "13c8a6f337a4e1ef043ffb8ea3c218ab2073afe0d3be36fcdf8ceb6f757210e8"
   },
   "cpython-3.12.1-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1091,18 +1091,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "60631211c701f8d2c56e5dd7b154e68868128a019b9db1d53a264f56c0d4aee2"
   },
-  "cpython-3.12.1-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "eca96158c1568dedd9a0b3425375637a83764d1fa74446438293089a8bfac1f8"
-  },
   "cpython-3.12.1-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1126,6 +1114,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "876389f071d62ee9a4bdd7ce31e69c3cdd256fe498e4dd6bb2b80e674e7351fe"
+  },
+  "cpython-3.12.1-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "13c8a6f337a4e1ef043ffb8ea3c218ab2073afe0d3be36fcdf8ceb6f757210e8"
   },
   "cpython-3.12.1-windows-x86_64-none": {
     "name": "cpython",
@@ -1151,6 +1151,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "4734a2be2becb813830112c780c9879ac3aff111a0b0cd590e65ec7465774d02"
   },
+  "cpython-3.12.0-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "5a9e88c8aa52b609d556777b52ebde464ae4b4f77e4aac4eb693af57395c9abf"
+  },
   "cpython-3.12.0-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1162,18 +1174,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "bccfe67cf5465a3dfb0336f053966e2613a9bc85a6588c2fcf1366ef930c4f88"
-  },
-  "cpython-3.12.0-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "6e4f30a998245cfaef00d1b87f8fd5f6c250bd222f933f8f38f124d4f03227f9"
   },
   "cpython-3.12.0-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1199,18 +1199,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "5681621349dd85d9726d1b67c84a9686ce78f72e73a6f9e4cc4119911655759e"
   },
-  "cpython-3.12.0-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "5a9e88c8aa52b609d556777b52ebde464ae4b4f77e4aac4eb693af57395c9abf"
-  },
   "cpython-3.12.0-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1235,6 +1223,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "922f9404f39dc4edb8558a93cef5c3330895a4c87acb1de2a2cf662ab942dbe5"
   },
+  "cpython-3.12.0-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "6e4f30a998245cfaef00d1b87f8fd5f6c250bd222f933f8f38f124d4f03227f9"
+  },
   "cpython-3.12.0-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1258,6 +1258,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "263b1b50ff705ab064c50c3165de9df2ed712a77cd81c55dd340c3172e103687"
+  },
+  "cpython-3.11.10-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "a8174aef8a662201d1bb4680571cf383e89f5b44dc06614df5928595ddf82876"
   },
   "cpython-3.11.10-linux-aarch64-gnu": {
     "name": "cpython",
@@ -1295,18 +1307,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "5f2b7e6b087e085ad6bfd6a43a49611ffcc47307e45bc65f8963717b2a59dc4c"
   },
-  "cpython-3.11.10-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "4840b2fb1d421a38d8ffabf80350093e4283a67e85e67ba8285170b44b371ad9"
-  },
   "cpython-3.11.10-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -1330,18 +1330,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "317320957770a4cdbe42f3810a67685045e1cd82adf545948ec64d9d566d0c4f"
-  },
-  "cpython-3.11.10-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "a8174aef8a662201d1bb4680571cf383e89f5b44dc06614df5928595ddf82876"
   },
   "cpython-3.11.10-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1367,6 +1355,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "b0c62b085e4adb7cc32be3a7dd267bc427c2ab588802f2918d90873ece382342"
   },
+  "cpython-3.11.10-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "4840b2fb1d421a38d8ffabf80350093e4283a67e85e67ba8285170b44b371ad9"
+  },
   "cpython-3.11.10-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1390,6 +1390,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "c4e2f7774421bcb381245945e132419b529399dfa4a56059acda1493751fa377"
+  },
+  "cpython-3.11.9-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "c8680f90137e36b54b3631271ccdfe5de363e7d563d8df87c53e11b956a00e04"
   },
   "cpython-3.11.9-linux-aarch64-gnu": {
     "name": "cpython",
@@ -1427,18 +1439,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "7630838c7602e6a6a56c41263d6a808a2a2004a7ea38770ffc4c7aaf34e169ae"
   },
-  "cpython-3.11.9-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "091c99a210f4f401a305231f3f218ee3d5714658b8d3aac344d34efc716dff85"
-  },
   "cpython-3.11.9-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -1462,18 +1462,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "30c71053e9360471b7f350f1562ff4e42eb91ad2ca61b391295b5dea8b2b9efd"
-  },
-  "cpython-3.11.9-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "c8680f90137e36b54b3631271ccdfe5de363e7d563d8df87c53e11b956a00e04"
   },
   "cpython-3.11.9-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1499,6 +1487,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "b3e94cbf19bd08bf02f6e6945f6c2211453f601c7c6f79721da63a06bf99b1f9"
   },
+  "cpython-3.11.9-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "091c99a210f4f401a305231f3f218ee3d5714658b8d3aac344d34efc716dff85"
+  },
   "cpython-3.11.9-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1523,6 +1523,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "389a51139f5abe071a0d70091ca5df3e7a3dfcfcbe3e0ba6ad85fb4c5638421e"
   },
+  "cpython-3.11.8-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "097f467b0c36706bfec13f199a2eaf924e668f70c6e2bd1f1366806962f7e86e"
+  },
   "cpython-3.11.8-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1534,18 +1546,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "389b9005fb78dd5a6f68df5ea45ab7b30d9a4b3222af96999e94fd20d4ad0c6a"
-  },
-  "cpython-3.11.8-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "75039951f8f94d7304bc17b674af1668b9e1ea6d6c9ba1da28e90c0ad8030e3c"
   },
   "cpython-3.11.8-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1571,18 +1571,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "844f64f4c16e24965778281da61d1e0e6cd1358a581df1662da814b1eed096b9"
   },
-  "cpython-3.11.8-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "097f467b0c36706bfec13f199a2eaf924e668f70c6e2bd1f1366806962f7e86e"
-  },
   "cpython-3.11.8-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1606,6 +1594,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "08e1ebf51b5965e23f8e68664d17274c1cdabb5b2d7509a2003920e5d58172c7"
+  },
+  "cpython-3.11.8-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "75039951f8f94d7304bc17b674af1668b9e1ea6d6c9ba1da28e90c0ad8030e3c"
   },
   "cpython-3.11.8-windows-x86_64-none": {
     "name": "cpython",
@@ -1631,6 +1631,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "b042c966920cf8465385ca3522986b12d745151a72c060991088977ca36d3883"
   },
+  "cpython-3.11.7-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "a0e615eef1fafdc742da0008425a9030b7ea68a4ae4e73ac557ef27b112836d4"
+  },
   "cpython-3.11.7-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1642,18 +1654,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "b102eaf865eb715aa98a8a2ef19037b6cc3ae7dfd4a632802650f29de635aa13"
-  },
-  "cpython-3.11.7-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "f5a6ca1280749d8ceaf8851585ef6b0cd2f1f76e801a77c1d744019554eef2f0"
   },
   "cpython-3.11.7-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1679,18 +1679,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "49520e3ff494708020f306e30b0964f079170be83e956be4504f850557378a22"
   },
-  "cpython-3.11.7-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "a0e615eef1fafdc742da0008425a9030b7ea68a4ae4e73ac557ef27b112836d4"
-  },
   "cpython-3.11.7-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1714,6 +1702,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "1a919a35172eb9419eba841eeb0ec9879dbc2b006b284ee5c454c08197b50f74"
+  },
+  "cpython-3.11.7-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "f5a6ca1280749d8ceaf8851585ef6b0cd2f1f76e801a77c1d744019554eef2f0"
   },
   "cpython-3.11.7-windows-x86_64-none": {
     "name": "cpython",
@@ -1739,6 +1739,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "916c35125b5d8323a21526d7a9154ca626453f63d0878e95b9f613a95006c990"
   },
+  "cpython-3.11.6-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371"
+  },
   "cpython-3.11.6-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1750,18 +1762,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec"
-  },
-  "cpython-3.11.6-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "dd48b2cfaae841b4cd9beed23e2ae68b13527a065ef3d271d228735769c4e64d"
   },
   "cpython-3.11.6-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1787,18 +1787,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "f9f19823dba3209cedc4647b00f46ed0177242917db20fb7fb539970e384531c"
   },
-  "cpython-3.11.6-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371"
-  },
   "cpython-3.11.6-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1822,6 +1810,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "c929e5fe676ad20afcf6807a797d21261ae0827e84ec18742031a9582aed0d46"
+  },
+  "cpython-3.11.6-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "dd48b2cfaae841b4cd9beed23e2ae68b13527a065ef3d271d228735769c4e64d"
   },
   "cpython-3.11.6-windows-x86_64-none": {
     "name": "cpython",
@@ -1847,6 +1847,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "dab64b3580118ad2073babd7c29fd2053b616479df5c107d31fe2af1f45e948b"
   },
+  "cpython-3.11.5-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "4a4efa7378c72f1dd8ebcce1afb99b24c01b07023aa6b8fea50eaedb50bf2bfc"
+  },
   "cpython-3.11.5-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1870,18 +1882,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "82de7e2551c015145c017742a5c0411d67a7544595df43c02b5efa4762d5123e"
-  },
-  "cpython-3.11.5-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "936b624c2512a3a3370aae8adf603d6ae71ba8ebd39cc4714a13306891ea36f0"
   },
   "cpython-3.11.5-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1907,18 +1907,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "fe459da39874443579d6fe88c68777c6d3e331038e1fb92a0451879fb6beb16d"
   },
-  "cpython-3.11.5-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "4a4efa7378c72f1dd8ebcce1afb99b24c01b07023aa6b8fea50eaedb50bf2bfc"
-  },
   "cpython-3.11.5-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1942,6 +1930,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "fe09ecd87f69a724acf26ca508d7ead91a951abb2da18dfb98fe22c284454121"
+  },
+  "cpython-3.11.5-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "936b624c2512a3a3370aae8adf603d6ae71ba8ebd39cc4714a13306891ea36f0"
   },
   "cpython-3.11.5-windows-x86_64-none": {
     "name": "cpython",
@@ -1967,6 +1967,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "cb6d2948384a857321f2aa40fa67744cd9676a330f08b6dad7070bda0b6120a4"
   },
+  "cpython-3.11.4-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00"
+  },
   "cpython-3.11.4-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1990,18 +2002,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "abdccc6ec7093f49da99680f5899a96bff0b96fde8f5d73f7aac121e0d05fdd8"
-  },
-  "cpython-3.11.4-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "e2f4b41c3d89c5ec735e2563d752856cb3c19a0aa712ec7ef341712bafa7e905"
   },
   "cpython-3.11.4-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2027,18 +2027,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e477f0749161f9aa7887964f089d9460a539f6b4a8fdab5166f898210e1a87a4"
   },
-  "cpython-3.11.4-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00"
-  },
   "cpython-3.11.4-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2062,6 +2050,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "1218ca44595aeaf34271508db64a2abc581c3ee1eb307c1b0537ea746922b806"
+  },
+  "cpython-3.11.4-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "e2f4b41c3d89c5ec735e2563d752856cb3c19a0aa712ec7ef341712bafa7e905"
   },
   "cpython-3.11.4-windows-x86_64-none": {
     "name": "cpython",
@@ -2087,6 +2087,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "09e412506a8d63edbb6901742b54da9aa7faf120b8dbdce56c57b303fc892c86"
   },
+  "cpython-3.11.3-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "f710b8d60621308149c100d5175fec39274ed0b9c99645484fd93d1716ef4310"
+  },
   "cpython-3.11.3-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -2111,18 +2123,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "36ff6c5ebca8bf07181b774874233eb37835a62b39493f975869acc5010d839d"
   },
-  "cpython-3.11.3-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "a6751e6fa5c7c4d4748ed534a7f00ad7f858f62ce73d63d44dd907036ba53985"
-  },
   "cpython-3.11.3-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -2134,18 +2134,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "767d24f3570b35fedb945f5ac66224c8983f2d556ab83c5cfaa5f3666e9c212c"
-  },
-  "cpython-3.11.3-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "f710b8d60621308149c100d5175fec39274ed0b9c99645484fd93d1716ef4310"
   },
   "cpython-3.11.3-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2171,6 +2159,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "82eed5ae1ca9e60ed9b9cac97e910927ffe2e80e91161c74b2d70e44d5227de0"
   },
+  "cpython-3.11.3-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "a6751e6fa5c7c4d4748ed534a7f00ad7f858f62ce73d63d44dd907036ba53985"
+  },
   "cpython-3.11.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2194,6 +2194,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "4918cdf1cab742a90f85318f88b8122aeaa2d04705803c7b6e78e81a3dd40f80"
+  },
+  "cpython-3.11.1-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733"
   },
   "cpython-3.11.1-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2219,30 +2231,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "8392230cf76c282cfeaf67dcbd2e0fac6da8cd3b3aead1250505c6ddd606caae"
   },
-  "cpython-3.11.1-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "50b250dd261c3cca9ae8d96cb921e4ffbc64f778a198b6f8b8b0a338f77ae486"
-  },
-  "cpython-3.11.1-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733"
-  },
   "cpython-3.11.1-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2267,6 +2255,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "7f0425d3e9b2283aba205493e9fe431bc2c2d67cc369bc922825b827a1b06b82"
   },
+  "cpython-3.11.1-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "50b250dd261c3cca9ae8d96cb921e4ffbc64f778a198b6f8b8b0a338f77ae486"
+  },
   "cpython-3.11.1-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2290,6 +2290,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "1f753073b2333b2977922387fe016255ebde0f8558c567ffb960b7f50477fd34"
+  },
+  "cpython-3.10.15-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "18dd6c0c219da1ec7daede9da923205594dbdc7f37a283873363b4634a5e3f8f"
   },
   "cpython-3.10.15-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2327,18 +2339,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "feab385a00f1312f318097521263cb17a68d4ce9c8945cfb97c07db3965838ca"
   },
-  "cpython-3.10.15-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "29ea71edc4899061a9c3d2fd85773c1ae5d353ea9cb39c3d6b3e4c2a9bf4fda0"
-  },
   "cpython-3.10.15-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -2362,18 +2362,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "14f8ed8e42db2296723f3e64e30e24ce2e27fc36534dcb77f474c8edb1fde872"
-  },
-  "cpython-3.10.15-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "18dd6c0c219da1ec7daede9da923205594dbdc7f37a283873363b4634a5e3f8f"
   },
   "cpython-3.10.15-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2399,6 +2387,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "a4eec7b3cbf5f2292f2d5ef0181317430a2e053d811bf8547918c27ded589416"
   },
+  "cpython-3.10.15-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "29ea71edc4899061a9c3d2fd85773c1ae5d353ea9cb39c3d6b3e4c2a9bf4fda0"
+  },
   "cpython-3.10.15-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2422,6 +2422,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "f7ca9bffbce433c8d445edd33a5424c405553d735efee65a2fc5d8bbb1c8e137"
+  },
+  "cpython-3.10.14-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "4404f44ec69c0708d4d88e98f39c2c1fe3bd462dc6a958b60aaf63028550c485"
   },
   "cpython-3.10.14-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2459,18 +2471,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "7f215b85df78c568847329faeb2c5007c301741d9c4ccebbd935a3a2963197b5"
   },
-  "cpython-3.10.14-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "a84742f13584fd39f4f4b0d9a5865621a3c88cad91b31f17f414186719063364"
-  },
   "cpython-3.10.14-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -2494,18 +2494,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "ff1c4f010b1c6f563c71fa30f68293168536e0ed65f7d470a7e8c73252d08653"
-  },
-  "cpython-3.10.14-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "4404f44ec69c0708d4d88e98f39c2c1fe3bd462dc6a958b60aaf63028550c485"
   },
   "cpython-3.10.14-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2531,6 +2519,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "8803a748f2197ec2360af6feebe9c936f4f6beabcae1db5557fdd98fc922982c"
   },
+  "cpython-3.10.14-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "a84742f13584fd39f4f4b0d9a5865621a3c88cad91b31f17f414186719063364"
+  },
   "cpython-3.10.14-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2554,6 +2554,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "5fdc0f6a5b5a90fd3c528e8b1da8e3aac931ea8690126c2fdb4254c84a3ff04a"
+  },
+  "cpython-3.10.13-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a"
   },
   "cpython-3.10.13-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2579,18 +2591,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "424d239b6df60e40849ad18505de394001233ab3d7470b5280fec6e643208bb9"
   },
-  "cpython-3.10.13-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "5365b90f9cba7186d12dd86516ece8b696db7311128e0b49c92234e01a74599f"
-  },
   "cpython-3.10.13-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -2614,18 +2614,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "09be8fb2cdfbb4a93d555f268f244dbe4d8ff1854b2658e8043aa4ec08aede3e"
-  },
-  "cpython-3.10.13-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a"
   },
   "cpython-3.10.13-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2651,6 +2639,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "48365ea10aa1b0768a153bfff50d1515a757d42409b02a4af4db354803f2d180"
   },
+  "cpython-3.10.13-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "5365b90f9cba7186d12dd86516ece8b696db7311128e0b49c92234e01a74599f"
+  },
   "cpython-3.10.13-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2674,6 +2674,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "bc66c706ea8c5fc891635fda8f9da971a1a901d41342f6798c20ad0b2a25d1d6"
+  },
+  "cpython-3.10.12-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "8a6e3ed973a671de468d9c691ed9cb2c3a4858c5defffcf0b08969fba9c1dd04"
   },
   "cpython-3.10.12-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2699,18 +2711,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "c7a5321a696ef6467791312368a04d36828907a8f5c557b96067fa534c716c18"
   },
-  "cpython-3.10.12-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "a5a5f9c9082b6503462a6b134111d3c303052cbc49ff31fff2ade38b39978e5d"
-  },
   "cpython-3.10.12-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -2734,18 +2734,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "8d33d435ae6fb93ded7fc26798cc0a1a4f546a4e527012a1e2909cc314b332df"
-  },
-  "cpython-3.10.12-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "8a6e3ed973a671de468d9c691ed9cb2c3a4858c5defffcf0b08969fba9c1dd04"
   },
   "cpython-3.10.12-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2771,6 +2759,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "9080014bee2d4bd1f96bcbebf447d40c35ae9354382246add1160bd0d433ebf7"
   },
+  "cpython-3.10.12-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "a5a5f9c9082b6503462a6b134111d3c303052cbc49ff31fff2ade38b39978e5d"
+  },
   "cpython-3.10.12-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2794,6 +2794,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "8348bc3c2311f94ec63751fb71bd0108174be1c4def002773cf519ee1506f96f"
+  },
+  "cpython-3.10.11-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "bd3fc6e4da6f4033ebf19d66704e73b0804c22641ddae10bbe347c48f82374ad"
   },
   "cpython-3.10.11-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2819,18 +2831,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "c70518620e32b074b1b40579012f0c67191a967e43e84b8f46052b6b893f7eeb"
   },
-  "cpython-3.10.11-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "e4ed3414cd0e687017f0a56fed88ff39b3f5dfb24a0d62e9c7ca55854178bcde"
-  },
   "cpython-3.10.11-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -2842,18 +2842,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "73a9d4c89ed51be39dd2de4e235078281087283e9fdedef65bec02f503e906ee"
-  },
-  "cpython-3.10.11-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "bd3fc6e4da6f4033ebf19d66704e73b0804c22641ddae10bbe347c48f82374ad"
   },
   "cpython-3.10.11-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2879,6 +2867,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "c5dde3276541a8ad000ba631ec70012aa2261926c13f54d2b1de83dad61d59c1"
   },
+  "cpython-3.10.11-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "e4ed3414cd0e687017f0a56fed88ff39b3f5dfb24a0d62e9c7ca55854178bcde"
+  },
   "cpython-3.10.11-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2902,6 +2902,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "018d05a779b2de7a476f3b3ff2d10f503d69d14efcedd0774e6dab8c22ef84ff"
+  },
+  "cpython-3.10.9-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "0e685f98dce0e5bc8da93c7081f4e6c10219792e223e4b5886730fd73a7ba4c6"
   },
   "cpython-3.10.9-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2927,30 +2939,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "44566c08eb8054aa0784f76b85d2c6c70a62f4988d5e9abcce819b517b329fdd"
   },
-  "cpython-3.10.9-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "c5c51d9a3e8d8cdac67d8f3ad7c4008de169ff1480e17021f154d5c99fcee9e3"
-  },
-  "cpython-3.10.9-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "0e685f98dce0e5bc8da93c7081f4e6c10219792e223e4b5886730fd73a7ba4c6"
-  },
   "cpython-3.10.9-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2974,6 +2962,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "cf17e6d042777170e423c6b80e096ad8273d9848708875db0d23dd45bdb3d516"
+  },
+  "cpython-3.10.9-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "c5c51d9a3e8d8cdac67d8f3ad7c4008de169ff1480e17021f154d5c99fcee9e3"
   },
   "cpython-3.10.9-windows-x86_64-none": {
     "name": "cpython",
@@ -2999,6 +2999,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "d52b03817bd245d28e0a8b2f715716cd0fcd112820ccff745636932c76afa20a"
   },
+  "cpython-3.10.8-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "525b79c7ce5de90ab66bd07b0ac1008bafa147ddc8a41bef15ffb7c9c1e9e7c5"
+  },
   "cpython-3.10.8-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3022,30 +3034,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "2deee7cbbd5dad339d713a75ec92239725d2035e833af5b9981b026dee0b9213"
-  },
-  "cpython-3.10.8-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "94e76273166f72624128e52b5402db244cea041dab4a6bcdc70b304b66e27e95"
-  },
-  "cpython-3.10.8-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "525b79c7ce5de90ab66bd07b0ac1008bafa147ddc8a41bef15ffb7c9c1e9e7c5"
   },
   "cpython-3.10.8-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3071,6 +3059,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "9f035bbe53f55fb406f95cb68459ba245b386084eeb5760f1660f416b730328d"
   },
+  "cpython-3.10.8-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "94e76273166f72624128e52b5402db244cea041dab4a6bcdc70b304b66e27e95"
+  },
   "cpython-3.10.8-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3094,6 +3094,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "70f6ca1da8e6fce832ad0b7f9fdaba0b84ba0ac0a4c626127acb6d49df4b8f91"
+  },
+  "cpython-3.10.7-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "6101f580434544d28d5590543029a7c6bdf07efa4bcdb5e4cbedb3cd83241922"
   },
   "cpython-3.10.7-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3119,30 +3131,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "4a611ce990dc1f32bc4b35d276f04521464127f77e1133ac5bb9c6ba23e94a82"
   },
-  "cpython-3.10.7-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "384e711dd657c3439be4e50b2485478a7ed7a259a741d4480fc96d82cc09d318"
-  },
-  "cpython-3.10.7-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "6101f580434544d28d5590543029a7c6bdf07efa4bcdb5e4cbedb3cd83241922"
-  },
   "cpython-3.10.7-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3166,6 +3154,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "3e0cab6e49ad5ef95851049463797ec713eee6e1f2fa1d99e30516d37797c3f0"
+  },
+  "cpython-3.10.7-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "384e711dd657c3439be4e50b2485478a7ed7a259a741d4480fc96d82cc09d318"
   },
   "cpython-3.10.7-windows-x86_64-none": {
     "name": "cpython",
@@ -3191,6 +3191,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "efaf66acdb9a4eb33d57702607d2e667b1a319d58c167a43c96896b97419b8b7"
   },
+  "cpython-3.10.6-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "7718411adf3ea1480f3f018a643eb0550282aefe39e5ecb3f363a4a566a9398c"
+  },
   "cpython-3.10.6-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3214,30 +3226,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "b152801a2609e6a38f3cc9e7e21d8b6cf5b6f31dacfcaca01e162c514e851ed6"
-  },
-  "cpython-3.10.6-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "27f22babf29ceebae18b2c2e38e2c48d22de686688c8a31c5f8d7d51541583c1"
-  },
-  "cpython-3.10.6-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "7718411adf3ea1480f3f018a643eb0550282aefe39e5ecb3f363a4a566a9398c"
   },
   "cpython-3.10.6-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3263,6 +3251,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "8cafe6409e9d192b288b84a21bc0c309f1d3f6b809a471b2858c7bf1bb09f3a7"
   },
+  "cpython-3.10.6-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "27f22babf29ceebae18b2c2e38e2c48d22de686688c8a31c5f8d7d51541583c1"
+  },
   "cpython-3.10.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3286,6 +3286,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "19d1aa4a6d9ddb0094fc36961b129de9abe1673bce66c86cd97b582795c496a8"
+  },
+  "cpython-3.10.5-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "eca0584397d9a3ef6f7bb32b0476318b01c89b7b0a031ef97a0dcaa5ba5127a8"
   },
   "cpython-3.10.5-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3311,30 +3323,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "5abf5baf40f8573ce7d7e4ad323457f511833e1663e61ac5a11d5563a735159f"
   },
-  "cpython-3.10.5-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "2846e9c7e8484034989ab218022009fdd9dcb12a7bfb4b0329a404552d37e9aa"
-  },
-  "cpython-3.10.5-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "eca0584397d9a3ef6f7bb32b0476318b01c89b7b0a031ef97a0dcaa5ba5127a8"
-  },
   "cpython-3.10.5-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3358,6 +3346,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "6aad42c7b03989173dd0e4d066e8c1e9f176f4b31d5bde26dbb5297f38f656d0"
+  },
+  "cpython-3.10.5-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "2846e9c7e8484034989ab218022009fdd9dcb12a7bfb4b0329a404552d37e9aa"
   },
   "cpython-3.10.5-windows-x86_64-none": {
     "name": "cpython",
@@ -3383,6 +3383,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "6d2e4e6b1c403bce84cfb846400754017f525fe8017f186e8e7072fcaaf3aa71"
   },
+  "cpython-3.10.4-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "c4a57a13b084d49ce8c2eb5b2662ee45b0c55b08ddd696f473233b0787f03988"
+  },
   "cpython-3.10.4-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3406,30 +3418,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "f3bc0828a0e0a8974e3fe90b4e99549296a7578de2321d791be1bad28191921d"
-  },
-  "cpython-3.10.4-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "e1dfa5dde910f908cad8bd688b29d28df832f7b150555679c204580d1af0c4a6"
-  },
-  "cpython-3.10.4-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "c4a57a13b084d49ce8c2eb5b2662ee45b0c55b08ddd696f473233b0787f03988"
   },
   "cpython-3.10.4-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3455,6 +3443,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "74c8da0aa24233c76bdd984d3c9e44442eca316be8a2cb4972d9264fedb0d5e8"
   },
+  "cpython-3.10.4-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "e1dfa5dde910f908cad8bd688b29d28df832f7b150555679c204580d1af0c4a6"
+  },
   "cpython-3.10.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3478,6 +3478,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "db46dadfccc407aa1f66ed607eefbf12f781e343adcb1edee0a3883d081292ce"
+  },
+  "cpython-3.10.3-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "ec2e90b6a589db7ef9f74358b1436558167629f9e4d725c8150496f9cb08a9d4"
   },
   "cpython-3.10.3-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3503,30 +3515,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "2f125a927c3af52ef89af11857df988a042e26ce095129701b915e75b2ec6bff"
   },
-  "cpython-3.10.3-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "bb7f2a5143010fa482c5b442cced85516696cfc416ca92c903ef374532401a33"
-  },
-  "cpython-3.10.3-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "ec2e90b6a589db7ef9f74358b1436558167629f9e4d725c8150496f9cb08a9d4"
-  },
   "cpython-3.10.3-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3550,6 +3538,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "a60b589176879bdd465659660b87e954f969bed072c03c578ec828d6134f4ae1"
+  },
+  "cpython-3.10.3-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "bb7f2a5143010fa482c5b442cced85516696cfc416ca92c903ef374532401a33"
   },
   "cpython-3.10.3-windows-x86_64-none": {
     "name": "cpython",
@@ -3575,6 +3575,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "1409acd9a506e2d1d3b65c1488db4e40d8f19d09a7df099667c87a506f71c0ef"
   },
+  "cpython-3.10.2-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "8146ad4390710ec69b316a5649912df0247d35f4a42e2aa9615bffd87b3e235a"
+  },
   "cpython-3.10.2-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3598,30 +3610,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "4fa49dab83bf82409816db431806525ce894280a509ca96c91e3efc9beed1fea"
-  },
-  "cpython-3.10.2-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "5321f8c2c71239b1e2002d284be8ec825d4a6f95cd921e58db71f259834b7aa1"
-  },
-  "cpython-3.10.2-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "8146ad4390710ec69b316a5649912df0247d35f4a42e2aa9615bffd87b3e235a"
   },
   "cpython-3.10.2-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3647,6 +3635,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "c4f398f6f7f9bbf0df98407ad66bc5760f3afc2cd8ba33a99cf4dcc8c90fd9ae"
   },
+  "cpython-3.10.2-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "5321f8c2c71239b1e2002d284be8ec825d4a6f95cd921e58db71f259834b7aa1"
+  },
   "cpython-3.10.2-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3669,6 +3669,18 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-apple-darwin-install_only-20211017T1616.tar.gz",
+    "sha256": null
+  },
+  "cpython-3.10.0-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
     "sha256": null
   },
   "cpython-3.10.0-linux-aarch64-gnu": {
@@ -3695,30 +3707,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.10.0-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.10.0-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
-    "sha256": null
-  },
   "cpython-3.10.0-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3741,6 +3729,18 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.10.0-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
     "sha256": null
   },
   "cpython-3.10.0-windows-x86_64-none": {
@@ -3766,6 +3766,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "02c376d7a931c7a4575158e8908978ec7686cd11ba93a0df1770858974f53822"
+  },
+  "cpython-3.9.20-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "dddb504549d27beb7ee39e88a9a9db72ac890df987d890edc5fa7310179ebe9f"
   },
   "cpython-3.9.20-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3803,18 +3815,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "0ceefbdf74ba55b7d75371b4a0cfec4e0a9dd72693f63236869e288e3bf920b1"
   },
-  "cpython-3.9.20-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "ef91a17d8f81b3b744be5bfbbd1531963fcfc4798832aae2ac1f8d093354bfee"
-  },
   "cpython-3.9.20-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -3838,18 +3838,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "88dfa9a5d9ded872716a8bccc7092bbd8a32519c1eaa17799fea45ddc3da19dd"
-  },
-  "cpython-3.9.20-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "dddb504549d27beb7ee39e88a9a9db72ac890df987d890edc5fa7310179ebe9f"
   },
   "cpython-3.9.20-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3875,6 +3863,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "0c224f88780706cea5eefe96e3853da8d358ebb1a5f33575097136a7891daa3f"
   },
+  "cpython-3.9.20-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "ef91a17d8f81b3b744be5bfbbd1531963fcfc4798832aae2ac1f8d093354bfee"
+  },
   "cpython-3.9.20-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3898,6 +3898,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "451582f8a6a8c15ef35a327afcdbf8d03b1ebba7192e90d850d092dac91f91c6"
+  },
+  "cpython-3.9.19-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+    "sha256": "ebaf4336d0cbff4466c994d5bcaa92a38c91d06694d0cd675ec663259d5f37c7"
   },
   "cpython-3.9.19-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3935,18 +3947,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "c32d3227c44919349172c27b35275bad379f1679f729fbd4f336625903171a1a"
   },
-  "cpython-3.9.19-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "1c78c6dd763e6d583c3c3f917544bc4446d0e9fbe2b6e206042fa801ff9fb9ab"
-  },
   "cpython-3.9.19-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -3970,18 +3970,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "b41f834311532ee9dcf76cad3cdeda285d0e283de2182ce9870c37c40970cdd3"
-  },
-  "cpython-3.9.19-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "ebaf4336d0cbff4466c994d5bcaa92a38c91d06694d0cd675ec663259d5f37c7"
   },
   "cpython-3.9.19-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4007,6 +3995,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "5c6605b1cfa6a952420f2267d10bed9ae20a02858a769b7275d8805f6b9fe40b"
   },
+  "cpython-3.9.19-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "1c78c6dd763e6d583c3c3f917544bc4446d0e9fbe2b6e206042fa801ff9fb9ab"
+  },
   "cpython-3.9.19-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4030,6 +4030,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "2548f911a6e316575c303ba42bb51540dc9b47a9f76a06a2a37460d93b177aa2"
+  },
+  "cpython-3.9.18-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "171d8b472fce0295be0e28bb702c43d5a2a39feccb3e72efe620ac3843c3e402"
   },
   "cpython-3.9.18-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4055,18 +4067,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "10c422080317886057e968010495037ba65731ab7653bcaeabadf67a6fa5e99e"
   },
-  "cpython-3.9.18-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "904ff5d2f6402640e2b7e2b12075af0bd75b3e8685cc5248fd2a3cda3105d2a8"
-  },
   "cpython-3.9.18-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -4090,18 +4090,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "15d059507c7e900e9665f31e8d903e5a24a68ceed24f9a1c5ac06ab42a354f3f"
-  },
-  "cpython-3.9.18-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "171d8b472fce0295be0e28bb702c43d5a2a39feccb3e72efe620ac3843c3e402"
   },
   "cpython-3.9.18-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4127,6 +4115,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "cb47455810ae63d98501b3bb4fcdfdb9924633fb2e86e62d77e523a3bdee44ba"
   },
+  "cpython-3.9.18-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "904ff5d2f6402640e2b7e2b12075af0bd75b3e8685cc5248fd2a3cda3105d2a8"
+  },
   "cpython-3.9.18-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4150,6 +4150,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "73dbe2d702210b566221da9265acc274ba15275c5d0d1fa327f44ad86cde9aa1"
+  },
+  "cpython-3.9.17-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "dfe1bea92c94b9cb779288b0b06e39157c5ff7e465cdd24032ac147c2af485c0"
   },
   "cpython-3.9.17-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4175,18 +4187,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "aed29a64c835444c2f1aff83c55b14123114d74c54d96493a0eabfdd8c6d012c"
   },
-  "cpython-3.9.17-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "09f9d4bc66be5e0df2dfd1dc4742923e46c271f8f085178696c77073477aa0c1"
-  },
   "cpython-3.9.17-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -4210,18 +4210,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-s390x-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "01454d7cc7c9c2fccde42ba868c4f372eaaafa48049d49dd94c9cf2875f497e6"
-  },
-  "cpython-3.9.17-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "dfe1bea92c94b9cb779288b0b06e39157c5ff7e465cdd24032ac147c2af485c0"
   },
   "cpython-3.9.17-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4247,6 +4235,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "194316e9cc7add1dd12be3e3eea2908fd4d623799edd7df69e360c6a446b750d"
   },
+  "cpython-3.9.17-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "09f9d4bc66be5e0df2dfd1dc4742923e46c271f8f085178696c77073477aa0c1"
+  },
   "cpython-3.9.17-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4270,6 +4270,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "c1de1d854717a6245f45262ef1bb17b09e2c587590e7e3f406593c143ff875bd"
+  },
+  "cpython-3.9.16-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf"
   },
   "cpython-3.9.16-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4295,18 +4307,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "ab0a14b3ae72bf48b94820e096e86b3cf3e05729862f768e109aa8318016c4f2"
   },
-  "cpython-3.9.16-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "219532ffa49af88e3b90e9135cf3b6e1fa11cf165b03098fb9776a07af8ca6d0"
-  },
   "cpython-3.9.16-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -4318,18 +4318,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "ff3ac35c58f67839aff9b5185a976abd3d1abbe61af02089f7105e876c1fe284"
-  },
-  "cpython-3.9.16-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf"
   },
   "cpython-3.9.16-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4355,6 +4343,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "5d9b13e8d5ee7a26fd0cf6e6d7e5a1ea90ddddd1f30ed2400bda60506f7dcea3"
   },
+  "cpython-3.9.16-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "219532ffa49af88e3b90e9135cf3b6e1fa11cf165b03098fb9776a07af8ca6d0"
+  },
   "cpython-3.9.16-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4378,6 +4378,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "64dc7e1013481c9864152c3dd806c41144c79d5e9cd3140e185c6a5060bdc9ab"
+  },
+  "cpython-3.9.15-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "f2bcade6fc976c472f18f2b3204d67202d43ae55cf6f9e670f95e488f780da08"
   },
   "cpython-3.9.15-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4403,30 +4415,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "bf32a86c220e4d1690bb92b67653f20b8325808accd81bff03b5c30ae74e6444"
   },
-  "cpython-3.9.15-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "0b81089247f258f244e9792daaa03675da6f58597daa6913e82f2679862238dd"
-  },
-  "cpython-3.9.15-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "f2bcade6fc976c472f18f2b3204d67202d43ae55cf6f9e670f95e488f780da08"
-  },
   "cpython-3.9.15-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4450,6 +4438,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "81b1c76ac789521fcececdcdc643f6de6fc282083b1a36a9973d835fc8a39391"
+  },
+  "cpython-3.9.15-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "0b81089247f258f244e9792daaa03675da6f58597daa6913e82f2679862238dd"
   },
   "cpython-3.9.15-windows-x86_64-none": {
     "name": "cpython",
@@ -4475,6 +4475,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "e38df7f230979ce6c53a5bafb3a81287838e5f3892c40cd1b98a0c961c444713"
   },
+  "cpython-3.9.14-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "b7d3a1f4b57e9350571ccee49c82f503133de0d113a2dbaebc8ccf108fb3fe1b"
+  },
   "cpython-3.9.14-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4498,30 +4510,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "3af1c255110c2f42ed0b7957502c92edf8b5c5e6fc5f699a2475bf8a560325c0"
-  },
-  "cpython-3.9.14-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "f3526e8416be86ff9091750ebc7388d6726acf32cc5ab0e6a60c67c6aacb2569"
-  },
-  "cpython-3.9.14-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "b7d3a1f4b57e9350571ccee49c82f503133de0d113a2dbaebc8ccf108fb3fe1b"
   },
   "cpython-3.9.14-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4547,6 +4535,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "ceb26ef5f5a9b7b47fa95225fffce9c8ef0c9c1fbeca69fbda236a0c10de7ad8"
   },
+  "cpython-3.9.14-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "f3526e8416be86ff9091750ebc7388d6726acf32cc5ab0e6a60c67c6aacb2569"
+  },
   "cpython-3.9.14-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4570,6 +4570,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "d9603edc296a2dcbc59d7ada780fd12527f05c3e0b99f7545112daf11636d6e5"
+  },
+  "cpython-3.9.13-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "9540a7efb7c8a54a48aff1cb9480e49588d9c0a3f934ad53f5b167338174afa3"
   },
   "cpython-3.9.13-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4595,30 +4607,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "efcc8fef0d498afe576ab209fee001fda3b552de1a85f621f2602787aa6cf3d4"
   },
-  "cpython-3.9.13-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "90e3879382f06fea3ba6d477f0c2a434a1e14cd83d174e1c7b87e2f22bc2e748"
-  },
-  "cpython-3.9.13-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "9540a7efb7c8a54a48aff1cb9480e49588d9c0a3f934ad53f5b167338174afa3"
-  },
   "cpython-3.9.13-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4642,6 +4630,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "766ed7e805e8c7abc4e50f1c94814575e7978ed7bd1f9e9ccec82d66b47b567f"
+  },
+  "cpython-3.9.13-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "90e3879382f06fea3ba6d477f0c2a434a1e14cd83d174e1c7b87e2f22bc2e748"
   },
   "cpython-3.9.13-windows-x86_64-none": {
     "name": "cpython",
@@ -4667,6 +4667,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "8dee06c07cc6429df34b6abe091a4684a86f7cec76f5d1ccc1c3ce2bd11168df"
   },
+  "cpython-3.9.12-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "2453ba7f76b3df3310353b48c881d6cff622ba06e30d2b6ae91588b2bc9e481a"
+  },
   "cpython-3.9.12-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4690,30 +4702,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "233e1a9626d9fe13baac8de3689df48401d0ad5da1c2f134ad57d8e3e878a1a5"
-  },
-  "cpython-3.9.12-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "8b7e440137bfa349a008641a75a2b1fd8ae22d290731778a144878a59a721c51"
-  },
-  "cpython-3.9.12-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "2453ba7f76b3df3310353b48c881d6cff622ba06e30d2b6ae91588b2bc9e481a"
   },
   "cpython-3.9.12-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4739,6 +4727,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "dd0eaf7ef64008d4a51a73243f368e0311b7936b0ac18f8d1305fffb0dfb76e6"
   },
+  "cpython-3.9.12-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "8b7e440137bfa349a008641a75a2b1fd8ae22d290731778a144878a59a721c51"
+  },
   "cpython-3.9.12-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4762,6 +4762,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "cf92a28f98c8d884df0937bf19d5f1a40caa25a6a211a237b7e9b592b2b71c2b"
+  },
+  "cpython-3.9.11-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "43889d1a424c84fb155e1619f062adb6984fbde80b6043611790f22bcbeec300"
   },
   "cpython-3.9.11-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4787,30 +4799,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "75ac727631eab002bd120246197a8235145cb90687be181f7a52de6f41d44d34"
   },
-  "cpython-3.9.11-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "ceac8729b285a8c8e861176dd2dadd7f8e7e26d8f64cac6c6226a14d2252cd4c"
-  },
-  "cpython-3.9.11-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "43889d1a424c84fb155e1619f062adb6984fbde80b6043611790f22bcbeec300"
-  },
   "cpython-3.9.11-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4834,6 +4822,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "ae8f55d90ae173f96e81f376daa5a9969a77531a6f7b8eacbe8ad90b41bbca1d"
+  },
+  "cpython-3.9.11-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "ceac8729b285a8c8e861176dd2dadd7f8e7e26d8f64cac6c6226a14d2252cd4c"
   },
   "cpython-3.9.11-windows-x86_64-none": {
     "name": "cpython",
@@ -4859,6 +4859,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "ad66c2a3e7263147e046a32694de7b897a46fb0124409d29d3a93ede631c8aee"
   },
+  "cpython-3.9.10-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "fdaf594142446029e314a9beb91f1ac75af866320b50b8b968181e592550cd68"
+  },
   "cpython-3.9.10-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4882,30 +4894,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "37ba43845c3df9ba012d69121ad29ea7f21ea2f5994a155007cf1560d74ce503"
-  },
-  "cpython-3.9.10-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "56c0342a9af0412676e89cdf7b52ac76037031786b3f5c40942b8b82d366c96f"
-  },
-  "cpython-3.9.10-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "fdaf594142446029e314a9beb91f1ac75af866320b50b8b968181e592550cd68"
   },
   "cpython-3.9.10-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4931,6 +4919,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "30add63ec16e07ad13e19f6d7061f7e4c7b971962354f48ab3e85656ce3b393d"
   },
+  "cpython-3.9.10-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "56c0342a9af0412676e89cdf7b52ac76037031786b3f5c40942b8b82d366c96f"
+  },
   "cpython-3.9.10-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4953,6 +4953,18 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-apple-darwin-install_only-20211017T1616.tar.gz",
+    "sha256": null
+  },
+  "cpython-3.9.7-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
     "sha256": null
   },
   "cpython-3.9.7-linux-aarch64-gnu": {
@@ -4979,30 +4991,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.7-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.7-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
-    "sha256": null
-  },
   "cpython-3.9.7-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5025,6 +5013,18 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.7-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
     "sha256": null
   },
   "cpython-3.9.7-windows-x86_64-none": {
@@ -5051,6 +5051,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-apple-darwin-install_only-20210724T1424.tar.gz",
     "sha256": null
   },
+  "cpython-3.9.6-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-install_only-20210724T1424.tar.gz",
+    "sha256": null
+  },
   "cpython-3.9.6-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5073,30 +5085,6 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.6-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.6-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-install_only-20210724T1424.tar.gz",
     "sha256": null
   },
   "cpython-3.9.6-linux-x86_64-gnu": {
@@ -5123,6 +5111,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.6-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5147,30 +5147,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-aarch64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.5-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.5-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-    "sha256": null
-  },
   "cpython-3.9.5-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5181,6 +5157,18 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.5-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
     "sha256": null
   },
   "cpython-3.9.5-linux-x86_64-gnu": {
@@ -5207,6 +5195,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.5-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5231,30 +5231,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-aarch64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.4-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.4-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-    "sha256": null
-  },
   "cpython-3.9.4-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5265,6 +5241,18 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.4-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
     "sha256": null
   },
   "cpython-3.9.4-linux-x86_64-gnu": {
@@ -5291,6 +5279,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.4-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5313,18 +5313,6 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-aarch64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.3-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-i686-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
     "sha256": null
   },
   "cpython-3.9.3-darwin-x86_64-none": {
@@ -5363,6 +5351,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-musl-lto-20210413T2055.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.3-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-i686-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5387,30 +5387,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-aarch64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
     "sha256": null
   },
-  "cpython-3.9.2-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.2-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-    "sha256": null
-  },
   "cpython-3.9.2-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5421,6 +5397,18 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.9.2-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
     "sha256": null
   },
   "cpython-3.9.2-linux-x86_64-gnu": {
@@ -5447,6 +5435,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.2-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.2-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5457,18 +5457,6 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.1-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
   "cpython-3.9.1-darwin-x86_64-none": {
@@ -5507,6 +5495,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.1-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.1-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5517,18 +5517,6 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.0-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-i686-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
     "sha256": null
   },
   "cpython-3.9.0-darwin-x86_64-none": {
@@ -5567,6 +5555,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
     "sha256": null
   },
+  "cpython-3.9.0-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-i686-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
+    "sha256": null
+  },
   "cpython-3.9.0-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5591,30 +5591,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "30ba44af64e599bde7307908393374bdcd99e185bf9b3c9de3f697f3fbe6bf8f"
   },
-  "cpython-3.8.20-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "75a187ebfab81096e3f3d91d70c1349e64defbdfb0e8a067cb5233d017655e31"
-  },
-  "cpython-3.8.20-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "d829105aaf53a1cadf8738e040c6211bc9bef2c6e4757b972954f0f322d57e7d"
-  },
   "cpython-3.8.20-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5626,6 +5602,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "375b6eead6c852cabbf3ccfd43dc4f6dd4c36381bf74c9a7910acb839fd5c57f"
+  },
+  "cpython-3.8.20-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "75a187ebfab81096e3f3d91d70c1349e64defbdfb0e8a067cb5233d017655e31"
   },
   "cpython-3.8.20-linux-x86_64-gnu": {
     "name": "cpython",
@@ -5651,6 +5639,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "fcddfd3f1090833e1f3106be021809630008b53026bc96dcaab2986625db27fa"
   },
+  "cpython-3.8.20-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "d829105aaf53a1cadf8738e040c6211bc9bef2c6e4757b972954f0f322d57e7d"
+  },
   "cpython-3.8.20-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5675,30 +5675,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "6a15ee2b507aed4d5b15fd1b66fc570aa49183f15aa6c412eccd065446f17d8e"
   },
-  "cpython-3.8.19-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "202211923850303f521146ee1831642aaf357ffeeadbe13a0a91884317227528"
-  },
-  "cpython-3.8.19-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "73bf0135330b96c48ca79ccd6d2f3287a7466573a5fc1b62d982bcdb1d5f0ab3"
-  },
   "cpython-3.8.19-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5710,6 +5686,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
     "sha256": "1a24263b039c1172bd42d74a5694492f3e3dbe4d3e52a1e7cc2856fee7dbee4a"
+  },
+  "cpython-3.8.19-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "202211923850303f521146ee1831642aaf357ffeeadbe13a0a91884317227528"
   },
   "cpython-3.8.19-linux-x86_64-gnu": {
     "name": "cpython",
@@ -5735,6 +5723,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
     "sha256": "6ee6c7469c9d2c7078beb95a9a3a261c42502e0b1603722a0689bdb2e789060c"
   },
+  "cpython-3.8.19-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "73bf0135330b96c48ca79ccd6d2f3287a7466573a5fc1b62d982bcdb1d5f0ab3"
+  },
   "cpython-3.8.19-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5759,30 +5759,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "4d493a1792bf211f37f98404cc1468f09bd781adc2602dea0df82ad264c11abc"
   },
-  "cpython-3.8.18-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "6588c9eed93833d9483d01fe40ac8935f691a1af8e583d404ec7666631b52487"
-  },
-  "cpython-3.8.18-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "c24f9c9e8638cff0ce6aa808a57cc5f22009bc33e3bcf410a726b79d7c5545fe"
-  },
   "cpython-3.8.18-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5794,6 +5770,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
     "sha256": "7d2cd8d289d5e3cdd0a8c06c028c7c621d3d00ce44b7e2f08c1724ae0471c626"
+  },
+  "cpython-3.8.18-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "6588c9eed93833d9483d01fe40ac8935f691a1af8e583d404ec7666631b52487"
   },
   "cpython-3.8.18-linux-x86_64-gnu": {
     "name": "cpython",
@@ -5819,6 +5807,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "e591d3925f88f78a5dffb765fd10b9dab6e497d35cf58169da83eab521c86a37"
   },
+  "cpython-3.8.18-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "c24f9c9e8638cff0ce6aa808a57cc5f22009bc33e3bcf410a726b79d7c5545fe"
+  },
   "cpython-3.8.18-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5842,6 +5842,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "c6f7a130d0044a78e39648f4dae56dcff5a41eba91888a99f6e560507162e6a1"
+  },
+  "cpython-3.8.17-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "155b06821607bae1a58ecc60a7d036b358c766f19e493b8876190765c883a5c2"
   },
   "cpython-3.8.17-linux-aarch64-gnu": {
     "name": "cpython",
@@ -5867,30 +5879,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e580fdd923bbae612334559dc58bd5fd13cce53b769294d63bc88e7c6662f7d9"
   },
-  "cpython-3.8.17-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "cb6af626ba811044e9c5ee09140a6920565d2b1b237a11886b96354a9fcc242e"
-  },
-  "cpython-3.8.17-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "155b06821607bae1a58ecc60a7d036b358c766f19e493b8876190765c883a5c2"
-  },
   "cpython-3.8.17-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5914,6 +5902,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "322b7837cfd8282c62ae3d2f0e98f0843cbe287e4b8c4852b786123f2e13b307"
+  },
+  "cpython-3.8.17-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "cb6af626ba811044e9c5ee09140a6920565d2b1b237a11886b96354a9fcc242e"
   },
   "cpython-3.8.17-windows-x86_64-none": {
     "name": "cpython",
@@ -5939,6 +5939,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "7e484eb6de40d6f6bdfd5099eaa9647f65e45fb6d846ccfc56b1cb1e38b5ab02"
   },
+  "cpython-3.8.16-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "28506e509646c11cb2f57a7203bd1b08b6e8e5b159ae308bd5bb93b0d334bdaf"
+  },
   "cpython-3.8.16-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5962,30 +5974,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "1260fd6af34104bbd57489175e6f7bfea76d4bd06a242a0f8e20e390e870b227"
-  },
-  "cpython-3.8.16-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "77466f93ef5b030cf13d0446067089b0ce0d415cc6d1702655bdbb12a8c18c97"
-  },
-  "cpython-3.8.16-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "28506e509646c11cb2f57a7203bd1b08b6e8e5b159ae308bd5bb93b0d334bdaf"
   },
   "cpython-3.8.16-linux-x86_64-gnu": {
     "name": "cpython",
@@ -6011,6 +5999,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "840aefa3b03b66b6561360735dc0ac4e0a36a3ebb4d1f85d92f5b5f6638953cc"
   },
+  "cpython-3.8.16-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "77466f93ef5b030cf13d0446067089b0ce0d415cc6d1702655bdbb12a8c18c97"
+  },
   "cpython-3.8.16-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6034,6 +6034,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "1e0a92d1a4f5e6d4a99f86b1cbf9773d703fe7fd032590f3e9c285c7a5eeb00a"
+  },
+  "cpython-3.8.15-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "70b57f28c2b5e1e3dd89f0d30edd5bc414e8b20195766cf328e1b26bed7890e1"
   },
   "cpython-3.8.15-linux-aarch64-gnu": {
     "name": "cpython",
@@ -6059,30 +6071,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "3bc1f49147913d93cea9cbb753fbaae90b86f1ee979f975c4712a35f02cbd86b"
   },
-  "cpython-3.8.15-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "318c059324b84b5d7685bcd0874698799d9e3689b51dbcf596e7a47a39a3d49a"
-  },
-  "cpython-3.8.15-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "70b57f28c2b5e1e3dd89f0d30edd5bc414e8b20195766cf328e1b26bed7890e1"
-  },
   "cpython-3.8.15-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6106,6 +6094,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "f767d0438eca5b18c1267c5121055a5808a1412ea7668ef17da3dc9bdd24a55f"
+  },
+  "cpython-3.8.15-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "318c059324b84b5d7685bcd0874698799d9e3689b51dbcf596e7a47a39a3d49a"
   },
   "cpython-3.8.15-windows-x86_64-none": {
     "name": "cpython",
@@ -6131,6 +6131,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "6c17f6dcda59de5d8eee922ef7eede403a540dae05423ef2c2a042d8d4f22467"
   },
+  "cpython-3.8.14-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "3ed4db8d0308c584196d97c629058ea69bbd8b7f9a034cf8c2c701ebb286c091"
+  },
   "cpython-3.8.14-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6154,30 +6166,6 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "d01d813939ad549ca253c52e5b8361b4490cc5c8cbda00ab6e0c524565153e2b"
-  },
-  "cpython-3.8.14-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "a0730f3a9e60581f02bdb852953fbb52cf98e8431259fa39cb668a060bd002a0"
-  },
-  "cpython-3.8.14-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "3ed4db8d0308c584196d97c629058ea69bbd8b7f9a034cf8c2c701ebb286c091"
   },
   "cpython-3.8.14-linux-x86_64-gnu": {
     "name": "cpython",
@@ -6203,6 +6191,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "72c08b1c1d8cc14cb8d22eab18b463bb514ea160472fdc7400bd69ae375cf9c4"
   },
+  "cpython-3.8.14-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "a0730f3a9e60581f02bdb852953fbb52cf98e8431259fa39cb668a060bd002a0"
+  },
   "cpython-3.8.14-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6226,6 +6226,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "ae4131253d890b013171cb5f7b03cadc585ae263719506f7b7e063a7cf6fde76"
+  },
+  "cpython-3.8.13-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
+    "sha256": "cd6e7c0a27daf7df00f6882eaba01490dd963f698e99aeee9706877333e0df69"
   },
   "cpython-3.8.13-linux-aarch64-gnu": {
     "name": "cpython",
@@ -6251,30 +6263,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "9485599ad9053dfba08c91854717272e95b7c81e0d099d9c51a46fc5a095ccb4"
   },
-  "cpython-3.8.13-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "a50668d4c5fbcb374d3ca93ee18db910bc3b462693db073669f31e6da993abf9"
-  },
-  "cpython-3.8.13-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "cd6e7c0a27daf7df00f6882eaba01490dd963f698e99aeee9706877333e0df69"
-  },
   "cpython-3.8.13-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6298,6 +6286,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "2c90a0d048caf146d4c33560d6eead1428a225219018d364b1af77f23c492984"
+  },
+  "cpython-3.8.13-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "a50668d4c5fbcb374d3ca93ee18db910bc3b462693db073669f31e6da993abf9"
   },
   "cpython-3.8.13-windows-x86_64-none": {
     "name": "cpython",
@@ -6323,30 +6323,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-aarch64-apple-darwin-install_only.tar.gz",
     "sha256": "f9a3cbb81e0463d6615125964762d133387d561b226a30199f5b039b20f1d944"
   },
-  "cpython-3.8.12-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "fcb2033f01a2b10a51be68c9a1b4c7d7759b582f58a503371fe67ab59987b418"
-  },
-  "cpython-3.8.12-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "aaa75b9115af73dc3daf7db050ed4f60fd67d2a23ebab30670f18fb8cfa71f33"
-  },
   "cpython-3.8.12-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6358,6 +6334,18 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
     "sha256": "f323fbc558035c13a85ce2267d0fad9e89282268ecb810e364fff1d0a079d525"
+  },
+  "cpython-3.8.12-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
+    "sha256": "fcb2033f01a2b10a51be68c9a1b4c7d7759b582f58a503371fe67ab59987b418"
   },
   "cpython-3.8.12-linux-x86_64-gnu": {
     "name": "cpython",
@@ -6383,6 +6371,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
     "sha256": "27faf8aa62de2cd4e59b75a6edce4cab549eba81f0f9cc21df0e370a8a2f3a25"
   },
+  "cpython-3.8.12-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
+    "sha256": "aaa75b9115af73dc3daf7db050ed4f60fd67d2a23ebab30670f18fb8cfa71f33"
+  },
   "cpython-3.8.12-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6395,30 +6395,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
     "sha256": "4658e08a00d60b1e01559b74d58ff4dd04da6df935d55f6268a15d6d0a679d74"
   },
-  "cpython-3.8.11-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.11-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-    "sha256": null
-  },
   "cpython-3.8.11-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6429,6 +6405,18 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.11-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
     "sha256": null
   },
   "cpython-3.8.11-linux-x86_64-gnu": {
@@ -6455,6 +6443,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.11-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.11-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6467,30 +6467,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.10-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.10-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-    "sha256": null
-  },
   "cpython-3.8.10-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6501,6 +6477,18 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.10-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
     "sha256": null
   },
   "cpython-3.8.10-linux-x86_64-gnu": {
@@ -6527,6 +6515,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.10-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.10-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6539,30 +6539,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.9-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.9-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-    "sha256": null
-  },
   "cpython-3.8.9-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6573,6 +6549,18 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.9-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
     "sha256": null
   },
   "cpython-3.8.9-linux-x86_64-gnu": {
@@ -6599,6 +6587,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.9-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.9-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6611,30 +6611,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
     "sha256": null
   },
-  "cpython-3.8.8-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.8-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-    "sha256": null
-  },
   "cpython-3.8.8-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6645,6 +6621,18 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
+    "sha256": null
+  },
+  "cpython-3.8.8-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
     "sha256": null
   },
   "cpython-3.8.8-linux-x86_64-gnu": {
@@ -6671,6 +6659,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.8-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.8-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6681,18 +6681,6 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.7-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
     "sha256": null
   },
   "cpython-3.8.7-darwin-x86_64-none": {
@@ -6731,6 +6719,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.7-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6741,18 +6741,6 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.6-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-i686-pc-windows-msvc-shared-pgo-20201021T0233.tar.zst",
     "sha256": null
   },
   "cpython-3.8.6-darwin-x86_64-none": {
@@ -6791,6 +6779,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.6-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-i686-pc-windows-msvc-shared-pgo-20201021T0233.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6801,18 +6801,6 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-pc-windows-msvc-shared-pgo-20201021T0232.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.5-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-i686-pc-windows-msvc-shared-pgo-20200830T2311.tar.zst",
     "sha256": null
   },
   "cpython-3.8.5-darwin-x86_64-none": {
@@ -6851,6 +6839,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.5-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-i686-pc-windows-msvc-shared-pgo-20200830T2311.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6861,18 +6861,6 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-x86_64-pc-windows-msvc-shared-pgo-20200830T2254.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.3-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-i686-pc-windows-msvc-shared-pgo-20200518T0154.tar.zst",
     "sha256": null
   },
   "cpython-3.8.3-darwin-x86_64-none": {
@@ -6911,6 +6899,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.3-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-i686-pc-windows-msvc-shared-pgo-20200518T0154.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6921,18 +6921,6 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-pc-windows-msvc-shared-pgo-20200517T2207.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.2-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-i686-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
     "sha256": null
   },
   "cpython-3.8.2-darwin-x86_64-none": {
@@ -6959,6 +6947,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-unknown-linux-gnu-pgo-20200418T2243.tar.zst",
     "sha256": null
   },
+  "cpython-3.8.2-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-i686-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
+    "sha256": null
+  },
   "cpython-3.8.2-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6969,18 +6969,6 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.9-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-i686-pc-windows-msvc-shared-pgo-20200823T0159.tar.zst",
     "sha256": null
   },
   "cpython-3.7.9-darwin-x86_64-none": {
@@ -7019,6 +7007,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
     "sha256": null
   },
+  "cpython-3.7.9-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-i686-pc-windows-msvc-shared-pgo-20200823T0159.tar.zst",
+    "sha256": null
+  },
   "cpython-3.7.9-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7029,18 +7029,6 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-pc-windows-msvc-shared-pgo-20200823T0118.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.7-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-i686-pc-windows-msvc-shared-pgo-20200517T2153.tar.zst",
     "sha256": null
   },
   "cpython-3.7.7-darwin-x86_64-none": {
@@ -7079,6 +7067,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
     "sha256": null
   },
+  "cpython-3.7.7-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-i686-pc-windows-msvc-shared-pgo-20200517T2153.tar.zst",
+    "sha256": null
+  },
   "cpython-3.7.7-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7089,18 +7089,6 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-pc-windows-msvc-shared-pgo-20200517T2128.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.6-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-x86-shared-pgo-20200217T0110.tar.zst",
     "sha256": null
   },
   "cpython-3.7.6-darwin-x86_64-none": {
@@ -7139,6 +7127,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200217/cpython-3.7.6-linux64-musl-20200218T0557.tar.zst",
     "sha256": null
   },
+  "cpython-3.7.6-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-x86-shared-pgo-20200217T0110.tar.zst",
+    "sha256": null
+  },
   "cpython-3.7.6-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7149,18 +7149,6 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-amd64-shared-pgo-20200217T0022.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.5-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-x86-20191025T0549.tar.zst",
     "sha256": null
   },
   "cpython-3.7.5-darwin-x86_64-none": {
@@ -7199,6 +7187,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-linux64-musl-20191026T0603.tar.zst",
     "sha256": null
   },
+  "cpython-3.7.5-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-x86-20191025T0549.tar.zst",
+    "sha256": null
+  },
   "cpython-3.7.5-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7209,18 +7209,6 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-amd64-20191025T0540.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.4-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-x86-20190817T0235.tar.zst",
     "sha256": null
   },
   "cpython-3.7.4-darwin-x86_64-none": {
@@ -7259,6 +7247,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-linux64-musl-20190817T0227.tar.zst",
     "sha256": null
   },
+  "cpython-3.7.4-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-x86-20190817T0235.tar.zst",
+    "sha256": null
+  },
   "cpython-3.7.4-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7269,18 +7269,6 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-amd64-20190817T0227.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.3-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-x86-20190709T0348.tar.zst",
     "sha256": null
   },
   "cpython-3.7.3-darwin-x86_64-none": {
@@ -7319,6 +7307,18 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-linux64-musl-20190618T0400.tar.zst",
     "sha256": null
   },
+  "cpython-3.7.3-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-x86-20190709T0348.tar.zst",
+    "sha256": null
+  },
   "cpython-3.7.3-windows-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7354,6 +7354,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_arm64.tar.bz2",
     "sha256": "a050e25e8d686853dd5afc363e55625165825dacfb55f8753d8225ebe417cfd2"
+  },
+  "pypy-3.10.14-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_x86_64.tar.bz2",
+    "sha256": "6c2c5f2300d7564e711421b4968abd63243cb96f76e363975dd648ebf4a362ee"
   },
   "pypy-3.10.14-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7391,18 +7403,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.16-s390x.tar.bz2",
     "sha256": "af97efe498a209ba18c7bc7d084164a9907fb3736588b6864955177e19d5216a"
   },
-  "pypy-3.10.14-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_x86_64.tar.bz2",
-    "sha256": "6c2c5f2300d7564e711421b4968abd63243cb96f76e363975dd648ebf4a362ee"
-  },
   "pypy-3.10.14-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -7438,6 +7438,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.15-macos_arm64.tar.bz2",
     "sha256": "d927c5105ea7880f7596fe459183e35cc17c853ef5105678b2ad62a8d000a548"
+  },
+  "pypy-3.10.13-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.15-macos_x86_64.tar.bz2",
+    "sha256": "559b61ba7e7c5a5c23cef5370f1fab47ccdb939ac5d2b42b4bef091abe3f6964"
   },
   "pypy-3.10.13-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7475,18 +7487,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.15-s390x.tar.bz2",
     "sha256": "209e57596381e13c9914d1332f359dc4b78de06576739747eb797bdbf85062b8"
   },
-  "pypy-3.10.13-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.15-macos_x86_64.tar.bz2",
-    "sha256": "559b61ba7e7c5a5c23cef5370f1fab47ccdb939ac5d2b42b4bef091abe3f6964"
-  },
   "pypy-3.10.13-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -7522,6 +7522,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.12-macos_arm64.tar.bz2",
     "sha256": "45671b1e9437f95ccd790af10dbeb57733cca1ed9661463b727d3c4f5caa7ba0"
+  },
+  "pypy-3.10.12-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.12-macos_x86_64.tar.bz2",
+    "sha256": "dbc15d8570560d5f79366883c24bc42231a92855ac19a0f28cb0adeb11242666"
   },
   "pypy-3.10.12-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7559,18 +7571,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.12-s390x.tar.bz2",
     "sha256": "043c13a585479428b463ab69575a088db74aadc16798d6e677d97f563585fee3"
   },
-  "pypy-3.10.12-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.12-macos_x86_64.tar.bz2",
-    "sha256": "dbc15d8570560d5f79366883c24bc42231a92855ac19a0f28cb0adeb11242666"
-  },
   "pypy-3.10.12-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -7606,6 +7606,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_arm64.tar.bz2",
     "sha256": "88f824e7a2d676440d09bc90fc959ae0fd3557d7e2f14bfbbe53d41d159a47fe"
+  },
+  "pypy-3.9.19-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_x86_64.tar.bz2",
+    "sha256": "fda015431621e7e5aa16359d114f2c45a77ed936992c1efff86302e768a6b21c"
   },
   "pypy-3.9.19-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7643,18 +7655,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-s390x.tar.bz2",
     "sha256": "7a56ebb27dba3110dc1ff52d8e0449cdb37fe5c2275f7faf11432e4e164833ba"
   },
-  "pypy-3.9.19-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_x86_64.tar.bz2",
-    "sha256": "fda015431621e7e5aa16359d114f2c45a77ed936992c1efff86302e768a6b21c"
-  },
   "pypy-3.9.19-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -7690,6 +7690,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.15-macos_arm64.tar.bz2",
     "sha256": "300541c32125767a91b182b03d9cc4257f04971af32d747ecd4d62549d72acfd"
+  },
+  "pypy-3.9.18-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.15-macos_x86_64.tar.bz2",
+    "sha256": "18ad7c9cb91c5e8ef9d40442b2fd1f6392ae113794c5b6b7d3a45e04f19edec6"
   },
   "pypy-3.9.18-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7727,18 +7739,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.15-s390x.tar.bz2",
     "sha256": "deeb5e54c36a0fd9cfefd16e63a0d5bed4f4a43e6bbc01c23f0ed8f7f1c0aaf3"
   },
-  "pypy-3.9.18-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.15-macos_x86_64.tar.bz2",
-    "sha256": "18ad7c9cb91c5e8ef9d40442b2fd1f6392ae113794c5b6b7d3a45e04f19edec6"
-  },
   "pypy-3.9.18-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -7774,6 +7774,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.12-macos_arm64.tar.bz2",
     "sha256": "0e8a1a3468b9790c734ac698f5b00cc03fc16899ccc6ce876465fac0b83980e3"
+  },
+  "pypy-3.9.17-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.12-macos_x86_64.tar.bz2",
+    "sha256": "64f008ffa070c407e5ef46c8256b2e014de7196ea5d858385861254e7959f4eb"
   },
   "pypy-3.9.17-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7811,18 +7823,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.12-s390x.tar.bz2",
     "sha256": "20d84658a6899bdd2ca35b00ead33a2f56cff2c40dce1af630466d27952f6d4f"
   },
-  "pypy-3.9.17-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.12-macos_x86_64.tar.bz2",
-    "sha256": "64f008ffa070c407e5ef46c8256b2e014de7196ea5d858385861254e7959f4eb"
-  },
   "pypy-3.9.17-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -7858,6 +7858,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.11-macos_arm64.tar.bz2",
     "sha256": "91ad7500f1a39531dbefa0b345a3dcff927ff9971654e8d2e9ef7c5ae311f57e"
+  },
+  "pypy-3.9.16-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.11-macos_x86_64.tar.bz2",
+    "sha256": "d33f40b207099872585afd71873575ca6ea638a27d823bc621238c5ae82542ed"
   },
   "pypy-3.9.16-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7895,18 +7907,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.11-s390x.tar.bz2",
     "sha256": "e1f30f2ddbe3f446ddacd79677b958d56c07463b20171fb2abf8f9a3178b79fc"
   },
-  "pypy-3.9.16-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.11-macos_x86_64.tar.bz2",
-    "sha256": "d33f40b207099872585afd71873575ca6ea638a27d823bc621238c5ae82542ed"
-  },
   "pypy-3.9.16-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -7942,6 +7942,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-macos_arm64.tar.bz2",
     "sha256": "e2a6bec7408e6497c7de8165aa4a1b15e2416aec4a72f2578f793fb06859ccba"
+  },
+  "pypy-3.9.15-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-macos_x86_64.tar.bz2",
+    "sha256": "f90c8619b41e68ec9ffd7d5e913fe02e60843da43d3735b1c1bc75bcfe638d97"
   },
   "pypy-3.9.15-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7979,18 +7991,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-s390x.tar.bz2",
     "sha256": "ca6525a540cf0c682d1592ae35d3fbc97559a97260e4b789255cc76dde7a14f0"
   },
-  "pypy-3.9.15-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-macos_x86_64.tar.bz2",
-    "sha256": "f90c8619b41e68ec9ffd7d5e913fe02e60843da43d3735b1c1bc75bcfe638d97"
-  },
   "pypy-3.9.15-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -8014,6 +8014,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-win64.zip",
     "sha256": "07e18b7b24c74af9730dfaab16e24b22ef94ea9a4b64cbb2c0d80610a381192a"
+  },
+  "pypy-3.9.12-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.9-osx64.tar.bz2",
+    "sha256": "59c8852168b2b1ba1f0211ff043c678760380d2f9faf2f95042a8878554dbc25"
   },
   "pypy-3.9.12-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8051,18 +8063,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.9-s390x.tar.bz2",
     "sha256": "774dca83bcb4403fb99b3d155e7bd572ef8c52b9fe87a657109f64e75ad71732"
   },
-  "pypy-3.9.12-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.9-osx64.tar.bz2",
-    "sha256": "59c8852168b2b1ba1f0211ff043c678760380d2f9faf2f95042a8878554dbc25"
-  },
   "pypy-3.9.12-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -8086,6 +8086,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.9-win64.zip",
     "sha256": "be48ab42f95c402543a7042c999c9433b17e55477c847612c8733a583ca6dff5"
+  },
+  "pypy-3.9.10-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-osx64.tar.bz2",
+    "sha256": "95bd88ac8d6372cd5b7b5393de7b7d5c615a0c6e42fdb1eb67f2d2d510965aee"
   },
   "pypy-3.9.10-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8123,18 +8135,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-s390x.tar.bz2",
     "sha256": "37b596bfe76707ead38ffb565629697e9b6fa24e722acc3c632b41ec624f5d95"
   },
-  "pypy-3.9.10-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-osx64.tar.bz2",
-    "sha256": "95bd88ac8d6372cd5b7b5393de7b7d5c615a0c6e42fdb1eb67f2d2d510965aee"
-  },
   "pypy-3.9.10-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -8170,6 +8170,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.11-macos_arm64.tar.bz2",
     "sha256": "78cdc79ff964c4bfd13eb45a7d43a011cbe8d8b513323d204891f703fdc4fa1a"
+  },
+  "pypy-3.8.16-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.11-macos_x86_64.tar.bz2",
+    "sha256": "194ca0b4d91ae409a9cb1a59eb7572d7affa8a451ea3daf26539aa515443433a"
   },
   "pypy-3.8.16-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8207,18 +8219,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.11-s390x.tar.bz2",
     "sha256": "eab7734d86d96549866f1cba67f4f9c73c989f6a802248beebc504080d4c3fcd"
   },
-  "pypy-3.8.16-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.11-macos_x86_64.tar.bz2",
-    "sha256": "194ca0b4d91ae409a9cb1a59eb7572d7affa8a451ea3daf26539aa515443433a"
-  },
   "pypy-3.8.16-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -8254,6 +8254,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-macos_arm64.tar.bz2",
     "sha256": "6cb1429371e4854b718148a509d80143f801e3abfc72fef58d88aeeee1e98f9e"
+  },
+  "pypy-3.8.15-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-macos_x86_64.tar.bz2",
+    "sha256": "399eb1ce4c65f62f6a096b7c273536601b7695e3c0dc0457393a659b95b7615b"
   },
   "pypy-3.8.15-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8291,18 +8303,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-s390x.tar.bz2",
     "sha256": "c294f8e815158388628fe77ac5b8ad6cd93c8db1359091fa02d41cf6da4d61a1"
   },
-  "pypy-3.8.15-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-macos_x86_64.tar.bz2",
-    "sha256": "399eb1ce4c65f62f6a096b7c273536601b7695e3c0dc0457393a659b95b7615b"
-  },
   "pypy-3.8.15-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -8326,6 +8326,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-win64.zip",
     "sha256": "362dd624d95bd64743190ea2539b97452ecb3d53ea92ceb2fbe9f48dc60e6b8f"
+  },
+  "pypy-3.8.13-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.9-osx64.tar.bz2",
+    "sha256": "91a5c2c1facd5a4931a8682b7d792f7cf4f2ba25cd2e7e44e982139a6d5e4840"
   },
   "pypy-3.8.13-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8363,18 +8375,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.9-s390x.tar.bz2",
     "sha256": "c6177a0016c9145c7b99fddb5d74cc2e518ccdb216a6deb51ef6a377510cc930"
   },
-  "pypy-3.8.13-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.9-osx64.tar.bz2",
-    "sha256": "91a5c2c1facd5a4931a8682b7d792f7cf4f2ba25cd2e7e44e982139a6d5e4840"
-  },
   "pypy-3.8.13-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -8398,6 +8398,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.9-win64.zip",
     "sha256": "05022baaa55db2b60880f2422312d9e4025e1267303ac57f33e8253559d0be88"
+  },
+  "pypy-3.8.12-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 8,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-osx64.tar.bz2",
+    "sha256": "de1b283ff112d76395c0162a1cf11528e192bdc230ee3f1b237f7694c7518dee"
   },
   "pypy-3.8.12-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8435,18 +8447,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-s390x.tar.bz2",
     "sha256": "ad53d373d6e275a41ca64da7d88afb6a17e48e7bfb2a6fff92daafdc06da6b90"
   },
-  "pypy-3.8.12-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-osx64.tar.bz2",
-    "sha256": "de1b283ff112d76395c0162a1cf11528e192bdc230ee3f1b237f7694c7518dee"
-  },
   "pypy-3.8.12-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -8470,6 +8470,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-win64.zip",
     "sha256": "0894c468e7de758c509a602a28ef0ba4fbf197ccdf946c7853a7283d9bb2a345"
+  },
+  "pypy-3.7.13-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.9-osx64.tar.bz2",
+    "sha256": "12d92f578a200d50959e55074b20f29f93c538943e9a6e6522df1a1cc9cef542"
   },
   "pypy-3.7.13-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8507,18 +8519,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.9-s390x.tar.bz2",
     "sha256": "fcab3b9e110379948217cf592229542f53c33bfe881006f95ce30ac815a6df48"
   },
-  "pypy-3.7.13-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.9-osx64.tar.bz2",
-    "sha256": "12d92f578a200d50959e55074b20f29f93c538943e9a6e6522df1a1cc9cef542"
-  },
   "pypy-3.7.13-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -8542,6 +8542,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.9-win64.zip",
     "sha256": "8acb184b48fb3c854de0662e4d23a66b90e73b1ab73a86695022c12c745d8b00"
+  },
+  "pypy-3.7.12-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-osx64.tar.bz2",
+    "sha256": "76b8eef5b059a7e478f525615482d2a6e9feb83375e3f63c16381d80521a693f"
   },
   "pypy-3.7.12-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8579,18 +8591,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-s390x.tar.bz2",
     "sha256": "5c2cd3f7cf04cb96f6bcc6b02e271f5d7275867763978e66651b8d1605ef3141"
   },
-  "pypy-3.7.12-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-osx64.tar.bz2",
-    "sha256": "76b8eef5b059a7e478f525615482d2a6e9feb83375e3f63c16381d80521a693f"
-  },
   "pypy-3.7.12-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -8614,6 +8614,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-win64.zip",
     "sha256": "96df67492bc8d62b2e71dddf5f6c58965a26cac9799c5f4081401af0494b3bcc"
+  },
+  "pypy-3.7.10-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.5-osx64.tar.bz2",
+    "sha256": "b3a7d3099ad83de7c267bb79ae609d5ce73b01800578ffd91ba7e221b13f80db"
   },
   "pypy-3.7.10-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8651,18 +8663,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.5-s390x.tar.bz2",
     "sha256": "dffdf5d73613be2c6809dc1a3cf3ee6ac2f3af015180910247ff24270b532ed5"
   },
-  "pypy-3.7.10-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.5-osx64.tar.bz2",
-    "sha256": "b3a7d3099ad83de7c267bb79ae609d5ce73b01800578ffd91ba7e221b13f80db"
-  },
   "pypy-3.7.10-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -8686,6 +8686,18 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.5-win64.zip",
     "sha256": "072bd22427178dc4e65d961f50281bd2f56e11c4e4d9f16311c703f69f46ae24"
+  },
+  "pypy-3.7.9-darwin-x86_64-none": {
+    "name": "pypy",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-osx64.tar.bz2",
+    "sha256": "d72b27d5bb60813273f14f07378a08822186a66e216c5d1a768ad295b582438d"
   },
   "pypy-3.7.9-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8711,18 +8723,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-linux32.tar.bz2",
     "sha256": "7d81b8e9fcd07c067cfe2f519ab770ec62928ee8787f952cadf2d2786246efc8"
   },
-  "pypy-3.7.9-windows-i686-none": {
-    "name": "pypy",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-win32.zip",
-    "sha256": "a282ce40aa4f853e877a5dbb38f0a586a29e563ae9ba82fd50c7e5dc465fb649"
-  },
   "pypy-3.7.9-linux-s390x-gnu": {
     "name": "pypy",
     "arch": "s390x",
@@ -8735,18 +8735,6 @@
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-s390x.tar.bz2",
     "sha256": "92000d90b9a37f2e9cb7885f2a872adfa9e48e74bf7f84a8b8185c8181f0502d"
   },
-  "pypy-3.7.9-darwin-x86_64-none": {
-    "name": "pypy",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-osx64.tar.bz2",
-    "sha256": "d72b27d5bb60813273f14f07378a08822186a66e216c5d1a768ad295b582438d"
-  },
   "pypy-3.7.9-linux-x86_64-gnu": {
     "name": "pypy",
     "arch": "x86_64",
@@ -8758,5 +8746,17 @@
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-linux64.tar.bz2",
     "sha256": "37e2804c4661c86c857d709d28c7de716b000d31e89766599fdf5a98928b7096"
+  },
+  "pypy-3.7.9-windows-i686-none": {
+    "name": "pypy",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 7,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-win32.zip",
+    "sha256": "a282ce40aa4f853e877a5dbb38f0a586a29e563ae9ba82fd50c7e5dc465fb649"
   }
 }

--- a/crates/uv-python/fetch-download-metadata.py
+++ b/crates/uv-python/fetch-download-metadata.py
@@ -73,8 +73,8 @@ def batched(iterable: Iterable, n: int) -> Generator[tuple, None, None]:
 
 
 class PlatformTriple(NamedTuple):
-    arch: str
     platform: str
+    arch: str
     libc: str
 
 
@@ -335,7 +335,7 @@ class CPythonFinder(Finder):
             logging.debug("Skipping %r: unknown triple", triple)
             return None
 
-        return PlatformTriple(arch, operating_system, libc)
+        return PlatformTriple(operating_system, arch, libc)
 
     def _normalize_arch(self, arch: str) -> str:
         arch = self.ARCH_MAP.get(arch, arch)
@@ -410,8 +410,8 @@ class PyPyFinder(Finder):
                 download = PythonDownload(
                     version=python_version,
                     triple=PlatformTriple(
-                        arch=arch,
                         platform=platform,
+                        arch=arch,
                         libc=libc,
                     ),
                     flavor="",

--- a/crates/uv-python/src/downloads.inc
+++ b/crates/uv-python/src/downloads.inc
@@ -27,6 +27,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Cow::Borrowed("rc3"),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("0f5f9fcf82093c428b80c552165544439f4adcdbe5129ecf721d619e532e9b5e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Cow::Borrowed("rc3"),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -69,20 +83,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Cow::Borrowed("rc3"),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("873905b3e5e8cba700126e8d6ed28ad3aef0dd102f730f8ca196018477dd2da6")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Cow::Borrowed("rc3"),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -103,20 +103,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("2769182e58b0dddec15222bfeecbd4b12fde61c38f23a90aa942514f3545fb9b")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Cow::Borrowed("rc3"),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("0f5f9fcf82093c428b80c552165544439f4adcdbe5129ecf721d619e532e9b5e")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -153,6 +139,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Cow::Borrowed("rc3"),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("873905b3e5e8cba700126e8d6ed28ad3aef0dd102f730f8ca196018477dd2da6")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Cow::Borrowed("rc3"),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -173,6 +173,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("9e17f9fcc314a5dd489089a7502a525c4dd08af862f9cf33b52161a752f2a5b7")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Cow::Borrowed("rc2"),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("971668ac7f3168efc4d2b589e9d36247ab8ca9f9525c56c8aa7bfd374060105b")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -223,20 +237,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Cow::Borrowed("rc2"),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("759f600b27a6a0ef2638cb02e8bbcc6de726dd1c896759f78da3e412f6c992e9")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Cow::Borrowed("rc2"),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -257,20 +257,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("50a2080e30d1504e76e5471e46830f0b4974c66b538ed8ec7df416975133ff89")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: Cow::Borrowed("rc2"),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("971668ac7f3168efc4d2b589e9d36247ab8ca9f9525c56c8aa7bfd374060105b")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -307,6 +293,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Cow::Borrowed("rc2"),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("759f600b27a6a0ef2638cb02e8bbcc6de726dd1c896759f78da3e412f6c992e9")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: Cow::Borrowed("rc2"),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -327,6 +327,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("473c8745464e2b20477bb4faa2e0de51b6fadae68ecd79ca7951df2d15c1b214")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 7,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("acc9294db71a23be6ca947b039b1fc5be40638d2ab212034dba37abe4df9f53b")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -377,20 +391,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("e55a74a174295a5fc32b0c3da07ef100bf27a99b381ed4e60f8bf981459eb63f")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 7,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -411,20 +411,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("dde181a2d7bcad9239b47d2e416f2fa0b0022052955227ab980ef6ca84a400c4")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 7,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("acc9294db71a23be6ca947b039b1fc5be40638d2ab212034dba37abe4df9f53b")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -461,6 +447,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.12.7%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("e55a74a174295a5fc32b0c3da07ef100bf27a99b381ed4e60f8bf981459eb63f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 7,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -481,6 +481,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("0419bafa4444a5aa0c554197bce0679e7cc0f28edc7ee8cfbe0ccea860bdb904")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 6,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("b10d19eb5548a3b3b0a5e6f9109834d7ecfc139bc15754f81a94d39eaa5bdd26")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -531,20 +545,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("d87275e613632ab738528fe20a94a7193e824e91ba7f1e7845e7fcfc1f114900")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 6,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -565,20 +565,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("89be19666ecb7cdbbfd596e462d690a78a380f1fe5c2967b25a1779b0cec9339")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 6,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("b10d19eb5548a3b3b0a5e6f9109834d7ecfc139bc15754f81a94d39eaa5bdd26")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -615,6 +601,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("d87275e613632ab738528fe20a94a7193e824e91ba7f1e7845e7fcfc1f114900")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 6,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -635,6 +635,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("90715cdab075e5a2680acf2695572d165b6269bdb5d1942ab577491478aea55f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 5,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("49a9f7ad41d62e0ece9e664ca5ae95f022e7b68eef48e8a6f11620ec9247c686")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -685,20 +699,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("b1009d46b87330c099d02411ca5e9e333f13305c5abdbe20810a7c467cedb051")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 5,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -719,20 +719,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("2b6ea3a5242de99574191ee42df864756eca6d7cb1dbd4cd7ab2850ba8b828f8")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 5,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("49a9f7ad41d62e0ece9e664ca5ae95f022e7b68eef48e8a6f11620ec9247c686")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -769,6 +755,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("b1009d46b87330c099d02411ca5e9e333f13305c5abdbe20810a7c467cedb051")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 5,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -789,6 +789,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("ef6948e836f531bd7a58ffbe602803ff1c83c65f99d1da19be369ea61f136c93")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 4,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("9d68cbdd12d1d6f98d35cc76add232c12db75c6b7f49733bffc88e7b1c025a79")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -839,20 +853,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("ff0fab24f38c22130e45b90b7ec10dc4ce9677b545d9fb9109a72d2ffbab7b02")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 4,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -873,20 +873,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("b2fd015ab3689e024de6fbb34a4942acdb54c2184d1963e22829aafa1d81ba2c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 4,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("9d68cbdd12d1d6f98d35cc76add232c12db75c6b7f49733bffc88e7b1c025a79")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -923,6 +909,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("ff0fab24f38c22130e45b90b7ec10dc4ce9677b545d9fb9109a72d2ffbab7b02")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 4,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -943,6 +943,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("ccc40e5af329ef2af81350db2a88bbd6c17b56676e82d62048c15d548401519e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 3,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -993,20 +1007,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-i686-pc-windows-msvc-install_only.tar.gz",
-        sha256: Some("bd723ad1aa05551627715a428660250f0e74db0f1421b03f399235772057ef55")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 3,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -1027,20 +1027,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("872fc321363b8cdd826fd2cb1adfd1ceb813bc1281f9d410c1c2c4e177e8df86")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 3,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1077,6 +1063,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-i686-pc-windows-msvc-install_only.tar.gz",
+        sha256: Some("bd723ad1aa05551627715a428660250f0e74db0f1421b03f399235772057ef55")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 3,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -1105,12 +1105,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
-        sha256: Some("e52550379e7c4ac27a87de832d172658bc04150e4e27d4e858e6d8cbb96fd709")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("a53a6670a202c96fec0b8c55ccc780ea3af5307eb89268d5b41a9775b109c094")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1119,12 +1119,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("1e919365f3e04eb111283f7a45d32eac2f327287ab7bf46720d5629e144cbff9")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("e52550379e7c4ac27a87de832d172658bc04150e4e27d4e858e6d8cbb96fd709")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1162,20 +1162,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("a53a6670a202c96fec0b8c55ccc780ea3af5307eb89268d5b41a9775b109c094")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 2,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -1195,6 +1181,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("b428b4151c70b85339ac2659e5f69f7e47142d34a506e05ecd095efe2e3dec81")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 2,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("1e919365f3e04eb111283f7a45d32eac2f327287ab7bf46720d5629e144cbff9")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1231,12 +1231,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
-        sha256: Some("236533ef20e665007a111c2f36efb59c87ae195ad7dca223b6dc03fb07064f0b")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("eca96158c1568dedd9a0b3425375637a83764d1fa74446438293089a8bfac1f8")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1245,12 +1245,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("13c8a6f337a4e1ef043ffb8ea3c218ab2073afe0d3be36fcdf8ceb6f757210e8")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("236533ef20e665007a111c2f36efb59c87ae195ad7dca223b6dc03fb07064f0b")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1288,20 +1288,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("eca96158c1568dedd9a0b3425375637a83764d1fa74446438293089a8bfac1f8")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 1,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -1321,6 +1307,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("876389f071d62ee9a4bdd7ce31e69c3cdd256fe498e4dd6bb2b80e674e7351fe")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 1,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("13c8a6f337a4e1ef043ffb8ea3c218ab2073afe0d3be36fcdf8ceb6f757210e8")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1357,12 +1357,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
-        sha256: Some("bccfe67cf5465a3dfb0336f053966e2613a9bc85a6588c2fcf1366ef930c4f88")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("5a9e88c8aa52b609d556777b52ebde464ae4b4f77e4aac4eb693af57395c9abf")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1371,12 +1371,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("6e4f30a998245cfaef00d1b87f8fd5f6c250bd222f933f8f38f124d4f03227f9")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("bccfe67cf5465a3dfb0336f053966e2613a9bc85a6588c2fcf1366ef930c4f88")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1414,20 +1414,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("5a9e88c8aa52b609d556777b52ebde464ae4b4f77e4aac4eb693af57395c9abf")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 12,
-            patch: 0,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -1447,6 +1433,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("922f9404f39dc4edb8558a93cef5c3330895a4c87acb1de2a2cf662ab942dbe5")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 12,
+            patch: 0,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("6e4f30a998245cfaef00d1b87f8fd5f6c250bd222f933f8f38f124d4f03227f9")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1475,6 +1475,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("263b1b50ff705ab064c50c3165de9df2ed712a77cd81c55dd340c3172e103687")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 10,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("a8174aef8a662201d1bb4680571cf383e89f5b44dc06614df5928595ddf82876")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1525,20 +1539,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("4840b2fb1d421a38d8ffabf80350093e4283a67e85e67ba8285170b44b371ad9")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 10,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -1559,20 +1559,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("317320957770a4cdbe42f3810a67685045e1cd82adf545948ec64d9d566d0c4f")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 10,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("a8174aef8a662201d1bb4680571cf383e89f5b44dc06614df5928595ddf82876")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1609,6 +1595,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.11.10%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("4840b2fb1d421a38d8ffabf80350093e4283a67e85e67ba8285170b44b371ad9")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 10,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -1629,6 +1629,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("c4e2f7774421bcb381245945e132419b529399dfa4a56059acda1493751fa377")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 9,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("c8680f90137e36b54b3631271ccdfe5de363e7d563d8df87c53e11b956a00e04")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1679,20 +1693,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("091c99a210f4f401a305231f3f218ee3d5714658b8d3aac344d34efc716dff85")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 9,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -1713,20 +1713,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("30c71053e9360471b7f350f1562ff4e42eb91ad2ca61b391295b5dea8b2b9efd")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 9,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("c8680f90137e36b54b3631271ccdfe5de363e7d563d8df87c53e11b956a00e04")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1763,6 +1749,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("091c99a210f4f401a305231f3f218ee3d5714658b8d3aac344d34efc716dff85")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 9,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -1791,12 +1791,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
-        sha256: Some("389b9005fb78dd5a6f68df5ea45ab7b30d9a4b3222af96999e94fd20d4ad0c6a")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("097f467b0c36706bfec13f199a2eaf924e668f70c6e2bd1f1366806962f7e86e")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1805,12 +1805,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("75039951f8f94d7304bc17b674af1668b9e1ea6d6c9ba1da28e90c0ad8030e3c")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("389b9005fb78dd5a6f68df5ea45ab7b30d9a4b3222af96999e94fd20d4ad0c6a")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1848,20 +1848,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("097f467b0c36706bfec13f199a2eaf924e668f70c6e2bd1f1366806962f7e86e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 8,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -1881,6 +1867,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("08e1ebf51b5965e23f8e68664d17274c1cdabb5b2d7509a2003920e5d58172c7")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 8,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("75039951f8f94d7304bc17b674af1668b9e1ea6d6c9ba1da28e90c0ad8030e3c")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1917,12 +1917,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
-        sha256: Some("b102eaf865eb715aa98a8a2ef19037b6cc3ae7dfd4a632802650f29de635aa13")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("a0e615eef1fafdc742da0008425a9030b7ea68a4ae4e73ac557ef27b112836d4")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1931,12 +1931,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("f5a6ca1280749d8ceaf8851585ef6b0cd2f1f76e801a77c1d744019554eef2f0")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("b102eaf865eb715aa98a8a2ef19037b6cc3ae7dfd4a632802650f29de635aa13")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -1974,20 +1974,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("a0e615eef1fafdc742da0008425a9030b7ea68a4ae4e73ac557ef27b112836d4")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 7,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -2007,6 +1993,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("1a919a35172eb9419eba841eeb0ec9879dbc2b006b284ee5c454c08197b50f74")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 7,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("f5a6ca1280749d8ceaf8851585ef6b0cd2f1f76e801a77c1d744019554eef2f0")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2043,12 +2043,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
-        sha256: Some("3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2057,12 +2057,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("dd48b2cfaae841b4cd9beed23e2ae68b13527a065ef3d271d228735769c4e64d")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2100,20 +2100,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 6,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -2133,6 +2119,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("c929e5fe676ad20afcf6807a797d21261ae0827e84ec18742031a9582aed0d46")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 6,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("dd48b2cfaae841b4cd9beed23e2ae68b13527a065ef3d271d228735769c4e64d")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2169,6 +2169,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("4a4efa7378c72f1dd8ebcce1afb99b24c01b07023aa6b8fea50eaedb50bf2bfc")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 5,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -2189,20 +2203,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("82de7e2551c015145c017742a5c0411d67a7544595df43c02b5efa4762d5123e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 5,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("936b624c2512a3a3370aae8adf603d6ae71ba8ebd39cc4714a13306891ea36f0")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2240,20 +2240,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("4a4efa7378c72f1dd8ebcce1afb99b24c01b07023aa6b8fea50eaedb50bf2bfc")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 5,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -2273,6 +2259,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("fe09ecd87f69a724acf26ca508d7ead91a951abb2da18dfb98fe22c284454121")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 5,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("936b624c2512a3a3370aae8adf603d6ae71ba8ebd39cc4714a13306891ea36f0")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2309,6 +2309,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 4,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -2329,20 +2343,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("abdccc6ec7093f49da99680f5899a96bff0b96fde8f5d73f7aac121e0d05fdd8")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 4,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("e2f4b41c3d89c5ec735e2563d752856cb3c19a0aa712ec7ef341712bafa7e905")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2380,20 +2380,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 4,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -2413,6 +2399,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("1218ca44595aeaf34271508db64a2abc581c3ee1eb307c1b0537ea746922b806")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 4,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("e2f4b41c3d89c5ec735e2563d752856cb3c19a0aa712ec7ef341712bafa7e905")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2449,6 +2449,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("f710b8d60621308149c100d5175fec39274ed0b9c99645484fd93d1716ef4310")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 3,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -2477,40 +2491,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("a6751e6fa5c7c4d4748ed534a7f00ad7f858f62ce73d63d44dd907036ba53985")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 3,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("767d24f3570b35fedb945f5ac66224c8983f2d556ab83c5cfaa5f3666e9c212c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 3,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("f710b8d60621308149c100d5175fec39274ed0b9c99645484fd93d1716ef4310")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2547,6 +2533,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("a6751e6fa5c7c4d4748ed534a7f00ad7f858f62ce73d63d44dd907036ba53985")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 3,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -2567,6 +2567,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("4918cdf1cab742a90f85318f88b8122aeaa2d04705803c7b6e78e81a3dd40f80")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 1,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2603,34 +2617,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("50b250dd261c3cca9ae8d96cb921e4ffbc64f778a198b6f8b8b0a338f77ae486")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 1,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 11,
-            patch: 1,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -2659,6 +2645,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("50b250dd261c3cca9ae8d96cb921e4ffbc64f778a198b6f8b8b0a338f77ae486")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 11,
+            patch: 1,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -2679,6 +2679,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("1f753073b2333b2977922387fe016255ebde0f8558c567ffb960b7f50477fd34")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 15,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("18dd6c0c219da1ec7daede9da923205594dbdc7f37a283873363b4634a5e3f8f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2729,20 +2743,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("29ea71edc4899061a9c3d2fd85773c1ae5d353ea9cb39c3d6b3e4c2a9bf4fda0")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 15,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -2763,20 +2763,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("14f8ed8e42db2296723f3e64e30e24ce2e27fc36534dcb77f474c8edb1fde872")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 15,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("18dd6c0c219da1ec7daede9da923205594dbdc7f37a283873363b4634a5e3f8f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2813,6 +2799,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.10.15%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("29ea71edc4899061a9c3d2fd85773c1ae5d353ea9cb39c3d6b3e4c2a9bf4fda0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 15,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -2833,6 +2833,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("f7ca9bffbce433c8d445edd33a5424c405553d735efee65a2fc5d8bbb1c8e137")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 14,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("4404f44ec69c0708d4d88e98f39c2c1fe3bd462dc6a958b60aaf63028550c485")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2883,20 +2897,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("a84742f13584fd39f4f4b0d9a5865621a3c88cad91b31f17f414186719063364")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 14,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -2917,20 +2917,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("ff1c4f010b1c6f563c71fa30f68293168536e0ed65f7d470a7e8c73252d08653")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 14,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("4404f44ec69c0708d4d88e98f39c2c1fe3bd462dc6a958b60aaf63028550c485")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -2967,6 +2953,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("a84742f13584fd39f4f4b0d9a5865621a3c88cad91b31f17f414186719063364")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 14,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -2995,6 +2995,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 13,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -3015,20 +3029,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("424d239b6df60e40849ad18505de394001233ab3d7470b5280fec6e643208bb9")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 13,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("5365b90f9cba7186d12dd86516ece8b696db7311128e0b49c92234e01a74599f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3066,20 +3066,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 13,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -3099,6 +3085,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("48365ea10aa1b0768a153bfff50d1515a757d42409b02a4af4db354803f2d180")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 13,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("5365b90f9cba7186d12dd86516ece8b696db7311128e0b49c92234e01a74599f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3135,6 +3135,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("8a6e3ed973a671de468d9c691ed9cb2c3a4858c5defffcf0b08969fba9c1dd04")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 12,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -3155,20 +3169,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("c7a5321a696ef6467791312368a04d36828907a8f5c557b96067fa534c716c18")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 12,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("a5a5f9c9082b6503462a6b134111d3c303052cbc49ff31fff2ade38b39978e5d")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3206,20 +3206,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("8a6e3ed973a671de468d9c691ed9cb2c3a4858c5defffcf0b08969fba9c1dd04")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 12,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -3239,6 +3225,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("9080014bee2d4bd1f96bcbebf447d40c35ae9354382246add1160bd0d433ebf7")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 12,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("a5a5f9c9082b6503462a6b134111d3c303052cbc49ff31fff2ade38b39978e5d")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3275,6 +3275,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("bd3fc6e4da6f4033ebf19d66704e73b0804c22641ddae10bbe347c48f82374ad")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 11,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -3303,40 +3317,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("e4ed3414cd0e687017f0a56fed88ff39b3f5dfb24a0d62e9c7ca55854178bcde")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 11,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("73a9d4c89ed51be39dd2de4e235078281087283e9fdedef65bec02f503e906ee")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 11,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("bd3fc6e4da6f4033ebf19d66704e73b0804c22641ddae10bbe347c48f82374ad")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3373,6 +3359,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("e4ed3414cd0e687017f0a56fed88ff39b3f5dfb24a0d62e9c7ca55854178bcde")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 11,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -3393,6 +3393,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("018d05a779b2de7a476f3b3ff2d10f503d69d14efcedd0774e6dab8c22ef84ff")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 9,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("0e685f98dce0e5bc8da93c7081f4e6c10219792e223e4b5886730fd73a7ba4c6")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3429,34 +3443,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("c5c51d9a3e8d8cdac67d8f3ad7c4008de169ff1480e17021f154d5c99fcee9e3")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 9,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("0e685f98dce0e5bc8da93c7081f4e6c10219792e223e4b5886730fd73a7ba4c6")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 9,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -3477,6 +3463,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("cf17e6d042777170e423c6b80e096ad8273d9848708875db0d23dd45bdb3d516")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 9,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("c5c51d9a3e8d8cdac67d8f3ad7c4008de169ff1480e17021f154d5c99fcee9e3")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3513,6 +3513,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("525b79c7ce5de90ab66bd07b0ac1008bafa147ddc8a41bef15ffb7c9c1e9e7c5")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 8,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -3533,34 +3547,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("2deee7cbbd5dad339d713a75ec92239725d2035e833af5b9981b026dee0b9213")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 8,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("94e76273166f72624128e52b5402db244cea041dab4a6bcdc70b304b66e27e95")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 8,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("525b79c7ce5de90ab66bd07b0ac1008bafa147ddc8a41bef15ffb7c9c1e9e7c5")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3597,6 +3583,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("94e76273166f72624128e52b5402db244cea041dab4a6bcdc70b304b66e27e95")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 8,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -3617,6 +3617,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("70f6ca1da8e6fce832ad0b7f9fdaba0b84ba0ac0a4c626127acb6d49df4b8f91")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 7,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("6101f580434544d28d5590543029a7c6bdf07efa4bcdb5e4cbedb3cd83241922")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3653,34 +3667,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("384e711dd657c3439be4e50b2485478a7ed7a259a741d4480fc96d82cc09d318")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 7,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("6101f580434544d28d5590543029a7c6bdf07efa4bcdb5e4cbedb3cd83241922")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 7,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -3701,6 +3687,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("3e0cab6e49ad5ef95851049463797ec713eee6e1f2fa1d99e30516d37797c3f0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 7,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("384e711dd657c3439be4e50b2485478a7ed7a259a741d4480fc96d82cc09d318")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3737,6 +3737,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("7718411adf3ea1480f3f018a643eb0550282aefe39e5ecb3f363a4a566a9398c")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 6,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -3757,34 +3771,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b152801a2609e6a38f3cc9e7e21d8b6cf5b6f31dacfcaca01e162c514e851ed6")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 6,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("27f22babf29ceebae18b2c2e38e2c48d22de686688c8a31c5f8d7d51541583c1")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 6,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("7718411adf3ea1480f3f018a643eb0550282aefe39e5ecb3f363a4a566a9398c")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3821,6 +3807,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("27f22babf29ceebae18b2c2e38e2c48d22de686688c8a31c5f8d7d51541583c1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 6,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -3841,6 +3841,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("19d1aa4a6d9ddb0094fc36961b129de9abe1673bce66c86cd97b582795c496a8")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 5,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("eca0584397d9a3ef6f7bb32b0476318b01c89b7b0a031ef97a0dcaa5ba5127a8")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3877,34 +3891,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("2846e9c7e8484034989ab218022009fdd9dcb12a7bfb4b0329a404552d37e9aa")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 5,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("eca0584397d9a3ef6f7bb32b0476318b01c89b7b0a031ef97a0dcaa5ba5127a8")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 5,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -3925,6 +3911,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("6aad42c7b03989173dd0e4d066e8c1e9f176f4b31d5bde26dbb5297f38f656d0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 5,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("2846e9c7e8484034989ab218022009fdd9dcb12a7bfb4b0329a404552d37e9aa")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -3961,6 +3961,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("c4a57a13b084d49ce8c2eb5b2662ee45b0c55b08ddd696f473233b0787f03988")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 4,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -3981,34 +3995,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("f3bc0828a0e0a8974e3fe90b4e99549296a7578de2321d791be1bad28191921d")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 4,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("e1dfa5dde910f908cad8bd688b29d28df832f7b150555679c204580d1af0c4a6")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 4,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("c4a57a13b084d49ce8c2eb5b2662ee45b0c55b08ddd696f473233b0787f03988")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4045,6 +4031,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("e1dfa5dde910f908cad8bd688b29d28df832f7b150555679c204580d1af0c4a6")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 4,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -4065,6 +4065,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("db46dadfccc407aa1f66ed607eefbf12f781e343adcb1edee0a3883d081292ce")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 3,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("ec2e90b6a589db7ef9f74358b1436558167629f9e4d725c8150496f9cb08a9d4")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4101,34 +4115,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("bb7f2a5143010fa482c5b442cced85516696cfc416ca92c903ef374532401a33")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 3,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("ec2e90b6a589db7ef9f74358b1436558167629f9e4d725c8150496f9cb08a9d4")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 3,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -4149,6 +4135,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("a60b589176879bdd465659660b87e954f969bed072c03c578ec828d6134f4ae1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 3,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("bb7f2a5143010fa482c5b442cced85516696cfc416ca92c903ef374532401a33")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4185,6 +4185,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("8146ad4390710ec69b316a5649912df0247d35f4a42e2aa9615bffd87b3e235a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 2,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -4205,34 +4219,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("4fa49dab83bf82409816db431806525ce894280a509ca96c91e3efc9beed1fea")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 2,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("5321f8c2c71239b1e2002d284be8ec825d4a6f95cd921e58db71f259834b7aa1")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 2,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("8146ad4390710ec69b316a5649912df0247d35f4a42e2aa9615bffd87b3e235a")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4269,6 +4255,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("5321f8c2c71239b1e2002d284be8ec825d4a6f95cd921e58db71f259834b7aa1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 2,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -4288,6 +4288,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-apple-darwin-install_only-20211017T1616.tar.gz",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 0,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
         sha256: None
     },
     ManagedPythonDownload {
@@ -4325,34 +4339,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 0,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 0,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -4372,6 +4358,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             libc: Libc::Some(target_lexicon::Environment::Musl),
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 0,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -4401,6 +4401,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("02c376d7a931c7a4575158e8908978ec7686cd11ba93a0df1770858974f53822")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 20,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("dddb504549d27beb7ee39e88a9a9db72ac890df987d890edc5fa7310179ebe9f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4451,20 +4465,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("ef91a17d8f81b3b744be5bfbbd1531963fcfc4798832aae2ac1f8d093354bfee")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 20,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -4485,20 +4485,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("88dfa9a5d9ded872716a8bccc7092bbd8a32519c1eaa17799fea45ddc3da19dd")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 20,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("dddb504549d27beb7ee39e88a9a9db72ac890df987d890edc5fa7310179ebe9f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4535,6 +4521,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.9.20%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("ef91a17d8f81b3b744be5bfbbd1531963fcfc4798832aae2ac1f8d093354bfee")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 20,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -4555,6 +4555,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("451582f8a6a8c15ef35a327afcdbf8d03b1ebba7192e90d850d092dac91f91c6")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 19,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
+        sha256: Some("ebaf4336d0cbff4466c994d5bcaa92a38c91d06694d0cd675ec663259d5f37c7")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4605,20 +4619,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("1c78c6dd763e6d583c3c3f917544bc4446d0e9fbe2b6e206042fa801ff9fb9ab")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 19,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -4639,20 +4639,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("b41f834311532ee9dcf76cad3cdeda285d0e283de2182ce9870c37c40970cdd3")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 19,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-        sha256: Some("ebaf4336d0cbff4466c994d5bcaa92a38c91d06694d0cd675ec663259d5f37c7")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4689,6 +4675,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("1c78c6dd763e6d583c3c3f917544bc4446d0e9fbe2b6e206042fa801ff9fb9ab")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 19,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -4717,6 +4717,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("171d8b472fce0295be0e28bb702c43d5a2a39feccb3e72efe620ac3843c3e402")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 18,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -4737,20 +4751,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("10c422080317886057e968010495037ba65731ab7653bcaeabadf67a6fa5e99e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 18,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("904ff5d2f6402640e2b7e2b12075af0bd75b3e8685cc5248fd2a3cda3105d2a8")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4788,20 +4788,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("171d8b472fce0295be0e28bb702c43d5a2a39feccb3e72efe620ac3843c3e402")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 18,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -4821,6 +4807,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("cb47455810ae63d98501b3bb4fcdfdb9924633fb2e86e62d77e523a3bdee44ba")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 18,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("904ff5d2f6402640e2b7e2b12075af0bd75b3e8685cc5248fd2a3cda3105d2a8")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4857,6 +4857,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("dfe1bea92c94b9cb779288b0b06e39157c5ff7e465cdd24032ac147c2af485c0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 17,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -4877,20 +4891,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("aed29a64c835444c2f1aff83c55b14123114d74c54d96493a0eabfdd8c6d012c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 17,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("09f9d4bc66be5e0df2dfd1dc4742923e46c271f8f085178696c77073477aa0c1")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4928,20 +4928,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("dfe1bea92c94b9cb779288b0b06e39157c5ff7e465cdd24032ac147c2af485c0")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 17,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -4961,6 +4947,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("194316e9cc7add1dd12be3e3eea2908fd4d623799edd7df69e360c6a446b750d")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 17,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("09f9d4bc66be5e0df2dfd1dc4742923e46c271f8f085178696c77073477aa0c1")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4997,6 +4997,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 16,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -5025,40 +5039,12 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("219532ffa49af88e3b90e9135cf3b6e1fa11cf165b03098fb9776a07af8ca6d0")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 16,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ff3ac35c58f67839aff9b5185a976abd3d1abbe61af02089f7105e876c1fe284")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 16,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5095,6 +5081,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("219532ffa49af88e3b90e9135cf3b6e1fa11cf165b03098fb9776a07af8ca6d0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 16,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -5115,6 +5115,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("64dc7e1013481c9864152c3dd806c41144c79d5e9cd3140e185c6a5060bdc9ab")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 15,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("f2bcade6fc976c472f18f2b3204d67202d43ae55cf6f9e670f95e488f780da08")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5151,34 +5165,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("0b81089247f258f244e9792daaa03675da6f58597daa6913e82f2679862238dd")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 15,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("f2bcade6fc976c472f18f2b3204d67202d43ae55cf6f9e670f95e488f780da08")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 15,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -5199,6 +5185,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("81b1c76ac789521fcececdcdc643f6de6fc282083b1a36a9973d835fc8a39391")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 15,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("0b81089247f258f244e9792daaa03675da6f58597daa6913e82f2679862238dd")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5235,6 +5235,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("b7d3a1f4b57e9350571ccee49c82f503133de0d113a2dbaebc8ccf108fb3fe1b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 14,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -5255,34 +5269,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("3af1c255110c2f42ed0b7957502c92edf8b5c5e6fc5f699a2475bf8a560325c0")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 14,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("f3526e8416be86ff9091750ebc7388d6726acf32cc5ab0e6a60c67c6aacb2569")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 14,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("b7d3a1f4b57e9350571ccee49c82f503133de0d113a2dbaebc8ccf108fb3fe1b")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5319,6 +5305,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("f3526e8416be86ff9091750ebc7388d6726acf32cc5ab0e6a60c67c6aacb2569")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 14,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -5339,6 +5339,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("d9603edc296a2dcbc59d7ada780fd12527f05c3e0b99f7545112daf11636d6e5")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 13,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("9540a7efb7c8a54a48aff1cb9480e49588d9c0a3f934ad53f5b167338174afa3")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5375,34 +5389,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("90e3879382f06fea3ba6d477f0c2a434a1e14cd83d174e1c7b87e2f22bc2e748")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 13,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("9540a7efb7c8a54a48aff1cb9480e49588d9c0a3f934ad53f5b167338174afa3")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 13,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -5423,6 +5409,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("766ed7e805e8c7abc4e50f1c94814575e7978ed7bd1f9e9ccec82d66b47b567f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 13,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("90e3879382f06fea3ba6d477f0c2a434a1e14cd83d174e1c7b87e2f22bc2e748")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5459,6 +5459,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("2453ba7f76b3df3310353b48c881d6cff622ba06e30d2b6ae91588b2bc9e481a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 12,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -5479,34 +5493,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("233e1a9626d9fe13baac8de3689df48401d0ad5da1c2f134ad57d8e3e878a1a5")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 12,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("8b7e440137bfa349a008641a75a2b1fd8ae22d290731778a144878a59a721c51")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 12,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("2453ba7f76b3df3310353b48c881d6cff622ba06e30d2b6ae91588b2bc9e481a")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5543,6 +5529,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("8b7e440137bfa349a008641a75a2b1fd8ae22d290731778a144878a59a721c51")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 12,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -5563,6 +5563,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("cf92a28f98c8d884df0937bf19d5f1a40caa25a6a211a237b7e9b592b2b71c2b")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 11,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("43889d1a424c84fb155e1619f062adb6984fbde80b6043611790f22bcbeec300")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5599,34 +5613,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("ceac8729b285a8c8e861176dd2dadd7f8e7e26d8f64cac6c6226a14d2252cd4c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 11,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("43889d1a424c84fb155e1619f062adb6984fbde80b6043611790f22bcbeec300")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 11,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -5647,6 +5633,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("ae8f55d90ae173f96e81f376daa5a9969a77531a6f7b8eacbe8ad90b41bbca1d")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 11,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("ceac8729b285a8c8e861176dd2dadd7f8e7e26d8f64cac6c6226a14d2252cd4c")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5683,6 +5683,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("fdaf594142446029e314a9beb91f1ac75af866320b50b8b968181e592550cd68")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 10,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -5703,34 +5717,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("37ba43845c3df9ba012d69121ad29ea7f21ea2f5994a155007cf1560d74ce503")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 10,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("56c0342a9af0412676e89cdf7b52ac76037031786b3f5c40942b8b82d366c96f")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 10,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("fdaf594142446029e314a9beb91f1ac75af866320b50b8b968181e592550cd68")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -5767,6 +5753,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("56c0342a9af0412676e89cdf7b52ac76037031786b3f5c40942b8b82d366c96f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 10,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -5786,6 +5786,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-apple-darwin-install_only-20211017T1616.tar.gz",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 7,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
         sha256: None
     },
     ManagedPythonDownload {
@@ -5823,34 +5837,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 7,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 7,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -5870,6 +5856,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             libc: Libc::Some(target_lexicon::Environment::Musl),
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 7,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -5907,6 +5907,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-install_only-20210724T1424.tar.gz",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 6,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -5926,34 +5940,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 6,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 6,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-install_only-20210724T1424.tar.gz",
         sha256: None
     },
     ManagedPythonDownload {
@@ -5991,6 +5977,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 6,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -6019,39 +6019,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 5,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 5,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 5,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -6089,6 +6075,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 5,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -6117,39 +6117,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 4,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 4,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 4,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -6187,6 +6173,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 4,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -6206,20 +6206,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-aarch64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 3,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-i686-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -6271,6 +6257,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-i686-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 3,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -6299,39 +6299,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 2,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 2,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 2,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -6369,25 +6355,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 9,
-            patch: 1,
+            patch: 2,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -6439,25 +6425,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 1,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 9,
-            patch: 0,
+            patch: 1,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-i686-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -6509,6 +6495,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-i686-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 0,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -6537,40 +6537,26 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-        sha256: Some("75a187ebfab81096e3f3d91d70c1349e64defbdfb0e8a067cb5233d017655e31")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 20,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("d829105aaf53a1cadf8738e040c6211bc9bef2c6e4757b972954f0f322d57e7d")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 20,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("375b6eead6c852cabbf3ccfd43dc4f6dd4c36381bf74c9a7910acb839fd5c57f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 20,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("75a187ebfab81096e3f3d91d70c1349e64defbdfb0e8a067cb5233d017655e31")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6607,6 +6593,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 20,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("d829105aaf53a1cadf8738e040c6211bc9bef2c6e4757b972954f0f322d57e7d")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 20,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -6635,40 +6635,26 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-        sha256: Some("202211923850303f521146ee1831642aaf357ffeeadbe13a0a91884317227528")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 19,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("73bf0135330b96c48ca79ccd6d2f3287a7466573a5fc1b62d982bcdb1d5f0ab3")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 19,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("1a24263b039c1172bd42d74a5694492f3e3dbe4d3e52a1e7cc2856fee7dbee4a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 19,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+        sha256: Some("202211923850303f521146ee1831642aaf357ffeeadbe13a0a91884317227528")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6705,6 +6691,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 19,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("73bf0135330b96c48ca79ccd6d2f3287a7466573a5fc1b62d982bcdb1d5f0ab3")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 19,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -6733,40 +6733,26 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
-        sha256: Some("6588c9eed93833d9483d01fe40ac8935f691a1af8e583d404ec7666631b52487")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 18,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("c24f9c9e8638cff0ce6aa808a57cc5f22009bc33e3bcf410a726b79d7c5545fe")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 18,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("7d2cd8d289d5e3cdd0a8c06c028c7c621d3d00ce44b7e2f08c1724ae0471c626")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 18,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("6588c9eed93833d9483d01fe40ac8935f691a1af8e583d404ec7666631b52487")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6803,6 +6789,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 18,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("c24f9c9e8638cff0ce6aa808a57cc5f22009bc33e3bcf410a726b79d7c5545fe")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 18,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -6823,6 +6823,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("c6f7a130d0044a78e39648f4dae56dcff5a41eba91888a99f6e560507162e6a1")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 17,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("155b06821607bae1a58ecc60a7d036b358c766f19e493b8876190765c883a5c2")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6859,34 +6873,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 17,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("cb6af626ba811044e9c5ee09140a6920565d2b1b237a11886b96354a9fcc242e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 17,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("155b06821607bae1a58ecc60a7d036b358c766f19e493b8876190765c883a5c2")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 17,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -6907,6 +6893,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("322b7837cfd8282c62ae3d2f0e98f0843cbe287e4b8c4852b786123f2e13b307")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 17,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("cb6af626ba811044e9c5ee09140a6920565d2b1b237a11886b96354a9fcc242e")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6943,6 +6943,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("28506e509646c11cb2f57a7203bd1b08b6e8e5b159ae308bd5bb93b0d334bdaf")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 16,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -6963,34 +6977,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("1260fd6af34104bbd57489175e6f7bfea76d4bd06a242a0f8e20e390e870b227")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 16,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("77466f93ef5b030cf13d0446067089b0ce0d415cc6d1702655bdbb12a8c18c97")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 16,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("28506e509646c11cb2f57a7203bd1b08b6e8e5b159ae308bd5bb93b0d334bdaf")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7027,6 +7013,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 16,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("77466f93ef5b030cf13d0446067089b0ce0d415cc6d1702655bdbb12a8c18c97")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 16,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -7047,6 +7047,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("1e0a92d1a4f5e6d4a99f86b1cbf9773d703fe7fd032590f3e9c285c7a5eeb00a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 15,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("70b57f28c2b5e1e3dd89f0d30edd5bc414e8b20195766cf328e1b26bed7890e1")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7083,34 +7097,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 15,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("318c059324b84b5d7685bcd0874698799d9e3689b51dbcf596e7a47a39a3d49a")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 15,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("70b57f28c2b5e1e3dd89f0d30edd5bc414e8b20195766cf328e1b26bed7890e1")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 15,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -7131,6 +7117,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("f767d0438eca5b18c1267c5121055a5808a1412ea7668ef17da3dc9bdd24a55f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 15,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("318c059324b84b5d7685bcd0874698799d9e3689b51dbcf596e7a47a39a3d49a")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7167,6 +7167,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("3ed4db8d0308c584196d97c629058ea69bbd8b7f9a034cf8c2c701ebb286c091")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 14,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -7187,34 +7201,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("d01d813939ad549ca253c52e5b8361b4490cc5c8cbda00ab6e0c524565153e2b")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 14,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("a0730f3a9e60581f02bdb852953fbb52cf98e8431259fa39cb668a060bd002a0")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 14,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("3ed4db8d0308c584196d97c629058ea69bbd8b7f9a034cf8c2c701ebb286c091")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7251,6 +7237,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 14,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("a0730f3a9e60581f02bdb852953fbb52cf98e8431259fa39cb668a060bd002a0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 14,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -7271,6 +7271,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("ae4131253d890b013171cb5f7b03cadc585ae263719506f7b7e063a7cf6fde76")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 13,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
+        sha256: Some("cd6e7c0a27daf7df00f6882eaba01490dd963f698e99aeee9706877333e0df69")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7307,34 +7321,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 13,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("a50668d4c5fbcb374d3ca93ee18db910bc3b462693db073669f31e6da993abf9")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 13,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
-        sha256: Some("cd6e7c0a27daf7df00f6882eaba01490dd963f698e99aeee9706877333e0df69")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 13,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -7355,6 +7341,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("2c90a0d048caf146d4c33560d6eead1428a225219018d364b1af77f23c492984")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 13,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("a50668d4c5fbcb374d3ca93ee18db910bc3b462693db073669f31e6da993abf9")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7391,40 +7391,26 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
-        sha256: Some("fcb2033f01a2b10a51be68c9a1b4c7d7759b582f58a503371fe67ab59987b418")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 12,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
-        sha256: Some("aaa75b9115af73dc3daf7db050ed4f60fd67d2a23ebab30670f18fb8cfa71f33")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 12,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("f323fbc558035c13a85ce2267d0fad9e89282268ecb810e364fff1d0a079d525")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 12,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
+        sha256: Some("fcb2033f01a2b10a51be68c9a1b4c7d7759b582f58a503371fe67ab59987b418")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -7461,6 +7447,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 12,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
+        sha256: Some("aaa75b9115af73dc3daf7db050ed4f60fd67d2a23ebab30670f18fb8cfa71f33")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 12,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -7475,39 +7475,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 11,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 11,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 11,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -7545,6 +7531,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 11,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 11,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -7559,39 +7559,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 10,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 10,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 10,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -7629,6 +7615,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 10,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 10,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -7643,39 +7643,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 9,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 9,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 9,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -7713,6 +7699,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 9,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -7727,39 +7727,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 8,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 8,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 8,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -7797,25 +7783,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 8,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 8,
-            patch: 7,
+            patch: 8,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -7867,25 +7853,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 8,
-            patch: 6,
+            patch: 7,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-i686-pc-windows-msvc-shared-pgo-20201021T0233.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -7937,25 +7923,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-pc-windows-msvc-shared-pgo-20201021T0232.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-i686-pc-windows-msvc-shared-pgo-20201021T0233.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 8,
-            patch: 5,
+            patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-i686-pc-windows-msvc-shared-pgo-20200830T2311.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-pc-windows-msvc-shared-pgo-20201021T0232.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -8007,25 +7993,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-x86_64-pc-windows-msvc-shared-pgo-20200830T2254.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-i686-pc-windows-msvc-shared-pgo-20200830T2311.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 8,
-            patch: 3,
+            patch: 5,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-i686-pc-windows-msvc-shared-pgo-20200518T0154.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-x86_64-pc-windows-msvc-shared-pgo-20200830T2254.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -8077,25 +8063,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-pc-windows-msvc-shared-pgo-20200517T2207.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-i686-pc-windows-msvc-shared-pgo-20200518T0154.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 8,
-            patch: 2,
+            patch: 3,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-i686-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-pc-windows-msvc-shared-pgo-20200517T2207.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -8133,25 +8119,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 2,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-i686-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
-            minor: 7,
-            patch: 9,
+            minor: 8,
+            patch: 2,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-i686-pc-windows-msvc-shared-pgo-20200823T0159.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -8203,25 +8189,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-pc-windows-msvc-shared-pgo-20200823T0118.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-i686-pc-windows-msvc-shared-pgo-20200823T0159.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 7,
-            patch: 7,
+            patch: 9,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-i686-pc-windows-msvc-shared-pgo-20200517T2153.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-pc-windows-msvc-shared-pgo-20200823T0118.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -8273,25 +8259,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 7,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-pc-windows-msvc-shared-pgo-20200517T2128.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-i686-pc-windows-msvc-shared-pgo-20200517T2153.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 7,
-            patch: 6,
+            patch: 7,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-x86-shared-pgo-20200217T0110.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-pc-windows-msvc-shared-pgo-20200517T2128.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -8343,25 +8329,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-amd64-shared-pgo-20200217T0022.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-x86-shared-pgo-20200217T0110.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 7,
-            patch: 5,
+            patch: 6,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-x86-20191025T0549.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-amd64-shared-pgo-20200217T0022.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -8413,25 +8399,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 5,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-amd64-20191025T0540.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-x86-20191025T0549.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 7,
-            patch: 4,
+            patch: 5,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-x86-20190817T0235.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-amd64-20191025T0540.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -8483,25 +8469,25 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 4,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-amd64-20190817T0227.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-x86-20190817T0235.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
             major: 3,
             minor: 7,
-            patch: 3,
+            patch: 4,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-x86-20190709T0348.tar.zst",
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-amd64-20190817T0227.tar.zst",
         sha256: None
     },
     ManagedPythonDownload {
@@ -8553,6 +8539,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 3,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-x86-20190709T0348.tar.zst",
+        sha256: None
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 7,
+            patch: 3,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
@@ -8587,6 +8587,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_arm64.tar.bz2",
         sha256: Some("a050e25e8d686853dd5afc363e55625165825dacfb55f8753d8225ebe417cfd2")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 14,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_x86_64.tar.bz2",
+        sha256: Some("6c2c5f2300d7564e711421b4968abd63243cb96f76e363975dd648ebf4a362ee")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8638,20 +8652,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_x86_64.tar.bz2",
-        sha256: Some("6c2c5f2300d7564e711421b4968abd63243cb96f76e363975dd648ebf4a362ee")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 14,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -8685,6 +8685,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.15-macos_arm64.tar.bz2",
         sha256: Some("d927c5105ea7880f7596fe459183e35cc17c853ef5105678b2ad62a8d000a548")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 13,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.10-v7.3.15-macos_x86_64.tar.bz2",
+        sha256: Some("559b61ba7e7c5a5c23cef5370f1fab47ccdb939ac5d2b42b4bef091abe3f6964")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8736,20 +8750,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.10-v7.3.15-macos_x86_64.tar.bz2",
-        sha256: Some("559b61ba7e7c5a5c23cef5370f1fab47ccdb939ac5d2b42b4bef091abe3f6964")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 13,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -8783,6 +8783,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.12-macos_arm64.tar.bz2",
         sha256: Some("45671b1e9437f95ccd790af10dbeb57733cca1ed9661463b727d3c4f5caa7ba0")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 10,
+            patch: 12,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.10-v7.3.12-macos_x86_64.tar.bz2",
+        sha256: Some("dbc15d8570560d5f79366883c24bc42231a92855ac19a0f28cb0adeb11242666")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8834,20 +8848,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.10-v7.3.12-macos_x86_64.tar.bz2",
-        sha256: Some("dbc15d8570560d5f79366883c24bc42231a92855ac19a0f28cb0adeb11242666")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 12,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -8881,6 +8881,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_arm64.tar.bz2",
         sha256: Some("88f824e7a2d676440d09bc90fc959ae0fd3557d7e2f14bfbbe53d41d159a47fe")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 19,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_x86_64.tar.bz2",
+        sha256: Some("fda015431621e7e5aa16359d114f2c45a77ed936992c1efff86302e768a6b21c")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8932,20 +8946,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_x86_64.tar.bz2",
-        sha256: Some("fda015431621e7e5aa16359d114f2c45a77ed936992c1efff86302e768a6b21c")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 19,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -8979,6 +8979,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.15-macos_arm64.tar.bz2",
         sha256: Some("300541c32125767a91b182b03d9cc4257f04971af32d747ecd4d62549d72acfd")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 18,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.15-macos_x86_64.tar.bz2",
+        sha256: Some("18ad7c9cb91c5e8ef9d40442b2fd1f6392ae113794c5b6b7d3a45e04f19edec6")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9030,20 +9044,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.15-macos_x86_64.tar.bz2",
-        sha256: Some("18ad7c9cb91c5e8ef9d40442b2fd1f6392ae113794c5b6b7d3a45e04f19edec6")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 18,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -9077,6 +9077,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.12-macos_arm64.tar.bz2",
         sha256: Some("0e8a1a3468b9790c734ac698f5b00cc03fc16899ccc6ce876465fac0b83980e3")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 17,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.12-macos_x86_64.tar.bz2",
+        sha256: Some("64f008ffa070c407e5ef46c8256b2e014de7196ea5d858385861254e7959f4eb")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9128,20 +9142,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.12-macos_x86_64.tar.bz2",
-        sha256: Some("64f008ffa070c407e5ef46c8256b2e014de7196ea5d858385861254e7959f4eb")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 17,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -9175,6 +9175,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.11-macos_arm64.tar.bz2",
         sha256: Some("91ad7500f1a39531dbefa0b345a3dcff927ff9971654e8d2e9ef7c5ae311f57e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 16,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.11-macos_x86_64.tar.bz2",
+        sha256: Some("d33f40b207099872585afd71873575ca6ea638a27d823bc621238c5ae82542ed")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9226,20 +9240,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.11-macos_x86_64.tar.bz2",
-        sha256: Some("d33f40b207099872585afd71873575ca6ea638a27d823bc621238c5ae82542ed")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 16,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -9273,6 +9273,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.10-macos_arm64.tar.bz2",
         sha256: Some("e2a6bec7408e6497c7de8165aa4a1b15e2416aec4a72f2578f793fb06859ccba")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 15,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.10-macos_x86_64.tar.bz2",
+        sha256: Some("f90c8619b41e68ec9ffd7d5e913fe02e60843da43d3735b1c1bc75bcfe638d97")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9324,20 +9338,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.10-macos_x86_64.tar.bz2",
-        sha256: Some("f90c8619b41e68ec9ffd7d5e913fe02e60843da43d3735b1c1bc75bcfe638d97")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 15,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -9357,6 +9357,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.10-win64.zip",
         sha256: Some("07e18b7b24c74af9730dfaab16e24b22ef94ea9a4b64cbb2c0d80610a381192a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 12,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.9-osx64.tar.bz2",
+        sha256: Some("59c8852168b2b1ba1f0211ff043c678760380d2f9faf2f95042a8878554dbc25")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9408,20 +9422,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.9-osx64.tar.bz2",
-        sha256: Some("59c8852168b2b1ba1f0211ff043c678760380d2f9faf2f95042a8878554dbc25")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 12,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -9441,6 +9441,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.9-win64.zip",
         sha256: Some("be48ab42f95c402543a7042c999c9433b17e55477c847612c8733a583ca6dff5")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 9,
+            patch: 10,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.8-osx64.tar.bz2",
+        sha256: Some("95bd88ac8d6372cd5b7b5393de7b7d5c615a0c6e42fdb1eb67f2d2d510965aee")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9492,20 +9506,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.9-v7.3.8-osx64.tar.bz2",
-        sha256: Some("95bd88ac8d6372cd5b7b5393de7b7d5c615a0c6e42fdb1eb67f2d2d510965aee")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 10,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -9539,6 +9539,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.11-macos_arm64.tar.bz2",
         sha256: Some("78cdc79ff964c4bfd13eb45a7d43a011cbe8d8b513323d204891f703fdc4fa1a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 16,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.8-v7.3.11-macos_x86_64.tar.bz2",
+        sha256: Some("194ca0b4d91ae409a9cb1a59eb7572d7affa8a451ea3daf26539aa515443433a")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9590,20 +9604,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.8-v7.3.11-macos_x86_64.tar.bz2",
-        sha256: Some("194ca0b4d91ae409a9cb1a59eb7572d7affa8a451ea3daf26539aa515443433a")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 16,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -9637,6 +9637,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.10-macos_arm64.tar.bz2",
         sha256: Some("6cb1429371e4854b718148a509d80143f801e3abfc72fef58d88aeeee1e98f9e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 15,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.8-v7.3.10-macos_x86_64.tar.bz2",
+        sha256: Some("399eb1ce4c65f62f6a096b7c273536601b7695e3c0dc0457393a659b95b7615b")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9688,20 +9702,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.8-v7.3.10-macos_x86_64.tar.bz2",
-        sha256: Some("399eb1ce4c65f62f6a096b7c273536601b7695e3c0dc0457393a659b95b7615b")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 15,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -9721,6 +9721,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.10-win64.zip",
         sha256: Some("362dd624d95bd64743190ea2539b97452ecb3d53ea92ceb2fbe9f48dc60e6b8f")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 13,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.8-v7.3.9-osx64.tar.bz2",
+        sha256: Some("91a5c2c1facd5a4931a8682b7d792f7cf4f2ba25cd2e7e44e982139a6d5e4840")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9772,20 +9786,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.8-v7.3.9-osx64.tar.bz2",
-        sha256: Some("91a5c2c1facd5a4931a8682b7d792f7cf4f2ba25cd2e7e44e982139a6d5e4840")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 13,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -9805,6 +9805,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.9-win64.zip",
         sha256: Some("05022baaa55db2b60880f2422312d9e4025e1267303ac57f33e8253559d0be88")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 8,
+            patch: 12,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.8-v7.3.8-osx64.tar.bz2",
+        sha256: Some("de1b283ff112d76395c0162a1cf11528e192bdc230ee3f1b237f7694c7518dee")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9856,20 +9870,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.8-v7.3.8-osx64.tar.bz2",
-        sha256: Some("de1b283ff112d76395c0162a1cf11528e192bdc230ee3f1b237f7694c7518dee")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 12,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -9889,6 +9889,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.8-win64.zip",
         sha256: Some("0894c468e7de758c509a602a28ef0ba4fbf197ccdf946c7853a7283d9bb2a345")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 7,
+            patch: 13,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.9-osx64.tar.bz2",
+        sha256: Some("12d92f578a200d50959e55074b20f29f93c538943e9a6e6522df1a1cc9cef542")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -9940,20 +9954,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.9-osx64.tar.bz2",
-        sha256: Some("12d92f578a200d50959e55074b20f29f93c538943e9a6e6522df1a1cc9cef542")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 13,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -9973,6 +9973,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.9-win64.zip",
         sha256: Some("8acb184b48fb3c854de0662e4d23a66b90e73b1ab73a86695022c12c745d8b00")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 7,
+            patch: 12,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.8-osx64.tar.bz2",
+        sha256: Some("76b8eef5b059a7e478f525615482d2a6e9feb83375e3f63c16381d80521a693f")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10024,20 +10038,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.8-osx64.tar.bz2",
-        sha256: Some("76b8eef5b059a7e478f525615482d2a6e9feb83375e3f63c16381d80521a693f")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 12,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -10057,6 +10057,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.8-win64.zip",
         sha256: Some("96df67492bc8d62b2e71dddf5f6c58965a26cac9799c5f4081401af0494b3bcc")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 7,
+            patch: 10,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.5-osx64.tar.bz2",
+        sha256: Some("b3a7d3099ad83de7c267bb79ae609d5ce73b01800578ffd91ba7e221b13f80db")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10108,20 +10122,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.5-osx64.tar.bz2",
-        sha256: Some("b3a7d3099ad83de7c267bb79ae609d5ce73b01800578ffd91ba7e221b13f80db")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 10,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
@@ -10141,6 +10141,20 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.5-win64.zip",
         sha256: Some("072bd22427178dc4e65d961f50281bd2f56e11c4e4d9f16311c703f69f46ae24")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 7,
+            patch: 9,
+            prerelease: Cow::Borrowed(""),
+            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+        },
+        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-osx64.tar.bz2",
+        sha256: Some("d72b27d5bb60813273f14f07378a08822186a66e216c5d1a768ad295b582438d")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10177,20 +10191,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-win32.zip",
-        sha256: Some("a282ce40aa4f853e877a5dbb38f0a586a29e563ae9ba82fd50c7e5dc465fb649")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 9,
-            prerelease: Cow::Borrowed(""),
-            implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
@@ -10206,11 +10206,11 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
             arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
         },
-        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-osx64.tar.bz2",
-        sha256: Some("d72b27d5bb60813273f14f07378a08822186a66e216c5d1a768ad295b582438d")
+        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-linux64.tar.bz2",
+        sha256: Some("37e2804c4661c86c857d709d28c7de716b000d31e89766599fdf5a98928b7096")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -10219,11 +10219,11 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 9,
             prerelease: Cow::Borrowed(""),
             implementation: LenientImplementationName::Known(ImplementationName::PyPy),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
         },
-        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-linux64.tar.bz2",
-        sha256: Some("37e2804c4661c86c857d709d28c7de716b000d31e89766599fdf5a98928b7096")
+        url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-win32.zip",
+        sha256: Some("a282ce40aa4f853e877a5dbb38f0a586a29e563ae9ba82fd50c7e5dc465fb649")
     },
 ];


### PR DESCRIPTION
## Summary

PythonDownloadKey (cpython-3.13.0rc3-darwin-aarch64-none) and PlatformTriple in `fetch-download-metadata.py` have a slight inconsistency in the ordering of `os` and `arch`. In PythonDownloadKey, `os` precedes `arch`, while in PlatformTriple, `arch` comes before `platform` (equivalent to os). This difference in ordering affects the sorting logic, giving arch higher priority than platform in the `download-metadata.json` file, leading to a little bit of unexpected order of entries.

Before:
<img width="676" alt="image" src="https://github.com/user-attachments/assets/adb24a2e-da70-4a09-a702-4b5d71600b2c">
After:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/c6c76e6a-d3fd-43dc-bfb0-b3a4a3fe2b6b">

