### PR TITLE
Add docs for the uv build backend

### DIFF
--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -133,7 +133,7 @@ impl PyProjectToml {
     ///
     /// ```toml
     /// [build-system]
-    /// requires = ["uv>=0.4.15,<5"]
+    /// requires = ["uv>=0.5.9,<0.6"]
     /// build-backend = "uv"
     /// ```
     pub fn check_build_system(&self, uv_version: &str) -> Vec<String> {
@@ -884,7 +884,7 @@ mod tests {
             {payload}
 
             [build-system]
-            requires = ["uv>=0.4.15,<5"]
+            requires = ["uv>=0.5.9,<0.6"]
             build-backend = "uv"
         "#
         }
@@ -967,7 +967,7 @@ mod tests {
             foo-bar = "foo:bar"
 
             [build-system]
-            requires = ["uv>=0.4.15,<5"]
+            requires = ["uv>=0.5.9,<0.6"]
             build-backend = "uv"
         "#
         };
@@ -1026,7 +1026,7 @@ mod tests {
         let contents = extend_project("");
         let pyproject_toml = PyProjectToml::parse(&contents).unwrap();
         assert_snapshot!(
-            pyproject_toml.check_build_system("1.0.0+test").join("\n"),
+            pyproject_toml.check_build_system("0.5.9+test").join("\n"),
             @""
         );
     }
@@ -1044,8 +1044,8 @@ mod tests {
         "#};
         let pyproject_toml = PyProjectToml::parse(contents).unwrap();
         assert_snapshot!(
-            pyproject_toml.check_build_system("0.4.15+test").join("\n"),
-            @r###"`build_system.requires = ["uv"]` is missing an upper bound on the uv version such as `<0.5`. Without bounding the uv version, the source distribution will break when a future, breaking version of uv is released."###
+            pyproject_toml.check_build_system("0.5.9+test").join("\n"),
+            @r###"`build_system.requires = ["uv"]` is missing an upper bound on the uv version such as `<0.6`. Without bounding the uv version, the source distribution will break when a future, breaking version of uv is released."###
         );
     }
 
@@ -1057,12 +1057,12 @@ mod tests {
             version = "0.1.0"
 
             [build-system]
-            requires = ["uv>=0.4.15,<5", "wheel"]
+            requires = ["uv>=0.5.9,<5", "wheel"]
             build-backend = "uv"
         "#};
         let pyproject_toml = PyProjectToml::parse(contents).unwrap();
         assert_snapshot!(
-            pyproject_toml.check_build_system("0.4.15+test").join("\n"),
+            pyproject_toml.check_build_system("0.5.9+test").join("\n"),
             @"Expected a single uv requirement in `build-system.requires`, found ``"
         );
     }
@@ -1080,7 +1080,7 @@ mod tests {
         "#};
         let pyproject_toml = PyProjectToml::parse(contents).unwrap();
         assert_snapshot!(
-            pyproject_toml.check_build_system("0.4.15+test").join("\n"),
+            pyproject_toml.check_build_system("0.5.9+test").join("\n"),
             @"Expected a single uv requirement in `build-system.requires`, found ``"
         );
     }
@@ -1093,12 +1093,12 @@ mod tests {
             version = "0.1.0"
 
             [build-system]
-            requires = ["uv>=0.4.15,<5"]
+            requires = ["uv>=0.5.9,<0.6"]
             build-backend = "setuptools"
         "#};
         let pyproject_toml = PyProjectToml::parse(contents).unwrap();
         assert_snapshot!(
-            pyproject_toml.check_build_system("0.4.15+test").join("\n"),
+            pyproject_toml.check_build_system("0.5.9+test").join("\n"),
             @r###"The value for `build_system.build-backend` should be `"uv"`, not `"setuptools"`"###
         );
     }

--- a/docs/guides/build_and_publish.md
+++ b/docs/guides/build_and_publish.md
@@ -1,12 +1,9 @@
-# Publishing a package
+# Building and publishing a package
 
-uv supports building Python packages into source and binary distributions via `uv build` and
-uploading them to a registry with `uv publish`.
+uv supports building Python packages into source and binary distributions via the `uv` build
+backend, the `uv build` build frontend and uploading them to a registry with `uv publish`.
 
-## Preparing your project for packaging
-
-Before attempting to publish your project, you'll want to make sure it's ready to be packaged for
-distribution.
+## Building your package
 
 If your project does not include a `[build-system]` definition in the `pyproject.toml`, uv will not
 build it by default. This means that your project may not be ready for distribution. Read more about
@@ -29,7 +26,15 @@ the effect of declaring a build system in the
     We also recommend only generating per-project tokens: Without a PyPI token matching the project,
     it can't be accidentally published.
 
-## Building your package
+To use uv as build backend, add the following to `pyproject.toml`:
+
+```toml
+[build-system]
+requires = ["uv>=0.5.9,<0.6"]
+build-backend = "uv"
+```
+
+By default, uv expects your code to be in `src/<package_name_with_underscores>`.
 
 Build your package with `uv build`:
 

--- a/docs/guides/integration/alternative-indexes.md
+++ b/docs/guides/integration/alternative-indexes.md
@@ -155,8 +155,8 @@ export UV_EXTRA_INDEX_URL="https://aws:${AWS_CODEARTIFACT_TOKEN}@${AWS_DOMAIN}-$
 ### Publishing packages
 
 If you also want to publish your own packages to AWS CodeArtifact, you can use `uv publish` as
-described in the [publishing guide](../publish.md). You will need to set `UV_PUBLISH_URL` separately
-from the credentials:
+described in the [publishing guide](../build_and_publish.md). You will need to set `UV_PUBLISH_URL`
+separately from the credentials:
 
 ```bash
 # Configure uv to use AWS CodeArtifact

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -214,4 +214,4 @@ To learn more about working on projects with uv, see the
 [projects concept](../concepts/projects/index.md) page and the
 [command reference](../reference/cli.md#uv).
 
-Or, read on to learn how to [publish your project as a package](./publish.md).
+Or, read on to learn how to [publish your project as a package](./build_and_publish).

--- a/docs/reference/build_backend.md
+++ b/docs/reference/build_backend.md
@@ -1,0 +1,136 @@
+# Build backend
+
+uv comes with a build backend implementation (`build-system = "uv"`). You can use uv with this build
+backend, or with any other build backend.
+
+The uv build backend is configured through `pyproject.toml`. It uses the standard `[project]` and
+`[build-system]` tables as well as the `[tool.uv.build-backend]` table for configuration . See
+[pyproject.toml](#pyproject_toml) for the `[project]` and `[build-system]` table.
+
+The uv build backend requires `project.name`, `project.version`, `build-system.requires` and
+`build-system.build-backend`, does not support `project.dynamic`, and all other fields are optional.
+
+### Example
+
+```toml
+[project]
+name = "built-by-uv"
+version = "0.1.0"
+description = "A package that is built with the uv build backend"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = ["anyio>=4,<5"]
+license-files = ["LICENSE*", "third-party-licenses/*"]
+
+[tool.uv.build-backend]
+# A file we need for the source dist -> wheel step, but not in the wheel itself (currently unused)
+source-include = ["data/build-script.py"]
+# A temporary or generated file we want to ignore
+source-exclude = ["/src/built_by_uv/not-packaged.txt"]
+# Headers are build-only
+wheel-exclude = ["build-*.h"]
+
+[tool.uv.build-backend.data]
+scripts = "scripts"
+data = "assets"
+
+[build-system]
+requires = ["uv>=0.5,<0.6"]
+build-backend = "uv"
+```
+
+## The `[build-system]` table
+
+There may be breaking changes to the uv build backend configuration in future uv versions, so you
+need to constrain the uv version with lower and upper bounds.
+
+```toml
+[build-system]
+requires = ["uv>=0.5.5,<6"]
+build-backend = "uv"
+```
+
+## Include and exclude configuration
+
+By default, uv expects your code to be in `src/<package_name_with_underscores>`.
+
+To select which files to include in the source distribution, we first add the includes, then remove
+the excludes from that. You can check the file list with `uv build --preview --list`.
+
+When building the source distribution, the following files and directories are included:
+
+- `pyproject.toml`
+- The module under `tool.uv.build-backend.module-root`, by default
+  `src/<project_name_with_underscores>/**`.
+- `project.license-files` and `project.readme`.
+- All directories under `tool.uv.build-backend.data`.
+- All patterns from `tool.uv.build-backend.source-include`.
+
+From these, we remove the `tool.uv.build-backend.source-exclude` matches.
+
+When building the wheel, the following files and directories are included:
+
+- The module under `tool.uv.build-backend.module-root`, by default
+  `src/<project_name_with_underscores>/**`.
+- `project.license-files` and `project.readme`, as part of the project metadata.
+- Each directory under `tool.uv.build-backend.data`, as data directories.
+
+From these, we remove the `tool.uv.build-backend.source-exclude` and
+`tool.uv.build-backend.wheel-exclude` matches. The source dist excludes are applied to avoid source
+tree -> wheel source including more files than source tree -> source distribution -> wheel.
+
+There are no specific wheel includes. There must only be one top level module, and all data files
+must either be under the module root or in a data directory. Most packages store small data in the
+module root alongside the source code.
+
+## Include and exclude syntax
+
+Includes are anchored, which means that `pyproject.toml` includes only
+`<project root>/pyproject.toml`. Use for example `assets/**/sample.csv` to include for all
+`sample.csv` files in `<project root>/assets` or any child directory. To recursively include all
+files under a directory, use a `/**` suffix, e.g. `src/**`. For performance and reproducibility,
+avoid unanchored matches such as `**/sample.csv`.
+
+Excludes are not anchored, which means that `__pycache__` excludes all directories named
+`__pycache__` and it's children anywhere. To anchor a directory, use a `/` prefix, e.g., `/dist`
+will exclude only `<project root>/dist`.
+
+The glob syntax is the reduced portable glob from
+[PEP 639](https://peps.python.org/pep-0639/#add-license-FILES-key).
+
+## Options
+
+**tool.uv.build-backend.module-root**
+
+The directory that contains the module directory, usually `src`, or an empty path when using the
+flat layout over the src layout.
+
+**tool.uv.build-backend.source-include**
+
+Glob expressions which files and directories to additionally include in the source distribution.
+
+`pyproject.toml` and the contents of the module directory are always included.
+
+The glob syntax is the reduced portable glob from
+[PEP 639](https://peps.python.org/pep-0639/#add-license-FILES-key).
+
+**tool.uv.build-backend.default-excludes**
+
+If set to `false`, the default excludes aren't applied.
+
+Default excludes: `__pycache__`, `*.pyc`, and `*.pyo`.
+
+**tool.uv.build-backend.source-excludes**
+
+Glob expressions which files and directories to exclude from the source distribution.
+
+**tool.uv.build-backend.wheel-excludes**
+
+Glob expressions which files and directories to exclude from the wheel.
+
+**tool.uv.build-backend.data**
+
+Data includes for wheels.
+
+The directories included here are also included in the source distribution. They are copied to the
+right wheel subdirectory on build.

--- a/docs/reference/pyproject_toml.md
+++ b/docs/reference/pyproject_toml.md
@@ -5,31 +5,15 @@
 specifying the metadata and build system of a Python project. See [Projects](../guides/projects.md)
 for an introduction.
 
-Most parts of uv only consider the name, version, (optional) dependencies and build system of a
-project, and read only those fields from `pyproject.toml`. The `project.name` is always required,
-while `project.version`. If `project.dependencies` is not specified, it means that the project has
-no dependencies. If you need to use dynamic dependencies (discouraged), you must add `dependencies`
-to `project.dynamic`. The same applies to `optional-dependencies`.
+Most of uv's subcommands only read the name, version, (optional) dependencies and build system of a
+project from its `pyproject.toml`. The `project.name` is always required, while `project.version`
+may be dynamic in some build backends. If `project.dependencies` is not specified, it means that the
+project has no dependencies. If you need to use dynamic dependencies (discouraged), you must add
+`dependencies` to `project.dynamic`. The same applies to `optional-dependencies`.
 
-For the build backend (`build-system = "uv"`), all fields are relevant and get translated to
-[Core Metadata](https://packaging.python.org/en/latest/specifications/core-metadata) in the final
-field. uv supports the
-[living standard](https://packaging.python.org/en/latest/specifications/core-metadata) in addition
-to the provisional [PEP 639](https://peps.python.org/pep-0639/) for better upload metadata. When
-using the uv build backend, the `project.name`, `project.version`, `build-system.requires` and
-`build-system.build-backend` keys are required, `project.dynamic` is not supported, and all other
-fields are optional.
-
-## The `[build-system]` table
-
-The may be breaking changes to the uv build backend configuration in future uv versions, so you
-constrain the uv version with lower and upper bounds.
-
-```toml
-[build-system]
-requires = ["uv>=0.4.15,<5"]
-build-backend = "uv"
-```
+When building a package, these fields get translated to
+[Core Metadata](https://packaging.python.org/en/latest/specifications/core-metadata) in the source
+distribution and wheel.
 
 ## The `[project]` table
 
@@ -85,11 +69,17 @@ as written, the resolver does only use the lower bound on published packages.
 
 ### `license` and `license-files`
 
-The packaging ecosystem is currently transitioning from packaging core metadata version 2.3 to
-version 2.4, which brings an overhaul of the license metadata.
+The recommended way to specify license information is using the `license` field, which takes an
+[SPDX Expression](https://spdx.org/licenses/), and `license-files`, which takes a list of globs of
+license files to include:
 
-In version 2.3, the two variants of the `license` key are supported, while `license-files` is not
-supported:
+```toml
+license = "MIT OR Apache-2.0"
+license-files = ["LICENSE.apache", "LICENSE.mit", "_vendor/licenses/*"]
+```
+
+There are two old variant of the `license` key that are also supported. `license.file` specifies the
+path to a license file to be included, `license.text` is included in the wheel metadata.
 
 ```toml
 license = { file = "LICENSE" }
@@ -99,17 +89,7 @@ license = { file = "LICENSE" }
 license = { text = "Lorem ipsum dolor sit amet\nconsetetur sadipscing elitr." }
 ```
 
-In version 2.4, the `license` key is an [SPDX Expression](https://spdx.org/licenses/) and
-`license-files` is a list of glob expression of license files to include:
-
-```toml
-license = "MIT OR Apache-2.0"
-license-files = ["LICENSE.apache", "LICENSE.mit", "_vendor/licenses/*"]
-```
-
-When using both `license-files` and `license`, `license` must be a valid SPDX expression. Using
-`license` with a string or specifying `license-files` increases the default metadata version from
-2.3 to 2.4. At time of writing, PyPI does not support publishing packages using version 2.4.
+These variants may not be combined with setting `license-files`.
 
 ### `authors` and `maintainers`
 
@@ -149,14 +129,23 @@ To prevent a private project from accidentally being uploaded to PyPI, add the
 
 ### `urls`
 
-Links to important pages of the project
+Links to important pages of the project. The following labels are known to be supported:
+
+- `changelog` (Changelog): The project's comprehensive changelog
+- `documentation` (Documentation): The project's online documentation
+- `download` (Download): A download URL for the current distribution
+- `funding` (Funding): Funding Information
+- `homepage` (Homepage): The project's home page
+- `issues` (Issue Tracker): The project's bug tracker
+- `releasenotes` (Release Notes): The project's curated release notes
+- `source` (Source Code): The project's hosted source code or repository
 
 ```toml
 [project.urls]
-Repository = "https://github.com/astral-sh/uv"
-Documentation = "https://docs.astral.sh/uv"
-Changelog = "https://github.com/astral-sh/uv/blob/main/CHANGELOG.md"
-Releases = "https://github.com/astral-sh/uv/releases"
+changelog = "https://github.com/astral-sh/uv/blob/main/CHANGELOG.md"
+documentation = "https://docs.astral.sh/uv"
+releases = "https://github.com/astral-sh/uv/releases"
+repository = "https://github.com/astral-sh/uv"
 ```
 
 ### `scripts`, `gui-scripts` and `entry-points`
@@ -187,7 +176,7 @@ See [Dependencies](../concepts/dependencies.md).
 
 ### `dynamic`
 
-Dynamic metadata is not support. Please specify all metadata statically.
+Dynamic metadata is not supported. Please specify all metadata statically.
 
 ## Full example
 
@@ -221,7 +210,7 @@ mysql = ["pymysql>=1.1.1,<2"]
 foo = "foo.cli:__main__"
 
 [project.gui-scripts]
-foo-gui = "foo.gui"
+foo-gui = "foo.gui:main"
 
 [project.entry-points.bar_group]
 foo-bar = "foo:bar"

--- a/docs/reference/pyproject_toml.md
+++ b/docs/reference/pyproject_toml.md
@@ -1,0 +1,232 @@
+# Pyproject.toml
+
+`pyproject.toml` is a
+[standardized](https://packaging.python.org/en/latest/specifications/pyproject-toml/) file for
+specifying the metadata and build system of a Python project. See [Projects](../guides/projects.md)
+for an introduction.
+
+Most parts of uv only consider the name, version, (optional) dependencies and build system of a
+project, and read only those fields from `pyproject.toml`. The `project.name` is always required,
+while `project.version`. If `project.dependencies` is not specified, it means that the project has
+no dependencies. If you need to use dynamic dependencies (discouraged), you must add `dependencies`
+to `project.dynamic`. The same applies to `optional-dependencies`.
+
+For the build backend (`build-system = "uv"`), all fields are relevant and get translated to
+[Core Metadata](https://packaging.python.org/en/latest/specifications/core-metadata) in the final
+field. uv supports the
+[living standard](https://packaging.python.org/en/latest/specifications/core-metadata) in addition
+to the provisional [PEP 639](https://peps.python.org/pep-0639/) for better upload metadata. When
+using the uv build backend, the `project.name`, `project.version`, `build-system.requires` and
+`build-system.build-backend` keys are required, `project.dynamic` is not supported, and all other
+fields are optional.
+
+## The `[build-system]` table
+
+The may be breaking changes to the uv build backend configuration in future uv versions, so you
+constrain the uv version with lower and upper bounds.
+
+```toml
+[build-system]
+requires = ["uv>=0.4.15,<5"]
+build-backend = "uv"
+```
+
+## The `[project]` table
+
+The following fields are recognized in the `[project]` table.
+
+### `name`
+
+The name of the project. The name of the package should match the name of the Python module it
+contains. The name can contain runs of `-`, `_`, and `.`, which uv internally replaces by a single
+`-` (or `_` in filenames).
+
+### `version`
+
+The version of the project, following the
+[Version Specifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/)
+rules. Examples: `1.2.3`, `1.2.3-alpha.4`, `1.2.3-beta.1`, `1.2.3-rc.3` and `2.0.0+cpu`.
+
+### `description`
+
+A short, single-line description of the project.
+
+### `readme`
+
+The path to the Readme, relative to project root.
+
+Three forms are supported:
+
+1. A single string value, containing the relative path to the Readme.
+
+   ```toml
+   readme = "path/to/Readme.md"
+   ```
+
+2. A table with the relative path to the Readme and a content type, one of `text/plain`,
+   `text/x-rst`, `text/markdown`.
+
+   ```toml
+   readme = { file = "path/to/Readme.md", content-type = "text/markdown"  }
+   ```
+
+3. A table with the Readme text inline and a content type, one of `text/plain`, `text/x-rst`,
+   `text/markdown`.
+
+   ```toml
+   readme = { text = "# Description\n\nThe project description", content-type = "text/markdown" }
+   ```
+
+### `requires-python`
+
+The minimum supported Python version as version specifiers, for example `>=3.10`. Adding an upper
+bound or anything other than a lower bound is not recommended. While uv does preserve the specifiers
+as written, the resolver does only use the lower bound on published packages.
+
+### `license` and `license-files`
+
+The packaging ecosystem is currently transitioning from packaging core metadata version 2.3 to
+version 2.4, which brings an overhaul of the license metadata.
+
+In version 2.3, the two variants of the `license` key are supported, while `license-files` is not
+supported:
+
+```toml
+license = { file = "LICENSE" }
+```
+
+```toml
+license = { text = "Lorem ipsum dolor sit amet\nconsetetur sadipscing elitr." }
+```
+
+In version 2.4, the `license` key is an [SPDX Expression](https://spdx.org/licenses/) and
+`license-files` is a list of glob expression of license files to include:
+
+```toml
+license = "MIT OR Apache-2.0"
+license-files = ["LICENSE.apache", "LICENSE.mit", "_vendor/licenses/*"]
+```
+
+When using both `license-files` and `license`, `license` must be a valid SPDX expression. Using
+`license` with a string or specifying `license-files` increases the default metadata version from
+2.3 to 2.4. At time of writing, PyPI does not support publishing packages using version 2.4.
+
+### `authors` and `maintainers`
+
+Name and/or email address for the authors or maintainers of the project. Either a `name` key or an
+`email` key must be present.
+
+```toml
+authors = [
+  { name = "Ferris the crab", email = "ferris@example.net" },
+  { name = "The project authors" },
+  { email = "say-hi@example.org" }
+]
+```
+
+### `keywords`
+
+List of terms that make the project easier to discover.
+
+```toml
+keywords = ["uv", "requirements", "packaging"]
+```
+
+### `classifiers`
+
+List of [Trove classifiers](https://pypi.org/classifiers/) describing the project.
+
+```toml
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+```
+
+To prevent a private project from accidentally being uploaded to PyPI, add the
+`"Private :: Do Not Upload"` classifier.
+
+### `urls`
+
+Links to important pages of the project
+
+```toml
+[project.urls]
+Repository = "https://github.com/astral-sh/uv"
+Documentation = "https://docs.astral.sh/uv"
+Changelog = "https://github.com/astral-sh/uv/blob/main/CHANGELOG.md"
+Releases = "https://github.com/astral-sh/uv/releases"
+```
+
+### `scripts`, `gui-scripts` and `entry-points`
+
+`scripts` define a mapping from a name to a Python function. When installing the package, the
+installer adds a launcher in `.venv/bin` (Unix) or `.venv\Scripts` (Windows) with that name that
+launches the Python function. The Python function is given as the import-path to a module, separated
+by dots, followed by a colon (`:`) and an argument-less function inside that module that will be
+called. On Windows, starting a script by default creates a terminal. You can suppress this by using
+`gui-scripts` instead. On other platforms, there is no difference between `scripts` and
+`gui-scripts`.
+
+`entry-points` can define additional name/Python function mappings that can be read across packages
+with [`importlib.metadata`](https://docs.python.org/3/library/importlib.metadata.html#entry-points),
+which is useful for plugin interfaces.
+
+```toml
+[project.scripts]
+foo = "foo.cli:launch"
+
+[project.entry-points.bar_group]
+foo-bar = "foo:bar"
+```
+
+### `dependencies` and `optional-dependencies`
+
+See [Dependencies](../concepts/dependencies.md).
+
+### `dynamic`
+
+Dynamic metadata is not support. Please specify all metadata statically.
+
+## Full example
+
+```toml
+[project]
+name = "foo"
+version = "0.1.0"
+description = "A Python package"
+readme = "Readme.md"
+requires_python = ">=3.12"
+license = { file = "License.txt" }
+authors = [{ name = "Ferris the crab", email = "ferris@rustacean.net" }]
+maintainers = [{ name = "Konsti", email = "konstin@mailbox.org" }]
+keywords = ["demo", "example", "package"]
+classifiers = [
+  "Development Status :: 6 - Mature",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python",
+]
+dependencies = ["flask>=3,<4", "sqlalchemy[asyncio]>=2.0.35<3"]
+
+[project.optional-dependencies]
+postgres = ["psycopg>=3.2.2,<4"]
+mysql = ["pymysql>=1.1.1,<2"]
+
+[project.urls]
+"Homepage" = "https://github.com/astral-sh/uv"
+"Repository" = "https://astral.sh"
+
+[project.scripts]
+foo = "foo.cli:__main__"
+
+[project.gui-scripts]
+foo-gui = "foo.gui"
+
+[project.entry-points.bar_group]
+foo-bar = "foo:bar"
+
+[build-system]
+requires = ["uv>=0.4.15,<5"]
+build-backend = "uv"
+```

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -100,7 +100,7 @@ nav:
       - Running scripts: guides/scripts.md
       - Using tools: guides/tools.md
       - Working on projects: guides/projects.md
-      - Publishing packages: guides/publish.md
+      - Building and Publishing: guides/build_and_publish.md
       - Integrations:
           - guides/integration/index.md
           - Docker: guides/integration/docker.md
@@ -148,6 +148,7 @@ nav:
       - Commands: reference/cli.md
       - Settings: reference/settings.md
       - Build failures: reference/build_failures.md
+      - pyproject.toml: reference/pyproject_toml.md
       - Resolver: reference/resolver-internals.md
       - Benchmarks: reference/benchmarks.md
       - Policies:


### PR DESCRIPTION
Documentation for the uv build backend. To be merged last since we can't hide it in preview.

There are no reference docs yet since there aren't any specific options yet (TBD).

CC @zanieb the guide vs. concept split is odd here, it requires repeating things in the concept section while eliding a lot in the guide section.