### PR TITLE
chore(renovate): move out of deprecated options

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
   semanticCommits: "disabled",
   separateMajorMinor: false,
   prHourlyLimit: 10,
-  enabledManagers: ["github-actions", "pre-commit", "cargo", "regex"],
+  enabledManagers: ["github-actions", "pre-commit", "cargo", "custom.regex"],
   cargo: {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy
     rangeStrategy: "update-lockfile",
@@ -25,13 +25,13 @@
     {
       // Disable updates of `zip-rs`; intentionally pinned for now due to ownership change
       // See: https://github.com/astral-sh/uv/issues/3642
-      matchPackagePatterns: ["zip"],
+      matchPackageNames: ["/zip/"],
       matchManagers: ["cargo"],
       enabled: false,
     },
     {
       // Create dedicated branches to update references to dependencies in the documentation.
-      matchPaths: ["docs/**/*.md"],
+      matchFileNames: ["docs/**/*.md"],
       commitMessageTopic: "documentation references to {{{depName}}}",
       semanticCommitType: "docs",
       semanticCommitScope: null,
@@ -42,7 +42,7 @@
       groupName: "Artifact GitHub Actions dependencies",
       matchManagers: ["github-actions"],
       matchDatasources: ["gitea-tags", "github-tags"],
-      matchPackagePatterns: ["actions/.*-artifact"],
+      matchPackageNames: ["/actions/.*-artifact/"],
       description: "Weekly update of artifact-related GitHub Actions dependencies",
     },
     {
@@ -71,7 +71,7 @@
       // of the PEP 440 and PEP 508 crates, which we vendored and forked.
       groupName: "pyo3",
       matchManagers: ["cargo"],
-      matchPackagePatterns: ["pyo3"],
+      matchPackageNames: ["/pyo3/"],
       description: "Weekly update of pyo3 dependencies",
       enabled: false,
     },


### PR DESCRIPTION
## Summary

Found out with `npx -p renovate renovate-config-validator`.

<details>
  <summary>Output</summary>

  ```console
   INFO: Validating .github/renovate.json5
   WARN: Config migration necessary
         "oldConfig": {
           "$schema": "https://docs.renovatebot.com/renovate-schema.json",
           "dependencyDashboard": true,
           "suppressNotifications": ["prEditedNotification"],
           "extends": ["config:recommended", "customManagers:githubActionsVersions"],
           "labels": ["internal"],
           "schedule": ["before 4am on Monday"],
           "semanticCommits": "disabled",
           "separateMajorMinor": false,
           "prHourlyLimit": 10,
           "enabledManagers": ["github-actions", "pre-commit", "cargo", "regex"],
           "cargo": {
             "rangeStrategy": "update-lockfile",
             "fileMatch": ["^crates/.*Cargo\\.toml$"]
           },
           "pre-commit": {"enabled": true},
           "packageRules": [
             {
               "matchPackagePatterns": ["zip"],
               "matchManagers": ["cargo"],
               "enabled": false
             },
             {
               "matchPaths": ["docs/**/*.md"],
               "commitMessageTopic": "documentation references to {{{depName}}}",
               "semanticCommitType": "docs",
               "semanticCommitScope": null,
               "additionalBranchPrefix": "docs-"
             },
             {
               "groupName": "Artifact GitHub Actions dependencies",
               "matchManagers": ["github-actions"],
               "matchDatasources": ["gitea-tags", "github-tags"],
               "matchPackagePatterns": ["actions/.*-artifact"],
               "description": "Weekly update of artifact-related GitHub Actions dependencies"
             },
             {
               "groupName": "GitHub runners",
               "matchManagers": ["github-actions"],
               "matchDatasources": ["github-runners"],
               "description": "Disable PRs updating GitHub runners (e.g. 'runs-on: macos-14')",
               "enabled": false
             },
             {
               "groupName": "pre-commit dependencies",
               "matchManagers": ["pre-commit"],
               "description": "Weekly update of pre-commit dependencies"
             },
             {
               "groupName": "Rust dev-dependencies",
               "matchManagers": ["cargo"],
               "matchDepTypes": ["devDependencies"],
               "description": "Weekly update of Rust development dependencies"
             },
             {
               "groupName": "pyo3",
               "matchManagers": ["cargo"],
               "matchPackagePatterns": ["pyo3"],
               "description": "Weekly update of pyo3 dependencies",
               "enabled": false
             }
           ],
           "customManagers": [
             {
               "customType": "regex",
               "fileMatch": ["^docs/.*\\.md$"],
               "matchStrings": [
                 "\\suses: (?<depName>[\\w-]+/[\\w-]+)(?<path>/.*)?@(?<currentValue>.+?)\\s"
               ],
               "datasourceTemplate": "github-tags",
               "versioningTemplate": "regex:^v(?<major>\\d+)$"
             }
           ],
           "vulnerabilityAlerts": {
             "commitMessageSuffix": "",
             "labels": ["internal", "security"]
           }
         },
         "newConfig": {
           "$schema": "https://docs.renovatebot.com/renovate-schema.json",
           "dependencyDashboard": true,
           "suppressNotifications": ["prEditedNotification"],
           "extends": ["config:recommended", "customManagers:githubActionsVersions"],
           "labels": ["internal"],
           "schedule": ["before 4am on Monday"],
           "semanticCommits": "disabled",
           "separateMajorMinor": false,
           "prHourlyLimit": 10,
           "enabledManagers": ["github-actions", "pre-commit", "cargo", "custom.regex"],
           "cargo": {
             "rangeStrategy": "update-lockfile",
             "fileMatch": ["^crates/.*Cargo\\.toml$"]
           },
           "pre-commit": {"enabled": true},
           "packageRules": [
             {
               "matchManagers": ["cargo"],
               "enabled": false,
               "matchPackageNames": ["/zip/"]
             },
             {
               "matchFileNames": ["docs/**/*.md"],
               "commitMessageTopic": "documentation references to {{{depName}}}",
               "semanticCommitType": "docs",
               "semanticCommitScope": null,
               "additionalBranchPrefix": "docs-"
             },
             {
               "groupName": "Artifact GitHub Actions dependencies",
               "matchManagers": ["github-actions"],
               "matchDatasources": ["gitea-tags", "github-tags"],
               "description": "Weekly update of artifact-related GitHub Actions dependencies",
               "matchPackageNames": ["/actions/.*-artifact/"]
             },
             {
               "groupName": "GitHub runners",
               "matchManagers": ["github-actions"],
               "matchDatasources": ["github-runners"],
               "description": "Disable PRs updating GitHub runners (e.g. 'runs-on: macos-14')",
               "enabled": false
             },
             {
               "groupName": "pre-commit dependencies",
               "matchManagers": ["pre-commit"],
               "description": "Weekly update of pre-commit dependencies"
             },
             {
               "groupName": "Rust dev-dependencies",
               "matchManagers": ["cargo"],
               "matchDepTypes": ["devDependencies"],
               "description": "Weekly update of Rust development dependencies"
             },
             {
               "groupName": "pyo3",
               "matchManagers": ["cargo"],
               "description": "Weekly update of pyo3 dependencies",
               "enabled": false,
               "matchPackageNames": ["/pyo3/"]
             }
           ],
           "customManagers": [
             {
               "customType": "regex",
               "fileMatch": ["^docs/.*\\.md$"],
               "matchStrings": [
                 "\\suses: (?<depName>[\\w-]+/[\\w-]+)(?<path>/.*)?@(?<currentValue>.+?)\\s"
               ],
               "datasourceTemplate": "github-tags",
               "versioningTemplate": "regex:^v(?<major>\\d+)$"
             }
           ],
           "vulnerabilityAlerts": {
             "commitMessageSuffix": "",
             "labels": ["internal", "security"]
           }
         }
  INFO: Config validated successfully
  ```
</details>

Relevant PRs:
- https://github.com/renovatebot/renovate/pull/22406
- https://github.com/renovatebot/renovate/pull/24079
- https://github.com/renovatebot/renovate/pull/30382