### PR TITLE
Implement build backend metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4271,7 +4271,6 @@ dependencies = [
 name = "uv-build-backend"
 version = "0.1.0"
 dependencies = [
- "async_zip",
  "fs-err",
  "glob",
  "indoc",
@@ -4281,8 +4280,6 @@ dependencies = [
  "spdx",
  "tempfile",
  "thiserror",
- "tokio",
- "tokio-util",
  "toml",
  "tracing",
  "uv-distribution-filename",
@@ -4294,6 +4291,7 @@ dependencies = [
  "uv-pypi-types",
  "uv-version",
  "uv-warnings",
+ "zip",
 ]
 
 [[package]]

--- a/crates/uv-build-backend/Cargo.toml
+++ b/crates/uv-build-backend/Cargo.toml
@@ -20,17 +20,15 @@ uv-pypi-types = { workspace = true }
 uv-version = { workspace = true }
 uv-warnings = { workspace = true }
 
-async_zip = { workspace = true }
-fs-err = { workspace = true, features = ["tokio"] }
+fs-err = { workspace = true }
 glob = { workspace = true }
 itertools = { workspace = true }
 serde = { workspace = true }
 spdx = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
-tokio-util = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
+zip = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -3,14 +3,13 @@ mod pep639_glob;
 
 use crate::metadata::{PyProjectToml, ValidationError};
 use crate::pep639_glob::Pep639GlobError;
-use async_zip::base::write::ZipFileWriter;
-use async_zip::error::ZipError;
-use async_zip::{Compression, ZipEntryBuilder, ZipString};
 use glob::{GlobError, PatternError};
 use std::io;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 use uv_distribution_filename::WheelFilename;
+use zip::{CompressionMethod, ZipWriter};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -28,51 +27,67 @@ pub enum Error {
     #[error(transparent)]
     Glob(#[from] GlobError),
     #[error("Failed to write wheel zip archive")]
-    Zip(#[from] ZipError),
+    Zip(#[from] zip::result::ZipError),
 }
 
 /// Allow dispatching between writing to a directory, writing to zip and writing to a `.tar.gz`.
-trait AsyncDirectoryWrite: Sized {
-    async fn write_bytes(
-        &mut self,
-        directory: &Path,
-        filename: &str,
-        bytes: &[u8],
-    ) -> Result<(), Error>;
+///
+/// All paths are string types instead of path types since wheel are portable between platforms.
+trait DirectoryWriter: Sized {
+    /// Add a file with the given content.
+    fn write_bytes(&mut self, path: &str, bytes: &[u8]) -> Result<(), Error>;
+
+    /// Create a directory.
+    fn write_directory(&mut self, directory: &str) -> Result<(), Error>;
 
     #[allow(clippy::unused_async)] // https://github.com/rust-lang/rust-clippy/issues/11660
-    async fn close(self) -> Result<(), Error> {
+    fn close(self) -> Result<(), Error> {
         Ok(())
     }
 }
 
 /// Zip archive (wheel) writer.
-struct AsyncZipWriter(ZipFileWriter<tokio_util::compat::Compat<fs_err::tokio::File>>);
+struct ZipDirectoryWriter {
+    writer: ZipWriter<fs_err::File>,
+    compression: CompressionMethod,
+}
 
-impl AsyncDirectoryWrite for AsyncZipWriter {
-    async fn write_bytes(
-        &mut self,
-        directory: &Path,
-        filename: &str,
-        bytes: &[u8],
-    ) -> Result<(), Error> {
-        self.0
-            .write_entry_whole(
-                ZipEntryBuilder::new(
-                    ZipString::from(format!("{}/{}", directory.display(), filename)),
-                    // TODO(konsti): Editables use stored.
-                    Compression::Deflate,
-                )
-                // https://github.com/Majored/rs-async-zip/issues/150
-                .unix_permissions(0o644),
-                bytes,
-            )
-            .await?;
+impl ZipDirectoryWriter {
+    /// A wheel writer with deflate compression.
+    fn new_wheel(file: fs_err::File) -> Self {
+        Self {
+            writer: ZipWriter::new(file),
+            compression: CompressionMethod::Deflated,
+        }
+    }
+
+    /// A wheel writer with no (stored) compression.
+    ///
+    /// Since editables are temporary, we save time be skipping compression and decompression.
+    #[expect(dead_code)]
+    fn new_editable(file: fs_err::File) -> Self {
+        Self {
+            writer: ZipWriter::new(file),
+            compression: CompressionMethod::Stored,
+        }
+    }
+}
+
+impl DirectoryWriter for ZipDirectoryWriter {
+    fn write_bytes(&mut self, path: &str, bytes: &[u8]) -> Result<(), Error> {
+        let options = zip::write::FileOptions::default().compression_method(self.compression);
+        self.writer.start_file(path, options)?;
+        self.writer.write_all(bytes)?;
         Ok(())
     }
 
-    async fn close(self) -> Result<(), Error> {
-        self.0.close().await?;
+    fn write_directory(&mut self, directory: &str) -> Result<(), Error> {
+        let options = zip::write::FileOptions::default().compression_method(self.compression);
+        Ok(self.writer.add_directory(directory, options)?)
+    }
+
+    fn close(mut self) -> Result<(), Error> {
+        self.writer.finish()?;
         Ok(())
     }
 }
@@ -82,22 +97,19 @@ struct AsyncFsWriter {
 }
 
 /// File system writer.
-impl AsyncDirectoryWrite for AsyncFsWriter {
-    async fn write_bytes(
-        &mut self,
-        directory: &Path,
-        filename: &str,
-        bytes: &[u8],
-    ) -> Result<(), Error> {
-        fs_err::tokio::create_dir_all(self.root.join(directory)).await?;
-        fs_err::tokio::write(self.root.join(directory).join(filename), bytes).await?;
-        Ok(())
+impl DirectoryWriter for AsyncFsWriter {
+    fn write_bytes(&mut self, path: &str, bytes: &[u8]) -> Result<(), Error> {
+        Ok(fs_err::write(path, bytes)?)
+    }
+
+    fn write_directory(&mut self, directory: &str) -> Result<(), Error> {
+        Ok(fs_err::create_dir(self.root.join(directory))?)
     }
 }
 
 /// Build a wheel from the source tree and place it in the output directory.
-pub async fn build(source_tree: &Path, wheel_dir: &Path) -> Result<WheelFilename, Error> {
-    let contents = fs_err::tokio::read_to_string(source_tree.join("pyproject.toml")).await?;
+pub fn build(source_tree: &Path, wheel_dir: &Path) -> Result<WheelFilename, Error> {
+    let contents = fs_err::read_to_string(source_tree.join("pyproject.toml"))?;
     let pyproject_toml = PyProjectToml::parse(&contents)?;
     pyproject_toml.check_build_system();
 
@@ -110,25 +122,24 @@ pub async fn build(source_tree: &Path, wheel_dir: &Path) -> Result<WheelFilename
         platform_tag: vec!["any".to_string()],
     };
 
-    // TODO(konsti): async-zip doesn't like a buffered writer
-    let wheel_file = fs_err::tokio::File::create(wheel_dir.join(filename.to_string())).await?;
-    let mut wheel_writer = AsyncZipWriter(ZipFileWriter::with_tokio(wheel_file));
-    write_dist_info(&mut wheel_writer, &pyproject_toml, source_tree).await?;
-    wheel_writer.close().await?;
+    let mut wheel_writer =
+        ZipDirectoryWriter::new_wheel(fs_err::File::create(wheel_dir.join(filename.to_string()))?);
+    write_dist_info(&mut wheel_writer, &pyproject_toml, source_tree)?;
+    wheel_writer.close()?;
     Ok(filename)
 }
 
 /// Write the dist-info directory to the output directory without building the wheel.
-pub async fn metadata(source_tree: &Path, metadata_directory: &Path) -> Result<String, Error> {
-    let contents = fs_err::tokio::read_to_string(source_tree.join("pyproject.toml")).await?;
+pub fn metadata(source_tree: &Path, metadata_directory: &Path) -> Result<String, Error> {
+    let contents = fs_err::read_to_string(source_tree.join("pyproject.toml"))?;
     let pyproject_toml = PyProjectToml::parse(&contents)?;
     pyproject_toml.check_build_system();
 
     let mut wheel_writer = AsyncFsWriter {
         root: metadata_directory.to_path_buf(),
     };
-    write_dist_info(&mut wheel_writer, &pyproject_toml, source_tree).await?;
-    wheel_writer.close().await?;
+    write_dist_info(&mut wheel_writer, &pyproject_toml, source_tree)?;
+    wheel_writer.close()?;
 
     Ok(format!(
         "{}-{}.dist-info",
@@ -138,29 +149,27 @@ pub async fn metadata(source_tree: &Path, metadata_directory: &Path) -> Result<S
 }
 
 /// Add `METADATA` and `entry_points.txt` to the dist-info directory.
-async fn write_dist_info(
-    writer: &mut impl AsyncDirectoryWrite,
+fn write_dist_info(
+    writer: &mut impl DirectoryWriter,
     pyproject_toml: &PyProjectToml,
     root: &Path,
 ) -> Result<(), Error> {
-    let dist_info_dir = PathBuf::from(format!(
+    let dist_info_dir = format!(
         "{}-{}.dist-info",
         pyproject_toml.name().as_dist_info_name(),
         pyproject_toml.version()
-    ));
+    );
 
-    let metadata = pyproject_toml
-        .to_metadata(root)
-        .await?
-        .core_metadata_format();
-    writer
-        .write_bytes(&dist_info_dir, "METADATA", metadata.as_bytes())
-        .await?;
+    writer.write_directory(&dist_info_dir)?;
+
+    let metadata = pyproject_toml.to_metadata(root)?.core_metadata_format();
+    writer.write_bytes(&format!("{dist_info_dir}/METADATA"), metadata.as_bytes())?;
 
     let entrypoint = pyproject_toml.to_entry_points()?;
-    writer
-        .write_bytes(&dist_info_dir, "entry_points.txt", entrypoint.as_bytes())
-        .await?;
+    writer.write_bytes(
+        &format!("{dist_info_dir}/entry_points.txt"),
+        entrypoint.as_bytes(),
+    )?;
 
     Ok(())
 }

--- a/crates/uv/src/commands/build_backend.rs
+++ b/crates/uv/src/commands/build_backend.rs
@@ -5,54 +5,42 @@ use anyhow::Result;
 use std::env;
 use std::path::Path;
 
-#[expect(clippy::unused_async)]
-pub(crate) async fn build_sdist(_sdist_directory: &Path) -> Result<ExitStatus> {
+pub(crate) fn build_sdist(_sdist_directory: &Path) -> Result<ExitStatus> {
     todo!()
 }
-
-pub(crate) async fn build_wheel(
+pub(crate) fn build_wheel(
     wheel_directory: &Path,
     _metadata_directory: Option<&Path>,
 ) -> Result<ExitStatus> {
-    let filename = uv_build_backend::build(&env::current_dir()?, wheel_directory).await?;
+    let filename = uv_build_backend::build(&env::current_dir()?, wheel_directory)?;
     println!("{filename}");
     Ok(ExitStatus::Success)
 }
 
-#[expect(clippy::unused_async)]
-pub(crate) async fn build_editable(
+pub(crate) fn build_editable(
     _wheel_directory: &Path,
     _metadata_directory: Option<&Path>,
 ) -> Result<ExitStatus> {
     todo!()
 }
 
-#[expect(clippy::unused_async)]
-pub(crate) async fn get_requires_for_build_sdist() -> Result<ExitStatus> {
+pub(crate) fn get_requires_for_build_sdist() -> Result<ExitStatus> {
     todo!()
 }
 
-#[expect(clippy::unused_async)]
-pub(crate) async fn get_requires_for_build_wheel() -> Result<ExitStatus> {
+pub(crate) fn get_requires_for_build_wheel() -> Result<ExitStatus> {
     todo!()
 }
-
-pub(crate) async fn prepare_metadata_for_build_wheel(
-    metadata_directory: &Path,
-) -> Result<ExitStatus> {
-    let filename = uv_build_backend::metadata(&env::current_dir()?, metadata_directory).await?;
+pub(crate) fn prepare_metadata_for_build_wheel(metadata_directory: &Path) -> Result<ExitStatus> {
+    let filename = uv_build_backend::metadata(&env::current_dir()?, metadata_directory)?;
     println!("{filename}");
     Ok(ExitStatus::Success)
 }
 
-#[expect(clippy::unused_async)]
-pub(crate) async fn get_requires_for_build_editable() -> Result<ExitStatus> {
+pub(crate) fn get_requires_for_build_editable() -> Result<ExitStatus> {
     todo!()
 }
 
-#[expect(clippy::unused_async)]
-pub(crate) async fn prepare_metadata_for_build_editable(
-    _wheel_directory: &Path,
-) -> Result<ExitStatus> {
+pub(crate) fn prepare_metadata_for_build_editable(_wheel_directory: &Path) -> Result<ExitStatus> {
     todo!()
 }


### PR DESCRIPTION
Following the discussion at https://github.com/astral-sh/uv/pull/7781#discussion_r1781734857, it makes more sense to keep the build backend sync.