### PR TITLE
Bump netrc crate to latest commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2974,8 +2974,7 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 [[package]]
 name = "rust-netrc"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32662f97cbfdbad9d5f78f1338116f06871e7dae4fd37e9f59a0f57cf2044868"
+source = "git+https://github.com/gribouille/netrc?rev=544f3890b621f0dc30fcefb4f804269c160ce2e9#544f3890b621f0dc30fcefb4f804269c160ce2e9"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ reqwest-middleware = { git = "https://github.com/astral-sh/reqwest-middleware", 
 reqwest-retry = { git = "https://github.com/astral-sh/reqwest-middleware", rev = "5e3eaf254b5bd481c75d2710eed055f95b756913" }
 rkyv = { version = "0.8.8", features = ["bytecheck"] }
 rmp-serde = { version = "1.3.0" }
-rust-netrc = { version = "0.1.1" }
+rust-netrc = { git = "https://github.com/gribouille/netrc", rev = "544f3890b621f0dc30fcefb4f804269c160ce2e9" }
 rustc-hash = { version = "2.0.0" }
 rustix = { version = "0.38.37", default-features = false, features = ["fs", "std"] }
 same-file = { version = "1.0.6" }


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/8003
Closes https://github.com/astral-sh/uv/issues/6809

This hasn't been released ~4 months later and these are pretty critical fixes for Windows users.