### PR TITLE
Use comma-separated values for `UV_FIND_LINKS`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3813,7 +3813,6 @@ pub struct IndexArgs {
         long,
         short,
         env = "UV_FIND_LINKS",
-        value_delimiter = ' ',
         value_parser = parse_flat_index,
         help_heading = "Index options"
     )]

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -7,7 +7,7 @@ uv accepts the following command-line arguments as environment variables:
 - `UV_EXTRA_INDEX_URL`: Equivalent to the `--extra-index-url` command-line argument. If set, uv will
   use this space-separated list of URLs as additional indexes when searching for packages.
 - `UV_FIND_LINKS`: Equivalent to the `--find-links` command-line argument. If set, uv will use this
-  space-separated list of additional locations to search for packages.
+  comma-separated list of additional locations to search for packages.
 - `UV_CACHE_DIR`: Equivalent to the `--cache-dir` command-line argument. If set, uv will use this
   directory for caching instead of the default cache directory.
 - `UV_NO_CACHE`: Equivalent to the `--no-cache` command-line argument. If set, uv will not use the


### PR DESCRIPTION
## Summary

These values can include spaces when passed on the command-line... Clap doesn't give us a way to provide a value separator for _only_ an environment variable (as is pip's behavior), so I think we're stuck using comma-separated for here right now.

See, e.g., https://github.com/clap-rs/clap/discussions/3796.

Closes #8057.