### PR TITLE
Treat resolver failures as fatal in lockfile validation

### DIFF
--- a/crates/uv/tests/lock.rs
+++ b/crates/uv/tests/lock.rs
@@ -1069,7 +1069,7 @@ fn lock_wheel_url() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to download: `anyio @ https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl`
+    error: failed to generate package metadata for `anyio==4.3.0 @ direct+https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl`
       Caused by: Network connectivity is disabled, but the requested data wasn't found in the cache for: `https://files.pythonhosted.org/packages/14/fd/2f20c40b45e4fb4324834aea24bd4afdf1143390242c0b33774da0e2e34f/anyio-4.3.0-py3-none-any.whl`
     "###);
 


### PR DESCRIPTION
## Summary

In the routine we use to verify whether the lockfile is up-to-date, we sometimes have to resolve package metadata. If that resolution step fails, the resolver is left in a bad state, as various tasks are marked as pending despite the error. Treating that as a recoverable failure thus leads to a deadlock.

This PR modifies the errors to be treated as fatal.

I think a more holistic fix here would be to add some kind of guard to ensure that any tasks that fail are no longer marked as pending (or enforce this in the type system).

Closes https://github.com/astral-sh/uv/issues/8074.
