### PR TITLE
Support for wildcard in UV_INSECURE_HOST

### DIFF
--- a/crates/uv-configuration/src/trusted_host.rs
+++ b/crates/uv-configuration/src/trusted_host.rs
@@ -25,11 +25,10 @@ impl TrustedHost {
             return false;
         }
 
-        if Some(self.host.as_ref()) != url.host_str() {
-            return false;
-        }
+        let allow_all_hosts = self.host == "*";
+        let same_host = Some(self.host.as_ref()) == url.host_str();
 
-        true
+        allow_all_hosts || same_host
     }
 }
 

--- a/crates/uv-configuration/src/trusted_host/tests.rs
+++ b/crates/uv-configuration/src/trusted_host/tests.rs
@@ -1,8 +1,13 @@
 #[test]
 fn parse() {
     assert_eq!(
+        "*".parse::<super::TrustedHost>().unwrap(),
+        super::TrustedHost::Wildcard
+    );
+
+    assert_eq!(
         "example.com".parse::<super::TrustedHost>().unwrap(),
-        super::TrustedHost {
+        super::TrustedHost::Host {
             scheme: None,
             host: "example.com".to_string(),
             port: None
@@ -11,7 +16,7 @@ fn parse() {
 
     assert_eq!(
         "example.com:8080".parse::<super::TrustedHost>().unwrap(),
-        super::TrustedHost {
+        super::TrustedHost::Host {
             scheme: None,
             host: "example.com".to_string(),
             port: Some(8080)
@@ -20,7 +25,7 @@ fn parse() {
 
     assert_eq!(
         "https://example.com".parse::<super::TrustedHost>().unwrap(),
-        super::TrustedHost {
+        super::TrustedHost::Host {
             scheme: Some("https".to_string()),
             host: "example.com".to_string(),
             port: None
@@ -31,7 +36,7 @@ fn parse() {
         "https://example.com/hello/world"
             .parse::<super::TrustedHost>()
             .unwrap(),
-        super::TrustedHost {
+        super::TrustedHost::Host {
             scheme: Some("https".to_string()),
             host: "example.com".to_string(),
             port: None

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -7,8 +7,8 @@ use std::io::BufReader;
 use url::Url;
 
 use crate::common::{
-    self, build_vendor_links_url, decode_token, packse_index_url, reqwest_blocking_get,
-    uv_snapshot, TestContext,
+    self, build_vendor_links_url, decode_token, download_to_disk, packse_index_url, uv_snapshot,
+    TestContext,
 };
 use uv_fs::Simplified;
 
@@ -7877,11 +7877,11 @@ fn lock_sources_archive() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download the source.
-    let bytes =
-        reqwest_blocking_get("https://github.com/user-attachments/files/16592193/workspace.zip");
     let workspace_archive = context.temp_dir.child("workspace.zip");
-    let mut workspace_archive_file = fs_err::File::create(&*workspace_archive)?;
-    std::io::copy(&mut &bytes[..], &mut workspace_archive_file)?;
+    download_to_disk(
+        "https://github.com/user-attachments/files/16592193/workspace.zip",
+        &workspace_archive,
+    );
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(&formatdoc! {
@@ -8016,11 +8016,11 @@ fn lock_sources_source_tree() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download the source.
-    let bytes =
-        reqwest_blocking_get("https://github.com/user-attachments/files/16592193/workspace.zip");
     let workspace_archive = context.temp_dir.child("workspace.zip");
-    let mut workspace_archive_file = fs_err::File::create(&*workspace_archive)?;
-    std::io::copy(&mut &bytes[..], &mut workspace_archive_file)?;
+    download_to_disk(
+        "https://github.com/user-attachments/files/16592193/workspace.zip",
+        &workspace_archive,
+    );
 
     // Unzip the file.
     let file = fs_err::File::open(&*workspace_archive)?;

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -7,7 +7,8 @@ use std::io::BufReader;
 use url::Url;
 
 use crate::common::{
-    self, build_vendor_links_url, decode_token, packse_index_url, uv_snapshot, TestContext,
+    self, build_vendor_links_url, decode_token, packse_index_url, reqwest_blocking_get,
+    uv_snapshot, TestContext,
 };
 use uv_fs::Simplified;
 
@@ -7876,11 +7877,11 @@ fn lock_sources_archive() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download the source.
-    let response =
-        reqwest::blocking::get("https://github.com/user-attachments/files/16592193/workspace.zip")?;
+    let bytes =
+        reqwest_blocking_get("https://github.com/user-attachments/files/16592193/workspace.zip");
     let workspace_archive = context.temp_dir.child("workspace.zip");
     let mut workspace_archive_file = fs_err::File::create(&*workspace_archive)?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut workspace_archive_file)?;
+    std::io::copy(&mut &bytes[..], &mut workspace_archive_file)?;
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(&formatdoc! {
@@ -8015,11 +8016,11 @@ fn lock_sources_source_tree() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download the source.
-    let response =
-        reqwest::blocking::get("https://github.com/user-attachments/files/16592193/workspace.zip")?;
+    let bytes =
+        reqwest_blocking_get("https://github.com/user-attachments/files/16592193/workspace.zip");
     let workspace_archive = context.temp_dir.child("workspace.zip");
     let mut workspace_archive_file = fs_err::File::create(&*workspace_archive)?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut workspace_archive_file)?;
+    std::io::copy(&mut &bytes[..], &mut workspace_archive_file)?;
 
     // Unzip the file.
     let file = fs_err::File::open(&*workspace_archive)?;

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -8,9 +8,9 @@ use anyhow::{bail, Context, Result};
 use assert_fs::prelude::*;
 use indoc::indoc;
 use url::Url;
-use uv_fs::Simplified;
 
-use crate::common::{uv_snapshot, TestContext};
+use crate::common::{reqwest_blocking_get, uv_snapshot, TestContext};
+use uv_fs::Simplified;
 
 #[test]
 fn compile_requirements_in() -> Result<()> {
@@ -2592,10 +2592,10 @@ fn compile_wheel_path_dependency() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let response = reqwest::blocking::get("https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl")?;
+    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl");
     let flask_wheel = context.temp_dir.child("flask-3.0.0-py3-none-any.whl");
     let mut flask_wheel_file = fs::File::create(&flask_wheel)?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut flask_wheel_file)?;
+    std::io::copy(&mut &bytes[..], &mut flask_wheel_file)?;
 
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str(&format!(
@@ -2842,10 +2842,10 @@ fn compile_wheel_path_dependency() -> Result<()> {
 fn compile_source_distribution_path_dependency() -> Result<()> {
     let context = TestContext::new("3.12");
     // Download a source distribution.
-    let response = reqwest::blocking::get("https://files.pythonhosted.org/packages/d8/09/c1a7354d3925a3c6c8cfdebf4245bae67d633ffda1ba415add06ffc839c5/flask-3.0.0.tar.gz")?;
+    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/d8/09/c1a7354d3925a3c6c8cfdebf4245bae67d633ffda1ba415add06ffc839c5/flask-3.0.0.tar.gz");
     let flask_wheel = context.temp_dir.child("flask-3.0.0.tar.gz");
     let mut flask_wheel_file = std::fs::File::create(&flask_wheel)?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut flask_wheel_file)?;
+    std::io::copy(&mut &bytes[..], &mut flask_wheel_file)?;
 
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str(&format!(
@@ -3517,10 +3517,10 @@ fn preserve_url() -> Result<()> {
 fn preserve_project_root() -> Result<()> {
     let context = TestContext::new("3.12");
     // Download a wheel.
-    let response = reqwest::blocking::get("https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl")?;
+    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl");
     let flask_wheel = context.temp_dir.child("flask-3.0.0-py3-none-any.whl");
     let mut flask_wheel_file = std::fs::File::create(flask_wheel)?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut flask_wheel_file)?;
+    std::io::copy(&mut &bytes[..], &mut flask_wheel_file)?;
 
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("flask @ file://${PROJECT_ROOT}/flask-3.0.0-py3-none-any.whl")?;
@@ -3670,10 +3670,10 @@ fn error_missing_unnamed_env_var() -> Result<()> {
 fn respect_file_env_var() -> Result<()> {
     let context = TestContext::new("3.12");
     // Download a wheel.
-    let response = reqwest::blocking::get("https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl")?;
+    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl");
     let flask_wheel = context.temp_dir.child("flask-3.0.0-py3-none-any.whl");
     let mut flask_wheel_file = std::fs::File::create(flask_wheel)?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut flask_wheel_file)?;
+    std::io::copy(&mut &bytes[..], &mut flask_wheel_file)?;
 
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("flask @ ${FILE_PATH}")?;

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -9,7 +9,7 @@ use assert_fs::prelude::*;
 use indoc::indoc;
 use url::Url;
 
-use crate::common::{reqwest_blocking_get, uv_snapshot, TestContext};
+use crate::common::{download_to_disk, uv_snapshot, TestContext};
 use uv_fs::Simplified;
 
 #[test]
@@ -2592,10 +2592,11 @@ fn compile_wheel_path_dependency() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl");
     let flask_wheel = context.temp_dir.child("flask-3.0.0-py3-none-any.whl");
-    let mut flask_wheel_file = fs::File::create(&flask_wheel)?;
-    std::io::copy(&mut &bytes[..], &mut flask_wheel_file)?;
+    download_to_disk(
+        "https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl",
+        &flask_wheel,
+    );
 
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str(&format!(
@@ -2842,10 +2843,11 @@ fn compile_wheel_path_dependency() -> Result<()> {
 fn compile_source_distribution_path_dependency() -> Result<()> {
     let context = TestContext::new("3.12");
     // Download a source distribution.
-    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/d8/09/c1a7354d3925a3c6c8cfdebf4245bae67d633ffda1ba415add06ffc839c5/flask-3.0.0.tar.gz");
     let flask_wheel = context.temp_dir.child("flask-3.0.0.tar.gz");
-    let mut flask_wheel_file = std::fs::File::create(&flask_wheel)?;
-    std::io::copy(&mut &bytes[..], &mut flask_wheel_file)?;
+    download_to_disk(
+        "https://files.pythonhosted.org/packages/d8/09/c1a7354d3925a3c6c8cfdebf4245bae67d633ffda1ba415add06ffc839c5/flask-3.0.0.tar.gz",
+        &flask_wheel,
+    );
 
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str(&format!(
@@ -3517,10 +3519,11 @@ fn preserve_url() -> Result<()> {
 fn preserve_project_root() -> Result<()> {
     let context = TestContext::new("3.12");
     // Download a wheel.
-    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl");
     let flask_wheel = context.temp_dir.child("flask-3.0.0-py3-none-any.whl");
-    let mut flask_wheel_file = std::fs::File::create(flask_wheel)?;
-    std::io::copy(&mut &bytes[..], &mut flask_wheel_file)?;
+    download_to_disk(
+        "https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl",
+        &flask_wheel,
+    );
 
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("flask @ file://${PROJECT_ROOT}/flask-3.0.0-py3-none-any.whl")?;
@@ -3670,10 +3673,11 @@ fn error_missing_unnamed_env_var() -> Result<()> {
 fn respect_file_env_var() -> Result<()> {
     let context = TestContext::new("3.12");
     // Download a wheel.
-    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl");
     let flask_wheel = context.temp_dir.child("flask-3.0.0-py3-none-any.whl");
-    let mut flask_wheel_file = std::fs::File::create(flask_wheel)?;
-    std::io::copy(&mut &bytes[..], &mut flask_wheel_file)?;
+    download_to_disk(
+        "https://files.pythonhosted.org/packages/36/42/015c23096649b908c809c69388a805a571a3bea44362fe87e33fc3afa01f/flask-3.0.0-py3-none-any.whl",
+        &flask_wheel,
+    );
 
     let requirements_in = context.temp_dir.child("requirements.in");
     requirements_in.write_str("flask @ ${FILE_PATH}")?;

--- a/crates/uv/tests/it/pip_sync.rs
+++ b/crates/uv/tests/it/pip_sync.rs
@@ -12,7 +12,7 @@ use predicates::Predicate;
 use url::Url;
 
 use crate::common::{
-    copy_dir_all, reqwest_blocking_get, site_packages_path, uv_snapshot, venv_to_interpreter,
+    copy_dir_all, download_to_disk, site_packages_path, uv_snapshot, venv_to_interpreter,
     TestContext,
 };
 use uv_fs::Simplified;
@@ -1070,10 +1070,8 @@ fn install_local_wheel() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let response = reqwest_blocking_get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl");
     let archive = context.temp_dir.child("tomli-2.0.1-py3-none-any.whl");
-    let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut &response[..], &mut archive_file)?;
+    download_to_disk("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl", &archive);
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!(
@@ -1209,10 +1207,8 @@ fn mismatched_version() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl");
     let archive = context.temp_dir.child("tomli-3.7.2-py3-none-any.whl");
-    let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut &bytes[..], &mut archive_file)?;
+    download_to_disk("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl", &archive);
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!(
@@ -1244,10 +1240,11 @@ fn mismatched_name() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl");
     let archive = context.temp_dir.child("foo-2.0.1-py3-none-any.whl");
-    let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut &bytes[..], &mut archive_file)?;
+    download_to_disk(
+        "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
+        &archive,
+    );
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!(
@@ -1280,10 +1277,11 @@ fn install_local_source_distribution() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a source distribution.
-    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/b0/b4/bc2baae3970c282fae6c2cb8e0f179923dceb7eaffb0e76170628f9af97b/wheel-0.42.0.tar.gz");
     let archive = context.temp_dir.child("wheel-0.42.0.tar.gz");
-    let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut &bytes[..], &mut archive_file)?;
+    download_to_disk(
+        "https://files.pythonhosted.org/packages/b0/b4/bc2baae3970c282fae6c2cb8e0f179923dceb7eaffb0e76170628f9af97b/wheel-0.42.0.tar.gz",
+        &archive,
+    );
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!(
@@ -1640,10 +1638,11 @@ fn install_path_source_dist_cached() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a source distribution.
-    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz");
     let archive = context.temp_dir.child("source_distribution-0.0.1.tar.gz");
-    let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut &bytes[..], &mut archive_file)?;
+    download_to_disk(
+        "https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz",
+        &archive,
+    );
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!(
@@ -1735,10 +1734,11 @@ fn install_path_built_dist_cached() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl");
     let archive = context.temp_dir.child("tomli-2.0.1-py3-none-any.whl");
-    let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut &bytes[..], &mut archive_file)?;
+    download_to_disk(
+        "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
+        &archive,
+    );
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     let url = Url::from_file_path(archive.path()).unwrap();

--- a/crates/uv/tests/it/pip_sync.rs
+++ b/crates/uv/tests/it/pip_sync.rs
@@ -12,7 +12,8 @@ use predicates::Predicate;
 use url::Url;
 
 use crate::common::{
-    copy_dir_all, site_packages_path, uv_snapshot, venv_to_interpreter, TestContext,
+    copy_dir_all, reqwest_blocking_get, site_packages_path, uv_snapshot, venv_to_interpreter,
+    TestContext,
 };
 use uv_fs::Simplified;
 
@@ -1069,10 +1070,10 @@ fn install_local_wheel() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let response = reqwest::blocking::get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl")?;
+    let response = reqwest_blocking_get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl");
     let archive = context.temp_dir.child("tomli-2.0.1-py3-none-any.whl");
     let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut archive_file)?;
+    std::io::copy(&mut &response[..], &mut archive_file)?;
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!(
@@ -1208,10 +1209,10 @@ fn mismatched_version() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let response = reqwest::blocking::get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl")?;
+    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl");
     let archive = context.temp_dir.child("tomli-3.7.2-py3-none-any.whl");
     let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut archive_file)?;
+    std::io::copy(&mut &bytes[..], &mut archive_file)?;
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!(
@@ -1243,10 +1244,10 @@ fn mismatched_name() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let response = reqwest::blocking::get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl")?;
+    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl");
     let archive = context.temp_dir.child("foo-2.0.1-py3-none-any.whl");
     let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut archive_file)?;
+    std::io::copy(&mut &bytes[..], &mut archive_file)?;
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!(
@@ -1279,10 +1280,10 @@ fn install_local_source_distribution() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a source distribution.
-    let response = reqwest::blocking::get("https://files.pythonhosted.org/packages/b0/b4/bc2baae3970c282fae6c2cb8e0f179923dceb7eaffb0e76170628f9af97b/wheel-0.42.0.tar.gz")?;
+    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/b0/b4/bc2baae3970c282fae6c2cb8e0f179923dceb7eaffb0e76170628f9af97b/wheel-0.42.0.tar.gz");
     let archive = context.temp_dir.child("wheel-0.42.0.tar.gz");
     let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut archive_file)?;
+    std::io::copy(&mut &bytes[..], &mut archive_file)?;
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!(
@@ -1639,10 +1640,10 @@ fn install_path_source_dist_cached() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a source distribution.
-    let response = reqwest::blocking::get("https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz")?;
+    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/10/1f/57aa4cce1b1abf6b433106676e15f9fa2c92ed2bd4cf77c3b50a9e9ac773/source_distribution-0.0.1.tar.gz");
     let archive = context.temp_dir.child("source_distribution-0.0.1.tar.gz");
     let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut archive_file)?;
+    std::io::copy(&mut &bytes[..], &mut archive_file)?;
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     requirements_txt.write_str(&format!(
@@ -1734,10 +1735,10 @@ fn install_path_built_dist_cached() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let response = reqwest::blocking::get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl")?;
+    let bytes = reqwest_blocking_get("https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl");
     let archive = context.temp_dir.child("tomli-2.0.1-py3-none-any.whl");
     let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut archive_file)?;
+    std::io::copy(&mut &bytes[..], &mut archive_file)?;
 
     let requirements_txt = context.temp_dir.child("requirements.txt");
     let url = Url::from_file_path(archive.path()).unwrap();

--- a/crates/uv/tests/it/show_settings.rs
+++ b/crates/uv/tests/it/show_settings.rs
@@ -3552,12 +3552,12 @@ fn allow_insecure_host() -> anyhow::Result<()> {
             index_strategy: FirstIndex,
             keyring_provider: Disabled,
             allow_insecure_host: [
-                TrustedHost {
+                Host {
                     scheme: None,
                     host: "google.com",
                     port: None,
                 },
-                TrustedHost {
+                Host {
                     scheme: None,
                     host: "example.com",
                     port: None,

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -2,10 +2,11 @@ use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::{fixture::ChildPath, prelude::*};
 use insta::assert_snapshot;
+
 use predicates::prelude::predicate;
 use tempfile::tempdir_in;
 
-use crate::common::{reqwest_blocking_get, uv_snapshot, venv_bin_path, TestContext};
+use crate::common::{download_to_disk, uv_snapshot, venv_bin_path, TestContext};
 
 #[test]
 fn sync() -> Result<()> {
@@ -2309,12 +2310,13 @@ fn sync_wheel_path_source_error() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let bytes = reqwest_blocking_get( "https://files.pythonhosted.org/packages/08/fd/cc2fedbd887223f9f5d170c96e57cbf655df9831a6546c1727ae13fa977a/cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl");
     let archive = context
         .temp_dir
         .child("cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl");
-    let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut &bytes[..], &mut archive_file)?;
+    download_to_disk(
+        "https://files.pythonhosted.org/packages/08/fd/cc2fedbd887223f9f5d170c96e57cbf655df9831a6546c1727ae13fa977a/cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl",
+        &archive,
+    );
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -1,13 +1,11 @@
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::{fixture::ChildPath, prelude::*};
-use common::{reqwest_blocking_get, uv_snapshot, venv_bin_path, TestContext};
 use insta::assert_snapshot;
 use predicates::prelude::predicate;
 use tempfile::tempdir_in;
 
-use crate::common::{uv_snapshot, venv_bin_path, TestContext};
-use predicates::prelude::predicate;
+use crate::common::{reqwest_blocking_get, uv_snapshot, venv_bin_path, TestContext};
 
 #[test]
 fn sync() -> Result<()> {

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use assert_cmd::prelude::*;
 use assert_fs::{fixture::ChildPath, prelude::*};
+use common::{reqwest_blocking_get, uv_snapshot, venv_bin_path, TestContext};
 use insta::assert_snapshot;
+use predicates::prelude::predicate;
 use tempfile::tempdir_in;
 
 use crate::common::{uv_snapshot, venv_bin_path, TestContext};
@@ -2309,12 +2311,12 @@ fn sync_wheel_path_source_error() -> Result<()> {
     let context = TestContext::new("3.12");
 
     // Download a wheel.
-    let response = reqwest::blocking::get("https://files.pythonhosted.org/packages/08/fd/cc2fedbd887223f9f5d170c96e57cbf655df9831a6546c1727ae13fa977a/cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl")?;
+    let bytes = reqwest_blocking_get( "https://files.pythonhosted.org/packages/08/fd/cc2fedbd887223f9f5d170c96e57cbf655df9831a6546c1727ae13fa977a/cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl");
     let archive = context
         .temp_dir
         .child("cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl");
     let mut archive_file = fs_err::File::create(archive.path())?;
-    std::io::copy(&mut response.bytes()?.as_ref(), &mut archive_file)?;
+    std::io::copy(&mut &bytes[..], &mut archive_file)?;
 
     let pyproject_toml = context.temp_dir.child("pyproject.toml");
     pyproject_toml.write_str(


### PR DESCRIPTION
Allow '*' as a value to match all hosts, and provide `reqwest_blocking_get` for uv tests, so that they also respect UV_INSECURE_HOST (since they respect `ALL_PROXY`).

This lets those tests pass with a forward proxy - we can think about setting a root certificate later so that we don't need to disable certificate verification at all.

---

I tested this locally by running:

```bash
GIT_SSL_NO_VERIFY=true ALL_PROXY=localhost:8080 UV_INSECURE_HOST="*" cargo nextest run sync_wheel_path_source_error
```

With my forward proxy showing:

```
2024-10-09T18:20:16.300188Z  INFO fopro: Proxied GET https://files.pythonhosted.org/packages/08/fd/cc2fedbd887223f9f5d170c96e57cbf655df9831a6546c1727ae13fa977a/cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl (headers 480.024958ms + body 92.345666ms)
2024-10-09T18:20:16.913298Z  INFO fopro: Proxied GET https://pypi.org/simple/pycparser/ (headers 509.664834ms + body 269.291µs)
2024-10-09T18:20:17.383975Z  INFO fopro: Proxied GET https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl.metadata (headers 443.184208ms + body 2.094792ms)
```