### PR TITLE
Add `pyenv-virtualenv` compatybility

### DIFF
--- a/crates/uv-python/src/discovery.rs
+++ b/crates/uv-python/src/discovery.rs
@@ -1309,6 +1309,16 @@ impl PythonRequest {
         if let Ok(request) = PythonDownloadRequest::from_str(value) {
             return Self::Key(request);
         }
+        // Check if the value is current active pyenv virtualenv
+        // It mean that name is end of path provided by PYENV_VIRTUAL_ENV variable
+        if let Some(pyenv_virtual_env) = std::env::var_os("PYENV_VIRTUAL_ENV") {
+            if let Some(pyenv_virtual_env) = pyenv_virtual_env.to_str() {
+                if value == Path::new(pyenv_virtual_env).file_name().unwrap().to_str().unwrap() {
+                    return Self::Directory(PathBuf::from(pyenv_virtual_env));
+                }
+            }
+        }
+
         // Finally, we'll treat it as the name of an executable (i.e. in the search PATH)
         // e.g. foo.exe
         Self::ExecutableName(value.to_string())

--- a/crates/uv-python/src/version_files.rs
+++ b/crates/uv-python/src/version_files.rs
@@ -70,6 +70,7 @@ impl PythonVersionFile {
                         let trimmed = line.trim();
                         !(trimmed.is_empty() || trimmed.starts_with('#'))
                     })
+                    .flat_map(|line| line.split_whitespace())
                     .map(ToString::to_string)
                     .map(|version| PythonRequest::parse(&version))
                     .collect();


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I'm using pyenv with pyenv-virtualenv for my daily workflow. 
Currently, `uv pip` nice works as a replacement of pip, however, try to use `uvx` or `uv build` it ends with error message 

```
error: No interpreter found for executable name `partsegcore` in virtual environments, managed installations, or system path
```

This PR is fixing this 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I tested it locally.

<!-- How was it tested? -->
