### PR TITLE
Implement build backend metadata

### DIFF
--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -358,7 +358,6 @@ impl PyProjectToml {
             }
         }
 
-        // TODO(konsti): https://peps.python.org/pep-0753/#label-normalization (Draft)
         let project_urls = self
             .project
             .urls


### PR DESCRIPTION
Implements https://peps.python.org/pep-0753/#label-normalization

Note that the PEP is currently in draft state.