### PR TITLE
Publish: Password requires username

### DIFF
--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -75,6 +75,10 @@ pub(crate) async fn publish(
         (username, password)
     };
 
+    if password.is_some() && username.is_none() {
+        bail!("You need to provide a username with a password, use `--token` for tokens");
+    }
+
     for (file, filename) in files {
         let size = fs_err::metadata(&file)?.len();
         let (bytes, unit) = human_readable_bytes(size);


### PR DESCRIPTION
You can't use a password without a username in `uv publish`, which we can catch in clap directly.

New error when using only a password:
```console
$ uv publish --password dummy
error: the following required arguments were not provided:
  --username <USERNAME>

Usage: uv.exe publish --username <USERNAME> --password <PASSWORD> [FILES]...

For more information, try '--help'.
```

Fixes #8023