### PR TITLE
Update `activate_this.py`; avoid polluting `__main__`

### DIFF
--- a/crates/uv-virtualenv/src/activator/activate_this.py
+++ b/crates/uv-virtualenv/src/activator/activate_this.py
@@ -31,8 +31,6 @@ This can be used when you must use an existing Python interpreter, not the virtu
 
 def _activate_this():
 
-    from __future__ import annotations
-
     import os
     import site
     import sys
@@ -63,6 +61,7 @@ def _activate_this():
 
     sys.real_prefix = sys.prefix
     sys.prefix = base
+
 
 _activate_this()
 del _activate_this

--- a/crates/uv-virtualenv/src/activator/activate_this.py
+++ b/crates/uv-virtualenv/src/activator/activate_this.py
@@ -28,32 +28,41 @@ runpy.run_path(this_file)
 This can be used when you must use an existing Python interpreter, not the virtualenv bin/python.
 """  # noqa: D415
 
-from __future__ import annotations
 
-import os
-import site
-import sys
+def _activate_this():
 
-try:
-    abs_file = os.path.abspath(__file__)
-except NameError as exc:
-    msg = "You must use import runpy; runpy.run_path(this_file)"
-    raise AssertionError(msg) from exc
+    from __future__ import annotations
 
-bin_dir = os.path.dirname(abs_file)
-base = bin_dir[: -len("{{ BIN_NAME }}") - 1]  # strip away the bin part from the __file__, plus the path separator
+    import os
+    import site
+    import sys
 
-# prepend bin to PATH (this file is inside the bin directory)
-os.environ["PATH"] = os.pathsep.join([bin_dir, *os.environ.get("PATH", "").split(os.pathsep)])
-os.environ["VIRTUAL_ENV"] = base  # virtual env is right above bin directory
-os.environ["VIRTUAL_ENV_PROMPT"] = "{{ VIRTUAL_PROMPT }}" or os.path.basename(base)  # noqa: SIM222
+    try:
+        abs_file = os.path.abspath(__file__)
+    except NameError as exc:
+        msg = "You must use import runpy; runpy.run_path(this_file)"
+        raise AssertionError(msg) from exc
 
-# add the virtual environments libraries to the host python import mechanism
-prev_length = len(sys.path)
-for lib in "{{ RELATIVE_SITE_PACKAGES }}".split(os.pathsep):
-    path = os.path.realpath(os.path.join(bin_dir, lib))
-    site.addsitedir(path)
-sys.path[:] = sys.path[prev_length:] + sys.path[0:prev_length]
+    bin_dir = os.path.dirname(abs_file)
+    # strip away the bin part from the __file__, plus the path separator
+    base = bin_dir[: -len("{{ BIN_NAME }}") - 1]
 
-sys.real_prefix = sys.prefix
-sys.prefix = base
+    # prepend bin to PATH (this file is inside the bin directory)
+    os.environ["PATH"] = os.pathsep.join(
+        [bin_dir, *os.environ.get("PATH", "").split(os.pathsep)]
+    )
+    os.environ["VIRTUAL_ENV"] = base  # virtual env is right above bin directory
+    os.environ["VIRTUAL_ENV_PROMPT"] = "{{ VIRTUAL_PROMPT }}" or os.path.basename(base)  # noqa: SIM222
+
+    # add the virtual environments libraries to the host python import mechanism
+    prev_length = len(sys.path)
+    for lib in "{{ RELATIVE_SITE_PACKAGES }}".split(os.pathsep):
+        path = os.path.realpath(os.path.join(bin_dir, lib))
+        site.addsitedir(path)
+    sys.path[:] = sys.path[prev_length:] + sys.path[0:prev_length]
+
+    sys.real_prefix = sys.prefix
+    sys.prefix = base
+
+_activate_this()
+del _activate_this


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Currently, running `activate_this.py` leaves the following symbols in `__main__`:
```
abs_file annotations base bin_dir lib os path prev_length site sys
```
This PR updates the `activate_this.py` script so it does not leave any detritus in `__main__`.

## Test Plan

This could be tested with something like this:

```bash
activate_this=$(python -c '__import__("sys").exec_prefix + "/bin/activate_this.py"')
pollution=$(python -c "start = set(dir()); __import__('runpy').run_path($activate_this); print(start.difference(['start']+dir()))'

# if len(pollution), error
```
