### PR TITLE
Add upgrade note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,23 +58,14 @@ $ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 $ pip install uv
 ```
 
-See the [installation documentation](https://docs.astral.sh/uv/getting-started/installation/) for
-details and alternative installation methods.
-
-## Upgrading uv
-
-If installed via standallone installer, uv can update itself:
+If installed via the standalone installer, uv can update itself to the latest version:
 
 ```console
 $ uv self update
 ```
 
-To prevent modifying shell profiles, set `INSTALLER_NO_MODIFY_PATH=1`. For other methods, use the
-package manager’s upgrade command, like:
-
-```console
-$ pip install --upgrade uv
-```
+See the [installation documentation](https://docs.astral.sh/uv/getting-started/installation/) for
+details and alternative installation methods.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ When uv is installed via the standalone installer, it can update itself on-deman
 $ uv self update
 ```
 
-Updating uv will re-run the installer and can modify your shell profiles. To disable this behavior, set `INSTALLER_NO_MODIFY_PATH=1`.
+Updating uv will re-run the installer and can modify your shell profiles. To disable this behavior,
+set `INSTALLER_NO_MODIFY_PATH=1`.
 
-When another installation method is used, self-updates are disabled. Use the package manager's upgrade method instead. For example, with pip:
+When another installation method is used, self-updates are disabled. Use the package manager's
+upgrade method instead. For example, with pip:
 
 ```console
 $ pip install --upgrade uv
-````
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ $ pip install uv
 See the [installation documentation](https://docs.astral.sh/uv/getting-started/installation/) for
 details and alternative installation methods.
 
+## Upgrading uv
+
+When uv is installed via the standalone installer, it can update itself on-demand:
+
+```console
+$ uv self update
+```
+
+Updating uv will re-run the installer and can modify your shell profiles. To disable this behavior, set `INSTALLER_NO_MODIFY_PATH=1`.
+
+When another installation method is used, self-updates are disabled. Use the package manager's upgrade method instead. For example, with pip:
+
+```console
+$ pip install --upgrade uv
+````
+
 ## Documentation
 
 uv's documentation is available at [docs.astral.sh/uv](https://docs.astral.sh/uv).

--- a/README.md
+++ b/README.md
@@ -63,17 +63,14 @@ details and alternative installation methods.
 
 ## Upgrading uv
 
-When uv is installed via the standalone installer, it can update itself on-demand:
+If installed via standallone installer, uv can update itself:
 
 ```console
 $ uv self update
 ```
 
-Updating uv will re-run the installer and can modify your shell profiles. To disable this behavior,
-set `INSTALLER_NO_MODIFY_PATH=1`.
-
-When another installation method is used, self-updates are disabled. Use the package manager's
-upgrade method instead. For example, with pip:
+To prevent modifying shell profiles, set `INSTALLER_NO_MODIFY_PATH=1`. For other methods, use the
+package manager’s upgrade command, like:
 
 ```console
 $ pip install --upgrade uv


### PR DESCRIPTION
closes #7858 

## Summary
Added the upgrading uv section in README.  Added the ` uv self update` method and the `pip install --upgrade uv` method.