### PR TITLE
Fix documentation (projects guide) regarding adding a git dependency

### DIFF
--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -124,7 +124,7 @@ $ # Specify a version constraint
 $ uv add 'requests==2.31.0'
 
 $ # Add a git dependency
-$ uv add requests --git https://github.com/psf/requests
+$ uv add git+https://github.com/psf/requests
 ```
 
 To remove a package, you can use `uv remove`:


### PR DESCRIPTION
## Summary

This is a trivial, one line documentation change that fixes the following documentation bug.

The current documentation suggests this for adding a git dependency

```
# Add a git dependency

uv add requests --git https://github.com/psf/requests
```

Executing what is suggested with `uv` version `0.4.18` results in this error message

```
uv add requests --git https://github.com/psf/requests
error: unexpected argument '--git' found
```

The working approach is to add the git depency like this:

```
uv add git+https://github.com/psf/requests
```

## Test Plan

I manually tested the command suggested currently in the guide against my change.
 