### PR TITLE
Clearly specify the minimum supported Windows Server version in the document

### DIFF
--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -28,7 +28,7 @@ or developed against, and so stability may vary in practice.
 
 Beyond the Tier 1 and Tier 2 platforms, uv is known to build on i686 Windows, and known _not_ to
 build on aarch64 Windows, but does not consider either platform to be supported at this time. The
-minimum supported Windows version is Windows 10, following
+minimum supported Windows versions are Windows 10 and Windows Server 2016, following
 [Rust's own Tier 1 support](https://blog.rust-lang.org/2024/02/26/Windows-7.html).
 
 uv supports and is tested against Python 3.8, 3.9, 3.10, 3.11, and 3.12.


### PR DESCRIPTION
## Summary
https://doc.rust-lang.org/1.81.0/rustc/platform-support.html
![image](https://github.com/user-attachments/assets/f3921374-5f49-4f89-99d8-4808d94b4647)

This is actually part of the change in minimum Windows version requirements in Rust 1.78.0, but subsequent versions of the documentation clearly specify the minimum version of Windows Server.
https://github.com/rust-lang/rust/pull/126034

## Test Plan
Run the document server locally.
![image](https://github.com/user-attachments/assets/94f6bbd0-7aa6-4a47-aee2-d6f9ee35d5e5)

