### PR TITLE
Fix parsing of `gnueabi` libc variants in Python version requests

### DIFF
--- a/crates/uv-python/src/platform.rs
+++ b/crates/uv-python/src/platform.rs
@@ -46,6 +46,8 @@ impl FromStr for Libc {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "gnu" => Ok(Self::Some(target_lexicon::Environment::Gnu)),
+            "gnueabi" => Ok(Self::Some(target_lexicon::Environment::Gnueabi)),
+            "gnueabihf" => Ok(Self::Some(target_lexicon::Environment::Gnueabihf)),
             "musl" => Ok(Self::Some(target_lexicon::Environment::Musl)),
             "none" => Ok(Self::None),
             _ => Err(Error::UnknownLibc(s.to_string())),


### PR DESCRIPTION
```
❯ cargo run -q -- python install cpython-3.12.6-linux-armv7-gnueabihf
Searching for Python versions matching: cpython-3.12.6-linux-armv7-gnueabihf
Installed Python 3.12.6 in 2.10s
 + cpython-3.12.6-linux-armv7-gnueabihf

❯ uv python install cpython-3.12.6-linux-armv7-gnueabihf
error: Cannot download managed Python for request: executable name `cpython-3.12.6-linux-armv7-gnueabihf`
```