### PR TITLE
Add `--show-urls` and `--only-downloads` to `uv python list`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -4225,8 +4225,20 @@ pub struct PythonListArgs {
     /// Only show installed Python versions, exclude available downloads.
     ///
     /// By default, available downloads for the current platform are shown.
-    #[arg(long)]
+    #[arg(long, conflicts_with("only_downloads"))]
     pub only_installed: bool,
+
+    /// Only show Python downloads, exclude installed distributions.
+    ///
+    /// By default, available downloads for the current platform are shown.
+    #[arg(long, conflicts_with("only_installed"))]
+    pub only_downloads: bool,
+
+    /// Show the URLs of available Python downloads.
+    ///
+    /// By default, these display as `<download available>`.
+    #[arg(long)]
+    pub show_urls: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/python/list.rs
+++ b/crates/uv/src/commands/python/list.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::fmt::Write;
 
 use anyhow::Result;
+use itertools::Either;
 use owo_colors::OwoColorize;
 use rustc_hash::FxHashSet;
 use uv_cache::Cache;
@@ -29,6 +30,7 @@ pub(crate) async fn list(
     kinds: PythonListKinds,
     all_versions: bool,
     all_platforms: bool,
+    show_urls: bool,
     python_preference: PythonPreference,
     python_downloads: PythonDownloads,
     cache: &Cache,
@@ -38,6 +40,11 @@ pub(crate) async fn list(
     if python_preference != PythonPreference::OnlySystem {
         let download_request = match kinds {
             PythonListKinds::Installed => None,
+            PythonListKinds::Downloads => Some(if all_platforms {
+                PythonDownloadRequest::default()
+            } else {
+                PythonDownloadRequest::from_env()?
+            }),
             PythonListKinds::Default => {
                 if python_downloads.is_automatic() {
                     Some(if all_platforms {
@@ -61,48 +68,60 @@ pub(crate) async fn list(
             .flatten();
 
         for download in downloads {
-            output.insert((download.key().clone(), Kind::Download, None));
+            output.insert((
+                download.key().clone(),
+                Kind::Download,
+                Either::Right(download.url()),
+            ));
         }
     };
 
-    let installed = find_python_installations(
-        &PythonRequest::Any,
-        EnvironmentPreference::OnlySystem,
-        python_preference,
-        cache,
-    )
-    // Raise discovery errors if critical
-    .filter(|result| {
-        result
-            .as_ref()
-            .err()
-            .map_or(true, DiscoveryError::is_critical)
-    })
-    .collect::<Result<Vec<Result<PythonInstallation, PythonNotFound>>, DiscoveryError>>()?
-    .into_iter()
-    // Drop any "missing" installations
-    .filter_map(Result::ok);
-
-    for installation in installed {
-        let kind = if matches!(installation.source(), PythonSource::Managed) {
-            Kind::Managed
-        } else {
-            Kind::System
+    let installed =
+        match kinds {
+            PythonListKinds::Installed | PythonListKinds::Default => {
+                Some(find_python_installations(
+                &PythonRequest::Any,
+                EnvironmentPreference::OnlySystem,
+                python_preference,
+                cache,
+            )
+            // Raise discovery errors if critical
+            .filter(|result| {
+                result
+                    .as_ref()
+                    .err()
+                    .map_or(true, DiscoveryError::is_critical)
+            })
+            .collect::<Result<Vec<Result<PythonInstallation, PythonNotFound>>, DiscoveryError>>()?
+            .into_iter()
+            // Drop any "missing" installations
+            .filter_map(Result::ok))
+            }
+            PythonListKinds::Downloads => None,
         };
-        output.insert((
-            installation.key(),
-            kind,
-            Some(installation.interpreter().sys_executable().to_path_buf()),
-        ));
+
+    if let Some(installed) = installed {
+        for installation in installed {
+            let kind = if matches!(installation.source(), PythonSource::Managed) {
+                Kind::Managed
+            } else {
+                Kind::System
+            };
+            output.insert((
+                installation.key(),
+                kind,
+                Either::Left(installation.interpreter().sys_executable().to_path_buf()),
+            ));
+        }
     }
 
     let mut seen_minor = FxHashSet::default();
     let mut seen_patch = FxHashSet::default();
     let mut seen_paths = FxHashSet::default();
     let mut include = Vec::new();
-    for (key, kind, path) in output.iter().rev() {
+    for (key, kind, uri) in output.iter().rev() {
         // Do not show the same path more than once
-        if let Some(path) = path {
+        if let Either::Left(path) = uri {
             if !seen_paths.insert(path) {
                 continue;
             }
@@ -142,7 +161,7 @@ pub(crate) async fn list(
                 }
             }
         }
-        include.push((key, path));
+        include.push((key, uri));
     }
 
     // Compute the width of the first column.
@@ -150,30 +169,37 @@ pub(crate) async fn list(
         .iter()
         .fold(0usize, |acc, (key, _)| acc.max(key.to_string().len()));
 
-    for (key, path) in include {
+    for (key, uri) in include {
         let key = key.to_string();
-        if let Some(path) = path {
-            let is_symlink = fs_err::symlink_metadata(path)?.is_symlink();
-            if is_symlink {
-                writeln!(
-                    printer.stdout(),
-                    "{key:width$}    {} -> {}",
-                    path.user_display().cyan(),
-                    path.read_link()?.user_display().cyan()
-                )?;
-            } else {
-                writeln!(
-                    printer.stdout(),
-                    "{key:width$}    {}",
-                    path.user_display().cyan()
-                )?;
+        match uri {
+            Either::Left(path) => {
+                let is_symlink = fs_err::symlink_metadata(path)?.is_symlink();
+                if is_symlink {
+                    writeln!(
+                        printer.stdout(),
+                        "{key:width$}    {} -> {}",
+                        path.user_display().cyan(),
+                        path.read_link()?.user_display().cyan()
+                    )?;
+                } else {
+                    writeln!(
+                        printer.stdout(),
+                        "{key:width$}    {}",
+                        path.user_display().cyan()
+                    )?;
+                }
             }
-        } else {
-            writeln!(
-                printer.stdout(),
-                "{key:width$}    {}",
-                "<download available>".dimmed()
-            )?;
+            Either::Right(url) => {
+                if show_urls {
+                    writeln!(printer.stdout(), "{key:width$}    {}", url.dimmed())?;
+                } else {
+                    writeln!(
+                        printer.stdout(),
+                        "{key:width$}    {}",
+                        "<download available>".dimmed()
+                    )?;
+                }
+            }
         }
     }
 

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1088,6 +1088,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.kinds,
                 args.all_versions,
                 args.all_platforms,
+                args.show_urls,
                 globals.python_preference,
                 globals.python_downloads,
                 &cache,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -703,6 +703,9 @@ impl ToolDirSettings {
 pub(crate) enum PythonListKinds {
     #[default]
     Default,
+    /// Only list version downloads.
+    Downloads,
+    /// Only list installed versions.
     Installed,
 }
 
@@ -713,6 +716,7 @@ pub(crate) struct PythonListSettings {
     pub(crate) kinds: PythonListKinds,
     pub(crate) all_platforms: bool,
     pub(crate) all_versions: bool,
+    pub(crate) show_urls: bool,
 }
 
 impl PythonListSettings {
@@ -723,10 +727,14 @@ impl PythonListSettings {
             all_versions,
             all_platforms,
             only_installed,
+            only_downloads,
+            show_urls,
         } = args;
 
         let kinds = if only_installed {
             PythonListKinds::Installed
+        } else if only_downloads {
+            PythonListKinds::Downloads
         } else {
             PythonListKinds::default()
         };
@@ -735,6 +743,7 @@ impl PythonListSettings {
             kinds,
             all_platforms,
             all_versions,
+            show_urls,
         }
     }
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4426,6 +4426,10 @@ uv python list [OPTIONS]
 
 <p>When disabled, uv will only use locally cached data and locally available files.</p>
 
+</dd><dt><code>--only-downloads</code></dt><dd><p>Only show Python downloads, exclude installed distributions.</p>
+
+<p>By default, available downloads for the current platform are shown.</p>
+
 </dd><dt><code>--only-installed</code></dt><dd><p>Only show installed Python versions, exclude available downloads.</p>
 
 <p>By default, available downloads for the current platform are shown.</p>
@@ -4457,6 +4461,10 @@ uv python list [OPTIONS]
 <li><code>only-system</code>:  Only use system Python installations; never use managed Python installations</li>
 </ul>
 </dd><dt><code>--quiet</code>, <code>-q</code></dt><dd><p>Do not print any output</p>
+
+</dd><dt><code>--show-urls</code></dt><dd><p>Show the URLs of available Python downloads.</p>
+
+<p>By default, these display as <code>&lt;download available&gt;</code>.</p>
 
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 


### PR DESCRIPTION
These are useful for creating a mirror of the Python downloads for a given uv version, e.g.:

```
❯ cargo run -q -- python list --show-urls --only-downloads
cpython-3.13.0-macos-aarch64-none     https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz
cpython-3.12.7-macos-aarch64-none     https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz
cpython-3.11.10-macos-aarch64-none    https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz
cpython-3.10.15-macos-aarch64-none    https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz
cpython-3.9.20-macos-aarch64-none     https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz
cpython-3.8.20-macos-aarch64-none     https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz
pypy-3.10.14-macos-aarch64-none       https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_arm64.tar.bz2
pypy-3.9.19-macos-aarch64-none        https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_arm64.tar.bz2
pypy-3.8.16-macos-aarch64-none        https://downloads.python.org/pypy/pypy3.8-v7.3.11-macos_arm64.tar.bz2
```
