### PR TITLE
Downgrade installer verbose logging to trace

### DIFF
--- a/crates/uv-install-wheel/src/linker.rs
+++ b/crates/uv-install-wheel/src/linker.rs
@@ -17,7 +17,7 @@ use reflink_copy as reflink;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tempfile::tempdir_in;
-use tracing::{debug, instrument};
+use tracing::{debug, instrument, trace};
 use uv_cache_info::CacheInfo;
 use uv_distribution_filename::WheelFilename;
 use uv_pypi_types::{DirectUrl, Metadata12};
@@ -74,13 +74,13 @@ pub fn install_wheel(
 
     // > 1.c If Root-Is-Purelib == ‘true’, unpack archive into purelib (site-packages).
     // > 1.d Else unpack archive into platlib (site-packages).
-    debug!(?name, "Extracting file");
+    trace!(?name, "Extracting file");
     let site_packages = match lib_kind {
         LibKind::Pure => &layout.scheme.purelib,
         LibKind::Plat => &layout.scheme.platlib,
     };
     let num_unpacked = link_mode.link_wheel_files(site_packages, &wheel, locks)?;
-    debug!(?name, "Extracted {num_unpacked} files");
+    trace!(?name, "Extracted {num_unpacked} files");
 
     // Read the RECORD file.
     let mut record_file = File::open(
@@ -94,9 +94,9 @@ pub fn install_wheel(
         parse_scripts(&wheel, &dist_info_prefix, None, layout.python_version.1)?;
 
     if console_scripts.is_empty() && gui_scripts.is_empty() {
-        debug!(?name, "No entrypoints");
+        trace!(?name, "No entrypoints");
     } else {
-        debug!(?name, "Writing entrypoints");
+        trace!(?name, "Writing entrypoints");
 
         fs_err::create_dir_all(&layout.scheme.scripts)?;
         write_script_entrypoints(
@@ -121,7 +121,7 @@ pub fn install_wheel(
     // 2.b Move each subtree of distribution-1.0.data/ onto its destination path. Each subdirectory of distribution-1.0.data/ is a key into a dict of destination directories, such as distribution-1.0.data/(purelib|platlib|headers|scripts|data). The initially supported paths are taken from distutils.command.install.
     let data_dir = site_packages.join(format!("{dist_info_prefix}.data"));
     if data_dir.is_dir() {
-        debug!(?name, "Installing data");
+        trace!(?name, "Installing data");
         install_data(
             layout,
             relocatable,
@@ -137,10 +137,10 @@ pub fn install_wheel(
         // 2.e Remove empty distribution-1.0.data directory.
         fs::remove_dir_all(data_dir)?;
     } else {
-        debug!(?name, "No data");
+        trace!(?name, "No data");
     }
 
-    debug!(?name, "Writing extra metadata");
+    trace!(?name, "Writing extra metadata");
     extra_dist_info(
         site_packages,
         &dist_info_prefix,
@@ -151,7 +151,7 @@ pub fn install_wheel(
         &mut record,
     )?;
 
-    debug!(?name, "Writing record");
+    trace!(?name, "Writing record");
     let mut record_writer = csv::WriterBuilder::new()
         .has_headers(false)
         .escape(b'"')
@@ -370,7 +370,7 @@ fn clone_recursive(
     let from = entry.path();
     let to = site_packages.join(from.strip_prefix(wheel).unwrap());
 
-    debug!("Cloning {} to {}", from.display(), to.display());
+    trace!("Cloning {} to {}", from.display(), to.display());
 
     if (cfg!(windows) || cfg!(target_os = "linux")) && from.is_dir() {
         // On Windows, reflinking directories is not supported, so we copy each file instead.

--- a/crates/uv-install-wheel/src/uninstall.rs
+++ b/crates/uv-install-wheel/src/uninstall.rs
@@ -3,7 +3,7 @@ use std::path::{Component, Path, PathBuf};
 
 use fs_err as fs;
 use std::sync::{LazyLock, Mutex};
-use tracing::debug;
+use tracing::trace;
 use uv_fs::write_atomic_sync;
 
 use crate::wheel::read_record_file;
@@ -39,7 +39,7 @@ pub fn uninstall_wheel(dist_info: &Path) -> Result<Uninstall, Error> {
         let path = site_packages.join(&entry.path);
         match fs::remove_file(&path) {
             Ok(()) => {
-                debug!("Removed file: {}", path.display());
+                trace!("Removed file: {}", path.display());
                 file_count += 1;
                 if let Some(parent) = path.parent() {
                     visited.insert(normalize_path(parent));
@@ -48,7 +48,7 @@ pub fn uninstall_wheel(dist_info: &Path) -> Result<Uninstall, Error> {
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
             Err(err) => match fs::remove_dir_all(&path) {
                 Ok(()) => {
-                    debug!("Removed directory: {}", path.display());
+                    trace!("Removed directory: {}", path.display());
                     dir_count += 1;
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -81,7 +81,7 @@ pub fn uninstall_wheel(dist_info: &Path) -> Result<Uninstall, Error> {
             let pycache = path.join("__pycache__");
             match fs::remove_dir_all(&pycache) {
                 Ok(()) => {
-                    debug!("Removed directory: {}", pycache.display());
+                    trace!("Removed directory: {}", pycache.display());
                     dir_count += 1;
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -103,7 +103,7 @@ pub fn uninstall_wheel(dist_info: &Path) -> Result<Uninstall, Error> {
 
             fs::remove_dir(path)?;
 
-            debug!("Removed directory: {}", path.display());
+            trace!("Removed directory: {}", path.display());
             dir_count += 1;
 
             if let Some(parent) = path.parent() {
@@ -169,7 +169,7 @@ pub fn uninstall_egg(egg_info: &Path) -> Result<Uninstall, Error> {
         // Remove as a directory.
         match fs_err::remove_dir_all(&path) {
             Ok(()) => {
-                debug!("Removed directory: {}", path.display());
+                trace!("Removed directory: {}", path.display());
                 dir_count += 1;
                 continue;
             }
@@ -182,7 +182,7 @@ pub fn uninstall_egg(egg_info: &Path) -> Result<Uninstall, Error> {
             let path = path.with_extension(extension);
             match fs_err::remove_file(&path) {
                 Ok(()) => {
-                    debug!("Removed file: {}", path.display());
+                    trace!("Removed file: {}", path.display());
                     file_count += 1;
                     break;
                 }
@@ -195,7 +195,7 @@ pub fn uninstall_egg(egg_info: &Path) -> Result<Uninstall, Error> {
     // Remove the `.egg-info` directory.
     match fs_err::remove_dir_all(egg_info) {
         Ok(()) => {
-            debug!("Removed directory: {}", egg_info.display());
+            trace!("Removed directory: {}", egg_info.display());
             dir_count += 1;
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -245,7 +245,7 @@ pub fn uninstall_legacy_editable(egg_link: &Path) -> Result<Uninstall, Error> {
 
     match fs::remove_file(egg_link) {
         Ok(()) => {
-            debug!("Removed file: {}", egg_link.display());
+            trace!("Removed file: {}", egg_link.display());
             file_count += 1;
         }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -277,7 +277,7 @@ pub fn uninstall_legacy_editable(egg_link: &Path) -> Result<Uninstall, Error> {
     }
     if removed {
         write_atomic_sync(&easy_install, new_content)?;
-        debug!("Removed line from `easy-install.pth`: {target_line}");
+        trace!("Removed line from `easy-install.pth`: {target_line}");
     }
 
     Ok(Uninstall {


### PR DESCRIPTION
## Summary

Now that `uv-install-wheel` output shows up in `--verbose`, lets leave `debug!` to logs that users might want to see. Logging _every_ file we install seems excessive.
