### PR TITLE
Add support for managed installs of free-threaded Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,6 +657,23 @@ jobs:
         run: |
           ./uv pip install anyio
 
+      - name: "Install free-threaded Python via uv"
+        run: |
+          ./uv python install 3.13t
+          ./uv venv -p 3.13t --python-preference only-managed
+
+      - name: "Check version"
+        run: |
+          .venv/bin/python --version
+
+      - name: "Check is free-threaded"
+        run: |
+          .venv/bin/python -c "import sys; exit(1) if sys._is_gil_enabled() else exit(0)"
+
+      - name: "Check install"
+        run: |
+          ./uv pip install anyio
+
   integration-test-pypy-linux:
     timeout-minutes: 10
     needs: build-binary-linux

--- a/crates/uv-python/download-metadata.json
+++ b/crates/uv-python/download-metadata.json
@@ -12,19 +12,6 @@
     "sha256": "7bc4b23590a1e4b41b21b6aae6f92046c1d16d09bc0c1ab81272aa81b55221d1",
     "variant": null
   },
-  "cpython-3.13.0+freethreaded-darwin-aarch64-none": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-apple-darwin-freethreaded%2Bdebug-full.tar.zst",
-    "sha256": "4ba7f477c56af4f057ca40535aa6907662b7206e3b8b39971d0a507b1c955e44",
-    "variant": "freethreaded"
-  },
   "cpython-3.13.0-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -38,6 +25,136 @@
     "sha256": "d6bc769002842147150a561502a23b57d5a8aa1ba643a6a0abf589bfe834e642",
     "variant": null
   },
+  "cpython-3.13.0-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "1bfc058821199c4313ae67bb6c105df2c9dd3515bca955ff96724976acf64462",
+    "variant": null
+  },
+  "cpython-3.13.0-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
+    "sha256": "ae89ef85195386ce232de29e0f62e7544f80a6923119ed85af40d09a6468bf30",
+    "variant": null
+  },
+  "cpython-3.13.0-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
+    "sha256": "030974b9e1826513001c94cea4ef9248940fecc6efca034715770f7be232942a",
+    "variant": null
+  },
+  "cpython-3.13.0-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "894014ceb5374d1c43a2e297126e588fd5fc60d93e57b76e1bba16430b80e3f3",
+    "variant": null
+  },
+  "cpython-3.13.0-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "85e05e27c31cd7267cb17c4c16b729969dd586cd715287f923334db20a51ce67",
+    "variant": null
+  },
+  "cpython-3.13.0-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
+    "sha256": "aa876c2660a802d0df8ef46f9c4b1c952e63c65d16e103663c22b9468dad40b7",
+    "variant": null
+  },
+  "cpython-3.13.0-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
+    "sha256": "9606d04c867ba034b901ef1a63c5b5efcb6951e4a6e2cce9703d0ff98d96f579",
+    "variant": null
+  },
+  "cpython-3.13.0-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "fc96cb6a3e70bfcee13f7c5d08d30ecbe1738d934f885674d57f3b07b4291e5f",
+    "variant": null
+  },
+  "cpython-3.13.0-windows-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
+    "sha256": "c82b440476fe04e80228791350a451b65e8080ff01b7168f1c4a5eb9645371f3",
+    "variant": null
+  },
+  "cpython-3.13.0+freethreaded-darwin-aarch64-none": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-apple-darwin-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "4ba7f477c56af4f057ca40535aa6907662b7206e3b8b39971d0a507b1c955e44",
+    "variant": "freethreaded"
+  },
   "cpython-3.13.0+freethreaded-darwin-x86_64-none": {
     "name": "cpython",
     "arch": "x86_64",
@@ -49,6 +166,110 @@
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-apple-darwin-freethreaded%2Bdebug-full.tar.zst",
     "sha256": "b72b7df7cd22a4e7462dbe95633c5ca61caab41237d68e0ff89e9774cd4985e7",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.0+freethreaded-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "678b0e9cbe2a8e19b0d83d518c7e3689918b22b2847e24f01fb2ce71164f5788",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.0+freethreaded-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "bee06f4fb52a8333f603a29e47e09e43b3bda9a2f338df6c0ccd3e3b81e5347e",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.0+freethreaded-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabihf-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "4d1e234314e1a809c8d027273dfcd647f600490ae59b59341051d973f0c0f586",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.0+freethreaded-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "2d72fb6c7c91c9c00aa1e2b982bc7442da8a51665dfea2193e5e9098a6d7b2cb",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.0+freethreaded-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "533087017cbd1287af93936d9007bc1bd6ca8886b2cdf59171554cf55c6253e6",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.0+freethreaded-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "2b46a0f38711cfcdffab90f69ea1372288bd6dcb0f9676b765babb491d42ce06",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.0+freethreaded-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-i686-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
+    "sha256": "1dd414e0787f180760952bdc339dfde42e0b7503419baf20d38a6470ed65e455",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.0+freethreaded-windows-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
+    "sha256": "fc665561556f4dc843cd3eeba4d482f716aec65d5b89a657316829cfbdc9462a",
     "variant": "freethreaded"
   },
   "cpython-3.13.0+debug-linux-aarch64-gnu": {
@@ -64,32 +285,6 @@
     "sha256": "1449ca72692a9db62d691a3433e1fbda1a3030d3481aa6c8cf5b481369f44281",
     "variant": "debug"
   },
-  "cpython-3.13.0+freethreaded-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
-    "sha256": "678b0e9cbe2a8e19b0d83d518c7e3689918b22b2847e24f01fb2ce71164f5788",
-    "variant": "freethreaded"
-  },
-  "cpython-3.13.0-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "1bfc058821199c4313ae67bb6c105df2c9dd3515bca955ff96724976acf64462",
-    "variant": null
-  },
   "cpython-3.13.0+debug-linux-armv7-gnueabi": {
     "name": "cpython",
     "arch": "armv7",
@@ -102,32 +297,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
     "sha256": "c2561006d736f10d8172092a08fb219ba262c2414a01b733bc3fa92c4299c6fb",
     "variant": "debug"
-  },
-  "cpython-3.13.0+freethreaded-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-freethreaded%2Bdebug-full.tar.zst",
-    "sha256": "bee06f4fb52a8333f603a29e47e09e43b3bda9a2f338df6c0ccd3e3b81e5347e",
-    "variant": "freethreaded"
-  },
-  "cpython-3.13.0-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "ae89ef85195386ce232de29e0f62e7544f80a6923119ed85af40d09a6468bf30",
-    "variant": null
   },
   "cpython-3.13.0+debug-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -142,32 +311,6 @@
     "sha256": "198c445fa25916f054bcfbd16c8f4483b5fa7bb22e795b2fd2a7304cfee4a112",
     "variant": "debug"
   },
-  "cpython-3.13.0+freethreaded-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabihf-freethreaded%2Bdebug-full.tar.zst",
-    "sha256": "4d1e234314e1a809c8d027273dfcd647f600490ae59b59341051d973f0c0f586",
-    "variant": "freethreaded"
-  },
-  "cpython-3.13.0-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "030974b9e1826513001c94cea4ef9248940fecc6efca034715770f7be232942a",
-    "variant": null
-  },
   "cpython-3.13.0+debug-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -180,32 +323,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
     "sha256": "e9daa925568d683d0db2503293917cec00e931d3a4455b7e56e1551525f41683",
     "variant": "debug"
-  },
-  "cpython-3.13.0+freethreaded-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
-    "sha256": "2d72fb6c7c91c9c00aa1e2b982bc7442da8a51665dfea2193e5e9098a6d7b2cb",
-    "variant": "freethreaded"
-  },
-  "cpython-3.13.0-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "894014ceb5374d1c43a2e297126e588fd5fc60d93e57b76e1bba16430b80e3f3",
-    "variant": null
   },
   "cpython-3.13.0+debug-linux-s390x-gnu": {
     "name": "cpython",
@@ -220,32 +337,6 @@
     "sha256": "f8d538e4d96fc2ece9fdcd974a625398351d3746b158f55e2636d728179b3234",
     "variant": "debug"
   },
-  "cpython-3.13.0+freethreaded-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
-    "sha256": "533087017cbd1287af93936d9007bc1bd6ca8886b2cdf59171554cf55c6253e6",
-    "variant": "freethreaded"
-  },
-  "cpython-3.13.0-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "85e05e27c31cd7267cb17c4c16b729969dd586cd715287f923334db20a51ce67",
-    "variant": null
-  },
   "cpython-3.13.0+debug-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -259,32 +350,6 @@
     "sha256": "028970bf32a20f52abf1296b13aa05fac28f1eed629f7fc8e4a952e6d98b614d",
     "variant": "debug"
   },
-  "cpython-3.13.0+freethreaded-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
-    "sha256": "2b46a0f38711cfcdffab90f69ea1372288bd6dcb0f9676b765babb491d42ce06",
-    "variant": "freethreaded"
-  },
-  "cpython-3.13.0-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "aa876c2660a802d0df8ef46f9c4b1c952e63c65d16e103663c22b9468dad40b7",
-    "variant": null
-  },
   "cpython-3.13.0+debug-linux-x86_64-musl": {
     "name": "cpython",
     "arch": "x86_64",
@@ -297,71 +362,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
     "sha256": "283f4bd169763fcd971432caf227622cd6258f56c9b58e404feec80fa2038152",
     "variant": "debug"
-  },
-  "cpython-3.13.0-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "9606d04c867ba034b901ef1a63c5b5efcb6951e4a6e2cce9703d0ff98d96f579",
-    "variant": null
-  },
-  "cpython-3.13.0+freethreaded-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-i686-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
-    "sha256": "1dd414e0787f180760952bdc339dfde42e0b7503419baf20d38a6470ed65e455",
-    "variant": "freethreaded"
-  },
-  "cpython-3.13.0-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "fc96cb6a3e70bfcee13f7c5d08d30ecbe1738d934f885674d57f3b07b4291e5f",
-    "variant": null
-  },
-  "cpython-3.13.0+freethreaded-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
-    "sha256": "fc665561556f4dc843cd3eeba4d482f716aec65d5b89a657316829cfbdc9462a",
-    "variant": "freethreaded"
-  },
-  "cpython-3.13.0-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "c82b440476fe04e80228791350a451b65e8080ff01b7168f1c4a5eb9645371f3",
-    "variant": null
   },
   "cpython-3.13.0rc3-darwin-aarch64-none": {
     "name": "cpython",
@@ -389,19 +389,6 @@
     "sha256": "0f5f9fcf82093c428b80c552165544439f4adcdbe5129ecf721d619e532e9b5e",
     "variant": null
   },
-  "cpython-3.13.0rc3+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "84ca46dcb5057453373ba8d7129d9998769194c8110c81ac97a99ec1160abf41",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc3-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -414,19 +401,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "1414c6b37f37e8fd9d14e48d81e313eb9c965cb0330747d5d2d689dd7e0c7043",
     "variant": null
-  },
-  "cpython-3.13.0rc3+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "a2416da5fdb5331d84b179ed047245b6379c04d1c57e3c8583fda84a31dd5979",
-    "variant": "debug"
   },
   "cpython-3.13.0rc3-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -441,19 +415,6 @@
     "sha256": "11befeaf4768c2ebbb258f5b07f94b7700f16424f858d6d2c250b434e99ce07c",
     "variant": null
   },
-  "cpython-3.13.0rc3+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "59af55b12d59f5fdc236ba40aebb105fc440c36effadcfa7199362b2ca09d0a5",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc3-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -466,19 +427,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "b7180d5ea5fda2f397d04e2e6e11a2a7e0d732542bf54c484afb81d087a7b927",
     "variant": null
-  },
-  "cpython-3.13.0rc3+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "3c2808375869079e47923368903501913f32c65dfe71fe43c9ebbcdfc13009d9",
-    "variant": "debug"
   },
   "cpython-3.13.0rc3-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -493,19 +441,6 @@
     "sha256": "59a2a81991d78bd658742d69b577a2b4c0734628ed42bff68615686eaf96f2ab",
     "variant": null
   },
-  "cpython-3.13.0rc3+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "660e31ef1a7b4358332ef419e639d09a025a0e222855e10d93ee884a7fa8f15e",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc3-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -519,19 +454,6 @@
     "sha256": "2769182e58b0dddec15222bfeecbd4b12fde61c38f23a90aa942514f3545fb9b",
     "variant": null
   },
-  "cpython-3.13.0rc3+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "92a80f38919a852edcff68fd489152a408e43c65e67b800c02801cc58f239b95",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc3-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -544,19 +466,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "445156c61e1cc167f7b8777ad08cc36e5598e12cd27e07453f6e6dc0f62e421e",
     "variant": null
-  },
-  "cpython-3.13.0rc3+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc3",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "59b19a2ae830bd67bc8190bd839ebdf2423e871ef2e5114f38b84dab652c2e1b",
-    "variant": "debug"
   },
   "cpython-3.13.0rc3-linux-x86_64-musl": {
     "name": "cpython",
@@ -597,6 +506,97 @@
     "sha256": "b59317828ef88f138ee122d420b60f2705bc72ae846ff69562e79e6c5cbc3177",
     "variant": null
   },
+  "cpython-3.13.0rc3+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "84ca46dcb5057453373ba8d7129d9998769194c8110c81ac97a99ec1160abf41",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc3+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "a2416da5fdb5331d84b179ed047245b6379c04d1c57e3c8583fda84a31dd5979",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc3+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "59af55b12d59f5fdc236ba40aebb105fc440c36effadcfa7199362b2ca09d0a5",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc3+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3c2808375869079e47923368903501913f32c65dfe71fe43c9ebbcdfc13009d9",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc3+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "660e31ef1a7b4358332ef419e639d09a025a0e222855e10d93ee884a7fa8f15e",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc3+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "92a80f38919a852edcff68fd489152a408e43c65e67b800c02801cc58f239b95",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc3+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "59b19a2ae830bd67bc8190bd839ebdf2423e871ef2e5114f38b84dab652c2e1b",
+    "variant": "debug"
+  },
   "cpython-3.13.0rc2-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -623,19 +623,6 @@
     "sha256": "971668ac7f3168efc4d2b589e9d36247ab8ca9f9525c56c8aa7bfd374060105b",
     "variant": null
   },
-  "cpython-3.13.0rc2+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "77005f4de8eab59d5323bf4c8236530f477b2585b92ffe6b533a1de15df3f9b2",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc2-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -648,19 +635,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "d99a663d3b9f8792a659e366372e685550045cad12aef11645c06a9b6edcd071",
     "variant": null
-  },
-  "cpython-3.13.0rc2+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "50110dd0a39e663394d0a0757753714efb853ee1a6fbf969bb4bbe159f6a3f83",
-    "variant": "debug"
   },
   "cpython-3.13.0rc2-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -675,19 +649,6 @@
     "sha256": "4ca7f2aeaabf8dbb2193f0fa86f869525a5c209eb403a39a73f4cf7040cf3613",
     "variant": null
   },
-  "cpython-3.13.0rc2+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "8a8c2d371ab7fe2d1d9f51717ad51821108c607f7ea7993f96920666afc51ac1",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc2-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -700,19 +661,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "0db2d263bdbb3af1e8dc0677fa44a5cda992ba989551346ccbbfd50a86135c3d",
     "variant": null
-  },
-  "cpython-3.13.0rc2+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "d1e56f2c54775edd51ef933cd2838f692c57e24e43c4bd1a1b11c86056a24ef4",
-    "variant": "debug"
   },
   "cpython-3.13.0rc2-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -727,19 +675,6 @@
     "sha256": "70073333f7d3f0b900c7299659fec069bbefd5e04808b3729d2434b2232ac729",
     "variant": null
   },
-  "cpython-3.13.0rc2+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "65ea35a96bce6d097ebbbf19ad484f0101b2b42fcca3ab518109c3ea3aefb952",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc2-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -753,19 +688,6 @@
     "sha256": "50a2080e30d1504e76e5471e46830f0b4974c66b538ed8ec7df416975133ff89",
     "variant": null
   },
-  "cpython-3.13.0rc2+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "8595be42ea7fa43ffe66761c713ad4b60e6270dca1771491d54e8d6556bb617b",
-    "variant": "debug"
-  },
   "cpython-3.13.0rc2-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -778,19 +700,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "1893a218709d3664b7a2b80f5598b5f25c0c3fe2bcc8d0a1c75eec6bbb93d602",
     "variant": null
-  },
-  "cpython-3.13.0rc2+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 13,
-    "patch": 0,
-    "prerelease": "rc2",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "634e538c9d9e8cec2f27aa278a1e99d6e652d7b013b4f27a0242265e0d8ad0ff",
-    "variant": "debug"
   },
   "cpython-3.13.0rc2-linux-x86_64-musl": {
     "name": "cpython",
@@ -831,6 +740,97 @@
     "sha256": "c883205751c714bd0519592673a88f160a55d34344cc1368353ad34a679eb94a",
     "variant": null
   },
+  "cpython-3.13.0rc2+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "77005f4de8eab59d5323bf4c8236530f477b2585b92ffe6b533a1de15df3f9b2",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc2+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "50110dd0a39e663394d0a0757753714efb853ee1a6fbf969bb4bbe159f6a3f83",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc2+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "8a8c2d371ab7fe2d1d9f51717ad51821108c607f7ea7993f96920666afc51ac1",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc2+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d1e56f2c54775edd51ef933cd2838f692c57e24e43c4bd1a1b11c86056a24ef4",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc2+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "65ea35a96bce6d097ebbbf19ad484f0101b2b42fcca3ab518109c3ea3aefb952",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc2+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8595be42ea7fa43ffe66761c713ad4b60e6270dca1771491d54e8d6556bb617b",
+    "variant": "debug"
+  },
+  "cpython-3.13.0rc2+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "634e538c9d9e8cec2f27aa278a1e99d6e652d7b013b4f27a0242265e0d8ad0ff",
+    "variant": "debug"
+  },
   "cpython-3.12.7-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -857,19 +857,6 @@
     "sha256": "7091bd9ce844bcbceb8f3466a9c9583a139f79edd3b0cbed82f7423d333b2d4b",
     "variant": null
   },
-  "cpython-3.12.7+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "b552a3749c02aac4c4d0fb96642e159b8ea1d37202d1d307627684cce7c3d20c",
-    "variant": "debug"
-  },
   "cpython-3.12.7-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -882,19 +869,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "e254373827bde6b389ed17b8bb8aa8ac7b3659cf56d36e084a53ed1d04a02210",
     "variant": null
-  },
-  "cpython-3.12.7+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "46f8266425d4f0393c00803e87e5a9186b849c96d937d62f6ff947e69a1c84b7",
-    "variant": "debug"
   },
   "cpython-3.12.7-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -909,19 +883,6 @@
     "sha256": "b05298a85d7494a7e1220c4948a357da0ff40d8a6e470cd9b00515203200136c",
     "variant": null
   },
-  "cpython-3.12.7+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "1a4a87ddf81ae16b873b17eddbbcbb761a2b8b974ece668ec6d42f4dd81c941d",
-    "variant": "debug"
-  },
   "cpython-3.12.7-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -934,19 +895,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "88a642de18a1baa044916eb2cebbf2d534b1c5d03c98c8f4ccc8f451a7526535",
     "variant": null
-  },
-  "cpython-3.12.7+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "a49b0fa30d270146258442680c5eddd4d0cc6bdd2e17d71044a8111540e0687b",
-    "variant": "debug"
   },
   "cpython-3.12.7-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -961,19 +909,6 @@
     "sha256": "1ff1e843d78f70fd2834e522ebd5a63193c67b47a31d40fa5e97d96ac0d64aaf",
     "variant": null
   },
-  "cpython-3.12.7+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9651eb9f8afb8c06e552d089290407e434e3a6e96b42223eaf31fb284592344d",
-    "variant": "debug"
-  },
   "cpython-3.12.7-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -987,19 +922,6 @@
     "sha256": "5a4128fc5523a8888b12767a275c8240c33d0ee96fdcf1a8c6c6cec9696d0f09",
     "variant": null
   },
-  "cpython-3.12.7+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7817bfb569c1daf2981a49fd2ca6677dd2151bdf1ea2c3102f63e424a14f28f5",
-    "variant": "debug"
-  },
   "cpython-3.12.7-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1012,19 +934,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "11091cd2eb8b7f4551665ba8f9f5b83aa3d09fc0e17f1649d76d5f4f75254bf8",
     "variant": null
-  },
-  "cpython-3.12.7+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "4a5b83c8ba86a2df4ab470970911d075ad413af17576b37e284a3441243994f8",
-    "variant": "debug"
   },
   "cpython-3.12.7-linux-x86_64-musl": {
     "name": "cpython",
@@ -1065,6 +974,97 @@
     "sha256": "480688c69be99f1fb9974c8a50f1efd214aaa3440ab5c8653a68d8a3d4ce1179",
     "variant": null
   },
+  "cpython-3.12.7+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b552a3749c02aac4c4d0fb96642e159b8ea1d37202d1d307627684cce7c3d20c",
+    "variant": "debug"
+  },
+  "cpython-3.12.7+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "46f8266425d4f0393c00803e87e5a9186b849c96d937d62f6ff947e69a1c84b7",
+    "variant": "debug"
+  },
+  "cpython-3.12.7+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "1a4a87ddf81ae16b873b17eddbbcbb761a2b8b974ece668ec6d42f4dd81c941d",
+    "variant": "debug"
+  },
+  "cpython-3.12.7+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a49b0fa30d270146258442680c5eddd4d0cc6bdd2e17d71044a8111540e0687b",
+    "variant": "debug"
+  },
+  "cpython-3.12.7+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9651eb9f8afb8c06e552d089290407e434e3a6e96b42223eaf31fb284592344d",
+    "variant": "debug"
+  },
+  "cpython-3.12.7+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7817bfb569c1daf2981a49fd2ca6677dd2151bdf1ea2c3102f63e424a14f28f5",
+    "variant": "debug"
+  },
+  "cpython-3.12.7+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "4a5b83c8ba86a2df4ab470970911d075ad413af17576b37e284a3441243994f8",
+    "variant": "debug"
+  },
   "cpython-3.12.6-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1091,19 +1091,6 @@
     "sha256": "b10d19eb5548a3b3b0a5e6f9109834d7ecfc139bc15754f81a94d39eaa5bdd26",
     "variant": null
   },
-  "cpython-3.12.6+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "ddddd8a1446754a75a637c35f61df33e2b99ea679455971dcabb336ffefb77db",
-    "variant": "debug"
-  },
   "cpython-3.12.6-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1116,19 +1103,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "22d119ac7df7f0bddfd4dfd075bcc4eb2532ed3df0bdba0579106835d49ef9cd",
     "variant": null
-  },
-  "cpython-3.12.6+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "1a4736063292701b4ed08f2f3c688647c4702e5381d1d1c208970f9bad68a457",
-    "variant": "debug"
   },
   "cpython-3.12.6-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -1143,19 +1117,6 @@
     "sha256": "190c23eb3b9c6b9638f69dc7fb829df8967ad64c82e82c93898a4d878d18ed2a",
     "variant": null
   },
-  "cpython-3.12.6+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "d1c9924e90db87826bfd4ffc5189ec8983962f95d09fb79cdbd7f75bb4d88daa",
-    "variant": "debug"
-  },
   "cpython-3.12.6-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -1168,19 +1129,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "31a043c40e1dbb528404ff6e1fcad25638d54dfab2d379c3989d47ec24e6938b",
     "variant": null
-  },
-  "cpython-3.12.6+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "edb11773eab6a91cd9407f1f8bf7055233453cf48c49cb300adca85048d8e887",
-    "variant": "debug"
   },
   "cpython-3.12.6-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1195,19 +1143,6 @@
     "sha256": "fb49374b512b0e9f2cd2a720b3836f8a04228d73eb0786e64221eb55979edc6e",
     "variant": null
   },
-  "cpython-3.12.6+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "d21426d4356bb5b0525465e9cc39c27dba7c39e7112855ea2cf90a194c2bdf42",
-    "variant": "debug"
-  },
   "cpython-3.12.6-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -1221,19 +1156,6 @@
     "sha256": "89be19666ecb7cdbbfd596e462d690a78a380f1fe5c2967b25a1779b0cec9339",
     "variant": null
   },
-  "cpython-3.12.6+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "110a8ba95943af6b30198c7f925bb655d4257704abe28b4cfddc374ff367312e",
-    "variant": "debug"
-  },
   "cpython-3.12.6-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1246,19 +1168,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "b080463e4f0c452e592cdac1ca97936a6a19bb3d9a64da669a50ca843fce0108",
     "variant": null
-  },
-  "cpython-3.12.6+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "1d678f6f70dc0cf32c6f5edd18f81a560ff087c7d1bb4185a810ccd1f145b0c3",
-    "variant": "debug"
   },
   "cpython-3.12.6-linux-x86_64-musl": {
     "name": "cpython",
@@ -1299,6 +1208,97 @@
     "sha256": "fe9898060f52c2171c2aa074f470f91339bdcf9896dae6709021c914f58aa863",
     "variant": null
   },
+  "cpython-3.12.6+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ddddd8a1446754a75a637c35f61df33e2b99ea679455971dcabb336ffefb77db",
+    "variant": "debug"
+  },
+  "cpython-3.12.6+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "1a4736063292701b4ed08f2f3c688647c4702e5381d1d1c208970f9bad68a457",
+    "variant": "debug"
+  },
+  "cpython-3.12.6+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "d1c9924e90db87826bfd4ffc5189ec8983962f95d09fb79cdbd7f75bb4d88daa",
+    "variant": "debug"
+  },
+  "cpython-3.12.6+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "edb11773eab6a91cd9407f1f8bf7055233453cf48c49cb300adca85048d8e887",
+    "variant": "debug"
+  },
+  "cpython-3.12.6+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d21426d4356bb5b0525465e9cc39c27dba7c39e7112855ea2cf90a194c2bdf42",
+    "variant": "debug"
+  },
+  "cpython-3.12.6+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "110a8ba95943af6b30198c7f925bb655d4257704abe28b4cfddc374ff367312e",
+    "variant": "debug"
+  },
+  "cpython-3.12.6+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "1d678f6f70dc0cf32c6f5edd18f81a560ff087c7d1bb4185a810ccd1f145b0c3",
+    "variant": "debug"
+  },
   "cpython-3.12.5-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1325,19 +1325,6 @@
     "sha256": "49a9f7ad41d62e0ece9e664ca5ae95f022e7b68eef48e8a6f11620ec9247c686",
     "variant": null
   },
-  "cpython-3.12.5+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "66ba3a4ee2d2196ce2d05275aa2c12c1cc4480530dadf54d6754e85cb11fa3da",
-    "variant": "debug"
-  },
   "cpython-3.12.5-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1350,19 +1337,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "06e512178cb513658a01c054b3eafc649ca362ccbeb02a6ae8a55b02c1ba75ca",
     "variant": null
-  },
-  "cpython-3.12.5+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "6617a003ff280523f6862ec2dcf7e900e999d4521e4b9363c7c32245fb12df12",
-    "variant": "debug"
   },
   "cpython-3.12.5-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -1377,19 +1351,6 @@
     "sha256": "7a584de9c2824f43d7a7b1c26eb61a18af770ebd603a74b45d57601ba62ba508",
     "variant": null
   },
-  "cpython-3.12.5+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "d8d9bbb21efdd6b4fbf5e004d57e7fad772ed1263615a6b2579803e9f2289dfa",
-    "variant": "debug"
-  },
   "cpython-3.12.5-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -1402,19 +1363,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "a9992b30d7b3ecb558cd12fde919e3e2836f161f8f777afea31140d5fff6362e",
     "variant": null
-  },
-  "cpython-3.12.5+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "895d2db8a2074578c86ce3f5499787923188bf559180b5cbd8401bae060a3f5e",
-    "variant": "debug"
   },
   "cpython-3.12.5-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1429,19 +1377,6 @@
     "sha256": "3bea081f4e6fa67e600a6a791bcfebb2891531ede2c21e23e1b7321b3369c737",
     "variant": null
   },
-  "cpython-3.12.5+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "e0a8bfe653421e687ed56bcc4269b3e65390529c61581193252ce689c12f128b",
-    "variant": "debug"
-  },
   "cpython-3.12.5-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -1455,19 +1390,6 @@
     "sha256": "2b6ea3a5242de99574191ee42df864756eca6d7cb1dbd4cd7ab2850ba8b828f8",
     "variant": null
   },
-  "cpython-3.12.5+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "580caa10b1c661409d35623d20b2b56f6c8f4c263122b0e8228a3cdaa482c8be",
-    "variant": "debug"
-  },
   "cpython-3.12.5-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1480,19 +1402,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "10680b593b5e31833218fd83104dee74af970a3463403a22bae613b952a34e8d",
     "variant": null
-  },
-  "cpython-3.12.5+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a2766d5627353e8ce8a8c43b0b5c3007a77f4f095bf773739f5bb936860546cd",
-    "variant": "debug"
   },
   "cpython-3.12.5-linux-x86_64-musl": {
     "name": "cpython",
@@ -1533,6 +1442,97 @@
     "sha256": "6eb0398795e8875575934cf21cdc9c7c7acddb46f9a52f91fdad509723f2f0e9",
     "variant": null
   },
+  "cpython-3.12.5+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "66ba3a4ee2d2196ce2d05275aa2c12c1cc4480530dadf54d6754e85cb11fa3da",
+    "variant": "debug"
+  },
+  "cpython-3.12.5+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "6617a003ff280523f6862ec2dcf7e900e999d4521e4b9363c7c32245fb12df12",
+    "variant": "debug"
+  },
+  "cpython-3.12.5+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "d8d9bbb21efdd6b4fbf5e004d57e7fad772ed1263615a6b2579803e9f2289dfa",
+    "variant": "debug"
+  },
+  "cpython-3.12.5+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "895d2db8a2074578c86ce3f5499787923188bf559180b5cbd8401bae060a3f5e",
+    "variant": "debug"
+  },
+  "cpython-3.12.5+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e0a8bfe653421e687ed56bcc4269b3e65390529c61581193252ce689c12f128b",
+    "variant": "debug"
+  },
+  "cpython-3.12.5+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "580caa10b1c661409d35623d20b2b56f6c8f4c263122b0e8228a3cdaa482c8be",
+    "variant": "debug"
+  },
+  "cpython-3.12.5+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a2766d5627353e8ce8a8c43b0b5c3007a77f4f095bf773739f5bb936860546cd",
+    "variant": "debug"
+  },
   "cpython-3.12.4-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1559,19 +1559,6 @@
     "sha256": "9d68cbdd12d1d6f98d35cc76add232c12db75c6b7f49733bffc88e7b1c025a79",
     "variant": null
   },
-  "cpython-3.12.4+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "35d7ef1f4f4849ad92ba6e29c46235b9f5a2951758bec1f9fcec4133744d8c02",
-    "variant": "debug"
-  },
   "cpython-3.12.4-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1584,19 +1571,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "6c9cf13644edc7250525ab1b2529ba1c0fff56c0c5a5c2242d84b6d4889d2bea",
     "variant": null
-  },
-  "cpython-3.12.4+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "541305f79e3e007f6313faf6e4a955ed47c08704dddb216bf6c810c30e8ec853",
-    "variant": "debug"
   },
   "cpython-3.12.4-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -1611,19 +1585,6 @@
     "sha256": "5a23ed8eaf948fe48d7c05dbfb58ea8638dcd2c4880d8519e069281ab427cbcb",
     "variant": null
   },
-  "cpython-3.12.4+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "f110f5db3d2ff9db5590d77f4af655202d570b9d9dff8d8aafbf67dea88b9dbf",
-    "variant": "debug"
-  },
   "cpython-3.12.4-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -1636,19 +1597,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "4281764e69339a138e30211b9923d74036d07c7a56c6aacc6dbdb2802a575f51",
     "variant": null
-  },
-  "cpython-3.12.4+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "342e9d3c36f8da4e57fb065641f7e6ae98af110fbddc641b88d6930cd1895943",
-    "variant": "debug"
   },
   "cpython-3.12.4-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1663,19 +1611,6 @@
     "sha256": "35a8359f1dc17a7a70007dae102a5e1562c0715a721377ede92137b2a0292406",
     "variant": null
   },
-  "cpython-3.12.4+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "f8df0b7ebd2893e845fbbeb8f133e317b49223fc128823f6743cbfd7a50bfc0d",
-    "variant": "debug"
-  },
   "cpython-3.12.4-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -1689,19 +1624,6 @@
     "sha256": "b2fd015ab3689e024de6fbb34a4942acdb54c2184d1963e22829aafa1d81ba2c",
     "variant": null
   },
-  "cpython-3.12.4+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "54324b36cf7b68af3ddbabd1ec482691a23bf059a7f46a8cb3f3615f5fd5d86d",
-    "variant": "debug"
-  },
   "cpython-3.12.4-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1714,19 +1636,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "ca076aee4329f53f988346eb0521ad2a2cf7f723b6296088d03b98d8f22f5420",
     "variant": null
-  },
-  "cpython-3.12.4+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "797b3d36a9df38925b7a7c5facb47e56a0d1c4031ae7b121ce41c07433fa1d2e",
-    "variant": "debug"
   },
   "cpython-3.12.4-linux-x86_64-musl": {
     "name": "cpython",
@@ -1767,6 +1676,97 @@
     "sha256": "6dd7b4607f8a25f0f5f68e745f4c572b1a20c3bbfa86accfa45b52ab93b18ece",
     "variant": null
   },
+  "cpython-3.12.4+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "35d7ef1f4f4849ad92ba6e29c46235b9f5a2951758bec1f9fcec4133744d8c02",
+    "variant": "debug"
+  },
+  "cpython-3.12.4+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "541305f79e3e007f6313faf6e4a955ed47c08704dddb216bf6c810c30e8ec853",
+    "variant": "debug"
+  },
+  "cpython-3.12.4+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "f110f5db3d2ff9db5590d77f4af655202d570b9d9dff8d8aafbf67dea88b9dbf",
+    "variant": "debug"
+  },
+  "cpython-3.12.4+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "342e9d3c36f8da4e57fb065641f7e6ae98af110fbddc641b88d6930cd1895943",
+    "variant": "debug"
+  },
+  "cpython-3.12.4+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f8df0b7ebd2893e845fbbeb8f133e317b49223fc128823f6743cbfd7a50bfc0d",
+    "variant": "debug"
+  },
+  "cpython-3.12.4+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "54324b36cf7b68af3ddbabd1ec482691a23bf059a7f46a8cb3f3615f5fd5d86d",
+    "variant": "debug"
+  },
+  "cpython-3.12.4+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "797b3d36a9df38925b7a7c5facb47e56a0d1c4031ae7b121ce41c07433fa1d2e",
+    "variant": "debug"
+  },
   "cpython-3.12.3-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1793,19 +1793,6 @@
     "sha256": "c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8",
     "variant": null
   },
-  "cpython-3.12.3+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "24daaf20123ac4b2b8657c1ac8227d391d2e5769d81237b68ee674569d307ad0",
-    "variant": "debug"
-  },
   "cpython-3.12.3-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -1818,19 +1805,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "ec8126de97945e629cca9aedc80a29c4ae2992c9d69f2655e27ae73906ba187d",
     "variant": null
-  },
-  "cpython-3.12.3+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "d4d76d1dfd2d1e344ab825d2991887fa31702004470a97d205c32b9e5541892a",
-    "variant": "debug"
   },
   "cpython-3.12.3-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -1845,19 +1819,6 @@
     "sha256": "f693dd22b69361c17076157889eb8f1ce1a5ea670c031fae46782481ad892a64",
     "variant": null
   },
-  "cpython-3.12.3+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "96a7a3725bae8cc0933eaaaffe99c6a71218b6593c28af042a9fa8c34fc722d3",
-    "variant": "debug"
-  },
   "cpython-3.12.3-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -1870,19 +1831,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabihf-install_only.tar.gz",
     "sha256": "635080827bed4616dc271545677837203098e5b55e7195d803e1dca7da24fc0c",
     "variant": null
-  },
-  "cpython-3.12.3+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "983f056cb8336a54364c2eec3d33808dd74f953f82b720c6a73ad943643b4920",
-    "variant": "debug"
   },
   "cpython-3.12.3-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1897,19 +1845,6 @@
     "sha256": "c5dcf08b8077e617d949bda23027c49712f583120b3ed744f9b143da1d580572",
     "variant": null
   },
-  "cpython-3.12.3+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "a009c51b178519e60b6b7848b0ea91f3a92007ca1bdf0a2e8b26b8b7a138cdc0",
-    "variant": "debug"
-  },
   "cpython-3.12.3-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -1923,19 +1858,6 @@
     "sha256": "872fc321363b8cdd826fd2cb1adfd1ceb813bc1281f9d410c1c2c4e177e8df86",
     "variant": null
   },
-  "cpython-3.12.3+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "ded92cd034b33df953c490d3343ef187ac065d1fcd78e8cee894be197c5f977e",
-    "variant": "debug"
-  },
   "cpython-3.12.3-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -1948,19 +1870,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "a73ba777b5d55ca89edef709e6b8521e3f3d4289581f174c8699adfb608d09d6",
     "variant": null
-  },
-  "cpython-3.12.3+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "81d9fc9ffd6860229e09b11be5d800db5966080ba6f4b7524ae7917423fd09c6",
-    "variant": "debug"
   },
   "cpython-3.12.3-linux-x86_64-musl": {
     "name": "cpython",
@@ -2001,6 +1910,97 @@
     "sha256": "f7cfa4ad072feb4578c8afca5ba9a54ad591d665a441dd0d63aa366edbe19279",
     "variant": null
   },
+  "cpython-3.12.3+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "24daaf20123ac4b2b8657c1ac8227d391d2e5769d81237b68ee674569d307ad0",
+    "variant": "debug"
+  },
+  "cpython-3.12.3+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "d4d76d1dfd2d1e344ab825d2991887fa31702004470a97d205c32b9e5541892a",
+    "variant": "debug"
+  },
+  "cpython-3.12.3+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "96a7a3725bae8cc0933eaaaffe99c6a71218b6593c28af042a9fa8c34fc722d3",
+    "variant": "debug"
+  },
+  "cpython-3.12.3+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "983f056cb8336a54364c2eec3d33808dd74f953f82b720c6a73ad943643b4920",
+    "variant": "debug"
+  },
+  "cpython-3.12.3+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a009c51b178519e60b6b7848b0ea91f3a92007ca1bdf0a2e8b26b8b7a138cdc0",
+    "variant": "debug"
+  },
+  "cpython-3.12.3+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ded92cd034b33df953c490d3343ef187ac065d1fcd78e8cee894be197c5f977e",
+    "variant": "debug"
+  },
+  "cpython-3.12.3+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "81d9fc9ffd6860229e09b11be5d800db5966080ba6f4b7524ae7917423fd09c6",
+    "variant": "debug"
+  },
   "cpython-3.12.2-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -2027,19 +2027,6 @@
     "sha256": "a53a6670a202c96fec0b8c55ccc780ea3af5307eb89268d5b41a9775b109c094",
     "variant": null
   },
-  "cpython-3.12.2+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "469a7fd0d0a09936c5db41b5ac83bb29d5bfeb721aa483ac92f3f7ac4d311097",
-    "variant": "debug"
-  },
   "cpython-3.12.2-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -2052,19 +2039,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e52550379e7c4ac27a87de832d172658bc04150e4e27d4e858e6d8cbb96fd709",
     "variant": null
-  },
-  "cpython-3.12.2+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "1d70476fb9013cc93e787417680b34629b510e6e2145cf48bb2f0fe887f7a4d8",
-    "variant": "debug"
   },
   "cpython-3.12.2-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2079,19 +2053,6 @@
     "sha256": "74bc02c4bbbd26245c37b29b9e12d0a9c1b7ab93477fed8b651c988b6a9a6251",
     "variant": null
   },
-  "cpython-3.12.2+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "f40b88607928b5ee34ff87c1d574c8493a1604d7a40474e1b03731184186f419",
-    "variant": "debug"
-  },
   "cpython-3.12.2-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -2105,19 +2066,6 @@
     "sha256": "ecd6b0285e5eef94deb784b588b4b425a15a43ae671bf206556659dc141a9825",
     "variant": null
   },
-  "cpython-3.12.2+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "15b61ed9d33b35ad014a13a68a55d8ea5ba7fb70945644747f4e53c659f2fed6",
-    "variant": "debug"
-  },
   "cpython-3.12.2-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2130,19 +2078,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "57a37b57f8243caa4cdac016176189573ad7620f0b6da5941c5e40660f9468ab",
     "variant": null
-  },
-  "cpython-3.12.2+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "2f5f088639e17981b0aeeeeab0fbb6858002d5f10bf57e26eaf32f99b4b6c765",
-    "variant": "debug"
   },
   "cpython-3.12.2-linux-x86_64-musl": {
     "name": "cpython",
@@ -2183,6 +2118,71 @@
     "sha256": "1e5655a6ccb1a64a78460e4e3ee21036c70246800f176a6c91043a3fe3654a3b",
     "variant": null
   },
+  "cpython-3.12.2+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "469a7fd0d0a09936c5db41b5ac83bb29d5bfeb721aa483ac92f3f7ac4d311097",
+    "variant": "debug"
+  },
+  "cpython-3.12.2+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1d70476fb9013cc93e787417680b34629b510e6e2145cf48bb2f0fe887f7a4d8",
+    "variant": "debug"
+  },
+  "cpython-3.12.2+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f40b88607928b5ee34ff87c1d574c8493a1604d7a40474e1b03731184186f419",
+    "variant": "debug"
+  },
+  "cpython-3.12.2+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "15b61ed9d33b35ad014a13a68a55d8ea5ba7fb70945644747f4e53c659f2fed6",
+    "variant": "debug"
+  },
+  "cpython-3.12.2+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "2f5f088639e17981b0aeeeeab0fbb6858002d5f10bf57e26eaf32f99b4b6c765",
+    "variant": "debug"
+  },
   "cpython-3.12.1-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -2209,19 +2209,6 @@
     "sha256": "eca96158c1568dedd9a0b3425375637a83764d1fa74446438293089a8bfac1f8",
     "variant": null
   },
-  "cpython-3.12.1+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9009da24f436611d0bf086b8ea62aaed1c27104af5b770ddcfc92b60db06da8c",
-    "variant": "debug"
-  },
   "cpython-3.12.1-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -2234,19 +2221,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "236533ef20e665007a111c2f36efb59c87ae195ad7dca223b6dc03fb07064f0b",
     "variant": null
-  },
-  "cpython-3.12.1+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "b61686ce05c58c913e4fdb7e7c7105ed36d9bcdcd1a841e7f08b243f40d5cf77",
-    "variant": "debug"
   },
   "cpython-3.12.1-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2261,19 +2235,6 @@
     "sha256": "78051f0d1411ee62bc2af5edfccf6e8400ac4ef82887a2affc19a7ace6a05267",
     "variant": null
   },
-  "cpython-3.12.1+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "505a4fbace661a43b354a059022eb31efb406859a5f7227109ebf0f278f20503",
-    "variant": "debug"
-  },
   "cpython-3.12.1-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -2287,19 +2248,6 @@
     "sha256": "60631211c701f8d2c56e5dd7b154e68868128a019b9db1d53a264f56c0d4aee2",
     "variant": null
   },
-  "cpython-3.12.1+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "89ef67b617b8c9804965509b2d256f53439ceede83b5b64085315f038ad81e60",
-    "variant": "debug"
-  },
   "cpython-3.12.1-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2312,19 +2260,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "74e330b8212ca22fd4d9a2003b9eec14892155566738febc8e5e572f267b9472",
     "variant": null
-  },
-  "cpython-3.12.1+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0823ed21f7b79129677c51c6a73d3ca53a37179931a5a40a1d53b565d54679ec",
-    "variant": "debug"
   },
   "cpython-3.12.1-linux-x86_64-musl": {
     "name": "cpython",
@@ -2365,6 +2300,71 @@
     "sha256": "fd5a9e0f41959d0341246d3643f2b8794f638adc0cec8dd5e1b6465198eae08a",
     "variant": null
   },
+  "cpython-3.12.1+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9009da24f436611d0bf086b8ea62aaed1c27104af5b770ddcfc92b60db06da8c",
+    "variant": "debug"
+  },
+  "cpython-3.12.1+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b61686ce05c58c913e4fdb7e7c7105ed36d9bcdcd1a841e7f08b243f40d5cf77",
+    "variant": "debug"
+  },
+  "cpython-3.12.1+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "505a4fbace661a43b354a059022eb31efb406859a5f7227109ebf0f278f20503",
+    "variant": "debug"
+  },
+  "cpython-3.12.1+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "89ef67b617b8c9804965509b2d256f53439ceede83b5b64085315f038ad81e60",
+    "variant": "debug"
+  },
+  "cpython-3.12.1+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0823ed21f7b79129677c51c6a73d3ca53a37179931a5a40a1d53b565d54679ec",
+    "variant": "debug"
+  },
   "cpython-3.12.0-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -2391,19 +2391,6 @@
     "sha256": "5a9e88c8aa52b609d556777b52ebde464ae4b4f77e4aac4eb693af57395c9abf",
     "variant": null
   },
-  "cpython-3.12.0+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "eb05c976374a9a44596ce340ab35e5461014f30202c3cbe10edcbfbe5ac4a6a1",
-    "variant": "debug"
-  },
   "cpython-3.12.0-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -2416,19 +2403,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "bccfe67cf5465a3dfb0336f053966e2613a9bc85a6588c2fcf1366ef930c4f88",
     "variant": null
-  },
-  "cpython-3.12.0+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "800a89873e30e24bb1b6075f8cd718964537c5ba62bcdbefdcdae4de68ddccc4",
-    "variant": "debug"
   },
   "cpython-3.12.0-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2443,19 +2417,6 @@
     "sha256": "b5dae075467ace32c594c7877fe6ebe0837681f814601d5d90ba4c0dfd87a1f2",
     "variant": null
   },
-  "cpython-3.12.0+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "5b1a1effbb43df57ad014fcebf4b20089e504d89613e7b8db22d9ccb9fb00a6c",
-    "variant": "debug"
-  },
   "cpython-3.12.0-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -2469,19 +2430,6 @@
     "sha256": "5681621349dd85d9726d1b67c84a9686ce78f72e73a6f9e4cc4119911655759e",
     "variant": null
   },
-  "cpython-3.12.0+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "a8c38cd2e53136c579632e2938d1b857f22e496c7dba99ad9a7ad6a67b43274a",
-    "variant": "debug"
-  },
   "cpython-3.12.0-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2494,19 +2442,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e51a5293f214053ddb4645b2c9f84542e2ef86870b8655704367bd4b29d39fe9",
     "variant": null
-  },
-  "cpython-3.12.0+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 12,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0b4380904d53f3322d3e5276de47bfa91a19289b7c734494c127ed0793017dde",
-    "variant": "debug"
   },
   "cpython-3.12.0-linux-x86_64-musl": {
     "name": "cpython",
@@ -2547,6 +2482,71 @@
     "sha256": "facfaa1fbc8653f95057f3c4a0f8aa833dab0e0b316e24ee8686bc761d4b4f8d",
     "variant": null
   },
+  "cpython-3.12.0+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "eb05c976374a9a44596ce340ab35e5461014f30202c3cbe10edcbfbe5ac4a6a1",
+    "variant": "debug"
+  },
+  "cpython-3.12.0+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "800a89873e30e24bb1b6075f8cd718964537c5ba62bcdbefdcdae4de68ddccc4",
+    "variant": "debug"
+  },
+  "cpython-3.12.0+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5b1a1effbb43df57ad014fcebf4b20089e504d89613e7b8db22d9ccb9fb00a6c",
+    "variant": "debug"
+  },
+  "cpython-3.12.0+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a8c38cd2e53136c579632e2938d1b857f22e496c7dba99ad9a7ad6a67b43274a",
+    "variant": "debug"
+  },
+  "cpython-3.12.0+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0b4380904d53f3322d3e5276de47bfa91a19289b7c734494c127ed0793017dde",
+    "variant": "debug"
+  },
   "cpython-3.11.10-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -2573,19 +2573,6 @@
     "sha256": "ecd44a6309939d6d06db2b9b3a9b40361dc1e248b4956bd635671a1475ee3f17",
     "variant": null
   },
-  "cpython-3.11.10+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "41baa3ab0cdfe1357406670f7c585b2129972526361b4ca09964ff81cfecb948",
-    "variant": "debug"
-  },
   "cpython-3.11.10-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -2598,19 +2585,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "4cc6a85666586732a08f456616e234e3a49f0c85e28df4703064118a465b32be",
     "variant": null
-  },
-  "cpython-3.11.10+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "2129e1284d77d26e7294f64cd7955d02c212f39df248e4dc10dd86bd754b6b03",
-    "variant": "debug"
   },
   "cpython-3.11.10-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -2625,19 +2599,6 @@
     "sha256": "83eadb32a80e4871066a0fbb2bad1b9642e5432225343d654aa0c7cbbf6e4c71",
     "variant": null
   },
-  "cpython-3.11.10+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "6021371a9dd85852601ac5783e9046b0f0cee3ad12efe79b72b1b8802daee0af",
-    "variant": "debug"
-  },
   "cpython-3.11.10-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -2650,19 +2611,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "30b071a9dd9dc34a77a510907210f74ad40620a1209fd936a852d4a038a5ebea",
     "variant": null
-  },
-  "cpython-3.11.10+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7de7c5509a98758499103241f7d593a0ac8f6a3f4b13080834ece368ff58f558",
-    "variant": "debug"
   },
   "cpython-3.11.10-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2677,19 +2625,6 @@
     "sha256": "03dd50143a9b95dbfc524e1e51e45205f2dc3d77bb75e51073f5645bd30f6263",
     "variant": null
   },
-  "cpython-3.11.10+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "0ffe09e72efc396c1def29a9ed6971d418c50ff360656d978db4d5e00829a153",
-    "variant": "debug"
-  },
   "cpython-3.11.10-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -2703,19 +2638,6 @@
     "sha256": "f67968330a66c2d9e6313e400b27fe848b038be0b67380e8a28e1e982af9f9a8",
     "variant": null
   },
-  "cpython-3.11.10+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "e6cc163eefb376478a2fd53b2c182b28db59de735814ca8d9912b6d352702578",
-    "variant": "debug"
-  },
   "cpython-3.11.10-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2728,19 +2650,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "d025f46c2ff20dd5ad8ff4628f65e691be73ca314b53b4145a691d9237601534",
     "variant": null
-  },
-  "cpython-3.11.10+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "7205c2b03db2bb06b08e3e397334734d287729c8c7cce5b9be7a3c34c93a1a00",
-    "variant": "debug"
   },
   "cpython-3.11.10-linux-x86_64-musl": {
     "name": "cpython",
@@ -2781,6 +2690,97 @@
     "sha256": "7d591a66f9118ee7aa8a6ea990619bcc61aa737bd7a79cc47336d4be4addcd91",
     "variant": null
   },
+  "cpython-3.11.10+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "41baa3ab0cdfe1357406670f7c585b2129972526361b4ca09964ff81cfecb948",
+    "variant": "debug"
+  },
+  "cpython-3.11.10+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "2129e1284d77d26e7294f64cd7955d02c212f39df248e4dc10dd86bd754b6b03",
+    "variant": "debug"
+  },
+  "cpython-3.11.10+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "6021371a9dd85852601ac5783e9046b0f0cee3ad12efe79b72b1b8802daee0af",
+    "variant": "debug"
+  },
+  "cpython-3.11.10+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7de7c5509a98758499103241f7d593a0ac8f6a3f4b13080834ece368ff58f558",
+    "variant": "debug"
+  },
+  "cpython-3.11.10+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "0ffe09e72efc396c1def29a9ed6971d418c50ff360656d978db4d5e00829a153",
+    "variant": "debug"
+  },
+  "cpython-3.11.10+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e6cc163eefb376478a2fd53b2c182b28db59de735814ca8d9912b6d352702578",
+    "variant": "debug"
+  },
+  "cpython-3.11.10+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "7205c2b03db2bb06b08e3e397334734d287729c8c7cce5b9be7a3c34c93a1a00",
+    "variant": "debug"
+  },
   "cpython-3.11.9-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -2807,19 +2807,6 @@
     "sha256": "c8680f90137e36b54b3631271ccdfe5de363e7d563d8df87c53e11b956a00e04",
     "variant": null
   },
-  "cpython-3.11.9+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "11f1f93ccdc399c3d029593ca147ba457500ce24c2cbd7df2040f44352c9039a",
-    "variant": "debug"
-  },
   "cpython-3.11.9-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -2832,19 +2819,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "364cf099524fff92c31b8ff5ae3f7b32b0fa6cf1d380c6e37cf56140d08dfc87",
     "variant": null
-  },
-  "cpython-3.11.9+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "2fe1c9df6e5ebd6ba6748207ca665e3087d35aa3ccacaa68fb7375e55c4d29e7",
-    "variant": "debug"
   },
   "cpython-3.11.9-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -2859,19 +2833,6 @@
     "sha256": "e64d3cf033c804e9c14aaf4ae746632c01894706098b20acbf00df4bd28d0b0e",
     "variant": null
   },
-  "cpython-3.11.9+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "e30eb0c9d50e7fe232e1f10391470136c7812a73401348dbdc60418cd0334fbe",
-    "variant": "debug"
-  },
   "cpython-3.11.9-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -2884,19 +2845,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "7630838c7602e6a6a56c41263d6a808a2a2004a7ea38770ffc4c7aaf34e169ae",
     "variant": null
-  },
-  "cpython-3.11.9+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "2a7302fa80ff26db99d8afe3824aab961487ec9362729e15c1421bbdf9115f79",
-    "variant": "debug"
   },
   "cpython-3.11.9-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2911,19 +2859,6 @@
     "sha256": "2387479d17127e5b087f582bac948f859c25c4b38c64f558e0a399af7a8a0225",
     "variant": null
   },
-  "cpython-3.11.9+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "09161f37bed9742b6e94262e047a666acb7d43a5d4e679fc87d7d0a58c92ec70",
-    "variant": "debug"
-  },
   "cpython-3.11.9-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -2937,19 +2872,6 @@
     "sha256": "30c71053e9360471b7f350f1562ff4e42eb91ad2ca61b391295b5dea8b2b9efd",
     "variant": null
   },
-  "cpython-3.11.9+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "1fbae62bc303512d4024bb69cab26766a5a8d12386aa79ed03b5fd8f4c08c77b",
-    "variant": "debug"
-  },
   "cpython-3.11.9-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -2962,19 +2884,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "daa487c7e73005c4426ac393273117cf0e2dc4ab9b2eeda366e04cd00eea00c9",
     "variant": null
-  },
-  "cpython-3.11.9+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "dc4fd5dd161a0c09375457f29b2c03b1aa026702abbdaedb9db01d2ccc17650b",
-    "variant": "debug"
   },
   "cpython-3.11.9-linux-x86_64-musl": {
     "name": "cpython",
@@ -3015,6 +2924,97 @@
     "sha256": "8ac54a8d711ef0d49b62a2c3521c2d0403f1b221dc9d84c5f85fe48903e82523",
     "variant": null
   },
+  "cpython-3.11.9+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "11f1f93ccdc399c3d029593ca147ba457500ce24c2cbd7df2040f44352c9039a",
+    "variant": "debug"
+  },
+  "cpython-3.11.9+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "2fe1c9df6e5ebd6ba6748207ca665e3087d35aa3ccacaa68fb7375e55c4d29e7",
+    "variant": "debug"
+  },
+  "cpython-3.11.9+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "e30eb0c9d50e7fe232e1f10391470136c7812a73401348dbdc60418cd0334fbe",
+    "variant": "debug"
+  },
+  "cpython-3.11.9+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2a7302fa80ff26db99d8afe3824aab961487ec9362729e15c1421bbdf9115f79",
+    "variant": "debug"
+  },
+  "cpython-3.11.9+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "09161f37bed9742b6e94262e047a666acb7d43a5d4e679fc87d7d0a58c92ec70",
+    "variant": "debug"
+  },
+  "cpython-3.11.9+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1fbae62bc303512d4024bb69cab26766a5a8d12386aa79ed03b5fd8f4c08c77b",
+    "variant": "debug"
+  },
+  "cpython-3.11.9+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "dc4fd5dd161a0c09375457f29b2c03b1aa026702abbdaedb9db01d2ccc17650b",
+    "variant": "debug"
+  },
   "cpython-3.11.8-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3041,19 +3041,6 @@
     "sha256": "097f467b0c36706bfec13f199a2eaf924e668f70c6e2bd1f1366806962f7e86e",
     "variant": null
   },
-  "cpython-3.11.8+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "45bf082aca6b7d5e7261852720a72b92f5305e9fdb07b10f6588cb51d8f83ff2",
-    "variant": "debug"
-  },
   "cpython-3.11.8-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3066,19 +3053,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "389b9005fb78dd5a6f68df5ea45ab7b30d9a4b3222af96999e94fd20d4ad0c6a",
     "variant": null
-  },
-  "cpython-3.11.8+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "a9716f2eebebe03de47d6d5d603d6ff78abf5eb38f88bf7607b17fd85e74ff16",
-    "variant": "debug"
   },
   "cpython-3.11.8-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -3093,19 +3067,6 @@
     "sha256": "eb2b31f8e50309aae493c6a359c32b723a676f07c641f5e8fe4b6aa4dbb50946",
     "variant": null
   },
-  "cpython-3.11.8+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "d495830b5980ed689bd7588aa556bac9c43ff766d8a8b32e7791b8ed664b04f3",
-    "variant": "debug"
-  },
   "cpython-3.11.8-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -3119,19 +3080,6 @@
     "sha256": "844f64f4c16e24965778281da61d1e0e6cd1358a581df1662da814b1eed096b9",
     "variant": null
   },
-  "cpython-3.11.8+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "d959c43184878d564b5368ce4d753cf059600aafdf3e50280e850f94b5a4ba61",
-    "variant": "debug"
-  },
   "cpython-3.11.8-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3144,19 +3092,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "94e13d0e5ad417035b80580f3e893a72e094b0900d5d64e7e34ab08e95439987",
     "variant": null
-  },
-  "cpython-3.11.8+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "868adbcbef61c119d10f4da18ecab180423443aa64be0d6c79790df2ed1d12b7",
-    "variant": "debug"
   },
   "cpython-3.11.8-linux-x86_64-musl": {
     "name": "cpython",
@@ -3197,6 +3132,71 @@
     "sha256": "b618f1f047349770ee1ef11d1b05899840abd53884b820fd25c7dfe2ec1664d4",
     "variant": null
   },
+  "cpython-3.11.8+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "45bf082aca6b7d5e7261852720a72b92f5305e9fdb07b10f6588cb51d8f83ff2",
+    "variant": "debug"
+  },
+  "cpython-3.11.8+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a9716f2eebebe03de47d6d5d603d6ff78abf5eb38f88bf7607b17fd85e74ff16",
+    "variant": "debug"
+  },
+  "cpython-3.11.8+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d495830b5980ed689bd7588aa556bac9c43ff766d8a8b32e7791b8ed664b04f3",
+    "variant": "debug"
+  },
+  "cpython-3.11.8+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d959c43184878d564b5368ce4d753cf059600aafdf3e50280e850f94b5a4ba61",
+    "variant": "debug"
+  },
+  "cpython-3.11.8+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "868adbcbef61c119d10f4da18ecab180423443aa64be0d6c79790df2ed1d12b7",
+    "variant": "debug"
+  },
   "cpython-3.11.7-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3223,19 +3223,6 @@
     "sha256": "a0e615eef1fafdc742da0008425a9030b7ea68a4ae4e73ac557ef27b112836d4",
     "variant": null
   },
-  "cpython-3.11.7+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "e3a375f8f16198ccf8dbede231536544265e5b4b6b0f0df97c5b29503c5864e2",
-    "variant": "debug"
-  },
   "cpython-3.11.7-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3248,19 +3235,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "b102eaf865eb715aa98a8a2ef19037b6cc3ae7dfd4a632802650f29de635aa13",
     "variant": null
-  },
-  "cpython-3.11.7+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "016ed6470c599ea5cc4dbb9c3f3fe86be059ad4e1b6cd2df10e40b7ec6970f16",
-    "variant": "debug"
   },
   "cpython-3.11.7-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -3275,19 +3249,6 @@
     "sha256": "b44e1b74afe75c7b19143413632c4386708ae229117f8f950c2094e9681d34c7",
     "variant": null
   },
-  "cpython-3.11.7+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "91b33369025b7e0079f603cd2a99f9a5932daa8ded113d5090f29c075c993df7",
-    "variant": "debug"
-  },
   "cpython-3.11.7-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -3301,19 +3262,6 @@
     "sha256": "49520e3ff494708020f306e30b0964f079170be83e956be4504f850557378a22",
     "variant": null
   },
-  "cpython-3.11.7+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "01bca7a2f457d4bd2b367640d9337d12b31db73d670a16500b7a751194942103",
-    "variant": "debug"
-  },
   "cpython-3.11.7-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3326,19 +3274,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "4a51ce60007a6facf64e5495f4cf322e311ba9f39a8cd3f3e4c026eae488e140",
     "variant": null
-  },
-  "cpython-3.11.7+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "766fd4a583fdfbe65e99b1e3caea843d0eeefde5675d73f3214a53c17a832320",
-    "variant": "debug"
   },
   "cpython-3.11.7-linux-x86_64-musl": {
     "name": "cpython",
@@ -3379,6 +3314,71 @@
     "sha256": "67077e6fa918e4f4fd60ba169820b00be7c390c497bf9bc9cab2c255ea8e6f3e",
     "variant": null
   },
+  "cpython-3.11.7+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e3a375f8f16198ccf8dbede231536544265e5b4b6b0f0df97c5b29503c5864e2",
+    "variant": "debug"
+  },
+  "cpython-3.11.7+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "016ed6470c599ea5cc4dbb9c3f3fe86be059ad4e1b6cd2df10e40b7ec6970f16",
+    "variant": "debug"
+  },
+  "cpython-3.11.7+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "91b33369025b7e0079f603cd2a99f9a5932daa8ded113d5090f29c075c993df7",
+    "variant": "debug"
+  },
+  "cpython-3.11.7+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "01bca7a2f457d4bd2b367640d9337d12b31db73d670a16500b7a751194942103",
+    "variant": "debug"
+  },
+  "cpython-3.11.7+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "766fd4a583fdfbe65e99b1e3caea843d0eeefde5675d73f3214a53c17a832320",
+    "variant": "debug"
+  },
   "cpython-3.11.6-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3405,19 +3405,6 @@
     "sha256": "178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371",
     "variant": null
   },
-  "cpython-3.11.6+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "d63d6eb065e60899b25853fe6bbd9f60ea6c3b12f4854adc75cb818bad55f4e9",
-    "variant": "debug"
-  },
   "cpython-3.11.6-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3430,19 +3417,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec",
     "variant": null
-  },
-  "cpython-3.11.6+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "71c34db1165860a6bf458d817aef00dea96146130bf5f8bd7ee39b12892ef463",
-    "variant": "debug"
   },
   "cpython-3.11.6-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -3457,19 +3431,6 @@
     "sha256": "7937035f690a624dba4d014ffd20c342e843dd46f89b0b0a1e5726b85deb8eaf",
     "variant": null
   },
-  "cpython-3.11.6+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "78252aa883fed18de7bb9b146450e42dd75d78c345f56c1301bb042317a1d4f7",
-    "variant": "debug"
-  },
   "cpython-3.11.6-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -3483,19 +3444,6 @@
     "sha256": "f9f19823dba3209cedc4647b00f46ed0177242917db20fb7fb539970e384531c",
     "variant": null
   },
-  "cpython-3.11.6+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "6e7889a15d861f1860ed84f3f5ea4586d198aa003b22556d91e180a44184dcd7",
-    "variant": "debug"
-  },
   "cpython-3.11.6-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3508,19 +3456,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8",
     "variant": null
-  },
-  "cpython-3.11.6+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "c2178b505ac315ede0a2659511841acd022bc7290ef65648e052bb1acebff59f",
-    "variant": "debug"
   },
   "cpython-3.11.6-linux-x86_64-musl": {
     "name": "cpython",
@@ -3561,6 +3496,71 @@
     "sha256": "3933545e6d41462dd6a47e44133ea40995bc6efeed8c2e4cbdf1a699303e95ea",
     "variant": null
   },
+  "cpython-3.11.6+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d63d6eb065e60899b25853fe6bbd9f60ea6c3b12f4854adc75cb818bad55f4e9",
+    "variant": "debug"
+  },
+  "cpython-3.11.6+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "71c34db1165860a6bf458d817aef00dea96146130bf5f8bd7ee39b12892ef463",
+    "variant": "debug"
+  },
+  "cpython-3.11.6+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "78252aa883fed18de7bb9b146450e42dd75d78c345f56c1301bb042317a1d4f7",
+    "variant": "debug"
+  },
+  "cpython-3.11.6+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6e7889a15d861f1860ed84f3f5ea4586d198aa003b22556d91e180a44184dcd7",
+    "variant": "debug"
+  },
+  "cpython-3.11.6+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "c2178b505ac315ede0a2659511841acd022bc7290ef65648e052bb1acebff59f",
+    "variant": "debug"
+  },
   "cpython-3.11.5-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3587,19 +3587,6 @@
     "sha256": "4a4efa7378c72f1dd8ebcce1afb99b24c01b07023aa6b8fea50eaedb50bf2bfc",
     "variant": null
   },
-  "cpython-3.11.5+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "ac4b1e91d1cb7027595bfa4667090406331b291b2e346fb74e42b7031b216787",
-    "variant": "debug"
-  },
   "cpython-3.11.5-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3612,19 +3599,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "bb5c5d1ea0f199fe2d3f0996fff4b48ca6ddc415a3dbd98f50bff7fce48aac80",
     "variant": null
-  },
-  "cpython-3.11.5+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "75d27b399b323c25d8250fda9857e388bf1b03ba1eb7925ec23cf12042a63a88",
-    "variant": "debug"
   },
   "cpython-3.11.5-linux-i686-gnu": {
     "name": "cpython",
@@ -3639,19 +3613,6 @@
     "sha256": "82de7e2551c015145c017742a5c0411d67a7544595df43c02b5efa4762d5123e",
     "variant": null
   },
-  "cpython-3.11.5+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "1aee6a613385a6355bed61a9b12259a5ed16e871b5bdfe5c9fe98b46ee2bb05e",
-    "variant": "debug"
-  },
   "cpython-3.11.5-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -3664,19 +3625,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-ppc64le-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "14121b53e9c8c6d0741f911ae00102a35adbcf5c3cdf732687ef7617b7d7304d",
     "variant": null
-  },
-  "cpython-3.11.5+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "b0819032ec336d6e1d9e9bfdba546bf854a7b7248f8720a6d07da72c4ac927e5",
-    "variant": "debug"
   },
   "cpython-3.11.5-linux-s390x-gnu": {
     "name": "cpython",
@@ -3691,19 +3639,6 @@
     "sha256": "fe459da39874443579d6fe88c68777c6d3e331038e1fb92a0451879fb6beb16d",
     "variant": null
   },
-  "cpython-3.11.5+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "93ee095b53de5a74af18e612f55095fcf3118c3c0a87eb6344d8eaca396bfb2d",
-    "variant": "debug"
-  },
   "cpython-3.11.5-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3716,19 +3651,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "fbed6f7694b2faae5d7c401a856219c945397f772eea5ca50c6eb825cbc9d1e1",
     "variant": null
-  },
-  "cpython-3.11.5+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "96c77d4b1cbb47ac5eca384d21d689995c46e6a86d487acb73c9210eed3c5614",
-    "variant": "debug"
   },
   "cpython-3.11.5-linux-x86_64-musl": {
     "name": "cpython",
@@ -3769,6 +3691,84 @@
     "sha256": "00f002263efc8aea896bcfaaf906b1f4dab3e5cd3db53e2b69ab9a10ba220b97",
     "variant": null
   },
+  "cpython-3.11.5+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ac4b1e91d1cb7027595bfa4667090406331b291b2e346fb74e42b7031b216787",
+    "variant": "debug"
+  },
+  "cpython-3.11.5+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "75d27b399b323c25d8250fda9857e388bf1b03ba1eb7925ec23cf12042a63a88",
+    "variant": "debug"
+  },
+  "cpython-3.11.5+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1aee6a613385a6355bed61a9b12259a5ed16e871b5bdfe5c9fe98b46ee2bb05e",
+    "variant": "debug"
+  },
+  "cpython-3.11.5+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b0819032ec336d6e1d9e9bfdba546bf854a7b7248f8720a6d07da72c4ac927e5",
+    "variant": "debug"
+  },
+  "cpython-3.11.5+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "93ee095b53de5a74af18e612f55095fcf3118c3c0a87eb6344d8eaca396bfb2d",
+    "variant": "debug"
+  },
+  "cpython-3.11.5+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "96c77d4b1cbb47ac5eca384d21d689995c46e6a86d487acb73c9210eed3c5614",
+    "variant": "debug"
+  },
   "cpython-3.11.4-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3795,19 +3795,6 @@
     "sha256": "47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00",
     "variant": null
   },
-  "cpython-3.11.4+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "37cf00439b57adf7ffef4a349d62dcf09739ba67b670e903b00b25f81fbb8a68",
-    "variant": "debug"
-  },
   "cpython-3.11.4-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -3820,19 +3807,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "2e84fc53f4e90e11963281c5c871f593abcb24fc796a50337fa516be99af02fb",
     "variant": null
-  },
-  "cpython-3.11.4+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "a9051364b5c2e28205f8484cae03d16c86b45df5d117324e846d0f5e870fe9fb",
-    "variant": "debug"
   },
   "cpython-3.11.4-linux-i686-gnu": {
     "name": "cpython",
@@ -3847,19 +3821,6 @@
     "sha256": "abdccc6ec7093f49da99680f5899a96bff0b96fde8f5d73f7aac121e0d05fdd8",
     "variant": null
   },
-  "cpython-3.11.4+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "b9f76fd226bfcbc6a8769934b17323ca3b563f1c24660582fcccfa6d0c7146af",
-    "variant": "debug"
-  },
   "cpython-3.11.4-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -3872,19 +3833,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-ppc64le-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "df7b92ed9cec96b3bb658fb586be947722ecd8e420fb23cee13d2e90abcfcf25",
     "variant": null
-  },
-  "cpython-3.11.4+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "8ef6b5fa86b4abf51865b346b7cf8df36e474ed308869fc0ac3fe82de39194a4",
-    "variant": "debug"
   },
   "cpython-3.11.4-linux-s390x-gnu": {
     "name": "cpython",
@@ -3899,19 +3847,6 @@
     "sha256": "e477f0749161f9aa7887964f089d9460a539f6b4a8fdab5166f898210e1a87a4",
     "variant": null
   },
-  "cpython-3.11.4+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "1b5fdeb2dc56c30843e7350f1684178755fae91666a0a987e5eb39074c42a052",
-    "variant": "debug"
-  },
   "cpython-3.11.4-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -3924,19 +3859,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e26247302bc8e9083a43ce9e8dd94905b40d464745b1603041f7bc9a93c65d05",
     "variant": null
-  },
-  "cpython-3.11.4+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "d5467468ddee2b779096c5c4c0dcc74065d35fb38fea6c1c6630e7c2c904b1b9",
-    "variant": "debug"
   },
   "cpython-3.11.4-linux-x86_64-musl": {
     "name": "cpython",
@@ -3977,6 +3899,84 @@
     "sha256": "878614c03ea38538ae2f758e36c85d2c0eb1eaaca86cd400ff8c76693ee0b3e1",
     "variant": null
   },
+  "cpython-3.11.4+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "37cf00439b57adf7ffef4a349d62dcf09739ba67b670e903b00b25f81fbb8a68",
+    "variant": "debug"
+  },
+  "cpython-3.11.4+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a9051364b5c2e28205f8484cae03d16c86b45df5d117324e846d0f5e870fe9fb",
+    "variant": "debug"
+  },
+  "cpython-3.11.4+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b9f76fd226bfcbc6a8769934b17323ca3b563f1c24660582fcccfa6d0c7146af",
+    "variant": "debug"
+  },
+  "cpython-3.11.4+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8ef6b5fa86b4abf51865b346b7cf8df36e474ed308869fc0ac3fe82de39194a4",
+    "variant": "debug"
+  },
+  "cpython-3.11.4+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1b5fdeb2dc56c30843e7350f1684178755fae91666a0a987e5eb39074c42a052",
+    "variant": "debug"
+  },
+  "cpython-3.11.4+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "d5467468ddee2b779096c5c4c0dcc74065d35fb38fea6c1c6630e7c2c904b1b9",
+    "variant": "debug"
+  },
   "cpython-3.11.3-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4003,19 +4003,6 @@
     "sha256": "f710b8d60621308149c100d5175fec39274ed0b9c99645484fd93d1716ef4310",
     "variant": null
   },
-  "cpython-3.11.3+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "991521082b0347878ba855c4986d77cc805c22ef75159bc95dd24bfd80275e27",
-    "variant": "debug"
-  },
   "cpython-3.11.3-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4028,19 +4015,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "8190accbbbbcf7620f1ff6d668e4dd090c639665d11188ce864b62554d40e5ab",
     "variant": null
-  },
-  "cpython-3.11.3+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7bd694eb848328e96f524ded0f9b9eca6230d71fce3cd49b335a5c33450f3e04",
-    "variant": "debug"
   },
   "cpython-3.11.3-linux-i686-gnu": {
     "name": "cpython",
@@ -4055,19 +4029,6 @@
     "sha256": "36ff6c5ebca8bf07181b774874233eb37835a62b39493f975869acc5010d839d",
     "variant": null
   },
-  "cpython-3.11.3+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "241d583be3ecc34d76fafa0d186cb504ce5625eb2c0e895dc4f4073a649e5c73",
-    "variant": "debug"
-  },
   "cpython-3.11.3-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -4081,19 +4042,6 @@
     "sha256": "767d24f3570b35fedb945f5ac66224c8983f2d556ab83c5cfaa5f3666e9c212c",
     "variant": null
   },
-  "cpython-3.11.3+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "4f1192179e1f62e69b8b45f7f699e6f0100fb0b8a39aad7a48472794d0c24bd4",
-    "variant": "debug"
-  },
   "cpython-3.11.3-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4106,19 +4054,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "da50b87d1ec42b3cb577dfd22a3655e43a53150f4f98a4bfb40757c9d7839ab5",
     "variant": null
-  },
-  "cpython-3.11.3+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "b753e060ccfb783b369f1e375ff6cc7a38d864a00506ec2e01ca01ba1956abc6",
-    "variant": "debug"
   },
   "cpython-3.11.3-linux-x86_64-musl": {
     "name": "cpython",
@@ -4159,6 +4094,71 @@
     "sha256": "24741066da6f35a7ff67bee65ce82eae870d84e1181843e64a7076d1571e95af",
     "variant": null
   },
+  "cpython-3.11.3+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "991521082b0347878ba855c4986d77cc805c22ef75159bc95dd24bfd80275e27",
+    "variant": "debug"
+  },
+  "cpython-3.11.3+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7bd694eb848328e96f524ded0f9b9eca6230d71fce3cd49b335a5c33450f3e04",
+    "variant": "debug"
+  },
+  "cpython-3.11.3+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "241d583be3ecc34d76fafa0d186cb504ce5625eb2c0e895dc4f4073a649e5c73",
+    "variant": "debug"
+  },
+  "cpython-3.11.3+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "4f1192179e1f62e69b8b45f7f699e6f0100fb0b8a39aad7a48472794d0c24bd4",
+    "variant": "debug"
+  },
+  "cpython-3.11.3+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "b753e060ccfb783b369f1e375ff6cc7a38d864a00506ec2e01ca01ba1956abc6",
+    "variant": "debug"
+  },
   "cpython-3.11.1-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4185,19 +4185,6 @@
     "sha256": "20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733",
     "variant": null
   },
-  "cpython-3.11.1+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "8fe27d850c02aa7bb34088fad5b48df90b4b841f40e1472243b8ab9da8776e40",
-    "variant": "debug"
-  },
   "cpython-3.11.1-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4210,19 +4197,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "debf15783bdcb5530504f533d33fda75a7b905cec5361ae8f33da5ba6599f8b4",
     "variant": null
-  },
-  "cpython-3.11.1+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7986ebe82c07ecd2eb94fd1b3c9ebbb2366db2360e38f29ae0543e857551d0bf",
-    "variant": "debug"
   },
   "cpython-3.11.1-linux-i686-gnu": {
     "name": "cpython",
@@ -4237,19 +4211,6 @@
     "sha256": "8392230cf76c282cfeaf67dcbd2e0fac6da8cd3b3aead1250505c6ddd606caae",
     "variant": null
   },
-  "cpython-3.11.1+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "b5bf700afc77588d853832d10b74ba793811cbec41b02ebc2c39a8b9987aacdd",
-    "variant": "debug"
-  },
   "cpython-3.11.1-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4262,19 +4223,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "02a551fefab3750effd0e156c25446547c238688a32fabde2995c941c03a6423",
     "variant": null
-  },
-  "cpython-3.11.1+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 11,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "7773aab3d1cbddbd0c6095c931fe841a2c511369e21744097276d22f4bc05621",
-    "variant": "debug"
   },
   "cpython-3.11.1-linux-x86_64-musl": {
     "name": "cpython",
@@ -4315,6 +4263,58 @@
     "sha256": "edc08979cb0666a597466176511529c049a6f0bba8adf70df441708f766de5bf",
     "variant": null
   },
+  "cpython-3.11.1+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8fe27d850c02aa7bb34088fad5b48df90b4b841f40e1472243b8ab9da8776e40",
+    "variant": "debug"
+  },
+  "cpython-3.11.1+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7986ebe82c07ecd2eb94fd1b3c9ebbb2366db2360e38f29ae0543e857551d0bf",
+    "variant": "debug"
+  },
+  "cpython-3.11.1+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b5bf700afc77588d853832d10b74ba793811cbec41b02ebc2c39a8b9987aacdd",
+    "variant": "debug"
+  },
+  "cpython-3.11.1+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "7773aab3d1cbddbd0c6095c931fe841a2c511369e21744097276d22f4bc05621",
+    "variant": "debug"
+  },
   "cpython-3.10.15-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4341,19 +4341,6 @@
     "sha256": "c8cc9d58f4c71106472e9b9b2801b702e7939db1922dceabe5b33b5602b490e4",
     "variant": null
   },
-  "cpython-3.10.15+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "349db5d799a16c1ed69af1ce88cef761ca4674395b666b40cdbf5ac5fdfbc926",
-    "variant": "debug"
-  },
   "cpython-3.10.15-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4366,19 +4353,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "4a354407285995b12dc67bd5e99c588699cc0c434fddc38c84a61909381a2e2f",
     "variant": null
-  },
-  "cpython-3.10.15+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "174b4253d89ec56476d24899ec5e2f3b8c26807fd6c40857ab676fafef760a75",
-    "variant": "debug"
   },
   "cpython-3.10.15-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -4393,19 +4367,6 @@
     "sha256": "c7d8880fdecf914dac880a0f5ba78678b24579ae58b531e92a163773a6426df9",
     "variant": null
   },
-  "cpython-3.10.15+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "61d0efe32d26dc1f8bb448dc1d3479605f847326b3f6a9ddd5078033352c6307",
-    "variant": "debug"
-  },
   "cpython-3.10.15-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -4418,19 +4379,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "b68ea12eb0c5941d6fd7158a709d951e87a5fdffc8f8d774bf9ba4498a1a2373",
     "variant": null
-  },
-  "cpython-3.10.15+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "2ce3dbdd77d2e715d7cf8026e7aab7147b7a18a0f352b64f7d70e2fc23deccde",
-    "variant": "debug"
   },
   "cpython-3.10.15-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -4445,19 +4393,6 @@
     "sha256": "211427f42462475671c015ddcbff6d7138b48738faa7239abe4b37418a809fbb",
     "variant": null
   },
-  "cpython-3.10.15+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "47829f1dd7f6aa3164fa229c37a83338e5c9ad656d47d24cd4ca37a85bc5b229",
-    "variant": "debug"
-  },
   "cpython-3.10.15-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -4471,19 +4406,6 @@
     "sha256": "46479ecd894fb38def946fee4464a7639f63850afd7692350138910805984e9d",
     "variant": null
   },
-  "cpython-3.10.15+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "81ec51925799a89f634609794d7ed2229127b562af6ca56dbaf8616b844e82b4",
-    "variant": "debug"
-  },
   "cpython-3.10.15-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4496,19 +4418,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "bf234c7fa23dfcc70c7248c4a46ea58775b39005f107084e51afd439e67f2baf",
     "variant": null
-  },
-  "cpython-3.10.15+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "01fc843dbac291e16041fa9eaf9eea0374eb0d5b64a0dbd97b6b3491b176b7b8",
-    "variant": "debug"
   },
   "cpython-3.10.15-linux-x86_64-musl": {
     "name": "cpython",
@@ -4549,6 +4458,97 @@
     "sha256": "e5dbed3cd4e718081219fd039046779aa4ef808f725f7d19e60196fdf12d39ac",
     "variant": null
   },
+  "cpython-3.10.15+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "349db5d799a16c1ed69af1ce88cef761ca4674395b666b40cdbf5ac5fdfbc926",
+    "variant": "debug"
+  },
+  "cpython-3.10.15+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "174b4253d89ec56476d24899ec5e2f3b8c26807fd6c40857ab676fafef760a75",
+    "variant": "debug"
+  },
+  "cpython-3.10.15+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "61d0efe32d26dc1f8bb448dc1d3479605f847326b3f6a9ddd5078033352c6307",
+    "variant": "debug"
+  },
+  "cpython-3.10.15+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2ce3dbdd77d2e715d7cf8026e7aab7147b7a18a0f352b64f7d70e2fc23deccde",
+    "variant": "debug"
+  },
+  "cpython-3.10.15+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "47829f1dd7f6aa3164fa229c37a83338e5c9ad656d47d24cd4ca37a85bc5b229",
+    "variant": "debug"
+  },
+  "cpython-3.10.15+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "81ec51925799a89f634609794d7ed2229127b562af6ca56dbaf8616b844e82b4",
+    "variant": "debug"
+  },
+  "cpython-3.10.15+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "01fc843dbac291e16041fa9eaf9eea0374eb0d5b64a0dbd97b6b3491b176b7b8",
+    "variant": "debug"
+  },
   "cpython-3.10.14-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4575,19 +4575,6 @@
     "sha256": "4404f44ec69c0708d4d88e98f39c2c1fe3bd462dc6a958b60aaf63028550c485",
     "variant": null
   },
-  "cpython-3.10.14+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "a5dad9640ce4af0091e347661effc6438573097cb85dabe6f7ae073266f5c261",
-    "variant": "debug"
-  },
   "cpython-3.10.14-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4600,19 +4587,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "0ffe64c77cacda7e3afcb0d8ba271c59ca0a30dfda218da39a573b412bb4afd7",
     "variant": null
-  },
-  "cpython-3.10.14+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "c6a1c577f10bc6c938e7e64c8b2f60914f4193d8f602a3b89b398f4a06d674af",
-    "variant": "debug"
   },
   "cpython-3.10.14-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -4627,19 +4601,6 @@
     "sha256": "451449f18a49e6ceecf9c1f70f4aee0d1552eff103c3db291319125238182c9d",
     "variant": null
   },
-  "cpython-3.10.14+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "10ed35c173a7e6c482d1dcace5be2a5a7a8c937ebd92169020e9f401456551f0",
-    "variant": "debug"
-  },
   "cpython-3.10.14-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -4652,19 +4613,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "7f215b85df78c568847329faeb2c5007c301741d9c4ccebbd935a3a2963197b5",
     "variant": null
-  },
-  "cpython-3.10.14+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "85d3914679b7c0b5cc317ee4888e9d458a5afc985aae4d95c698d0fbf7a2b1c5",
-    "variant": "debug"
   },
   "cpython-3.10.14-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -4679,19 +4627,6 @@
     "sha256": "8b83fdd95cb864f8ebfa1a1dd7e700bb046b8283bfd0a3aa04f1ff259eaff99e",
     "variant": null
   },
-  "cpython-3.10.14+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9134680d4c4488a23c876188f066804625e64041ee9bd0e4e57a2d519f575eae",
-    "variant": "debug"
-  },
   "cpython-3.10.14-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -4705,19 +4640,6 @@
     "sha256": "ff1c4f010b1c6f563c71fa30f68293168536e0ed65f7d470a7e8c73252d08653",
     "variant": null
   },
-  "cpython-3.10.14+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "060bcd01e5ba9cbd3f5b8da98c16480320b19fa9f67cf9ecf94a0c20ba08db6e",
-    "variant": "debug"
-  },
   "cpython-3.10.14-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4730,19 +4652,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "159c456bb4a3802bafbce065ff54b99ddb16422500d75c1315573ee3b673af17",
     "variant": null
-  },
-  "cpython-3.10.14+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "cd33d23d8fb79ca99db1398a555daad44af4122d01fb4065fd79e121929c5cb3",
-    "variant": "debug"
   },
   "cpython-3.10.14-linux-x86_64-musl": {
     "name": "cpython",
@@ -4783,6 +4692,97 @@
     "sha256": "61ad1abcaca639eecb5bd0b129ac0315d79f7b90cf0aca8e9fb85c9e7269c26b",
     "variant": null
   },
+  "cpython-3.10.14+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a5dad9640ce4af0091e347661effc6438573097cb85dabe6f7ae073266f5c261",
+    "variant": "debug"
+  },
+  "cpython-3.10.14+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "c6a1c577f10bc6c938e7e64c8b2f60914f4193d8f602a3b89b398f4a06d674af",
+    "variant": "debug"
+  },
+  "cpython-3.10.14+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "10ed35c173a7e6c482d1dcace5be2a5a7a8c937ebd92169020e9f401456551f0",
+    "variant": "debug"
+  },
+  "cpython-3.10.14+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "85d3914679b7c0b5cc317ee4888e9d458a5afc985aae4d95c698d0fbf7a2b1c5",
+    "variant": "debug"
+  },
+  "cpython-3.10.14+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9134680d4c4488a23c876188f066804625e64041ee9bd0e4e57a2d519f575eae",
+    "variant": "debug"
+  },
+  "cpython-3.10.14+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "060bcd01e5ba9cbd3f5b8da98c16480320b19fa9f67cf9ecf94a0c20ba08db6e",
+    "variant": "debug"
+  },
+  "cpython-3.10.14+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "cd33d23d8fb79ca99db1398a555daad44af4122d01fb4065fd79e121929c5cb3",
+    "variant": "debug"
+  },
   "cpython-3.10.13-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4809,19 +4809,6 @@
     "sha256": "6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a",
     "variant": null
   },
-  "cpython-3.10.13+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "06a53040504e1e2fdcb32dc0d61b123bea76725b5c14031c8f64e28f52ae5a5f",
-    "variant": "debug"
-  },
   "cpython-3.10.13-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -4834,19 +4821,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "a898a88705611b372297bb8fe4d23cc16b8603ce5f24494c3a8cfa65d83787f9",
     "variant": null
-  },
-  "cpython-3.10.13+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "08a3a1ff61b7ed2c87db7a9f88630781d98fabc2efb499f38ae0ead05973eb56",
-    "variant": "debug"
   },
   "cpython-3.10.13-linux-i686-gnu": {
     "name": "cpython",
@@ -4861,19 +4835,6 @@
     "sha256": "424d239b6df60e40849ad18505de394001233ab3d7470b5280fec6e643208bb9",
     "variant": null
   },
-  "cpython-3.10.13+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "cab4c8756445d1d1987c7c94d3bcf323684e44fb9070329d8287d4c38e155711",
-    "variant": "debug"
-  },
   "cpython-3.10.13-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -4886,19 +4847,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-ppc64le-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "c23706e138a0351fc1e9def2974af7b8206bac7ecbbb98a78f5aa9e7535fee42",
     "variant": null
-  },
-  "cpython-3.10.13+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "fe46914541126297c7a8636845c2e7188868eaa617bb6e293871fca4a5cb63f7",
-    "variant": "debug"
   },
   "cpython-3.10.13-linux-s390x-gnu": {
     "name": "cpython",
@@ -4913,19 +4861,6 @@
     "sha256": "09be8fb2cdfbb4a93d555f268f244dbe4d8ff1854b2658e8043aa4ec08aede3e",
     "variant": null
   },
-  "cpython-3.10.13+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "41b20e9d87f57d27f608685b714a57eea81c9e079aa647d59837ec6659536626",
-    "variant": "debug"
-  },
   "cpython-3.10.13-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -4938,19 +4873,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "d995d032ca702afd2fc3a689c1f84a6c64972ecd82bba76a61d525f08eb0e195",
     "variant": null
-  },
-  "cpython-3.10.13+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "3eec53aef154273c0bc30bb9905734762171f474f73ba256c8883022915b7439",
-    "variant": "debug"
   },
   "cpython-3.10.13-linux-x86_64-musl": {
     "name": "cpython",
@@ -4991,6 +4913,84 @@
     "sha256": "086f7fe9156b897bb401273db8359017104168ac36f60f3af4e31ac7acd6634e",
     "variant": null
   },
+  "cpython-3.10.13+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "06a53040504e1e2fdcb32dc0d61b123bea76725b5c14031c8f64e28f52ae5a5f",
+    "variant": "debug"
+  },
+  "cpython-3.10.13+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "08a3a1ff61b7ed2c87db7a9f88630781d98fabc2efb499f38ae0ead05973eb56",
+    "variant": "debug"
+  },
+  "cpython-3.10.13+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "cab4c8756445d1d1987c7c94d3bcf323684e44fb9070329d8287d4c38e155711",
+    "variant": "debug"
+  },
+  "cpython-3.10.13+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fe46914541126297c7a8636845c2e7188868eaa617bb6e293871fca4a5cb63f7",
+    "variant": "debug"
+  },
+  "cpython-3.10.13+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "41b20e9d87f57d27f608685b714a57eea81c9e079aa647d59837ec6659536626",
+    "variant": "debug"
+  },
+  "cpython-3.10.13+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "3eec53aef154273c0bc30bb9905734762171f474f73ba256c8883022915b7439",
+    "variant": "debug"
+  },
   "cpython-3.10.12-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5017,19 +5017,6 @@
     "sha256": "8a6e3ed973a671de468d9c691ed9cb2c3a4858c5defffcf0b08969fba9c1dd04",
     "variant": null
   },
-  "cpython-3.10.12+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "e30f2b4fd9bd79b9122e2975f3c17c9ddd727f8326b2e246378e81f7ecc7d74f",
-    "variant": "debug"
-  },
   "cpython-3.10.12-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5042,19 +5029,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "fee80e221663eca5174bd794cb5047e40d3910dbeadcdf1f09d405a4c1c15fe4",
     "variant": null
-  },
-  "cpython-3.10.12+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "89c83fcdfd41c67e2dd2a037982556c657dc55fc1938c6f6cdcd5ffa614c1fb3",
-    "variant": "debug"
   },
   "cpython-3.10.12-linux-i686-gnu": {
     "name": "cpython",
@@ -5069,19 +5043,6 @@
     "sha256": "c7a5321a696ef6467791312368a04d36828907a8f5c557b96067fa534c716c18",
     "variant": null
   },
-  "cpython-3.10.12+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "c318050fa91d84d447f5c8a5887a44f1cc8dd34d4c1d357cd755407d46ed1b21",
-    "variant": "debug"
-  },
   "cpython-3.10.12-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -5094,19 +5055,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-ppc64le-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "bb5e8cb0d2e44241725fa9b342238245503e7849917660006b0246a9c97b1d6c",
     "variant": null
-  },
-  "cpython-3.10.12+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "756579b52acb9b13b162ac901e56ff311def443e69d7f7259a91198b76a30ecb",
-    "variant": "debug"
   },
   "cpython-3.10.12-linux-s390x-gnu": {
     "name": "cpython",
@@ -5121,19 +5069,6 @@
     "sha256": "8d33d435ae6fb93ded7fc26798cc0a1a4f546a4e527012a1e2909cc314b332df",
     "variant": null
   },
-  "cpython-3.10.12+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "fb7354fcee7b17dd0793ebd3f6f1fc8b7b205332afcf8d700cc1119f2dc33ff7",
-    "variant": "debug"
-  },
   "cpython-3.10.12-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5146,19 +5081,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "a476dbca9184df9fc69fe6309cda5ebaf031d27ca9e529852437c94ec1bc43d3",
     "variant": null
-  },
-  "cpython-3.10.12+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "ebff76754ae37694581afe80749efb1260a6da95a9d88f8e60aa2cab75fd5497",
-    "variant": "debug"
   },
   "cpython-3.10.12-linux-x86_64-musl": {
     "name": "cpython",
@@ -5199,6 +5121,84 @@
     "sha256": "c1a31c353ca44de7d1b1a3b6c55a823e9c1eed0423d4f9f66e617bdb1b608685",
     "variant": null
   },
+  "cpython-3.10.12+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e30f2b4fd9bd79b9122e2975f3c17c9ddd727f8326b2e246378e81f7ecc7d74f",
+    "variant": "debug"
+  },
+  "cpython-3.10.12+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "89c83fcdfd41c67e2dd2a037982556c657dc55fc1938c6f6cdcd5ffa614c1fb3",
+    "variant": "debug"
+  },
+  "cpython-3.10.12+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c318050fa91d84d447f5c8a5887a44f1cc8dd34d4c1d357cd755407d46ed1b21",
+    "variant": "debug"
+  },
+  "cpython-3.10.12+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "756579b52acb9b13b162ac901e56ff311def443e69d7f7259a91198b76a30ecb",
+    "variant": "debug"
+  },
+  "cpython-3.10.12+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fb7354fcee7b17dd0793ebd3f6f1fc8b7b205332afcf8d700cc1119f2dc33ff7",
+    "variant": "debug"
+  },
+  "cpython-3.10.12+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "ebff76754ae37694581afe80749efb1260a6da95a9d88f8e60aa2cab75fd5497",
+    "variant": "debug"
+  },
   "cpython-3.10.11-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5225,19 +5225,6 @@
     "sha256": "bd3fc6e4da6f4033ebf19d66704e73b0804c22641ddae10bbe347c48f82374ad",
     "variant": null
   },
-  "cpython-3.10.11+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "a5271cc014f2ce2ab54a0789556c15b84668e2afcc530512818c4b87c6a94483",
-    "variant": "debug"
-  },
   "cpython-3.10.11-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5250,19 +5237,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "c7573fdb00239f86b22ea0e8e926ca881d24fde5e5890851339911d76110bc35",
     "variant": null
-  },
-  "cpython-3.10.11+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9304d6eeef48bd246a2959ebc76b20dbb2c6a81aa1d214f4471cb273c11717f2",
-    "variant": "debug"
   },
   "cpython-3.10.11-linux-i686-gnu": {
     "name": "cpython",
@@ -5277,19 +5251,6 @@
     "sha256": "c70518620e32b074b1b40579012f0c67191a967e43e84b8f46052b6b893f7eeb",
     "variant": null
   },
-  "cpython-3.10.11+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "ac32e3788109ff0cc536a6108072d9203217df744cf56d3a4ab0b19857d8e244",
-    "variant": "debug"
-  },
   "cpython-3.10.11-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -5303,19 +5264,6 @@
     "sha256": "73a9d4c89ed51be39dd2de4e235078281087283e9fdedef65bec02f503e906ee",
     "variant": null
   },
-  "cpython-3.10.11+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "544e5020f71ad1525dbc92b08e429cc1e1e11866c48c07d91e99f531b9ba68b0",
-    "variant": "debug"
-  },
   "cpython-3.10.11-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5328,19 +5276,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "c5bcaac91bc80bfc29cf510669ecad12d506035ecb3ad85ef213416d54aecd79",
     "variant": null
-  },
-  "cpython-3.10.11+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "0d5bd092b85ada04f6f27a5ef30e026ec2df8ddc73f89d7d1d397623405011c1",
-    "variant": "debug"
   },
   "cpython-3.10.11-linux-x86_64-musl": {
     "name": "cpython",
@@ -5381,6 +5316,71 @@
     "sha256": "9c2d3604a06fcd422289df73015cd00e7271d90de28d2c910f0e2309a7f73a68",
     "variant": null
   },
+  "cpython-3.10.11+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a5271cc014f2ce2ab54a0789556c15b84668e2afcc530512818c4b87c6a94483",
+    "variant": "debug"
+  },
+  "cpython-3.10.11+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9304d6eeef48bd246a2959ebc76b20dbb2c6a81aa1d214f4471cb273c11717f2",
+    "variant": "debug"
+  },
+  "cpython-3.10.11+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ac32e3788109ff0cc536a6108072d9203217df744cf56d3a4ab0b19857d8e244",
+    "variant": "debug"
+  },
+  "cpython-3.10.11+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "544e5020f71ad1525dbc92b08e429cc1e1e11866c48c07d91e99f531b9ba68b0",
+    "variant": "debug"
+  },
+  "cpython-3.10.11+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0d5bd092b85ada04f6f27a5ef30e026ec2df8ddc73f89d7d1d397623405011c1",
+    "variant": "debug"
+  },
   "cpython-3.10.9-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5407,19 +5407,6 @@
     "sha256": "0e685f98dce0e5bc8da93c7081f4e6c10219792e223e4b5886730fd73a7ba4c6",
     "variant": null
   },
-  "cpython-3.10.9+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "2c0996dd1fe35314e06e042081b24fb53f3b7b361c3e1b94a6ed659c275ca069",
-    "variant": "debug"
-  },
   "cpython-3.10.9-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5432,19 +5419,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "2003750f40cd09d4bf7a850342613992f8d9454f03b3c067989911fb37e7a4d1",
     "variant": null
-  },
-  "cpython-3.10.9+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "f8c3a63620f412c4a9ccfb6e2435a96a55775550c81a452d164caa6d03a6a1da",
-    "variant": "debug"
   },
   "cpython-3.10.9-linux-i686-gnu": {
     "name": "cpython",
@@ -5459,19 +5433,6 @@
     "sha256": "44566c08eb8054aa0784f76b85d2c6c70a62f4988d5e9abcce819b517b329fdd",
     "variant": null
   },
-  "cpython-3.10.9+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "a90a45ba7afcbd1df9aef96a614acbb210607299ac74dadbb6bd66af22be34db",
-    "variant": "debug"
-  },
   "cpython-3.10.9-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5484,19 +5445,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "d196347aeb701a53fe2bb2b095abec38d27d0fa0443f8a1c2023a1bed6e18cdf",
     "variant": null
-  },
-  "cpython-3.10.9+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "7e0a0094b580d285163ede7797945e86bd4905d6af3340e6554e6abba7bcb832",
-    "variant": "debug"
   },
   "cpython-3.10.9-linux-x86_64-musl": {
     "name": "cpython",
@@ -5537,6 +5485,58 @@
     "sha256": "59c6970cecb357dc1d8554bd0540eb81ee7f6d16a07acf3d14ed294ece02c035",
     "variant": null
   },
+  "cpython-3.10.9+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2c0996dd1fe35314e06e042081b24fb53f3b7b361c3e1b94a6ed659c275ca069",
+    "variant": "debug"
+  },
+  "cpython-3.10.9+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f8c3a63620f412c4a9ccfb6e2435a96a55775550c81a452d164caa6d03a6a1da",
+    "variant": "debug"
+  },
+  "cpython-3.10.9+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a90a45ba7afcbd1df9aef96a614acbb210607299ac74dadbb6bd66af22be34db",
+    "variant": "debug"
+  },
+  "cpython-3.10.9+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "7e0a0094b580d285163ede7797945e86bd4905d6af3340e6554e6abba7bcb832",
+    "variant": "debug"
+  },
   "cpython-3.10.8-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5563,19 +5563,6 @@
     "sha256": "525b79c7ce5de90ab66bd07b0ac1008bafa147ddc8a41bef15ffb7c9c1e9e7c5",
     "variant": null
   },
-  "cpython-3.10.8+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "879e76260be226512693e37a28cc3a6670b5ee270a4440e4b04a7b415dba451c",
-    "variant": "debug"
-  },
   "cpython-3.10.8-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5588,19 +5575,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "33170bef18c811906b738be530f934640491b065bf16c4d276c6515321918132",
     "variant": null
-  },
-  "cpython-3.10.8+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "ab434eccffeec4f6f51af017e4eed69d4f1ea55f48c5b89b8a8779df3fa799df",
-    "variant": "debug"
   },
   "cpython-3.10.8-linux-i686-gnu": {
     "name": "cpython",
@@ -5615,19 +5589,6 @@
     "sha256": "2deee7cbbd5dad339d713a75ec92239725d2035e833af5b9981b026dee0b9213",
     "variant": null
   },
-  "cpython-3.10.8+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "c86182951a82e761588476a0155afe99ae4ae1030e4a8e1e8bcb8e1d42f6327c",
-    "variant": "debug"
-  },
   "cpython-3.10.8-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5640,19 +5601,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "6c8db44ae0e18e320320bbaaafd2d69cde8bfea171ae2d651b7993d1396260b7",
     "variant": null
-  },
-  "cpython-3.10.8+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "935eb97e0c3ef358a2f25e78b0b56aebad68d371e3b63979a157c7588a03585b",
-    "variant": "debug"
   },
   "cpython-3.10.8-linux-x86_64-musl": {
     "name": "cpython",
@@ -5693,6 +5641,58 @@
     "sha256": "f2b6d2f77118f06dd2ca04dae1175e44aaa5077a5ed8ddc63333c15347182bfe",
     "variant": null
   },
+  "cpython-3.10.8+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "879e76260be226512693e37a28cc3a6670b5ee270a4440e4b04a7b415dba451c",
+    "variant": "debug"
+  },
+  "cpython-3.10.8+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ab434eccffeec4f6f51af017e4eed69d4f1ea55f48c5b89b8a8779df3fa799df",
+    "variant": "debug"
+  },
+  "cpython-3.10.8+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c86182951a82e761588476a0155afe99ae4ae1030e4a8e1e8bcb8e1d42f6327c",
+    "variant": "debug"
+  },
+  "cpython-3.10.8+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "935eb97e0c3ef358a2f25e78b0b56aebad68d371e3b63979a157c7588a03585b",
+    "variant": "debug"
+  },
   "cpython-3.10.7-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5719,19 +5719,6 @@
     "sha256": "6101f580434544d28d5590543029a7c6bdf07efa4bcdb5e4cbedb3cd83241922",
     "variant": null
   },
-  "cpython-3.10.7+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9f346729b523e860194635eb67c9f6bc8f12728ba7ddfe4fd80f2e6d685781e3",
-    "variant": "debug"
-  },
   "cpython-3.10.7-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5744,19 +5731,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "dfeec186a62a6068259d90e8d77e7d30eaf9c2b4ae7b205ff8caab7cb21f277c",
     "variant": null
-  },
-  "cpython-3.10.7+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "a79816c50abeb2752530f68b4d7d95b6f48392f44a9a7f135b91807d76872972",
-    "variant": "debug"
   },
   "cpython-3.10.7-linux-i686-gnu": {
     "name": "cpython",
@@ -5771,19 +5745,6 @@
     "sha256": "4a611ce990dc1f32bc4b35d276f04521464127f77e1133ac5bb9c6ba23e94a82",
     "variant": null
   },
-  "cpython-3.10.7+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "ce3fe27e6ca3a0e75a7f4f3b6568cd1bf967230a67e73393e94a23380dddaf10",
-    "variant": "debug"
-  },
   "cpython-3.10.7-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5796,19 +5757,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "c12c9ad2b2c75464541d897c0528013adecd8be5b30acf4411f7759729841711",
     "variant": null
-  },
-  "cpython-3.10.7+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "08f725cdb4d4f6bd76c582b798f7d7685c8f5c5afa03e1553e28e55a3859014e",
-    "variant": "debug"
   },
   "cpython-3.10.7-linux-x86_64-musl": {
     "name": "cpython",
@@ -5849,6 +5797,58 @@
     "sha256": "b464352f8cbf06ab4c041b7559c9bda7e9f6001a94f67ab0a342cba078f3805f",
     "variant": null
   },
+  "cpython-3.10.7+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9f346729b523e860194635eb67c9f6bc8f12728ba7ddfe4fd80f2e6d685781e3",
+    "variant": "debug"
+  },
+  "cpython-3.10.7+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a79816c50abeb2752530f68b4d7d95b6f48392f44a9a7f135b91807d76872972",
+    "variant": "debug"
+  },
+  "cpython-3.10.7+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ce3fe27e6ca3a0e75a7f4f3b6568cd1bf967230a67e73393e94a23380dddaf10",
+    "variant": "debug"
+  },
+  "cpython-3.10.7+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "08f725cdb4d4f6bd76c582b798f7d7685c8f5c5afa03e1553e28e55a3859014e",
+    "variant": "debug"
+  },
   "cpython-3.10.6-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5875,19 +5875,6 @@
     "sha256": "7718411adf3ea1480f3f018a643eb0550282aefe39e5ecb3f363a4a566a9398c",
     "variant": null
   },
-  "cpython-3.10.6+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "edc1c9742b824caebbc5cb224c8990aa8658b81593fd9219accf3efa3e849501",
-    "variant": "debug"
-  },
   "cpython-3.10.6-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -5900,19 +5887,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "81625f5c97f61e2e3d7e9f62c484b1aa5311f21bd6545451714b949a29da5435",
     "variant": null
-  },
-  "cpython-3.10.6+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "07fa4f5499b8885d1eea49caf5476d76305ab73494b7398dfd22c14093859e4f",
-    "variant": "debug"
   },
   "cpython-3.10.6-linux-i686-gnu": {
     "name": "cpython",
@@ -5927,19 +5901,6 @@
     "sha256": "b152801a2609e6a38f3cc9e7e21d8b6cf5b6f31dacfcaca01e162c514e851ed6",
     "variant": null
   },
-  "cpython-3.10.6+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "407e5951e39f5652b32b72b715c4aa772dd8c2da1065161c58c30a1f976dd1b2",
-    "variant": "debug"
-  },
   "cpython-3.10.6-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -5952,19 +5913,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "55aa2190d28dcfdf414d96dc5dcea9fe048fadcd583dc3981fec020869826111",
     "variant": null
-  },
-  "cpython-3.10.6+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "6cd58957e286c132dc7cdbd937144aa180b557772be8a2b70bd1c3f2644ebe65",
-    "variant": "debug"
   },
   "cpython-3.10.6-linux-x86_64-musl": {
     "name": "cpython",
@@ -6005,6 +5953,58 @@
     "sha256": "91889a7dbdceea585ff4d3b7856a6bb8f8a4eca83a0ff52a73542c2e67220eaa",
     "variant": null
   },
+  "cpython-3.10.6+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "edc1c9742b824caebbc5cb224c8990aa8658b81593fd9219accf3efa3e849501",
+    "variant": "debug"
+  },
+  "cpython-3.10.6+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "07fa4f5499b8885d1eea49caf5476d76305ab73494b7398dfd22c14093859e4f",
+    "variant": "debug"
+  },
+  "cpython-3.10.6+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "407e5951e39f5652b32b72b715c4aa772dd8c2da1065161c58c30a1f976dd1b2",
+    "variant": "debug"
+  },
+  "cpython-3.10.6+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "6cd58957e286c132dc7cdbd937144aa180b557772be8a2b70bd1c3f2644ebe65",
+    "variant": "debug"
+  },
   "cpython-3.10.5-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6031,19 +6031,6 @@
     "sha256": "eca0584397d9a3ef6f7bb32b0476318b01c89b7b0a031ef97a0dcaa5ba5127a8",
     "variant": null
   },
-  "cpython-3.10.5+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9fa6970a3d0a5dc26c4ed272bb1836d1f1f7a8f4b9d67f634d0262ff8c1fed0b",
-    "variant": "debug"
-  },
   "cpython-3.10.5-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6056,19 +6043,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "012fa37c12d2647d76d004dc003302563864d2f1cd0731b71eeafad63d28b3f0",
     "variant": null
-  },
-  "cpython-3.10.5+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "63fcfc425adabc034c851dadfb499de3083fd7758582191c12162ad2471256b0",
-    "variant": "debug"
   },
   "cpython-3.10.5-linux-i686-gnu": {
     "name": "cpython",
@@ -6083,19 +6057,6 @@
     "sha256": "5abf5baf40f8573ce7d7e4ad323457f511833e1663e61ac5a11d5563a735159f",
     "variant": null
   },
-  "cpython-3.10.5+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "f8dfb83885d1cbc82febfa613258c1f6954ea88ef43ed7dc710d6df20efecdab",
-    "variant": "debug"
-  },
   "cpython-3.10.5-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6108,19 +6069,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "460f87a389be28c953c24c6f942f172f9ce7f331367b4daf89cb450baedd51d7",
     "variant": null
-  },
-  "cpython-3.10.5+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "5217476a38b5273fd98ce45b7f0efcd579b8740c4d2911c6900fa16d59368fcc",
-    "variant": "debug"
   },
   "cpython-3.10.5-linux-x86_64-musl": {
     "name": "cpython",
@@ -6161,6 +6109,58 @@
     "sha256": "c830ab2a3a488f9cf95e4e81c581d9ef73e483c2e6546136379443e9bb725119",
     "variant": null
   },
+  "cpython-3.10.5+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9fa6970a3d0a5dc26c4ed272bb1836d1f1f7a8f4b9d67f634d0262ff8c1fed0b",
+    "variant": "debug"
+  },
+  "cpython-3.10.5+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "63fcfc425adabc034c851dadfb499de3083fd7758582191c12162ad2471256b0",
+    "variant": "debug"
+  },
+  "cpython-3.10.5+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f8dfb83885d1cbc82febfa613258c1f6954ea88ef43ed7dc710d6df20efecdab",
+    "variant": "debug"
+  },
+  "cpython-3.10.5+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "5217476a38b5273fd98ce45b7f0efcd579b8740c4d2911c6900fa16d59368fcc",
+    "variant": "debug"
+  },
   "cpython-3.10.4-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6187,19 +6187,6 @@
     "sha256": "c4a57a13b084d49ce8c2eb5b2662ee45b0c55b08ddd696f473233b0787f03988",
     "variant": null
   },
-  "cpython-3.10.4+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "092369e9d170c4c1074e1b305accb74f9486e6185d2e3f3f971869ff89538d3e",
-    "variant": "debug"
-  },
   "cpython-3.10.4-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6212,19 +6199,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "7a8989392dc9b41d85959a752448c60852cf0061de565e98445c27f6bbdf63be",
     "variant": null
-  },
-  "cpython-3.10.4+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "ba940a74a7434fe78d81aed9fb1e5ccdc3d97191a2db35716fc94e3b6604ace0",
-    "variant": "debug"
   },
   "cpython-3.10.4-linux-i686-gnu": {
     "name": "cpython",
@@ -6239,19 +6213,6 @@
     "sha256": "f3bc0828a0e0a8974e3fe90b4e99549296a7578de2321d791be1bad28191921d",
     "variant": null
   },
-  "cpython-3.10.4+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7699f76ef89b436b452eacdbab508da3cd94146ba29b099f5cb6e250afba3210",
-    "variant": "debug"
-  },
   "cpython-3.10.4-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6264,19 +6225,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "1f8423808ad84c0e56c8e14c32685cbfbc1159e0d9f943ac946f29e84cf1b5ee",
     "variant": null
-  },
-  "cpython-3.10.4+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "8fb78fbf9266b23ee0eaf569f7a36d1696f7102c396106c1d71b3a991b27ad27",
-    "variant": "debug"
   },
   "cpython-3.10.4-linux-x86_64-musl": {
     "name": "cpython",
@@ -6317,6 +6265,58 @@
     "sha256": "7231ba2af9525cae620a5f4ae3bf89a939fdc053ba0cc64ee3dead8f13188005",
     "variant": null
   },
+  "cpython-3.10.4+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "092369e9d170c4c1074e1b305accb74f9486e6185d2e3f3f971869ff89538d3e",
+    "variant": "debug"
+  },
+  "cpython-3.10.4+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ba940a74a7434fe78d81aed9fb1e5ccdc3d97191a2db35716fc94e3b6604ace0",
+    "variant": "debug"
+  },
+  "cpython-3.10.4+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7699f76ef89b436b452eacdbab508da3cd94146ba29b099f5cb6e250afba3210",
+    "variant": "debug"
+  },
+  "cpython-3.10.4+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "8fb78fbf9266b23ee0eaf569f7a36d1696f7102c396106c1d71b3a991b27ad27",
+    "variant": "debug"
+  },
   "cpython-3.10.3-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6343,19 +6343,6 @@
     "sha256": "ec2e90b6a589db7ef9f74358b1436558167629f9e4d725c8150496f9cb08a9d4",
     "variant": null
   },
-  "cpython-3.10.3+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "101284d27578438da200be1f6b9a1ba621432c5549fa5517797ec320bf75e3d5",
-    "variant": "debug"
-  },
   "cpython-3.10.3-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6368,19 +6355,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "f52ee68c13c4f9356eb78a5305d3178af2cb90c38a8ce8ce9990a7cf6ff06144",
     "variant": null
-  },
-  "cpython-3.10.3+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "43c1cd6e203bfba1a2eeb96cd2a15ce0ebde0e72ecc9555934116459347a9c28",
-    "variant": "debug"
   },
   "cpython-3.10.3-linux-i686-gnu": {
     "name": "cpython",
@@ -6395,19 +6369,6 @@
     "sha256": "2f125a927c3af52ef89af11857df988a042e26ce095129701b915e75b2ec6bff",
     "variant": null
   },
-  "cpython-3.10.3+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "04760d869234ee8f801feb08edc042a6965320f6c0a7aedf92ec35501fef3b21",
-    "variant": "debug"
-  },
   "cpython-3.10.3-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6420,19 +6381,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "b9989411bed71ba4867538c991f20b55f549dd9131905733f0df9f3fde81ad1d",
     "variant": null
-  },
-  "cpython-3.10.3+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "47637777bc44c6476e499bfcb214959c7abc386879dd66683a0d8e1b714c07cf",
-    "variant": "debug"
   },
   "cpython-3.10.3-linux-x86_64-musl": {
     "name": "cpython",
@@ -6473,6 +6421,58 @@
     "sha256": "ba593370742ed8a7bc70ce563dd6a53e30ece1f6881e3888d334c1b485b0d9d0",
     "variant": null
   },
+  "cpython-3.10.3+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "101284d27578438da200be1f6b9a1ba621432c5549fa5517797ec320bf75e3d5",
+    "variant": "debug"
+  },
+  "cpython-3.10.3+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "43c1cd6e203bfba1a2eeb96cd2a15ce0ebde0e72ecc9555934116459347a9c28",
+    "variant": "debug"
+  },
+  "cpython-3.10.3+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "04760d869234ee8f801feb08edc042a6965320f6c0a7aedf92ec35501fef3b21",
+    "variant": "debug"
+  },
+  "cpython-3.10.3+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "47637777bc44c6476e499bfcb214959c7abc386879dd66683a0d8e1b714c07cf",
+    "variant": "debug"
+  },
   "cpython-3.10.2-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6499,19 +6499,6 @@
     "sha256": "8146ad4390710ec69b316a5649912df0247d35f4a42e2aa9615bffd87b3e235a",
     "variant": null
   },
-  "cpython-3.10.2+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9936f1549f950311229465de509b35c062aa474e504c20a1d6f0f632da57e002",
-    "variant": "debug"
-  },
   "cpython-3.10.2-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6524,19 +6511,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "8f351a8cc348bb45c0f95b8634c8345ec6e749e483384188ad865b7428342703",
     "variant": null
-  },
-  "cpython-3.10.2+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9be2a667f29ed048165cfb3f5dbe61703fd3e5956f8f517ae098740ac8411c0b",
-    "variant": "debug"
   },
   "cpython-3.10.2-linux-i686-gnu": {
     "name": "cpython",
@@ -6551,19 +6525,6 @@
     "sha256": "4fa49dab83bf82409816db431806525ce894280a509ca96c91e3efc9beed1fea",
     "variant": null
   },
-  "cpython-3.10.2+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "d22d85f60b2ef982b747adda2d1bde4a32c23c3d8f652c00ce44526750859e4e",
-    "variant": "debug"
-  },
   "cpython-3.10.2-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6576,19 +6537,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "9b64eca2a94f7aff9409ad70bdaa7fbbf8148692662e764401883957943620dd",
     "variant": null
-  },
-  "cpython-3.10.2+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a696f058a0cf69fa49c7e65c0b0b630c3fdc23474d45795e5c742c474abb8f24",
-    "variant": "debug"
   },
   "cpython-3.10.2-linux-x86_64-musl": {
     "name": "cpython",
@@ -6629,6 +6577,58 @@
     "sha256": "a1d9a594cd3103baa24937ad9150c1a389544b4350e859200b3e5c036ac352bd",
     "variant": null
   },
+  "cpython-3.10.2+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9936f1549f950311229465de509b35c062aa474e504c20a1d6f0f632da57e002",
+    "variant": "debug"
+  },
+  "cpython-3.10.2+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9be2a667f29ed048165cfb3f5dbe61703fd3e5956f8f517ae098740ac8411c0b",
+    "variant": "debug"
+  },
+  "cpython-3.10.2+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d22d85f60b2ef982b747adda2d1bde4a32c23c3d8f652c00ce44526750859e4e",
+    "variant": "debug"
+  },
+  "cpython-3.10.2+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a696f058a0cf69fa49c7e65c0b0b630c3fdc23474d45795e5c742c474abb8f24",
+    "variant": "debug"
+  },
   "cpython-3.9.20-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6655,19 +6655,6 @@
     "sha256": "02a912676153c0b87a2b6127f5bc9ddccf831b5c390e44073b1f45e829e712ca",
     "variant": null
   },
-  "cpython-3.9.20+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "b0f0ce29dd593991b9f5f940667d5116e49397e3f8c73e17e7e578d320fde788",
-    "variant": "debug"
-  },
   "cpython-3.9.20-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6680,19 +6667,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "7b3fe4868b127b75c82c7e56815e9ea90d7d5f76676d5d79c4e5901423a0e271",
     "variant": null
-  },
-  "cpython-3.9.20+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "6cc50f0d4ad4b9ef4a1c98f6a5735f993933bc0b6bd85a43de6c10d4d6c6b7d3",
-    "variant": "debug"
   },
   "cpython-3.9.20-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -6707,19 +6681,6 @@
     "sha256": "8950ba405e3fbf53fec01f5f2b20b3d50c987879b0d9b9ee385916f29e73a434",
     "variant": null
   },
-  "cpython-3.9.20+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "1f4bace709fd51d67ce611f0036306e9a035a7cd0a4635c4cf189d543c312df9",
-    "variant": "debug"
-  },
   "cpython-3.9.20-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -6732,19 +6693,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "681b2aee6563be3b28370762e4a7c99cf5afeb6789ce7e5ae5646223515da578",
     "variant": null
-  },
-  "cpython-3.9.20+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7448b72126d08260ae3951cba235ccbe79137f3c6c686ee30b92acefe13cf8be",
-    "variant": "debug"
   },
   "cpython-3.9.20-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -6759,19 +6707,6 @@
     "sha256": "82bb46cccdfc186e448e433baab343b1ce1e6d7c74e2e3ac4b32b1825583a7dc",
     "variant": null
   },
-  "cpython-3.9.20+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "ffeb5969992a2e4e5a50e43d0fe5ffa27f7e2454f7c8866446817d893f631200",
-    "variant": "debug"
-  },
   "cpython-3.9.20-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -6785,19 +6720,6 @@
     "sha256": "adecf1aa825d4b73ea42a04c3a4996c19733d1b66a79c5fb0cb77f9589174588",
     "variant": null
   },
-  "cpython-3.9.20+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "5608bc546d0066de0d747c336c97d76aea3954ca5effc41209a7ee345b4c0459",
-    "variant": "debug"
-  },
   "cpython-3.9.20-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -6810,19 +6732,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "f78ac2daa816647d8de170a1b7296d08d3a1227d1a5b46bde4d0e20834dc9212",
     "variant": null
-  },
-  "cpython-3.9.20+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "d93d2386c194c39a5a6b67b45d17fcba44ebf12774f8659dbc8ce352e667b5f4",
-    "variant": "debug"
   },
   "cpython-3.9.20-linux-x86_64-musl": {
     "name": "cpython",
@@ -6863,6 +6772,97 @@
     "sha256": "980f094ecd84894d2708696f3da641213480893bf0133b4be85ab60723c2f891",
     "variant": null
   },
+  "cpython-3.9.20+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b0f0ce29dd593991b9f5f940667d5116e49397e3f8c73e17e7e578d320fde788",
+    "variant": "debug"
+  },
+  "cpython-3.9.20+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "6cc50f0d4ad4b9ef4a1c98f6a5735f993933bc0b6bd85a43de6c10d4d6c6b7d3",
+    "variant": "debug"
+  },
+  "cpython-3.9.20+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "1f4bace709fd51d67ce611f0036306e9a035a7cd0a4635c4cf189d543c312df9",
+    "variant": "debug"
+  },
+  "cpython-3.9.20+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7448b72126d08260ae3951cba235ccbe79137f3c6c686ee30b92acefe13cf8be",
+    "variant": "debug"
+  },
+  "cpython-3.9.20+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ffeb5969992a2e4e5a50e43d0fe5ffa27f7e2454f7c8866446817d893f631200",
+    "variant": "debug"
+  },
+  "cpython-3.9.20+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5608bc546d0066de0d747c336c97d76aea3954ca5effc41209a7ee345b4c0459",
+    "variant": "debug"
+  },
+  "cpython-3.9.20+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "d93d2386c194c39a5a6b67b45d17fcba44ebf12774f8659dbc8ce352e667b5f4",
+    "variant": "debug"
+  },
   "cpython-3.9.19-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6889,19 +6889,6 @@
     "sha256": "ebaf4336d0cbff4466c994d5bcaa92a38c91d06694d0cd675ec663259d5f37c7",
     "variant": null
   },
-  "cpython-3.9.19+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "40cc476967b3da12fdf2b0251954c37539d8ae2359f9e54913eff178d666b627",
-    "variant": "debug"
-  },
   "cpython-3.9.19-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -6914,19 +6901,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "23d08f7f0bf151c2ea54b2c9c143bc710faf166ff74225b0f967fab1e2d7a151",
     "variant": null
-  },
-  "cpython-3.9.19+debug-linux-armv7-gnueabi": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabi",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
-    "sha256": "9a861ef69ae7ec4b98bc5612d3410b873bfe7067b93d97566a125b71a33b75da",
-    "variant": "debug"
   },
   "cpython-3.9.19-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -6941,19 +6915,6 @@
     "sha256": "cebb879d47874f3f943a4334a8fcd8baa3cd7ef4be8cae6b4c8ae980d981a28d",
     "variant": null
   },
-  "cpython-3.9.19+debug-linux-armv7-gnueabihf": {
-    "name": "cpython",
-    "arch": "armv7",
-    "os": "linux",
-    "libc": "gnueabihf",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
-    "sha256": "798d8455cb5ce1e9df8e880b17f5852853620184b49c3c9310ae9c7fc2d05470",
-    "variant": "debug"
-  },
   "cpython-3.9.19-linux-armv7-gnueabihf": {
     "name": "cpython",
     "arch": "armv7",
@@ -6966,19 +6927,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
     "sha256": "c32d3227c44919349172c27b35275bad379f1679f729fbd4f336625903171a1a",
     "variant": null
-  },
-  "cpython-3.9.19+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "818dd8d3e63722facf8fb92b3c1ffda77dfd0a98e2a8278952ffa41e05b0d5d1",
-    "variant": "debug"
   },
   "cpython-3.9.19-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -6993,19 +6941,6 @@
     "sha256": "3cc60442d5694db1abe2a0c6e73459ebb6e7ba7fc7b0a986f3699d463a8f9557",
     "variant": null
   },
-  "cpython-3.9.19+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "dd79bef1974374dcdbe312f1f6cb6cd6ffaa95971b94e01391edb8125b980d90",
-    "variant": "debug"
-  },
   "cpython-3.9.19-linux-s390x-gnu": {
     "name": "cpython",
     "arch": "s390x",
@@ -7019,19 +6954,6 @@
     "sha256": "b41f834311532ee9dcf76cad3cdeda285d0e283de2182ce9870c37c40970cdd3",
     "variant": null
   },
-  "cpython-3.9.19+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9e938140a8ecd343045a0c0cad77165db8bb0b24cc68012f628c937ae8748216",
-    "variant": "debug"
-  },
   "cpython-3.9.19-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7044,19 +6966,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "3b7d574b6bbf8303789a1d26b96a81dcca907381441ce15818c784e18d1db299",
     "variant": null
-  },
-  "cpython-3.9.19+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "bb16ecadf1bbd907da5f0e9c65e2b2bd66770e73c1f3a38ac0ca5fa9ac6fc7a2",
-    "variant": "debug"
   },
   "cpython-3.9.19-linux-x86_64-musl": {
     "name": "cpython",
@@ -7097,6 +7006,97 @@
     "sha256": "426da4d31e665b77dacf15cd89494a995ed634a9b97324bbef9cf36fcda4c8a9",
     "variant": null
   },
+  "cpython-3.9.19+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "40cc476967b3da12fdf2b0251954c37539d8ae2359f9e54913eff178d666b627",
+    "variant": "debug"
+  },
+  "cpython-3.9.19+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "9a861ef69ae7ec4b98bc5612d3410b873bfe7067b93d97566a125b71a33b75da",
+    "variant": "debug"
+  },
+  "cpython-3.9.19+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "798d8455cb5ce1e9df8e880b17f5852853620184b49c3c9310ae9c7fc2d05470",
+    "variant": "debug"
+  },
+  "cpython-3.9.19+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "818dd8d3e63722facf8fb92b3c1ffda77dfd0a98e2a8278952ffa41e05b0d5d1",
+    "variant": "debug"
+  },
+  "cpython-3.9.19+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "dd79bef1974374dcdbe312f1f6cb6cd6ffaa95971b94e01391edb8125b980d90",
+    "variant": "debug"
+  },
+  "cpython-3.9.19+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9e938140a8ecd343045a0c0cad77165db8bb0b24cc68012f628c937ae8748216",
+    "variant": "debug"
+  },
+  "cpython-3.9.19+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "bb16ecadf1bbd907da5f0e9c65e2b2bd66770e73c1f3a38ac0ca5fa9ac6fc7a2",
+    "variant": "debug"
+  },
   "cpython-3.9.18-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -7123,19 +7123,6 @@
     "sha256": "171d8b472fce0295be0e28bb702c43d5a2a39feccb3e72efe620ac3843c3e402",
     "variant": null
   },
-  "cpython-3.9.18+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "d27efd4609a3e15ff901040529d5689be99f2ebfe5132ab980d066d775068265",
-    "variant": "debug"
-  },
   "cpython-3.9.18-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -7148,19 +7135,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e5bc5196baa603d635ee6b0cd141e359752ad3e8ea76127eb9141a3155c51200",
     "variant": null
-  },
-  "cpython-3.9.18+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7faf8fdfbad04e0356a9d52c9b8be4d40ffef85c9ab3e312c45bd64997ef8aa9",
-    "variant": "debug"
   },
   "cpython-3.9.18-linux-i686-gnu": {
     "name": "cpython",
@@ -7175,19 +7149,6 @@
     "sha256": "10c422080317886057e968010495037ba65731ab7653bcaeabadf67a6fa5e99e",
     "variant": null
   },
-  "cpython-3.9.18+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "c138eef19229351226a11e752230b8aa9d499ba9720f9f0574fa3260ccacb99b",
-    "variant": "debug"
-  },
   "cpython-3.9.18-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -7200,19 +7161,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-ppc64le-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "d6b18df7a25fe034fd5ce4e64216df2cc78b2d4d908d2a1c94058ae700d73d22",
     "variant": null
-  },
-  "cpython-3.9.18+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "dd05eff699ce5a7eee545bc05e4869c4e64ee02bf0c70691bcee215604c6b393",
-    "variant": "debug"
   },
   "cpython-3.9.18-linux-s390x-gnu": {
     "name": "cpython",
@@ -7227,19 +7175,6 @@
     "sha256": "15d059507c7e900e9665f31e8d903e5a24a68ceed24f9a1c5ac06ab42a354f3f",
     "variant": null
   },
-  "cpython-3.9.18+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "e1fa92798fab6f3b44a48f24b8e284660c34738d560681b206f0deb0616465f9",
-    "variant": "debug"
-  },
   "cpython-3.9.18-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7252,19 +7187,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "0e5663025121186bd17d331538a44f48b41baff247891d014f3f962cbe2716b4",
     "variant": null
-  },
-  "cpython-3.9.18+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "6f199ddd447d3946381c3ccbb89c0f67643fb8a98205b89caa8e217ad0a20fd7",
-    "variant": "debug"
   },
   "cpython-3.9.18-linux-x86_64-musl": {
     "name": "cpython",
@@ -7305,6 +7227,84 @@
     "sha256": "a9bdbd728ed4c353a4157ecf74386117fb2a2769a9353f491c528371cfe7f6cd",
     "variant": null
   },
+  "cpython-3.9.18+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d27efd4609a3e15ff901040529d5689be99f2ebfe5132ab980d066d775068265",
+    "variant": "debug"
+  },
+  "cpython-3.9.18+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7faf8fdfbad04e0356a9d52c9b8be4d40ffef85c9ab3e312c45bd64997ef8aa9",
+    "variant": "debug"
+  },
+  "cpython-3.9.18+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c138eef19229351226a11e752230b8aa9d499ba9720f9f0574fa3260ccacb99b",
+    "variant": "debug"
+  },
+  "cpython-3.9.18+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "dd05eff699ce5a7eee545bc05e4869c4e64ee02bf0c70691bcee215604c6b393",
+    "variant": "debug"
+  },
+  "cpython-3.9.18+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e1fa92798fab6f3b44a48f24b8e284660c34738d560681b206f0deb0616465f9",
+    "variant": "debug"
+  },
+  "cpython-3.9.18+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "6f199ddd447d3946381c3ccbb89c0f67643fb8a98205b89caa8e217ad0a20fd7",
+    "variant": "debug"
+  },
   "cpython-3.9.17-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -7331,19 +7331,6 @@
     "sha256": "dfe1bea92c94b9cb779288b0b06e39157c5ff7e465cdd24032ac147c2af485c0",
     "variant": null
   },
-  "cpython-3.9.17+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "1f6c43d92ba9f4e15149cf5db6ecde11e05eee92c070a085e44f46c559520257",
-    "variant": "debug"
-  },
   "cpython-3.9.17-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -7356,19 +7343,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "b77012ddaf7e0673e4aa4b1c5085275a06eee2d66f33442b5c54a12b62b96cbe",
     "variant": null
-  },
-  "cpython-3.9.17+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "1a9b7edc16683410c27bc5b4b1761143bef7831a1ad172e7e3581c152c6837a2",
-    "variant": "debug"
   },
   "cpython-3.9.17-linux-i686-gnu": {
     "name": "cpython",
@@ -7383,19 +7357,6 @@
     "sha256": "aed29a64c835444c2f1aff83c55b14123114d74c54d96493a0eabfdd8c6d012c",
     "variant": null
   },
-  "cpython-3.9.17+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "bcb0ec31342df52b4555be309080a9c3224e7ff60a6291e34337ddfddef111cf",
-    "variant": "debug"
-  },
   "cpython-3.9.17-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -7408,19 +7369,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-ppc64le-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "c591a28d943dce5cf9833e916125fdfbeb3120270c4866ee214493ccb5b83c3c",
     "variant": null
-  },
-  "cpython-3.9.17+debug-linux-s390x-gnu": {
-    "name": "cpython",
-    "arch": "s390x",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "bf8c846c1a4e52355d4ae294f4e1da9587d5415467eb6890bdf0f5a4c8cda396",
-    "variant": "debug"
   },
   "cpython-3.9.17-linux-s390x-gnu": {
     "name": "cpython",
@@ -7435,19 +7383,6 @@
     "sha256": "01454d7cc7c9c2fccde42ba868c4f372eaaafa48049d49dd94c9cf2875f497e6",
     "variant": null
   },
-  "cpython-3.9.17+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "649fff6048f4cb9e64a85eaf8e720eb4c3257e27e7c4ee46f75bfa48c18c6826",
-    "variant": "debug"
-  },
   "cpython-3.9.17-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7460,19 +7395,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "26c4a712b4b8e11ed5c027db5654eb12927c02da4857b777afb98f7a930ce637",
     "variant": null
-  },
-  "cpython-3.9.17+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "5a117bc64d6545821083afbfb4a381afee05ddaeb0dd45d2c5adbf3b0a67ec88",
-    "variant": "debug"
   },
   "cpython-3.9.17-linux-x86_64-musl": {
     "name": "cpython",
@@ -7513,6 +7435,84 @@
     "sha256": "9b9a1e21eff29dcf043cea38180cf8ca3604b90117d00062a7b31605d4157714",
     "variant": null
   },
+  "cpython-3.9.17+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1f6c43d92ba9f4e15149cf5db6ecde11e05eee92c070a085e44f46c559520257",
+    "variant": "debug"
+  },
+  "cpython-3.9.17+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1a9b7edc16683410c27bc5b4b1761143bef7831a1ad172e7e3581c152c6837a2",
+    "variant": "debug"
+  },
+  "cpython-3.9.17+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bcb0ec31342df52b4555be309080a9c3224e7ff60a6291e34337ddfddef111cf",
+    "variant": "debug"
+  },
+  "cpython-3.9.17+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bf8c846c1a4e52355d4ae294f4e1da9587d5415467eb6890bdf0f5a4c8cda396",
+    "variant": "debug"
+  },
+  "cpython-3.9.17+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "649fff6048f4cb9e64a85eaf8e720eb4c3257e27e7c4ee46f75bfa48c18c6826",
+    "variant": "debug"
+  },
+  "cpython-3.9.17+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "5a117bc64d6545821083afbfb4a381afee05ddaeb0dd45d2c5adbf3b0a67ec88",
+    "variant": "debug"
+  },
   "cpython-3.9.16-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -7539,19 +7539,6 @@
     "sha256": "3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf",
     "variant": null
   },
-  "cpython-3.9.16+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "57ac7ce9d3dd32c1277ee7295daf5ad7b5ecc929e65b31f11b1e7b94cd355ed1",
-    "variant": "debug"
-  },
   "cpython-3.9.16-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -7564,19 +7551,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "f629b75ebfcafe9ceee2e796b7e4df5cf8dbd14f3c021afca078d159ab797acf",
     "variant": null
-  },
-  "cpython-3.9.16+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "e2a0226165550492e895369ee1b69a515f82e12cb969656012ee8e1543409661",
-    "variant": "debug"
   },
   "cpython-3.9.16-linux-i686-gnu": {
     "name": "cpython",
@@ -7591,19 +7565,6 @@
     "sha256": "ab0a14b3ae72bf48b94820e096e86b3cf3e05729862f768e109aa8318016c4f2",
     "variant": null
   },
-  "cpython-3.9.16+debug-linux-powerpc64le-gnu": {
-    "name": "cpython",
-    "arch": "powerpc64le",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "8b2e7ddc6feb116dfa6829cfc478be90a374dc5ce123a98bc77e86d0e93e917d",
-    "variant": "debug"
-  },
   "cpython-3.9.16-linux-powerpc64le-gnu": {
     "name": "cpython",
     "arch": "powerpc64le",
@@ -7617,19 +7578,6 @@
     "sha256": "ff3ac35c58f67839aff9b5185a976abd3d1abbe61af02089f7105e876c1fe284",
     "variant": null
   },
-  "cpython-3.9.16+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "cdc1290b9bdb2f74a6c48ab24531919551128e39773365c6f3e17668216275a0",
-    "variant": "debug"
-  },
   "cpython-3.9.16-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7642,19 +7590,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "2b6e146234a4ef2a8946081fc3fbfffe0765b80b690425a49ebe40b47c33445b",
     "variant": null
-  },
-  "cpython-3.9.16+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "e698c7a51e7e998e893b0dd25886d477778a14296bd560e6e585352b9d6194f8",
-    "variant": "debug"
   },
   "cpython-3.9.16-linux-x86_64-musl": {
     "name": "cpython",
@@ -7695,6 +7630,71 @@
     "sha256": "cdabb47204e96ce7ea31fbd0b5ed586114dd7d8f8eddf60a509a7f70b48a1c5e",
     "variant": null
   },
+  "cpython-3.9.16+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "57ac7ce9d3dd32c1277ee7295daf5ad7b5ecc929e65b31f11b1e7b94cd355ed1",
+    "variant": "debug"
+  },
+  "cpython-3.9.16+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e2a0226165550492e895369ee1b69a515f82e12cb969656012ee8e1543409661",
+    "variant": "debug"
+  },
+  "cpython-3.9.16+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8b2e7ddc6feb116dfa6829cfc478be90a374dc5ce123a98bc77e86d0e93e917d",
+    "variant": "debug"
+  },
+  "cpython-3.9.16+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "cdc1290b9bdb2f74a6c48ab24531919551128e39773365c6f3e17668216275a0",
+    "variant": "debug"
+  },
+  "cpython-3.9.16+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "e698c7a51e7e998e893b0dd25886d477778a14296bd560e6e585352b9d6194f8",
+    "variant": "debug"
+  },
   "cpython-3.9.15-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -7721,19 +7721,6 @@
     "sha256": "f2bcade6fc976c472f18f2b3204d67202d43ae55cf6f9e670f95e488f780da08",
     "variant": null
   },
-  "cpython-3.9.15+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "0da1f081313b088c1381206e698e70fffdffc01e1b2ce284145c24ee5f5b4cbb",
-    "variant": "debug"
-  },
   "cpython-3.9.15-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -7746,19 +7733,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "52a8c0a67fb919f80962d992da1bddb511cdf92faf382701ce7673e10a8ff98f",
     "variant": null
-  },
-  "cpython-3.9.15+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "cbc6a14835022d89f4ca6042a06c4959d74d4bbb58e70bdbe0fe8d2928934922",
-    "variant": "debug"
   },
   "cpython-3.9.15-linux-i686-gnu": {
     "name": "cpython",
@@ -7773,19 +7747,6 @@
     "sha256": "bf32a86c220e4d1690bb92b67653f20b8325808accd81bff03b5c30ae74e6444",
     "variant": null
   },
-  "cpython-3.9.15+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "6a08761bb725b8d3a92144f81628febeab8b12326ca264ffe28255fa67c7bf17",
-    "variant": "debug"
-  },
   "cpython-3.9.15-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7798,19 +7759,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "cdc3a4cfddcd63b6cebdd75b14970e02d8ef0ac5be4d350e57ab5df56c19e85e",
     "variant": null
-  },
-  "cpython-3.9.15+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "c4bf3bd40dc301eb41984b205a204fb85ebe190bfe35fe73c79b749b48ec7a31",
-    "variant": "debug"
   },
   "cpython-3.9.15-linux-x86_64-musl": {
     "name": "cpython",
@@ -7851,6 +7799,58 @@
     "sha256": "022daacab215679b87f0d200d08b9068a721605fa4721ebeda38220fc641ccf6",
     "variant": null
   },
+  "cpython-3.9.15+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "0da1f081313b088c1381206e698e70fffdffc01e1b2ce284145c24ee5f5b4cbb",
+    "variant": "debug"
+  },
+  "cpython-3.9.15+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "cbc6a14835022d89f4ca6042a06c4959d74d4bbb58e70bdbe0fe8d2928934922",
+    "variant": "debug"
+  },
+  "cpython-3.9.15+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6a08761bb725b8d3a92144f81628febeab8b12326ca264ffe28255fa67c7bf17",
+    "variant": "debug"
+  },
+  "cpython-3.9.15+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "c4bf3bd40dc301eb41984b205a204fb85ebe190bfe35fe73c79b749b48ec7a31",
+    "variant": "debug"
+  },
   "cpython-3.9.14-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -7877,19 +7877,6 @@
     "sha256": "b7d3a1f4b57e9350571ccee49c82f503133de0d113a2dbaebc8ccf108fb3fe1b",
     "variant": null
   },
-  "cpython-3.9.14+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "3020c743e4742d6e0e5d27fcb166c694bf1d9565369b2eaee9d68434304aebd2",
-    "variant": "debug"
-  },
   "cpython-3.9.14-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -7902,19 +7889,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "fe538201559ca37f44cd5f66c42a65fe7272cb4f1f63edd698b6f306771db1e9",
     "variant": null
-  },
-  "cpython-3.9.14+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "83a11c4f3d1c0ec39119bd0513a8684b59b68c3989cf1e5042d7417d4770c904",
-    "variant": "debug"
   },
   "cpython-3.9.14-linux-i686-gnu": {
     "name": "cpython",
@@ -7929,19 +7903,6 @@
     "sha256": "3af1c255110c2f42ed0b7957502c92edf8b5c5e6fc5f699a2475bf8a560325c0",
     "variant": null
   },
-  "cpython-3.9.14+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "54529c0a8ffe621f5c9c6bdd22968cac9d3207cbd5dcd9c07bbe61140c49937e",
-    "variant": "debug"
-  },
   "cpython-3.9.14-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -7954,19 +7915,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e63d0c00a499e0202ba7a0f53ce69fca6d30237af39af9bc3c76bce6c7bf14d7",
     "variant": null
-  },
-  "cpython-3.9.14+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "598de16fbb955c2de02ac7765f162bee74601e28b3de9b6efeeecf30d97aecd6",
-    "variant": "debug"
   },
   "cpython-3.9.14-linux-x86_64-musl": {
     "name": "cpython",
@@ -8007,6 +7955,58 @@
     "sha256": "f111c3c129f4a5a171d25350ce58dad4c7e58fbe664e9b4f7c275345c9fe18a6",
     "variant": null
   },
+  "cpython-3.9.14+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3020c743e4742d6e0e5d27fcb166c694bf1d9565369b2eaee9d68434304aebd2",
+    "variant": "debug"
+  },
+  "cpython-3.9.14+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "83a11c4f3d1c0ec39119bd0513a8684b59b68c3989cf1e5042d7417d4770c904",
+    "variant": "debug"
+  },
+  "cpython-3.9.14+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "54529c0a8ffe621f5c9c6bdd22968cac9d3207cbd5dcd9c07bbe61140c49937e",
+    "variant": "debug"
+  },
+  "cpython-3.9.14+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "598de16fbb955c2de02ac7765f162bee74601e28b3de9b6efeeecf30d97aecd6",
+    "variant": "debug"
+  },
   "cpython-3.9.13-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8033,19 +8033,6 @@
     "sha256": "9540a7efb7c8a54a48aff1cb9480e49588d9c0a3f934ad53f5b167338174afa3",
     "variant": null
   },
-  "cpython-3.9.13+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "8c706ebb2c8970da4fbec95b0520b4632309bc6a3e115cf309e38f181b553d14",
-    "variant": "debug"
-  },
   "cpython-3.9.13-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8058,19 +8045,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "80415aac1b96255b9211f6a4c300f31e9940c7e07a23d0dec12b53aa52c0d25e",
     "variant": null
-  },
-  "cpython-3.9.13+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7d33637b48c45acf8805d5460895dca29bf2740fd2cf502fde6c6a00637db6b5",
-    "variant": "debug"
   },
   "cpython-3.9.13-linux-i686-gnu": {
     "name": "cpython",
@@ -8085,19 +8059,6 @@
     "sha256": "efcc8fef0d498afe576ab209fee001fda3b552de1a85f621f2602787aa6cf3d4",
     "variant": null
   },
-  "cpython-3.9.13+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "352d00a4630d0665387bcb158aec3f6c7fc5a4d14d65ac26e1b826e20611222f",
-    "variant": "debug"
-  },
   "cpython-3.9.13-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -8110,19 +8071,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "ce1cfca2715e7e646dd618a8cb9baff93000e345ccc979b801fc6ccde7ce97df",
     "variant": null
-  },
-  "cpython-3.9.13+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "fd18bcb560764e7456431b577ce3b35057c3dd4cda60dfb98a9af8739ec95c43",
-    "variant": "debug"
   },
   "cpython-3.9.13-linux-x86_64-musl": {
     "name": "cpython",
@@ -8163,6 +8111,58 @@
     "sha256": "b538127025a467c64b3351babca2e4d2ea7bdfb7867d5febb3529c34456cdcd4",
     "variant": null
   },
+  "cpython-3.9.13+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8c706ebb2c8970da4fbec95b0520b4632309bc6a3e115cf309e38f181b553d14",
+    "variant": "debug"
+  },
+  "cpython-3.9.13+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7d33637b48c45acf8805d5460895dca29bf2740fd2cf502fde6c6a00637db6b5",
+    "variant": "debug"
+  },
+  "cpython-3.9.13+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "352d00a4630d0665387bcb158aec3f6c7fc5a4d14d65ac26e1b826e20611222f",
+    "variant": "debug"
+  },
+  "cpython-3.9.13+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "fd18bcb560764e7456431b577ce3b35057c3dd4cda60dfb98a9af8739ec95c43",
+    "variant": "debug"
+  },
   "cpython-3.9.12-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8189,19 +8189,6 @@
     "sha256": "2453ba7f76b3df3310353b48c881d6cff622ba06e30d2b6ae91588b2bc9e481a",
     "variant": null
   },
-  "cpython-3.9.12+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "202ef64e43570f0843ff5895fd9c1a2c36a96b48d52842fa95842d7d11025b20",
-    "variant": "debug"
-  },
   "cpython-3.9.12-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8214,19 +8201,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "2ee1426c181e65133e57dc55c6a685cb1fb5e63ef02d684b8a667d5c031c4203",
     "variant": null
-  },
-  "cpython-3.9.12+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "e52fdbe61dea847323cd6e81142d16a571dca9c0bcde3bfe5ae75a8d3d1a3bf4",
-    "variant": "debug"
   },
   "cpython-3.9.12-linux-i686-gnu": {
     "name": "cpython",
@@ -8241,19 +8215,6 @@
     "sha256": "233e1a9626d9fe13baac8de3689df48401d0ad5da1c2f134ad57d8e3e878a1a5",
     "variant": null
   },
-  "cpython-3.9.12+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7290ac14e43749afdb37d3c9690f300f5f0786f19982e8960566ecdc3e42c3eb",
-    "variant": "debug"
-  },
   "cpython-3.9.12-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -8266,19 +8227,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "ccca12f698b3b810d79c52f007078f520d588232a36bc12ede944ec3ea417816",
     "variant": null
-  },
-  "cpython-3.9.12+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "410d7e68366f0e4fce4540a73ab3228060aa469949154fc08dc00d9da8ad51c6",
-    "variant": "debug"
   },
   "cpython-3.9.12-linux-x86_64-musl": {
     "name": "cpython",
@@ -8319,6 +8267,58 @@
     "sha256": "3024147fd987d9e1b064a3d94932178ff8e0fe98cfea955704213c0762fee8df",
     "variant": null
   },
+  "cpython-3.9.12+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "202ef64e43570f0843ff5895fd9c1a2c36a96b48d52842fa95842d7d11025b20",
+    "variant": "debug"
+  },
+  "cpython-3.9.12+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e52fdbe61dea847323cd6e81142d16a571dca9c0bcde3bfe5ae75a8d3d1a3bf4",
+    "variant": "debug"
+  },
+  "cpython-3.9.12+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7290ac14e43749afdb37d3c9690f300f5f0786f19982e8960566ecdc3e42c3eb",
+    "variant": "debug"
+  },
+  "cpython-3.9.12+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "410d7e68366f0e4fce4540a73ab3228060aa469949154fc08dc00d9da8ad51c6",
+    "variant": "debug"
+  },
   "cpython-3.9.11-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8345,19 +8345,6 @@
     "sha256": "43889d1a424c84fb155e1619f062adb6984fbde80b6043611790f22bcbeec300",
     "variant": null
   },
-  "cpython-3.9.11+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "e1f3ae07a28a687f8602fb4d29a1b72cc5e113c61dc6769d0d85081ab3e09c71",
-    "variant": "debug"
-  },
   "cpython-3.9.11-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8370,19 +8357,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "0e50f099409c5e651b5fddd16124af1d830d11653e786a93c28e5b8f8aa470c4",
     "variant": null
-  },
-  "cpython-3.9.11+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "0be0a5f524c68d521be2417565ca43f3125b1845f996d6d62266aa431e673f93",
-    "variant": "debug"
   },
   "cpython-3.9.11-linux-i686-gnu": {
     "name": "cpython",
@@ -8397,19 +8371,6 @@
     "sha256": "75ac727631eab002bd120246197a8235145cb90687be181f7a52de6f41d44d34",
     "variant": null
   },
-  "cpython-3.9.11+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "020bcbfff16dc5ce35a898763be3d847c97df2e14dabf483a8ec88b0455ff971",
-    "variant": "debug"
-  },
   "cpython-3.9.11-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -8422,19 +8383,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "0429d5ceb095d5e24c292bf1a39208b88ae236a680ef8fa3e1830e3a1a7e8882",
     "variant": null
-  },
-  "cpython-3.9.11+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "046c027a79ab60b70f2853ef978d89a97d2d35d9af3e7d7e9684d20b66afa6bc",
-    "variant": "debug"
   },
   "cpython-3.9.11-linux-x86_64-musl": {
     "name": "cpython",
@@ -8475,6 +8423,58 @@
     "sha256": "0c529a511f7a03908fc126c4a8467b47e24a4d98812147e8e786cf59e86febf0",
     "variant": null
   },
+  "cpython-3.9.11+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e1f3ae07a28a687f8602fb4d29a1b72cc5e113c61dc6769d0d85081ab3e09c71",
+    "variant": "debug"
+  },
+  "cpython-3.9.11+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "0be0a5f524c68d521be2417565ca43f3125b1845f996d6d62266aa431e673f93",
+    "variant": "debug"
+  },
+  "cpython-3.9.11+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "020bcbfff16dc5ce35a898763be3d847c97df2e14dabf483a8ec88b0455ff971",
+    "variant": "debug"
+  },
+  "cpython-3.9.11+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "046c027a79ab60b70f2853ef978d89a97d2d35d9af3e7d7e9684d20b66afa6bc",
+    "variant": "debug"
+  },
   "cpython-3.9.10-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8501,19 +8501,6 @@
     "sha256": "fdaf594142446029e314a9beb91f1ac75af866320b50b8b968181e592550cd68",
     "variant": null
   },
-  "cpython-3.9.10+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "8bf7ac2cd5825b8fde0a6e535266a57c97e82fd5a97877940920b403ca5e53d7",
-    "variant": "debug"
-  },
   "cpython-3.9.10-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8526,19 +8513,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "12dd1f125762f47975990ec744532a1cf3db74ad60f4dfb476ca42deb7f78ca4",
     "variant": null
-  },
-  "cpython-3.9.10+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "3e3bf4d3e71a2131e6c064d1e5019f58cb9c58fdceae4b76b26ac978a6d49aad",
-    "variant": "debug"
   },
   "cpython-3.9.10-linux-i686-gnu": {
     "name": "cpython",
@@ -8553,19 +8527,6 @@
     "sha256": "37ba43845c3df9ba012d69121ad29ea7f21ea2f5994a155007cf1560d74ce503",
     "variant": null
   },
-  "cpython-3.9.10+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "d453abf741c3196ffc8470f3ea6404a3e2b55b2674a501bb79162f06122423e5",
-    "variant": "debug"
-  },
   "cpython-3.9.10-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -8578,19 +8539,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "455089cc576bd9a58db45e919d1fc867ecdbb0208067dffc845cc9bbf0701b70",
     "variant": null
-  },
-  "cpython-3.9.10+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "3ea1f4b06710a87a4f817b9084f60cc7ea481eb1090adc81306031ac4b382131",
-    "variant": "debug"
   },
   "cpython-3.9.10-linux-x86_64-musl": {
     "name": "cpython",
@@ -8631,6 +8579,58 @@
     "sha256": "c145d9d8143ce163670af124b623d7a2405143a3708b033b4d33eed355e61b24",
     "variant": null
   },
+  "cpython-3.9.10+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8bf7ac2cd5825b8fde0a6e535266a57c97e82fd5a97877940920b403ca5e53d7",
+    "variant": "debug"
+  },
+  "cpython-3.9.10+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3e3bf4d3e71a2131e6c064d1e5019f58cb9c58fdceae4b76b26ac978a6d49aad",
+    "variant": "debug"
+  },
+  "cpython-3.9.10+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d453abf741c3196ffc8470f3ea6404a3e2b55b2674a501bb79162f06122423e5",
+    "variant": "debug"
+  },
+  "cpython-3.9.10+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "3ea1f4b06710a87a4f817b9084f60cc7ea481eb1090adc81306031ac4b382131",
+    "variant": "debug"
+  },
   "cpython-3.8.20-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8657,19 +8657,6 @@
     "sha256": "375b6eead6c852cabbf3ccfd43dc4f6dd4c36381bf74c9a7910acb839fd5c57f",
     "variant": null
   },
-  "cpython-3.8.20+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "e9e2244eeb0d849925c63e077b8e659e50af7b8faa7c778bea49012a356cd9b5",
-    "variant": "debug"
-  },
   "cpython-3.8.20-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8683,19 +8670,6 @@
     "sha256": "75a187ebfab81096e3f3d91d70c1349e64defbdfb0e8a067cb5233d017655e31",
     "variant": null
   },
-  "cpython-3.8.20+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "311c259280fb53844d281f2c2a2f4d7343fc520628a79cff488ee7e045843751",
-    "variant": "debug"
-  },
   "cpython-3.8.20-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -8708,19 +8682,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "a3a75094545912d4e9413673441b3f0d2e58ce9b264477f910800148801ccf11",
     "variant": null
-  },
-  "cpython-3.8.20+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 20,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "451432b8c869484464f26690839857dd7380aa588c3c052314c5324a26b5727e",
-    "variant": "debug"
   },
   "cpython-3.8.20-linux-x86_64-musl": {
     "name": "cpython",
@@ -8761,6 +8722,45 @@
     "sha256": "ec2f723dcfbf09581578a716c05cc67823a43d77111e6dd9e0d1557ccc6dcbf3",
     "variant": null
   },
+  "cpython-3.8.20+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e9e2244eeb0d849925c63e077b8e659e50af7b8faa7c778bea49012a356cd9b5",
+    "variant": "debug"
+  },
+  "cpython-3.8.20+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "311c259280fb53844d281f2c2a2f4d7343fc520628a79cff488ee7e045843751",
+    "variant": "debug"
+  },
+  "cpython-3.8.20+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "451432b8c869484464f26690839857dd7380aa588c3c052314c5324a26b5727e",
+    "variant": "debug"
+  },
   "cpython-3.8.19-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8787,19 +8787,6 @@
     "sha256": "1a24263b039c1172bd42d74a5694492f3e3dbe4d3e52a1e7cc2856fee7dbee4a",
     "variant": null
   },
-  "cpython-3.8.19+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "d4c0800b9684236145310c6eda4505ba28cee3a3f10e8b22929a406b32b5f4fc",
-    "variant": "debug"
-  },
   "cpython-3.8.19-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8813,19 +8800,6 @@
     "sha256": "202211923850303f521146ee1831642aaf357ffeeadbe13a0a91884317227528",
     "variant": null
   },
-  "cpython-3.8.19+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "0bd4dc46b451d40c04ff329ecb30e6a9eb375973d9457421e7afaaaa86614f74",
-    "variant": "debug"
-  },
   "cpython-3.8.19-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -8838,19 +8812,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
     "sha256": "0f1579dbb01c98af7a12fef4c9aa8a99d45b91393f64431f5de712f892bc5c0b",
     "variant": null
-  },
-  "cpython-3.8.19+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 19,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a165c74be970b1804bda7acba186b7e3b96bd76e4e38fafd95bf7a40e21c8128",
-    "variant": "debug"
   },
   "cpython-3.8.19-linux-x86_64-musl": {
     "name": "cpython",
@@ -8891,6 +8852,45 @@
     "sha256": "89d238b125cd7546b7d0cbd7f484a438d2c2f239c15c9b38ec3c62b1f343a6ca",
     "variant": null
   },
+  "cpython-3.8.19+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d4c0800b9684236145310c6eda4505ba28cee3a3f10e8b22929a406b32b5f4fc",
+    "variant": "debug"
+  },
+  "cpython-3.8.19+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "0bd4dc46b451d40c04ff329ecb30e6a9eb375973d9457421e7afaaaa86614f74",
+    "variant": "debug"
+  },
+  "cpython-3.8.19+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a165c74be970b1804bda7acba186b7e3b96bd76e4e38fafd95bf7a40e21c8128",
+    "variant": "debug"
+  },
   "cpython-3.8.18-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8917,19 +8917,6 @@
     "sha256": "7d2cd8d289d5e3cdd0a8c06c028c7c621d3d00ce44b7e2f08c1724ae0471c626",
     "variant": null
   },
-  "cpython-3.8.18+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "6d71175a090950c2063680f250b8799ab39eb139aa1721c853d8950aadd1d4e2",
-    "variant": "debug"
-  },
   "cpython-3.8.18-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -8943,19 +8930,6 @@
     "sha256": "6588c9eed93833d9483d01fe40ac8935f691a1af8e583d404ec7666631b52487",
     "variant": null
   },
-  "cpython-3.8.18+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "189ae3b8249c57217e3253f9fc89857e088763cf2107a3f22ab2ac2398f41a65",
-    "variant": "debug"
-  },
   "cpython-3.8.18-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -8968,19 +8942,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "5ae36825492372554c02708bdd26b8dcd57e3dbf34b3d6d599ad91d93540b2b7",
     "variant": null
-  },
-  "cpython-3.8.18+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 18,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "375d241bbd7d8704794fbda9387de8328999b5fb377f091ebb026bdace4abc24",
-    "variant": "debug"
   },
   "cpython-3.8.18-linux-x86_64-musl": {
     "name": "cpython",
@@ -9021,6 +8982,45 @@
     "sha256": "dba923ee5df8f99db04f599e826be92880746c02247c8d8e4d955d4bc711af11",
     "variant": null
   },
+  "cpython-3.8.18+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6d71175a090950c2063680f250b8799ab39eb139aa1721c853d8950aadd1d4e2",
+    "variant": "debug"
+  },
+  "cpython-3.8.18+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "189ae3b8249c57217e3253f9fc89857e088763cf2107a3f22ab2ac2398f41a65",
+    "variant": "debug"
+  },
+  "cpython-3.8.18+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "375d241bbd7d8704794fbda9387de8328999b5fb377f091ebb026bdace4abc24",
+    "variant": "debug"
+  },
   "cpython-3.8.17-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -9047,19 +9047,6 @@
     "sha256": "155b06821607bae1a58ecc60a7d036b358c766f19e493b8876190765c883a5c2",
     "variant": null
   },
-  "cpython-3.8.17+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "eaee5a0b79cc28943e19df54f314634795aee43a6670ce99c0306893a18fa784",
-    "variant": "debug"
-  },
   "cpython-3.8.17-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -9072,19 +9059,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "9f6d585091fe26906ff1dbb80437a3fe37a1e3db34d6ecc0098f3d6a78356682",
     "variant": null
-  },
-  "cpython-3.8.17+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "61ac08680c022f180a32dc82d84548aeb92c7194a489e3b3c532dc48f999d757",
-    "variant": "debug"
   },
   "cpython-3.8.17-linux-i686-gnu": {
     "name": "cpython",
@@ -9099,19 +9073,6 @@
     "sha256": "e580fdd923bbae612334559dc58bd5fd13cce53b769294d63bc88e7c6662f7d9",
     "variant": null
   },
-  "cpython-3.8.17+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "f499750ab0019f36ccb4d964e222051d0d49a1d1e8dbada98abae738cf48c9dc",
-    "variant": "debug"
-  },
   "cpython-3.8.17-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -9124,19 +9085,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "8d3e1826c0bb7821ec63288038644808a2d45553245af106c685ef5892fabcd8",
     "variant": null
-  },
-  "cpython-3.8.17+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 17,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "c396b744f28286fc0980073efd08ce55eef5bd0197a4944c3bae5c339ef91269",
-    "variant": "debug"
   },
   "cpython-3.8.17-linux-x86_64-musl": {
     "name": "cpython",
@@ -9177,6 +9125,58 @@
     "sha256": "6428e1b4e0b4482d390828de7d4c82815257443416cb786abe10cb2466ca68cd",
     "variant": null
   },
+  "cpython-3.8.17+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "eaee5a0b79cc28943e19df54f314634795aee43a6670ce99c0306893a18fa784",
+    "variant": "debug"
+  },
+  "cpython-3.8.17+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "61ac08680c022f180a32dc82d84548aeb92c7194a489e3b3c532dc48f999d757",
+    "variant": "debug"
+  },
+  "cpython-3.8.17+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f499750ab0019f36ccb4d964e222051d0d49a1d1e8dbada98abae738cf48c9dc",
+    "variant": "debug"
+  },
+  "cpython-3.8.17+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "c396b744f28286fc0980073efd08ce55eef5bd0197a4944c3bae5c339ef91269",
+    "variant": "debug"
+  },
   "cpython-3.8.16-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -9203,19 +9203,6 @@
     "sha256": "28506e509646c11cb2f57a7203bd1b08b6e8e5b159ae308bd5bb93b0d334bdaf",
     "variant": null
   },
-  "cpython-3.8.16+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "423d43d93e2fe33b41ad66d35426f16541f09fee9d7272ae5decf5474ebbc225",
-    "variant": "debug"
-  },
   "cpython-3.8.16-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -9228,19 +9215,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "9c6615931fd1045bf9f2148aa7dd9ce1ece8575ed68a5483a0b615322a43d54c",
     "variant": null
-  },
-  "cpython-3.8.16+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9aa3e559130a47c33ee2b67f6ca69e2f10d8f70c1fd1e2871763b892372a6d9e",
-    "variant": "debug"
   },
   "cpython-3.8.16-linux-i686-gnu": {
     "name": "cpython",
@@ -9255,19 +9229,6 @@
     "sha256": "1260fd6af34104bbd57489175e6f7bfea76d4bd06a242a0f8e20e390e870b227",
     "variant": null
   },
-  "cpython-3.8.16+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "f12f5cb38f796ca48dc73262c05506a6f21f59d24e709ea0390b18bf71c2e1f9",
-    "variant": "debug"
-  },
   "cpython-3.8.16-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -9280,19 +9241,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "b1f1502c3a13b899724dbd32bd77a973fa9733b932c5700d747fe33d5de9ac4f",
     "variant": null
-  },
-  "cpython-3.8.16+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 16,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "54898fbd313530295cf103bb4e7c7922096ed1c56f46a955975ecd4fb5b02987",
-    "variant": "debug"
   },
   "cpython-3.8.16-linux-x86_64-musl": {
     "name": "cpython",
@@ -9333,6 +9281,58 @@
     "sha256": "120b3312fa79bac2ace45641171c2bc590c4e4462d7ad124d64597e124a36ae7",
     "variant": null
   },
+  "cpython-3.8.16+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "423d43d93e2fe33b41ad66d35426f16541f09fee9d7272ae5decf5474ebbc225",
+    "variant": "debug"
+  },
+  "cpython-3.8.16+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9aa3e559130a47c33ee2b67f6ca69e2f10d8f70c1fd1e2871763b892372a6d9e",
+    "variant": "debug"
+  },
+  "cpython-3.8.16+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f12f5cb38f796ca48dc73262c05506a6f21f59d24e709ea0390b18bf71c2e1f9",
+    "variant": "debug"
+  },
+  "cpython-3.8.16+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "54898fbd313530295cf103bb4e7c7922096ed1c56f46a955975ecd4fb5b02987",
+    "variant": "debug"
+  },
   "cpython-3.8.15-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -9359,19 +9359,6 @@
     "sha256": "70b57f28c2b5e1e3dd89f0d30edd5bc414e8b20195766cf328e1b26bed7890e1",
     "variant": null
   },
-  "cpython-3.8.15+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "2e80025eda686c14a9a0618ced40043c1d577a754b904fd7a382cd41abf9ca00",
-    "variant": "debug"
-  },
   "cpython-3.8.15-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -9384,19 +9371,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "886ab33ced13c84bf59ce8ff79eba6448365bfcafea1bf415bd1d75e21b690aa",
     "variant": null
-  },
-  "cpython-3.8.15+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "b8436415ea9bd9970fb766f791a14b0e14ce6351fc4604eb158f1425e8bb4a33",
-    "variant": "debug"
   },
   "cpython-3.8.15-linux-i686-gnu": {
     "name": "cpython",
@@ -9411,19 +9385,6 @@
     "sha256": "3bc1f49147913d93cea9cbb753fbaae90b86f1ee979f975c4712a35f02cbd86b",
     "variant": null
   },
-  "cpython-3.8.15+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "c3c8c23e34bddb4a2b90333ff17041f344401775d505700f1ceddb3ad9d589e0",
-    "variant": "debug"
-  },
   "cpython-3.8.15-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -9436,19 +9397,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "e47edfb2ceaf43fc699e20c179ec428b6f3e497cf8e2dcd8e9c936d4b96b1e56",
     "variant": null
-  },
-  "cpython-3.8.15+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 15,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "ef23e1c394127b770995e021aff6b1ee3580d5c4f3d12abd6d5c64e007b972cf",
-    "variant": "debug"
   },
   "cpython-3.8.15-linux-x86_64-musl": {
     "name": "cpython",
@@ -9489,6 +9437,58 @@
     "sha256": "2fdc3fa1c95f982179bbbaedae2b328197658638799b6dcb63f9f494b0de59e2",
     "variant": null
   },
+  "cpython-3.8.15+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2e80025eda686c14a9a0618ced40043c1d577a754b904fd7a382cd41abf9ca00",
+    "variant": "debug"
+  },
+  "cpython-3.8.15+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b8436415ea9bd9970fb766f791a14b0e14ce6351fc4604eb158f1425e8bb4a33",
+    "variant": "debug"
+  },
+  "cpython-3.8.15+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c3c8c23e34bddb4a2b90333ff17041f344401775d505700f1ceddb3ad9d589e0",
+    "variant": "debug"
+  },
+  "cpython-3.8.15+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "ef23e1c394127b770995e021aff6b1ee3580d5c4f3d12abd6d5c64e007b972cf",
+    "variant": "debug"
+  },
   "cpython-3.8.14-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -9515,19 +9515,6 @@
     "sha256": "3ed4db8d0308c584196d97c629058ea69bbd8b7f9a034cf8c2c701ebb286c091",
     "variant": null
   },
-  "cpython-3.8.14+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "a14d8b5cbd8e1ca45cbcb49f4bf0b0440dc86eb95b7c3da3c463a704a3b4593c",
-    "variant": "debug"
-  },
   "cpython-3.8.14-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -9540,19 +9527,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "c45e42deee43e3ebc4ca5b019c37d8ae25fb5b5f1ba5f602098a81b99d2bc804",
     "variant": null
-  },
-  "cpython-3.8.14+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "631bb90fe8f2965d03400b268de90fe155ce51961296360d6578b7151aa9ef4c",
-    "variant": "debug"
   },
   "cpython-3.8.14-linux-i686-gnu": {
     "name": "cpython",
@@ -9567,19 +9541,6 @@
     "sha256": "d01d813939ad549ca253c52e5b8361b4490cc5c8cbda00ab6e0c524565153e2b",
     "variant": null
   },
-  "cpython-3.8.14+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "bd1e8e09edccaab82fbd75b457205a076847d62e3354c3d9b5abe985181047fc",
-    "variant": "debug"
-  },
   "cpython-3.8.14-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -9592,19 +9553,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "4eb53bce831bf52682067579c09ccaccb6524dd44bd4b8047454c69b4817f4f0",
     "variant": null
-  },
-  "cpython-3.8.14+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 14,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "a63a6565153b0f8b2e23611c7622ded3b5cb488d090f26fb4895bd396f8f72ea",
-    "variant": "debug"
   },
   "cpython-3.8.14-linux-x86_64-musl": {
     "name": "cpython",
@@ -9645,6 +9593,58 @@
     "sha256": "1af39953b4c8324ed0608e316bc763006f27e76643155d92eae18e4db6fc162f",
     "variant": null
   },
+  "cpython-3.8.14+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a14d8b5cbd8e1ca45cbcb49f4bf0b0440dc86eb95b7c3da3c463a704a3b4593c",
+    "variant": "debug"
+  },
+  "cpython-3.8.14+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "631bb90fe8f2965d03400b268de90fe155ce51961296360d6578b7151aa9ef4c",
+    "variant": "debug"
+  },
+  "cpython-3.8.14+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bd1e8e09edccaab82fbd75b457205a076847d62e3354c3d9b5abe985181047fc",
+    "variant": "debug"
+  },
+  "cpython-3.8.14+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a63a6565153b0f8b2e23611c7622ded3b5cb488d090f26fb4895bd396f8f72ea",
+    "variant": "debug"
+  },
   "cpython-3.8.13-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -9671,19 +9671,6 @@
     "sha256": "cd6e7c0a27daf7df00f6882eaba01490dd963f698e99aeee9706877333e0df69",
     "variant": null
   },
-  "cpython-3.8.13+debug-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "3a927205db4686c182b5e8f3fc7fd7d82ec8f61c70d5b2bfddd9673c7ddc07ba",
-    "variant": "debug"
-  },
   "cpython-3.8.13-linux-aarch64-gnu": {
     "name": "cpython",
     "arch": "aarch64",
@@ -9696,19 +9683,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "8dc7814bf3425bbf78c6e6e5a6529ded6ae463fa6a4b79c025b343bae4fd955a",
     "variant": null
-  },
-  "cpython-3.8.13+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "6daf0405beae6d127a2dcae61d51a719236b861b4cabc220727e48547fd6f045",
-    "variant": "debug"
   },
   "cpython-3.8.13-linux-i686-gnu": {
     "name": "cpython",
@@ -9723,19 +9697,6 @@
     "sha256": "9485599ad9053dfba08c91854717272e95b7c81e0d099d9c51a46fc5a095ccb4",
     "variant": null
   },
-  "cpython-3.8.13+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "891b5d7b0e936b98a62f65bc0b28fff61ca9002125a2fc1ebb9c72f6b0056712",
-    "variant": "debug"
-  },
   "cpython-3.8.13-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -9748,19 +9709,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "fb566629ccb5f76ef56d275a3f8017d683f1c20c5beb5d5f38b155ed11e16187",
     "variant": null
-  },
-  "cpython-3.8.13+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 13,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "45802706624fe2b2aa57bd42418b5d2f9f94f5372f31c664762393316223389e",
-    "variant": "debug"
   },
   "cpython-3.8.13-linux-x86_64-musl": {
     "name": "cpython",
@@ -9801,6 +9749,58 @@
     "sha256": "f20643f1b3e263a56287319aea5c3888530c09ad9de3a5629b1a5d207807e6b9",
     "variant": null
   },
+  "cpython-3.8.13+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3a927205db4686c182b5e8f3fc7fd7d82ec8f61c70d5b2bfddd9673c7ddc07ba",
+    "variant": "debug"
+  },
+  "cpython-3.8.13+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6daf0405beae6d127a2dcae61d51a719236b861b4cabc220727e48547fd6f045",
+    "variant": "debug"
+  },
+  "cpython-3.8.13+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "891b5d7b0e936b98a62f65bc0b28fff61ca9002125a2fc1ebb9c72f6b0056712",
+    "variant": "debug"
+  },
+  "cpython-3.8.13+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "45802706624fe2b2aa57bd42418b5d2f9f94f5372f31c664762393316223389e",
+    "variant": "debug"
+  },
   "cpython-3.8.12-darwin-aarch64-none": {
     "name": "cpython",
     "arch": "aarch64",
@@ -9827,19 +9827,6 @@
     "sha256": "f323fbc558035c13a85ce2267d0fad9e89282268ecb810e364fff1d0a079d525",
     "variant": null
   },
-  "cpython-3.8.12+debug-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "7cfac9a57e262be3e889036d7fc570293e6d3d74411ee23e1fa9aa470d387e6a",
-    "variant": "debug"
-  },
   "cpython-3.8.12-linux-i686-gnu": {
     "name": "cpython",
     "arch": "i686",
@@ -9853,19 +9840,6 @@
     "sha256": "fcb2033f01a2b10a51be68c9a1b4c7d7759b582f58a503371fe67ab59987b418",
     "variant": null
   },
-  "cpython-3.8.12+debug-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
-    "sha256": "9ad20c520c291d08087e9afb4390f389d2b66c7fc97f23fffc1313ebafc5fee0",
-    "variant": "debug"
-  },
   "cpython-3.8.12-linux-x86_64-gnu": {
     "name": "cpython",
     "arch": "x86_64",
@@ -9878,19 +9852,6 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "sha256": "5be9c6d61e238b90dfd94755051c0d3a2d8023ebffdb4b0fa4e8fedd09a6cab6",
     "variant": null
-  },
-  "cpython-3.8.12+debug-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 12,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
-    "sha256": "10bca8ab83f2ebb0f7b308a9e2bfebe9a0e638485f6947da9cdb26d95889ef32",
-    "variant": "debug"
   },
   "cpython-3.8.12-linux-x86_64-musl": {
     "name": "cpython",
@@ -9930,6 +9891,45 @@
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
     "sha256": "4658e08a00d60b1e01559b74d58ff4dd04da6df935d55f6268a15d6d0a679d74",
     "variant": null
+  },
+  "cpython-3.8.12+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7cfac9a57e262be3e889036d7fc570293e6d3d74411ee23e1fa9aa470d387e6a",
+    "variant": "debug"
+  },
+  "cpython-3.8.12+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9ad20c520c291d08087e9afb4390f389d2b66c7fc97f23fffc1313ebafc5fee0",
+    "variant": "debug"
+  },
+  "cpython-3.8.12+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "10bca8ab83f2ebb0f7b308a9e2bfebe9a0e638485f6947da9cdb26d95889ef32",
+    "variant": "debug"
   },
   "pypy-3.10.14-darwin-aarch64-none": {
     "name": "pypy",

--- a/crates/uv-python/download-metadata.json
+++ b/crates/uv-python/download-metadata.json
@@ -9,7 +9,21 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "7bc4b23590a1e4b41b21b6aae6f92046c1d16d09bc0c1ab81272aa81b55221d1"
+    "sha256": "7bc4b23590a1e4b41b21b6aae6f92046c1d16d09bc0c1ab81272aa81b55221d1",
+    "variant": null
+  },
+  "cpython-3.13.0+freethreaded-darwin-aarch64-none": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-apple-darwin-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "4ba7f477c56af4f057ca40535aa6907662b7206e3b8b39971d0a507b1c955e44",
+    "variant": "freethreaded"
   },
   "cpython-3.13.0-darwin-x86_64-none": {
     "name": "cpython",
@@ -21,7 +35,47 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "d6bc769002842147150a561502a23b57d5a8aa1ba643a6a0abf589bfe834e642"
+    "sha256": "d6bc769002842147150a561502a23b57d5a8aa1ba643a6a0abf589bfe834e642",
+    "variant": null
+  },
+  "cpython-3.13.0+freethreaded-darwin-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "darwin",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-apple-darwin-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "b72b7df7cd22a4e7462dbe95633c5ca61caab41237d68e0ff89e9774cd4985e7",
+    "variant": "freethreaded"
+  },
+  "cpython-3.13.0+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1449ca72692a9db62d691a3433e1fbda1a3030d3481aa6c8cf5b481369f44281",
+    "variant": "debug"
+  },
+  "cpython-3.13.0+freethreaded-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "678b0e9cbe2a8e19b0d83d518c7e3689918b22b2847e24f01fb2ce71164f5788",
+    "variant": "freethreaded"
   },
   "cpython-3.13.0-linux-aarch64-gnu": {
     "name": "cpython",
@@ -33,7 +87,34 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "1bfc058821199c4313ae67bb6c105df2c9dd3515bca955ff96724976acf64462"
+    "sha256": "1bfc058821199c4313ae67bb6c105df2c9dd3515bca955ff96724976acf64462",
+    "variant": null
+  },
+  "cpython-3.13.0+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "c2561006d736f10d8172092a08fb219ba262c2414a01b733bc3fa92c4299c6fb",
+    "variant": "debug"
+  },
+  "cpython-3.13.0+freethreaded-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "bee06f4fb52a8333f603a29e47e09e43b3bda9a2f338df6c0ccd3e3b81e5347e",
+    "variant": "freethreaded"
   },
   "cpython-3.13.0-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -45,7 +126,34 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "ae89ef85195386ce232de29e0f62e7544f80a6923119ed85af40d09a6468bf30"
+    "sha256": "ae89ef85195386ce232de29e0f62e7544f80a6923119ed85af40d09a6468bf30",
+    "variant": null
+  },
+  "cpython-3.13.0+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "198c445fa25916f054bcfbd16c8f4483b5fa7bb22e795b2fd2a7304cfee4a112",
+    "variant": "debug"
+  },
+  "cpython-3.13.0+freethreaded-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabihf-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "4d1e234314e1a809c8d027273dfcd647f600490ae59b59341051d973f0c0f586",
+    "variant": "freethreaded"
   },
   "cpython-3.13.0-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -57,7 +165,34 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "030974b9e1826513001c94cea4ef9248940fecc6efca034715770f7be232942a"
+    "sha256": "030974b9e1826513001c94cea4ef9248940fecc6efca034715770f7be232942a",
+    "variant": null
+  },
+  "cpython-3.13.0+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e9daa925568d683d0db2503293917cec00e931d3a4455b7e56e1551525f41683",
+    "variant": "debug"
+  },
+  "cpython-3.13.0+freethreaded-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "2d72fb6c7c91c9c00aa1e2b982bc7442da8a51665dfea2193e5e9098a6d7b2cb",
+    "variant": "freethreaded"
   },
   "cpython-3.13.0-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -69,7 +204,34 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "894014ceb5374d1c43a2e297126e588fd5fc60d93e57b76e1bba16430b80e3f3"
+    "sha256": "894014ceb5374d1c43a2e297126e588fd5fc60d93e57b76e1bba16430b80e3f3",
+    "variant": null
+  },
+  "cpython-3.13.0+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f8d538e4d96fc2ece9fdcd974a625398351d3746b158f55e2636d728179b3234",
+    "variant": "debug"
+  },
+  "cpython-3.13.0+freethreaded-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "533087017cbd1287af93936d9007bc1bd6ca8886b2cdf59171554cf55c6253e6",
+    "variant": "freethreaded"
   },
   "cpython-3.13.0-linux-s390x-gnu": {
     "name": "cpython",
@@ -81,7 +243,34 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "85e05e27c31cd7267cb17c4c16b729969dd586cd715287f923334db20a51ce67"
+    "sha256": "85e05e27c31cd7267cb17c4c16b729969dd586cd715287f923334db20a51ce67",
+    "variant": null
+  },
+  "cpython-3.13.0+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "028970bf32a20f52abf1296b13aa05fac28f1eed629f7fc8e4a952e6d98b614d",
+    "variant": "debug"
+  },
+  "cpython-3.13.0+freethreaded-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+    "sha256": "2b46a0f38711cfcdffab90f69ea1372288bd6dcb0f9676b765babb491d42ce06",
+    "variant": "freethreaded"
   },
   "cpython-3.13.0-linux-x86_64-gnu": {
     "name": "cpython",
@@ -93,7 +282,21 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "aa876c2660a802d0df8ef46f9c4b1c952e63c65d16e103663c22b9468dad40b7"
+    "sha256": "aa876c2660a802d0df8ef46f9c4b1c952e63c65d16e103663c22b9468dad40b7",
+    "variant": null
+  },
+  "cpython-3.13.0+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "283f4bd169763fcd971432caf227622cd6258f56c9b58e404feec80fa2038152",
+    "variant": "debug"
   },
   "cpython-3.13.0-linux-x86_64-musl": {
     "name": "cpython",
@@ -105,7 +308,21 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "9606d04c867ba034b901ef1a63c5b5efcb6951e4a6e2cce9703d0ff98d96f579"
+    "sha256": "9606d04c867ba034b901ef1a63c5b5efcb6951e4a6e2cce9703d0ff98d96f579",
+    "variant": null
+  },
+  "cpython-3.13.0+freethreaded-windows-i686-none": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-i686-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
+    "sha256": "1dd414e0787f180760952bdc339dfde42e0b7503419baf20d38a6470ed65e455",
+    "variant": "freethreaded"
   },
   "cpython-3.13.0-windows-i686-none": {
     "name": "cpython",
@@ -117,7 +334,21 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "fc96cb6a3e70bfcee13f7c5d08d30ecbe1738d934f885674d57f3b07b4291e5f"
+    "sha256": "fc96cb6a3e70bfcee13f7c5d08d30ecbe1738d934f885674d57f3b07b4291e5f",
+    "variant": null
+  },
+  "cpython-3.13.0+freethreaded-windows-x86_64-none": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "windows",
+    "libc": "none",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
+    "sha256": "fc665561556f4dc843cd3eeba4d482f716aec65d5b89a657316829cfbdc9462a",
+    "variant": "freethreaded"
   },
   "cpython-3.13.0-windows-x86_64-none": {
     "name": "cpython",
@@ -129,7 +360,8 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "c82b440476fe04e80228791350a451b65e8080ff01b7168f1c4a5eb9645371f3"
+    "sha256": "c82b440476fe04e80228791350a451b65e8080ff01b7168f1c4a5eb9645371f3",
+    "variant": null
   },
   "cpython-3.13.0rc3-darwin-aarch64-none": {
     "name": "cpython",
@@ -141,7 +373,8 @@
     "patch": 0,
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "685ef71882f16eabab0bc838094727978370f0ad95c29f7f5c244ffa31316aeb"
+    "sha256": "685ef71882f16eabab0bc838094727978370f0ad95c29f7f5c244ffa31316aeb",
+    "variant": null
   },
   "cpython-3.13.0rc3-darwin-x86_64-none": {
     "name": "cpython",
@@ -153,7 +386,21 @@
     "patch": 0,
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "0f5f9fcf82093c428b80c552165544439f4adcdbe5129ecf721d619e532e9b5e"
+    "sha256": "0f5f9fcf82093c428b80c552165544439f4adcdbe5129ecf721d619e532e9b5e",
+    "variant": null
+  },
+  "cpython-3.13.0rc3+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "84ca46dcb5057453373ba8d7129d9998769194c8110c81ac97a99ec1160abf41",
+    "variant": "debug"
   },
   "cpython-3.13.0rc3-linux-aarch64-gnu": {
     "name": "cpython",
@@ -165,7 +412,21 @@
     "patch": 0,
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "1414c6b37f37e8fd9d14e48d81e313eb9c965cb0330747d5d2d689dd7e0c7043"
+    "sha256": "1414c6b37f37e8fd9d14e48d81e313eb9c965cb0330747d5d2d689dd7e0c7043",
+    "variant": null
+  },
+  "cpython-3.13.0rc3+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "a2416da5fdb5331d84b179ed047245b6379c04d1c57e3c8583fda84a31dd5979",
+    "variant": "debug"
   },
   "cpython-3.13.0rc3-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -177,7 +438,21 @@
     "patch": 0,
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "11befeaf4768c2ebbb258f5b07f94b7700f16424f858d6d2c250b434e99ce07c"
+    "sha256": "11befeaf4768c2ebbb258f5b07f94b7700f16424f858d6d2c250b434e99ce07c",
+    "variant": null
+  },
+  "cpython-3.13.0rc3+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "59af55b12d59f5fdc236ba40aebb105fc440c36effadcfa7199362b2ca09d0a5",
+    "variant": "debug"
   },
   "cpython-3.13.0rc3-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -189,7 +464,21 @@
     "patch": 0,
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "b7180d5ea5fda2f397d04e2e6e11a2a7e0d732542bf54c484afb81d087a7b927"
+    "sha256": "b7180d5ea5fda2f397d04e2e6e11a2a7e0d732542bf54c484afb81d087a7b927",
+    "variant": null
+  },
+  "cpython-3.13.0rc3+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3c2808375869079e47923368903501913f32c65dfe71fe43c9ebbcdfc13009d9",
+    "variant": "debug"
   },
   "cpython-3.13.0rc3-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -201,7 +490,21 @@
     "patch": 0,
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "59a2a81991d78bd658742d69b577a2b4c0734628ed42bff68615686eaf96f2ab"
+    "sha256": "59a2a81991d78bd658742d69b577a2b4c0734628ed42bff68615686eaf96f2ab",
+    "variant": null
+  },
+  "cpython-3.13.0rc3+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "660e31ef1a7b4358332ef419e639d09a025a0e222855e10d93ee884a7fa8f15e",
+    "variant": "debug"
   },
   "cpython-3.13.0rc3-linux-s390x-gnu": {
     "name": "cpython",
@@ -213,7 +516,21 @@
     "patch": 0,
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "2769182e58b0dddec15222bfeecbd4b12fde61c38f23a90aa942514f3545fb9b"
+    "sha256": "2769182e58b0dddec15222bfeecbd4b12fde61c38f23a90aa942514f3545fb9b",
+    "variant": null
+  },
+  "cpython-3.13.0rc3+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "92a80f38919a852edcff68fd489152a408e43c65e67b800c02801cc58f239b95",
+    "variant": "debug"
   },
   "cpython-3.13.0rc3-linux-x86_64-gnu": {
     "name": "cpython",
@@ -225,7 +542,21 @@
     "patch": 0,
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "445156c61e1cc167f7b8777ad08cc36e5598e12cd27e07453f6e6dc0f62e421e"
+    "sha256": "445156c61e1cc167f7b8777ad08cc36e5598e12cd27e07453f6e6dc0f62e421e",
+    "variant": null
+  },
+  "cpython-3.13.0rc3+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc3",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "59b19a2ae830bd67bc8190bd839ebdf2423e871ef2e5114f38b84dab652c2e1b",
+    "variant": "debug"
   },
   "cpython-3.13.0rc3-linux-x86_64-musl": {
     "name": "cpython",
@@ -237,7 +568,8 @@
     "patch": 0,
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "4df6b7665c735a728d72e6f49034f1a6b7d9a54b0fbc472dc2ca525eb3dd513f"
+    "sha256": "4df6b7665c735a728d72e6f49034f1a6b7d9a54b0fbc472dc2ca525eb3dd513f",
+    "variant": null
   },
   "cpython-3.13.0rc3-windows-i686-none": {
     "name": "cpython",
@@ -249,7 +581,8 @@
     "patch": 0,
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "873905b3e5e8cba700126e8d6ed28ad3aef0dd102f730f8ca196018477dd2da6"
+    "sha256": "873905b3e5e8cba700126e8d6ed28ad3aef0dd102f730f8ca196018477dd2da6",
+    "variant": null
   },
   "cpython-3.13.0rc3-windows-x86_64-none": {
     "name": "cpython",
@@ -261,7 +594,8 @@
     "patch": 0,
     "prerelease": "rc3",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "b59317828ef88f138ee122d420b60f2705bc72ae846ff69562e79e6c5cbc3177"
+    "sha256": "b59317828ef88f138ee122d420b60f2705bc72ae846ff69562e79e6c5cbc3177",
+    "variant": null
   },
   "cpython-3.13.0rc2-darwin-aarch64-none": {
     "name": "cpython",
@@ -273,7 +607,8 @@
     "patch": 0,
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "9e17f9fcc314a5dd489089a7502a525c4dd08af862f9cf33b52161a752f2a5b7"
+    "sha256": "9e17f9fcc314a5dd489089a7502a525c4dd08af862f9cf33b52161a752f2a5b7",
+    "variant": null
   },
   "cpython-3.13.0rc2-darwin-x86_64-none": {
     "name": "cpython",
@@ -285,7 +620,21 @@
     "patch": 0,
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "971668ac7f3168efc4d2b589e9d36247ab8ca9f9525c56c8aa7bfd374060105b"
+    "sha256": "971668ac7f3168efc4d2b589e9d36247ab8ca9f9525c56c8aa7bfd374060105b",
+    "variant": null
+  },
+  "cpython-3.13.0rc2+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "77005f4de8eab59d5323bf4c8236530f477b2585b92ffe6b533a1de15df3f9b2",
+    "variant": "debug"
   },
   "cpython-3.13.0rc2-linux-aarch64-gnu": {
     "name": "cpython",
@@ -297,7 +646,21 @@
     "patch": 0,
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "d99a663d3b9f8792a659e366372e685550045cad12aef11645c06a9b6edcd071"
+    "sha256": "d99a663d3b9f8792a659e366372e685550045cad12aef11645c06a9b6edcd071",
+    "variant": null
+  },
+  "cpython-3.13.0rc2+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "50110dd0a39e663394d0a0757753714efb853ee1a6fbf969bb4bbe159f6a3f83",
+    "variant": "debug"
   },
   "cpython-3.13.0rc2-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -309,7 +672,21 @@
     "patch": 0,
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "4ca7f2aeaabf8dbb2193f0fa86f869525a5c209eb403a39a73f4cf7040cf3613"
+    "sha256": "4ca7f2aeaabf8dbb2193f0fa86f869525a5c209eb403a39a73f4cf7040cf3613",
+    "variant": null
+  },
+  "cpython-3.13.0rc2+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "8a8c2d371ab7fe2d1d9f51717ad51821108c607f7ea7993f96920666afc51ac1",
+    "variant": "debug"
   },
   "cpython-3.13.0rc2-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -321,7 +698,21 @@
     "patch": 0,
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "0db2d263bdbb3af1e8dc0677fa44a5cda992ba989551346ccbbfd50a86135c3d"
+    "sha256": "0db2d263bdbb3af1e8dc0677fa44a5cda992ba989551346ccbbfd50a86135c3d",
+    "variant": null
+  },
+  "cpython-3.13.0rc2+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d1e56f2c54775edd51ef933cd2838f692c57e24e43c4bd1a1b11c86056a24ef4",
+    "variant": "debug"
   },
   "cpython-3.13.0rc2-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -333,7 +724,21 @@
     "patch": 0,
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "70073333f7d3f0b900c7299659fec069bbefd5e04808b3729d2434b2232ac729"
+    "sha256": "70073333f7d3f0b900c7299659fec069bbefd5e04808b3729d2434b2232ac729",
+    "variant": null
+  },
+  "cpython-3.13.0rc2+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "65ea35a96bce6d097ebbbf19ad484f0101b2b42fcca3ab518109c3ea3aefb952",
+    "variant": "debug"
   },
   "cpython-3.13.0rc2-linux-s390x-gnu": {
     "name": "cpython",
@@ -345,7 +750,21 @@
     "patch": 0,
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "50a2080e30d1504e76e5471e46830f0b4974c66b538ed8ec7df416975133ff89"
+    "sha256": "50a2080e30d1504e76e5471e46830f0b4974c66b538ed8ec7df416975133ff89",
+    "variant": null
+  },
+  "cpython-3.13.0rc2+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8595be42ea7fa43ffe66761c713ad4b60e6270dca1771491d54e8d6556bb617b",
+    "variant": "debug"
   },
   "cpython-3.13.0rc2-linux-x86_64-gnu": {
     "name": "cpython",
@@ -357,7 +776,21 @@
     "patch": 0,
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "1893a218709d3664b7a2b80f5598b5f25c0c3fe2bcc8d0a1c75eec6bbb93d602"
+    "sha256": "1893a218709d3664b7a2b80f5598b5f25c0c3fe2bcc8d0a1c75eec6bbb93d602",
+    "variant": null
+  },
+  "cpython-3.13.0rc2+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 13,
+    "patch": 0,
+    "prerelease": "rc2",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "634e538c9d9e8cec2f27aa278a1e99d6e652d7b013b4f27a0242265e0d8ad0ff",
+    "variant": "debug"
   },
   "cpython-3.13.0rc2-linux-x86_64-musl": {
     "name": "cpython",
@@ -369,7 +802,8 @@
     "patch": 0,
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "6f09aa5ba6aab8bf21955dbc3d6bab19125130ef0ebe29242b0e5ac1eebb3161"
+    "sha256": "6f09aa5ba6aab8bf21955dbc3d6bab19125130ef0ebe29242b0e5ac1eebb3161",
+    "variant": null
   },
   "cpython-3.13.0rc2-windows-i686-none": {
     "name": "cpython",
@@ -381,7 +815,8 @@
     "patch": 0,
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "759f600b27a6a0ef2638cb02e8bbcc6de726dd1c896759f78da3e412f6c992e9"
+    "sha256": "759f600b27a6a0ef2638cb02e8bbcc6de726dd1c896759f78da3e412f6c992e9",
+    "variant": null
   },
   "cpython-3.13.0rc2-windows-x86_64-none": {
     "name": "cpython",
@@ -393,7 +828,8 @@
     "patch": 0,
     "prerelease": "rc2",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "c883205751c714bd0519592673a88f160a55d34344cc1368353ad34a679eb94a"
+    "sha256": "c883205751c714bd0519592673a88f160a55d34344cc1368353ad34a679eb94a",
+    "variant": null
   },
   "cpython-3.12.7-darwin-aarch64-none": {
     "name": "cpython",
@@ -405,7 +841,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "dc1f4d80c9b4ae40ba2c725e310e61446f8f778a7bea4efa56e4b1b4446e0a1a"
+    "sha256": "dc1f4d80c9b4ae40ba2c725e310e61446f8f778a7bea4efa56e4b1b4446e0a1a",
+    "variant": null
   },
   "cpython-3.12.7-darwin-x86_64-none": {
     "name": "cpython",
@@ -417,7 +854,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "7091bd9ce844bcbceb8f3466a9c9583a139f79edd3b0cbed82f7423d333b2d4b"
+    "sha256": "7091bd9ce844bcbceb8f3466a9c9583a139f79edd3b0cbed82f7423d333b2d4b",
+    "variant": null
+  },
+  "cpython-3.12.7+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b552a3749c02aac4c4d0fb96642e159b8ea1d37202d1d307627684cce7c3d20c",
+    "variant": "debug"
   },
   "cpython-3.12.7-linux-aarch64-gnu": {
     "name": "cpython",
@@ -429,7 +880,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "e254373827bde6b389ed17b8bb8aa8ac7b3659cf56d36e084a53ed1d04a02210"
+    "sha256": "e254373827bde6b389ed17b8bb8aa8ac7b3659cf56d36e084a53ed1d04a02210",
+    "variant": null
+  },
+  "cpython-3.12.7+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "46f8266425d4f0393c00803e87e5a9186b849c96d937d62f6ff947e69a1c84b7",
+    "variant": "debug"
   },
   "cpython-3.12.7-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -441,7 +906,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "b05298a85d7494a7e1220c4948a357da0ff40d8a6e470cd9b00515203200136c"
+    "sha256": "b05298a85d7494a7e1220c4948a357da0ff40d8a6e470cd9b00515203200136c",
+    "variant": null
+  },
+  "cpython-3.12.7+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "1a4a87ddf81ae16b873b17eddbbcbb761a2b8b974ece668ec6d42f4dd81c941d",
+    "variant": "debug"
   },
   "cpython-3.12.7-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -453,7 +932,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "88a642de18a1baa044916eb2cebbf2d534b1c5d03c98c8f4ccc8f451a7526535"
+    "sha256": "88a642de18a1baa044916eb2cebbf2d534b1c5d03c98c8f4ccc8f451a7526535",
+    "variant": null
+  },
+  "cpython-3.12.7+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a49b0fa30d270146258442680c5eddd4d0cc6bdd2e17d71044a8111540e0687b",
+    "variant": "debug"
   },
   "cpython-3.12.7-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -465,7 +958,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "1ff1e843d78f70fd2834e522ebd5a63193c67b47a31d40fa5e97d96ac0d64aaf"
+    "sha256": "1ff1e843d78f70fd2834e522ebd5a63193c67b47a31d40fa5e97d96ac0d64aaf",
+    "variant": null
+  },
+  "cpython-3.12.7+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9651eb9f8afb8c06e552d089290407e434e3a6e96b42223eaf31fb284592344d",
+    "variant": "debug"
   },
   "cpython-3.12.7-linux-s390x-gnu": {
     "name": "cpython",
@@ -477,7 +984,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "5a4128fc5523a8888b12767a275c8240c33d0ee96fdcf1a8c6c6cec9696d0f09"
+    "sha256": "5a4128fc5523a8888b12767a275c8240c33d0ee96fdcf1a8c6c6cec9696d0f09",
+    "variant": null
+  },
+  "cpython-3.12.7+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7817bfb569c1daf2981a49fd2ca6677dd2151bdf1ea2c3102f63e424a14f28f5",
+    "variant": "debug"
   },
   "cpython-3.12.7-linux-x86_64-gnu": {
     "name": "cpython",
@@ -489,7 +1010,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "11091cd2eb8b7f4551665ba8f9f5b83aa3d09fc0e17f1649d76d5f4f75254bf8"
+    "sha256": "11091cd2eb8b7f4551665ba8f9f5b83aa3d09fc0e17f1649d76d5f4f75254bf8",
+    "variant": null
+  },
+  "cpython-3.12.7+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "4a5b83c8ba86a2df4ab470970911d075ad413af17576b37e284a3441243994f8",
+    "variant": "debug"
   },
   "cpython-3.12.7-linux-x86_64-musl": {
     "name": "cpython",
@@ -501,7 +1036,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "b4396fc04d77cd991ebfc21312790acf2a82da5140a7becf47d3173f07131905"
+    "sha256": "b4396fc04d77cd991ebfc21312790acf2a82da5140a7becf47d3173f07131905",
+    "variant": null
   },
   "cpython-3.12.7-windows-i686-none": {
     "name": "cpython",
@@ -513,7 +1049,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "291de4fc77b3788b43a2b6b5c4587d106793754399e0fcb8a08db8ba993c65a5"
+    "sha256": "291de4fc77b3788b43a2b6b5c4587d106793754399e0fcb8a08db8ba993c65a5",
+    "variant": null
   },
   "cpython-3.12.7-windows-x86_64-none": {
     "name": "cpython",
@@ -525,7 +1062,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "480688c69be99f1fb9974c8a50f1efd214aaa3440ab5c8653a68d8a3d4ce1179"
+    "sha256": "480688c69be99f1fb9974c8a50f1efd214aaa3440ab5c8653a68d8a3d4ce1179",
+    "variant": null
   },
   "cpython-3.12.6-darwin-aarch64-none": {
     "name": "cpython",
@@ -537,7 +1075,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "0419bafa4444a5aa0c554197bce0679e7cc0f28edc7ee8cfbe0ccea860bdb904"
+    "sha256": "0419bafa4444a5aa0c554197bce0679e7cc0f28edc7ee8cfbe0ccea860bdb904",
+    "variant": null
   },
   "cpython-3.12.6-darwin-x86_64-none": {
     "name": "cpython",
@@ -549,7 +1088,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "b10d19eb5548a3b3b0a5e6f9109834d7ecfc139bc15754f81a94d39eaa5bdd26"
+    "sha256": "b10d19eb5548a3b3b0a5e6f9109834d7ecfc139bc15754f81a94d39eaa5bdd26",
+    "variant": null
+  },
+  "cpython-3.12.6+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ddddd8a1446754a75a637c35f61df33e2b99ea679455971dcabb336ffefb77db",
+    "variant": "debug"
   },
   "cpython-3.12.6-linux-aarch64-gnu": {
     "name": "cpython",
@@ -561,7 +1114,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "22d119ac7df7f0bddfd4dfd075bcc4eb2532ed3df0bdba0579106835d49ef9cd"
+    "sha256": "22d119ac7df7f0bddfd4dfd075bcc4eb2532ed3df0bdba0579106835d49ef9cd",
+    "variant": null
+  },
+  "cpython-3.12.6+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "1a4736063292701b4ed08f2f3c688647c4702e5381d1d1c208970f9bad68a457",
+    "variant": "debug"
   },
   "cpython-3.12.6-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -573,7 +1140,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "190c23eb3b9c6b9638f69dc7fb829df8967ad64c82e82c93898a4d878d18ed2a"
+    "sha256": "190c23eb3b9c6b9638f69dc7fb829df8967ad64c82e82c93898a4d878d18ed2a",
+    "variant": null
+  },
+  "cpython-3.12.6+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "d1c9924e90db87826bfd4ffc5189ec8983962f95d09fb79cdbd7f75bb4d88daa",
+    "variant": "debug"
   },
   "cpython-3.12.6-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -585,7 +1166,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "31a043c40e1dbb528404ff6e1fcad25638d54dfab2d379c3989d47ec24e6938b"
+    "sha256": "31a043c40e1dbb528404ff6e1fcad25638d54dfab2d379c3989d47ec24e6938b",
+    "variant": null
+  },
+  "cpython-3.12.6+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "edb11773eab6a91cd9407f1f8bf7055233453cf48c49cb300adca85048d8e887",
+    "variant": "debug"
   },
   "cpython-3.12.6-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -597,7 +1192,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "fb49374b512b0e9f2cd2a720b3836f8a04228d73eb0786e64221eb55979edc6e"
+    "sha256": "fb49374b512b0e9f2cd2a720b3836f8a04228d73eb0786e64221eb55979edc6e",
+    "variant": null
+  },
+  "cpython-3.12.6+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d21426d4356bb5b0525465e9cc39c27dba7c39e7112855ea2cf90a194c2bdf42",
+    "variant": "debug"
   },
   "cpython-3.12.6-linux-s390x-gnu": {
     "name": "cpython",
@@ -609,7 +1218,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "89be19666ecb7cdbbfd596e462d690a78a380f1fe5c2967b25a1779b0cec9339"
+    "sha256": "89be19666ecb7cdbbfd596e462d690a78a380f1fe5c2967b25a1779b0cec9339",
+    "variant": null
+  },
+  "cpython-3.12.6+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "110a8ba95943af6b30198c7f925bb655d4257704abe28b4cfddc374ff367312e",
+    "variant": "debug"
   },
   "cpython-3.12.6-linux-x86_64-gnu": {
     "name": "cpython",
@@ -621,7 +1244,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "b080463e4f0c452e592cdac1ca97936a6a19bb3d9a64da669a50ca843fce0108"
+    "sha256": "b080463e4f0c452e592cdac1ca97936a6a19bb3d9a64da669a50ca843fce0108",
+    "variant": null
+  },
+  "cpython-3.12.6+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "1d678f6f70dc0cf32c6f5edd18f81a560ff087c7d1bb4185a810ccd1f145b0c3",
+    "variant": "debug"
   },
   "cpython-3.12.6-linux-x86_64-musl": {
     "name": "cpython",
@@ -633,7 +1270,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "661e2a4b03d6eccbb5b15f5bd2869fbdd39132513394d758287e46115e48d4ef"
+    "sha256": "661e2a4b03d6eccbb5b15f5bd2869fbdd39132513394d758287e46115e48d4ef",
+    "variant": null
   },
   "cpython-3.12.6-windows-i686-none": {
     "name": "cpython",
@@ -645,7 +1283,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "d87275e613632ab738528fe20a94a7193e824e91ba7f1e7845e7fcfc1f114900"
+    "sha256": "d87275e613632ab738528fe20a94a7193e824e91ba7f1e7845e7fcfc1f114900",
+    "variant": null
   },
   "cpython-3.12.6-windows-x86_64-none": {
     "name": "cpython",
@@ -657,7 +1296,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "fe9898060f52c2171c2aa074f470f91339bdcf9896dae6709021c914f58aa863"
+    "sha256": "fe9898060f52c2171c2aa074f470f91339bdcf9896dae6709021c914f58aa863",
+    "variant": null
   },
   "cpython-3.12.5-darwin-aarch64-none": {
     "name": "cpython",
@@ -669,7 +1309,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "90715cdab075e5a2680acf2695572d165b6269bdb5d1942ab577491478aea55f"
+    "sha256": "90715cdab075e5a2680acf2695572d165b6269bdb5d1942ab577491478aea55f",
+    "variant": null
   },
   "cpython-3.12.5-darwin-x86_64-none": {
     "name": "cpython",
@@ -681,7 +1322,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "49a9f7ad41d62e0ece9e664ca5ae95f022e7b68eef48e8a6f11620ec9247c686"
+    "sha256": "49a9f7ad41d62e0ece9e664ca5ae95f022e7b68eef48e8a6f11620ec9247c686",
+    "variant": null
+  },
+  "cpython-3.12.5+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "66ba3a4ee2d2196ce2d05275aa2c12c1cc4480530dadf54d6754e85cb11fa3da",
+    "variant": "debug"
   },
   "cpython-3.12.5-linux-aarch64-gnu": {
     "name": "cpython",
@@ -693,7 +1348,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "06e512178cb513658a01c054b3eafc649ca362ccbeb02a6ae8a55b02c1ba75ca"
+    "sha256": "06e512178cb513658a01c054b3eafc649ca362ccbeb02a6ae8a55b02c1ba75ca",
+    "variant": null
+  },
+  "cpython-3.12.5+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "6617a003ff280523f6862ec2dcf7e900e999d4521e4b9363c7c32245fb12df12",
+    "variant": "debug"
   },
   "cpython-3.12.5-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -705,7 +1374,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "7a584de9c2824f43d7a7b1c26eb61a18af770ebd603a74b45d57601ba62ba508"
+    "sha256": "7a584de9c2824f43d7a7b1c26eb61a18af770ebd603a74b45d57601ba62ba508",
+    "variant": null
+  },
+  "cpython-3.12.5+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "d8d9bbb21efdd6b4fbf5e004d57e7fad772ed1263615a6b2579803e9f2289dfa",
+    "variant": "debug"
   },
   "cpython-3.12.5-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -717,7 +1400,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "a9992b30d7b3ecb558cd12fde919e3e2836f161f8f777afea31140d5fff6362e"
+    "sha256": "a9992b30d7b3ecb558cd12fde919e3e2836f161f8f777afea31140d5fff6362e",
+    "variant": null
+  },
+  "cpython-3.12.5+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "895d2db8a2074578c86ce3f5499787923188bf559180b5cbd8401bae060a3f5e",
+    "variant": "debug"
   },
   "cpython-3.12.5-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -729,7 +1426,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "3bea081f4e6fa67e600a6a791bcfebb2891531ede2c21e23e1b7321b3369c737"
+    "sha256": "3bea081f4e6fa67e600a6a791bcfebb2891531ede2c21e23e1b7321b3369c737",
+    "variant": null
+  },
+  "cpython-3.12.5+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e0a8bfe653421e687ed56bcc4269b3e65390529c61581193252ce689c12f128b",
+    "variant": "debug"
   },
   "cpython-3.12.5-linux-s390x-gnu": {
     "name": "cpython",
@@ -741,7 +1452,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "2b6ea3a5242de99574191ee42df864756eca6d7cb1dbd4cd7ab2850ba8b828f8"
+    "sha256": "2b6ea3a5242de99574191ee42df864756eca6d7cb1dbd4cd7ab2850ba8b828f8",
+    "variant": null
+  },
+  "cpython-3.12.5+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "580caa10b1c661409d35623d20b2b56f6c8f4c263122b0e8228a3cdaa482c8be",
+    "variant": "debug"
   },
   "cpython-3.12.5-linux-x86_64-gnu": {
     "name": "cpython",
@@ -753,7 +1478,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "10680b593b5e31833218fd83104dee74af970a3463403a22bae613b952a34e8d"
+    "sha256": "10680b593b5e31833218fd83104dee74af970a3463403a22bae613b952a34e8d",
+    "variant": null
+  },
+  "cpython-3.12.5+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a2766d5627353e8ce8a8c43b0b5c3007a77f4f095bf773739f5bb936860546cd",
+    "variant": "debug"
   },
   "cpython-3.12.5-linux-x86_64-musl": {
     "name": "cpython",
@@ -765,7 +1504,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "e61b1274e1195f227cb30ba5d89ea32d743796d992adcaffad4819e4b0405d24"
+    "sha256": "e61b1274e1195f227cb30ba5d89ea32d743796d992adcaffad4819e4b0405d24",
+    "variant": null
   },
   "cpython-3.12.5-windows-i686-none": {
     "name": "cpython",
@@ -777,7 +1517,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "b1009d46b87330c099d02411ca5e9e333f13305c5abdbe20810a7c467cedb051"
+    "sha256": "b1009d46b87330c099d02411ca5e9e333f13305c5abdbe20810a7c467cedb051",
+    "variant": null
   },
   "cpython-3.12.5-windows-x86_64-none": {
     "name": "cpython",
@@ -789,7 +1530,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "6eb0398795e8875575934cf21cdc9c7c7acddb46f9a52f91fdad509723f2f0e9"
+    "sha256": "6eb0398795e8875575934cf21cdc9c7c7acddb46f9a52f91fdad509723f2f0e9",
+    "variant": null
   },
   "cpython-3.12.4-darwin-aarch64-none": {
     "name": "cpython",
@@ -801,7 +1543,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "ef6948e836f531bd7a58ffbe602803ff1c83c65f99d1da19be369ea61f136c93"
+    "sha256": "ef6948e836f531bd7a58ffbe602803ff1c83c65f99d1da19be369ea61f136c93",
+    "variant": null
   },
   "cpython-3.12.4-darwin-x86_64-none": {
     "name": "cpython",
@@ -813,7 +1556,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "9d68cbdd12d1d6f98d35cc76add232c12db75c6b7f49733bffc88e7b1c025a79"
+    "sha256": "9d68cbdd12d1d6f98d35cc76add232c12db75c6b7f49733bffc88e7b1c025a79",
+    "variant": null
+  },
+  "cpython-3.12.4+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "35d7ef1f4f4849ad92ba6e29c46235b9f5a2951758bec1f9fcec4133744d8c02",
+    "variant": "debug"
   },
   "cpython-3.12.4-linux-aarch64-gnu": {
     "name": "cpython",
@@ -825,7 +1582,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "6c9cf13644edc7250525ab1b2529ba1c0fff56c0c5a5c2242d84b6d4889d2bea"
+    "sha256": "6c9cf13644edc7250525ab1b2529ba1c0fff56c0c5a5c2242d84b6d4889d2bea",
+    "variant": null
+  },
+  "cpython-3.12.4+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "541305f79e3e007f6313faf6e4a955ed47c08704dddb216bf6c810c30e8ec853",
+    "variant": "debug"
   },
   "cpython-3.12.4-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -837,7 +1608,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "5a23ed8eaf948fe48d7c05dbfb58ea8638dcd2c4880d8519e069281ab427cbcb"
+    "sha256": "5a23ed8eaf948fe48d7c05dbfb58ea8638dcd2c4880d8519e069281ab427cbcb",
+    "variant": null
+  },
+  "cpython-3.12.4+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "f110f5db3d2ff9db5590d77f4af655202d570b9d9dff8d8aafbf67dea88b9dbf",
+    "variant": "debug"
   },
   "cpython-3.12.4-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -849,7 +1634,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "4281764e69339a138e30211b9923d74036d07c7a56c6aacc6dbdb2802a575f51"
+    "sha256": "4281764e69339a138e30211b9923d74036d07c7a56c6aacc6dbdb2802a575f51",
+    "variant": null
+  },
+  "cpython-3.12.4+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "342e9d3c36f8da4e57fb065641f7e6ae98af110fbddc641b88d6930cd1895943",
+    "variant": "debug"
   },
   "cpython-3.12.4-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -861,7 +1660,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "35a8359f1dc17a7a70007dae102a5e1562c0715a721377ede92137b2a0292406"
+    "sha256": "35a8359f1dc17a7a70007dae102a5e1562c0715a721377ede92137b2a0292406",
+    "variant": null
+  },
+  "cpython-3.12.4+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f8df0b7ebd2893e845fbbeb8f133e317b49223fc128823f6743cbfd7a50bfc0d",
+    "variant": "debug"
   },
   "cpython-3.12.4-linux-s390x-gnu": {
     "name": "cpython",
@@ -873,7 +1686,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "b2fd015ab3689e024de6fbb34a4942acdb54c2184d1963e22829aafa1d81ba2c"
+    "sha256": "b2fd015ab3689e024de6fbb34a4942acdb54c2184d1963e22829aafa1d81ba2c",
+    "variant": null
+  },
+  "cpython-3.12.4+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "54324b36cf7b68af3ddbabd1ec482691a23bf059a7f46a8cb3f3615f5fd5d86d",
+    "variant": "debug"
   },
   "cpython-3.12.4-linux-x86_64-gnu": {
     "name": "cpython",
@@ -885,7 +1712,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "ca076aee4329f53f988346eb0521ad2a2cf7f723b6296088d03b98d8f22f5420"
+    "sha256": "ca076aee4329f53f988346eb0521ad2a2cf7f723b6296088d03b98d8f22f5420",
+    "variant": null
+  },
+  "cpython-3.12.4+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "797b3d36a9df38925b7a7c5facb47e56a0d1c4031ae7b121ce41c07433fa1d2e",
+    "variant": "debug"
   },
   "cpython-3.12.4-linux-x86_64-musl": {
     "name": "cpython",
@@ -897,7 +1738,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "de4983ffa610ff2c3b9bcb62882366f017d94bf11b194c1fce17ad9e502acce6"
+    "sha256": "de4983ffa610ff2c3b9bcb62882366f017d94bf11b194c1fce17ad9e502acce6",
+    "variant": null
   },
   "cpython-3.12.4-windows-i686-none": {
     "name": "cpython",
@@ -909,7 +1751,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "ff0fab24f38c22130e45b90b7ec10dc4ce9677b545d9fb9109a72d2ffbab7b02"
+    "sha256": "ff0fab24f38c22130e45b90b7ec10dc4ce9677b545d9fb9109a72d2ffbab7b02",
+    "variant": null
   },
   "cpython-3.12.4-windows-x86_64-none": {
     "name": "cpython",
@@ -921,7 +1764,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "6dd7b4607f8a25f0f5f68e745f4c572b1a20c3bbfa86accfa45b52ab93b18ece"
+    "sha256": "6dd7b4607f8a25f0f5f68e745f4c572b1a20c3bbfa86accfa45b52ab93b18ece",
+    "variant": null
   },
   "cpython-3.12.3-darwin-aarch64-none": {
     "name": "cpython",
@@ -933,7 +1777,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "ccc40e5af329ef2af81350db2a88bbd6c17b56676e82d62048c15d548401519e"
+    "sha256": "ccc40e5af329ef2af81350db2a88bbd6c17b56676e82d62048c15d548401519e",
+    "variant": null
   },
   "cpython-3.12.3-darwin-x86_64-none": {
     "name": "cpython",
@@ -945,7 +1790,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8"
+    "sha256": "c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8",
+    "variant": null
+  },
+  "cpython-3.12.3+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "24daaf20123ac4b2b8657c1ac8227d391d2e5769d81237b68ee674569d307ad0",
+    "variant": "debug"
   },
   "cpython-3.12.3-linux-aarch64-gnu": {
     "name": "cpython",
@@ -957,7 +1816,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "ec8126de97945e629cca9aedc80a29c4ae2992c9d69f2655e27ae73906ba187d"
+    "sha256": "ec8126de97945e629cca9aedc80a29c4ae2992c9d69f2655e27ae73906ba187d",
+    "variant": null
+  },
+  "cpython-3.12.3+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "d4d76d1dfd2d1e344ab825d2991887fa31702004470a97d205c32b9e5541892a",
+    "variant": "debug"
   },
   "cpython-3.12.3-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -969,7 +1842,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabi-install_only.tar.gz",
-    "sha256": "f693dd22b69361c17076157889eb8f1ce1a5ea670c031fae46782481ad892a64"
+    "sha256": "f693dd22b69361c17076157889eb8f1ce1a5ea670c031fae46782481ad892a64",
+    "variant": null
+  },
+  "cpython-3.12.3+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "96a7a3725bae8cc0933eaaaffe99c6a71218b6593c28af042a9fa8c34fc722d3",
+    "variant": "debug"
   },
   "cpython-3.12.3-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -981,7 +1868,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabihf-install_only.tar.gz",
-    "sha256": "635080827bed4616dc271545677837203098e5b55e7195d803e1dca7da24fc0c"
+    "sha256": "635080827bed4616dc271545677837203098e5b55e7195d803e1dca7da24fc0c",
+    "variant": null
+  },
+  "cpython-3.12.3+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "983f056cb8336a54364c2eec3d33808dd74f953f82b720c6a73ad943643b4920",
+    "variant": "debug"
   },
   "cpython-3.12.3-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -993,7 +1894,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "c5dcf08b8077e617d949bda23027c49712f583120b3ed744f9b143da1d580572"
+    "sha256": "c5dcf08b8077e617d949bda23027c49712f583120b3ed744f9b143da1d580572",
+    "variant": null
+  },
+  "cpython-3.12.3+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a009c51b178519e60b6b7848b0ea91f3a92007ca1bdf0a2e8b26b8b7a138cdc0",
+    "variant": "debug"
   },
   "cpython-3.12.3-linux-s390x-gnu": {
     "name": "cpython",
@@ -1005,7 +1920,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "872fc321363b8cdd826fd2cb1adfd1ceb813bc1281f9d410c1c2c4e177e8df86"
+    "sha256": "872fc321363b8cdd826fd2cb1adfd1ceb813bc1281f9d410c1c2c4e177e8df86",
+    "variant": null
+  },
+  "cpython-3.12.3+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ded92cd034b33df953c490d3343ef187ac065d1fcd78e8cee894be197c5f977e",
+    "variant": "debug"
   },
   "cpython-3.12.3-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1017,7 +1946,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "a73ba777b5d55ca89edef709e6b8521e3f3d4289581f174c8699adfb608d09d6"
+    "sha256": "a73ba777b5d55ca89edef709e6b8521e3f3d4289581f174c8699adfb608d09d6",
+    "variant": null
+  },
+  "cpython-3.12.3+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "81d9fc9ffd6860229e09b11be5d800db5966080ba6f4b7524ae7917423fd09c6",
+    "variant": "debug"
   },
   "cpython-3.12.3-linux-x86_64-musl": {
     "name": "cpython",
@@ -1029,7 +1972,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "eb70814dc254f02714c77305de01b8ed2250c146320e22d0ed14b39021f89a8a"
+    "sha256": "eb70814dc254f02714c77305de01b8ed2250c146320e22d0ed14b39021f89a8a",
+    "variant": null
   },
   "cpython-3.12.3-windows-i686-none": {
     "name": "cpython",
@@ -1041,7 +1985,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-i686-pc-windows-msvc-install_only.tar.gz",
-    "sha256": "bd723ad1aa05551627715a428660250f0e74db0f1421b03f399235772057ef55"
+    "sha256": "bd723ad1aa05551627715a428660250f0e74db0f1421b03f399235772057ef55",
+    "variant": null
   },
   "cpython-3.12.3-windows-x86_64-none": {
     "name": "cpython",
@@ -1053,7 +1998,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-pc-windows-msvc-install_only.tar.gz",
-    "sha256": "f7cfa4ad072feb4578c8afca5ba9a54ad591d665a441dd0d63aa366edbe19279"
+    "sha256": "f7cfa4ad072feb4578c8afca5ba9a54ad591d665a441dd0d63aa366edbe19279",
+    "variant": null
   },
   "cpython-3.12.2-darwin-aarch64-none": {
     "name": "cpython",
@@ -1065,7 +2011,8 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "01c064c00013b0175c7858b159989819ead53f4746d40580b5b0b35b6e80fba6"
+    "sha256": "01c064c00013b0175c7858b159989819ead53f4746d40580b5b0b35b6e80fba6",
+    "variant": null
   },
   "cpython-3.12.2-darwin-x86_64-none": {
     "name": "cpython",
@@ -1077,7 +2024,21 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "a53a6670a202c96fec0b8c55ccc780ea3af5307eb89268d5b41a9775b109c094"
+    "sha256": "a53a6670a202c96fec0b8c55ccc780ea3af5307eb89268d5b41a9775b109c094",
+    "variant": null
+  },
+  "cpython-3.12.2+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "469a7fd0d0a09936c5db41b5ac83bb29d5bfeb721aa483ac92f3f7ac4d311097",
+    "variant": "debug"
   },
   "cpython-3.12.2-linux-aarch64-gnu": {
     "name": "cpython",
@@ -1089,7 +2050,21 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "e52550379e7c4ac27a87de832d172658bc04150e4e27d4e858e6d8cbb96fd709"
+    "sha256": "e52550379e7c4ac27a87de832d172658bc04150e4e27d4e858e6d8cbb96fd709",
+    "variant": null
+  },
+  "cpython-3.12.2+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1d70476fb9013cc93e787417680b34629b510e6e2145cf48bb2f0fe887f7a4d8",
+    "variant": "debug"
   },
   "cpython-3.12.2-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1101,7 +2076,21 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "74bc02c4bbbd26245c37b29b9e12d0a9c1b7ab93477fed8b651c988b6a9a6251"
+    "sha256": "74bc02c4bbbd26245c37b29b9e12d0a9c1b7ab93477fed8b651c988b6a9a6251",
+    "variant": null
+  },
+  "cpython-3.12.2+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f40b88607928b5ee34ff87c1d574c8493a1604d7a40474e1b03731184186f419",
+    "variant": "debug"
   },
   "cpython-3.12.2-linux-s390x-gnu": {
     "name": "cpython",
@@ -1113,7 +2102,21 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "ecd6b0285e5eef94deb784b588b4b425a15a43ae671bf206556659dc141a9825"
+    "sha256": "ecd6b0285e5eef94deb784b588b4b425a15a43ae671bf206556659dc141a9825",
+    "variant": null
+  },
+  "cpython-3.12.2+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "15b61ed9d33b35ad014a13a68a55d8ea5ba7fb70945644747f4e53c659f2fed6",
+    "variant": "debug"
   },
   "cpython-3.12.2-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1125,7 +2128,21 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "57a37b57f8243caa4cdac016176189573ad7620f0b6da5941c5e40660f9468ab"
+    "sha256": "57a37b57f8243caa4cdac016176189573ad7620f0b6da5941c5e40660f9468ab",
+    "variant": null
+  },
+  "cpython-3.12.2+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "2f5f088639e17981b0aeeeeab0fbb6858002d5f10bf57e26eaf32f99b4b6c765",
+    "variant": "debug"
   },
   "cpython-3.12.2-linux-x86_64-musl": {
     "name": "cpython",
@@ -1137,7 +2154,8 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "b428b4151c70b85339ac2659e5f69f7e47142d34a506e05ecd095efe2e3dec81"
+    "sha256": "b428b4151c70b85339ac2659e5f69f7e47142d34a506e05ecd095efe2e3dec81",
+    "variant": null
   },
   "cpython-3.12.2-windows-i686-none": {
     "name": "cpython",
@@ -1149,7 +2167,8 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "1e919365f3e04eb111283f7a45d32eac2f327287ab7bf46720d5629e144cbff9"
+    "sha256": "1e919365f3e04eb111283f7a45d32eac2f327287ab7bf46720d5629e144cbff9",
+    "variant": null
   },
   "cpython-3.12.2-windows-x86_64-none": {
     "name": "cpython",
@@ -1161,7 +2180,8 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "1e5655a6ccb1a64a78460e4e3ee21036c70246800f176a6c91043a3fe3654a3b"
+    "sha256": "1e5655a6ccb1a64a78460e4e3ee21036c70246800f176a6c91043a3fe3654a3b",
+    "variant": null
   },
   "cpython-3.12.1-darwin-aarch64-none": {
     "name": "cpython",
@@ -1173,7 +2193,8 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "f93f8375ca6ac0a35d58ff007043cbd3a88d9609113f1cb59cf7c8d215f064af"
+    "sha256": "f93f8375ca6ac0a35d58ff007043cbd3a88d9609113f1cb59cf7c8d215f064af",
+    "variant": null
   },
   "cpython-3.12.1-darwin-x86_64-none": {
     "name": "cpython",
@@ -1185,7 +2206,21 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "eca96158c1568dedd9a0b3425375637a83764d1fa74446438293089a8bfac1f8"
+    "sha256": "eca96158c1568dedd9a0b3425375637a83764d1fa74446438293089a8bfac1f8",
+    "variant": null
+  },
+  "cpython-3.12.1+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9009da24f436611d0bf086b8ea62aaed1c27104af5b770ddcfc92b60db06da8c",
+    "variant": "debug"
   },
   "cpython-3.12.1-linux-aarch64-gnu": {
     "name": "cpython",
@@ -1197,7 +2232,21 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "236533ef20e665007a111c2f36efb59c87ae195ad7dca223b6dc03fb07064f0b"
+    "sha256": "236533ef20e665007a111c2f36efb59c87ae195ad7dca223b6dc03fb07064f0b",
+    "variant": null
+  },
+  "cpython-3.12.1+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b61686ce05c58c913e4fdb7e7c7105ed36d9bcdcd1a841e7f08b243f40d5cf77",
+    "variant": "debug"
   },
   "cpython-3.12.1-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1209,7 +2258,21 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "78051f0d1411ee62bc2af5edfccf6e8400ac4ef82887a2affc19a7ace6a05267"
+    "sha256": "78051f0d1411ee62bc2af5edfccf6e8400ac4ef82887a2affc19a7ace6a05267",
+    "variant": null
+  },
+  "cpython-3.12.1+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "505a4fbace661a43b354a059022eb31efb406859a5f7227109ebf0f278f20503",
+    "variant": "debug"
   },
   "cpython-3.12.1-linux-s390x-gnu": {
     "name": "cpython",
@@ -1221,7 +2284,21 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "60631211c701f8d2c56e5dd7b154e68868128a019b9db1d53a264f56c0d4aee2"
+    "sha256": "60631211c701f8d2c56e5dd7b154e68868128a019b9db1d53a264f56c0d4aee2",
+    "variant": null
+  },
+  "cpython-3.12.1+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "89ef67b617b8c9804965509b2d256f53439ceede83b5b64085315f038ad81e60",
+    "variant": "debug"
   },
   "cpython-3.12.1-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1233,7 +2310,21 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "74e330b8212ca22fd4d9a2003b9eec14892155566738febc8e5e572f267b9472"
+    "sha256": "74e330b8212ca22fd4d9a2003b9eec14892155566738febc8e5e572f267b9472",
+    "variant": null
+  },
+  "cpython-3.12.1+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0823ed21f7b79129677c51c6a73d3ca53a37179931a5a40a1d53b565d54679ec",
+    "variant": "debug"
   },
   "cpython-3.12.1-linux-x86_64-musl": {
     "name": "cpython",
@@ -1245,7 +2336,8 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "876389f071d62ee9a4bdd7ce31e69c3cdd256fe498e4dd6bb2b80e674e7351fe"
+    "sha256": "876389f071d62ee9a4bdd7ce31e69c3cdd256fe498e4dd6bb2b80e674e7351fe",
+    "variant": null
   },
   "cpython-3.12.1-windows-i686-none": {
     "name": "cpython",
@@ -1257,7 +2349,8 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "13c8a6f337a4e1ef043ffb8ea3c218ab2073afe0d3be36fcdf8ceb6f757210e8"
+    "sha256": "13c8a6f337a4e1ef043ffb8ea3c218ab2073afe0d3be36fcdf8ceb6f757210e8",
+    "variant": null
   },
   "cpython-3.12.1-windows-x86_64-none": {
     "name": "cpython",
@@ -1269,7 +2362,8 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "fd5a9e0f41959d0341246d3643f2b8794f638adc0cec8dd5e1b6465198eae08a"
+    "sha256": "fd5a9e0f41959d0341246d3643f2b8794f638adc0cec8dd5e1b6465198eae08a",
+    "variant": null
   },
   "cpython-3.12.0-darwin-aarch64-none": {
     "name": "cpython",
@@ -1281,7 +2375,8 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "4734a2be2becb813830112c780c9879ac3aff111a0b0cd590e65ec7465774d02"
+    "sha256": "4734a2be2becb813830112c780c9879ac3aff111a0b0cd590e65ec7465774d02",
+    "variant": null
   },
   "cpython-3.12.0-darwin-x86_64-none": {
     "name": "cpython",
@@ -1293,7 +2388,21 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "5a9e88c8aa52b609d556777b52ebde464ae4b4f77e4aac4eb693af57395c9abf"
+    "sha256": "5a9e88c8aa52b609d556777b52ebde464ae4b4f77e4aac4eb693af57395c9abf",
+    "variant": null
+  },
+  "cpython-3.12.0+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "eb05c976374a9a44596ce340ab35e5461014f30202c3cbe10edcbfbe5ac4a6a1",
+    "variant": "debug"
   },
   "cpython-3.12.0-linux-aarch64-gnu": {
     "name": "cpython",
@@ -1305,7 +2414,21 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "bccfe67cf5465a3dfb0336f053966e2613a9bc85a6588c2fcf1366ef930c4f88"
+    "sha256": "bccfe67cf5465a3dfb0336f053966e2613a9bc85a6588c2fcf1366ef930c4f88",
+    "variant": null
+  },
+  "cpython-3.12.0+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "800a89873e30e24bb1b6075f8cd718964537c5ba62bcdbefdcdae4de68ddccc4",
+    "variant": "debug"
   },
   "cpython-3.12.0-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1317,7 +2440,21 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "b5dae075467ace32c594c7877fe6ebe0837681f814601d5d90ba4c0dfd87a1f2"
+    "sha256": "b5dae075467ace32c594c7877fe6ebe0837681f814601d5d90ba4c0dfd87a1f2",
+    "variant": null
+  },
+  "cpython-3.12.0+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5b1a1effbb43df57ad014fcebf4b20089e504d89613e7b8db22d9ccb9fb00a6c",
+    "variant": "debug"
   },
   "cpython-3.12.0-linux-s390x-gnu": {
     "name": "cpython",
@@ -1329,7 +2466,21 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "5681621349dd85d9726d1b67c84a9686ce78f72e73a6f9e4cc4119911655759e"
+    "sha256": "5681621349dd85d9726d1b67c84a9686ce78f72e73a6f9e4cc4119911655759e",
+    "variant": null
+  },
+  "cpython-3.12.0+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a8c38cd2e53136c579632e2938d1b857f22e496c7dba99ad9a7ad6a67b43274a",
+    "variant": "debug"
   },
   "cpython-3.12.0-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1341,7 +2492,21 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "e51a5293f214053ddb4645b2c9f84542e2ef86870b8655704367bd4b29d39fe9"
+    "sha256": "e51a5293f214053ddb4645b2c9f84542e2ef86870b8655704367bd4b29d39fe9",
+    "variant": null
+  },
+  "cpython-3.12.0+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 12,
+    "patch": 0,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0b4380904d53f3322d3e5276de47bfa91a19289b7c734494c127ed0793017dde",
+    "variant": "debug"
   },
   "cpython-3.12.0-linux-x86_64-musl": {
     "name": "cpython",
@@ -1353,7 +2518,8 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "922f9404f39dc4edb8558a93cef5c3330895a4c87acb1de2a2cf662ab942dbe5"
+    "sha256": "922f9404f39dc4edb8558a93cef5c3330895a4c87acb1de2a2cf662ab942dbe5",
+    "variant": null
   },
   "cpython-3.12.0-windows-i686-none": {
     "name": "cpython",
@@ -1365,7 +2531,8 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "6e4f30a998245cfaef00d1b87f8fd5f6c250bd222f933f8f38f124d4f03227f9"
+    "sha256": "6e4f30a998245cfaef00d1b87f8fd5f6c250bd222f933f8f38f124d4f03227f9",
+    "variant": null
   },
   "cpython-3.12.0-windows-x86_64-none": {
     "name": "cpython",
@@ -1377,7 +2544,8 @@
     "patch": 0,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "facfaa1fbc8653f95057f3c4a0f8aa833dab0e0b316e24ee8686bc761d4b4f8d"
+    "sha256": "facfaa1fbc8653f95057f3c4a0f8aa833dab0e0b316e24ee8686bc761d4b4f8d",
+    "variant": null
   },
   "cpython-3.11.10-darwin-aarch64-none": {
     "name": "cpython",
@@ -1389,7 +2557,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "fd187c5c12813e27261768d37ad46f08bc182f346d6ca9f3f87b57442ef9ed56"
+    "sha256": "fd187c5c12813e27261768d37ad46f08bc182f346d6ca9f3f87b57442ef9ed56",
+    "variant": null
   },
   "cpython-3.11.10-darwin-x86_64-none": {
     "name": "cpython",
@@ -1401,7 +2570,21 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "ecd44a6309939d6d06db2b9b3a9b40361dc1e248b4956bd635671a1475ee3f17"
+    "sha256": "ecd44a6309939d6d06db2b9b3a9b40361dc1e248b4956bd635671a1475ee3f17",
+    "variant": null
+  },
+  "cpython-3.11.10+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "41baa3ab0cdfe1357406670f7c585b2129972526361b4ca09964ff81cfecb948",
+    "variant": "debug"
   },
   "cpython-3.11.10-linux-aarch64-gnu": {
     "name": "cpython",
@@ -1413,7 +2596,21 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "4cc6a85666586732a08f456616e234e3a49f0c85e28df4703064118a465b32be"
+    "sha256": "4cc6a85666586732a08f456616e234e3a49f0c85e28df4703064118a465b32be",
+    "variant": null
+  },
+  "cpython-3.11.10+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "2129e1284d77d26e7294f64cd7955d02c212f39df248e4dc10dd86bd754b6b03",
+    "variant": "debug"
   },
   "cpython-3.11.10-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -1425,7 +2622,21 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "83eadb32a80e4871066a0fbb2bad1b9642e5432225343d654aa0c7cbbf6e4c71"
+    "sha256": "83eadb32a80e4871066a0fbb2bad1b9642e5432225343d654aa0c7cbbf6e4c71",
+    "variant": null
+  },
+  "cpython-3.11.10+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "6021371a9dd85852601ac5783e9046b0f0cee3ad12efe79b72b1b8802daee0af",
+    "variant": "debug"
   },
   "cpython-3.11.10-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -1437,7 +2648,21 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "30b071a9dd9dc34a77a510907210f74ad40620a1209fd936a852d4a038a5ebea"
+    "sha256": "30b071a9dd9dc34a77a510907210f74ad40620a1209fd936a852d4a038a5ebea",
+    "variant": null
+  },
+  "cpython-3.11.10+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7de7c5509a98758499103241f7d593a0ac8f6a3f4b13080834ece368ff58f558",
+    "variant": "debug"
   },
   "cpython-3.11.10-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1449,7 +2674,21 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "03dd50143a9b95dbfc524e1e51e45205f2dc3d77bb75e51073f5645bd30f6263"
+    "sha256": "03dd50143a9b95dbfc524e1e51e45205f2dc3d77bb75e51073f5645bd30f6263",
+    "variant": null
+  },
+  "cpython-3.11.10+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "0ffe09e72efc396c1def29a9ed6971d418c50ff360656d978db4d5e00829a153",
+    "variant": "debug"
   },
   "cpython-3.11.10-linux-s390x-gnu": {
     "name": "cpython",
@@ -1461,7 +2700,21 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "f67968330a66c2d9e6313e400b27fe848b038be0b67380e8a28e1e982af9f9a8"
+    "sha256": "f67968330a66c2d9e6313e400b27fe848b038be0b67380e8a28e1e982af9f9a8",
+    "variant": null
+  },
+  "cpython-3.11.10+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e6cc163eefb376478a2fd53b2c182b28db59de735814ca8d9912b6d352702578",
+    "variant": "debug"
   },
   "cpython-3.11.10-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1473,7 +2726,21 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "d025f46c2ff20dd5ad8ff4628f65e691be73ca314b53b4145a691d9237601534"
+    "sha256": "d025f46c2ff20dd5ad8ff4628f65e691be73ca314b53b4145a691d9237601534",
+    "variant": null
+  },
+  "cpython-3.11.10+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "7205c2b03db2bb06b08e3e397334734d287729c8c7cce5b9be7a3c34c93a1a00",
+    "variant": "debug"
   },
   "cpython-3.11.10-linux-x86_64-musl": {
     "name": "cpython",
@@ -1485,7 +2752,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "1d7d18d74cb572181d8f6401a6d172a47c3d782116b947ab5c18258f9dce9e0a"
+    "sha256": "1d7d18d74cb572181d8f6401a6d172a47c3d782116b947ab5c18258f9dce9e0a",
+    "variant": null
   },
   "cpython-3.11.10-windows-i686-none": {
     "name": "cpython",
@@ -1497,7 +2765,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "13f259e764ec76f02c2dbbe118d78ce465b1692c824a7b3f28af132705491ee8"
+    "sha256": "13f259e764ec76f02c2dbbe118d78ce465b1692c824a7b3f28af132705491ee8",
+    "variant": null
   },
   "cpython-3.11.10-windows-x86_64-none": {
     "name": "cpython",
@@ -1509,7 +2778,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "7d591a66f9118ee7aa8a6ea990619bcc61aa737bd7a79cc47336d4be4addcd91"
+    "sha256": "7d591a66f9118ee7aa8a6ea990619bcc61aa737bd7a79cc47336d4be4addcd91",
+    "variant": null
   },
   "cpython-3.11.9-darwin-aarch64-none": {
     "name": "cpython",
@@ -1521,7 +2791,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "c4e2f7774421bcb381245945e132419b529399dfa4a56059acda1493751fa377"
+    "sha256": "c4e2f7774421bcb381245945e132419b529399dfa4a56059acda1493751fa377",
+    "variant": null
   },
   "cpython-3.11.9-darwin-x86_64-none": {
     "name": "cpython",
@@ -1533,7 +2804,21 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "c8680f90137e36b54b3631271ccdfe5de363e7d563d8df87c53e11b956a00e04"
+    "sha256": "c8680f90137e36b54b3631271ccdfe5de363e7d563d8df87c53e11b956a00e04",
+    "variant": null
+  },
+  "cpython-3.11.9+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "11f1f93ccdc399c3d029593ca147ba457500ce24c2cbd7df2040f44352c9039a",
+    "variant": "debug"
   },
   "cpython-3.11.9-linux-aarch64-gnu": {
     "name": "cpython",
@@ -1545,7 +2830,21 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "364cf099524fff92c31b8ff5ae3f7b32b0fa6cf1d380c6e37cf56140d08dfc87"
+    "sha256": "364cf099524fff92c31b8ff5ae3f7b32b0fa6cf1d380c6e37cf56140d08dfc87",
+    "variant": null
+  },
+  "cpython-3.11.9+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "2fe1c9df6e5ebd6ba6748207ca665e3087d35aa3ccacaa68fb7375e55c4d29e7",
+    "variant": "debug"
   },
   "cpython-3.11.9-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -1557,7 +2856,21 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "e64d3cf033c804e9c14aaf4ae746632c01894706098b20acbf00df4bd28d0b0e"
+    "sha256": "e64d3cf033c804e9c14aaf4ae746632c01894706098b20acbf00df4bd28d0b0e",
+    "variant": null
+  },
+  "cpython-3.11.9+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "e30eb0c9d50e7fe232e1f10391470136c7812a73401348dbdc60418cd0334fbe",
+    "variant": "debug"
   },
   "cpython-3.11.9-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -1569,7 +2882,21 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "7630838c7602e6a6a56c41263d6a808a2a2004a7ea38770ffc4c7aaf34e169ae"
+    "sha256": "7630838c7602e6a6a56c41263d6a808a2a2004a7ea38770ffc4c7aaf34e169ae",
+    "variant": null
+  },
+  "cpython-3.11.9+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2a7302fa80ff26db99d8afe3824aab961487ec9362729e15c1421bbdf9115f79",
+    "variant": "debug"
   },
   "cpython-3.11.9-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1581,7 +2908,21 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "2387479d17127e5b087f582bac948f859c25c4b38c64f558e0a399af7a8a0225"
+    "sha256": "2387479d17127e5b087f582bac948f859c25c4b38c64f558e0a399af7a8a0225",
+    "variant": null
+  },
+  "cpython-3.11.9+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "09161f37bed9742b6e94262e047a666acb7d43a5d4e679fc87d7d0a58c92ec70",
+    "variant": "debug"
   },
   "cpython-3.11.9-linux-s390x-gnu": {
     "name": "cpython",
@@ -1593,7 +2934,21 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "30c71053e9360471b7f350f1562ff4e42eb91ad2ca61b391295b5dea8b2b9efd"
+    "sha256": "30c71053e9360471b7f350f1562ff4e42eb91ad2ca61b391295b5dea8b2b9efd",
+    "variant": null
+  },
+  "cpython-3.11.9+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1fbae62bc303512d4024bb69cab26766a5a8d12386aa79ed03b5fd8f4c08c77b",
+    "variant": "debug"
   },
   "cpython-3.11.9-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1605,7 +2960,21 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "daa487c7e73005c4426ac393273117cf0e2dc4ab9b2eeda366e04cd00eea00c9"
+    "sha256": "daa487c7e73005c4426ac393273117cf0e2dc4ab9b2eeda366e04cd00eea00c9",
+    "variant": null
+  },
+  "cpython-3.11.9+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "dc4fd5dd161a0c09375457f29b2c03b1aa026702abbdaedb9db01d2ccc17650b",
+    "variant": "debug"
   },
   "cpython-3.11.9-linux-x86_64-musl": {
     "name": "cpython",
@@ -1617,7 +2986,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "b3e94cbf19bd08bf02f6e6945f6c2211453f601c7c6f79721da63a06bf99b1f9"
+    "sha256": "b3e94cbf19bd08bf02f6e6945f6c2211453f601c7c6f79721da63a06bf99b1f9",
+    "variant": null
   },
   "cpython-3.11.9-windows-i686-none": {
     "name": "cpython",
@@ -1629,7 +2999,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "091c99a210f4f401a305231f3f218ee3d5714658b8d3aac344d34efc716dff85"
+    "sha256": "091c99a210f4f401a305231f3f218ee3d5714658b8d3aac344d34efc716dff85",
+    "variant": null
   },
   "cpython-3.11.9-windows-x86_64-none": {
     "name": "cpython",
@@ -1641,7 +3012,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "8ac54a8d711ef0d49b62a2c3521c2d0403f1b221dc9d84c5f85fe48903e82523"
+    "sha256": "8ac54a8d711ef0d49b62a2c3521c2d0403f1b221dc9d84c5f85fe48903e82523",
+    "variant": null
   },
   "cpython-3.11.8-darwin-aarch64-none": {
     "name": "cpython",
@@ -1653,7 +3025,8 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "389a51139f5abe071a0d70091ca5df3e7a3dfcfcbe3e0ba6ad85fb4c5638421e"
+    "sha256": "389a51139f5abe071a0d70091ca5df3e7a3dfcfcbe3e0ba6ad85fb4c5638421e",
+    "variant": null
   },
   "cpython-3.11.8-darwin-x86_64-none": {
     "name": "cpython",
@@ -1665,7 +3038,21 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "097f467b0c36706bfec13f199a2eaf924e668f70c6e2bd1f1366806962f7e86e"
+    "sha256": "097f467b0c36706bfec13f199a2eaf924e668f70c6e2bd1f1366806962f7e86e",
+    "variant": null
+  },
+  "cpython-3.11.8+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "45bf082aca6b7d5e7261852720a72b92f5305e9fdb07b10f6588cb51d8f83ff2",
+    "variant": "debug"
   },
   "cpython-3.11.8-linux-aarch64-gnu": {
     "name": "cpython",
@@ -1677,7 +3064,21 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "389b9005fb78dd5a6f68df5ea45ab7b30d9a4b3222af96999e94fd20d4ad0c6a"
+    "sha256": "389b9005fb78dd5a6f68df5ea45ab7b30d9a4b3222af96999e94fd20d4ad0c6a",
+    "variant": null
+  },
+  "cpython-3.11.8+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a9716f2eebebe03de47d6d5d603d6ff78abf5eb38f88bf7607b17fd85e74ff16",
+    "variant": "debug"
   },
   "cpython-3.11.8-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1689,7 +3090,21 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "eb2b31f8e50309aae493c6a359c32b723a676f07c641f5e8fe4b6aa4dbb50946"
+    "sha256": "eb2b31f8e50309aae493c6a359c32b723a676f07c641f5e8fe4b6aa4dbb50946",
+    "variant": null
+  },
+  "cpython-3.11.8+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d495830b5980ed689bd7588aa556bac9c43ff766d8a8b32e7791b8ed664b04f3",
+    "variant": "debug"
   },
   "cpython-3.11.8-linux-s390x-gnu": {
     "name": "cpython",
@@ -1701,7 +3116,21 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "844f64f4c16e24965778281da61d1e0e6cd1358a581df1662da814b1eed096b9"
+    "sha256": "844f64f4c16e24965778281da61d1e0e6cd1358a581df1662da814b1eed096b9",
+    "variant": null
+  },
+  "cpython-3.11.8+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d959c43184878d564b5368ce4d753cf059600aafdf3e50280e850f94b5a4ba61",
+    "variant": "debug"
   },
   "cpython-3.11.8-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1713,7 +3142,21 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "94e13d0e5ad417035b80580f3e893a72e094b0900d5d64e7e34ab08e95439987"
+    "sha256": "94e13d0e5ad417035b80580f3e893a72e094b0900d5d64e7e34ab08e95439987",
+    "variant": null
+  },
+  "cpython-3.11.8+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "868adbcbef61c119d10f4da18ecab180423443aa64be0d6c79790df2ed1d12b7",
+    "variant": "debug"
   },
   "cpython-3.11.8-linux-x86_64-musl": {
     "name": "cpython",
@@ -1725,7 +3168,8 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "08e1ebf51b5965e23f8e68664d17274c1cdabb5b2d7509a2003920e5d58172c7"
+    "sha256": "08e1ebf51b5965e23f8e68664d17274c1cdabb5b2d7509a2003920e5d58172c7",
+    "variant": null
   },
   "cpython-3.11.8-windows-i686-none": {
     "name": "cpython",
@@ -1737,7 +3181,8 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "75039951f8f94d7304bc17b674af1668b9e1ea6d6c9ba1da28e90c0ad8030e3c"
+    "sha256": "75039951f8f94d7304bc17b674af1668b9e1ea6d6c9ba1da28e90c0ad8030e3c",
+    "variant": null
   },
   "cpython-3.11.8-windows-x86_64-none": {
     "name": "cpython",
@@ -1749,7 +3194,8 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "b618f1f047349770ee1ef11d1b05899840abd53884b820fd25c7dfe2ec1664d4"
+    "sha256": "b618f1f047349770ee1ef11d1b05899840abd53884b820fd25c7dfe2ec1664d4",
+    "variant": null
   },
   "cpython-3.11.7-darwin-aarch64-none": {
     "name": "cpython",
@@ -1761,7 +3207,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "b042c966920cf8465385ca3522986b12d745151a72c060991088977ca36d3883"
+    "sha256": "b042c966920cf8465385ca3522986b12d745151a72c060991088977ca36d3883",
+    "variant": null
   },
   "cpython-3.11.7-darwin-x86_64-none": {
     "name": "cpython",
@@ -1773,7 +3220,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "a0e615eef1fafdc742da0008425a9030b7ea68a4ae4e73ac557ef27b112836d4"
+    "sha256": "a0e615eef1fafdc742da0008425a9030b7ea68a4ae4e73ac557ef27b112836d4",
+    "variant": null
+  },
+  "cpython-3.11.7+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e3a375f8f16198ccf8dbede231536544265e5b4b6b0f0df97c5b29503c5864e2",
+    "variant": "debug"
   },
   "cpython-3.11.7-linux-aarch64-gnu": {
     "name": "cpython",
@@ -1785,7 +3246,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "b102eaf865eb715aa98a8a2ef19037b6cc3ae7dfd4a632802650f29de635aa13"
+    "sha256": "b102eaf865eb715aa98a8a2ef19037b6cc3ae7dfd4a632802650f29de635aa13",
+    "variant": null
+  },
+  "cpython-3.11.7+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "016ed6470c599ea5cc4dbb9c3f3fe86be059ad4e1b6cd2df10e40b7ec6970f16",
+    "variant": "debug"
   },
   "cpython-3.11.7-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1797,7 +3272,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "b44e1b74afe75c7b19143413632c4386708ae229117f8f950c2094e9681d34c7"
+    "sha256": "b44e1b74afe75c7b19143413632c4386708ae229117f8f950c2094e9681d34c7",
+    "variant": null
+  },
+  "cpython-3.11.7+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "91b33369025b7e0079f603cd2a99f9a5932daa8ded113d5090f29c075c993df7",
+    "variant": "debug"
   },
   "cpython-3.11.7-linux-s390x-gnu": {
     "name": "cpython",
@@ -1809,7 +3298,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "49520e3ff494708020f306e30b0964f079170be83e956be4504f850557378a22"
+    "sha256": "49520e3ff494708020f306e30b0964f079170be83e956be4504f850557378a22",
+    "variant": null
+  },
+  "cpython-3.11.7+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "01bca7a2f457d4bd2b367640d9337d12b31db73d670a16500b7a751194942103",
+    "variant": "debug"
   },
   "cpython-3.11.7-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1821,7 +3324,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "4a51ce60007a6facf64e5495f4cf322e311ba9f39a8cd3f3e4c026eae488e140"
+    "sha256": "4a51ce60007a6facf64e5495f4cf322e311ba9f39a8cd3f3e4c026eae488e140",
+    "variant": null
+  },
+  "cpython-3.11.7+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "766fd4a583fdfbe65e99b1e3caea843d0eeefde5675d73f3214a53c17a832320",
+    "variant": "debug"
   },
   "cpython-3.11.7-linux-x86_64-musl": {
     "name": "cpython",
@@ -1833,7 +3350,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "1a919a35172eb9419eba841eeb0ec9879dbc2b006b284ee5c454c08197b50f74"
+    "sha256": "1a919a35172eb9419eba841eeb0ec9879dbc2b006b284ee5c454c08197b50f74",
+    "variant": null
   },
   "cpython-3.11.7-windows-i686-none": {
     "name": "cpython",
@@ -1845,7 +3363,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "f5a6ca1280749d8ceaf8851585ef6b0cd2f1f76e801a77c1d744019554eef2f0"
+    "sha256": "f5a6ca1280749d8ceaf8851585ef6b0cd2f1f76e801a77c1d744019554eef2f0",
+    "variant": null
   },
   "cpython-3.11.7-windows-x86_64-none": {
     "name": "cpython",
@@ -1857,7 +3376,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "67077e6fa918e4f4fd60ba169820b00be7c390c497bf9bc9cab2c255ea8e6f3e"
+    "sha256": "67077e6fa918e4f4fd60ba169820b00be7c390c497bf9bc9cab2c255ea8e6f3e",
+    "variant": null
   },
   "cpython-3.11.6-darwin-aarch64-none": {
     "name": "cpython",
@@ -1869,7 +3389,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "916c35125b5d8323a21526d7a9154ca626453f63d0878e95b9f613a95006c990"
+    "sha256": "916c35125b5d8323a21526d7a9154ca626453f63d0878e95b9f613a95006c990",
+    "variant": null
   },
   "cpython-3.11.6-darwin-x86_64-none": {
     "name": "cpython",
@@ -1881,7 +3402,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371"
+    "sha256": "178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371",
+    "variant": null
+  },
+  "cpython-3.11.6+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d63d6eb065e60899b25853fe6bbd9f60ea6c3b12f4854adc75cb818bad55f4e9",
+    "variant": "debug"
   },
   "cpython-3.11.6-linux-aarch64-gnu": {
     "name": "cpython",
@@ -1893,7 +3428,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec"
+    "sha256": "3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec",
+    "variant": null
+  },
+  "cpython-3.11.6+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "71c34db1165860a6bf458d817aef00dea96146130bf5f8bd7ee39b12892ef463",
+    "variant": "debug"
   },
   "cpython-3.11.6-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -1905,7 +3454,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "7937035f690a624dba4d014ffd20c342e843dd46f89b0b0a1e5726b85deb8eaf"
+    "sha256": "7937035f690a624dba4d014ffd20c342e843dd46f89b0b0a1e5726b85deb8eaf",
+    "variant": null
+  },
+  "cpython-3.11.6+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "78252aa883fed18de7bb9b146450e42dd75d78c345f56c1301bb042317a1d4f7",
+    "variant": "debug"
   },
   "cpython-3.11.6-linux-s390x-gnu": {
     "name": "cpython",
@@ -1917,7 +3480,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "f9f19823dba3209cedc4647b00f46ed0177242917db20fb7fb539970e384531c"
+    "sha256": "f9f19823dba3209cedc4647b00f46ed0177242917db20fb7fb539970e384531c",
+    "variant": null
+  },
+  "cpython-3.11.6+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6e7889a15d861f1860ed84f3f5ea4586d198aa003b22556d91e180a44184dcd7",
+    "variant": "debug"
   },
   "cpython-3.11.6-linux-x86_64-gnu": {
     "name": "cpython",
@@ -1929,7 +3506,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8"
+    "sha256": "ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8",
+    "variant": null
+  },
+  "cpython-3.11.6+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "c2178b505ac315ede0a2659511841acd022bc7290ef65648e052bb1acebff59f",
+    "variant": "debug"
   },
   "cpython-3.11.6-linux-x86_64-musl": {
     "name": "cpython",
@@ -1941,7 +3532,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c929e5fe676ad20afcf6807a797d21261ae0827e84ec18742031a9582aed0d46"
+    "sha256": "c929e5fe676ad20afcf6807a797d21261ae0827e84ec18742031a9582aed0d46",
+    "variant": null
   },
   "cpython-3.11.6-windows-i686-none": {
     "name": "cpython",
@@ -1953,7 +3545,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "dd48b2cfaae841b4cd9beed23e2ae68b13527a065ef3d271d228735769c4e64d"
+    "sha256": "dd48b2cfaae841b4cd9beed23e2ae68b13527a065ef3d271d228735769c4e64d",
+    "variant": null
   },
   "cpython-3.11.6-windows-x86_64-none": {
     "name": "cpython",
@@ -1965,7 +3558,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "3933545e6d41462dd6a47e44133ea40995bc6efeed8c2e4cbdf1a699303e95ea"
+    "sha256": "3933545e6d41462dd6a47e44133ea40995bc6efeed8c2e4cbdf1a699303e95ea",
+    "variant": null
   },
   "cpython-3.11.5-darwin-aarch64-none": {
     "name": "cpython",
@@ -1977,7 +3571,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "dab64b3580118ad2073babd7c29fd2053b616479df5c107d31fe2af1f45e948b"
+    "sha256": "dab64b3580118ad2073babd7c29fd2053b616479df5c107d31fe2af1f45e948b",
+    "variant": null
   },
   "cpython-3.11.5-darwin-x86_64-none": {
     "name": "cpython",
@@ -1989,7 +3584,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "4a4efa7378c72f1dd8ebcce1afb99b24c01b07023aa6b8fea50eaedb50bf2bfc"
+    "sha256": "4a4efa7378c72f1dd8ebcce1afb99b24c01b07023aa6b8fea50eaedb50bf2bfc",
+    "variant": null
+  },
+  "cpython-3.11.5+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ac4b1e91d1cb7027595bfa4667090406331b291b2e346fb74e42b7031b216787",
+    "variant": "debug"
   },
   "cpython-3.11.5-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2001,7 +3610,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "bb5c5d1ea0f199fe2d3f0996fff4b48ca6ddc415a3dbd98f50bff7fce48aac80"
+    "sha256": "bb5c5d1ea0f199fe2d3f0996fff4b48ca6ddc415a3dbd98f50bff7fce48aac80",
+    "variant": null
+  },
+  "cpython-3.11.5+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "75d27b399b323c25d8250fda9857e388bf1b03ba1eb7925ec23cf12042a63a88",
+    "variant": "debug"
   },
   "cpython-3.11.5-linux-i686-gnu": {
     "name": "cpython",
@@ -2013,7 +3636,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "82de7e2551c015145c017742a5c0411d67a7544595df43c02b5efa4762d5123e"
+    "sha256": "82de7e2551c015145c017742a5c0411d67a7544595df43c02b5efa4762d5123e",
+    "variant": null
+  },
+  "cpython-3.11.5+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1aee6a613385a6355bed61a9b12259a5ed16e871b5bdfe5c9fe98b46ee2bb05e",
+    "variant": "debug"
   },
   "cpython-3.11.5-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2025,7 +3662,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "14121b53e9c8c6d0741f911ae00102a35adbcf5c3cdf732687ef7617b7d7304d"
+    "sha256": "14121b53e9c8c6d0741f911ae00102a35adbcf5c3cdf732687ef7617b7d7304d",
+    "variant": null
+  },
+  "cpython-3.11.5+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b0819032ec336d6e1d9e9bfdba546bf854a7b7248f8720a6d07da72c4ac927e5",
+    "variant": "debug"
   },
   "cpython-3.11.5-linux-s390x-gnu": {
     "name": "cpython",
@@ -2037,7 +3688,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "fe459da39874443579d6fe88c68777c6d3e331038e1fb92a0451879fb6beb16d"
+    "sha256": "fe459da39874443579d6fe88c68777c6d3e331038e1fb92a0451879fb6beb16d",
+    "variant": null
+  },
+  "cpython-3.11.5+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "93ee095b53de5a74af18e612f55095fcf3118c3c0a87eb6344d8eaca396bfb2d",
+    "variant": "debug"
   },
   "cpython-3.11.5-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2049,7 +3714,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "fbed6f7694b2faae5d7c401a856219c945397f772eea5ca50c6eb825cbc9d1e1"
+    "sha256": "fbed6f7694b2faae5d7c401a856219c945397f772eea5ca50c6eb825cbc9d1e1",
+    "variant": null
+  },
+  "cpython-3.11.5+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "96c77d4b1cbb47ac5eca384d21d689995c46e6a86d487acb73c9210eed3c5614",
+    "variant": "debug"
   },
   "cpython-3.11.5-linux-x86_64-musl": {
     "name": "cpython",
@@ -2061,7 +3740,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "fe09ecd87f69a724acf26ca508d7ead91a951abb2da18dfb98fe22c284454121"
+    "sha256": "fe09ecd87f69a724acf26ca508d7ead91a951abb2da18dfb98fe22c284454121",
+    "variant": null
   },
   "cpython-3.11.5-windows-i686-none": {
     "name": "cpython",
@@ -2073,7 +3753,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "936b624c2512a3a3370aae8adf603d6ae71ba8ebd39cc4714a13306891ea36f0"
+    "sha256": "936b624c2512a3a3370aae8adf603d6ae71ba8ebd39cc4714a13306891ea36f0",
+    "variant": null
   },
   "cpython-3.11.5-windows-x86_64-none": {
     "name": "cpython",
@@ -2085,7 +3766,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "00f002263efc8aea896bcfaaf906b1f4dab3e5cd3db53e2b69ab9a10ba220b97"
+    "sha256": "00f002263efc8aea896bcfaaf906b1f4dab3e5cd3db53e2b69ab9a10ba220b97",
+    "variant": null
   },
   "cpython-3.11.4-darwin-aarch64-none": {
     "name": "cpython",
@@ -2097,7 +3779,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "cb6d2948384a857321f2aa40fa67744cd9676a330f08b6dad7070bda0b6120a4"
+    "sha256": "cb6d2948384a857321f2aa40fa67744cd9676a330f08b6dad7070bda0b6120a4",
+    "variant": null
   },
   "cpython-3.11.4-darwin-x86_64-none": {
     "name": "cpython",
@@ -2109,7 +3792,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00"
+    "sha256": "47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00",
+    "variant": null
+  },
+  "cpython-3.11.4+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "37cf00439b57adf7ffef4a349d62dcf09739ba67b670e903b00b25f81fbb8a68",
+    "variant": "debug"
   },
   "cpython-3.11.4-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2121,7 +3818,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "2e84fc53f4e90e11963281c5c871f593abcb24fc796a50337fa516be99af02fb"
+    "sha256": "2e84fc53f4e90e11963281c5c871f593abcb24fc796a50337fa516be99af02fb",
+    "variant": null
+  },
+  "cpython-3.11.4+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a9051364b5c2e28205f8484cae03d16c86b45df5d117324e846d0f5e870fe9fb",
+    "variant": "debug"
   },
   "cpython-3.11.4-linux-i686-gnu": {
     "name": "cpython",
@@ -2133,7 +3844,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "abdccc6ec7093f49da99680f5899a96bff0b96fde8f5d73f7aac121e0d05fdd8"
+    "sha256": "abdccc6ec7093f49da99680f5899a96bff0b96fde8f5d73f7aac121e0d05fdd8",
+    "variant": null
+  },
+  "cpython-3.11.4+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b9f76fd226bfcbc6a8769934b17323ca3b563f1c24660582fcccfa6d0c7146af",
+    "variant": "debug"
   },
   "cpython-3.11.4-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2145,7 +3870,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "df7b92ed9cec96b3bb658fb586be947722ecd8e420fb23cee13d2e90abcfcf25"
+    "sha256": "df7b92ed9cec96b3bb658fb586be947722ecd8e420fb23cee13d2e90abcfcf25",
+    "variant": null
+  },
+  "cpython-3.11.4+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8ef6b5fa86b4abf51865b346b7cf8df36e474ed308869fc0ac3fe82de39194a4",
+    "variant": "debug"
   },
   "cpython-3.11.4-linux-s390x-gnu": {
     "name": "cpython",
@@ -2157,7 +3896,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "e477f0749161f9aa7887964f089d9460a539f6b4a8fdab5166f898210e1a87a4"
+    "sha256": "e477f0749161f9aa7887964f089d9460a539f6b4a8fdab5166f898210e1a87a4",
+    "variant": null
+  },
+  "cpython-3.11.4+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1b5fdeb2dc56c30843e7350f1684178755fae91666a0a987e5eb39074c42a052",
+    "variant": "debug"
   },
   "cpython-3.11.4-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2169,7 +3922,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "e26247302bc8e9083a43ce9e8dd94905b40d464745b1603041f7bc9a93c65d05"
+    "sha256": "e26247302bc8e9083a43ce9e8dd94905b40d464745b1603041f7bc9a93c65d05",
+    "variant": null
+  },
+  "cpython-3.11.4+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "d5467468ddee2b779096c5c4c0dcc74065d35fb38fea6c1c6630e7c2c904b1b9",
+    "variant": "debug"
   },
   "cpython-3.11.4-linux-x86_64-musl": {
     "name": "cpython",
@@ -2181,7 +3948,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "1218ca44595aeaf34271508db64a2abc581c3ee1eb307c1b0537ea746922b806"
+    "sha256": "1218ca44595aeaf34271508db64a2abc581c3ee1eb307c1b0537ea746922b806",
+    "variant": null
   },
   "cpython-3.11.4-windows-i686-none": {
     "name": "cpython",
@@ -2193,7 +3961,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "e2f4b41c3d89c5ec735e2563d752856cb3c19a0aa712ec7ef341712bafa7e905"
+    "sha256": "e2f4b41c3d89c5ec735e2563d752856cb3c19a0aa712ec7ef341712bafa7e905",
+    "variant": null
   },
   "cpython-3.11.4-windows-x86_64-none": {
     "name": "cpython",
@@ -2205,7 +3974,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "878614c03ea38538ae2f758e36c85d2c0eb1eaaca86cd400ff8c76693ee0b3e1"
+    "sha256": "878614c03ea38538ae2f758e36c85d2c0eb1eaaca86cd400ff8c76693ee0b3e1",
+    "variant": null
   },
   "cpython-3.11.3-darwin-aarch64-none": {
     "name": "cpython",
@@ -2217,7 +3987,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "09e412506a8d63edbb6901742b54da9aa7faf120b8dbdce56c57b303fc892c86"
+    "sha256": "09e412506a8d63edbb6901742b54da9aa7faf120b8dbdce56c57b303fc892c86",
+    "variant": null
   },
   "cpython-3.11.3-darwin-x86_64-none": {
     "name": "cpython",
@@ -2229,7 +4000,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "f710b8d60621308149c100d5175fec39274ed0b9c99645484fd93d1716ef4310"
+    "sha256": "f710b8d60621308149c100d5175fec39274ed0b9c99645484fd93d1716ef4310",
+    "variant": null
+  },
+  "cpython-3.11.3+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "991521082b0347878ba855c4986d77cc805c22ef75159bc95dd24bfd80275e27",
+    "variant": "debug"
   },
   "cpython-3.11.3-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2241,7 +4026,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "8190accbbbbcf7620f1ff6d668e4dd090c639665d11188ce864b62554d40e5ab"
+    "sha256": "8190accbbbbcf7620f1ff6d668e4dd090c639665d11188ce864b62554d40e5ab",
+    "variant": null
+  },
+  "cpython-3.11.3+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7bd694eb848328e96f524ded0f9b9eca6230d71fce3cd49b335a5c33450f3e04",
+    "variant": "debug"
   },
   "cpython-3.11.3-linux-i686-gnu": {
     "name": "cpython",
@@ -2253,7 +4052,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "36ff6c5ebca8bf07181b774874233eb37835a62b39493f975869acc5010d839d"
+    "sha256": "36ff6c5ebca8bf07181b774874233eb37835a62b39493f975869acc5010d839d",
+    "variant": null
+  },
+  "cpython-3.11.3+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "241d583be3ecc34d76fafa0d186cb504ce5625eb2c0e895dc4f4073a649e5c73",
+    "variant": "debug"
   },
   "cpython-3.11.3-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2265,7 +4078,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "767d24f3570b35fedb945f5ac66224c8983f2d556ab83c5cfaa5f3666e9c212c"
+    "sha256": "767d24f3570b35fedb945f5ac66224c8983f2d556ab83c5cfaa5f3666e9c212c",
+    "variant": null
+  },
+  "cpython-3.11.3+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "4f1192179e1f62e69b8b45f7f699e6f0100fb0b8a39aad7a48472794d0c24bd4",
+    "variant": "debug"
   },
   "cpython-3.11.3-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2277,7 +4104,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "da50b87d1ec42b3cb577dfd22a3655e43a53150f4f98a4bfb40757c9d7839ab5"
+    "sha256": "da50b87d1ec42b3cb577dfd22a3655e43a53150f4f98a4bfb40757c9d7839ab5",
+    "variant": null
+  },
+  "cpython-3.11.3+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "b753e060ccfb783b369f1e375ff6cc7a38d864a00506ec2e01ca01ba1956abc6",
+    "variant": "debug"
   },
   "cpython-3.11.3-linux-x86_64-musl": {
     "name": "cpython",
@@ -2289,7 +4130,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "82eed5ae1ca9e60ed9b9cac97e910927ffe2e80e91161c74b2d70e44d5227de0"
+    "sha256": "82eed5ae1ca9e60ed9b9cac97e910927ffe2e80e91161c74b2d70e44d5227de0",
+    "variant": null
   },
   "cpython-3.11.3-windows-i686-none": {
     "name": "cpython",
@@ -2301,7 +4143,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "a6751e6fa5c7c4d4748ed534a7f00ad7f858f62ce73d63d44dd907036ba53985"
+    "sha256": "a6751e6fa5c7c4d4748ed534a7f00ad7f858f62ce73d63d44dd907036ba53985",
+    "variant": null
   },
   "cpython-3.11.3-windows-x86_64-none": {
     "name": "cpython",
@@ -2313,7 +4156,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "24741066da6f35a7ff67bee65ce82eae870d84e1181843e64a7076d1571e95af"
+    "sha256": "24741066da6f35a7ff67bee65ce82eae870d84e1181843e64a7076d1571e95af",
+    "variant": null
   },
   "cpython-3.11.1-darwin-aarch64-none": {
     "name": "cpython",
@@ -2325,7 +4169,8 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "4918cdf1cab742a90f85318f88b8122aeaa2d04705803c7b6e78e81a3dd40f80"
+    "sha256": "4918cdf1cab742a90f85318f88b8122aeaa2d04705803c7b6e78e81a3dd40f80",
+    "variant": null
   },
   "cpython-3.11.1-darwin-x86_64-none": {
     "name": "cpython",
@@ -2337,7 +4182,21 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733"
+    "sha256": "20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733",
+    "variant": null
+  },
+  "cpython-3.11.1+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8fe27d850c02aa7bb34088fad5b48df90b4b841f40e1472243b8ab9da8776e40",
+    "variant": "debug"
   },
   "cpython-3.11.1-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2349,7 +4208,21 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "debf15783bdcb5530504f533d33fda75a7b905cec5361ae8f33da5ba6599f8b4"
+    "sha256": "debf15783bdcb5530504f533d33fda75a7b905cec5361ae8f33da5ba6599f8b4",
+    "variant": null
+  },
+  "cpython-3.11.1+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7986ebe82c07ecd2eb94fd1b3c9ebbb2366db2360e38f29ae0543e857551d0bf",
+    "variant": "debug"
   },
   "cpython-3.11.1-linux-i686-gnu": {
     "name": "cpython",
@@ -2361,7 +4234,21 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "8392230cf76c282cfeaf67dcbd2e0fac6da8cd3b3aead1250505c6ddd606caae"
+    "sha256": "8392230cf76c282cfeaf67dcbd2e0fac6da8cd3b3aead1250505c6ddd606caae",
+    "variant": null
+  },
+  "cpython-3.11.1+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b5bf700afc77588d853832d10b74ba793811cbec41b02ebc2c39a8b9987aacdd",
+    "variant": "debug"
   },
   "cpython-3.11.1-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2373,7 +4260,21 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "02a551fefab3750effd0e156c25446547c238688a32fabde2995c941c03a6423"
+    "sha256": "02a551fefab3750effd0e156c25446547c238688a32fabde2995c941c03a6423",
+    "variant": null
+  },
+  "cpython-3.11.1+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 11,
+    "patch": 1,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "7773aab3d1cbddbd0c6095c931fe841a2c511369e21744097276d22f4bc05621",
+    "variant": "debug"
   },
   "cpython-3.11.1-linux-x86_64-musl": {
     "name": "cpython",
@@ -2385,7 +4286,8 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "7f0425d3e9b2283aba205493e9fe431bc2c2d67cc369bc922825b827a1b06b82"
+    "sha256": "7f0425d3e9b2283aba205493e9fe431bc2c2d67cc369bc922825b827a1b06b82",
+    "variant": null
   },
   "cpython-3.11.1-windows-i686-none": {
     "name": "cpython",
@@ -2397,7 +4299,8 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "50b250dd261c3cca9ae8d96cb921e4ffbc64f778a198b6f8b8b0a338f77ae486"
+    "sha256": "50b250dd261c3cca9ae8d96cb921e4ffbc64f778a198b6f8b8b0a338f77ae486",
+    "variant": null
   },
   "cpython-3.11.1-windows-x86_64-none": {
     "name": "cpython",
@@ -2409,7 +4312,8 @@
     "patch": 1,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "edc08979cb0666a597466176511529c049a6f0bba8adf70df441708f766de5bf"
+    "sha256": "edc08979cb0666a597466176511529c049a6f0bba8adf70df441708f766de5bf",
+    "variant": null
   },
   "cpython-3.10.15-darwin-aarch64-none": {
     "name": "cpython",
@@ -2421,7 +4325,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "bcd994f136c4568763e2d642f4236c81e19ffc2a3536224598dc1ad0c3e16bf7"
+    "sha256": "bcd994f136c4568763e2d642f4236c81e19ffc2a3536224598dc1ad0c3e16bf7",
+    "variant": null
   },
   "cpython-3.10.15-darwin-x86_64-none": {
     "name": "cpython",
@@ -2433,7 +4338,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "c8cc9d58f4c71106472e9b9b2801b702e7939db1922dceabe5b33b5602b490e4"
+    "sha256": "c8cc9d58f4c71106472e9b9b2801b702e7939db1922dceabe5b33b5602b490e4",
+    "variant": null
+  },
+  "cpython-3.10.15+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "349db5d799a16c1ed69af1ce88cef761ca4674395b666b40cdbf5ac5fdfbc926",
+    "variant": "debug"
   },
   "cpython-3.10.15-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2445,7 +4364,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "4a354407285995b12dc67bd5e99c588699cc0c434fddc38c84a61909381a2e2f"
+    "sha256": "4a354407285995b12dc67bd5e99c588699cc0c434fddc38c84a61909381a2e2f",
+    "variant": null
+  },
+  "cpython-3.10.15+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "174b4253d89ec56476d24899ec5e2f3b8c26807fd6c40857ab676fafef760a75",
+    "variant": "debug"
   },
   "cpython-3.10.15-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -2457,7 +4390,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "c7d8880fdecf914dac880a0f5ba78678b24579ae58b531e92a163773a6426df9"
+    "sha256": "c7d8880fdecf914dac880a0f5ba78678b24579ae58b531e92a163773a6426df9",
+    "variant": null
+  },
+  "cpython-3.10.15+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "61d0efe32d26dc1f8bb448dc1d3479605f847326b3f6a9ddd5078033352c6307",
+    "variant": "debug"
   },
   "cpython-3.10.15-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -2469,7 +4416,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "b68ea12eb0c5941d6fd7158a709d951e87a5fdffc8f8d774bf9ba4498a1a2373"
+    "sha256": "b68ea12eb0c5941d6fd7158a709d951e87a5fdffc8f8d774bf9ba4498a1a2373",
+    "variant": null
+  },
+  "cpython-3.10.15+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2ce3dbdd77d2e715d7cf8026e7aab7147b7a18a0f352b64f7d70e2fc23deccde",
+    "variant": "debug"
   },
   "cpython-3.10.15-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2481,7 +4442,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "211427f42462475671c015ddcbff6d7138b48738faa7239abe4b37418a809fbb"
+    "sha256": "211427f42462475671c015ddcbff6d7138b48738faa7239abe4b37418a809fbb",
+    "variant": null
+  },
+  "cpython-3.10.15+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "47829f1dd7f6aa3164fa229c37a83338e5c9ad656d47d24cd4ca37a85bc5b229",
+    "variant": "debug"
   },
   "cpython-3.10.15-linux-s390x-gnu": {
     "name": "cpython",
@@ -2493,7 +4468,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "46479ecd894fb38def946fee4464a7639f63850afd7692350138910805984e9d"
+    "sha256": "46479ecd894fb38def946fee4464a7639f63850afd7692350138910805984e9d",
+    "variant": null
+  },
+  "cpython-3.10.15+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "81ec51925799a89f634609794d7ed2229127b562af6ca56dbaf8616b844e82b4",
+    "variant": "debug"
   },
   "cpython-3.10.15-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2505,7 +4494,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "bf234c7fa23dfcc70c7248c4a46ea58775b39005f107084e51afd439e67f2baf"
+    "sha256": "bf234c7fa23dfcc70c7248c4a46ea58775b39005f107084e51afd439e67f2baf",
+    "variant": null
+  },
+  "cpython-3.10.15+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "01fc843dbac291e16041fa9eaf9eea0374eb0d5b64a0dbd97b6b3491b176b7b8",
+    "variant": "debug"
   },
   "cpython-3.10.15-linux-x86_64-musl": {
     "name": "cpython",
@@ -2517,7 +4520,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "492f5e2d30aa70a1733911f4d3256c3bf2738e53e219f1b4740bf2d8736fdd03"
+    "sha256": "492f5e2d30aa70a1733911f4d3256c3bf2738e53e219f1b4740bf2d8736fdd03",
+    "variant": null
   },
   "cpython-3.10.15-windows-i686-none": {
     "name": "cpython",
@@ -2529,7 +4533,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "eff2d69f0f19cdb8bf00c2a45addee6d477c4bc20da67337f4115a8b90f92e12"
+    "sha256": "eff2d69f0f19cdb8bf00c2a45addee6d477c4bc20da67337f4115a8b90f92e12",
+    "variant": null
   },
   "cpython-3.10.15-windows-x86_64-none": {
     "name": "cpython",
@@ -2541,7 +4546,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "e5dbed3cd4e718081219fd039046779aa4ef808f725f7d19e60196fdf12d39ac"
+    "sha256": "e5dbed3cd4e718081219fd039046779aa4ef808f725f7d19e60196fdf12d39ac",
+    "variant": null
   },
   "cpython-3.10.14-darwin-aarch64-none": {
     "name": "cpython",
@@ -2553,7 +4559,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "f7ca9bffbce433c8d445edd33a5424c405553d735efee65a2fc5d8bbb1c8e137"
+    "sha256": "f7ca9bffbce433c8d445edd33a5424c405553d735efee65a2fc5d8bbb1c8e137",
+    "variant": null
   },
   "cpython-3.10.14-darwin-x86_64-none": {
     "name": "cpython",
@@ -2565,7 +4572,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "4404f44ec69c0708d4d88e98f39c2c1fe3bd462dc6a958b60aaf63028550c485"
+    "sha256": "4404f44ec69c0708d4d88e98f39c2c1fe3bd462dc6a958b60aaf63028550c485",
+    "variant": null
+  },
+  "cpython-3.10.14+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a5dad9640ce4af0091e347661effc6438573097cb85dabe6f7ae073266f5c261",
+    "variant": "debug"
   },
   "cpython-3.10.14-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2577,7 +4598,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "0ffe64c77cacda7e3afcb0d8ba271c59ca0a30dfda218da39a573b412bb4afd7"
+    "sha256": "0ffe64c77cacda7e3afcb0d8ba271c59ca0a30dfda218da39a573b412bb4afd7",
+    "variant": null
+  },
+  "cpython-3.10.14+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "c6a1c577f10bc6c938e7e64c8b2f60914f4193d8f602a3b89b398f4a06d674af",
+    "variant": "debug"
   },
   "cpython-3.10.14-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -2589,7 +4624,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "451449f18a49e6ceecf9c1f70f4aee0d1552eff103c3db291319125238182c9d"
+    "sha256": "451449f18a49e6ceecf9c1f70f4aee0d1552eff103c3db291319125238182c9d",
+    "variant": null
+  },
+  "cpython-3.10.14+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "10ed35c173a7e6c482d1dcace5be2a5a7a8c937ebd92169020e9f401456551f0",
+    "variant": "debug"
   },
   "cpython-3.10.14-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -2601,7 +4650,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "7f215b85df78c568847329faeb2c5007c301741d9c4ccebbd935a3a2963197b5"
+    "sha256": "7f215b85df78c568847329faeb2c5007c301741d9c4ccebbd935a3a2963197b5",
+    "variant": null
+  },
+  "cpython-3.10.14+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "85d3914679b7c0b5cc317ee4888e9d458a5afc985aae4d95c698d0fbf7a2b1c5",
+    "variant": "debug"
   },
   "cpython-3.10.14-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2613,7 +4676,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "8b83fdd95cb864f8ebfa1a1dd7e700bb046b8283bfd0a3aa04f1ff259eaff99e"
+    "sha256": "8b83fdd95cb864f8ebfa1a1dd7e700bb046b8283bfd0a3aa04f1ff259eaff99e",
+    "variant": null
+  },
+  "cpython-3.10.14+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9134680d4c4488a23c876188f066804625e64041ee9bd0e4e57a2d519f575eae",
+    "variant": "debug"
   },
   "cpython-3.10.14-linux-s390x-gnu": {
     "name": "cpython",
@@ -2625,7 +4702,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "ff1c4f010b1c6f563c71fa30f68293168536e0ed65f7d470a7e8c73252d08653"
+    "sha256": "ff1c4f010b1c6f563c71fa30f68293168536e0ed65f7d470a7e8c73252d08653",
+    "variant": null
+  },
+  "cpython-3.10.14+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "060bcd01e5ba9cbd3f5b8da98c16480320b19fa9f67cf9ecf94a0c20ba08db6e",
+    "variant": "debug"
   },
   "cpython-3.10.14-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2637,7 +4728,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "159c456bb4a3802bafbce065ff54b99ddb16422500d75c1315573ee3b673af17"
+    "sha256": "159c456bb4a3802bafbce065ff54b99ddb16422500d75c1315573ee3b673af17",
+    "variant": null
+  },
+  "cpython-3.10.14+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "cd33d23d8fb79ca99db1398a555daad44af4122d01fb4065fd79e121929c5cb3",
+    "variant": "debug"
   },
   "cpython-3.10.14-linux-x86_64-musl": {
     "name": "cpython",
@@ -2649,7 +4754,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "8803a748f2197ec2360af6feebe9c936f4f6beabcae1db5557fdd98fc922982c"
+    "sha256": "8803a748f2197ec2360af6feebe9c936f4f6beabcae1db5557fdd98fc922982c",
+    "variant": null
   },
   "cpython-3.10.14-windows-i686-none": {
     "name": "cpython",
@@ -2661,7 +4767,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "a84742f13584fd39f4f4b0d9a5865621a3c88cad91b31f17f414186719063364"
+    "sha256": "a84742f13584fd39f4f4b0d9a5865621a3c88cad91b31f17f414186719063364",
+    "variant": null
   },
   "cpython-3.10.14-windows-x86_64-none": {
     "name": "cpython",
@@ -2673,7 +4780,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "61ad1abcaca639eecb5bd0b129ac0315d79f7b90cf0aca8e9fb85c9e7269c26b"
+    "sha256": "61ad1abcaca639eecb5bd0b129ac0315d79f7b90cf0aca8e9fb85c9e7269c26b",
+    "variant": null
   },
   "cpython-3.10.13-darwin-aarch64-none": {
     "name": "cpython",
@@ -2685,7 +4793,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "5fdc0f6a5b5a90fd3c528e8b1da8e3aac931ea8690126c2fdb4254c84a3ff04a"
+    "sha256": "5fdc0f6a5b5a90fd3c528e8b1da8e3aac931ea8690126c2fdb4254c84a3ff04a",
+    "variant": null
   },
   "cpython-3.10.13-darwin-x86_64-none": {
     "name": "cpython",
@@ -2697,7 +4806,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a"
+    "sha256": "6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a",
+    "variant": null
+  },
+  "cpython-3.10.13+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "06a53040504e1e2fdcb32dc0d61b123bea76725b5c14031c8f64e28f52ae5a5f",
+    "variant": "debug"
   },
   "cpython-3.10.13-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2709,7 +4832,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "a898a88705611b372297bb8fe4d23cc16b8603ce5f24494c3a8cfa65d83787f9"
+    "sha256": "a898a88705611b372297bb8fe4d23cc16b8603ce5f24494c3a8cfa65d83787f9",
+    "variant": null
+  },
+  "cpython-3.10.13+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "08a3a1ff61b7ed2c87db7a9f88630781d98fabc2efb499f38ae0ead05973eb56",
+    "variant": "debug"
   },
   "cpython-3.10.13-linux-i686-gnu": {
     "name": "cpython",
@@ -2721,7 +4858,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "424d239b6df60e40849ad18505de394001233ab3d7470b5280fec6e643208bb9"
+    "sha256": "424d239b6df60e40849ad18505de394001233ab3d7470b5280fec6e643208bb9",
+    "variant": null
+  },
+  "cpython-3.10.13+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "cab4c8756445d1d1987c7c94d3bcf323684e44fb9070329d8287d4c38e155711",
+    "variant": "debug"
   },
   "cpython-3.10.13-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2733,7 +4884,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "c23706e138a0351fc1e9def2974af7b8206bac7ecbbb98a78f5aa9e7535fee42"
+    "sha256": "c23706e138a0351fc1e9def2974af7b8206bac7ecbbb98a78f5aa9e7535fee42",
+    "variant": null
+  },
+  "cpython-3.10.13+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fe46914541126297c7a8636845c2e7188868eaa617bb6e293871fca4a5cb63f7",
+    "variant": "debug"
   },
   "cpython-3.10.13-linux-s390x-gnu": {
     "name": "cpython",
@@ -2745,7 +4910,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "09be8fb2cdfbb4a93d555f268f244dbe4d8ff1854b2658e8043aa4ec08aede3e"
+    "sha256": "09be8fb2cdfbb4a93d555f268f244dbe4d8ff1854b2658e8043aa4ec08aede3e",
+    "variant": null
+  },
+  "cpython-3.10.13+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "41b20e9d87f57d27f608685b714a57eea81c9e079aa647d59837ec6659536626",
+    "variant": "debug"
   },
   "cpython-3.10.13-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2757,7 +4936,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "d995d032ca702afd2fc3a689c1f84a6c64972ecd82bba76a61d525f08eb0e195"
+    "sha256": "d995d032ca702afd2fc3a689c1f84a6c64972ecd82bba76a61d525f08eb0e195",
+    "variant": null
+  },
+  "cpython-3.10.13+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "3eec53aef154273c0bc30bb9905734762171f474f73ba256c8883022915b7439",
+    "variant": "debug"
   },
   "cpython-3.10.13-linux-x86_64-musl": {
     "name": "cpython",
@@ -2769,7 +4962,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "48365ea10aa1b0768a153bfff50d1515a757d42409b02a4af4db354803f2d180"
+    "sha256": "48365ea10aa1b0768a153bfff50d1515a757d42409b02a4af4db354803f2d180",
+    "variant": null
   },
   "cpython-3.10.13-windows-i686-none": {
     "name": "cpython",
@@ -2781,7 +4975,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "5365b90f9cba7186d12dd86516ece8b696db7311128e0b49c92234e01a74599f"
+    "sha256": "5365b90f9cba7186d12dd86516ece8b696db7311128e0b49c92234e01a74599f",
+    "variant": null
   },
   "cpython-3.10.13-windows-x86_64-none": {
     "name": "cpython",
@@ -2793,7 +4988,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "086f7fe9156b897bb401273db8359017104168ac36f60f3af4e31ac7acd6634e"
+    "sha256": "086f7fe9156b897bb401273db8359017104168ac36f60f3af4e31ac7acd6634e",
+    "variant": null
   },
   "cpython-3.10.12-darwin-aarch64-none": {
     "name": "cpython",
@@ -2805,7 +5001,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "bc66c706ea8c5fc891635fda8f9da971a1a901d41342f6798c20ad0b2a25d1d6"
+    "sha256": "bc66c706ea8c5fc891635fda8f9da971a1a901d41342f6798c20ad0b2a25d1d6",
+    "variant": null
   },
   "cpython-3.10.12-darwin-x86_64-none": {
     "name": "cpython",
@@ -2817,7 +5014,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "8a6e3ed973a671de468d9c691ed9cb2c3a4858c5defffcf0b08969fba9c1dd04"
+    "sha256": "8a6e3ed973a671de468d9c691ed9cb2c3a4858c5defffcf0b08969fba9c1dd04",
+    "variant": null
+  },
+  "cpython-3.10.12+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e30f2b4fd9bd79b9122e2975f3c17c9ddd727f8326b2e246378e81f7ecc7d74f",
+    "variant": "debug"
   },
   "cpython-3.10.12-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2829,7 +5040,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "fee80e221663eca5174bd794cb5047e40d3910dbeadcdf1f09d405a4c1c15fe4"
+    "sha256": "fee80e221663eca5174bd794cb5047e40d3910dbeadcdf1f09d405a4c1c15fe4",
+    "variant": null
+  },
+  "cpython-3.10.12+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "89c83fcdfd41c67e2dd2a037982556c657dc55fc1938c6f6cdcd5ffa614c1fb3",
+    "variant": "debug"
   },
   "cpython-3.10.12-linux-i686-gnu": {
     "name": "cpython",
@@ -2841,7 +5066,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "c7a5321a696ef6467791312368a04d36828907a8f5c557b96067fa534c716c18"
+    "sha256": "c7a5321a696ef6467791312368a04d36828907a8f5c557b96067fa534c716c18",
+    "variant": null
+  },
+  "cpython-3.10.12+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c318050fa91d84d447f5c8a5887a44f1cc8dd34d4c1d357cd755407d46ed1b21",
+    "variant": "debug"
   },
   "cpython-3.10.12-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2853,7 +5092,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "bb5e8cb0d2e44241725fa9b342238245503e7849917660006b0246a9c97b1d6c"
+    "sha256": "bb5e8cb0d2e44241725fa9b342238245503e7849917660006b0246a9c97b1d6c",
+    "variant": null
+  },
+  "cpython-3.10.12+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "756579b52acb9b13b162ac901e56ff311def443e69d7f7259a91198b76a30ecb",
+    "variant": "debug"
   },
   "cpython-3.10.12-linux-s390x-gnu": {
     "name": "cpython",
@@ -2865,7 +5118,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "8d33d435ae6fb93ded7fc26798cc0a1a4f546a4e527012a1e2909cc314b332df"
+    "sha256": "8d33d435ae6fb93ded7fc26798cc0a1a4f546a4e527012a1e2909cc314b332df",
+    "variant": null
+  },
+  "cpython-3.10.12+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "fb7354fcee7b17dd0793ebd3f6f1fc8b7b205332afcf8d700cc1119f2dc33ff7",
+    "variant": "debug"
   },
   "cpython-3.10.12-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2877,7 +5144,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "a476dbca9184df9fc69fe6309cda5ebaf031d27ca9e529852437c94ec1bc43d3"
+    "sha256": "a476dbca9184df9fc69fe6309cda5ebaf031d27ca9e529852437c94ec1bc43d3",
+    "variant": null
+  },
+  "cpython-3.10.12+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "ebff76754ae37694581afe80749efb1260a6da95a9d88f8e60aa2cab75fd5497",
+    "variant": "debug"
   },
   "cpython-3.10.12-linux-x86_64-musl": {
     "name": "cpython",
@@ -2889,7 +5170,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "9080014bee2d4bd1f96bcbebf447d40c35ae9354382246add1160bd0d433ebf7"
+    "sha256": "9080014bee2d4bd1f96bcbebf447d40c35ae9354382246add1160bd0d433ebf7",
+    "variant": null
   },
   "cpython-3.10.12-windows-i686-none": {
     "name": "cpython",
@@ -2901,7 +5183,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "a5a5f9c9082b6503462a6b134111d3c303052cbc49ff31fff2ade38b39978e5d"
+    "sha256": "a5a5f9c9082b6503462a6b134111d3c303052cbc49ff31fff2ade38b39978e5d",
+    "variant": null
   },
   "cpython-3.10.12-windows-x86_64-none": {
     "name": "cpython",
@@ -2913,7 +5196,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "c1a31c353ca44de7d1b1a3b6c55a823e9c1eed0423d4f9f66e617bdb1b608685"
+    "sha256": "c1a31c353ca44de7d1b1a3b6c55a823e9c1eed0423d4f9f66e617bdb1b608685",
+    "variant": null
   },
   "cpython-3.10.11-darwin-aarch64-none": {
     "name": "cpython",
@@ -2925,7 +5209,8 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "8348bc3c2311f94ec63751fb71bd0108174be1c4def002773cf519ee1506f96f"
+    "sha256": "8348bc3c2311f94ec63751fb71bd0108174be1c4def002773cf519ee1506f96f",
+    "variant": null
   },
   "cpython-3.10.11-darwin-x86_64-none": {
     "name": "cpython",
@@ -2937,7 +5222,21 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "bd3fc6e4da6f4033ebf19d66704e73b0804c22641ddae10bbe347c48f82374ad"
+    "sha256": "bd3fc6e4da6f4033ebf19d66704e73b0804c22641ddae10bbe347c48f82374ad",
+    "variant": null
+  },
+  "cpython-3.10.11+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a5271cc014f2ce2ab54a0789556c15b84668e2afcc530512818c4b87c6a94483",
+    "variant": "debug"
   },
   "cpython-3.10.11-linux-aarch64-gnu": {
     "name": "cpython",
@@ -2949,7 +5248,21 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "c7573fdb00239f86b22ea0e8e926ca881d24fde5e5890851339911d76110bc35"
+    "sha256": "c7573fdb00239f86b22ea0e8e926ca881d24fde5e5890851339911d76110bc35",
+    "variant": null
+  },
+  "cpython-3.10.11+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9304d6eeef48bd246a2959ebc76b20dbb2c6a81aa1d214f4471cb273c11717f2",
+    "variant": "debug"
   },
   "cpython-3.10.11-linux-i686-gnu": {
     "name": "cpython",
@@ -2961,7 +5274,21 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "c70518620e32b074b1b40579012f0c67191a967e43e84b8f46052b6b893f7eeb"
+    "sha256": "c70518620e32b074b1b40579012f0c67191a967e43e84b8f46052b6b893f7eeb",
+    "variant": null
+  },
+  "cpython-3.10.11+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ac32e3788109ff0cc536a6108072d9203217df744cf56d3a4ab0b19857d8e244",
+    "variant": "debug"
   },
   "cpython-3.10.11-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -2973,7 +5300,21 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "73a9d4c89ed51be39dd2de4e235078281087283e9fdedef65bec02f503e906ee"
+    "sha256": "73a9d4c89ed51be39dd2de4e235078281087283e9fdedef65bec02f503e906ee",
+    "variant": null
+  },
+  "cpython-3.10.11+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "544e5020f71ad1525dbc92b08e429cc1e1e11866c48c07d91e99f531b9ba68b0",
+    "variant": "debug"
   },
   "cpython-3.10.11-linux-x86_64-gnu": {
     "name": "cpython",
@@ -2985,7 +5326,21 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "c5bcaac91bc80bfc29cf510669ecad12d506035ecb3ad85ef213416d54aecd79"
+    "sha256": "c5bcaac91bc80bfc29cf510669ecad12d506035ecb3ad85ef213416d54aecd79",
+    "variant": null
+  },
+  "cpython-3.10.11+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "0d5bd092b85ada04f6f27a5ef30e026ec2df8ddc73f89d7d1d397623405011c1",
+    "variant": "debug"
   },
   "cpython-3.10.11-linux-x86_64-musl": {
     "name": "cpython",
@@ -2997,7 +5352,8 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c5dde3276541a8ad000ba631ec70012aa2261926c13f54d2b1de83dad61d59c1"
+    "sha256": "c5dde3276541a8ad000ba631ec70012aa2261926c13f54d2b1de83dad61d59c1",
+    "variant": null
   },
   "cpython-3.10.11-windows-i686-none": {
     "name": "cpython",
@@ -3009,7 +5365,8 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "e4ed3414cd0e687017f0a56fed88ff39b3f5dfb24a0d62e9c7ca55854178bcde"
+    "sha256": "e4ed3414cd0e687017f0a56fed88ff39b3f5dfb24a0d62e9c7ca55854178bcde",
+    "variant": null
   },
   "cpython-3.10.11-windows-x86_64-none": {
     "name": "cpython",
@@ -3021,7 +5378,8 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "9c2d3604a06fcd422289df73015cd00e7271d90de28d2c910f0e2309a7f73a68"
+    "sha256": "9c2d3604a06fcd422289df73015cd00e7271d90de28d2c910f0e2309a7f73a68",
+    "variant": null
   },
   "cpython-3.10.9-darwin-aarch64-none": {
     "name": "cpython",
@@ -3033,7 +5391,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "018d05a779b2de7a476f3b3ff2d10f503d69d14efcedd0774e6dab8c22ef84ff"
+    "sha256": "018d05a779b2de7a476f3b3ff2d10f503d69d14efcedd0774e6dab8c22ef84ff",
+    "variant": null
   },
   "cpython-3.10.9-darwin-x86_64-none": {
     "name": "cpython",
@@ -3045,7 +5404,21 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "0e685f98dce0e5bc8da93c7081f4e6c10219792e223e4b5886730fd73a7ba4c6"
+    "sha256": "0e685f98dce0e5bc8da93c7081f4e6c10219792e223e4b5886730fd73a7ba4c6",
+    "variant": null
+  },
+  "cpython-3.10.9+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2c0996dd1fe35314e06e042081b24fb53f3b7b361c3e1b94a6ed659c275ca069",
+    "variant": "debug"
   },
   "cpython-3.10.9-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3057,7 +5430,21 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "2003750f40cd09d4bf7a850342613992f8d9454f03b3c067989911fb37e7a4d1"
+    "sha256": "2003750f40cd09d4bf7a850342613992f8d9454f03b3c067989911fb37e7a4d1",
+    "variant": null
+  },
+  "cpython-3.10.9+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f8c3a63620f412c4a9ccfb6e2435a96a55775550c81a452d164caa6d03a6a1da",
+    "variant": "debug"
   },
   "cpython-3.10.9-linux-i686-gnu": {
     "name": "cpython",
@@ -3069,7 +5456,21 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "44566c08eb8054aa0784f76b85d2c6c70a62f4988d5e9abcce819b517b329fdd"
+    "sha256": "44566c08eb8054aa0784f76b85d2c6c70a62f4988d5e9abcce819b517b329fdd",
+    "variant": null
+  },
+  "cpython-3.10.9+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a90a45ba7afcbd1df9aef96a614acbb210607299ac74dadbb6bd66af22be34db",
+    "variant": "debug"
   },
   "cpython-3.10.9-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3081,7 +5482,21 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "d196347aeb701a53fe2bb2b095abec38d27d0fa0443f8a1c2023a1bed6e18cdf"
+    "sha256": "d196347aeb701a53fe2bb2b095abec38d27d0fa0443f8a1c2023a1bed6e18cdf",
+    "variant": null
+  },
+  "cpython-3.10.9+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 9,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "7e0a0094b580d285163ede7797945e86bd4905d6af3340e6554e6abba7bcb832",
+    "variant": "debug"
   },
   "cpython-3.10.9-linux-x86_64-musl": {
     "name": "cpython",
@@ -3093,7 +5508,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "cf17e6d042777170e423c6b80e096ad8273d9848708875db0d23dd45bdb3d516"
+    "sha256": "cf17e6d042777170e423c6b80e096ad8273d9848708875db0d23dd45bdb3d516",
+    "variant": null
   },
   "cpython-3.10.9-windows-i686-none": {
     "name": "cpython",
@@ -3105,7 +5521,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "c5c51d9a3e8d8cdac67d8f3ad7c4008de169ff1480e17021f154d5c99fcee9e3"
+    "sha256": "c5c51d9a3e8d8cdac67d8f3ad7c4008de169ff1480e17021f154d5c99fcee9e3",
+    "variant": null
   },
   "cpython-3.10.9-windows-x86_64-none": {
     "name": "cpython",
@@ -3117,7 +5534,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "59c6970cecb357dc1d8554bd0540eb81ee7f6d16a07acf3d14ed294ece02c035"
+    "sha256": "59c6970cecb357dc1d8554bd0540eb81ee7f6d16a07acf3d14ed294ece02c035",
+    "variant": null
   },
   "cpython-3.10.8-darwin-aarch64-none": {
     "name": "cpython",
@@ -3129,7 +5547,8 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "d52b03817bd245d28e0a8b2f715716cd0fcd112820ccff745636932c76afa20a"
+    "sha256": "d52b03817bd245d28e0a8b2f715716cd0fcd112820ccff745636932c76afa20a",
+    "variant": null
   },
   "cpython-3.10.8-darwin-x86_64-none": {
     "name": "cpython",
@@ -3141,7 +5560,21 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "525b79c7ce5de90ab66bd07b0ac1008bafa147ddc8a41bef15ffb7c9c1e9e7c5"
+    "sha256": "525b79c7ce5de90ab66bd07b0ac1008bafa147ddc8a41bef15ffb7c9c1e9e7c5",
+    "variant": null
+  },
+  "cpython-3.10.8+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "879e76260be226512693e37a28cc3a6670b5ee270a4440e4b04a7b415dba451c",
+    "variant": "debug"
   },
   "cpython-3.10.8-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3153,7 +5586,21 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "33170bef18c811906b738be530f934640491b065bf16c4d276c6515321918132"
+    "sha256": "33170bef18c811906b738be530f934640491b065bf16c4d276c6515321918132",
+    "variant": null
+  },
+  "cpython-3.10.8+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ab434eccffeec4f6f51af017e4eed69d4f1ea55f48c5b89b8a8779df3fa799df",
+    "variant": "debug"
   },
   "cpython-3.10.8-linux-i686-gnu": {
     "name": "cpython",
@@ -3165,7 +5612,21 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "2deee7cbbd5dad339d713a75ec92239725d2035e833af5b9981b026dee0b9213"
+    "sha256": "2deee7cbbd5dad339d713a75ec92239725d2035e833af5b9981b026dee0b9213",
+    "variant": null
+  },
+  "cpython-3.10.8+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c86182951a82e761588476a0155afe99ae4ae1030e4a8e1e8bcb8e1d42f6327c",
+    "variant": "debug"
   },
   "cpython-3.10.8-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3177,7 +5638,21 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "6c8db44ae0e18e320320bbaaafd2d69cde8bfea171ae2d651b7993d1396260b7"
+    "sha256": "6c8db44ae0e18e320320bbaaafd2d69cde8bfea171ae2d651b7993d1396260b7",
+    "variant": null
+  },
+  "cpython-3.10.8+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 8,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "935eb97e0c3ef358a2f25e78b0b56aebad68d371e3b63979a157c7588a03585b",
+    "variant": "debug"
   },
   "cpython-3.10.8-linux-x86_64-musl": {
     "name": "cpython",
@@ -3189,7 +5664,8 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "9f035bbe53f55fb406f95cb68459ba245b386084eeb5760f1660f416b730328d"
+    "sha256": "9f035bbe53f55fb406f95cb68459ba245b386084eeb5760f1660f416b730328d",
+    "variant": null
   },
   "cpython-3.10.8-windows-i686-none": {
     "name": "cpython",
@@ -3201,7 +5677,8 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "94e76273166f72624128e52b5402db244cea041dab4a6bcdc70b304b66e27e95"
+    "sha256": "94e76273166f72624128e52b5402db244cea041dab4a6bcdc70b304b66e27e95",
+    "variant": null
   },
   "cpython-3.10.8-windows-x86_64-none": {
     "name": "cpython",
@@ -3213,7 +5690,8 @@
     "patch": 8,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "f2b6d2f77118f06dd2ca04dae1175e44aaa5077a5ed8ddc63333c15347182bfe"
+    "sha256": "f2b6d2f77118f06dd2ca04dae1175e44aaa5077a5ed8ddc63333c15347182bfe",
+    "variant": null
   },
   "cpython-3.10.7-darwin-aarch64-none": {
     "name": "cpython",
@@ -3225,7 +5703,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "70f6ca1da8e6fce832ad0b7f9fdaba0b84ba0ac0a4c626127acb6d49df4b8f91"
+    "sha256": "70f6ca1da8e6fce832ad0b7f9fdaba0b84ba0ac0a4c626127acb6d49df4b8f91",
+    "variant": null
   },
   "cpython-3.10.7-darwin-x86_64-none": {
     "name": "cpython",
@@ -3237,7 +5716,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "6101f580434544d28d5590543029a7c6bdf07efa4bcdb5e4cbedb3cd83241922"
+    "sha256": "6101f580434544d28d5590543029a7c6bdf07efa4bcdb5e4cbedb3cd83241922",
+    "variant": null
+  },
+  "cpython-3.10.7+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9f346729b523e860194635eb67c9f6bc8f12728ba7ddfe4fd80f2e6d685781e3",
+    "variant": "debug"
   },
   "cpython-3.10.7-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3249,7 +5742,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "dfeec186a62a6068259d90e8d77e7d30eaf9c2b4ae7b205ff8caab7cb21f277c"
+    "sha256": "dfeec186a62a6068259d90e8d77e7d30eaf9c2b4ae7b205ff8caab7cb21f277c",
+    "variant": null
+  },
+  "cpython-3.10.7+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a79816c50abeb2752530f68b4d7d95b6f48392f44a9a7f135b91807d76872972",
+    "variant": "debug"
   },
   "cpython-3.10.7-linux-i686-gnu": {
     "name": "cpython",
@@ -3261,7 +5768,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "4a611ce990dc1f32bc4b35d276f04521464127f77e1133ac5bb9c6ba23e94a82"
+    "sha256": "4a611ce990dc1f32bc4b35d276f04521464127f77e1133ac5bb9c6ba23e94a82",
+    "variant": null
+  },
+  "cpython-3.10.7+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ce3fe27e6ca3a0e75a7f4f3b6568cd1bf967230a67e73393e94a23380dddaf10",
+    "variant": "debug"
   },
   "cpython-3.10.7-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3273,7 +5794,21 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "c12c9ad2b2c75464541d897c0528013adecd8be5b30acf4411f7759729841711"
+    "sha256": "c12c9ad2b2c75464541d897c0528013adecd8be5b30acf4411f7759729841711",
+    "variant": null
+  },
+  "cpython-3.10.7+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 7,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "08f725cdb4d4f6bd76c582b798f7d7685c8f5c5afa03e1553e28e55a3859014e",
+    "variant": "debug"
   },
   "cpython-3.10.7-linux-x86_64-musl": {
     "name": "cpython",
@@ -3285,7 +5820,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "3e0cab6e49ad5ef95851049463797ec713eee6e1f2fa1d99e30516d37797c3f0"
+    "sha256": "3e0cab6e49ad5ef95851049463797ec713eee6e1f2fa1d99e30516d37797c3f0",
+    "variant": null
   },
   "cpython-3.10.7-windows-i686-none": {
     "name": "cpython",
@@ -3297,7 +5833,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "384e711dd657c3439be4e50b2485478a7ed7a259a741d4480fc96d82cc09d318"
+    "sha256": "384e711dd657c3439be4e50b2485478a7ed7a259a741d4480fc96d82cc09d318",
+    "variant": null
   },
   "cpython-3.10.7-windows-x86_64-none": {
     "name": "cpython",
@@ -3309,7 +5846,8 @@
     "patch": 7,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "b464352f8cbf06ab4c041b7559c9bda7e9f6001a94f67ab0a342cba078f3805f"
+    "sha256": "b464352f8cbf06ab4c041b7559c9bda7e9f6001a94f67ab0a342cba078f3805f",
+    "variant": null
   },
   "cpython-3.10.6-darwin-aarch64-none": {
     "name": "cpython",
@@ -3321,7 +5859,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "efaf66acdb9a4eb33d57702607d2e667b1a319d58c167a43c96896b97419b8b7"
+    "sha256": "efaf66acdb9a4eb33d57702607d2e667b1a319d58c167a43c96896b97419b8b7",
+    "variant": null
   },
   "cpython-3.10.6-darwin-x86_64-none": {
     "name": "cpython",
@@ -3333,7 +5872,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "7718411adf3ea1480f3f018a643eb0550282aefe39e5ecb3f363a4a566a9398c"
+    "sha256": "7718411adf3ea1480f3f018a643eb0550282aefe39e5ecb3f363a4a566a9398c",
+    "variant": null
+  },
+  "cpython-3.10.6+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "edc1c9742b824caebbc5cb224c8990aa8658b81593fd9219accf3efa3e849501",
+    "variant": "debug"
   },
   "cpython-3.10.6-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3345,7 +5898,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "81625f5c97f61e2e3d7e9f62c484b1aa5311f21bd6545451714b949a29da5435"
+    "sha256": "81625f5c97f61e2e3d7e9f62c484b1aa5311f21bd6545451714b949a29da5435",
+    "variant": null
+  },
+  "cpython-3.10.6+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "07fa4f5499b8885d1eea49caf5476d76305ab73494b7398dfd22c14093859e4f",
+    "variant": "debug"
   },
   "cpython-3.10.6-linux-i686-gnu": {
     "name": "cpython",
@@ -3357,7 +5924,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "b152801a2609e6a38f3cc9e7e21d8b6cf5b6f31dacfcaca01e162c514e851ed6"
+    "sha256": "b152801a2609e6a38f3cc9e7e21d8b6cf5b6f31dacfcaca01e162c514e851ed6",
+    "variant": null
+  },
+  "cpython-3.10.6+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "407e5951e39f5652b32b72b715c4aa772dd8c2da1065161c58c30a1f976dd1b2",
+    "variant": "debug"
   },
   "cpython-3.10.6-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3369,7 +5950,21 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "55aa2190d28dcfdf414d96dc5dcea9fe048fadcd583dc3981fec020869826111"
+    "sha256": "55aa2190d28dcfdf414d96dc5dcea9fe048fadcd583dc3981fec020869826111",
+    "variant": null
+  },
+  "cpython-3.10.6+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 6,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "6cd58957e286c132dc7cdbd937144aa180b557772be8a2b70bd1c3f2644ebe65",
+    "variant": "debug"
   },
   "cpython-3.10.6-linux-x86_64-musl": {
     "name": "cpython",
@@ -3381,7 +5976,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "8cafe6409e9d192b288b84a21bc0c309f1d3f6b809a471b2858c7bf1bb09f3a7"
+    "sha256": "8cafe6409e9d192b288b84a21bc0c309f1d3f6b809a471b2858c7bf1bb09f3a7",
+    "variant": null
   },
   "cpython-3.10.6-windows-i686-none": {
     "name": "cpython",
@@ -3393,7 +5989,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "27f22babf29ceebae18b2c2e38e2c48d22de686688c8a31c5f8d7d51541583c1"
+    "sha256": "27f22babf29ceebae18b2c2e38e2c48d22de686688c8a31c5f8d7d51541583c1",
+    "variant": null
   },
   "cpython-3.10.6-windows-x86_64-none": {
     "name": "cpython",
@@ -3405,7 +6002,8 @@
     "patch": 6,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "91889a7dbdceea585ff4d3b7856a6bb8f8a4eca83a0ff52a73542c2e67220eaa"
+    "sha256": "91889a7dbdceea585ff4d3b7856a6bb8f8a4eca83a0ff52a73542c2e67220eaa",
+    "variant": null
   },
   "cpython-3.10.5-darwin-aarch64-none": {
     "name": "cpython",
@@ -3417,7 +6015,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "19d1aa4a6d9ddb0094fc36961b129de9abe1673bce66c86cd97b582795c496a8"
+    "sha256": "19d1aa4a6d9ddb0094fc36961b129de9abe1673bce66c86cd97b582795c496a8",
+    "variant": null
   },
   "cpython-3.10.5-darwin-x86_64-none": {
     "name": "cpython",
@@ -3429,7 +6028,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "eca0584397d9a3ef6f7bb32b0476318b01c89b7b0a031ef97a0dcaa5ba5127a8"
+    "sha256": "eca0584397d9a3ef6f7bb32b0476318b01c89b7b0a031ef97a0dcaa5ba5127a8",
+    "variant": null
+  },
+  "cpython-3.10.5+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9fa6970a3d0a5dc26c4ed272bb1836d1f1f7a8f4b9d67f634d0262ff8c1fed0b",
+    "variant": "debug"
   },
   "cpython-3.10.5-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3441,7 +6054,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "012fa37c12d2647d76d004dc003302563864d2f1cd0731b71eeafad63d28b3f0"
+    "sha256": "012fa37c12d2647d76d004dc003302563864d2f1cd0731b71eeafad63d28b3f0",
+    "variant": null
+  },
+  "cpython-3.10.5+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "63fcfc425adabc034c851dadfb499de3083fd7758582191c12162ad2471256b0",
+    "variant": "debug"
   },
   "cpython-3.10.5-linux-i686-gnu": {
     "name": "cpython",
@@ -3453,7 +6080,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "5abf5baf40f8573ce7d7e4ad323457f511833e1663e61ac5a11d5563a735159f"
+    "sha256": "5abf5baf40f8573ce7d7e4ad323457f511833e1663e61ac5a11d5563a735159f",
+    "variant": null
+  },
+  "cpython-3.10.5+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f8dfb83885d1cbc82febfa613258c1f6954ea88ef43ed7dc710d6df20efecdab",
+    "variant": "debug"
   },
   "cpython-3.10.5-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3465,7 +6106,21 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "460f87a389be28c953c24c6f942f172f9ce7f331367b4daf89cb450baedd51d7"
+    "sha256": "460f87a389be28c953c24c6f942f172f9ce7f331367b4daf89cb450baedd51d7",
+    "variant": null
+  },
+  "cpython-3.10.5+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 5,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "5217476a38b5273fd98ce45b7f0efcd579b8740c4d2911c6900fa16d59368fcc",
+    "variant": "debug"
   },
   "cpython-3.10.5-linux-x86_64-musl": {
     "name": "cpython",
@@ -3477,7 +6132,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "6aad42c7b03989173dd0e4d066e8c1e9f176f4b31d5bde26dbb5297f38f656d0"
+    "sha256": "6aad42c7b03989173dd0e4d066e8c1e9f176f4b31d5bde26dbb5297f38f656d0",
+    "variant": null
   },
   "cpython-3.10.5-windows-i686-none": {
     "name": "cpython",
@@ -3489,7 +6145,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "2846e9c7e8484034989ab218022009fdd9dcb12a7bfb4b0329a404552d37e9aa"
+    "sha256": "2846e9c7e8484034989ab218022009fdd9dcb12a7bfb4b0329a404552d37e9aa",
+    "variant": null
   },
   "cpython-3.10.5-windows-x86_64-none": {
     "name": "cpython",
@@ -3501,7 +6158,8 @@
     "patch": 5,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "c830ab2a3a488f9cf95e4e81c581d9ef73e483c2e6546136379443e9bb725119"
+    "sha256": "c830ab2a3a488f9cf95e4e81c581d9ef73e483c2e6546136379443e9bb725119",
+    "variant": null
   },
   "cpython-3.10.4-darwin-aarch64-none": {
     "name": "cpython",
@@ -3513,7 +6171,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "6d2e4e6b1c403bce84cfb846400754017f525fe8017f186e8e7072fcaaf3aa71"
+    "sha256": "6d2e4e6b1c403bce84cfb846400754017f525fe8017f186e8e7072fcaaf3aa71",
+    "variant": null
   },
   "cpython-3.10.4-darwin-x86_64-none": {
     "name": "cpython",
@@ -3525,7 +6184,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "c4a57a13b084d49ce8c2eb5b2662ee45b0c55b08ddd696f473233b0787f03988"
+    "sha256": "c4a57a13b084d49ce8c2eb5b2662ee45b0c55b08ddd696f473233b0787f03988",
+    "variant": null
+  },
+  "cpython-3.10.4+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "092369e9d170c4c1074e1b305accb74f9486e6185d2e3f3f971869ff89538d3e",
+    "variant": "debug"
   },
   "cpython-3.10.4-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3537,7 +6210,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "7a8989392dc9b41d85959a752448c60852cf0061de565e98445c27f6bbdf63be"
+    "sha256": "7a8989392dc9b41d85959a752448c60852cf0061de565e98445c27f6bbdf63be",
+    "variant": null
+  },
+  "cpython-3.10.4+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ba940a74a7434fe78d81aed9fb1e5ccdc3d97191a2db35716fc94e3b6604ace0",
+    "variant": "debug"
   },
   "cpython-3.10.4-linux-i686-gnu": {
     "name": "cpython",
@@ -3549,7 +6236,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "f3bc0828a0e0a8974e3fe90b4e99549296a7578de2321d791be1bad28191921d"
+    "sha256": "f3bc0828a0e0a8974e3fe90b4e99549296a7578de2321d791be1bad28191921d",
+    "variant": null
+  },
+  "cpython-3.10.4+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7699f76ef89b436b452eacdbab508da3cd94146ba29b099f5cb6e250afba3210",
+    "variant": "debug"
   },
   "cpython-3.10.4-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3561,7 +6262,21 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "1f8423808ad84c0e56c8e14c32685cbfbc1159e0d9f943ac946f29e84cf1b5ee"
+    "sha256": "1f8423808ad84c0e56c8e14c32685cbfbc1159e0d9f943ac946f29e84cf1b5ee",
+    "variant": null
+  },
+  "cpython-3.10.4+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 4,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "8fb78fbf9266b23ee0eaf569f7a36d1696f7102c396106c1d71b3a991b27ad27",
+    "variant": "debug"
   },
   "cpython-3.10.4-linux-x86_64-musl": {
     "name": "cpython",
@@ -3573,7 +6288,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "74c8da0aa24233c76bdd984d3c9e44442eca316be8a2cb4972d9264fedb0d5e8"
+    "sha256": "74c8da0aa24233c76bdd984d3c9e44442eca316be8a2cb4972d9264fedb0d5e8",
+    "variant": null
   },
   "cpython-3.10.4-windows-i686-none": {
     "name": "cpython",
@@ -3585,7 +6301,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "e1dfa5dde910f908cad8bd688b29d28df832f7b150555679c204580d1af0c4a6"
+    "sha256": "e1dfa5dde910f908cad8bd688b29d28df832f7b150555679c204580d1af0c4a6",
+    "variant": null
   },
   "cpython-3.10.4-windows-x86_64-none": {
     "name": "cpython",
@@ -3597,7 +6314,8 @@
     "patch": 4,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "7231ba2af9525cae620a5f4ae3bf89a939fdc053ba0cc64ee3dead8f13188005"
+    "sha256": "7231ba2af9525cae620a5f4ae3bf89a939fdc053ba0cc64ee3dead8f13188005",
+    "variant": null
   },
   "cpython-3.10.3-darwin-aarch64-none": {
     "name": "cpython",
@@ -3609,7 +6327,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "db46dadfccc407aa1f66ed607eefbf12f781e343adcb1edee0a3883d081292ce"
+    "sha256": "db46dadfccc407aa1f66ed607eefbf12f781e343adcb1edee0a3883d081292ce",
+    "variant": null
   },
   "cpython-3.10.3-darwin-x86_64-none": {
     "name": "cpython",
@@ -3621,7 +6340,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "ec2e90b6a589db7ef9f74358b1436558167629f9e4d725c8150496f9cb08a9d4"
+    "sha256": "ec2e90b6a589db7ef9f74358b1436558167629f9e4d725c8150496f9cb08a9d4",
+    "variant": null
+  },
+  "cpython-3.10.3+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "101284d27578438da200be1f6b9a1ba621432c5549fa5517797ec320bf75e3d5",
+    "variant": "debug"
   },
   "cpython-3.10.3-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3633,7 +6366,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "f52ee68c13c4f9356eb78a5305d3178af2cb90c38a8ce8ce9990a7cf6ff06144"
+    "sha256": "f52ee68c13c4f9356eb78a5305d3178af2cb90c38a8ce8ce9990a7cf6ff06144",
+    "variant": null
+  },
+  "cpython-3.10.3+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "43c1cd6e203bfba1a2eeb96cd2a15ce0ebde0e72ecc9555934116459347a9c28",
+    "variant": "debug"
   },
   "cpython-3.10.3-linux-i686-gnu": {
     "name": "cpython",
@@ -3645,7 +6392,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "2f125a927c3af52ef89af11857df988a042e26ce095129701b915e75b2ec6bff"
+    "sha256": "2f125a927c3af52ef89af11857df988a042e26ce095129701b915e75b2ec6bff",
+    "variant": null
+  },
+  "cpython-3.10.3+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "04760d869234ee8f801feb08edc042a6965320f6c0a7aedf92ec35501fef3b21",
+    "variant": "debug"
   },
   "cpython-3.10.3-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3657,7 +6418,21 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "b9989411bed71ba4867538c991f20b55f549dd9131905733f0df9f3fde81ad1d"
+    "sha256": "b9989411bed71ba4867538c991f20b55f549dd9131905733f0df9f3fde81ad1d",
+    "variant": null
+  },
+  "cpython-3.10.3+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 3,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "47637777bc44c6476e499bfcb214959c7abc386879dd66683a0d8e1b714c07cf",
+    "variant": "debug"
   },
   "cpython-3.10.3-linux-x86_64-musl": {
     "name": "cpython",
@@ -3669,7 +6444,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "a60b589176879bdd465659660b87e954f969bed072c03c578ec828d6134f4ae1"
+    "sha256": "a60b589176879bdd465659660b87e954f969bed072c03c578ec828d6134f4ae1",
+    "variant": null
   },
   "cpython-3.10.3-windows-i686-none": {
     "name": "cpython",
@@ -3681,7 +6457,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "bb7f2a5143010fa482c5b442cced85516696cfc416ca92c903ef374532401a33"
+    "sha256": "bb7f2a5143010fa482c5b442cced85516696cfc416ca92c903ef374532401a33",
+    "variant": null
   },
   "cpython-3.10.3-windows-x86_64-none": {
     "name": "cpython",
@@ -3693,7 +6470,8 @@
     "patch": 3,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "ba593370742ed8a7bc70ce563dd6a53e30ece1f6881e3888d334c1b485b0d9d0"
+    "sha256": "ba593370742ed8a7bc70ce563dd6a53e30ece1f6881e3888d334c1b485b0d9d0",
+    "variant": null
   },
   "cpython-3.10.2-darwin-aarch64-none": {
     "name": "cpython",
@@ -3705,7 +6483,8 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "1409acd9a506e2d1d3b65c1488db4e40d8f19d09a7df099667c87a506f71c0ef"
+    "sha256": "1409acd9a506e2d1d3b65c1488db4e40d8f19d09a7df099667c87a506f71c0ef",
+    "variant": null
   },
   "cpython-3.10.2-darwin-x86_64-none": {
     "name": "cpython",
@@ -3717,7 +6496,21 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "8146ad4390710ec69b316a5649912df0247d35f4a42e2aa9615bffd87b3e235a"
+    "sha256": "8146ad4390710ec69b316a5649912df0247d35f4a42e2aa9615bffd87b3e235a",
+    "variant": null
+  },
+  "cpython-3.10.2+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9936f1549f950311229465de509b35c062aa474e504c20a1d6f0f632da57e002",
+    "variant": "debug"
   },
   "cpython-3.10.2-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3729,7 +6522,21 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "8f351a8cc348bb45c0f95b8634c8345ec6e749e483384188ad865b7428342703"
+    "sha256": "8f351a8cc348bb45c0f95b8634c8345ec6e749e483384188ad865b7428342703",
+    "variant": null
+  },
+  "cpython-3.10.2+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9be2a667f29ed048165cfb3f5dbe61703fd3e5956f8f517ae098740ac8411c0b",
+    "variant": "debug"
   },
   "cpython-3.10.2-linux-i686-gnu": {
     "name": "cpython",
@@ -3741,7 +6548,21 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "4fa49dab83bf82409816db431806525ce894280a509ca96c91e3efc9beed1fea"
+    "sha256": "4fa49dab83bf82409816db431806525ce894280a509ca96c91e3efc9beed1fea",
+    "variant": null
+  },
+  "cpython-3.10.2+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d22d85f60b2ef982b747adda2d1bde4a32c23c3d8f652c00ce44526750859e4e",
+    "variant": "debug"
   },
   "cpython-3.10.2-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3753,7 +6574,21 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "9b64eca2a94f7aff9409ad70bdaa7fbbf8148692662e764401883957943620dd"
+    "sha256": "9b64eca2a94f7aff9409ad70bdaa7fbbf8148692662e764401883957943620dd",
+    "variant": null
+  },
+  "cpython-3.10.2+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 10,
+    "patch": 2,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a696f058a0cf69fa49c7e65c0b0b630c3fdc23474d45795e5c742c474abb8f24",
+    "variant": "debug"
   },
   "cpython-3.10.2-linux-x86_64-musl": {
     "name": "cpython",
@@ -3765,7 +6600,8 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "c4f398f6f7f9bbf0df98407ad66bc5760f3afc2cd8ba33a99cf4dcc8c90fd9ae"
+    "sha256": "c4f398f6f7f9bbf0df98407ad66bc5760f3afc2cd8ba33a99cf4dcc8c90fd9ae",
+    "variant": null
   },
   "cpython-3.10.2-windows-i686-none": {
     "name": "cpython",
@@ -3777,7 +6613,8 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "5321f8c2c71239b1e2002d284be8ec825d4a6f95cd921e58db71f259834b7aa1"
+    "sha256": "5321f8c2c71239b1e2002d284be8ec825d4a6f95cd921e58db71f259834b7aa1",
+    "variant": null
   },
   "cpython-3.10.2-windows-x86_64-none": {
     "name": "cpython",
@@ -3789,103 +6626,8 @@
     "patch": 2,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "a1d9a594cd3103baa24937ad9150c1a389544b4350e859200b3e5c036ac352bd"
-  },
-  "cpython-3.10.0-darwin-aarch64-none": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-apple-darwin-install_only-20211017T1616.tar.gz",
-    "sha256": null
-  },
-  "cpython-3.10.0-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
-    "sha256": null
-  },
-  "cpython-3.10.0-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-unknown-linux-gnu-lto-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.10.0-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.10.0-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-gnu-install_only-20211017T1616.tar.gz",
-    "sha256": null
-  },
-  "cpython-3.10.0-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.10.0-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.10.0-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 10,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-pc-windows-msvc-shared-install_only-20211017T1616.tar.gz",
-    "sha256": null
+    "sha256": "a1d9a594cd3103baa24937ad9150c1a389544b4350e859200b3e5c036ac352bd",
+    "variant": null
   },
   "cpython-3.9.20-darwin-aarch64-none": {
     "name": "cpython",
@@ -3897,7 +6639,8 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "e7551a119bded40bfc268c850110b6a5af1d5fdd63842a56569477490d20e0a6"
+    "sha256": "e7551a119bded40bfc268c850110b6a5af1d5fdd63842a56569477490d20e0a6",
+    "variant": null
   },
   "cpython-3.9.20-darwin-x86_64-none": {
     "name": "cpython",
@@ -3909,7 +6652,21 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "02a912676153c0b87a2b6127f5bc9ddccf831b5c390e44073b1f45e829e712ca"
+    "sha256": "02a912676153c0b87a2b6127f5bc9ddccf831b5c390e44073b1f45e829e712ca",
+    "variant": null
+  },
+  "cpython-3.9.20+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b0f0ce29dd593991b9f5f940667d5116e49397e3f8c73e17e7e578d320fde788",
+    "variant": "debug"
   },
   "cpython-3.9.20-linux-aarch64-gnu": {
     "name": "cpython",
@@ -3921,7 +6678,21 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "7b3fe4868b127b75c82c7e56815e9ea90d7d5f76676d5d79c4e5901423a0e271"
+    "sha256": "7b3fe4868b127b75c82c7e56815e9ea90d7d5f76676d5d79c4e5901423a0e271",
+    "variant": null
+  },
+  "cpython-3.9.20+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "6cc50f0d4ad4b9ef4a1c98f6a5735f993933bc0b6bd85a43de6c10d4d6c6b7d3",
+    "variant": "debug"
   },
   "cpython-3.9.20-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -3933,7 +6704,21 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "8950ba405e3fbf53fec01f5f2b20b3d50c987879b0d9b9ee385916f29e73a434"
+    "sha256": "8950ba405e3fbf53fec01f5f2b20b3d50c987879b0d9b9ee385916f29e73a434",
+    "variant": null
+  },
+  "cpython-3.9.20+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "1f4bace709fd51d67ce611f0036306e9a035a7cd0a4635c4cf189d543c312df9",
+    "variant": "debug"
   },
   "cpython-3.9.20-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -3945,7 +6730,21 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "681b2aee6563be3b28370762e4a7c99cf5afeb6789ce7e5ae5646223515da578"
+    "sha256": "681b2aee6563be3b28370762e4a7c99cf5afeb6789ce7e5ae5646223515da578",
+    "variant": null
+  },
+  "cpython-3.9.20+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7448b72126d08260ae3951cba235ccbe79137f3c6c686ee30b92acefe13cf8be",
+    "variant": "debug"
   },
   "cpython-3.9.20-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -3957,7 +6756,21 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "82bb46cccdfc186e448e433baab343b1ce1e6d7c74e2e3ac4b32b1825583a7dc"
+    "sha256": "82bb46cccdfc186e448e433baab343b1ce1e6d7c74e2e3ac4b32b1825583a7dc",
+    "variant": null
+  },
+  "cpython-3.9.20+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "ffeb5969992a2e4e5a50e43d0fe5ffa27f7e2454f7c8866446817d893f631200",
+    "variant": "debug"
   },
   "cpython-3.9.20-linux-s390x-gnu": {
     "name": "cpython",
@@ -3969,7 +6782,21 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "adecf1aa825d4b73ea42a04c3a4996c19733d1b66a79c5fb0cb77f9589174588"
+    "sha256": "adecf1aa825d4b73ea42a04c3a4996c19733d1b66a79c5fb0cb77f9589174588",
+    "variant": null
+  },
+  "cpython-3.9.20+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "5608bc546d0066de0d747c336c97d76aea3954ca5effc41209a7ee345b4c0459",
+    "variant": "debug"
   },
   "cpython-3.9.20-linux-x86_64-gnu": {
     "name": "cpython",
@@ -3981,7 +6808,21 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "f78ac2daa816647d8de170a1b7296d08d3a1227d1a5b46bde4d0e20834dc9212"
+    "sha256": "f78ac2daa816647d8de170a1b7296d08d3a1227d1a5b46bde4d0e20834dc9212",
+    "variant": null
+  },
+  "cpython-3.9.20+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "d93d2386c194c39a5a6b67b45d17fcba44ebf12774f8659dbc8ce352e667b5f4",
+    "variant": "debug"
   },
   "cpython-3.9.20-linux-x86_64-musl": {
     "name": "cpython",
@@ -3993,7 +6834,8 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "2c03d1a3b3c2b8a05cd24dad8a0307a3ae464bd7508e637b47c74abf3304e531"
+    "sha256": "2c03d1a3b3c2b8a05cd24dad8a0307a3ae464bd7508e637b47c74abf3304e531",
+    "variant": null
   },
   "cpython-3.9.20-windows-i686-none": {
     "name": "cpython",
@@ -4005,7 +6847,8 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "95c290f7eef20439b9e962a229608a0f6ea8d7f75de3cefff8298bac91b70cb4"
+    "sha256": "95c290f7eef20439b9e962a229608a0f6ea8d7f75de3cefff8298bac91b70cb4",
+    "variant": null
   },
   "cpython-3.9.20-windows-x86_64-none": {
     "name": "cpython",
@@ -4017,7 +6860,8 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "980f094ecd84894d2708696f3da641213480893bf0133b4be85ab60723c2f891"
+    "sha256": "980f094ecd84894d2708696f3da641213480893bf0133b4be85ab60723c2f891",
+    "variant": null
   },
   "cpython-3.9.19-darwin-aarch64-none": {
     "name": "cpython",
@@ -4029,7 +6873,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "451582f8a6a8c15ef35a327afcdbf8d03b1ebba7192e90d850d092dac91f91c6"
+    "sha256": "451582f8a6a8c15ef35a327afcdbf8d03b1ebba7192e90d850d092dac91f91c6",
+    "variant": null
   },
   "cpython-3.9.19-darwin-x86_64-none": {
     "name": "cpython",
@@ -4041,7 +6886,21 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "ebaf4336d0cbff4466c994d5bcaa92a38c91d06694d0cd675ec663259d5f37c7"
+    "sha256": "ebaf4336d0cbff4466c994d5bcaa92a38c91d06694d0cd675ec663259d5f37c7",
+    "variant": null
+  },
+  "cpython-3.9.19+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "40cc476967b3da12fdf2b0251954c37539d8ae2359f9e54913eff178d666b627",
+    "variant": "debug"
   },
   "cpython-3.9.19-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4053,7 +6912,21 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "23d08f7f0bf151c2ea54b2c9c143bc710faf166ff74225b0f967fab1e2d7a151"
+    "sha256": "23d08f7f0bf151c2ea54b2c9c143bc710faf166ff74225b0f967fab1e2d7a151",
+    "variant": null
+  },
+  "cpython-3.9.19+debug-linux-armv7-gnueabi": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabi",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabi-debug-full.tar.zst",
+    "sha256": "9a861ef69ae7ec4b98bc5612d3410b873bfe7067b93d97566a125b71a33b75da",
+    "variant": "debug"
   },
   "cpython-3.9.19-linux-armv7-gnueabi": {
     "name": "cpython",
@@ -4065,7 +6938,21 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
-    "sha256": "cebb879d47874f3f943a4334a8fcd8baa3cd7ef4be8cae6b4c8ae980d981a28d"
+    "sha256": "cebb879d47874f3f943a4334a8fcd8baa3cd7ef4be8cae6b4c8ae980d981a28d",
+    "variant": null
+  },
+  "cpython-3.9.19+debug-linux-armv7-gnueabihf": {
+    "name": "cpython",
+    "arch": "armv7",
+    "os": "linux",
+    "libc": "gnueabihf",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabihf-debug-full.tar.zst",
+    "sha256": "798d8455cb5ce1e9df8e880b17f5852853620184b49c3c9310ae9c7fc2d05470",
+    "variant": "debug"
   },
   "cpython-3.9.19-linux-armv7-gnueabihf": {
     "name": "cpython",
@@ -4077,7 +6964,21 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
-    "sha256": "c32d3227c44919349172c27b35275bad379f1679f729fbd4f336625903171a1a"
+    "sha256": "c32d3227c44919349172c27b35275bad379f1679f729fbd4f336625903171a1a",
+    "variant": null
+  },
+  "cpython-3.9.19+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "818dd8d3e63722facf8fb92b3c1ffda77dfd0a98e2a8278952ffa41e05b0d5d1",
+    "variant": "debug"
   },
   "cpython-3.9.19-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -4089,7 +6990,21 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "3cc60442d5694db1abe2a0c6e73459ebb6e7ba7fc7b0a986f3699d463a8f9557"
+    "sha256": "3cc60442d5694db1abe2a0c6e73459ebb6e7ba7fc7b0a986f3699d463a8f9557",
+    "variant": null
+  },
+  "cpython-3.9.19+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "dd79bef1974374dcdbe312f1f6cb6cd6ffaa95971b94e01391edb8125b980d90",
+    "variant": "debug"
   },
   "cpython-3.9.19-linux-s390x-gnu": {
     "name": "cpython",
@@ -4101,7 +7016,21 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "b41f834311532ee9dcf76cad3cdeda285d0e283de2182ce9870c37c40970cdd3"
+    "sha256": "b41f834311532ee9dcf76cad3cdeda285d0e283de2182ce9870c37c40970cdd3",
+    "variant": null
+  },
+  "cpython-3.9.19+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9e938140a8ecd343045a0c0cad77165db8bb0b24cc68012f628c937ae8748216",
+    "variant": "debug"
   },
   "cpython-3.9.19-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4113,7 +7042,21 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "3b7d574b6bbf8303789a1d26b96a81dcca907381441ce15818c784e18d1db299"
+    "sha256": "3b7d574b6bbf8303789a1d26b96a81dcca907381441ce15818c784e18d1db299",
+    "variant": null
+  },
+  "cpython-3.9.19+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "bb16ecadf1bbd907da5f0e9c65e2b2bd66770e73c1f3a38ac0ca5fa9ac6fc7a2",
+    "variant": "debug"
   },
   "cpython-3.9.19-linux-x86_64-musl": {
     "name": "cpython",
@@ -4125,7 +7068,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "5c6605b1cfa6a952420f2267d10bed9ae20a02858a769b7275d8805f6b9fe40b"
+    "sha256": "5c6605b1cfa6a952420f2267d10bed9ae20a02858a769b7275d8805f6b9fe40b",
+    "variant": null
   },
   "cpython-3.9.19-windows-i686-none": {
     "name": "cpython",
@@ -4137,7 +7081,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "1c78c6dd763e6d583c3c3f917544bc4446d0e9fbe2b6e206042fa801ff9fb9ab"
+    "sha256": "1c78c6dd763e6d583c3c3f917544bc4446d0e9fbe2b6e206042fa801ff9fb9ab",
+    "variant": null
   },
   "cpython-3.9.19-windows-x86_64-none": {
     "name": "cpython",
@@ -4149,7 +7094,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "426da4d31e665b77dacf15cd89494a995ed634a9b97324bbef9cf36fcda4c8a9"
+    "sha256": "426da4d31e665b77dacf15cd89494a995ed634a9b97324bbef9cf36fcda4c8a9",
+    "variant": null
   },
   "cpython-3.9.18-darwin-aarch64-none": {
     "name": "cpython",
@@ -4161,7 +7107,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "2548f911a6e316575c303ba42bb51540dc9b47a9f76a06a2a37460d93b177aa2"
+    "sha256": "2548f911a6e316575c303ba42bb51540dc9b47a9f76a06a2a37460d93b177aa2",
+    "variant": null
   },
   "cpython-3.9.18-darwin-x86_64-none": {
     "name": "cpython",
@@ -4173,7 +7120,21 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "171d8b472fce0295be0e28bb702c43d5a2a39feccb3e72efe620ac3843c3e402"
+    "sha256": "171d8b472fce0295be0e28bb702c43d5a2a39feccb3e72efe620ac3843c3e402",
+    "variant": null
+  },
+  "cpython-3.9.18+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d27efd4609a3e15ff901040529d5689be99f2ebfe5132ab980d066d775068265",
+    "variant": "debug"
   },
   "cpython-3.9.18-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4185,7 +7146,21 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "e5bc5196baa603d635ee6b0cd141e359752ad3e8ea76127eb9141a3155c51200"
+    "sha256": "e5bc5196baa603d635ee6b0cd141e359752ad3e8ea76127eb9141a3155c51200",
+    "variant": null
+  },
+  "cpython-3.9.18+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7faf8fdfbad04e0356a9d52c9b8be4d40ffef85c9ab3e312c45bd64997ef8aa9",
+    "variant": "debug"
   },
   "cpython-3.9.18-linux-i686-gnu": {
     "name": "cpython",
@@ -4197,7 +7172,21 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "10c422080317886057e968010495037ba65731ab7653bcaeabadf67a6fa5e99e"
+    "sha256": "10c422080317886057e968010495037ba65731ab7653bcaeabadf67a6fa5e99e",
+    "variant": null
+  },
+  "cpython-3.9.18+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c138eef19229351226a11e752230b8aa9d499ba9720f9f0574fa3260ccacb99b",
+    "variant": "debug"
   },
   "cpython-3.9.18-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -4209,7 +7198,21 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "d6b18df7a25fe034fd5ce4e64216df2cc78b2d4d908d2a1c94058ae700d73d22"
+    "sha256": "d6b18df7a25fe034fd5ce4e64216df2cc78b2d4d908d2a1c94058ae700d73d22",
+    "variant": null
+  },
+  "cpython-3.9.18+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "dd05eff699ce5a7eee545bc05e4869c4e64ee02bf0c70691bcee215604c6b393",
+    "variant": "debug"
   },
   "cpython-3.9.18-linux-s390x-gnu": {
     "name": "cpython",
@@ -4221,7 +7224,21 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "15d059507c7e900e9665f31e8d903e5a24a68ceed24f9a1c5ac06ab42a354f3f"
+    "sha256": "15d059507c7e900e9665f31e8d903e5a24a68ceed24f9a1c5ac06ab42a354f3f",
+    "variant": null
+  },
+  "cpython-3.9.18+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e1fa92798fab6f3b44a48f24b8e284660c34738d560681b206f0deb0616465f9",
+    "variant": "debug"
   },
   "cpython-3.9.18-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4233,7 +7250,21 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "0e5663025121186bd17d331538a44f48b41baff247891d014f3f962cbe2716b4"
+    "sha256": "0e5663025121186bd17d331538a44f48b41baff247891d014f3f962cbe2716b4",
+    "variant": null
+  },
+  "cpython-3.9.18+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "6f199ddd447d3946381c3ccbb89c0f67643fb8a98205b89caa8e217ad0a20fd7",
+    "variant": "debug"
   },
   "cpython-3.9.18-linux-x86_64-musl": {
     "name": "cpython",
@@ -4245,7 +7276,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "cb47455810ae63d98501b3bb4fcdfdb9924633fb2e86e62d77e523a3bdee44ba"
+    "sha256": "cb47455810ae63d98501b3bb4fcdfdb9924633fb2e86e62d77e523a3bdee44ba",
+    "variant": null
   },
   "cpython-3.9.18-windows-i686-none": {
     "name": "cpython",
@@ -4257,7 +7289,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "904ff5d2f6402640e2b7e2b12075af0bd75b3e8685cc5248fd2a3cda3105d2a8"
+    "sha256": "904ff5d2f6402640e2b7e2b12075af0bd75b3e8685cc5248fd2a3cda3105d2a8",
+    "variant": null
   },
   "cpython-3.9.18-windows-x86_64-none": {
     "name": "cpython",
@@ -4269,7 +7302,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "a9bdbd728ed4c353a4157ecf74386117fb2a2769a9353f491c528371cfe7f6cd"
+    "sha256": "a9bdbd728ed4c353a4157ecf74386117fb2a2769a9353f491c528371cfe7f6cd",
+    "variant": null
   },
   "cpython-3.9.17-darwin-aarch64-none": {
     "name": "cpython",
@@ -4281,7 +7315,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "73dbe2d702210b566221da9265acc274ba15275c5d0d1fa327f44ad86cde9aa1"
+    "sha256": "73dbe2d702210b566221da9265acc274ba15275c5d0d1fa327f44ad86cde9aa1",
+    "variant": null
   },
   "cpython-3.9.17-darwin-x86_64-none": {
     "name": "cpython",
@@ -4293,7 +7328,21 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "dfe1bea92c94b9cb779288b0b06e39157c5ff7e465cdd24032ac147c2af485c0"
+    "sha256": "dfe1bea92c94b9cb779288b0b06e39157c5ff7e465cdd24032ac147c2af485c0",
+    "variant": null
+  },
+  "cpython-3.9.17+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1f6c43d92ba9f4e15149cf5db6ecde11e05eee92c070a085e44f46c559520257",
+    "variant": "debug"
   },
   "cpython-3.9.17-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4305,7 +7354,21 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "b77012ddaf7e0673e4aa4b1c5085275a06eee2d66f33442b5c54a12b62b96cbe"
+    "sha256": "b77012ddaf7e0673e4aa4b1c5085275a06eee2d66f33442b5c54a12b62b96cbe",
+    "variant": null
+  },
+  "cpython-3.9.17+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "1a9b7edc16683410c27bc5b4b1761143bef7831a1ad172e7e3581c152c6837a2",
+    "variant": "debug"
   },
   "cpython-3.9.17-linux-i686-gnu": {
     "name": "cpython",
@@ -4317,7 +7380,21 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "aed29a64c835444c2f1aff83c55b14123114d74c54d96493a0eabfdd8c6d012c"
+    "sha256": "aed29a64c835444c2f1aff83c55b14123114d74c54d96493a0eabfdd8c6d012c",
+    "variant": null
+  },
+  "cpython-3.9.17+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bcb0ec31342df52b4555be309080a9c3224e7ff60a6291e34337ddfddef111cf",
+    "variant": "debug"
   },
   "cpython-3.9.17-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -4329,7 +7406,21 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "c591a28d943dce5cf9833e916125fdfbeb3120270c4866ee214493ccb5b83c3c"
+    "sha256": "c591a28d943dce5cf9833e916125fdfbeb3120270c4866ee214493ccb5b83c3c",
+    "variant": null
+  },
+  "cpython-3.9.17+debug-linux-s390x-gnu": {
+    "name": "cpython",
+    "arch": "s390x",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-s390x-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bf8c846c1a4e52355d4ae294f4e1da9587d5415467eb6890bdf0f5a4c8cda396",
+    "variant": "debug"
   },
   "cpython-3.9.17-linux-s390x-gnu": {
     "name": "cpython",
@@ -4341,7 +7432,21 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-s390x-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "01454d7cc7c9c2fccde42ba868c4f372eaaafa48049d49dd94c9cf2875f497e6"
+    "sha256": "01454d7cc7c9c2fccde42ba868c4f372eaaafa48049d49dd94c9cf2875f497e6",
+    "variant": null
+  },
+  "cpython-3.9.17+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "649fff6048f4cb9e64a85eaf8e720eb4c3257e27e7c4ee46f75bfa48c18c6826",
+    "variant": "debug"
   },
   "cpython-3.9.17-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4353,7 +7458,21 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "26c4a712b4b8e11ed5c027db5654eb12927c02da4857b777afb98f7a930ce637"
+    "sha256": "26c4a712b4b8e11ed5c027db5654eb12927c02da4857b777afb98f7a930ce637",
+    "variant": null
+  },
+  "cpython-3.9.17+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "5a117bc64d6545821083afbfb4a381afee05ddaeb0dd45d2c5adbf3b0a67ec88",
+    "variant": "debug"
   },
   "cpython-3.9.17-linux-x86_64-musl": {
     "name": "cpython",
@@ -4365,7 +7484,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "194316e9cc7add1dd12be3e3eea2908fd4d623799edd7df69e360c6a446b750d"
+    "sha256": "194316e9cc7add1dd12be3e3eea2908fd4d623799edd7df69e360c6a446b750d",
+    "variant": null
   },
   "cpython-3.9.17-windows-i686-none": {
     "name": "cpython",
@@ -4377,7 +7497,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "09f9d4bc66be5e0df2dfd1dc4742923e46c271f8f085178696c77073477aa0c1"
+    "sha256": "09f9d4bc66be5e0df2dfd1dc4742923e46c271f8f085178696c77073477aa0c1",
+    "variant": null
   },
   "cpython-3.9.17-windows-x86_64-none": {
     "name": "cpython",
@@ -4389,7 +7510,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "9b9a1e21eff29dcf043cea38180cf8ca3604b90117d00062a7b31605d4157714"
+    "sha256": "9b9a1e21eff29dcf043cea38180cf8ca3604b90117d00062a7b31605d4157714",
+    "variant": null
   },
   "cpython-3.9.16-darwin-aarch64-none": {
     "name": "cpython",
@@ -4401,7 +7523,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "c1de1d854717a6245f45262ef1bb17b09e2c587590e7e3f406593c143ff875bd"
+    "sha256": "c1de1d854717a6245f45262ef1bb17b09e2c587590e7e3f406593c143ff875bd",
+    "variant": null
   },
   "cpython-3.9.16-darwin-x86_64-none": {
     "name": "cpython",
@@ -4413,7 +7536,21 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf"
+    "sha256": "3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf",
+    "variant": null
+  },
+  "cpython-3.9.16+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "57ac7ce9d3dd32c1277ee7295daf5ad7b5ecc929e65b31f11b1e7b94cd355ed1",
+    "variant": "debug"
   },
   "cpython-3.9.16-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4425,7 +7562,21 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "f629b75ebfcafe9ceee2e796b7e4df5cf8dbd14f3c021afca078d159ab797acf"
+    "sha256": "f629b75ebfcafe9ceee2e796b7e4df5cf8dbd14f3c021afca078d159ab797acf",
+    "variant": null
+  },
+  "cpython-3.9.16+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e2a0226165550492e895369ee1b69a515f82e12cb969656012ee8e1543409661",
+    "variant": "debug"
   },
   "cpython-3.9.16-linux-i686-gnu": {
     "name": "cpython",
@@ -4437,7 +7588,21 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "ab0a14b3ae72bf48b94820e096e86b3cf3e05729862f768e109aa8318016c4f2"
+    "sha256": "ab0a14b3ae72bf48b94820e096e86b3cf3e05729862f768e109aa8318016c4f2",
+    "variant": null
+  },
+  "cpython-3.9.16+debug-linux-powerpc64le-gnu": {
+    "name": "cpython",
+    "arch": "powerpc64le",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-ppc64le-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8b2e7ddc6feb116dfa6829cfc478be90a374dc5ce123a98bc77e86d0e93e917d",
+    "variant": "debug"
   },
   "cpython-3.9.16-linux-powerpc64le-gnu": {
     "name": "cpython",
@@ -4449,7 +7614,21 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "ff3ac35c58f67839aff9b5185a976abd3d1abbe61af02089f7105e876c1fe284"
+    "sha256": "ff3ac35c58f67839aff9b5185a976abd3d1abbe61af02089f7105e876c1fe284",
+    "variant": null
+  },
+  "cpython-3.9.16+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "cdc1290b9bdb2f74a6c48ab24531919551128e39773365c6f3e17668216275a0",
+    "variant": "debug"
   },
   "cpython-3.9.16-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4461,7 +7640,21 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "2b6e146234a4ef2a8946081fc3fbfffe0765b80b690425a49ebe40b47c33445b"
+    "sha256": "2b6e146234a4ef2a8946081fc3fbfffe0765b80b690425a49ebe40b47c33445b",
+    "variant": null
+  },
+  "cpython-3.9.16+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "e698c7a51e7e998e893b0dd25886d477778a14296bd560e6e585352b9d6194f8",
+    "variant": "debug"
   },
   "cpython-3.9.16-linux-x86_64-musl": {
     "name": "cpython",
@@ -4473,7 +7666,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "5d9b13e8d5ee7a26fd0cf6e6d7e5a1ea90ddddd1f30ed2400bda60506f7dcea3"
+    "sha256": "5d9b13e8d5ee7a26fd0cf6e6d7e5a1ea90ddddd1f30ed2400bda60506f7dcea3",
+    "variant": null
   },
   "cpython-3.9.16-windows-i686-none": {
     "name": "cpython",
@@ -4485,7 +7679,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "219532ffa49af88e3b90e9135cf3b6e1fa11cf165b03098fb9776a07af8ca6d0"
+    "sha256": "219532ffa49af88e3b90e9135cf3b6e1fa11cf165b03098fb9776a07af8ca6d0",
+    "variant": null
   },
   "cpython-3.9.16-windows-x86_64-none": {
     "name": "cpython",
@@ -4497,7 +7692,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "cdabb47204e96ce7ea31fbd0b5ed586114dd7d8f8eddf60a509a7f70b48a1c5e"
+    "sha256": "cdabb47204e96ce7ea31fbd0b5ed586114dd7d8f8eddf60a509a7f70b48a1c5e",
+    "variant": null
   },
   "cpython-3.9.15-darwin-aarch64-none": {
     "name": "cpython",
@@ -4509,7 +7705,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "64dc7e1013481c9864152c3dd806c41144c79d5e9cd3140e185c6a5060bdc9ab"
+    "sha256": "64dc7e1013481c9864152c3dd806c41144c79d5e9cd3140e185c6a5060bdc9ab",
+    "variant": null
   },
   "cpython-3.9.15-darwin-x86_64-none": {
     "name": "cpython",
@@ -4521,7 +7718,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "f2bcade6fc976c472f18f2b3204d67202d43ae55cf6f9e670f95e488f780da08"
+    "sha256": "f2bcade6fc976c472f18f2b3204d67202d43ae55cf6f9e670f95e488f780da08",
+    "variant": null
+  },
+  "cpython-3.9.15+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "0da1f081313b088c1381206e698e70fffdffc01e1b2ce284145c24ee5f5b4cbb",
+    "variant": "debug"
   },
   "cpython-3.9.15-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4533,7 +7744,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "52a8c0a67fb919f80962d992da1bddb511cdf92faf382701ce7673e10a8ff98f"
+    "sha256": "52a8c0a67fb919f80962d992da1bddb511cdf92faf382701ce7673e10a8ff98f",
+    "variant": null
+  },
+  "cpython-3.9.15+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "cbc6a14835022d89f4ca6042a06c4959d74d4bbb58e70bdbe0fe8d2928934922",
+    "variant": "debug"
   },
   "cpython-3.9.15-linux-i686-gnu": {
     "name": "cpython",
@@ -4545,7 +7770,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "bf32a86c220e4d1690bb92b67653f20b8325808accd81bff03b5c30ae74e6444"
+    "sha256": "bf32a86c220e4d1690bb92b67653f20b8325808accd81bff03b5c30ae74e6444",
+    "variant": null
+  },
+  "cpython-3.9.15+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6a08761bb725b8d3a92144f81628febeab8b12326ca264ffe28255fa67c7bf17",
+    "variant": "debug"
   },
   "cpython-3.9.15-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4557,7 +7796,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "cdc3a4cfddcd63b6cebdd75b14970e02d8ef0ac5be4d350e57ab5df56c19e85e"
+    "sha256": "cdc3a4cfddcd63b6cebdd75b14970e02d8ef0ac5be4d350e57ab5df56c19e85e",
+    "variant": null
+  },
+  "cpython-3.9.15+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "c4bf3bd40dc301eb41984b205a204fb85ebe190bfe35fe73c79b749b48ec7a31",
+    "variant": "debug"
   },
   "cpython-3.9.15-linux-x86_64-musl": {
     "name": "cpython",
@@ -4569,7 +7822,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "81b1c76ac789521fcececdcdc643f6de6fc282083b1a36a9973d835fc8a39391"
+    "sha256": "81b1c76ac789521fcececdcdc643f6de6fc282083b1a36a9973d835fc8a39391",
+    "variant": null
   },
   "cpython-3.9.15-windows-i686-none": {
     "name": "cpython",
@@ -4581,7 +7835,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "0b81089247f258f244e9792daaa03675da6f58597daa6913e82f2679862238dd"
+    "sha256": "0b81089247f258f244e9792daaa03675da6f58597daa6913e82f2679862238dd",
+    "variant": null
   },
   "cpython-3.9.15-windows-x86_64-none": {
     "name": "cpython",
@@ -4593,7 +7848,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "022daacab215679b87f0d200d08b9068a721605fa4721ebeda38220fc641ccf6"
+    "sha256": "022daacab215679b87f0d200d08b9068a721605fa4721ebeda38220fc641ccf6",
+    "variant": null
   },
   "cpython-3.9.14-darwin-aarch64-none": {
     "name": "cpython",
@@ -4605,7 +7861,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "e38df7f230979ce6c53a5bafb3a81287838e5f3892c40cd1b98a0c961c444713"
+    "sha256": "e38df7f230979ce6c53a5bafb3a81287838e5f3892c40cd1b98a0c961c444713",
+    "variant": null
   },
   "cpython-3.9.14-darwin-x86_64-none": {
     "name": "cpython",
@@ -4617,7 +7874,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "b7d3a1f4b57e9350571ccee49c82f503133de0d113a2dbaebc8ccf108fb3fe1b"
+    "sha256": "b7d3a1f4b57e9350571ccee49c82f503133de0d113a2dbaebc8ccf108fb3fe1b",
+    "variant": null
+  },
+  "cpython-3.9.14+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3020c743e4742d6e0e5d27fcb166c694bf1d9565369b2eaee9d68434304aebd2",
+    "variant": "debug"
   },
   "cpython-3.9.14-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4629,7 +7900,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "fe538201559ca37f44cd5f66c42a65fe7272cb4f1f63edd698b6f306771db1e9"
+    "sha256": "fe538201559ca37f44cd5f66c42a65fe7272cb4f1f63edd698b6f306771db1e9",
+    "variant": null
+  },
+  "cpython-3.9.14+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "83a11c4f3d1c0ec39119bd0513a8684b59b68c3989cf1e5042d7417d4770c904",
+    "variant": "debug"
   },
   "cpython-3.9.14-linux-i686-gnu": {
     "name": "cpython",
@@ -4641,7 +7926,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "3af1c255110c2f42ed0b7957502c92edf8b5c5e6fc5f699a2475bf8a560325c0"
+    "sha256": "3af1c255110c2f42ed0b7957502c92edf8b5c5e6fc5f699a2475bf8a560325c0",
+    "variant": null
+  },
+  "cpython-3.9.14+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "54529c0a8ffe621f5c9c6bdd22968cac9d3207cbd5dcd9c07bbe61140c49937e",
+    "variant": "debug"
   },
   "cpython-3.9.14-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4653,7 +7952,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "e63d0c00a499e0202ba7a0f53ce69fca6d30237af39af9bc3c76bce6c7bf14d7"
+    "sha256": "e63d0c00a499e0202ba7a0f53ce69fca6d30237af39af9bc3c76bce6c7bf14d7",
+    "variant": null
+  },
+  "cpython-3.9.14+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "598de16fbb955c2de02ac7765f162bee74601e28b3de9b6efeeecf30d97aecd6",
+    "variant": "debug"
   },
   "cpython-3.9.14-linux-x86_64-musl": {
     "name": "cpython",
@@ -4665,7 +7978,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "ceb26ef5f5a9b7b47fa95225fffce9c8ef0c9c1fbeca69fbda236a0c10de7ad8"
+    "sha256": "ceb26ef5f5a9b7b47fa95225fffce9c8ef0c9c1fbeca69fbda236a0c10de7ad8",
+    "variant": null
   },
   "cpython-3.9.14-windows-i686-none": {
     "name": "cpython",
@@ -4677,7 +7991,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "f3526e8416be86ff9091750ebc7388d6726acf32cc5ab0e6a60c67c6aacb2569"
+    "sha256": "f3526e8416be86ff9091750ebc7388d6726acf32cc5ab0e6a60c67c6aacb2569",
+    "variant": null
   },
   "cpython-3.9.14-windows-x86_64-none": {
     "name": "cpython",
@@ -4689,7 +8004,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "f111c3c129f4a5a171d25350ce58dad4c7e58fbe664e9b4f7c275345c9fe18a6"
+    "sha256": "f111c3c129f4a5a171d25350ce58dad4c7e58fbe664e9b4f7c275345c9fe18a6",
+    "variant": null
   },
   "cpython-3.9.13-darwin-aarch64-none": {
     "name": "cpython",
@@ -4701,7 +8017,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "d9603edc296a2dcbc59d7ada780fd12527f05c3e0b99f7545112daf11636d6e5"
+    "sha256": "d9603edc296a2dcbc59d7ada780fd12527f05c3e0b99f7545112daf11636d6e5",
+    "variant": null
   },
   "cpython-3.9.13-darwin-x86_64-none": {
     "name": "cpython",
@@ -4713,7 +8030,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "9540a7efb7c8a54a48aff1cb9480e49588d9c0a3f934ad53f5b167338174afa3"
+    "sha256": "9540a7efb7c8a54a48aff1cb9480e49588d9c0a3f934ad53f5b167338174afa3",
+    "variant": null
+  },
+  "cpython-3.9.13+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8c706ebb2c8970da4fbec95b0520b4632309bc6a3e115cf309e38f181b553d14",
+    "variant": "debug"
   },
   "cpython-3.9.13-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4725,7 +8056,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "80415aac1b96255b9211f6a4c300f31e9940c7e07a23d0dec12b53aa52c0d25e"
+    "sha256": "80415aac1b96255b9211f6a4c300f31e9940c7e07a23d0dec12b53aa52c0d25e",
+    "variant": null
+  },
+  "cpython-3.9.13+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7d33637b48c45acf8805d5460895dca29bf2740fd2cf502fde6c6a00637db6b5",
+    "variant": "debug"
   },
   "cpython-3.9.13-linux-i686-gnu": {
     "name": "cpython",
@@ -4737,7 +8082,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "efcc8fef0d498afe576ab209fee001fda3b552de1a85f621f2602787aa6cf3d4"
+    "sha256": "efcc8fef0d498afe576ab209fee001fda3b552de1a85f621f2602787aa6cf3d4",
+    "variant": null
+  },
+  "cpython-3.9.13+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "352d00a4630d0665387bcb158aec3f6c7fc5a4d14d65ac26e1b826e20611222f",
+    "variant": "debug"
   },
   "cpython-3.9.13-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4749,7 +8108,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "ce1cfca2715e7e646dd618a8cb9baff93000e345ccc979b801fc6ccde7ce97df"
+    "sha256": "ce1cfca2715e7e646dd618a8cb9baff93000e345ccc979b801fc6ccde7ce97df",
+    "variant": null
+  },
+  "cpython-3.9.13+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "fd18bcb560764e7456431b577ce3b35057c3dd4cda60dfb98a9af8739ec95c43",
+    "variant": "debug"
   },
   "cpython-3.9.13-linux-x86_64-musl": {
     "name": "cpython",
@@ -4761,7 +8134,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "766ed7e805e8c7abc4e50f1c94814575e7978ed7bd1f9e9ccec82d66b47b567f"
+    "sha256": "766ed7e805e8c7abc4e50f1c94814575e7978ed7bd1f9e9ccec82d66b47b567f",
+    "variant": null
   },
   "cpython-3.9.13-windows-i686-none": {
     "name": "cpython",
@@ -4773,7 +8147,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "90e3879382f06fea3ba6d477f0c2a434a1e14cd83d174e1c7b87e2f22bc2e748"
+    "sha256": "90e3879382f06fea3ba6d477f0c2a434a1e14cd83d174e1c7b87e2f22bc2e748",
+    "variant": null
   },
   "cpython-3.9.13-windows-x86_64-none": {
     "name": "cpython",
@@ -4785,7 +8160,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "b538127025a467c64b3351babca2e4d2ea7bdfb7867d5febb3529c34456cdcd4"
+    "sha256": "b538127025a467c64b3351babca2e4d2ea7bdfb7867d5febb3529c34456cdcd4",
+    "variant": null
   },
   "cpython-3.9.12-darwin-aarch64-none": {
     "name": "cpython",
@@ -4797,7 +8173,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "8dee06c07cc6429df34b6abe091a4684a86f7cec76f5d1ccc1c3ce2bd11168df"
+    "sha256": "8dee06c07cc6429df34b6abe091a4684a86f7cec76f5d1ccc1c3ce2bd11168df",
+    "variant": null
   },
   "cpython-3.9.12-darwin-x86_64-none": {
     "name": "cpython",
@@ -4809,7 +8186,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "2453ba7f76b3df3310353b48c881d6cff622ba06e30d2b6ae91588b2bc9e481a"
+    "sha256": "2453ba7f76b3df3310353b48c881d6cff622ba06e30d2b6ae91588b2bc9e481a",
+    "variant": null
+  },
+  "cpython-3.9.12+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "202ef64e43570f0843ff5895fd9c1a2c36a96b48d52842fa95842d7d11025b20",
+    "variant": "debug"
   },
   "cpython-3.9.12-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4821,7 +8212,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "2ee1426c181e65133e57dc55c6a685cb1fb5e63ef02d684b8a667d5c031c4203"
+    "sha256": "2ee1426c181e65133e57dc55c6a685cb1fb5e63ef02d684b8a667d5c031c4203",
+    "variant": null
+  },
+  "cpython-3.9.12+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e52fdbe61dea847323cd6e81142d16a571dca9c0bcde3bfe5ae75a8d3d1a3bf4",
+    "variant": "debug"
   },
   "cpython-3.9.12-linux-i686-gnu": {
     "name": "cpython",
@@ -4833,7 +8238,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "233e1a9626d9fe13baac8de3689df48401d0ad5da1c2f134ad57d8e3e878a1a5"
+    "sha256": "233e1a9626d9fe13baac8de3689df48401d0ad5da1c2f134ad57d8e3e878a1a5",
+    "variant": null
+  },
+  "cpython-3.9.12+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7290ac14e43749afdb37d3c9690f300f5f0786f19982e8960566ecdc3e42c3eb",
+    "variant": "debug"
   },
   "cpython-3.9.12-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4845,7 +8264,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "ccca12f698b3b810d79c52f007078f520d588232a36bc12ede944ec3ea417816"
+    "sha256": "ccca12f698b3b810d79c52f007078f520d588232a36bc12ede944ec3ea417816",
+    "variant": null
+  },
+  "cpython-3.9.12+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "410d7e68366f0e4fce4540a73ab3228060aa469949154fc08dc00d9da8ad51c6",
+    "variant": "debug"
   },
   "cpython-3.9.12-linux-x86_64-musl": {
     "name": "cpython",
@@ -4857,7 +8290,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "dd0eaf7ef64008d4a51a73243f368e0311b7936b0ac18f8d1305fffb0dfb76e6"
+    "sha256": "dd0eaf7ef64008d4a51a73243f368e0311b7936b0ac18f8d1305fffb0dfb76e6",
+    "variant": null
   },
   "cpython-3.9.12-windows-i686-none": {
     "name": "cpython",
@@ -4869,7 +8303,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "8b7e440137bfa349a008641a75a2b1fd8ae22d290731778a144878a59a721c51"
+    "sha256": "8b7e440137bfa349a008641a75a2b1fd8ae22d290731778a144878a59a721c51",
+    "variant": null
   },
   "cpython-3.9.12-windows-x86_64-none": {
     "name": "cpython",
@@ -4881,7 +8316,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "3024147fd987d9e1b064a3d94932178ff8e0fe98cfea955704213c0762fee8df"
+    "sha256": "3024147fd987d9e1b064a3d94932178ff8e0fe98cfea955704213c0762fee8df",
+    "variant": null
   },
   "cpython-3.9.11-darwin-aarch64-none": {
     "name": "cpython",
@@ -4893,7 +8329,8 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "cf92a28f98c8d884df0937bf19d5f1a40caa25a6a211a237b7e9b592b2b71c2b"
+    "sha256": "cf92a28f98c8d884df0937bf19d5f1a40caa25a6a211a237b7e9b592b2b71c2b",
+    "variant": null
   },
   "cpython-3.9.11-darwin-x86_64-none": {
     "name": "cpython",
@@ -4905,7 +8342,21 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "43889d1a424c84fb155e1619f062adb6984fbde80b6043611790f22bcbeec300"
+    "sha256": "43889d1a424c84fb155e1619f062adb6984fbde80b6043611790f22bcbeec300",
+    "variant": null
+  },
+  "cpython-3.9.11+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e1f3ae07a28a687f8602fb4d29a1b72cc5e113c61dc6769d0d85081ab3e09c71",
+    "variant": "debug"
   },
   "cpython-3.9.11-linux-aarch64-gnu": {
     "name": "cpython",
@@ -4917,7 +8368,21 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "0e50f099409c5e651b5fddd16124af1d830d11653e786a93c28e5b8f8aa470c4"
+    "sha256": "0e50f099409c5e651b5fddd16124af1d830d11653e786a93c28e5b8f8aa470c4",
+    "variant": null
+  },
+  "cpython-3.9.11+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "0be0a5f524c68d521be2417565ca43f3125b1845f996d6d62266aa431e673f93",
+    "variant": "debug"
   },
   "cpython-3.9.11-linux-i686-gnu": {
     "name": "cpython",
@@ -4929,7 +8394,21 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "75ac727631eab002bd120246197a8235145cb90687be181f7a52de6f41d44d34"
+    "sha256": "75ac727631eab002bd120246197a8235145cb90687be181f7a52de6f41d44d34",
+    "variant": null
+  },
+  "cpython-3.9.11+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "020bcbfff16dc5ce35a898763be3d847c97df2e14dabf483a8ec88b0455ff971",
+    "variant": "debug"
   },
   "cpython-3.9.11-linux-x86_64-gnu": {
     "name": "cpython",
@@ -4941,7 +8420,21 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "0429d5ceb095d5e24c292bf1a39208b88ae236a680ef8fa3e1830e3a1a7e8882"
+    "sha256": "0429d5ceb095d5e24c292bf1a39208b88ae236a680ef8fa3e1830e3a1a7e8882",
+    "variant": null
+  },
+  "cpython-3.9.11+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 11,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "046c027a79ab60b70f2853ef978d89a97d2d35d9af3e7d7e9684d20b66afa6bc",
+    "variant": "debug"
   },
   "cpython-3.9.11-linux-x86_64-musl": {
     "name": "cpython",
@@ -4953,7 +8446,8 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "ae8f55d90ae173f96e81f376daa5a9969a77531a6f7b8eacbe8ad90b41bbca1d"
+    "sha256": "ae8f55d90ae173f96e81f376daa5a9969a77531a6f7b8eacbe8ad90b41bbca1d",
+    "variant": null
   },
   "cpython-3.9.11-windows-i686-none": {
     "name": "cpython",
@@ -4965,7 +8459,8 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "ceac8729b285a8c8e861176dd2dadd7f8e7e26d8f64cac6c6226a14d2252cd4c"
+    "sha256": "ceac8729b285a8c8e861176dd2dadd7f8e7e26d8f64cac6c6226a14d2252cd4c",
+    "variant": null
   },
   "cpython-3.9.11-windows-x86_64-none": {
     "name": "cpython",
@@ -4977,7 +8472,8 @@
     "patch": 11,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "0c529a511f7a03908fc126c4a8467b47e24a4d98812147e8e786cf59e86febf0"
+    "sha256": "0c529a511f7a03908fc126c4a8467b47e24a4d98812147e8e786cf59e86febf0",
+    "variant": null
   },
   "cpython-3.9.10-darwin-aarch64-none": {
     "name": "cpython",
@@ -4989,7 +8485,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "ad66c2a3e7263147e046a32694de7b897a46fb0124409d29d3a93ede631c8aee"
+    "sha256": "ad66c2a3e7263147e046a32694de7b897a46fb0124409d29d3a93ede631c8aee",
+    "variant": null
   },
   "cpython-3.9.10-darwin-x86_64-none": {
     "name": "cpython",
@@ -5001,7 +8498,21 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "fdaf594142446029e314a9beb91f1ac75af866320b50b8b968181e592550cd68"
+    "sha256": "fdaf594142446029e314a9beb91f1ac75af866320b50b8b968181e592550cd68",
+    "variant": null
+  },
+  "cpython-3.9.10+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "8bf7ac2cd5825b8fde0a6e535266a57c97e82fd5a97877940920b403ca5e53d7",
+    "variant": "debug"
   },
   "cpython-3.9.10-linux-aarch64-gnu": {
     "name": "cpython",
@@ -5013,7 +8524,21 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "12dd1f125762f47975990ec744532a1cf3db74ad60f4dfb476ca42deb7f78ca4"
+    "sha256": "12dd1f125762f47975990ec744532a1cf3db74ad60f4dfb476ca42deb7f78ca4",
+    "variant": null
+  },
+  "cpython-3.9.10+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3e3bf4d3e71a2131e6c064d1e5019f58cb9c58fdceae4b76b26ac978a6d49aad",
+    "variant": "debug"
   },
   "cpython-3.9.10-linux-i686-gnu": {
     "name": "cpython",
@@ -5025,7 +8550,21 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "37ba43845c3df9ba012d69121ad29ea7f21ea2f5994a155007cf1560d74ce503"
+    "sha256": "37ba43845c3df9ba012d69121ad29ea7f21ea2f5994a155007cf1560d74ce503",
+    "variant": null
+  },
+  "cpython-3.9.10+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d453abf741c3196ffc8470f3ea6404a3e2b55b2674a501bb79162f06122423e5",
+    "variant": "debug"
   },
   "cpython-3.9.10-linux-x86_64-gnu": {
     "name": "cpython",
@@ -5037,7 +8576,21 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "455089cc576bd9a58db45e919d1fc867ecdbb0208067dffc845cc9bbf0701b70"
+    "sha256": "455089cc576bd9a58db45e919d1fc867ecdbb0208067dffc845cc9bbf0701b70",
+    "variant": null
+  },
+  "cpython-3.9.10+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 9,
+    "patch": 10,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "3ea1f4b06710a87a4f817b9084f60cc7ea481eb1090adc81306031ac4b382131",
+    "variant": "debug"
   },
   "cpython-3.9.10-linux-x86_64-musl": {
     "name": "cpython",
@@ -5049,7 +8602,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "30add63ec16e07ad13e19f6d7061f7e4c7b971962354f48ab3e85656ce3b393d"
+    "sha256": "30add63ec16e07ad13e19f6d7061f7e4c7b971962354f48ab3e85656ce3b393d",
+    "variant": null
   },
   "cpython-3.9.10-windows-i686-none": {
     "name": "cpython",
@@ -5061,7 +8615,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "56c0342a9af0412676e89cdf7b52ac76037031786b3f5c40942b8b82d366c96f"
+    "sha256": "56c0342a9af0412676e89cdf7b52ac76037031786b3f5c40942b8b82d366c96f",
+    "variant": null
   },
   "cpython-3.9.10-windows-x86_64-none": {
     "name": "cpython",
@@ -5073,643 +8628,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "c145d9d8143ce163670af124b623d7a2405143a3708b033b4d33eed355e61b24"
-  },
-  "cpython-3.9.7-darwin-aarch64-none": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-apple-darwin-install_only-20211017T1616.tar.gz",
-    "sha256": null
-  },
-  "cpython-3.9.7-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
-    "sha256": null
-  },
-  "cpython-3.9.7-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-unknown-linux-gnu-lto-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.7-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.7-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-gnu-install_only-20211017T1616.tar.gz",
-    "sha256": null
-  },
-  "cpython-3.9.7-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.7-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.7-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-pc-windows-msvc-shared-install_only-20211017T1616.tar.gz",
-    "sha256": null
-  },
-  "cpython-3.9.6-darwin-aarch64-none": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-apple-darwin-install_only-20210724T1424.tar.gz",
-    "sha256": null
-  },
-  "cpython-3.9.6-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-install_only-20210724T1424.tar.gz",
-    "sha256": null
-  },
-  "cpython-3.9.6-linux-aarch64-gnu": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-unknown-linux-gnu-lto-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.6-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.6-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-gnu-install_only-20210724T1424.tar.gz",
-    "sha256": null
-  },
-  "cpython-3.9.6-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.6-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.6-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-pc-windows-msvc-shared-install_only-20210724T1424.tar.gz",
-    "sha256": null
-  },
-  "cpython-3.9.5-darwin-aarch64-none": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-aarch64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.5-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.5-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.5-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.5-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.5-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.5-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.4-darwin-aarch64-none": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-aarch64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.4-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.4-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.4-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.4-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.4-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.4-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.3-darwin-aarch64-none": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-aarch64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.3-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.3-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-gnu-pgo%2Blto-20210413T2055.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.3-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-musl-lto-20210413T2055.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.3-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-i686-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.3-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.2-darwin-aarch64-none": {
-    "name": "cpython",
-    "arch": "aarch64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-aarch64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.2-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.2-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.2-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.2-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.2-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.2-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.1-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.1-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-gnu-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.1-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.1-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.1-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.0-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.0-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 9,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-gnu-pgo-20201020T0627.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.0-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 9,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.0-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-i686-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.9.0-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 9,
-    "patch": 0,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
-    "sha256": null
+    "sha256": "c145d9d8143ce163670af124b623d7a2405143a3708b033b4d33eed355e61b24",
+    "variant": null
   },
   "cpython-3.8.20-darwin-aarch64-none": {
     "name": "cpython",
@@ -5721,7 +8641,8 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "30ba44af64e599bde7307908393374bdcd99e185bf9b3c9de3f697f3fbe6bf8f"
+    "sha256": "30ba44af64e599bde7307908393374bdcd99e185bf9b3c9de3f697f3fbe6bf8f",
+    "variant": null
   },
   "cpython-3.8.20-darwin-x86_64-none": {
     "name": "cpython",
@@ -5733,7 +8654,21 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "375b6eead6c852cabbf3ccfd43dc4f6dd4c36381bf74c9a7910acb839fd5c57f"
+    "sha256": "375b6eead6c852cabbf3ccfd43dc4f6dd4c36381bf74c9a7910acb839fd5c57f",
+    "variant": null
+  },
+  "cpython-3.8.20+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "e9e2244eeb0d849925c63e077b8e659e50af7b8faa7c778bea49012a356cd9b5",
+    "variant": "debug"
   },
   "cpython-3.8.20-linux-aarch64-gnu": {
     "name": "cpython",
@@ -5745,7 +8680,21 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "75a187ebfab81096e3f3d91d70c1349e64defbdfb0e8a067cb5233d017655e31"
+    "sha256": "75a187ebfab81096e3f3d91d70c1349e64defbdfb0e8a067cb5233d017655e31",
+    "variant": null
+  },
+  "cpython-3.8.20+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "311c259280fb53844d281f2c2a2f4d7343fc520628a79cff488ee7e045843751",
+    "variant": "debug"
   },
   "cpython-3.8.20-linux-x86_64-gnu": {
     "name": "cpython",
@@ -5757,7 +8706,21 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "a3a75094545912d4e9413673441b3f0d2e58ce9b264477f910800148801ccf11"
+    "sha256": "a3a75094545912d4e9413673441b3f0d2e58ce9b264477f910800148801ccf11",
+    "variant": null
+  },
+  "cpython-3.8.20+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 20,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "451432b8c869484464f26690839857dd7380aa588c3c052314c5324a26b5727e",
+    "variant": "debug"
   },
   "cpython-3.8.20-linux-x86_64-musl": {
     "name": "cpython",
@@ -5769,7 +8732,8 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "fcddfd3f1090833e1f3106be021809630008b53026bc96dcaab2986625db27fa"
+    "sha256": "fcddfd3f1090833e1f3106be021809630008b53026bc96dcaab2986625db27fa",
+    "variant": null
   },
   "cpython-3.8.20-windows-i686-none": {
     "name": "cpython",
@@ -5781,7 +8745,8 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "d829105aaf53a1cadf8738e040c6211bc9bef2c6e4757b972954f0f322d57e7d"
+    "sha256": "d829105aaf53a1cadf8738e040c6211bc9bef2c6e4757b972954f0f322d57e7d",
+    "variant": null
   },
   "cpython-3.8.20-windows-x86_64-none": {
     "name": "cpython",
@@ -5793,7 +8758,8 @@
     "patch": 20,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "ec2f723dcfbf09581578a716c05cc67823a43d77111e6dd9e0d1557ccc6dcbf3"
+    "sha256": "ec2f723dcfbf09581578a716c05cc67823a43d77111e6dd9e0d1557ccc6dcbf3",
+    "variant": null
   },
   "cpython-3.8.19-darwin-aarch64-none": {
     "name": "cpython",
@@ -5805,7 +8771,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "6a15ee2b507aed4d5b15fd1b66fc570aa49183f15aa6c412eccd065446f17d8e"
+    "sha256": "6a15ee2b507aed4d5b15fd1b66fc570aa49183f15aa6c412eccd065446f17d8e",
+    "variant": null
   },
   "cpython-3.8.19-darwin-x86_64-none": {
     "name": "cpython",
@@ -5817,7 +8784,21 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
-    "sha256": "1a24263b039c1172bd42d74a5694492f3e3dbe4d3e52a1e7cc2856fee7dbee4a"
+    "sha256": "1a24263b039c1172bd42d74a5694492f3e3dbe4d3e52a1e7cc2856fee7dbee4a",
+    "variant": null
+  },
+  "cpython-3.8.19+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "d4c0800b9684236145310c6eda4505ba28cee3a3f10e8b22929a406b32b5f4fc",
+    "variant": "debug"
   },
   "cpython-3.8.19-linux-aarch64-gnu": {
     "name": "cpython",
@@ -5829,7 +8810,21 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "202211923850303f521146ee1831642aaf357ffeeadbe13a0a91884317227528"
+    "sha256": "202211923850303f521146ee1831642aaf357ffeeadbe13a0a91884317227528",
+    "variant": null
+  },
+  "cpython-3.8.19+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "0bd4dc46b451d40c04ff329ecb30e6a9eb375973d9457421e7afaaaa86614f74",
+    "variant": "debug"
   },
   "cpython-3.8.19-linux-x86_64-gnu": {
     "name": "cpython",
@@ -5841,7 +8836,21 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
-    "sha256": "0f1579dbb01c98af7a12fef4c9aa8a99d45b91393f64431f5de712f892bc5c0b"
+    "sha256": "0f1579dbb01c98af7a12fef4c9aa8a99d45b91393f64431f5de712f892bc5c0b",
+    "variant": null
+  },
+  "cpython-3.8.19+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 19,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a165c74be970b1804bda7acba186b7e3b96bd76e4e38fafd95bf7a40e21c8128",
+    "variant": "debug"
   },
   "cpython-3.8.19-linux-x86_64-musl": {
     "name": "cpython",
@@ -5853,7 +8862,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
-    "sha256": "6ee6c7469c9d2c7078beb95a9a3a261c42502e0b1603722a0689bdb2e789060c"
+    "sha256": "6ee6c7469c9d2c7078beb95a9a3a261c42502e0b1603722a0689bdb2e789060c",
+    "variant": null
   },
   "cpython-3.8.19-windows-i686-none": {
     "name": "cpython",
@@ -5865,7 +8875,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "73bf0135330b96c48ca79ccd6d2f3287a7466573a5fc1b62d982bcdb1d5f0ab3"
+    "sha256": "73bf0135330b96c48ca79ccd6d2f3287a7466573a5fc1b62d982bcdb1d5f0ab3",
+    "variant": null
   },
   "cpython-3.8.19-windows-x86_64-none": {
     "name": "cpython",
@@ -5877,7 +8888,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-    "sha256": "89d238b125cd7546b7d0cbd7f484a438d2c2f239c15c9b38ec3c62b1f343a6ca"
+    "sha256": "89d238b125cd7546b7d0cbd7f484a438d2c2f239c15c9b38ec3c62b1f343a6ca",
+    "variant": null
   },
   "cpython-3.8.18-darwin-aarch64-none": {
     "name": "cpython",
@@ -5889,7 +8901,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "4d493a1792bf211f37f98404cc1468f09bd781adc2602dea0df82ad264c11abc"
+    "sha256": "4d493a1792bf211f37f98404cc1468f09bd781adc2602dea0df82ad264c11abc",
+    "variant": null
   },
   "cpython-3.8.18-darwin-x86_64-none": {
     "name": "cpython",
@@ -5901,7 +8914,21 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "7d2cd8d289d5e3cdd0a8c06c028c7c621d3d00ce44b7e2f08c1724ae0471c626"
+    "sha256": "7d2cd8d289d5e3cdd0a8c06c028c7c621d3d00ce44b7e2f08c1724ae0471c626",
+    "variant": null
+  },
+  "cpython-3.8.18+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6d71175a090950c2063680f250b8799ab39eb139aa1721c853d8950aadd1d4e2",
+    "variant": "debug"
   },
   "cpython-3.8.18-linux-aarch64-gnu": {
     "name": "cpython",
@@ -5913,7 +8940,21 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "6588c9eed93833d9483d01fe40ac8935f691a1af8e583d404ec7666631b52487"
+    "sha256": "6588c9eed93833d9483d01fe40ac8935f691a1af8e583d404ec7666631b52487",
+    "variant": null
+  },
+  "cpython-3.8.18+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "189ae3b8249c57217e3253f9fc89857e088763cf2107a3f22ab2ac2398f41a65",
+    "variant": "debug"
   },
   "cpython-3.8.18-linux-x86_64-gnu": {
     "name": "cpython",
@@ -5925,7 +8966,21 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "5ae36825492372554c02708bdd26b8dcd57e3dbf34b3d6d599ad91d93540b2b7"
+    "sha256": "5ae36825492372554c02708bdd26b8dcd57e3dbf34b3d6d599ad91d93540b2b7",
+    "variant": null
+  },
+  "cpython-3.8.18+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 18,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "375d241bbd7d8704794fbda9387de8328999b5fb377f091ebb026bdace4abc24",
+    "variant": "debug"
   },
   "cpython-3.8.18-linux-x86_64-musl": {
     "name": "cpython",
@@ -5937,7 +8992,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "e591d3925f88f78a5dffb765fd10b9dab6e497d35cf58169da83eab521c86a37"
+    "sha256": "e591d3925f88f78a5dffb765fd10b9dab6e497d35cf58169da83eab521c86a37",
+    "variant": null
   },
   "cpython-3.8.18-windows-i686-none": {
     "name": "cpython",
@@ -5949,7 +9005,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "c24f9c9e8638cff0ce6aa808a57cc5f22009bc33e3bcf410a726b79d7c5545fe"
+    "sha256": "c24f9c9e8638cff0ce6aa808a57cc5f22009bc33e3bcf410a726b79d7c5545fe",
+    "variant": null
   },
   "cpython-3.8.18-windows-x86_64-none": {
     "name": "cpython",
@@ -5961,7 +9018,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "dba923ee5df8f99db04f599e826be92880746c02247c8d8e4d955d4bc711af11"
+    "sha256": "dba923ee5df8f99db04f599e826be92880746c02247c8d8e4d955d4bc711af11",
+    "variant": null
   },
   "cpython-3.8.17-darwin-aarch64-none": {
     "name": "cpython",
@@ -5973,7 +9031,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "c6f7a130d0044a78e39648f4dae56dcff5a41eba91888a99f6e560507162e6a1"
+    "sha256": "c6f7a130d0044a78e39648f4dae56dcff5a41eba91888a99f6e560507162e6a1",
+    "variant": null
   },
   "cpython-3.8.17-darwin-x86_64-none": {
     "name": "cpython",
@@ -5985,7 +9044,21 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "155b06821607bae1a58ecc60a7d036b358c766f19e493b8876190765c883a5c2"
+    "sha256": "155b06821607bae1a58ecc60a7d036b358c766f19e493b8876190765c883a5c2",
+    "variant": null
+  },
+  "cpython-3.8.17+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "eaee5a0b79cc28943e19df54f314634795aee43a6670ce99c0306893a18fa784",
+    "variant": "debug"
   },
   "cpython-3.8.17-linux-aarch64-gnu": {
     "name": "cpython",
@@ -5997,7 +9070,21 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "9f6d585091fe26906ff1dbb80437a3fe37a1e3db34d6ecc0098f3d6a78356682"
+    "sha256": "9f6d585091fe26906ff1dbb80437a3fe37a1e3db34d6ecc0098f3d6a78356682",
+    "variant": null
+  },
+  "cpython-3.8.17+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "61ac08680c022f180a32dc82d84548aeb92c7194a489e3b3c532dc48f999d757",
+    "variant": "debug"
   },
   "cpython-3.8.17-linux-i686-gnu": {
     "name": "cpython",
@@ -6009,7 +9096,21 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "e580fdd923bbae612334559dc58bd5fd13cce53b769294d63bc88e7c6662f7d9"
+    "sha256": "e580fdd923bbae612334559dc58bd5fd13cce53b769294d63bc88e7c6662f7d9",
+    "variant": null
+  },
+  "cpython-3.8.17+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f499750ab0019f36ccb4d964e222051d0d49a1d1e8dbada98abae738cf48c9dc",
+    "variant": "debug"
   },
   "cpython-3.8.17-linux-x86_64-gnu": {
     "name": "cpython",
@@ -6021,7 +9122,21 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "8d3e1826c0bb7821ec63288038644808a2d45553245af106c685ef5892fabcd8"
+    "sha256": "8d3e1826c0bb7821ec63288038644808a2d45553245af106c685ef5892fabcd8",
+    "variant": null
+  },
+  "cpython-3.8.17+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 17,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "c396b744f28286fc0980073efd08ce55eef5bd0197a4944c3bae5c339ef91269",
+    "variant": "debug"
   },
   "cpython-3.8.17-linux-x86_64-musl": {
     "name": "cpython",
@@ -6033,7 +9148,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "322b7837cfd8282c62ae3d2f0e98f0843cbe287e4b8c4852b786123f2e13b307"
+    "sha256": "322b7837cfd8282c62ae3d2f0e98f0843cbe287e4b8c4852b786123f2e13b307",
+    "variant": null
   },
   "cpython-3.8.17-windows-i686-none": {
     "name": "cpython",
@@ -6045,7 +9161,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "cb6af626ba811044e9c5ee09140a6920565d2b1b237a11886b96354a9fcc242e"
+    "sha256": "cb6af626ba811044e9c5ee09140a6920565d2b1b237a11886b96354a9fcc242e",
+    "variant": null
   },
   "cpython-3.8.17-windows-x86_64-none": {
     "name": "cpython",
@@ -6057,7 +9174,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "6428e1b4e0b4482d390828de7d4c82815257443416cb786abe10cb2466ca68cd"
+    "sha256": "6428e1b4e0b4482d390828de7d4c82815257443416cb786abe10cb2466ca68cd",
+    "variant": null
   },
   "cpython-3.8.16-darwin-aarch64-none": {
     "name": "cpython",
@@ -6069,7 +9187,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "7e484eb6de40d6f6bdfd5099eaa9647f65e45fb6d846ccfc56b1cb1e38b5ab02"
+    "sha256": "7e484eb6de40d6f6bdfd5099eaa9647f65e45fb6d846ccfc56b1cb1e38b5ab02",
+    "variant": null
   },
   "cpython-3.8.16-darwin-x86_64-none": {
     "name": "cpython",
@@ -6081,7 +9200,21 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "28506e509646c11cb2f57a7203bd1b08b6e8e5b159ae308bd5bb93b0d334bdaf"
+    "sha256": "28506e509646c11cb2f57a7203bd1b08b6e8e5b159ae308bd5bb93b0d334bdaf",
+    "variant": null
+  },
+  "cpython-3.8.16+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "423d43d93e2fe33b41ad66d35426f16541f09fee9d7272ae5decf5474ebbc225",
+    "variant": "debug"
   },
   "cpython-3.8.16-linux-aarch64-gnu": {
     "name": "cpython",
@@ -6093,7 +9226,21 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "9c6615931fd1045bf9f2148aa7dd9ce1ece8575ed68a5483a0b615322a43d54c"
+    "sha256": "9c6615931fd1045bf9f2148aa7dd9ce1ece8575ed68a5483a0b615322a43d54c",
+    "variant": null
+  },
+  "cpython-3.8.16+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9aa3e559130a47c33ee2b67f6ca69e2f10d8f70c1fd1e2871763b892372a6d9e",
+    "variant": "debug"
   },
   "cpython-3.8.16-linux-i686-gnu": {
     "name": "cpython",
@@ -6105,7 +9252,21 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "1260fd6af34104bbd57489175e6f7bfea76d4bd06a242a0f8e20e390e870b227"
+    "sha256": "1260fd6af34104bbd57489175e6f7bfea76d4bd06a242a0f8e20e390e870b227",
+    "variant": null
+  },
+  "cpython-3.8.16+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "f12f5cb38f796ca48dc73262c05506a6f21f59d24e709ea0390b18bf71c2e1f9",
+    "variant": "debug"
   },
   "cpython-3.8.16-linux-x86_64-gnu": {
     "name": "cpython",
@@ -6117,7 +9278,21 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "b1f1502c3a13b899724dbd32bd77a973fa9733b932c5700d747fe33d5de9ac4f"
+    "sha256": "b1f1502c3a13b899724dbd32bd77a973fa9733b932c5700d747fe33d5de9ac4f",
+    "variant": null
+  },
+  "cpython-3.8.16+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 16,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "54898fbd313530295cf103bb4e7c7922096ed1c56f46a955975ecd4fb5b02987",
+    "variant": "debug"
   },
   "cpython-3.8.16-linux-x86_64-musl": {
     "name": "cpython",
@@ -6129,7 +9304,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "840aefa3b03b66b6561360735dc0ac4e0a36a3ebb4d1f85d92f5b5f6638953cc"
+    "sha256": "840aefa3b03b66b6561360735dc0ac4e0a36a3ebb4d1f85d92f5b5f6638953cc",
+    "variant": null
   },
   "cpython-3.8.16-windows-i686-none": {
     "name": "cpython",
@@ -6141,7 +9317,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "77466f93ef5b030cf13d0446067089b0ce0d415cc6d1702655bdbb12a8c18c97"
+    "sha256": "77466f93ef5b030cf13d0446067089b0ce0d415cc6d1702655bdbb12a8c18c97",
+    "variant": null
   },
   "cpython-3.8.16-windows-x86_64-none": {
     "name": "cpython",
@@ -6153,7 +9330,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "120b3312fa79bac2ace45641171c2bc590c4e4462d7ad124d64597e124a36ae7"
+    "sha256": "120b3312fa79bac2ace45641171c2bc590c4e4462d7ad124d64597e124a36ae7",
+    "variant": null
   },
   "cpython-3.8.15-darwin-aarch64-none": {
     "name": "cpython",
@@ -6165,7 +9343,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "1e0a92d1a4f5e6d4a99f86b1cbf9773d703fe7fd032590f3e9c285c7a5eeb00a"
+    "sha256": "1e0a92d1a4f5e6d4a99f86b1cbf9773d703fe7fd032590f3e9c285c7a5eeb00a",
+    "variant": null
   },
   "cpython-3.8.15-darwin-x86_64-none": {
     "name": "cpython",
@@ -6177,7 +9356,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "70b57f28c2b5e1e3dd89f0d30edd5bc414e8b20195766cf328e1b26bed7890e1"
+    "sha256": "70b57f28c2b5e1e3dd89f0d30edd5bc414e8b20195766cf328e1b26bed7890e1",
+    "variant": null
+  },
+  "cpython-3.8.15+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "2e80025eda686c14a9a0618ced40043c1d577a754b904fd7a382cd41abf9ca00",
+    "variant": "debug"
   },
   "cpython-3.8.15-linux-aarch64-gnu": {
     "name": "cpython",
@@ -6189,7 +9382,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "886ab33ced13c84bf59ce8ff79eba6448365bfcafea1bf415bd1d75e21b690aa"
+    "sha256": "886ab33ced13c84bf59ce8ff79eba6448365bfcafea1bf415bd1d75e21b690aa",
+    "variant": null
+  },
+  "cpython-3.8.15+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "b8436415ea9bd9970fb766f791a14b0e14ce6351fc4604eb158f1425e8bb4a33",
+    "variant": "debug"
   },
   "cpython-3.8.15-linux-i686-gnu": {
     "name": "cpython",
@@ -6201,7 +9408,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "3bc1f49147913d93cea9cbb753fbaae90b86f1ee979f975c4712a35f02cbd86b"
+    "sha256": "3bc1f49147913d93cea9cbb753fbaae90b86f1ee979f975c4712a35f02cbd86b",
+    "variant": null
+  },
+  "cpython-3.8.15+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "c3c8c23e34bddb4a2b90333ff17041f344401775d505700f1ceddb3ad9d589e0",
+    "variant": "debug"
   },
   "cpython-3.8.15-linux-x86_64-gnu": {
     "name": "cpython",
@@ -6213,7 +9434,21 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "e47edfb2ceaf43fc699e20c179ec428b6f3e497cf8e2dcd8e9c936d4b96b1e56"
+    "sha256": "e47edfb2ceaf43fc699e20c179ec428b6f3e497cf8e2dcd8e9c936d4b96b1e56",
+    "variant": null
+  },
+  "cpython-3.8.15+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 15,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "ef23e1c394127b770995e021aff6b1ee3580d5c4f3d12abd6d5c64e007b972cf",
+    "variant": "debug"
   },
   "cpython-3.8.15-linux-x86_64-musl": {
     "name": "cpython",
@@ -6225,7 +9460,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "f767d0438eca5b18c1267c5121055a5808a1412ea7668ef17da3dc9bdd24a55f"
+    "sha256": "f767d0438eca5b18c1267c5121055a5808a1412ea7668ef17da3dc9bdd24a55f",
+    "variant": null
   },
   "cpython-3.8.15-windows-i686-none": {
     "name": "cpython",
@@ -6237,7 +9473,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "318c059324b84b5d7685bcd0874698799d9e3689b51dbcf596e7a47a39a3d49a"
+    "sha256": "318c059324b84b5d7685bcd0874698799d9e3689b51dbcf596e7a47a39a3d49a",
+    "variant": null
   },
   "cpython-3.8.15-windows-x86_64-none": {
     "name": "cpython",
@@ -6249,7 +9486,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "2fdc3fa1c95f982179bbbaedae2b328197658638799b6dcb63f9f494b0de59e2"
+    "sha256": "2fdc3fa1c95f982179bbbaedae2b328197658638799b6dcb63f9f494b0de59e2",
+    "variant": null
   },
   "cpython-3.8.14-darwin-aarch64-none": {
     "name": "cpython",
@@ -6261,7 +9499,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "6c17f6dcda59de5d8eee922ef7eede403a540dae05423ef2c2a042d8d4f22467"
+    "sha256": "6c17f6dcda59de5d8eee922ef7eede403a540dae05423ef2c2a042d8d4f22467",
+    "variant": null
   },
   "cpython-3.8.14-darwin-x86_64-none": {
     "name": "cpython",
@@ -6273,7 +9512,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "3ed4db8d0308c584196d97c629058ea69bbd8b7f9a034cf8c2c701ebb286c091"
+    "sha256": "3ed4db8d0308c584196d97c629058ea69bbd8b7f9a034cf8c2c701ebb286c091",
+    "variant": null
+  },
+  "cpython-3.8.14+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "a14d8b5cbd8e1ca45cbcb49f4bf0b0440dc86eb95b7c3da3c463a704a3b4593c",
+    "variant": "debug"
   },
   "cpython-3.8.14-linux-aarch64-gnu": {
     "name": "cpython",
@@ -6285,7 +9538,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "c45e42deee43e3ebc4ca5b019c37d8ae25fb5b5f1ba5f602098a81b99d2bc804"
+    "sha256": "c45e42deee43e3ebc4ca5b019c37d8ae25fb5b5f1ba5f602098a81b99d2bc804",
+    "variant": null
+  },
+  "cpython-3.8.14+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "631bb90fe8f2965d03400b268de90fe155ce51961296360d6578b7151aa9ef4c",
+    "variant": "debug"
   },
   "cpython-3.8.14-linux-i686-gnu": {
     "name": "cpython",
@@ -6297,7 +9564,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "d01d813939ad549ca253c52e5b8361b4490cc5c8cbda00ab6e0c524565153e2b"
+    "sha256": "d01d813939ad549ca253c52e5b8361b4490cc5c8cbda00ab6e0c524565153e2b",
+    "variant": null
+  },
+  "cpython-3.8.14+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "bd1e8e09edccaab82fbd75b457205a076847d62e3354c3d9b5abe985181047fc",
+    "variant": "debug"
   },
   "cpython-3.8.14-linux-x86_64-gnu": {
     "name": "cpython",
@@ -6309,7 +9590,21 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "4eb53bce831bf52682067579c09ccaccb6524dd44bd4b8047454c69b4817f4f0"
+    "sha256": "4eb53bce831bf52682067579c09ccaccb6524dd44bd4b8047454c69b4817f4f0",
+    "variant": null
+  },
+  "cpython-3.8.14+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 14,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "a63a6565153b0f8b2e23611c7622ded3b5cb488d090f26fb4895bd396f8f72ea",
+    "variant": "debug"
   },
   "cpython-3.8.14-linux-x86_64-musl": {
     "name": "cpython",
@@ -6321,7 +9616,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "72c08b1c1d8cc14cb8d22eab18b463bb514ea160472fdc7400bd69ae375cf9c4"
+    "sha256": "72c08b1c1d8cc14cb8d22eab18b463bb514ea160472fdc7400bd69ae375cf9c4",
+    "variant": null
   },
   "cpython-3.8.14-windows-i686-none": {
     "name": "cpython",
@@ -6333,7 +9629,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "a0730f3a9e60581f02bdb852953fbb52cf98e8431259fa39cb668a060bd002a0"
+    "sha256": "a0730f3a9e60581f02bdb852953fbb52cf98e8431259fa39cb668a060bd002a0",
+    "variant": null
   },
   "cpython-3.8.14-windows-x86_64-none": {
     "name": "cpython",
@@ -6345,7 +9642,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "1af39953b4c8324ed0608e316bc763006f27e76643155d92eae18e4db6fc162f"
+    "sha256": "1af39953b4c8324ed0608e316bc763006f27e76643155d92eae18e4db6fc162f",
+    "variant": null
   },
   "cpython-3.8.13-darwin-aarch64-none": {
     "name": "cpython",
@@ -6357,7 +9655,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "ae4131253d890b013171cb5f7b03cadc585ae263719506f7b7e063a7cf6fde76"
+    "sha256": "ae4131253d890b013171cb5f7b03cadc585ae263719506f7b7e063a7cf6fde76",
+    "variant": null
   },
   "cpython-3.8.13-darwin-x86_64-none": {
     "name": "cpython",
@@ -6369,7 +9668,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "cd6e7c0a27daf7df00f6882eaba01490dd963f698e99aeee9706877333e0df69"
+    "sha256": "cd6e7c0a27daf7df00f6882eaba01490dd963f698e99aeee9706877333e0df69",
+    "variant": null
+  },
+  "cpython-3.8.13+debug-linux-aarch64-gnu": {
+    "name": "cpython",
+    "arch": "aarch64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "3a927205db4686c182b5e8f3fc7fd7d82ec8f61c70d5b2bfddd9673c7ddc07ba",
+    "variant": "debug"
   },
   "cpython-3.8.13-linux-aarch64-gnu": {
     "name": "cpython",
@@ -6381,7 +9694,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "8dc7814bf3425bbf78c6e6e5a6529ded6ae463fa6a4b79c025b343bae4fd955a"
+    "sha256": "8dc7814bf3425bbf78c6e6e5a6529ded6ae463fa6a4b79c025b343bae4fd955a",
+    "variant": null
+  },
+  "cpython-3.8.13+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "6daf0405beae6d127a2dcae61d51a719236b861b4cabc220727e48547fd6f045",
+    "variant": "debug"
   },
   "cpython-3.8.13-linux-i686-gnu": {
     "name": "cpython",
@@ -6393,7 +9720,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "9485599ad9053dfba08c91854717272e95b7c81e0d099d9c51a46fc5a095ccb4"
+    "sha256": "9485599ad9053dfba08c91854717272e95b7c81e0d099d9c51a46fc5a095ccb4",
+    "variant": null
+  },
+  "cpython-3.8.13+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "891b5d7b0e936b98a62f65bc0b28fff61ca9002125a2fc1ebb9c72f6b0056712",
+    "variant": "debug"
   },
   "cpython-3.8.13-linux-x86_64-gnu": {
     "name": "cpython",
@@ -6405,7 +9746,21 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "fb566629ccb5f76ef56d275a3f8017d683f1c20c5beb5d5f38b155ed11e16187"
+    "sha256": "fb566629ccb5f76ef56d275a3f8017d683f1c20c5beb5d5f38b155ed11e16187",
+    "variant": null
+  },
+  "cpython-3.8.13+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 13,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "45802706624fe2b2aa57bd42418b5d2f9f94f5372f31c664762393316223389e",
+    "variant": "debug"
   },
   "cpython-3.8.13-linux-x86_64-musl": {
     "name": "cpython",
@@ -6417,7 +9772,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "2c90a0d048caf146d4c33560d6eead1428a225219018d364b1af77f23c492984"
+    "sha256": "2c90a0d048caf146d4c33560d6eead1428a225219018d364b1af77f23c492984",
+    "variant": null
   },
   "cpython-3.8.13-windows-i686-none": {
     "name": "cpython",
@@ -6429,7 +9785,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "a50668d4c5fbcb374d3ca93ee18db910bc3b462693db073669f31e6da993abf9"
+    "sha256": "a50668d4c5fbcb374d3ca93ee18db910bc3b462693db073669f31e6da993abf9",
+    "variant": null
   },
   "cpython-3.8.13-windows-x86_64-none": {
     "name": "cpython",
@@ -6441,7 +9798,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "f20643f1b3e263a56287319aea5c3888530c09ad9de3a5629b1a5d207807e6b9"
+    "sha256": "f20643f1b3e263a56287319aea5c3888530c09ad9de3a5629b1a5d207807e6b9",
+    "variant": null
   },
   "cpython-3.8.12-darwin-aarch64-none": {
     "name": "cpython",
@@ -6453,7 +9811,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-aarch64-apple-darwin-install_only.tar.gz",
-    "sha256": "f9a3cbb81e0463d6615125964762d133387d561b226a30199f5b039b20f1d944"
+    "sha256": "f9a3cbb81e0463d6615125964762d133387d561b226a30199f5b039b20f1d944",
+    "variant": null
   },
   "cpython-3.8.12-darwin-x86_64-none": {
     "name": "cpython",
@@ -6465,7 +9824,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
-    "sha256": "f323fbc558035c13a85ce2267d0fad9e89282268ecb810e364fff1d0a079d525"
+    "sha256": "f323fbc558035c13a85ce2267d0fad9e89282268ecb810e364fff1d0a079d525",
+    "variant": null
+  },
+  "cpython-3.8.12+debug-linux-i686-gnu": {
+    "name": "cpython",
+    "arch": "i686",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "7cfac9a57e262be3e889036d7fc570293e6d3d74411ee23e1fa9aa470d387e6a",
+    "variant": "debug"
   },
   "cpython-3.8.12-linux-i686-gnu": {
     "name": "cpython",
@@ -6477,7 +9850,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "fcb2033f01a2b10a51be68c9a1b4c7d7759b582f58a503371fe67ab59987b418"
+    "sha256": "fcb2033f01a2b10a51be68c9a1b4c7d7759b582f58a503371fe67ab59987b418",
+    "variant": null
+  },
+  "cpython-3.8.12+debug-linux-x86_64-gnu": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "gnu",
+    "major": 3,
+    "minor": 8,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-gnu-debug-full.tar.zst",
+    "sha256": "9ad20c520c291d08087e9afb4390f389d2b66c7fc97f23fffc1313ebafc5fee0",
+    "variant": "debug"
   },
   "cpython-3.8.12-linux-x86_64-gnu": {
     "name": "cpython",
@@ -6489,7 +9876,21 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz",
-    "sha256": "5be9c6d61e238b90dfd94755051c0d3a2d8023ebffdb4b0fa4e8fedd09a6cab6"
+    "sha256": "5be9c6d61e238b90dfd94755051c0d3a2d8023ebffdb4b0fa4e8fedd09a6cab6",
+    "variant": null
+  },
+  "cpython-3.8.12+debug-linux-x86_64-musl": {
+    "name": "cpython",
+    "arch": "x86_64",
+    "os": "linux",
+    "libc": "musl",
+    "major": 3,
+    "minor": 8,
+    "patch": 12,
+    "prerelease": "",
+    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-musl-debug-full.tar.zst",
+    "sha256": "10bca8ab83f2ebb0f7b308a9e2bfebe9a0e638485f6947da9cdb26d95889ef32",
+    "variant": "debug"
   },
   "cpython-3.8.12-linux-x86_64-musl": {
     "name": "cpython",
@@ -6501,7 +9902,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
-    "sha256": "27faf8aa62de2cd4e59b75a6edce4cab549eba81f0f9cc21df0e370a8a2f3a25"
+    "sha256": "27faf8aa62de2cd4e59b75a6edce4cab549eba81f0f9cc21df0e370a8a2f3a25",
+    "variant": null
   },
   "cpython-3.8.12-windows-i686-none": {
     "name": "cpython",
@@ -6513,7 +9915,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "aaa75b9115af73dc3daf7db050ed4f60fd67d2a23ebab30670f18fb8cfa71f33"
+    "sha256": "aaa75b9115af73dc3daf7db050ed4f60fd67d2a23ebab30670f18fb8cfa71f33",
+    "variant": null
   },
   "cpython-3.8.12-windows-x86_64-none": {
     "name": "cpython",
@@ -6525,955 +9928,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-    "sha256": "4658e08a00d60b1e01559b74d58ff4dd04da6df935d55f6268a15d6d0a679d74"
-  },
-  "cpython-3.8.11-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.11-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.11-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.11-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.11-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.11-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 11,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.10-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.10-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.10-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.10-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.10-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.10-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 10,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.9-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.9-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.9-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.9-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.9-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.9-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.8-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.8-linux-i686-gnu": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.8-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.8-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.8-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.8-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 8,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.7-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.7-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-gnu-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.7-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.7-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.7-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.6-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.6-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-gnu-pgo-20201020T0627.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.6-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.6-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-i686-pc-windows-msvc-shared-pgo-20201021T0233.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.6-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-pc-windows-msvc-shared-pgo-20201021T0232.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.5-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.8.5-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.5-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-gnu-pgo-20200823T0036.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.5-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.5-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-i686-pc-windows-msvc-shared-pgo-20200830T2311.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.5-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-x86_64-pc-windows-msvc-shared-pgo-20200830T2254.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.3-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.8.3-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.3-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-gnu-pgo-20200518T0040.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.3-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 8,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.3-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-i686-pc-windows-msvc-shared-pgo-20200518T0154.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.3-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-pc-windows-msvc-shared-pgo-20200517T2207.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.2-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-apple-darwin-pgo-20200418T2238.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.2-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 8,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-unknown-linux-gnu-pgo-20200418T2243.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.2-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-i686-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.8.2-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 8,
-    "patch": 2,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.9-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.7.9-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.9-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 7,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-gnu-pgo-20200823T0036.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.9-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 7,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.9-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-i686-pc-windows-msvc-shared-pgo-20200823T0159.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.9-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 9,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-pc-windows-msvc-shared-pgo-20200823T0118.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.7-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.7.7-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.7-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 7,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-gnu-pgo-20200518T0040.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.7-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 7,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.7-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-i686-pc-windows-msvc-shared-pgo-20200517T2153.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.7-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 7,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-pc-windows-msvc-shared-pgo-20200517T2128.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.6-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-macos-20200216T2344.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.6-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 7,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-linux64-20200216T2303.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.6-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 7,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200217/cpython-3.7.6-linux64-musl-20200218T0557.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.6-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-x86-shared-pgo-20200217T0110.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.6-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 6,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-amd64-shared-pgo-20200217T0022.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.5-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-macos-20191026T0535.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.5-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 7,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-linux64-20191025T0506.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.5-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 7,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-linux64-musl-20191026T0603.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.5-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-x86-20191025T0549.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.5-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 5,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-amd64-20191025T0540.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.4-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-macos-20190817T0220.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.4-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 7,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-linux64-20190817T0224.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.4-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 7,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-linux64-musl-20190817T0227.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.4-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-x86-20190817T0235.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.4-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 4,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-amd64-20190817T0227.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.3-darwin-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "darwin",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-macos-20190618T0523.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.3-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 7,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-linux64-20190618T0324.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.3-linux-x86_64-musl": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "musl",
-    "major": 3,
-    "minor": 7,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-linux64-musl-20190618T0400.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.3-windows-i686-none": {
-    "name": "cpython",
-    "arch": "i686",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-x86-20190709T0348.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.3-windows-x86_64-none": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "windows",
-    "libc": "none",
-    "major": 3,
-    "minor": 7,
-    "patch": 3,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-amd64-20190618T0516.tar.zst",
-    "sha256": null
-  },
-  "cpython-3.7.1-linux-x86_64-gnu": {
-    "name": "cpython",
-    "arch": "x86_64",
-    "os": "linux",
-    "libc": "gnu",
-    "major": 3,
-    "minor": 7,
-    "patch": 1,
-    "prerelease": "",
-    "url": "https://github.com/indygreg/python-build-standalone/releases/download/20181218/cpython-3.7.1-linux64-20181218T1905.tar.zst",
-    "sha256": null
+    "sha256": "4658e08a00d60b1e01559b74d58ff4dd04da6df935d55f6268a15d6d0a679d74",
+    "variant": null
   },
   "pypy-3.10.14-darwin-aarch64-none": {
     "name": "pypy",
@@ -7485,7 +9941,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_arm64.tar.bz2",
-    "sha256": "a050e25e8d686853dd5afc363e55625165825dacfb55f8753d8225ebe417cfd2"
+    "sha256": "a050e25e8d686853dd5afc363e55625165825dacfb55f8753d8225ebe417cfd2",
+    "variant": null
   },
   "pypy-3.10.14-darwin-x86_64-none": {
     "name": "pypy",
@@ -7497,7 +9954,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_x86_64.tar.bz2",
-    "sha256": "6c2c5f2300d7564e711421b4968abd63243cb96f76e363975dd648ebf4a362ee"
+    "sha256": "6c2c5f2300d7564e711421b4968abd63243cb96f76e363975dd648ebf4a362ee",
+    "variant": null
   },
   "pypy-3.10.14-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7509,7 +9967,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-aarch64.tar.bz2",
-    "sha256": "53b6e5907df869c49e4eae7aca09fba16d150741097efb245892c1477d2395f2"
+    "sha256": "53b6e5907df869c49e4eae7aca09fba16d150741097efb245892c1477d2395f2",
+    "variant": null
   },
   "pypy-3.10.14-linux-i686-gnu": {
     "name": "pypy",
@@ -7521,7 +9980,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-linux32.tar.bz2",
-    "sha256": "e534110e1047da37c1d586c392f74de3424f871d906a2083de6d41f2a8cc9164"
+    "sha256": "e534110e1047da37c1d586c392f74de3424f871d906a2083de6d41f2a8cc9164",
+    "variant": null
   },
   "pypy-3.10.14-linux-s390x-gnu": {
     "name": "pypy",
@@ -7533,7 +9993,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.16-s390x.tar.bz2",
-    "sha256": "af97efe498a209ba18c7bc7d084164a9907fb3736588b6864955177e19d5216a"
+    "sha256": "af97efe498a209ba18c7bc7d084164a9907fb3736588b6864955177e19d5216a",
+    "variant": null
   },
   "pypy-3.10.14-linux-x86_64-gnu": {
     "name": "pypy",
@@ -7545,7 +10006,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-linux64.tar.bz2",
-    "sha256": "fdcdb9b24f1a7726003586503fdeb264fd68fc37fbfcea022dcfe825a7fee18b"
+    "sha256": "fdcdb9b24f1a7726003586503fdeb264fd68fc37fbfcea022dcfe825a7fee18b",
+    "variant": null
   },
   "pypy-3.10.14-windows-x86_64-none": {
     "name": "pypy",
@@ -7557,7 +10019,8 @@
     "patch": 14,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.17-win64.zip",
-    "sha256": "cab794a03ddda26238c72942ea6f225612e0dc17c76cac6652da83a95024e6e8"
+    "sha256": "cab794a03ddda26238c72942ea6f225612e0dc17c76cac6652da83a95024e6e8",
+    "variant": null
   },
   "pypy-3.10.13-darwin-aarch64-none": {
     "name": "pypy",
@@ -7569,7 +10032,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.15-macos_arm64.tar.bz2",
-    "sha256": "d927c5105ea7880f7596fe459183e35cc17c853ef5105678b2ad62a8d000a548"
+    "sha256": "d927c5105ea7880f7596fe459183e35cc17c853ef5105678b2ad62a8d000a548",
+    "variant": null
   },
   "pypy-3.10.13-darwin-x86_64-none": {
     "name": "pypy",
@@ -7581,7 +10045,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.15-macos_x86_64.tar.bz2",
-    "sha256": "559b61ba7e7c5a5c23cef5370f1fab47ccdb939ac5d2b42b4bef091abe3f6964"
+    "sha256": "559b61ba7e7c5a5c23cef5370f1fab47ccdb939ac5d2b42b4bef091abe3f6964",
+    "variant": null
   },
   "pypy-3.10.13-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7593,7 +10058,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.15-aarch64.tar.bz2",
-    "sha256": "52146fccaf64e87e71d178dda8de63c01577ec3923073dc69e1519622bcacb74"
+    "sha256": "52146fccaf64e87e71d178dda8de63c01577ec3923073dc69e1519622bcacb74",
+    "variant": null
   },
   "pypy-3.10.13-linux-i686-gnu": {
     "name": "pypy",
@@ -7605,7 +10071,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.15-linux32.tar.bz2",
-    "sha256": "75dd58c9abd8b9d78220373148355bc3119febcf27a2c781d64ad85e7232c4aa"
+    "sha256": "75dd58c9abd8b9d78220373148355bc3119febcf27a2c781d64ad85e7232c4aa",
+    "variant": null
   },
   "pypy-3.10.13-linux-s390x-gnu": {
     "name": "pypy",
@@ -7617,7 +10084,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.15-s390x.tar.bz2",
-    "sha256": "209e57596381e13c9914d1332f359dc4b78de06576739747eb797bdbf85062b8"
+    "sha256": "209e57596381e13c9914d1332f359dc4b78de06576739747eb797bdbf85062b8",
+    "variant": null
   },
   "pypy-3.10.13-linux-x86_64-gnu": {
     "name": "pypy",
@@ -7629,7 +10097,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.15-linux64.tar.bz2",
-    "sha256": "33c584e9a70a71afd0cb7dd8ba9996720b911b3b8ed0156aea298d4487ad22c3"
+    "sha256": "33c584e9a70a71afd0cb7dd8ba9996720b911b3b8ed0156aea298d4487ad22c3",
+    "variant": null
   },
   "pypy-3.10.13-windows-x86_64-none": {
     "name": "pypy",
@@ -7641,7 +10110,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.15-win64.zip",
-    "sha256": "b378b3ab1c3719aee0c3e5519e7bff93ff67b2d8aa987fe4f088b54382db676c"
+    "sha256": "b378b3ab1c3719aee0c3e5519e7bff93ff67b2d8aa987fe4f088b54382db676c",
+    "variant": null
   },
   "pypy-3.10.12-darwin-aarch64-none": {
     "name": "pypy",
@@ -7653,7 +10123,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.12-macos_arm64.tar.bz2",
-    "sha256": "45671b1e9437f95ccd790af10dbeb57733cca1ed9661463b727d3c4f5caa7ba0"
+    "sha256": "45671b1e9437f95ccd790af10dbeb57733cca1ed9661463b727d3c4f5caa7ba0",
+    "variant": null
   },
   "pypy-3.10.12-darwin-x86_64-none": {
     "name": "pypy",
@@ -7665,7 +10136,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.12-macos_x86_64.tar.bz2",
-    "sha256": "dbc15d8570560d5f79366883c24bc42231a92855ac19a0f28cb0adeb11242666"
+    "sha256": "dbc15d8570560d5f79366883c24bc42231a92855ac19a0f28cb0adeb11242666",
+    "variant": null
   },
   "pypy-3.10.12-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7677,7 +10149,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.12-aarch64.tar.bz2",
-    "sha256": "26208b5a134d9860a08f74cce60960005758e82dc5f0e3566a48ed863a1f16a1"
+    "sha256": "26208b5a134d9860a08f74cce60960005758e82dc5f0e3566a48ed863a1f16a1",
+    "variant": null
   },
   "pypy-3.10.12-linux-i686-gnu": {
     "name": "pypy",
@@ -7689,7 +10162,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.12-linux32.tar.bz2",
-    "sha256": "811667825ae58ada4b7c3d8bc1b5055b9f9d6a377e51aedfbe0727966603f60e"
+    "sha256": "811667825ae58ada4b7c3d8bc1b5055b9f9d6a377e51aedfbe0727966603f60e",
+    "variant": null
   },
   "pypy-3.10.12-linux-s390x-gnu": {
     "name": "pypy",
@@ -7701,7 +10175,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.12-s390x.tar.bz2",
-    "sha256": "043c13a585479428b463ab69575a088db74aadc16798d6e677d97f563585fee3"
+    "sha256": "043c13a585479428b463ab69575a088db74aadc16798d6e677d97f563585fee3",
+    "variant": null
   },
   "pypy-3.10.12-linux-x86_64-gnu": {
     "name": "pypy",
@@ -7713,7 +10188,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.12-linux64.tar.bz2",
-    "sha256": "6c577993160b6f5ee8cab73cd1a807affcefafe2f7441c87bd926c10505e8731"
+    "sha256": "6c577993160b6f5ee8cab73cd1a807affcefafe2f7441c87bd926c10505e8731",
+    "variant": null
   },
   "pypy-3.10.12-windows-x86_64-none": {
     "name": "pypy",
@@ -7725,7 +10201,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.10-v7.3.12-win64.zip",
-    "sha256": "8c3b1d34fb99100e230e94560410a38d450dc844effbee9ea183518e4aff595c"
+    "sha256": "8c3b1d34fb99100e230e94560410a38d450dc844effbee9ea183518e4aff595c",
+    "variant": null
   },
   "pypy-3.9.19-darwin-aarch64-none": {
     "name": "pypy",
@@ -7737,7 +10214,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_arm64.tar.bz2",
-    "sha256": "88f824e7a2d676440d09bc90fc959ae0fd3557d7e2f14bfbbe53d41d159a47fe"
+    "sha256": "88f824e7a2d676440d09bc90fc959ae0fd3557d7e2f14bfbbe53d41d159a47fe",
+    "variant": null
   },
   "pypy-3.9.19-darwin-x86_64-none": {
     "name": "pypy",
@@ -7749,7 +10227,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_x86_64.tar.bz2",
-    "sha256": "fda015431621e7e5aa16359d114f2c45a77ed936992c1efff86302e768a6b21c"
+    "sha256": "fda015431621e7e5aa16359d114f2c45a77ed936992c1efff86302e768a6b21c",
+    "variant": null
   },
   "pypy-3.9.19-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7761,7 +10240,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-aarch64.tar.bz2",
-    "sha256": "de3f2ed3581b30555ac0dd3e4df78a262ec736a36fb2e8f28259f8539b278ef4"
+    "sha256": "de3f2ed3581b30555ac0dd3e4df78a262ec736a36fb2e8f28259f8539b278ef4",
+    "variant": null
   },
   "pypy-3.9.19-linux-i686-gnu": {
     "name": "pypy",
@@ -7773,7 +10253,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-linux32.tar.bz2",
-    "sha256": "583b6d6dd4e8c07cbc04da04a7ec2bdfa6674825289c2378c5e018d5abe779ea"
+    "sha256": "583b6d6dd4e8c07cbc04da04a7ec2bdfa6674825289c2378c5e018d5abe779ea",
+    "variant": null
   },
   "pypy-3.9.19-linux-s390x-gnu": {
     "name": "pypy",
@@ -7785,7 +10266,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-s390x.tar.bz2",
-    "sha256": "7a56ebb27dba3110dc1ff52d8e0449cdb37fe5c2275f7faf11432e4e164833ba"
+    "sha256": "7a56ebb27dba3110dc1ff52d8e0449cdb37fe5c2275f7faf11432e4e164833ba",
+    "variant": null
   },
   "pypy-3.9.19-linux-x86_64-gnu": {
     "name": "pypy",
@@ -7797,7 +10279,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-linux64.tar.bz2",
-    "sha256": "16f9c5b808c848516e742986e826b833cdbeda09ad8764e8704595adbe791b23"
+    "sha256": "16f9c5b808c848516e742986e826b833cdbeda09ad8764e8704595adbe791b23",
+    "variant": null
   },
   "pypy-3.9.19-windows-x86_64-none": {
     "name": "pypy",
@@ -7809,7 +10292,8 @@
     "patch": 19,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.16-win64.zip",
-    "sha256": "06ec12a5e964dc0ad33e6f380185a4d295178dce6d6df512f508e7aee00a1323"
+    "sha256": "06ec12a5e964dc0ad33e6f380185a4d295178dce6d6df512f508e7aee00a1323",
+    "variant": null
   },
   "pypy-3.9.18-darwin-aarch64-none": {
     "name": "pypy",
@@ -7821,7 +10305,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.15-macos_arm64.tar.bz2",
-    "sha256": "300541c32125767a91b182b03d9cc4257f04971af32d747ecd4d62549d72acfd"
+    "sha256": "300541c32125767a91b182b03d9cc4257f04971af32d747ecd4d62549d72acfd",
+    "variant": null
   },
   "pypy-3.9.18-darwin-x86_64-none": {
     "name": "pypy",
@@ -7833,7 +10318,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.15-macos_x86_64.tar.bz2",
-    "sha256": "18ad7c9cb91c5e8ef9d40442b2fd1f6392ae113794c5b6b7d3a45e04f19edec6"
+    "sha256": "18ad7c9cb91c5e8ef9d40442b2fd1f6392ae113794c5b6b7d3a45e04f19edec6",
+    "variant": null
   },
   "pypy-3.9.18-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7845,7 +10331,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.15-aarch64.tar.bz2",
-    "sha256": "03e35fcba290454bb0ccf7ee57fb42d1e63108d10d593776a382c0a2fe355de0"
+    "sha256": "03e35fcba290454bb0ccf7ee57fb42d1e63108d10d593776a382c0a2fe355de0",
+    "variant": null
   },
   "pypy-3.9.18-linux-i686-gnu": {
     "name": "pypy",
@@ -7857,7 +10344,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.15-linux32.tar.bz2",
-    "sha256": "c6209380977066c9e8b96e8258821c70f996004ce1bc8659ae83d4fd5a89ff5c"
+    "sha256": "c6209380977066c9e8b96e8258821c70f996004ce1bc8659ae83d4fd5a89ff5c",
+    "variant": null
   },
   "pypy-3.9.18-linux-s390x-gnu": {
     "name": "pypy",
@@ -7869,7 +10357,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.15-s390x.tar.bz2",
-    "sha256": "deeb5e54c36a0fd9cfefd16e63a0d5bed4f4a43e6bbc01c23f0ed8f7f1c0aaf3"
+    "sha256": "deeb5e54c36a0fd9cfefd16e63a0d5bed4f4a43e6bbc01c23f0ed8f7f1c0aaf3",
+    "variant": null
   },
   "pypy-3.9.18-linux-x86_64-gnu": {
     "name": "pypy",
@@ -7881,7 +10370,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.15-linux64.tar.bz2",
-    "sha256": "f062be307200bde434817e1620cebc13f563d6ab25309442c5f4d0f0d68f0912"
+    "sha256": "f062be307200bde434817e1620cebc13f563d6ab25309442c5f4d0f0d68f0912",
+    "variant": null
   },
   "pypy-3.9.18-windows-x86_64-none": {
     "name": "pypy",
@@ -7893,7 +10383,8 @@
     "patch": 18,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.15-win64.zip",
-    "sha256": "a156dad8b58570597eaaabe05663f00f80c60bc11df4a9c46d0953b6c5eb9209"
+    "sha256": "a156dad8b58570597eaaabe05663f00f80c60bc11df4a9c46d0953b6c5eb9209",
+    "variant": null
   },
   "pypy-3.9.17-darwin-aarch64-none": {
     "name": "pypy",
@@ -7905,7 +10396,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.12-macos_arm64.tar.bz2",
-    "sha256": "0e8a1a3468b9790c734ac698f5b00cc03fc16899ccc6ce876465fac0b83980e3"
+    "sha256": "0e8a1a3468b9790c734ac698f5b00cc03fc16899ccc6ce876465fac0b83980e3",
+    "variant": null
   },
   "pypy-3.9.17-darwin-x86_64-none": {
     "name": "pypy",
@@ -7917,7 +10409,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.12-macos_x86_64.tar.bz2",
-    "sha256": "64f008ffa070c407e5ef46c8256b2e014de7196ea5d858385861254e7959f4eb"
+    "sha256": "64f008ffa070c407e5ef46c8256b2e014de7196ea5d858385861254e7959f4eb",
+    "variant": null
   },
   "pypy-3.9.17-linux-aarch64-gnu": {
     "name": "pypy",
@@ -7929,7 +10422,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.12-aarch64.tar.bz2",
-    "sha256": "e9327fb9edaf2ad91935d5b8563ec5ff24193bddb175c1acaaf772c025af1824"
+    "sha256": "e9327fb9edaf2ad91935d5b8563ec5ff24193bddb175c1acaaf772c025af1824",
+    "variant": null
   },
   "pypy-3.9.17-linux-i686-gnu": {
     "name": "pypy",
@@ -7941,7 +10435,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.12-linux32.tar.bz2",
-    "sha256": "aa04370d38f451683ccc817d76c2b3e0f471dbb879e0bd618d9affbdc9cd37a4"
+    "sha256": "aa04370d38f451683ccc817d76c2b3e0f471dbb879e0bd618d9affbdc9cd37a4",
+    "variant": null
   },
   "pypy-3.9.17-linux-s390x-gnu": {
     "name": "pypy",
@@ -7953,7 +10448,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.12-s390x.tar.bz2",
-    "sha256": "20d84658a6899bdd2ca35b00ead33a2f56cff2c40dce1af630466d27952f6d4f"
+    "sha256": "20d84658a6899bdd2ca35b00ead33a2f56cff2c40dce1af630466d27952f6d4f",
+    "variant": null
   },
   "pypy-3.9.17-linux-x86_64-gnu": {
     "name": "pypy",
@@ -7965,7 +10461,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.12-linux64.tar.bz2",
-    "sha256": "84c89b966fab2b58f451a482ee30ca7fec3350435bd0b9614615c61dc6da2390"
+    "sha256": "84c89b966fab2b58f451a482ee30ca7fec3350435bd0b9614615c61dc6da2390",
+    "variant": null
   },
   "pypy-3.9.17-windows-x86_64-none": {
     "name": "pypy",
@@ -7977,7 +10474,8 @@
     "patch": 17,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.12-win64.zip",
-    "sha256": "0996054207b401aeacace1aa11bad82cfcb463838a1603c5f263626c47bbe0e6"
+    "sha256": "0996054207b401aeacace1aa11bad82cfcb463838a1603c5f263626c47bbe0e6",
+    "variant": null
   },
   "pypy-3.9.16-darwin-aarch64-none": {
     "name": "pypy",
@@ -7989,7 +10487,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.11-macos_arm64.tar.bz2",
-    "sha256": "91ad7500f1a39531dbefa0b345a3dcff927ff9971654e8d2e9ef7c5ae311f57e"
+    "sha256": "91ad7500f1a39531dbefa0b345a3dcff927ff9971654e8d2e9ef7c5ae311f57e",
+    "variant": null
   },
   "pypy-3.9.16-darwin-x86_64-none": {
     "name": "pypy",
@@ -8001,7 +10500,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.11-macos_x86_64.tar.bz2",
-    "sha256": "d33f40b207099872585afd71873575ca6ea638a27d823bc621238c5ae82542ed"
+    "sha256": "d33f40b207099872585afd71873575ca6ea638a27d823bc621238c5ae82542ed",
+    "variant": null
   },
   "pypy-3.9.16-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8013,7 +10513,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.11-aarch64.tar.bz2",
-    "sha256": "09175dc652ed895d98e9ad63d216812bf3ee7e398d900a9bf9eb2906ba8302b9"
+    "sha256": "09175dc652ed895d98e9ad63d216812bf3ee7e398d900a9bf9eb2906ba8302b9",
+    "variant": null
   },
   "pypy-3.9.16-linux-i686-gnu": {
     "name": "pypy",
@@ -8025,7 +10526,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.11-linux32.tar.bz2",
-    "sha256": "0099d72c2897b229057bff7e2c343624aeabdc60d6fb43ca882bff082f1ffa48"
+    "sha256": "0099d72c2897b229057bff7e2c343624aeabdc60d6fb43ca882bff082f1ffa48",
+    "variant": null
   },
   "pypy-3.9.16-linux-s390x-gnu": {
     "name": "pypy",
@@ -8037,7 +10539,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.11-s390x.tar.bz2",
-    "sha256": "e1f30f2ddbe3f446ddacd79677b958d56c07463b20171fb2abf8f9a3178b79fc"
+    "sha256": "e1f30f2ddbe3f446ddacd79677b958d56c07463b20171fb2abf8f9a3178b79fc",
+    "variant": null
   },
   "pypy-3.9.16-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8049,7 +10552,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.11-linux64.tar.bz2",
-    "sha256": "d506172ca11071274175d74e9c581c3166432d0179b036470e3b9e8d20eae581"
+    "sha256": "d506172ca11071274175d74e9c581c3166432d0179b036470e3b9e8d20eae581",
+    "variant": null
   },
   "pypy-3.9.16-windows-x86_64-none": {
     "name": "pypy",
@@ -8061,7 +10565,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.11-win64.zip",
-    "sha256": "57faad132d42d3e7a6406fcffafffe0b4f390cf0e2966abb8090d073c6edf405"
+    "sha256": "57faad132d42d3e7a6406fcffafffe0b4f390cf0e2966abb8090d073c6edf405",
+    "variant": null
   },
   "pypy-3.9.15-darwin-aarch64-none": {
     "name": "pypy",
@@ -8073,7 +10578,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-macos_arm64.tar.bz2",
-    "sha256": "e2a6bec7408e6497c7de8165aa4a1b15e2416aec4a72f2578f793fb06859ccba"
+    "sha256": "e2a6bec7408e6497c7de8165aa4a1b15e2416aec4a72f2578f793fb06859ccba",
+    "variant": null
   },
   "pypy-3.9.15-darwin-x86_64-none": {
     "name": "pypy",
@@ -8085,7 +10591,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-macos_x86_64.tar.bz2",
-    "sha256": "f90c8619b41e68ec9ffd7d5e913fe02e60843da43d3735b1c1bc75bcfe638d97"
+    "sha256": "f90c8619b41e68ec9ffd7d5e913fe02e60843da43d3735b1c1bc75bcfe638d97",
+    "variant": null
   },
   "pypy-3.9.15-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8097,7 +10604,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-aarch64.tar.bz2",
-    "sha256": "657a04fd9a5a992a2f116a9e7e9132ea0c578721f59139c9fb2083775f71e514"
+    "sha256": "657a04fd9a5a992a2f116a9e7e9132ea0c578721f59139c9fb2083775f71e514",
+    "variant": null
   },
   "pypy-3.9.15-linux-i686-gnu": {
     "name": "pypy",
@@ -8109,7 +10617,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-linux32.tar.bz2",
-    "sha256": "b6db59613b9a1c0c1ab87bc103f52ee95193423882dc8a848b68850b8ba59cc5"
+    "sha256": "b6db59613b9a1c0c1ab87bc103f52ee95193423882dc8a848b68850b8ba59cc5",
+    "variant": null
   },
   "pypy-3.9.15-linux-s390x-gnu": {
     "name": "pypy",
@@ -8121,7 +10630,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-s390x.tar.bz2",
-    "sha256": "ca6525a540cf0c682d1592ae35d3fbc97559a97260e4b789255cc76dde7a14f0"
+    "sha256": "ca6525a540cf0c682d1592ae35d3fbc97559a97260e4b789255cc76dde7a14f0",
+    "variant": null
   },
   "pypy-3.9.15-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8133,7 +10643,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-linux64.tar.bz2",
-    "sha256": "95cf99406179460d63ddbfe1ec870f889d05f7767ce81cef14b88a3a9e127266"
+    "sha256": "95cf99406179460d63ddbfe1ec870f889d05f7767ce81cef14b88a3a9e127266",
+    "variant": null
   },
   "pypy-3.9.15-windows-x86_64-none": {
     "name": "pypy",
@@ -8145,7 +10656,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.10-win64.zip",
-    "sha256": "07e18b7b24c74af9730dfaab16e24b22ef94ea9a4b64cbb2c0d80610a381192a"
+    "sha256": "07e18b7b24c74af9730dfaab16e24b22ef94ea9a4b64cbb2c0d80610a381192a",
+    "variant": null
   },
   "pypy-3.9.12-darwin-x86_64-none": {
     "name": "pypy",
@@ -8157,7 +10669,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.9-osx64.tar.bz2",
-    "sha256": "59c8852168b2b1ba1f0211ff043c678760380d2f9faf2f95042a8878554dbc25"
+    "sha256": "59c8852168b2b1ba1f0211ff043c678760380d2f9faf2f95042a8878554dbc25",
+    "variant": null
   },
   "pypy-3.9.12-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8169,7 +10682,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.9-aarch64.tar.bz2",
-    "sha256": "2e1ae193d98bc51439642a7618d521ea019f45b8fb226940f7e334c548d2b4b9"
+    "sha256": "2e1ae193d98bc51439642a7618d521ea019f45b8fb226940f7e334c548d2b4b9",
+    "variant": null
   },
   "pypy-3.9.12-linux-i686-gnu": {
     "name": "pypy",
@@ -8181,7 +10695,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.9-linux32.tar.bz2",
-    "sha256": "0de4b9501cf28524cdedcff5052deee9ea4630176a512bdc408edfa30914bae7"
+    "sha256": "0de4b9501cf28524cdedcff5052deee9ea4630176a512bdc408edfa30914bae7",
+    "variant": null
   },
   "pypy-3.9.12-linux-s390x-gnu": {
     "name": "pypy",
@@ -8193,7 +10708,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.9-s390x.tar.bz2",
-    "sha256": "774dca83bcb4403fb99b3d155e7bd572ef8c52b9fe87a657109f64e75ad71732"
+    "sha256": "774dca83bcb4403fb99b3d155e7bd572ef8c52b9fe87a657109f64e75ad71732",
+    "variant": null
   },
   "pypy-3.9.12-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8205,7 +10721,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.9-linux64.tar.bz2",
-    "sha256": "46818cb3d74b96b34787548343d266e2562b531ddbaf330383ba930ff1930ed5"
+    "sha256": "46818cb3d74b96b34787548343d266e2562b531ddbaf330383ba930ff1930ed5",
+    "variant": null
   },
   "pypy-3.9.12-windows-x86_64-none": {
     "name": "pypy",
@@ -8217,7 +10734,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.9-win64.zip",
-    "sha256": "be48ab42f95c402543a7042c999c9433b17e55477c847612c8733a583ca6dff5"
+    "sha256": "be48ab42f95c402543a7042c999c9433b17e55477c847612c8733a583ca6dff5",
+    "variant": null
   },
   "pypy-3.9.10-darwin-x86_64-none": {
     "name": "pypy",
@@ -8229,7 +10747,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-osx64.tar.bz2",
-    "sha256": "95bd88ac8d6372cd5b7b5393de7b7d5c615a0c6e42fdb1eb67f2d2d510965aee"
+    "sha256": "95bd88ac8d6372cd5b7b5393de7b7d5c615a0c6e42fdb1eb67f2d2d510965aee",
+    "variant": null
   },
   "pypy-3.9.10-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8241,7 +10760,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64-portable.tar.bz2",
-    "sha256": "b7282bc4484bceae5bc4cc04e05ee4faf51cb624c8fc7a69d92e5fdf0d0c96aa"
+    "sha256": "b7282bc4484bceae5bc4cc04e05ee4faf51cb624c8fc7a69d92e5fdf0d0c96aa",
+    "variant": null
   },
   "pypy-3.9.10-linux-i686-gnu": {
     "name": "pypy",
@@ -8253,7 +10773,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-linux32.tar.bz2",
-    "sha256": "a0d18e4e73cc655eb02354759178b8fb161d3e53b64297d05e2fff91f7cf862d"
+    "sha256": "a0d18e4e73cc655eb02354759178b8fb161d3e53b64297d05e2fff91f7cf862d",
+    "variant": null
   },
   "pypy-3.9.10-linux-s390x-gnu": {
     "name": "pypy",
@@ -8265,7 +10786,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-s390x.tar.bz2",
-    "sha256": "37b596bfe76707ead38ffb565629697e9b6fa24e722acc3c632b41ec624f5d95"
+    "sha256": "37b596bfe76707ead38ffb565629697e9b6fa24e722acc3c632b41ec624f5d95",
+    "variant": null
   },
   "pypy-3.9.10-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8277,7 +10799,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-linux64.tar.bz2",
-    "sha256": "129a055032bba700cd1d0acacab3659cf6b7180e25b1b2f730e792f06d5b3010"
+    "sha256": "129a055032bba700cd1d0acacab3659cf6b7180e25b1b2f730e792f06d5b3010",
+    "variant": null
   },
   "pypy-3.9.10-windows-x86_64-none": {
     "name": "pypy",
@@ -8289,7 +10812,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.9-v7.3.8-win64.zip",
-    "sha256": "c1b2e4cde2dcd1208d41ef7b7df8e5c90564a521e7a5db431673da335a1ba697"
+    "sha256": "c1b2e4cde2dcd1208d41ef7b7df8e5c90564a521e7a5db431673da335a1ba697",
+    "variant": null
   },
   "pypy-3.8.16-darwin-aarch64-none": {
     "name": "pypy",
@@ -8301,7 +10825,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.11-macos_arm64.tar.bz2",
-    "sha256": "78cdc79ff964c4bfd13eb45a7d43a011cbe8d8b513323d204891f703fdc4fa1a"
+    "sha256": "78cdc79ff964c4bfd13eb45a7d43a011cbe8d8b513323d204891f703fdc4fa1a",
+    "variant": null
   },
   "pypy-3.8.16-darwin-x86_64-none": {
     "name": "pypy",
@@ -8313,7 +10838,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.11-macos_x86_64.tar.bz2",
-    "sha256": "194ca0b4d91ae409a9cb1a59eb7572d7affa8a451ea3daf26539aa515443433a"
+    "sha256": "194ca0b4d91ae409a9cb1a59eb7572d7affa8a451ea3daf26539aa515443433a",
+    "variant": null
   },
   "pypy-3.8.16-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8325,7 +10851,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.11-aarch64.tar.bz2",
-    "sha256": "9a2fa0b8d92b7830aa31774a9a76129b0ff81afbd22cd5c41fbdd9119e859f55"
+    "sha256": "9a2fa0b8d92b7830aa31774a9a76129b0ff81afbd22cd5c41fbdd9119e859f55",
+    "variant": null
   },
   "pypy-3.8.16-linux-i686-gnu": {
     "name": "pypy",
@@ -8337,7 +10864,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.11-linux32.tar.bz2",
-    "sha256": "a79b31fce8f5bc1f9940b6777134189a1d3d18bda4b1c830384cda90077c9176"
+    "sha256": "a79b31fce8f5bc1f9940b6777134189a1d3d18bda4b1c830384cda90077c9176",
+    "variant": null
   },
   "pypy-3.8.16-linux-s390x-gnu": {
     "name": "pypy",
@@ -8349,7 +10877,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.11-s390x.tar.bz2",
-    "sha256": "eab7734d86d96549866f1cba67f4f9c73c989f6a802248beebc504080d4c3fcd"
+    "sha256": "eab7734d86d96549866f1cba67f4f9c73c989f6a802248beebc504080d4c3fcd",
+    "variant": null
   },
   "pypy-3.8.16-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8361,7 +10890,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.11-linux64.tar.bz2",
-    "sha256": "470330e58ac105c094041aa07bb05676b06292bc61409e26f5c5593ebb2292d9"
+    "sha256": "470330e58ac105c094041aa07bb05676b06292bc61409e26f5c5593ebb2292d9",
+    "variant": null
   },
   "pypy-3.8.16-windows-x86_64-none": {
     "name": "pypy",
@@ -8373,7 +10903,8 @@
     "patch": 16,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.11-win64.zip",
-    "sha256": "0f46fb6df32941ea016f77cfd7e9b426d5ac25a2af2453414df66103941c8435"
+    "sha256": "0f46fb6df32941ea016f77cfd7e9b426d5ac25a2af2453414df66103941c8435",
+    "variant": null
   },
   "pypy-3.8.15-darwin-aarch64-none": {
     "name": "pypy",
@@ -8385,7 +10916,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-macos_arm64.tar.bz2",
-    "sha256": "6cb1429371e4854b718148a509d80143f801e3abfc72fef58d88aeeee1e98f9e"
+    "sha256": "6cb1429371e4854b718148a509d80143f801e3abfc72fef58d88aeeee1e98f9e",
+    "variant": null
   },
   "pypy-3.8.15-darwin-x86_64-none": {
     "name": "pypy",
@@ -8397,7 +10929,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-macos_x86_64.tar.bz2",
-    "sha256": "399eb1ce4c65f62f6a096b7c273536601b7695e3c0dc0457393a659b95b7615b"
+    "sha256": "399eb1ce4c65f62f6a096b7c273536601b7695e3c0dc0457393a659b95b7615b",
+    "variant": null
   },
   "pypy-3.8.15-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8409,7 +10942,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-aarch64.tar.bz2",
-    "sha256": "e4caa1a545f22cfee87d5b9aa6f8852347f223643ad7d2562e0b2a2f4663ad98"
+    "sha256": "e4caa1a545f22cfee87d5b9aa6f8852347f223643ad7d2562e0b2a2f4663ad98",
+    "variant": null
   },
   "pypy-3.8.15-linux-i686-gnu": {
     "name": "pypy",
@@ -8421,7 +10955,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-linux32.tar.bz2",
-    "sha256": "b70ed7fdc73a74ebdc04f07439f7bad1a849aaca95e26b4a74049d0e483f071c"
+    "sha256": "b70ed7fdc73a74ebdc04f07439f7bad1a849aaca95e26b4a74049d0e483f071c",
+    "variant": null
   },
   "pypy-3.8.15-linux-s390x-gnu": {
     "name": "pypy",
@@ -8433,7 +10968,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-s390x.tar.bz2",
-    "sha256": "c294f8e815158388628fe77ac5b8ad6cd93c8db1359091fa02d41cf6da4d61a1"
+    "sha256": "c294f8e815158388628fe77ac5b8ad6cd93c8db1359091fa02d41cf6da4d61a1",
+    "variant": null
   },
   "pypy-3.8.15-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8445,7 +10981,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-linux64.tar.bz2",
-    "sha256": "ceef6496fd4ab1c99e3ec22ce657b8f10f8bb77a32427fadfb5e1dd943806011"
+    "sha256": "ceef6496fd4ab1c99e3ec22ce657b8f10f8bb77a32427fadfb5e1dd943806011",
+    "variant": null
   },
   "pypy-3.8.15-windows-x86_64-none": {
     "name": "pypy",
@@ -8457,7 +10994,8 @@
     "patch": 15,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.10-win64.zip",
-    "sha256": "362dd624d95bd64743190ea2539b97452ecb3d53ea92ceb2fbe9f48dc60e6b8f"
+    "sha256": "362dd624d95bd64743190ea2539b97452ecb3d53ea92ceb2fbe9f48dc60e6b8f",
+    "variant": null
   },
   "pypy-3.8.13-darwin-x86_64-none": {
     "name": "pypy",
@@ -8469,7 +11007,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.9-osx64.tar.bz2",
-    "sha256": "91a5c2c1facd5a4931a8682b7d792f7cf4f2ba25cd2e7e44e982139a6d5e4840"
+    "sha256": "91a5c2c1facd5a4931a8682b7d792f7cf4f2ba25cd2e7e44e982139a6d5e4840",
+    "variant": null
   },
   "pypy-3.8.13-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8481,7 +11020,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.9-aarch64.tar.bz2",
-    "sha256": "5e124455e207425e80731dff317f0432fa0aba1f025845ffca813770e2447e32"
+    "sha256": "5e124455e207425e80731dff317f0432fa0aba1f025845ffca813770e2447e32",
+    "variant": null
   },
   "pypy-3.8.13-linux-i686-gnu": {
     "name": "pypy",
@@ -8493,7 +11033,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.9-linux32.tar.bz2",
-    "sha256": "4b261516c6c59078ab0c8bd7207327a1b97057b4ec1714ed5e79a026f9efd492"
+    "sha256": "4b261516c6c59078ab0c8bd7207327a1b97057b4ec1714ed5e79a026f9efd492",
+    "variant": null
   },
   "pypy-3.8.13-linux-s390x-gnu": {
     "name": "pypy",
@@ -8505,7 +11046,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.9-s390x.tar.bz2",
-    "sha256": "c6177a0016c9145c7b99fddb5d74cc2e518ccdb216a6deb51ef6a377510cc930"
+    "sha256": "c6177a0016c9145c7b99fddb5d74cc2e518ccdb216a6deb51ef6a377510cc930",
+    "variant": null
   },
   "pypy-3.8.13-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8517,7 +11059,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.9-linux64.tar.bz2",
-    "sha256": "08be25ec82fc5d23b78563eda144923517daba481a90af0ace7a047c9c9a3c34"
+    "sha256": "08be25ec82fc5d23b78563eda144923517daba481a90af0ace7a047c9c9a3c34",
+    "variant": null
   },
   "pypy-3.8.13-windows-x86_64-none": {
     "name": "pypy",
@@ -8529,7 +11072,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.9-win64.zip",
-    "sha256": "05022baaa55db2b60880f2422312d9e4025e1267303ac57f33e8253559d0be88"
+    "sha256": "05022baaa55db2b60880f2422312d9e4025e1267303ac57f33e8253559d0be88",
+    "variant": null
   },
   "pypy-3.8.12-darwin-x86_64-none": {
     "name": "pypy",
@@ -8541,7 +11085,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-osx64.tar.bz2",
-    "sha256": "de1b283ff112d76395c0162a1cf11528e192bdc230ee3f1b237f7694c7518dee"
+    "sha256": "de1b283ff112d76395c0162a1cf11528e192bdc230ee3f1b237f7694c7518dee",
+    "variant": null
   },
   "pypy-3.8.12-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8553,7 +11098,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64-portable.tar.bz2",
-    "sha256": "0210536e9f1841ba283c13b04783394050837bb3e6f4091c9f1bd9c7f2b94b55"
+    "sha256": "0210536e9f1841ba283c13b04783394050837bb3e6f4091c9f1bd9c7f2b94b55",
+    "variant": null
   },
   "pypy-3.8.12-linux-i686-gnu": {
     "name": "pypy",
@@ -8565,7 +11111,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-linux32.tar.bz2",
-    "sha256": "bea4b275decd492af6462157d293dd6fcf08a949859f8aec0959537b40afd032"
+    "sha256": "bea4b275decd492af6462157d293dd6fcf08a949859f8aec0959537b40afd032",
+    "variant": null
   },
   "pypy-3.8.12-linux-s390x-gnu": {
     "name": "pypy",
@@ -8577,7 +11124,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-s390x.tar.bz2",
-    "sha256": "ad53d373d6e275a41ca64da7d88afb6a17e48e7bfb2a6fff92daafdc06da6b90"
+    "sha256": "ad53d373d6e275a41ca64da7d88afb6a17e48e7bfb2a6fff92daafdc06da6b90",
+    "variant": null
   },
   "pypy-3.8.12-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8589,7 +11137,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-linux64.tar.bz2",
-    "sha256": "089f8e3e357d6130815964ddd3507c13bd53e4976ccf0a89b5c36a9a6775a188"
+    "sha256": "089f8e3e357d6130815964ddd3507c13bd53e4976ccf0a89b5c36a9a6775a188",
+    "variant": null
   },
   "pypy-3.8.12-windows-x86_64-none": {
     "name": "pypy",
@@ -8601,7 +11150,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.8-v7.3.8-win64.zip",
-    "sha256": "0894c468e7de758c509a602a28ef0ba4fbf197ccdf946c7853a7283d9bb2a345"
+    "sha256": "0894c468e7de758c509a602a28ef0ba4fbf197ccdf946c7853a7283d9bb2a345",
+    "variant": null
   },
   "pypy-3.7.13-darwin-x86_64-none": {
     "name": "pypy",
@@ -8613,7 +11163,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.9-osx64.tar.bz2",
-    "sha256": "12d92f578a200d50959e55074b20f29f93c538943e9a6e6522df1a1cc9cef542"
+    "sha256": "12d92f578a200d50959e55074b20f29f93c538943e9a6e6522df1a1cc9cef542",
+    "variant": null
   },
   "pypy-3.7.13-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8625,7 +11176,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.9-aarch64.tar.bz2",
-    "sha256": "dfc62f2c453fb851d10a1879c6e75c31ffebbf2a44d181bb06fcac4750d023fc"
+    "sha256": "dfc62f2c453fb851d10a1879c6e75c31ffebbf2a44d181bb06fcac4750d023fc",
+    "variant": null
   },
   "pypy-3.7.13-linux-i686-gnu": {
     "name": "pypy",
@@ -8637,7 +11189,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.9-linux32.tar.bz2",
-    "sha256": "3398cece0167b81baa219c9cd54a549443d8c0a6b553ec8ec13236281e0d86cd"
+    "sha256": "3398cece0167b81baa219c9cd54a549443d8c0a6b553ec8ec13236281e0d86cd",
+    "variant": null
   },
   "pypy-3.7.13-linux-s390x-gnu": {
     "name": "pypy",
@@ -8649,7 +11202,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.9-s390x.tar.bz2",
-    "sha256": "fcab3b9e110379948217cf592229542f53c33bfe881006f95ce30ac815a6df48"
+    "sha256": "fcab3b9e110379948217cf592229542f53c33bfe881006f95ce30ac815a6df48",
+    "variant": null
   },
   "pypy-3.7.13-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8661,7 +11215,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.9-linux64.tar.bz2",
-    "sha256": "c58195124d807ecc527499ee19bc511ed753f4f2e418203ca51bc7e3b124d5d1"
+    "sha256": "c58195124d807ecc527499ee19bc511ed753f4f2e418203ca51bc7e3b124d5d1",
+    "variant": null
   },
   "pypy-3.7.13-windows-x86_64-none": {
     "name": "pypy",
@@ -8673,7 +11228,8 @@
     "patch": 13,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.9-win64.zip",
-    "sha256": "8acb184b48fb3c854de0662e4d23a66b90e73b1ab73a86695022c12c745d8b00"
+    "sha256": "8acb184b48fb3c854de0662e4d23a66b90e73b1ab73a86695022c12c745d8b00",
+    "variant": null
   },
   "pypy-3.7.12-darwin-x86_64-none": {
     "name": "pypy",
@@ -8685,7 +11241,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-osx64.tar.bz2",
-    "sha256": "76b8eef5b059a7e478f525615482d2a6e9feb83375e3f63c16381d80521a693f"
+    "sha256": "76b8eef5b059a7e478f525615482d2a6e9feb83375e3f63c16381d80521a693f",
+    "variant": null
   },
   "pypy-3.7.12-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8697,7 +11254,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64-portable.tar.bz2",
-    "sha256": "639c76f128a856747aee23a34276fa101a7a157ea81e76394fbaf80b97dcf2f2"
+    "sha256": "639c76f128a856747aee23a34276fa101a7a157ea81e76394fbaf80b97dcf2f2",
+    "variant": null
   },
   "pypy-3.7.12-linux-i686-gnu": {
     "name": "pypy",
@@ -8709,7 +11267,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-linux32.tar.bz2",
-    "sha256": "38429ec6ea1aca391821ee4fbda7358ae86de4600146643f2af2fe2c085af839"
+    "sha256": "38429ec6ea1aca391821ee4fbda7358ae86de4600146643f2af2fe2c085af839",
+    "variant": null
   },
   "pypy-3.7.12-linux-s390x-gnu": {
     "name": "pypy",
@@ -8721,7 +11280,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-s390x.tar.bz2",
-    "sha256": "5c2cd3f7cf04cb96f6bcc6b02e271f5d7275867763978e66651b8d1605ef3141"
+    "sha256": "5c2cd3f7cf04cb96f6bcc6b02e271f5d7275867763978e66651b8d1605ef3141",
+    "variant": null
   },
   "pypy-3.7.12-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8733,7 +11293,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-linux64.tar.bz2",
-    "sha256": "409085db79a6d90bfcf4f576dca1538498e65937acfbe03bd4909bdc262ff378"
+    "sha256": "409085db79a6d90bfcf4f576dca1538498e65937acfbe03bd4909bdc262ff378",
+    "variant": null
   },
   "pypy-3.7.12-windows-x86_64-none": {
     "name": "pypy",
@@ -8745,7 +11306,8 @@
     "patch": 12,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.8-win64.zip",
-    "sha256": "96df67492bc8d62b2e71dddf5f6c58965a26cac9799c5f4081401af0494b3bcc"
+    "sha256": "96df67492bc8d62b2e71dddf5f6c58965a26cac9799c5f4081401af0494b3bcc",
+    "variant": null
   },
   "pypy-3.7.10-darwin-x86_64-none": {
     "name": "pypy",
@@ -8757,7 +11319,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.5-osx64.tar.bz2",
-    "sha256": "b3a7d3099ad83de7c267bb79ae609d5ce73b01800578ffd91ba7e221b13f80db"
+    "sha256": "b3a7d3099ad83de7c267bb79ae609d5ce73b01800578ffd91ba7e221b13f80db",
+    "variant": null
   },
   "pypy-3.7.10-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8769,7 +11332,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.5-aarch64.tar.bz2",
-    "sha256": "85d83093b3ef5b863f641bc4073d057cc98bb821e16aa9361a5ff4898e70e8ee"
+    "sha256": "85d83093b3ef5b863f641bc4073d057cc98bb821e16aa9361a5ff4898e70e8ee",
+    "variant": null
   },
   "pypy-3.7.10-linux-i686-gnu": {
     "name": "pypy",
@@ -8781,7 +11345,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.5-linux32.tar.bz2",
-    "sha256": "3dd8b565203d372829e53945c599296fa961895130342ea13791b17c84ed06c4"
+    "sha256": "3dd8b565203d372829e53945c599296fa961895130342ea13791b17c84ed06c4",
+    "variant": null
   },
   "pypy-3.7.10-linux-s390x-gnu": {
     "name": "pypy",
@@ -8793,7 +11358,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.5-s390x.tar.bz2",
-    "sha256": "dffdf5d73613be2c6809dc1a3cf3ee6ac2f3af015180910247ff24270b532ed5"
+    "sha256": "dffdf5d73613be2c6809dc1a3cf3ee6ac2f3af015180910247ff24270b532ed5",
+    "variant": null
   },
   "pypy-3.7.10-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8805,7 +11371,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.5-linux64.tar.bz2",
-    "sha256": "9000db3e87b54638e55177e68cbeb30a30fe5d17b6be48a9eb43d65b3ebcfc26"
+    "sha256": "9000db3e87b54638e55177e68cbeb30a30fe5d17b6be48a9eb43d65b3ebcfc26",
+    "variant": null
   },
   "pypy-3.7.10-windows-x86_64-none": {
     "name": "pypy",
@@ -8817,7 +11384,8 @@
     "patch": 10,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.5-win64.zip",
-    "sha256": "072bd22427178dc4e65d961f50281bd2f56e11c4e4d9f16311c703f69f46ae24"
+    "sha256": "072bd22427178dc4e65d961f50281bd2f56e11c4e4d9f16311c703f69f46ae24",
+    "variant": null
   },
   "pypy-3.7.9-darwin-x86_64-none": {
     "name": "pypy",
@@ -8829,7 +11397,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-osx64.tar.bz2",
-    "sha256": "d72b27d5bb60813273f14f07378a08822186a66e216c5d1a768ad295b582438d"
+    "sha256": "d72b27d5bb60813273f14f07378a08822186a66e216c5d1a768ad295b582438d",
+    "variant": null
   },
   "pypy-3.7.9-linux-aarch64-gnu": {
     "name": "pypy",
@@ -8841,7 +11410,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-aarch64.tar.bz2",
-    "sha256": "ee4aa041558b58de6063dd6df93b3def221c4ca4c900d6a9db5b1b52135703a8"
+    "sha256": "ee4aa041558b58de6063dd6df93b3def221c4ca4c900d6a9db5b1b52135703a8",
+    "variant": null
   },
   "pypy-3.7.9-linux-i686-gnu": {
     "name": "pypy",
@@ -8853,7 +11423,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-linux32.tar.bz2",
-    "sha256": "7d81b8e9fcd07c067cfe2f519ab770ec62928ee8787f952cadf2d2786246efc8"
+    "sha256": "7d81b8e9fcd07c067cfe2f519ab770ec62928ee8787f952cadf2d2786246efc8",
+    "variant": null
   },
   "pypy-3.7.9-linux-s390x-gnu": {
     "name": "pypy",
@@ -8865,7 +11436,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-s390x.tar.bz2",
-    "sha256": "92000d90b9a37f2e9cb7885f2a872adfa9e48e74bf7f84a8b8185c8181f0502d"
+    "sha256": "92000d90b9a37f2e9cb7885f2a872adfa9e48e74bf7f84a8b8185c8181f0502d",
+    "variant": null
   },
   "pypy-3.7.9-linux-x86_64-gnu": {
     "name": "pypy",
@@ -8877,7 +11449,8 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-linux64.tar.bz2",
-    "sha256": "37e2804c4661c86c857d709d28c7de716b000d31e89766599fdf5a98928b7096"
+    "sha256": "37e2804c4661c86c857d709d28c7de716b000d31e89766599fdf5a98928b7096",
+    "variant": null
   },
   "pypy-3.7.9-windows-i686-none": {
     "name": "pypy",
@@ -8889,6 +11462,7 @@
     "patch": 9,
     "prerelease": "",
     "url": "https://downloads.python.org/pypy/pypy3.7-v7.3.3-win32.zip",
-    "sha256": "a282ce40aa4f853e877a5dbb38f0a586a29e563ae9ba82fd50c7e5dc465fb649"
+    "sha256": "a282ce40aa4f853e877a5dbb38f0a586a29e563ae9ba82fd50c7e5dc465fb649",
+    "variant": null
   }
 }

--- a/crates/uv-python/fetch-download-metadata.py
+++ b/crates/uv-python/fetch-download-metadata.py
@@ -151,7 +151,6 @@ class CPythonFinder(Finder):
         "shared-noopt",
         "static-noopt",
     ]
-    VARIANTS = ["pgo", "lto", "debug", "noopt", "freethreaded"]
     SPECIAL_TRIPLES = {
         "macos": "x86_64-apple-darwin",
         "linux64": "x86_64-unknown-linux-gnu",
@@ -467,6 +466,16 @@ def render(downloads: list[PythonDownload]) -> None:
             return 2, int(prerelease[2:])
         return 3, 0
 
+    def variant_sort_key(variant: Variant | None) -> int:
+        if variant is None:
+            return 0
+        match variant:
+            case Variant.FREETHREADED:
+                return 1
+            case Variant.DEBUG:
+                return 2
+        raise ValueError(f"Missing sort key implementation for variant: {variant}")
+
     def sort_key(download: PythonDownload) -> tuple:
         # Sort by implementation, version (latest first), and then by triple.
         impl_order = [ImplementationName.CPYTHON, ImplementationName.PYPY]
@@ -478,6 +487,7 @@ def render(downloads: list[PythonDownload]) -> None:
             -download.version.patch,
             -prerelease[0],
             -prerelease[1],
+            variant_sort_key(download.variant),
             download.triple,
         )
 

--- a/crates/uv-python/fetch-download-metadata.py
+++ b/crates/uv-python/fetch-download-metadata.py
@@ -106,6 +106,11 @@ class ImplementationName(StrEnum):
     PYPY = "pypy"
 
 
+class Variant(StrEnum):
+    FREETHREADED = "freethreaded"
+    DEBUG = "debug"
+
+
 @dataclass
 class PythonDownload:
     version: Version
@@ -115,9 +120,13 @@ class PythonDownload:
     filename: str
     url: str
     sha256: str | None = None
+    variant: Variant | None = None
 
     def key(self) -> str:
-        return f"{self.implementation}-{self.version}-{self.triple.platform}-{self.triple.arch}-{self.triple.libc}"
+        if self.variant:
+            return f"{self.implementation}-{self.version}+{self.variant}-{self.triple.platform}-{self.triple.arch}-{self.triple.libc}"
+        else:
+            return f"{self.implementation}-{self.version}-{self.triple.platform}-{self.triple.arch}-{self.triple.libc}"
 
 
 class Finder:
@@ -141,14 +150,8 @@ class CPythonFinder(Finder):
         "shared-pgo",
         "shared-noopt",
         "static-noopt",
-        "pgo+lto",
-        "pgo",
-        "lto",
-        "debug",
     ]
-    HIDDEN_FLAVORS = [
-        "noopt",
-    ]
+    VARIANTS = ["pgo", "lto", "debug", "noopt", "freethreaded"]
     SPECIAL_TRIPLES = {
         "macos": "x86_64-apple-darwin",
         "linux64": "x86_64-unknown-linux-gnu",
@@ -167,24 +170,15 @@ class CPythonFinder(Finder):
     _filename_re = re.compile(
         r"""(?x)
         ^
-            cpython-(?P<ver>\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)
-            (?:\+\d+)?
-            -(?P<triple>.*?)
-            (?:-[\dT]+)?\.tar\.(?:gz|zst)
+            cpython-
+            (?P<ver>\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)(?:\+\d+)?\+
+            (?P<date>\d+)-
+            (?P<triple>[a-z\d_]+-[a-z\d]+(?>-[a-z\d]+)?-[a-z\d]+)-
+            (?>(?P<build_options>.+)-)?
+            (?P<flavor>.+)
+            \.tar\.(?:gz|zst)
         $
     """
-    )
-
-    _flavor_re = re.compile(
-        r"""(?x)^(.*?)-(%s)$"""
-        % (
-            "|".join(
-                map(
-                    re.escape,
-                    sorted(FLAVOR_PREFERENCES + HIDDEN_FLAVORS, key=len, reverse=True),
-                )
-            )
-        )
     )
 
     def __init__(self, client: httpx.AsyncClient):
@@ -197,7 +191,7 @@ class CPythonFinder(Finder):
 
     async def _fetch_downloads(self, pages: int = 100) -> list[PythonDownload]:
         """Fetch all the indygreg downloads from the release API."""
-        results: dict[Version, list[PythonDownload]] = {}
+        downloads_by_version: dict[Version, list[PythonDownload]] = {}
 
         # Collect all available Python downloads
         for page in range(1, pages + 1):
@@ -213,24 +207,39 @@ class CPythonFinder(Finder):
                     download = self._parse_download_url(url)
                     if download is None:
                         continue
-                    results.setdefault(download.version, []).append(download)
+                    logging.debug("Found %s (%s)", download.key(), download.filename)
+                    downloads_by_version.setdefault(download.version, []).append(
+                        download
+                    )
 
-        # Collapse CPython variants to a single URL flavor per triple
+        # Collapse CPython variants to a single URL flavor per triple and variant
         downloads = []
-        for choices in results.values():
-            flavors: dict[PlatformTriple, tuple[PythonDownload, int]] = {}
-            for choice in choices:
-                priority = self._get_flavor_priority(choice.flavor)
-                existing = flavors.get(choice.triple)
+        for version_downloads in downloads_by_version.values():
+            selected: dict[
+                tuple[PlatformTriple, Variant | None], tuple[PythonDownload, int]
+            ] = {}
+            for download in version_downloads:
+                priority = self._get_flavor_priority(download.flavor)
+                existing = selected.get((download.triple, download.variant))
                 if existing:
-                    _, existing_priority = existing
+                    existing_download, existing_priority = existing
                     # Skip if we have a flavor with higher priority already (indicated by a smaller value)
                     if priority >= existing_priority:
+                        logging.debug(
+                            "Skipping %s (%s): lower priority than %s (%s)",
+                            download.key(),
+                            download.flavor,
+                            existing_download.key(),
+                            existing_download.flavor,
+                        )
                         continue
-                flavors[choice.triple] = (choice, priority)
+                selected[(download.triple, download.variant)] = (
+                    download,
+                    priority,
+                )
 
             # Drop the priorities
-            downloads.extend([choice for choice, _ in flavors.values()])
+            downloads.extend([download for download, _ in selected.values()])
 
         return downloads
 
@@ -288,23 +297,22 @@ class CPythonFinder(Finder):
 
         match = self._filename_re.match(filename)
         if match is None:
+            logging.debug("Skipping %s: no regex match", filename)
             return None
 
-        version, triple = match.groups()
-        if triple.endswith("-full"):
-            triple = triple[:-5]
+        version, _date, triple, build_options, flavor = match.groups()
 
-        match = self._flavor_re.match(triple)
-        if match is not None:
-            triple, flavor = match.groups()
+        variants = build_options.split("+") if build_options else []
+        for variant in Variant:
+            if variant in variants:
+                break
         else:
-            flavor = ""
-        if flavor in self.HIDDEN_FLAVORS:
-            return None
+            variant = None
 
         version = Version.from_str(version)
         triple = self._normalize_triple(triple)
         if triple is None:
+            # Skip is logged in `_normalize_triple`
             return None
 
         return PythonDownload(
@@ -314,6 +322,7 @@ class CPythonFinder(Finder):
             implementation=self.implementation,
             filename=filename,
             url=url,
+            variant=variant,
         )
 
     def _normalize_triple(self, triple: str) -> PlatformTriple | None:
@@ -477,7 +486,7 @@ def render(downloads: list[PythonDownload]) -> None:
     for download in downloads:
         key = download.key()
         logging.info(
-            "Found %s%s", key, (" (%s)" % download.flavor) if download.flavor else ""
+            "Selected %s%s", key, (" (%s)" % download.flavor) if download.flavor else ""
         )
         results[key] = {
             "name": download.implementation,
@@ -490,6 +499,7 @@ def render(downloads: list[PythonDownload]) -> None:
             "prerelease": download.version.prerelease,
             "url": download.url,
             "sha256": download.sha256,
+            "variant": download.variant if download.variant else None,
         }
 
     VERSIONS_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/crates/uv-python/fetch-download-metadata.py
+++ b/crates/uv-python/fetch-download-metadata.py
@@ -303,6 +303,7 @@ class CPythonFinder(Finder):
         version, _date, triple, build_options, flavor = match.groups()
 
         variants = build_options.split("+") if build_options else []
+        variant: Variant | None
         for variant in Variant:
             if variant in variants:
                 break

--- a/crates/uv-python/src/downloads.inc
+++ b/crates/uv-python/src/downloads.inc
@@ -30,22 +30,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-            variant: PythonVariant::Freethreaded
-
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-apple-darwin-freethreaded%2Bdebug-full.tar.zst",
-        sha256: Some("4ba7f477c56af4f057ca40535aa6907662b7206e3b8b39971d0a507b1c955e44")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
@@ -54,38 +38,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("d6bc769002842147150a561502a23b57d5a8aa1ba643a6a0abf589bfe834e642")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-            variant: PythonVariant::Freethreaded
-
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-apple-darwin-freethreaded%2Bdebug-full.tar.zst",
-        sha256: Some("b72b7df7cd22a4e7462dbe95633c5ca61caab41237d68e0ff89e9774cd4985e7")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-            variant: PythonVariant::Freethreaded
-
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
-        sha256: Some("678b0e9cbe2a8e19b0d83d518c7e3689918b22b2847e24f01fb2ce71164f5788")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -113,43 +65,11 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
-            variant: PythonVariant::Freethreaded
-
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-freethreaded%2Bdebug-full.tar.zst",
-        sha256: Some("bee06f4fb52a8333f603a29e47e09e43b3bda9a2f338df6c0ccd3e3b81e5347e")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnueabi),
             variant: PythonVariant::Default
 
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("ae89ef85195386ce232de29e0f62e7544f80a6923119ed85af40d09a6468bf30")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
-            variant: PythonVariant::Freethreaded
-
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabihf-freethreaded%2Bdebug-full.tar.zst",
-        sha256: Some("4d1e234314e1a809c8d027273dfcd647f600490ae59b59341051d973f0c0f586")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -177,22 +97,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
-            variant: PythonVariant::Freethreaded
-
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
-        sha256: Some("2d72fb6c7c91c9c00aa1e2b982bc7442da8a51665dfea2193e5e9098a6d7b2cb")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Powerpc64le),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
 
         },
@@ -209,43 +113,11 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
-            variant: PythonVariant::Freethreaded
-
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
-        sha256: Some("533087017cbd1287af93936d9007bc1bd6ca8886b2cdf59171554cf55c6253e6")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::S390x),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
             variant: PythonVariant::Default
 
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("85e05e27c31cd7267cb17c4c16b729969dd586cd715287f923334db20a51ce67")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-            variant: PythonVariant::Freethreaded
-
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
-        sha256: Some("2b46a0f38711cfcdffab90f69ea1372288bd6dcb0f9676b765babb491d42ce06")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -289,22 +161,6 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
-            variant: PythonVariant::Freethreaded
-
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-i686-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
-        sha256: Some("1dd414e0787f180760952bdc339dfde42e0b7503419baf20d38a6470ed65e455")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 13,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
             variant: PythonVariant::Default
 
         },
@@ -321,11 +177,155 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
+        sha256: Some("c82b440476fe04e80228791350a451b65e8080ff01b7168f1c4a5eb9645371f3")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
             variant: PythonVariant::Freethreaded
 
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
-        sha256: Some("fc665561556f4dc843cd3eeba4d482f716aec65d5b89a657316829cfbdc9462a")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-apple-darwin-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("4ba7f477c56af4f057ca40535aa6907662b7206e3b8b39971d0a507b1c955e44")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-apple-darwin-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("b72b7df7cd22a4e7462dbe95633c5ca61caab41237d68e0ff89e9774cd4985e7")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("678b0e9cbe2a8e19b0d83d518c7e3689918b22b2847e24f01fb2ce71164f5788")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("bee06f4fb52a8333f603a29e47e09e43b3bda9a2f338df6c0ccd3e3b81e5347e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabihf-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("4d1e234314e1a809c8d027273dfcd647f600490ae59b59341051d973f0c0f586")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("2d72fb6c7c91c9c00aa1e2b982bc7442da8a51665dfea2193e5e9098a6d7b2cb")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::S390x),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("533087017cbd1287af93936d9007bc1bd6ca8886b2cdf59171554cf55c6253e6")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("2b46a0f38711cfcdffab90f69ea1372288bd6dcb0f9676b765babb491d42ce06")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-i686-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
+        sha256: Some("1dd414e0787f180760952bdc339dfde42e0b7503419baf20d38a6470ed65e455")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -337,11 +337,11 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
-            variant: PythonVariant::Default
+            variant: PythonVariant::Freethreaded
 
         },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
-        sha256: Some("c82b440476fe04e80228791350a451b65e8080ff01b7168f1c4a5eb9645371f3")
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
+        sha256: Some("fc665561556f4dc843cd3eeba4d482f716aec65d5b89a657316829cfbdc9462a")
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {

--- a/crates/uv-python/src/downloads.inc
+++ b/crates/uv-python/src/downloads.inc
@@ -3,6 +3,7 @@
 // Generated with `crates/uv-python/template-download-metadata.py`
 // From template at `crates/uv-python/src/downloads.inc.mustache`
 
+use crate::PythonVariant;
 use uv_pep440::{Prerelease, PrereleaseKind};
 
 pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
@@ -16,6 +17,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("7bc4b23590a1e4b41b21b6aae6f92046c1d16d09bc0c1ab81272aa81b55221d1")
@@ -27,9 +30,27 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-apple-darwin-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("4ba7f477c56af4f057ca40535aa6907662b7206e3b8b39971d0a507b1c955e44")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("d6bc769002842147150a561502a23b57d5a8aa1ba643a6a0abf589bfe834e642")
@@ -41,9 +62,43 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             patch: 0,
             prerelease: None,
             implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Darwin),
+            libc: Libc::None,
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-apple-darwin-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("b72b7df7cd22a4e7462dbe95633c5ca61caab41237d68e0ff89e9774cd4985e7")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("678b0e9cbe2a8e19b0d83d518c7e3689918b22b2847e24f01fb2ce71164f5788")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("1bfc058821199c4313ae67bb6c105df2c9dd3515bca955ff96724976acf64462")
@@ -58,6 +113,24 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("bee06f4fb52a8333f603a29e47e09e43b3bda9a2f338df6c0ccd3e3b81e5347e")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("ae89ef85195386ce232de29e0f62e7544f80a6923119ed85af40d09a6468bf30")
@@ -72,6 +145,24 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabihf-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("4d1e234314e1a809c8d027273dfcd647f600490ae59b59341051d973f0c0f586")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("030974b9e1826513001c94cea4ef9248940fecc6efca034715770f7be232942a")
@@ -86,6 +177,24 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("2d72fb6c7c91c9c00aa1e2b982bc7442da8a51665dfea2193e5e9098a6d7b2cb")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::Powerpc64le),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("894014ceb5374d1c43a2e297126e588fd5fc60d93e57b76e1bba16430b80e3f3")
@@ -100,6 +209,24 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("533087017cbd1287af93936d9007bc1bd6ca8886b2cdf59171554cf55c6253e6")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::S390x),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("85e05e27c31cd7267cb17c4c16b729969dd586cd715287f923334db20a51ce67")
@@ -114,6 +241,24 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-freethreaded%2Bdebug-full.tar.zst",
+        sha256: Some("2b46a0f38711cfcdffab90f69ea1372288bd6dcb0f9676b765babb491d42ce06")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Linux),
+            libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("aa876c2660a802d0df8ef46f9c4b1c952e63c65d16e103663c22b9468dad40b7")
@@ -128,6 +273,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("9606d04c867ba034b901ef1a63c5b5efcb6951e4a6e2cce9703d0ff98d96f579")
@@ -142,6 +289,24 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-i686-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
+        sha256: Some("1dd414e0787f180760952bdc339dfde42e0b7503419baf20d38a6470ed65e455")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("fc96cb6a3e70bfcee13f7c5d08d30ecbe1738d934f885674d57f3b07b4291e5f")
@@ -156,6 +321,24 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Freethreaded
+
+        },
+        url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-freethreaded%2Bpgo-full.tar.zst",
+        sha256: Some("fc665561556f4dc843cd3eeba4d482f716aec65d5b89a657316829cfbdc9462a")
+    },
+    ManagedPythonDownload {
+        key: PythonInstallationKey {
+            major: 3,
+            minor: 13,
+            patch: 0,
+            prerelease: None,
+            implementation: LenientImplementationName::Known(ImplementationName::CPython),
+            arch: Arch(target_lexicon::Architecture::X86_64),
+            os: Os(target_lexicon::OperatingSystem::Windows),
+            libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.13.0%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("c82b440476fe04e80228791350a451b65e8080ff01b7168f1c4a5eb9645371f3")
@@ -170,6 +353,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("685ef71882f16eabab0bc838094727978370f0ad95c29f7f5c244ffa31316aeb")
@@ -184,6 +369,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("0f5f9fcf82093c428b80c552165544439f4adcdbe5129ecf721d619e532e9b5e")
@@ -198,6 +385,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("1414c6b37f37e8fd9d14e48d81e313eb9c965cb0330747d5d2d689dd7e0c7043")
@@ -212,6 +401,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("11befeaf4768c2ebbb258f5b07f94b7700f16424f858d6d2c250b434e99ce07c")
@@ -226,6 +417,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("b7180d5ea5fda2f397d04e2e6e11a2a7e0d732542bf54c484afb81d087a7b927")
@@ -240,6 +433,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("59a2a81991d78bd658742d69b577a2b4c0734628ed42bff68615686eaf96f2ab")
@@ -254,6 +449,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("2769182e58b0dddec15222bfeecbd4b12fde61c38f23a90aa942514f3545fb9b")
@@ -268,6 +465,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("445156c61e1cc167f7b8777ad08cc36e5598e12cd27e07453f6e6dc0f62e421e")
@@ -282,6 +481,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("4df6b7665c735a728d72e6f49034f1a6b7d9a54b0fbc472dc2ca525eb3dd513f")
@@ -296,6 +497,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("873905b3e5e8cba700126e8d6ed28ad3aef0dd102f730f8ca196018477dd2da6")
@@ -310,6 +513,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.13.0rc3%2B20241002-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("b59317828ef88f138ee122d420b60f2705bc72ae846ff69562e79e6c5cbc3177")
@@ -324,6 +529,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("9e17f9fcc314a5dd489089a7502a525c4dd08af862f9cf33b52161a752f2a5b7")
@@ -338,6 +545,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("971668ac7f3168efc4d2b589e9d36247ab8ca9f9525c56c8aa7bfd374060105b")
@@ -352,6 +561,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("d99a663d3b9f8792a659e366372e685550045cad12aef11645c06a9b6edcd071")
@@ -366,6 +577,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("4ca7f2aeaabf8dbb2193f0fa86f869525a5c209eb403a39a73f4cf7040cf3613")
@@ -380,6 +593,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("0db2d263bdbb3af1e8dc0677fa44a5cda992ba989551346ccbbfd50a86135c3d")
@@ -394,6 +609,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("70073333f7d3f0b900c7299659fec069bbefd5e04808b3729d2434b2232ac729")
@@ -408,6 +625,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("50a2080e30d1504e76e5471e46830f0b4974c66b538ed8ec7df416975133ff89")
@@ -422,6 +641,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("1893a218709d3664b7a2b80f5598b5f25c0c3fe2bcc8d0a1c75eec6bbb93d602")
@@ -436,6 +657,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("6f09aa5ba6aab8bf21955dbc3d6bab19125130ef0ebe29242b0e5ac1eebb3161")
@@ -450,6 +673,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("759f600b27a6a0ef2638cb02e8bbcc6de726dd1c896759f78da3e412f6c992e9")
@@ -464,6 +689,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.13.0rc2%2B20240909-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("c883205751c714bd0519592673a88f160a55d34344cc1368353ad34a679eb94a")
@@ -478,6 +705,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("dc1f4d80c9b4ae40ba2c725e310e61446f8f778a7bea4efa56e4b1b4446e0a1a")
@@ -492,6 +721,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("7091bd9ce844bcbceb8f3466a9c9583a139f79edd3b0cbed82f7423d333b2d4b")
@@ -506,6 +737,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("e254373827bde6b389ed17b8bb8aa8ac7b3659cf56d36e084a53ed1d04a02210")
@@ -520,6 +753,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("b05298a85d7494a7e1220c4948a357da0ff40d8a6e470cd9b00515203200136c")
@@ -534,6 +769,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("88a642de18a1baa044916eb2cebbf2d534b1c5d03c98c8f4ccc8f451a7526535")
@@ -548,6 +785,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("1ff1e843d78f70fd2834e522ebd5a63193c67b47a31d40fa5e97d96ac0d64aaf")
@@ -562,6 +801,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("5a4128fc5523a8888b12767a275c8240c33d0ee96fdcf1a8c6c6cec9696d0f09")
@@ -576,6 +817,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("11091cd2eb8b7f4551665ba8f9f5b83aa3d09fc0e17f1649d76d5f4f75254bf8")
@@ -590,6 +833,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("b4396fc04d77cd991ebfc21312790acf2a82da5140a7becf47d3173f07131905")
@@ -604,6 +849,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("291de4fc77b3788b43a2b6b5c4587d106793754399e0fcb8a08db8ba993c65a5")
@@ -618,6 +865,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.12.7%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("480688c69be99f1fb9974c8a50f1efd214aaa3440ab5c8653a68d8a3d4ce1179")
@@ -632,6 +881,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("0419bafa4444a5aa0c554197bce0679e7cc0f28edc7ee8cfbe0ccea860bdb904")
@@ -646,6 +897,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("b10d19eb5548a3b3b0a5e6f9109834d7ecfc139bc15754f81a94d39eaa5bdd26")
@@ -660,6 +913,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("22d119ac7df7f0bddfd4dfd075bcc4eb2532ed3df0bdba0579106835d49ef9cd")
@@ -674,6 +929,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("190c23eb3b9c6b9638f69dc7fb829df8967ad64c82e82c93898a4d878d18ed2a")
@@ -688,6 +945,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("31a043c40e1dbb528404ff6e1fcad25638d54dfab2d379c3989d47ec24e6938b")
@@ -702,6 +961,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("fb49374b512b0e9f2cd2a720b3836f8a04228d73eb0786e64221eb55979edc6e")
@@ -716,6 +977,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("89be19666ecb7cdbbfd596e462d690a78a380f1fe5c2967b25a1779b0cec9339")
@@ -730,6 +993,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("b080463e4f0c452e592cdac1ca97936a6a19bb3d9a64da669a50ca843fce0108")
@@ -744,6 +1009,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("661e2a4b03d6eccbb5b15f5bd2869fbdd39132513394d758287e46115e48d4ef")
@@ -758,6 +1025,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("d87275e613632ab738528fe20a94a7193e824e91ba7f1e7845e7fcfc1f114900")
@@ -772,6 +1041,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240909/cpython-3.12.6%2B20240909-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("fe9898060f52c2171c2aa074f470f91339bdcf9896dae6709021c914f58aa863")
@@ -786,6 +1057,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("90715cdab075e5a2680acf2695572d165b6269bdb5d1942ab577491478aea55f")
@@ -800,6 +1073,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("49a9f7ad41d62e0ece9e664ca5ae95f022e7b68eef48e8a6f11620ec9247c686")
@@ -814,6 +1089,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("06e512178cb513658a01c054b3eafc649ca362ccbeb02a6ae8a55b02c1ba75ca")
@@ -828,6 +1105,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("7a584de9c2824f43d7a7b1c26eb61a18af770ebd603a74b45d57601ba62ba508")
@@ -842,6 +1121,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("a9992b30d7b3ecb558cd12fde919e3e2836f161f8f777afea31140d5fff6362e")
@@ -856,6 +1137,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("3bea081f4e6fa67e600a6a791bcfebb2891531ede2c21e23e1b7321b3369c737")
@@ -870,6 +1153,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("2b6ea3a5242de99574191ee42df864756eca6d7cb1dbd4cd7ab2850ba8b828f8")
@@ -884,6 +1169,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("10680b593b5e31833218fd83104dee74af970a3463403a22bae613b952a34e8d")
@@ -898,6 +1185,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("e61b1274e1195f227cb30ba5d89ea32d743796d992adcaffad4819e4b0405d24")
@@ -912,6 +1201,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("b1009d46b87330c099d02411ca5e9e333f13305c5abdbe20810a7c467cedb051")
@@ -926,6 +1217,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.12.5%2B20240814-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("6eb0398795e8875575934cf21cdc9c7c7acddb46f9a52f91fdad509723f2f0e9")
@@ -940,6 +1233,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("ef6948e836f531bd7a58ffbe602803ff1c83c65f99d1da19be369ea61f136c93")
@@ -954,6 +1249,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("9d68cbdd12d1d6f98d35cc76add232c12db75c6b7f49733bffc88e7b1c025a79")
@@ -968,6 +1265,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("6c9cf13644edc7250525ab1b2529ba1c0fff56c0c5a5c2242d84b6d4889d2bea")
@@ -982,6 +1281,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("5a23ed8eaf948fe48d7c05dbfb58ea8638dcd2c4880d8519e069281ab427cbcb")
@@ -996,6 +1297,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("4281764e69339a138e30211b9923d74036d07c7a56c6aacc6dbdb2802a575f51")
@@ -1010,6 +1313,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("35a8359f1dc17a7a70007dae102a5e1562c0715a721377ede92137b2a0292406")
@@ -1024,6 +1329,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("b2fd015ab3689e024de6fbb34a4942acdb54c2184d1963e22829aafa1d81ba2c")
@@ -1038,6 +1345,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("ca076aee4329f53f988346eb0521ad2a2cf7f723b6296088d03b98d8f22f5420")
@@ -1052,6 +1361,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("de4983ffa610ff2c3b9bcb62882366f017d94bf11b194c1fce17ad9e502acce6")
@@ -1066,6 +1377,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("ff0fab24f38c22130e45b90b7ec10dc4ce9677b545d9fb9109a72d2ffbab7b02")
@@ -1080,6 +1393,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240726/cpython-3.12.4%2B20240726-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("6dd7b4607f8a25f0f5f68e745f4c572b1a20c3bbfa86accfa45b52ab93b18ece")
@@ -1094,6 +1409,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("ccc40e5af329ef2af81350db2a88bbd6c17b56676e82d62048c15d548401519e")
@@ -1108,6 +1425,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("c37a22fca8f57d4471e3708de6d13097668c5f160067f264bb2b18f524c890c8")
@@ -1122,6 +1441,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ec8126de97945e629cca9aedc80a29c4ae2992c9d69f2655e27ae73906ba187d")
@@ -1136,6 +1457,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabi-install_only.tar.gz",
         sha256: Some("f693dd22b69361c17076157889eb8f1ce1a5ea670c031fae46782481ad892a64")
@@ -1150,6 +1473,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-armv7-unknown-linux-gnueabihf-install_only.tar.gz",
         sha256: Some("635080827bed4616dc271545677837203098e5b55e7195d803e1dca7da24fc0c")
@@ -1164,6 +1489,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("c5dcf08b8077e617d949bda23027c49712f583120b3ed744f9b143da1d580572")
@@ -1178,6 +1505,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("872fc321363b8cdd826fd2cb1adfd1ceb813bc1281f9d410c1c2c4e177e8df86")
@@ -1192,6 +1521,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("a73ba777b5d55ca89edef709e6b8521e3f3d4289581f174c8699adfb608d09d6")
@@ -1206,6 +1537,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("eb70814dc254f02714c77305de01b8ed2250c146320e22d0ed14b39021f89a8a")
@@ -1220,6 +1553,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-i686-pc-windows-msvc-install_only.tar.gz",
         sha256: Some("bd723ad1aa05551627715a428660250f0e74db0f1421b03f399235772057ef55")
@@ -1234,6 +1569,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.12.3%2B20240415-x86_64-pc-windows-msvc-install_only.tar.gz",
         sha256: Some("f7cfa4ad072feb4578c8afca5ba9a54ad591d665a441dd0d63aa366edbe19279")
@@ -1248,6 +1585,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("01c064c00013b0175c7858b159989819ead53f4746d40580b5b0b35b6e80fba6")
@@ -1262,6 +1601,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("a53a6670a202c96fec0b8c55ccc780ea3af5307eb89268d5b41a9775b109c094")
@@ -1276,6 +1617,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e52550379e7c4ac27a87de832d172658bc04150e4e27d4e858e6d8cbb96fd709")
@@ -1290,6 +1633,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("74bc02c4bbbd26245c37b29b9e12d0a9c1b7ab93477fed8b651c988b6a9a6251")
@@ -1304,6 +1649,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ecd6b0285e5eef94deb784b588b4b425a15a43ae671bf206556659dc141a9825")
@@ -1318,6 +1665,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("57a37b57f8243caa4cdac016176189573ad7620f0b6da5941c5e40660f9468ab")
@@ -1332,6 +1681,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("b428b4151c70b85339ac2659e5f69f7e47142d34a506e05ecd095efe2e3dec81")
@@ -1346,6 +1697,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("1e919365f3e04eb111283f7a45d32eac2f327287ab7bf46720d5629e144cbff9")
@@ -1360,6 +1713,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.12.2%2B20240224-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("1e5655a6ccb1a64a78460e4e3ee21036c70246800f176a6c91043a3fe3654a3b")
@@ -1374,6 +1729,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("f93f8375ca6ac0a35d58ff007043cbd3a88d9609113f1cb59cf7c8d215f064af")
@@ -1388,6 +1745,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("eca96158c1568dedd9a0b3425375637a83764d1fa74446438293089a8bfac1f8")
@@ -1402,6 +1761,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("236533ef20e665007a111c2f36efb59c87ae195ad7dca223b6dc03fb07064f0b")
@@ -1416,6 +1777,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("78051f0d1411ee62bc2af5edfccf6e8400ac4ef82887a2affc19a7ace6a05267")
@@ -1430,6 +1793,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("60631211c701f8d2c56e5dd7b154e68868128a019b9db1d53a264f56c0d4aee2")
@@ -1444,6 +1809,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("74e330b8212ca22fd4d9a2003b9eec14892155566738febc8e5e572f267b9472")
@@ -1458,6 +1825,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("876389f071d62ee9a4bdd7ce31e69c3cdd256fe498e4dd6bb2b80e674e7351fe")
@@ -1472,6 +1841,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("13c8a6f337a4e1ef043ffb8ea3c218ab2073afe0d3be36fcdf8ceb6f757210e8")
@@ -1486,6 +1857,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.12.1%2B20240107-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("fd5a9e0f41959d0341246d3643f2b8794f638adc0cec8dd5e1b6465198eae08a")
@@ -1500,6 +1873,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("4734a2be2becb813830112c780c9879ac3aff111a0b0cd590e65ec7465774d02")
@@ -1514,6 +1889,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("5a9e88c8aa52b609d556777b52ebde464ae4b4f77e4aac4eb693af57395c9abf")
@@ -1528,6 +1905,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("bccfe67cf5465a3dfb0336f053966e2613a9bc85a6588c2fcf1366ef930c4f88")
@@ -1542,6 +1921,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b5dae075467ace32c594c7877fe6ebe0837681f814601d5d90ba4c0dfd87a1f2")
@@ -1556,6 +1937,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("5681621349dd85d9726d1b67c84a9686ce78f72e73a6f9e4cc4119911655759e")
@@ -1570,6 +1953,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e51a5293f214053ddb4645b2c9f84542e2ef86870b8655704367bd4b29d39fe9")
@@ -1584,6 +1969,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("922f9404f39dc4edb8558a93cef5c3330895a4c87acb1de2a2cf662ab942dbe5")
@@ -1598,6 +1985,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("6e4f30a998245cfaef00d1b87f8fd5f6c250bd222f933f8f38f124d4f03227f9")
@@ -1612,6 +2001,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.12.0%2B20231002-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("facfaa1fbc8653f95057f3c4a0f8aa833dab0e0b316e24ee8686bc761d4b4f8d")
@@ -1626,6 +2017,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("fd187c5c12813e27261768d37ad46f08bc182f346d6ca9f3f87b57442ef9ed56")
@@ -1640,6 +2033,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("ecd44a6309939d6d06db2b9b3a9b40361dc1e248b4956bd635671a1475ee3f17")
@@ -1654,6 +2049,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("4cc6a85666586732a08f456616e234e3a49f0c85e28df4703064118a465b32be")
@@ -1668,6 +2065,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("83eadb32a80e4871066a0fbb2bad1b9642e5432225343d654aa0c7cbbf6e4c71")
@@ -1682,6 +2081,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("30b071a9dd9dc34a77a510907210f74ad40620a1209fd936a852d4a038a5ebea")
@@ -1696,6 +2097,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("03dd50143a9b95dbfc524e1e51e45205f2dc3d77bb75e51073f5645bd30f6263")
@@ -1710,6 +2113,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("f67968330a66c2d9e6313e400b27fe848b038be0b67380e8a28e1e982af9f9a8")
@@ -1724,6 +2129,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("d025f46c2ff20dd5ad8ff4628f65e691be73ca314b53b4145a691d9237601534")
@@ -1738,6 +2145,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("1d7d18d74cb572181d8f6401a6d172a47c3d782116b947ab5c18258f9dce9e0a")
@@ -1752,6 +2161,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("13f259e764ec76f02c2dbbe118d78ce465b1692c824a7b3f28af132705491ee8")
@@ -1766,6 +2177,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.11.10%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("7d591a66f9118ee7aa8a6ea990619bcc61aa737bd7a79cc47336d4be4addcd91")
@@ -1780,6 +2193,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("c4e2f7774421bcb381245945e132419b529399dfa4a56059acda1493751fa377")
@@ -1794,6 +2209,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("c8680f90137e36b54b3631271ccdfe5de363e7d563d8df87c53e11b956a00e04")
@@ -1808,6 +2225,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("364cf099524fff92c31b8ff5ae3f7b32b0fa6cf1d380c6e37cf56140d08dfc87")
@@ -1822,6 +2241,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("e64d3cf033c804e9c14aaf4ae746632c01894706098b20acbf00df4bd28d0b0e")
@@ -1836,6 +2257,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("7630838c7602e6a6a56c41263d6a808a2a2004a7ea38770ffc4c7aaf34e169ae")
@@ -1850,6 +2273,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("2387479d17127e5b087f582bac948f859c25c4b38c64f558e0a399af7a8a0225")
@@ -1864,6 +2289,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("30c71053e9360471b7f350f1562ff4e42eb91ad2ca61b391295b5dea8b2b9efd")
@@ -1878,6 +2305,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("daa487c7e73005c4426ac393273117cf0e2dc4ab9b2eeda366e04cd00eea00c9")
@@ -1892,6 +2321,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("b3e94cbf19bd08bf02f6e6945f6c2211453f601c7c6f79721da63a06bf99b1f9")
@@ -1906,6 +2337,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("091c99a210f4f401a305231f3f218ee3d5714658b8d3aac344d34efc716dff85")
@@ -1920,6 +2353,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.11.9%2B20240814-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("8ac54a8d711ef0d49b62a2c3521c2d0403f1b221dc9d84c5f85fe48903e82523")
@@ -1934,6 +2369,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("389a51139f5abe071a0d70091ca5df3e7a3dfcfcbe3e0ba6ad85fb4c5638421e")
@@ -1948,6 +2385,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("097f467b0c36706bfec13f199a2eaf924e668f70c6e2bd1f1366806962f7e86e")
@@ -1962,6 +2401,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("389b9005fb78dd5a6f68df5ea45ab7b30d9a4b3222af96999e94fd20d4ad0c6a")
@@ -1976,6 +2417,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("eb2b31f8e50309aae493c6a359c32b723a676f07c641f5e8fe4b6aa4dbb50946")
@@ -1990,6 +2433,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("844f64f4c16e24965778281da61d1e0e6cd1358a581df1662da814b1eed096b9")
@@ -2004,6 +2449,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("94e13d0e5ad417035b80580f3e893a72e094b0900d5d64e7e34ab08e95439987")
@@ -2018,6 +2465,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("08e1ebf51b5965e23f8e68664d17274c1cdabb5b2d7509a2003920e5d58172c7")
@@ -2032,6 +2481,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("75039951f8f94d7304bc17b674af1668b9e1ea6d6c9ba1da28e90c0ad8030e3c")
@@ -2046,6 +2497,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8%2B20240224-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("b618f1f047349770ee1ef11d1b05899840abd53884b820fd25c7dfe2ec1664d4")
@@ -2060,6 +2513,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("b042c966920cf8465385ca3522986b12d745151a72c060991088977ca36d3883")
@@ -2074,6 +2529,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("a0e615eef1fafdc742da0008425a9030b7ea68a4ae4e73ac557ef27b112836d4")
@@ -2088,6 +2545,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b102eaf865eb715aa98a8a2ef19037b6cc3ae7dfd4a632802650f29de635aa13")
@@ -2102,6 +2561,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b44e1b74afe75c7b19143413632c4386708ae229117f8f950c2094e9681d34c7")
@@ -2116,6 +2577,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("49520e3ff494708020f306e30b0964f079170be83e956be4504f850557378a22")
@@ -2130,6 +2593,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("4a51ce60007a6facf64e5495f4cf322e311ba9f39a8cd3f3e4c026eae488e140")
@@ -2144,6 +2609,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("1a919a35172eb9419eba841eeb0ec9879dbc2b006b284ee5c454c08197b50f74")
@@ -2158,6 +2625,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("f5a6ca1280749d8ceaf8851585ef6b0cd2f1f76e801a77c1d744019554eef2f0")
@@ -2172,6 +2641,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240107/cpython-3.11.7%2B20240107-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("67077e6fa918e4f4fd60ba169820b00be7c390c497bf9bc9cab2c255ea8e6f3e")
@@ -2186,6 +2657,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("916c35125b5d8323a21526d7a9154ca626453f63d0878e95b9f613a95006c990")
@@ -2200,6 +2673,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("178cb1716c2abc25cb56ae915096c1a083e60abeba57af001996e8bc6ce1a371")
@@ -2214,6 +2689,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("3e26a672df17708c4dc928475a5974c3fb3a34a9b45c65fb4bd1e50504cc84ec")
@@ -2228,6 +2705,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("7937035f690a624dba4d014ffd20c342e843dd46f89b0b0a1e5726b85deb8eaf")
@@ -2242,6 +2721,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("f9f19823dba3209cedc4647b00f46ed0177242917db20fb7fb539970e384531c")
@@ -2256,6 +2737,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ee37a7eae6e80148c7e3abc56e48a397c1664f044920463ad0df0fc706eacea8")
@@ -2270,6 +2753,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("c929e5fe676ad20afcf6807a797d21261ae0827e84ec18742031a9582aed0d46")
@@ -2284,6 +2769,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("dd48b2cfaae841b4cd9beed23e2ae68b13527a065ef3d271d228735769c4e64d")
@@ -2298,6 +2785,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20231002/cpython-3.11.6%2B20231002-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("3933545e6d41462dd6a47e44133ea40995bc6efeed8c2e4cbdf1a699303e95ea")
@@ -2312,6 +2801,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("dab64b3580118ad2073babd7c29fd2053b616479df5c107d31fe2af1f45e948b")
@@ -2326,6 +2817,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("4a4efa7378c72f1dd8ebcce1afb99b24c01b07023aa6b8fea50eaedb50bf2bfc")
@@ -2340,6 +2833,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("bb5c5d1ea0f199fe2d3f0996fff4b48ca6ddc415a3dbd98f50bff7fce48aac80")
@@ -2354,6 +2849,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("82de7e2551c015145c017742a5c0411d67a7544595df43c02b5efa4762d5123e")
@@ -2368,6 +2865,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("14121b53e9c8c6d0741f911ae00102a35adbcf5c3cdf732687ef7617b7d7304d")
@@ -2382,6 +2881,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("fe459da39874443579d6fe88c68777c6d3e331038e1fb92a0451879fb6beb16d")
@@ -2396,6 +2897,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("fbed6f7694b2faae5d7c401a856219c945397f772eea5ca50c6eb825cbc9d1e1")
@@ -2410,6 +2913,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("fe09ecd87f69a724acf26ca508d7ead91a951abb2da18dfb98fe22c284454121")
@@ -2424,6 +2929,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("936b624c2512a3a3370aae8adf603d6ae71ba8ebd39cc4714a13306891ea36f0")
@@ -2438,6 +2945,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5%2B20230826-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("00f002263efc8aea896bcfaaf906b1f4dab3e5cd3db53e2b69ab9a10ba220b97")
@@ -2452,6 +2961,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("cb6d2948384a857321f2aa40fa67744cd9676a330f08b6dad7070bda0b6120a4")
@@ -2466,6 +2977,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("47e1557d93a42585972772e82661047ca5f608293158acb2778dccf120eabb00")
@@ -2480,6 +2993,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("2e84fc53f4e90e11963281c5c871f593abcb24fc796a50337fa516be99af02fb")
@@ -2494,6 +3009,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("abdccc6ec7093f49da99680f5899a96bff0b96fde8f5d73f7aac121e0d05fdd8")
@@ -2508,6 +3025,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("df7b92ed9cec96b3bb658fb586be947722ecd8e420fb23cee13d2e90abcfcf25")
@@ -2522,6 +3041,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e477f0749161f9aa7887964f089d9460a539f6b4a8fdab5166f898210e1a87a4")
@@ -2536,6 +3057,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e26247302bc8e9083a43ce9e8dd94905b40d464745b1603041f7bc9a93c65d05")
@@ -2550,6 +3073,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("1218ca44595aeaf34271508db64a2abc581c3ee1eb307c1b0537ea746922b806")
@@ -2564,6 +3089,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("e2f4b41c3d89c5ec735e2563d752856cb3c19a0aa712ec7ef341712bafa7e905")
@@ -2578,6 +3105,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.11.4%2B20230726-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("878614c03ea38538ae2f758e36c85d2c0eb1eaaca86cd400ff8c76693ee0b3e1")
@@ -2592,6 +3121,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("09e412506a8d63edbb6901742b54da9aa7faf120b8dbdce56c57b303fc892c86")
@@ -2606,6 +3137,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("f710b8d60621308149c100d5175fec39274ed0b9c99645484fd93d1716ef4310")
@@ -2620,6 +3153,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("8190accbbbbcf7620f1ff6d668e4dd090c639665d11188ce864b62554d40e5ab")
@@ -2634,6 +3169,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("36ff6c5ebca8bf07181b774874233eb37835a62b39493f975869acc5010d839d")
@@ -2648,6 +3185,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("767d24f3570b35fedb945f5ac66224c8983f2d556ab83c5cfaa5f3666e9c212c")
@@ -2662,6 +3201,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("da50b87d1ec42b3cb577dfd22a3655e43a53150f4f98a4bfb40757c9d7839ab5")
@@ -2676,6 +3217,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("82eed5ae1ca9e60ed9b9cac97e910927ffe2e80e91161c74b2d70e44d5227de0")
@@ -2690,6 +3233,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("a6751e6fa5c7c4d4748ed534a7f00ad7f858f62ce73d63d44dd907036ba53985")
@@ -2704,6 +3249,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.11.3%2B20230507-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("24741066da6f35a7ff67bee65ce82eae870d84e1181843e64a7076d1571e95af")
@@ -2718,6 +3265,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("4918cdf1cab742a90f85318f88b8122aeaa2d04705803c7b6e78e81a3dd40f80")
@@ -2732,6 +3281,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733")
@@ -2746,6 +3297,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("debf15783bdcb5530504f533d33fda75a7b905cec5361ae8f33da5ba6599f8b4")
@@ -2760,6 +3313,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("8392230cf76c282cfeaf67dcbd2e0fac6da8cd3b3aead1250505c6ddd606caae")
@@ -2774,6 +3329,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("02a551fefab3750effd0e156c25446547c238688a32fabde2995c941c03a6423")
@@ -2788,6 +3345,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("7f0425d3e9b2283aba205493e9fe431bc2c2d67cc369bc922825b827a1b06b82")
@@ -2802,6 +3361,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("50b250dd261c3cca9ae8d96cb921e4ffbc64f778a198b6f8b8b0a338f77ae486")
@@ -2816,6 +3377,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1%2B20230116-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("edc08979cb0666a597466176511529c049a6f0bba8adf70df441708f766de5bf")
@@ -2830,6 +3393,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("bcd994f136c4568763e2d642f4236c81e19ffc2a3536224598dc1ad0c3e16bf7")
@@ -2844,6 +3409,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("c8cc9d58f4c71106472e9b9b2801b702e7939db1922dceabe5b33b5602b490e4")
@@ -2858,6 +3425,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("4a354407285995b12dc67bd5e99c588699cc0c434fddc38c84a61909381a2e2f")
@@ -2872,6 +3441,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("c7d8880fdecf914dac880a0f5ba78678b24579ae58b531e92a163773a6426df9")
@@ -2886,6 +3457,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("b68ea12eb0c5941d6fd7158a709d951e87a5fdffc8f8d774bf9ba4498a1a2373")
@@ -2900,6 +3473,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("211427f42462475671c015ddcbff6d7138b48738faa7239abe4b37418a809fbb")
@@ -2914,6 +3489,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("46479ecd894fb38def946fee4464a7639f63850afd7692350138910805984e9d")
@@ -2928,6 +3505,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("bf234c7fa23dfcc70c7248c4a46ea58775b39005f107084e51afd439e67f2baf")
@@ -2942,6 +3521,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("492f5e2d30aa70a1733911f4d3256c3bf2738e53e219f1b4740bf2d8736fdd03")
@@ -2956,6 +3537,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("eff2d69f0f19cdb8bf00c2a45addee6d477c4bc20da67337f4115a8b90f92e12")
@@ -2970,6 +3553,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.10.15%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("e5dbed3cd4e718081219fd039046779aa4ef808f725f7d19e60196fdf12d39ac")
@@ -2984,6 +3569,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("f7ca9bffbce433c8d445edd33a5424c405553d735efee65a2fc5d8bbb1c8e137")
@@ -2998,6 +3585,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("4404f44ec69c0708d4d88e98f39c2c1fe3bd462dc6a958b60aaf63028550c485")
@@ -3012,6 +3601,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("0ffe64c77cacda7e3afcb0d8ba271c59ca0a30dfda218da39a573b412bb4afd7")
@@ -3026,6 +3617,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("451449f18a49e6ceecf9c1f70f4aee0d1552eff103c3db291319125238182c9d")
@@ -3040,6 +3633,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("7f215b85df78c568847329faeb2c5007c301741d9c4ccebbd935a3a2963197b5")
@@ -3054,6 +3649,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("8b83fdd95cb864f8ebfa1a1dd7e700bb046b8283bfd0a3aa04f1ff259eaff99e")
@@ -3068,6 +3665,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("ff1c4f010b1c6f563c71fa30f68293168536e0ed65f7d470a7e8c73252d08653")
@@ -3082,6 +3681,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("159c456bb4a3802bafbce065ff54b99ddb16422500d75c1315573ee3b673af17")
@@ -3096,6 +3697,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("8803a748f2197ec2360af6feebe9c936f4f6beabcae1db5557fdd98fc922982c")
@@ -3110,6 +3713,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("a84742f13584fd39f4f4b0d9a5865621a3c88cad91b31f17f414186719063364")
@@ -3124,6 +3729,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.10.14%2B20240814-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("61ad1abcaca639eecb5bd0b129ac0315d79f7b90cf0aca8e9fb85c9e7269c26b")
@@ -3138,6 +3745,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("5fdc0f6a5b5a90fd3c528e8b1da8e3aac931ea8690126c2fdb4254c84a3ff04a")
@@ -3152,6 +3761,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("6378dfd22f58bb553ddb02be28304d739cd730c1f95c15c74955c923a1bc3d6a")
@@ -3166,6 +3777,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("a898a88705611b372297bb8fe4d23cc16b8603ce5f24494c3a8cfa65d83787f9")
@@ -3180,6 +3793,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.10.13%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("424d239b6df60e40849ad18505de394001233ab3d7470b5280fec6e643208bb9")
@@ -3194,6 +3809,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("c23706e138a0351fc1e9def2974af7b8206bac7ecbbb98a78f5aa9e7535fee42")
@@ -3208,6 +3825,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("09be8fb2cdfbb4a93d555f268f244dbe4d8ff1854b2658e8043aa4ec08aede3e")
@@ -3222,6 +3841,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("d995d032ca702afd2fc3a689c1f84a6c64972ecd82bba76a61d525f08eb0e195")
@@ -3236,6 +3857,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("48365ea10aa1b0768a153bfff50d1515a757d42409b02a4af4db354803f2d180")
@@ -3250,6 +3873,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("5365b90f9cba7186d12dd86516ece8b696db7311128e0b49c92234e01a74599f")
@@ -3264,6 +3889,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.10.13%2B20240224-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("086f7fe9156b897bb401273db8359017104168ac36f60f3af4e31ac7acd6634e")
@@ -3278,6 +3905,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("bc66c706ea8c5fc891635fda8f9da971a1a901d41342f6798c20ad0b2a25d1d6")
@@ -3292,6 +3921,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("8a6e3ed973a671de468d9c691ed9cb2c3a4858c5defffcf0b08969fba9c1dd04")
@@ -3306,6 +3937,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("fee80e221663eca5174bd794cb5047e40d3910dbeadcdf1f09d405a4c1c15fe4")
@@ -3320,6 +3953,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("c7a5321a696ef6467791312368a04d36828907a8f5c557b96067fa534c716c18")
@@ -3334,6 +3969,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("bb5e8cb0d2e44241725fa9b342238245503e7849917660006b0246a9c97b1d6c")
@@ -3348,6 +3985,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("8d33d435ae6fb93ded7fc26798cc0a1a4f546a4e527012a1e2909cc314b332df")
@@ -3362,6 +4001,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("a476dbca9184df9fc69fe6309cda5ebaf031d27ca9e529852437c94ec1bc43d3")
@@ -3376,6 +4017,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("9080014bee2d4bd1f96bcbebf447d40c35ae9354382246add1160bd0d433ebf7")
@@ -3390,6 +4033,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("a5a5f9c9082b6503462a6b134111d3c303052cbc49ff31fff2ade38b39978e5d")
@@ -3404,6 +4049,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.10.12%2B20230726-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("c1a31c353ca44de7d1b1a3b6c55a823e9c1eed0423d4f9f66e617bdb1b608685")
@@ -3418,6 +4065,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("8348bc3c2311f94ec63751fb71bd0108174be1c4def002773cf519ee1506f96f")
@@ -3432,6 +4081,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("bd3fc6e4da6f4033ebf19d66704e73b0804c22641ddae10bbe347c48f82374ad")
@@ -3446,6 +4097,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("c7573fdb00239f86b22ea0e8e926ca881d24fde5e5890851339911d76110bc35")
@@ -3460,6 +4113,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("c70518620e32b074b1b40579012f0c67191a967e43e84b8f46052b6b893f7eeb")
@@ -3474,6 +4129,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("73a9d4c89ed51be39dd2de4e235078281087283e9fdedef65bec02f503e906ee")
@@ -3488,6 +4145,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("c5bcaac91bc80bfc29cf510669ecad12d506035ecb3ad85ef213416d54aecd79")
@@ -3502,6 +4161,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("c5dde3276541a8ad000ba631ec70012aa2261926c13f54d2b1de83dad61d59c1")
@@ -3516,6 +4177,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("e4ed3414cd0e687017f0a56fed88ff39b3f5dfb24a0d62e9c7ca55854178bcde")
@@ -3530,6 +4193,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.10.11%2B20230507-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("9c2d3604a06fcd422289df73015cd00e7271d90de28d2c910f0e2309a7f73a68")
@@ -3544,6 +4209,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("018d05a779b2de7a476f3b3ff2d10f503d69d14efcedd0774e6dab8c22ef84ff")
@@ -3558,6 +4225,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("0e685f98dce0e5bc8da93c7081f4e6c10219792e223e4b5886730fd73a7ba4c6")
@@ -3572,6 +4241,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("2003750f40cd09d4bf7a850342613992f8d9454f03b3c067989911fb37e7a4d1")
@@ -3586,6 +4257,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("44566c08eb8054aa0784f76b85d2c6c70a62f4988d5e9abcce819b517b329fdd")
@@ -3600,6 +4273,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("d196347aeb701a53fe2bb2b095abec38d27d0fa0443f8a1c2023a1bed6e18cdf")
@@ -3614,6 +4289,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("cf17e6d042777170e423c6b80e096ad8273d9848708875db0d23dd45bdb3d516")
@@ -3628,6 +4305,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("c5c51d9a3e8d8cdac67d8f3ad7c4008de169ff1480e17021f154d5c99fcee9e3")
@@ -3642,6 +4321,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.10.9%2B20230116-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("59c6970cecb357dc1d8554bd0540eb81ee7f6d16a07acf3d14ed294ece02c035")
@@ -3656,6 +4337,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("d52b03817bd245d28e0a8b2f715716cd0fcd112820ccff745636932c76afa20a")
@@ -3670,6 +4353,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("525b79c7ce5de90ab66bd07b0ac1008bafa147ddc8a41bef15ffb7c9c1e9e7c5")
@@ -3684,6 +4369,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("33170bef18c811906b738be530f934640491b065bf16c4d276c6515321918132")
@@ -3698,6 +4385,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("2deee7cbbd5dad339d713a75ec92239725d2035e833af5b9981b026dee0b9213")
@@ -3712,6 +4401,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("6c8db44ae0e18e320320bbaaafd2d69cde8bfea171ae2d651b7993d1396260b7")
@@ -3726,6 +4417,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("9f035bbe53f55fb406f95cb68459ba245b386084eeb5760f1660f416b730328d")
@@ -3740,6 +4433,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("94e76273166f72624128e52b5402db244cea041dab4a6bcdc70b304b66e27e95")
@@ -3754,6 +4449,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.10.8%2B20221106-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("f2b6d2f77118f06dd2ca04dae1175e44aaa5077a5ed8ddc63333c15347182bfe")
@@ -3768,6 +4465,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("70f6ca1da8e6fce832ad0b7f9fdaba0b84ba0ac0a4c626127acb6d49df4b8f91")
@@ -3782,6 +4481,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("6101f580434544d28d5590543029a7c6bdf07efa4bcdb5e4cbedb3cd83241922")
@@ -3796,6 +4497,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("dfeec186a62a6068259d90e8d77e7d30eaf9c2b4ae7b205ff8caab7cb21f277c")
@@ -3810,6 +4513,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("4a611ce990dc1f32bc4b35d276f04521464127f77e1133ac5bb9c6ba23e94a82")
@@ -3824,6 +4529,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("c12c9ad2b2c75464541d897c0528013adecd8be5b30acf4411f7759729841711")
@@ -3838,6 +4545,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("3e0cab6e49ad5ef95851049463797ec713eee6e1f2fa1d99e30516d37797c3f0")
@@ -3852,6 +4561,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("384e711dd657c3439be4e50b2485478a7ed7a259a741d4480fc96d82cc09d318")
@@ -3866,6 +4577,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.10.7%2B20221002-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("b464352f8cbf06ab4c041b7559c9bda7e9f6001a94f67ab0a342cba078f3805f")
@@ -3880,6 +4593,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("efaf66acdb9a4eb33d57702607d2e667b1a319d58c167a43c96896b97419b8b7")
@@ -3894,6 +4609,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("7718411adf3ea1480f3f018a643eb0550282aefe39e5ecb3f363a4a566a9398c")
@@ -3908,6 +4625,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("81625f5c97f61e2e3d7e9f62c484b1aa5311f21bd6545451714b949a29da5435")
@@ -3922,6 +4641,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b152801a2609e6a38f3cc9e7e21d8b6cf5b6f31dacfcaca01e162c514e851ed6")
@@ -3936,6 +4657,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("55aa2190d28dcfdf414d96dc5dcea9fe048fadcd583dc3981fec020869826111")
@@ -3950,6 +4673,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("8cafe6409e9d192b288b84a21bc0c309f1d3f6b809a471b2858c7bf1bb09f3a7")
@@ -3964,6 +4689,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("27f22babf29ceebae18b2c2e38e2c48d22de686688c8a31c5f8d7d51541583c1")
@@ -3978,6 +4705,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.10.6%2B20220802-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("91889a7dbdceea585ff4d3b7856a6bb8f8a4eca83a0ff52a73542c2e67220eaa")
@@ -3992,6 +4721,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("19d1aa4a6d9ddb0094fc36961b129de9abe1673bce66c86cd97b582795c496a8")
@@ -4006,6 +4737,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("eca0584397d9a3ef6f7bb32b0476318b01c89b7b0a031ef97a0dcaa5ba5127a8")
@@ -4020,6 +4753,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("012fa37c12d2647d76d004dc003302563864d2f1cd0731b71eeafad63d28b3f0")
@@ -4034,6 +4769,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("5abf5baf40f8573ce7d7e4ad323457f511833e1663e61ac5a11d5563a735159f")
@@ -4048,6 +4785,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("460f87a389be28c953c24c6f942f172f9ce7f331367b4daf89cb450baedd51d7")
@@ -4062,6 +4801,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("6aad42c7b03989173dd0e4d066e8c1e9f176f4b31d5bde26dbb5297f38f656d0")
@@ -4076,6 +4817,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("2846e9c7e8484034989ab218022009fdd9dcb12a7bfb4b0329a404552d37e9aa")
@@ -4090,6 +4833,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220630/cpython-3.10.5%2B20220630-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("c830ab2a3a488f9cf95e4e81c581d9ef73e483c2e6546136379443e9bb725119")
@@ -4104,6 +4849,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("6d2e4e6b1c403bce84cfb846400754017f525fe8017f186e8e7072fcaaf3aa71")
@@ -4118,6 +4865,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("c4a57a13b084d49ce8c2eb5b2662ee45b0c55b08ddd696f473233b0787f03988")
@@ -4132,6 +4881,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("7a8989392dc9b41d85959a752448c60852cf0061de565e98445c27f6bbdf63be")
@@ -4146,6 +4897,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("f3bc0828a0e0a8974e3fe90b4e99549296a7578de2321d791be1bad28191921d")
@@ -4160,6 +4913,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("1f8423808ad84c0e56c8e14c32685cbfbc1159e0d9f943ac946f29e84cf1b5ee")
@@ -4174,6 +4929,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("74c8da0aa24233c76bdd984d3c9e44442eca316be8a2cb4972d9264fedb0d5e8")
@@ -4188,6 +4945,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("e1dfa5dde910f908cad8bd688b29d28df832f7b150555679c204580d1af0c4a6")
@@ -4202,6 +4961,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220528/cpython-3.10.4%2B20220528-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("7231ba2af9525cae620a5f4ae3bf89a939fdc053ba0cc64ee3dead8f13188005")
@@ -4216,6 +4977,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("db46dadfccc407aa1f66ed607eefbf12f781e343adcb1edee0a3883d081292ce")
@@ -4230,6 +4993,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("ec2e90b6a589db7ef9f74358b1436558167629f9e4d725c8150496f9cb08a9d4")
@@ -4244,6 +5009,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("f52ee68c13c4f9356eb78a5305d3178af2cb90c38a8ce8ce9990a7cf6ff06144")
@@ -4258,6 +5025,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("2f125a927c3af52ef89af11857df988a042e26ce095129701b915e75b2ec6bff")
@@ -4272,6 +5041,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b9989411bed71ba4867538c991f20b55f549dd9131905733f0df9f3fde81ad1d")
@@ -4286,6 +5057,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("a60b589176879bdd465659660b87e954f969bed072c03c578ec828d6134f4ae1")
@@ -4300,6 +5073,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("bb7f2a5143010fa482c5b442cced85516696cfc416ca92c903ef374532401a33")
@@ -4314,6 +5089,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.10.3%2B20220318-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("ba593370742ed8a7bc70ce563dd6a53e30ece1f6881e3888d334c1b485b0d9d0")
@@ -4328,6 +5105,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("1409acd9a506e2d1d3b65c1488db4e40d8f19d09a7df099667c87a506f71c0ef")
@@ -4342,6 +5121,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("8146ad4390710ec69b316a5649912df0247d35f4a42e2aa9615bffd87b3e235a")
@@ -4356,6 +5137,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("8f351a8cc348bb45c0f95b8634c8345ec6e749e483384188ad865b7428342703")
@@ -4370,6 +5153,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("4fa49dab83bf82409816db431806525ce894280a509ca96c91e3efc9beed1fea")
@@ -4384,6 +5169,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("9b64eca2a94f7aff9409ad70bdaa7fbbf8148692662e764401883957943620dd")
@@ -4398,6 +5185,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("c4f398f6f7f9bbf0df98407ad66bc5760f3afc2cd8ba33a99cf4dcc8c90fd9ae")
@@ -4412,6 +5201,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("5321f8c2c71239b1e2002d284be8ec825d4a6f95cd921e58db71f259834b7aa1")
@@ -4426,121 +5217,11 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.10.2%2B20220227-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("a1d9a594cd3103baa24937ad9150c1a389544b4350e859200b3e5c036ac352bd")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-apple-darwin-install_only-20211017T1616.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-aarch64-unknown-linux-gnu-lto-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-gnu-install_only-20211017T1616.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 10,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.10.0-x86_64-pc-windows-msvc-shared-install_only-20211017T1616.tar.gz",
-        sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -4552,6 +5233,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("e7551a119bded40bfc268c850110b6a5af1d5fdd63842a56569477490d20e0a6")
@@ -4566,6 +5249,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("02a912676153c0b87a2b6127f5bc9ddccf831b5c390e44073b1f45e829e712ca")
@@ -4580,6 +5265,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("7b3fe4868b127b75c82c7e56815e9ea90d7d5f76676d5d79c4e5901423a0e271")
@@ -4594,6 +5281,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("8950ba405e3fbf53fec01f5f2b20b3d50c987879b0d9b9ee385916f29e73a434")
@@ -4608,6 +5297,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("681b2aee6563be3b28370762e4a7c99cf5afeb6789ce7e5ae5646223515da578")
@@ -4622,6 +5313,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("82bb46cccdfc186e448e433baab343b1ce1e6d7c74e2e3ac4b32b1825583a7dc")
@@ -4636,6 +5329,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("adecf1aa825d4b73ea42a04c3a4996c19733d1b66a79c5fb0cb77f9589174588")
@@ -4650,6 +5345,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("f78ac2daa816647d8de170a1b7296d08d3a1227d1a5b46bde4d0e20834dc9212")
@@ -4664,6 +5361,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("2c03d1a3b3c2b8a05cd24dad8a0307a3ae464bd7508e637b47c74abf3304e531")
@@ -4678,6 +5377,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("95c290f7eef20439b9e962a229608a0f6ea8d7f75de3cefff8298bac91b70cb4")
@@ -4692,6 +5393,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241008/cpython-3.9.20%2B20241008-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("980f094ecd84894d2708696f3da641213480893bf0133b4be85ab60723c2f891")
@@ -4706,6 +5409,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("451582f8a6a8c15ef35a327afcdbf8d03b1ebba7192e90d850d092dac91f91c6")
@@ -4720,6 +5425,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("ebaf4336d0cbff4466c994d5bcaa92a38c91d06694d0cd675ec663259d5f37c7")
@@ -4734,6 +5441,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("23d08f7f0bf151c2ea54b2c9c143bc710faf166ff74225b0f967fab1e2d7a151")
@@ -4748,6 +5457,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabi),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabi-install_only_stripped.tar.gz",
         sha256: Some("cebb879d47874f3f943a4334a8fcd8baa3cd7ef4be8cae6b4c8ae980d981a28d")
@@ -4762,6 +5473,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Arm(target_lexicon::ArmArchitecture::Armv7)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnueabihf),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-armv7-unknown-linux-gnueabihf-install_only_stripped.tar.gz",
         sha256: Some("c32d3227c44919349172c27b35275bad379f1679f729fbd4f336625903171a1a")
@@ -4776,6 +5489,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-ppc64le-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("3cc60442d5694db1abe2a0c6e73459ebb6e7ba7fc7b0a986f3699d463a8f9557")
@@ -4790,6 +5505,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-s390x-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("b41f834311532ee9dcf76cad3cdeda285d0e283de2182ce9870c37c40970cdd3")
@@ -4804,6 +5521,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("3b7d574b6bbf8303789a1d26b96a81dcca907381441ce15818c784e18d1db299")
@@ -4818,6 +5537,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("5c6605b1cfa6a952420f2267d10bed9ae20a02858a769b7275d8805f6b9fe40b")
@@ -4832,6 +5553,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("1c78c6dd763e6d583c3c3f917544bc4446d0e9fbe2b6e206042fa801ff9fb9ab")
@@ -4846,6 +5569,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.9.19%2B20240814-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("426da4d31e665b77dacf15cd89494a995ed634a9b97324bbef9cf36fcda4c8a9")
@@ -4860,6 +5585,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("2548f911a6e316575c303ba42bb51540dc9b47a9f76a06a2a37460d93b177aa2")
@@ -4874,6 +5601,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("171d8b472fce0295be0e28bb702c43d5a2a39feccb3e72efe620ac3843c3e402")
@@ -4888,6 +5617,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e5bc5196baa603d635ee6b0cd141e359752ad3e8ea76127eb9141a3155c51200")
@@ -4902,6 +5633,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.9.18%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("10c422080317886057e968010495037ba65731ab7653bcaeabadf67a6fa5e99e")
@@ -4916,6 +5649,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("d6b18df7a25fe034fd5ce4e64216df2cc78b2d4d908d2a1c94058ae700d73d22")
@@ -4930,6 +5665,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("15d059507c7e900e9665f31e8d903e5a24a68ceed24f9a1c5ac06ab42a354f3f")
@@ -4944,6 +5681,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("0e5663025121186bd17d331538a44f48b41baff247891d014f3f962cbe2716b4")
@@ -4958,6 +5697,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("cb47455810ae63d98501b3bb4fcdfdb9924633fb2e86e62d77e523a3bdee44ba")
@@ -4972,6 +5713,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("904ff5d2f6402640e2b7e2b12075af0bd75b3e8685cc5248fd2a3cda3105d2a8")
@@ -4986,6 +5729,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.9.18%2B20240224-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("a9bdbd728ed4c353a4157ecf74386117fb2a2769a9353f491c528371cfe7f6cd")
@@ -5000,6 +5745,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("73dbe2d702210b566221da9265acc274ba15275c5d0d1fa327f44ad86cde9aa1")
@@ -5014,6 +5761,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("dfe1bea92c94b9cb779288b0b06e39157c5ff7e465cdd24032ac147c2af485c0")
@@ -5028,6 +5777,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b77012ddaf7e0673e4aa4b1c5085275a06eee2d66f33442b5c54a12b62b96cbe")
@@ -5042,6 +5793,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("aed29a64c835444c2f1aff83c55b14123114d74c54d96493a0eabfdd8c6d012c")
@@ -5056,6 +5809,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("c591a28d943dce5cf9833e916125fdfbeb3120270c4866ee214493ccb5b83c3c")
@@ -5070,6 +5825,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-s390x-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("01454d7cc7c9c2fccde42ba868c4f372eaaafa48049d49dd94c9cf2875f497e6")
@@ -5084,6 +5841,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("26c4a712b4b8e11ed5c027db5654eb12927c02da4857b777afb98f7a930ce637")
@@ -5098,6 +5857,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("194316e9cc7add1dd12be3e3eea2908fd4d623799edd7df69e360c6a446b750d")
@@ -5112,6 +5873,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("09f9d4bc66be5e0df2dfd1dc4742923e46c271f8f085178696c77073477aa0c1")
@@ -5126,6 +5889,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.9.17%2B20230726-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("9b9a1e21eff29dcf043cea38180cf8ca3604b90117d00062a7b31605d4157714")
@@ -5140,6 +5905,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("c1de1d854717a6245f45262ef1bb17b09e2c587590e7e3f406593c143ff875bd")
@@ -5154,6 +5921,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf")
@@ -5168,6 +5937,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("f629b75ebfcafe9ceee2e796b7e4df5cf8dbd14f3c021afca078d159ab797acf")
@@ -5182,6 +5953,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ab0a14b3ae72bf48b94820e096e86b3cf3e05729862f768e109aa8318016c4f2")
@@ -5196,6 +5969,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Powerpc64le),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ff3ac35c58f67839aff9b5185a976abd3d1abbe61af02089f7105e876c1fe284")
@@ -5210,6 +5985,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("2b6e146234a4ef2a8946081fc3fbfffe0765b80b690425a49ebe40b47c33445b")
@@ -5224,6 +6001,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("5d9b13e8d5ee7a26fd0cf6e6d7e5a1ea90ddddd1f30ed2400bda60506f7dcea3")
@@ -5238,6 +6017,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("219532ffa49af88e3b90e9135cf3b6e1fa11cf165b03098fb9776a07af8ca6d0")
@@ -5252,6 +6033,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16%2B20230507-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("cdabb47204e96ce7ea31fbd0b5ed586114dd7d8f8eddf60a509a7f70b48a1c5e")
@@ -5266,6 +6049,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("64dc7e1013481c9864152c3dd806c41144c79d5e9cd3140e185c6a5060bdc9ab")
@@ -5280,6 +6065,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("f2bcade6fc976c472f18f2b3204d67202d43ae55cf6f9e670f95e488f780da08")
@@ -5294,6 +6081,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("52a8c0a67fb919f80962d992da1bddb511cdf92faf382701ce7673e10a8ff98f")
@@ -5308,6 +6097,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("bf32a86c220e4d1690bb92b67653f20b8325808accd81bff03b5c30ae74e6444")
@@ -5322,6 +6113,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("cdc3a4cfddcd63b6cebdd75b14970e02d8ef0ac5be4d350e57ab5df56c19e85e")
@@ -5336,6 +6129,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("81b1c76ac789521fcececdcdc643f6de6fc282083b1a36a9973d835fc8a39391")
@@ -5350,6 +6145,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("0b81089247f258f244e9792daaa03675da6f58597daa6913e82f2679862238dd")
@@ -5364,6 +6161,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.9.15%2B20221106-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("022daacab215679b87f0d200d08b9068a721605fa4721ebeda38220fc641ccf6")
@@ -5378,6 +6177,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("e38df7f230979ce6c53a5bafb3a81287838e5f3892c40cd1b98a0c961c444713")
@@ -5392,6 +6193,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("b7d3a1f4b57e9350571ccee49c82f503133de0d113a2dbaebc8ccf108fb3fe1b")
@@ -5406,6 +6209,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("fe538201559ca37f44cd5f66c42a65fe7272cb4f1f63edd698b6f306771db1e9")
@@ -5420,6 +6225,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("3af1c255110c2f42ed0b7957502c92edf8b5c5e6fc5f699a2475bf8a560325c0")
@@ -5434,6 +6241,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e63d0c00a499e0202ba7a0f53ce69fca6d30237af39af9bc3c76bce6c7bf14d7")
@@ -5448,6 +6257,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("ceb26ef5f5a9b7b47fa95225fffce9c8ef0c9c1fbeca69fbda236a0c10de7ad8")
@@ -5462,6 +6273,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("f3526e8416be86ff9091750ebc7388d6726acf32cc5ab0e6a60c67c6aacb2569")
@@ -5476,6 +6289,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.9.14%2B20221002-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("f111c3c129f4a5a171d25350ce58dad4c7e58fbe664e9b4f7c275345c9fe18a6")
@@ -5490,6 +6305,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("d9603edc296a2dcbc59d7ada780fd12527f05c3e0b99f7545112daf11636d6e5")
@@ -5504,6 +6321,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("9540a7efb7c8a54a48aff1cb9480e49588d9c0a3f934ad53f5b167338174afa3")
@@ -5518,6 +6337,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("80415aac1b96255b9211f6a4c300f31e9940c7e07a23d0dec12b53aa52c0d25e")
@@ -5532,6 +6353,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("efcc8fef0d498afe576ab209fee001fda3b552de1a85f621f2602787aa6cf3d4")
@@ -5546,6 +6369,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ce1cfca2715e7e646dd618a8cb9baff93000e345ccc979b801fc6ccde7ce97df")
@@ -5560,6 +6385,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("766ed7e805e8c7abc4e50f1c94814575e7978ed7bd1f9e9ccec82d66b47b567f")
@@ -5574,6 +6401,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("90e3879382f06fea3ba6d477f0c2a434a1e14cd83d174e1c7b87e2f22bc2e748")
@@ -5588,6 +6417,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.9.13%2B20220802-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("b538127025a467c64b3351babca2e4d2ea7bdfb7867d5febb3529c34456cdcd4")
@@ -5602,6 +6433,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("8dee06c07cc6429df34b6abe091a4684a86f7cec76f5d1ccc1c3ce2bd11168df")
@@ -5616,6 +6449,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("2453ba7f76b3df3310353b48c881d6cff622ba06e30d2b6ae91588b2bc9e481a")
@@ -5630,6 +6465,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("2ee1426c181e65133e57dc55c6a685cb1fb5e63ef02d684b8a667d5c031c4203")
@@ -5644,6 +6481,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("233e1a9626d9fe13baac8de3689df48401d0ad5da1c2f134ad57d8e3e878a1a5")
@@ -5658,6 +6497,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("ccca12f698b3b810d79c52f007078f520d588232a36bc12ede944ec3ea417816")
@@ -5672,6 +6513,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("dd0eaf7ef64008d4a51a73243f368e0311b7936b0ac18f8d1305fffb0dfb76e6")
@@ -5686,6 +6529,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("8b7e440137bfa349a008641a75a2b1fd8ae22d290731778a144878a59a721c51")
@@ -5700,6 +6545,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220502/cpython-3.9.12%2B20220502-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("3024147fd987d9e1b064a3d94932178ff8e0fe98cfea955704213c0762fee8df")
@@ -5714,6 +6561,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("cf92a28f98c8d884df0937bf19d5f1a40caa25a6a211a237b7e9b592b2b71c2b")
@@ -5728,6 +6577,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("43889d1a424c84fb155e1619f062adb6984fbde80b6043611790f22bcbeec300")
@@ -5742,6 +6593,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("0e50f099409c5e651b5fddd16124af1d830d11653e786a93c28e5b8f8aa470c4")
@@ -5756,6 +6609,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("75ac727631eab002bd120246197a8235145cb90687be181f7a52de6f41d44d34")
@@ -5770,6 +6625,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("0429d5ceb095d5e24c292bf1a39208b88ae236a680ef8fa3e1830e3a1a7e8882")
@@ -5784,6 +6641,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("ae8f55d90ae173f96e81f376daa5a9969a77531a6f7b8eacbe8ad90b41bbca1d")
@@ -5798,6 +6657,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("ceac8729b285a8c8e861176dd2dadd7f8e7e26d8f64cac6c6226a14d2252cd4c")
@@ -5812,6 +6673,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220318/cpython-3.9.11%2B20220318-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("0c529a511f7a03908fc126c4a8467b47e24a4d98812147e8e786cf59e86febf0")
@@ -5826,6 +6689,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("ad66c2a3e7263147e046a32694de7b897a46fb0124409d29d3a93ede631c8aee")
@@ -5840,6 +6705,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("fdaf594142446029e314a9beb91f1ac75af866320b50b8b968181e592550cd68")
@@ -5854,6 +6721,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("12dd1f125762f47975990ec744532a1cf3db74ad60f4dfb476ca42deb7f78ca4")
@@ -5868,6 +6737,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("37ba43845c3df9ba012d69121ad29ea7f21ea2f5994a155007cf1560d74ce503")
@@ -5882,6 +6753,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("455089cc576bd9a58db45e919d1fc867ecdbb0208067dffc845cc9bbf0701b70")
@@ -5896,6 +6769,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("30add63ec16e07ad13e19f6d7061f7e4c7b971962354f48ab3e85656ce3b393d")
@@ -5910,6 +6785,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("56c0342a9af0412676e89cdf7b52ac76037031786b3f5c40942b8b82d366c96f")
@@ -5924,751 +6801,11 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.9.10%2B20220227-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("c145d9d8143ce163670af124b623d7a2405143a3708b033b4d33eed355e61b24")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-apple-darwin-install_only-20211017T1616.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-apple-darwin-install_only-20211017T1616.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-aarch64-unknown-linux-gnu-lto-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-unknown-linux-gnu-pgo%2Blto-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-gnu-install_only-20211017T1616.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-unknown-linux-musl-lto-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-i686-pc-windows-msvc-shared-pgo-20211017T1616.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20211017/cpython-3.9.7-x86_64-pc-windows-msvc-shared-install_only-20211017T1616.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-apple-darwin-install_only-20210724T1424.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-apple-darwin-install_only-20210724T1424.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-aarch64-unknown-linux-gnu-lto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-gnu-install_only-20210724T1424.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.9.6-x86_64-pc-windows-msvc-shared-install_only-20210724T1424.tar.gz",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-aarch64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.9.5-x86_64-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-aarch64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.9.4-x86_64-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-aarch64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-apple-darwin-pgo%2Blto-20210413T2055.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-gnu-pgo%2Blto-20210413T2055.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-unknown-linux-musl-lto-20210413T2055.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-i686-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210414/cpython-3.9.3-x86_64-pc-windows-msvc-shared-pgo-20210413T2055.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-aarch64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.9.2-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-gnu-pgo-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.9.1-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-gnu-pgo-20201020T0627.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-i686-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 9,
-            patch: 0,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.9.0-x86_64-pc-windows-msvc-shared-pgo-20201021T0245.tar.zst",
-        sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -6680,6 +6817,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("30ba44af64e599bde7307908393374bdcd99e185bf9b3c9de3f697f3fbe6bf8f")
@@ -6694,6 +6833,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("375b6eead6c852cabbf3ccfd43dc4f6dd4c36381bf74c9a7910acb839fd5c57f")
@@ -6708,6 +6849,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("75a187ebfab81096e3f3d91d70c1349e64defbdfb0e8a067cb5233d017655e31")
@@ -6722,6 +6865,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("a3a75094545912d4e9413673441b3f0d2e58ce9b264477f910800148801ccf11")
@@ -6736,6 +6881,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("fcddfd3f1090833e1f3106be021809630008b53026bc96dcaab2986625db27fa")
@@ -6750,6 +6897,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("d829105aaf53a1cadf8738e040c6211bc9bef2c6e4757b972954f0f322d57e7d")
@@ -6764,6 +6913,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20241002/cpython-3.8.20%2B20241002-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("ec2f723dcfbf09581578a716c05cc67823a43d77111e6dd9e0d1557ccc6dcbf3")
@@ -6778,6 +6929,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("6a15ee2b507aed4d5b15fd1b66fc570aa49183f15aa6c412eccd065446f17d8e")
@@ -6792,6 +6945,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-apple-darwin-install_only_stripped.tar.gz",
         sha256: Some("1a24263b039c1172bd42d74a5694492f3e3dbe4d3e52a1e7cc2856fee7dbee4a")
@@ -6806,6 +6961,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("202211923850303f521146ee1831642aaf357ffeeadbe13a0a91884317227528")
@@ -6820,6 +6977,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz",
         sha256: Some("0f1579dbb01c98af7a12fef4c9aa8a99d45b91393f64431f5de712f892bc5c0b")
@@ -6834,6 +6993,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
         sha256: Some("6ee6c7469c9d2c7078beb95a9a3a261c42502e0b1603722a0689bdb2e789060c")
@@ -6848,6 +7009,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-i686-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("73bf0135330b96c48ca79ccd6d2f3287a7466573a5fc1b62d982bcdb1d5f0ab3")
@@ -6862,6 +7025,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240814/cpython-3.8.19%2B20240814-x86_64-pc-windows-msvc-install_only_stripped.tar.gz",
         sha256: Some("89d238b125cd7546b7d0cbd7f484a438d2c2f239c15c9b38ec3c62b1f343a6ca")
@@ -6876,6 +7041,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("4d493a1792bf211f37f98404cc1468f09bd781adc2602dea0df82ad264c11abc")
@@ -6890,6 +7057,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("7d2cd8d289d5e3cdd0a8c06c028c7c621d3d00ce44b7e2f08c1724ae0471c626")
@@ -6904,6 +7073,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("6588c9eed93833d9483d01fe40ac8935f691a1af8e583d404ec7666631b52487")
@@ -6918,6 +7089,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("5ae36825492372554c02708bdd26b8dcd57e3dbf34b3d6d599ad91d93540b2b7")
@@ -6932,6 +7105,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("e591d3925f88f78a5dffb765fd10b9dab6e497d35cf58169da83eab521c86a37")
@@ -6946,6 +7121,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("c24f9c9e8638cff0ce6aa808a57cc5f22009bc33e3bcf410a726b79d7c5545fe")
@@ -6960,6 +7137,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.8.18%2B20240224-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("dba923ee5df8f99db04f599e826be92880746c02247c8d8e4d955d4bc711af11")
@@ -6974,6 +7153,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("c6f7a130d0044a78e39648f4dae56dcff5a41eba91888a99f6e560507162e6a1")
@@ -6988,6 +7169,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("155b06821607bae1a58ecc60a7d036b358c766f19e493b8876190765c883a5c2")
@@ -7002,6 +7185,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("9f6d585091fe26906ff1dbb80437a3fe37a1e3db34d6ecc0098f3d6a78356682")
@@ -7016,6 +7201,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e580fdd923bbae612334559dc58bd5fd13cce53b769294d63bc88e7c6662f7d9")
@@ -7030,6 +7217,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("8d3e1826c0bb7821ec63288038644808a2d45553245af106c685ef5892fabcd8")
@@ -7044,6 +7233,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("322b7837cfd8282c62ae3d2f0e98f0843cbe287e4b8c4852b786123f2e13b307")
@@ -7058,6 +7249,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("cb6af626ba811044e9c5ee09140a6920565d2b1b237a11886b96354a9fcc242e")
@@ -7072,6 +7265,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.8.17%2B20230826-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("6428e1b4e0b4482d390828de7d4c82815257443416cb786abe10cb2466ca68cd")
@@ -7086,6 +7281,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("7e484eb6de40d6f6bdfd5099eaa9647f65e45fb6d846ccfc56b1cb1e38b5ab02")
@@ -7100,6 +7297,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("28506e509646c11cb2f57a7203bd1b08b6e8e5b159ae308bd5bb93b0d334bdaf")
@@ -7114,6 +7313,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("9c6615931fd1045bf9f2148aa7dd9ce1ece8575ed68a5483a0b615322a43d54c")
@@ -7128,6 +7329,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("1260fd6af34104bbd57489175e6f7bfea76d4bd06a242a0f8e20e390e870b227")
@@ -7142,6 +7345,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("b1f1502c3a13b899724dbd32bd77a973fa9733b932c5700d747fe33d5de9ac4f")
@@ -7156,6 +7361,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("840aefa3b03b66b6561360735dc0ac4e0a36a3ebb4d1f85d92f5b5f6638953cc")
@@ -7170,6 +7377,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("77466f93ef5b030cf13d0446067089b0ce0d415cc6d1702655bdbb12a8c18c97")
@@ -7184,6 +7393,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20230726/cpython-3.8.16%2B20230726-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("120b3312fa79bac2ace45641171c2bc590c4e4462d7ad124d64597e124a36ae7")
@@ -7198,6 +7409,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("1e0a92d1a4f5e6d4a99f86b1cbf9773d703fe7fd032590f3e9c285c7a5eeb00a")
@@ -7212,6 +7425,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("70b57f28c2b5e1e3dd89f0d30edd5bc414e8b20195766cf328e1b26bed7890e1")
@@ -7226,6 +7441,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("886ab33ced13c84bf59ce8ff79eba6448365bfcafea1bf415bd1d75e21b690aa")
@@ -7240,6 +7457,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("3bc1f49147913d93cea9cbb753fbaae90b86f1ee979f975c4712a35f02cbd86b")
@@ -7254,6 +7473,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("e47edfb2ceaf43fc699e20c179ec428b6f3e497cf8e2dcd8e9c936d4b96b1e56")
@@ -7268,6 +7489,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("f767d0438eca5b18c1267c5121055a5808a1412ea7668ef17da3dc9bdd24a55f")
@@ -7282,6 +7505,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("318c059324b84b5d7685bcd0874698799d9e3689b51dbcf596e7a47a39a3d49a")
@@ -7296,6 +7521,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221106/cpython-3.8.15%2B20221106-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("2fdc3fa1c95f982179bbbaedae2b328197658638799b6dcb63f9f494b0de59e2")
@@ -7310,6 +7537,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("6c17f6dcda59de5d8eee922ef7eede403a540dae05423ef2c2a042d8d4f22467")
@@ -7324,6 +7553,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("3ed4db8d0308c584196d97c629058ea69bbd8b7f9a034cf8c2c701ebb286c091")
@@ -7338,6 +7569,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("c45e42deee43e3ebc4ca5b019c37d8ae25fb5b5f1ba5f602098a81b99d2bc804")
@@ -7352,6 +7585,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("d01d813939ad549ca253c52e5b8361b4490cc5c8cbda00ab6e0c524565153e2b")
@@ -7366,6 +7601,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("4eb53bce831bf52682067579c09ccaccb6524dd44bd4b8047454c69b4817f4f0")
@@ -7380,6 +7617,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("72c08b1c1d8cc14cb8d22eab18b463bb514ea160472fdc7400bd69ae375cf9c4")
@@ -7394,6 +7633,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("a0730f3a9e60581f02bdb852953fbb52cf98e8431259fa39cb668a060bd002a0")
@@ -7408,6 +7649,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20221002/cpython-3.8.14%2B20221002-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("1af39953b4c8324ed0608e316bc763006f27e76643155d92eae18e4db6fc162f")
@@ -7422,6 +7665,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("ae4131253d890b013171cb5f7b03cadc585ae263719506f7b7e063a7cf6fde76")
@@ -7436,6 +7681,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("cd6e7c0a27daf7df00f6882eaba01490dd963f698e99aeee9706877333e0df69")
@@ -7450,6 +7697,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-aarch64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("8dc7814bf3425bbf78c6e6e5a6529ded6ae463fa6a4b79c025b343bae4fd955a")
@@ -7464,6 +7713,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("9485599ad9053dfba08c91854717272e95b7c81e0d099d9c51a46fc5a095ccb4")
@@ -7478,6 +7729,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("fb566629ccb5f76ef56d275a3f8017d683f1c20c5beb5d5f38b155ed11e16187")
@@ -7492,6 +7745,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("2c90a0d048caf146d4c33560d6eead1428a225219018d364b1af77f23c492984")
@@ -7506,6 +7761,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("a50668d4c5fbcb374d3ca93ee18db910bc3b462693db073669f31e6da993abf9")
@@ -7520,6 +7777,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220802/cpython-3.8.13%2B20220802-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("f20643f1b3e263a56287319aea5c3888530c09ad9de3a5629b1a5d207807e6b9")
@@ -7534,6 +7793,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-aarch64-apple-darwin-install_only.tar.gz",
         sha256: Some("f9a3cbb81e0463d6615125964762d133387d561b226a30199f5b039b20f1d944")
@@ -7548,6 +7809,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-apple-darwin-install_only.tar.gz",
         sha256: Some("f323fbc558035c13a85ce2267d0fad9e89282268ecb810e364fff1d0a079d525")
@@ -7562,6 +7825,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("fcb2033f01a2b10a51be68c9a1b4c7d7759b582f58a503371fe67ab59987b418")
@@ -7576,6 +7841,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-gnu-install_only.tar.gz",
         sha256: Some("5be9c6d61e238b90dfd94755051c0d3a2d8023ebffdb4b0fa4e8fedd09a6cab6")
@@ -7590,6 +7857,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Musl),
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-unknown-linux-musl-install_only.tar.gz",
         sha256: Some("27faf8aa62de2cd4e59b75a6edce4cab549eba81f0f9cc21df0e370a8a2f3a25")
@@ -7604,6 +7873,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-i686-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("aaa75b9115af73dc3daf7db050ed4f60fd67d2a23ebab30670f18fb8cfa71f33")
@@ -7618,1115 +7889,11 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://github.com/indygreg/python-build-standalone/releases/download/20220227/cpython-3.8.12%2B20220227-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
         sha256: Some("4658e08a00d60b1e01559b74d58ff4dd04da6df935d55f6268a15d6d0a679d74")
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-apple-darwin-pgo%2Blto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-gnu-pgo%2Blto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-unknown-linux-musl-lto-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-i686-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 11,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210724/cpython-3.8.11-x86_64-pc-windows-msvc-shared-pgo-20210724T1424.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-apple-darwin-pgo%2Blto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-gnu-pgo%2Blto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-unknown-linux-musl-lto-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-i686-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 10,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210506/cpython-3.8.10-x86_64-pc-windows-msvc-shared-pgo-20210506T0943.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-apple-darwin-pgo%2Blto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-gnu-pgo%2Blto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-unknown-linux-musl-lto-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-i686-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210415/cpython-3.8.9-x86_64-pc-windows-msvc-shared-pgo-20210414T1515.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-apple-darwin-pgo%2Blto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-gnu-pgo%2Blto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-unknown-linux-musl-lto-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-i686-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 8,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210327/cpython-3.8.8-x86_64-pc-windows-msvc-shared-pgo-20210327T1202.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-apple-darwin-pgo-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-gnu-pgo-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-unknown-linux-musl-debug-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-i686-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20210103/cpython-3.8.7-x86_64-pc-windows-msvc-shared-pgo-20210103T1125.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-apple-darwin-pgo-20201020T0626.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-gnu-pgo-20201020T0627.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-unknown-linux-musl-debug-20201020T0627.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-i686-pc-windows-msvc-shared-pgo-20201021T0233.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20201020/cpython-3.8.6-x86_64-pc-windows-msvc-shared-pgo-20201021T0232.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.8.5-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-gnu-pgo-20200823T0036.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.8.5-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-i686-pc-windows-msvc-shared-pgo-20200830T2311.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200830/cpython-3.8.5-x86_64-pc-windows-msvc-shared-pgo-20200830T2254.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.8.3-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-gnu-pgo-20200518T0040.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-i686-pc-windows-msvc-shared-pgo-20200518T0154.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.8.3-x86_64-pc-windows-msvc-shared-pgo-20200517T2207.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-apple-darwin-pgo-20200418T2238.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-unknown-linux-gnu-pgo-20200418T2243.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-i686-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 8,
-            patch: 2,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200418/cpython-3.8.2-x86_64-pc-windows-msvc-shared-pgo-20200418T2315.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200823/cpython-3.7.9-x86_64-apple-darwin-pgo-20200823T2228.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-gnu-pgo-20200823T0036.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-unknown-linux-musl-debug-20200823T0036.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-i686-pc-windows-msvc-shared-pgo-20200823T0159.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 9,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200822/cpython-3.7.9-x86_64-pc-windows-msvc-shared-pgo-20200823T0118.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200530/cpython-3.7.7-x86_64-apple-darwin-pgo-20200530T1845.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-gnu-pgo-20200518T0040.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-unknown-linux-musl-debug-20200518T0040.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-i686-pc-windows-msvc-shared-pgo-20200517T2153.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 7,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200517/cpython-3.7.7-x86_64-pc-windows-msvc-shared-pgo-20200517T2128.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-macos-20200216T2344.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-linux64-20200216T2303.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200217/cpython-3.7.6-linux64-musl-20200218T0557.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-x86-shared-pgo-20200217T0110.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 6,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20200216/cpython-3.7.6-windows-amd64-shared-pgo-20200217T0022.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-macos-20191026T0535.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-linux64-20191025T0506.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-linux64-musl-20191026T0603.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-x86-20191025T0549.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 5,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20191025/cpython-3.7.5-windows-amd64-20191025T0540.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-macos-20190817T0220.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-linux64-20190817T0224.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-linux64-musl-20190817T0227.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-x86-20190817T0235.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 4,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190816/cpython-3.7.4-windows-amd64-20190817T0227.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Darwin),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-macos-20190618T0523.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-linux64-20190618T0324.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Musl),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-linux64-musl-20190618T0400.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-x86-20190709T0348.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 3,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Windows),
-            libc: Libc::None,
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20190617/cpython-3.7.3-windows-amd64-20190618T0516.tar.zst",
-        sha256: None
-    },
-    ManagedPythonDownload {
-        key: PythonInstallationKey {
-            major: 3,
-            minor: 7,
-            patch: 1,
-            prerelease: None,
-            implementation: LenientImplementationName::Known(ImplementationName::CPython),
-            arch: Arch(target_lexicon::Architecture::X86_64),
-            os: Os(target_lexicon::OperatingSystem::Linux),
-            libc: Libc::Some(target_lexicon::Environment::Gnu),
-        },
-        url: "https://github.com/indygreg/python-build-standalone/releases/download/20181218/cpython-3.7.1-linux64-20181218T1905.tar.zst",
-        sha256: None
     },
     ManagedPythonDownload {
         key: PythonInstallationKey {
@@ -8738,6 +7905,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_arm64.tar.bz2",
         sha256: Some("a050e25e8d686853dd5afc363e55625165825dacfb55f8753d8225ebe417cfd2")
@@ -8752,6 +7921,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.17-macos_x86_64.tar.bz2",
         sha256: Some("6c2c5f2300d7564e711421b4968abd63243cb96f76e363975dd648ebf4a362ee")
@@ -8766,6 +7937,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.17-aarch64.tar.bz2",
         sha256: Some("53b6e5907df869c49e4eae7aca09fba16d150741097efb245892c1477d2395f2")
@@ -8780,6 +7953,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.17-linux32.tar.bz2",
         sha256: Some("e534110e1047da37c1d586c392f74de3424f871d906a2083de6d41f2a8cc9164")
@@ -8794,6 +7969,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.16-s390x.tar.bz2",
         sha256: Some("af97efe498a209ba18c7bc7d084164a9907fb3736588b6864955177e19d5216a")
@@ -8808,6 +7985,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.17-linux64.tar.bz2",
         sha256: Some("fdcdb9b24f1a7726003586503fdeb264fd68fc37fbfcea022dcfe825a7fee18b")
@@ -8822,6 +8001,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.17-win64.zip",
         sha256: Some("cab794a03ddda26238c72942ea6f225612e0dc17c76cac6652da83a95024e6e8")
@@ -8836,6 +8017,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.15-macos_arm64.tar.bz2",
         sha256: Some("d927c5105ea7880f7596fe459183e35cc17c853ef5105678b2ad62a8d000a548")
@@ -8850,6 +8033,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.15-macos_x86_64.tar.bz2",
         sha256: Some("559b61ba7e7c5a5c23cef5370f1fab47ccdb939ac5d2b42b4bef091abe3f6964")
@@ -8864,6 +8049,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.15-aarch64.tar.bz2",
         sha256: Some("52146fccaf64e87e71d178dda8de63c01577ec3923073dc69e1519622bcacb74")
@@ -8878,6 +8065,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.15-linux32.tar.bz2",
         sha256: Some("75dd58c9abd8b9d78220373148355bc3119febcf27a2c781d64ad85e7232c4aa")
@@ -8892,6 +8081,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.15-s390x.tar.bz2",
         sha256: Some("209e57596381e13c9914d1332f359dc4b78de06576739747eb797bdbf85062b8")
@@ -8906,6 +8097,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.15-linux64.tar.bz2",
         sha256: Some("33c584e9a70a71afd0cb7dd8ba9996720b911b3b8ed0156aea298d4487ad22c3")
@@ -8920,6 +8113,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.15-win64.zip",
         sha256: Some("b378b3ab1c3719aee0c3e5519e7bff93ff67b2d8aa987fe4f088b54382db676c")
@@ -8934,6 +8129,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.12-macos_arm64.tar.bz2",
         sha256: Some("45671b1e9437f95ccd790af10dbeb57733cca1ed9661463b727d3c4f5caa7ba0")
@@ -8948,6 +8145,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.12-macos_x86_64.tar.bz2",
         sha256: Some("dbc15d8570560d5f79366883c24bc42231a92855ac19a0f28cb0adeb11242666")
@@ -8962,6 +8161,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.12-aarch64.tar.bz2",
         sha256: Some("26208b5a134d9860a08f74cce60960005758e82dc5f0e3566a48ed863a1f16a1")
@@ -8976,6 +8177,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.12-linux32.tar.bz2",
         sha256: Some("811667825ae58ada4b7c3d8bc1b5055b9f9d6a377e51aedfbe0727966603f60e")
@@ -8990,6 +8193,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.12-s390x.tar.bz2",
         sha256: Some("043c13a585479428b463ab69575a088db74aadc16798d6e677d97f563585fee3")
@@ -9004,6 +8209,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.12-linux64.tar.bz2",
         sha256: Some("6c577993160b6f5ee8cab73cd1a807affcefafe2f7441c87bd926c10505e8731")
@@ -9018,6 +8225,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.10-v7.3.12-win64.zip",
         sha256: Some("8c3b1d34fb99100e230e94560410a38d450dc844effbee9ea183518e4aff595c")
@@ -9032,6 +8241,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_arm64.tar.bz2",
         sha256: Some("88f824e7a2d676440d09bc90fc959ae0fd3557d7e2f14bfbbe53d41d159a47fe")
@@ -9046,6 +8257,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.16-macos_x86_64.tar.bz2",
         sha256: Some("fda015431621e7e5aa16359d114f2c45a77ed936992c1efff86302e768a6b21c")
@@ -9060,6 +8273,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.16-aarch64.tar.bz2",
         sha256: Some("de3f2ed3581b30555ac0dd3e4df78a262ec736a36fb2e8f28259f8539b278ef4")
@@ -9074,6 +8289,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.16-linux32.tar.bz2",
         sha256: Some("583b6d6dd4e8c07cbc04da04a7ec2bdfa6674825289c2378c5e018d5abe779ea")
@@ -9088,6 +8305,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.16-s390x.tar.bz2",
         sha256: Some("7a56ebb27dba3110dc1ff52d8e0449cdb37fe5c2275f7faf11432e4e164833ba")
@@ -9102,6 +8321,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.16-linux64.tar.bz2",
         sha256: Some("16f9c5b808c848516e742986e826b833cdbeda09ad8764e8704595adbe791b23")
@@ -9116,6 +8337,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.16-win64.zip",
         sha256: Some("06ec12a5e964dc0ad33e6f380185a4d295178dce6d6df512f508e7aee00a1323")
@@ -9130,6 +8353,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.15-macos_arm64.tar.bz2",
         sha256: Some("300541c32125767a91b182b03d9cc4257f04971af32d747ecd4d62549d72acfd")
@@ -9144,6 +8369,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.15-macos_x86_64.tar.bz2",
         sha256: Some("18ad7c9cb91c5e8ef9d40442b2fd1f6392ae113794c5b6b7d3a45e04f19edec6")
@@ -9158,6 +8385,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.15-aarch64.tar.bz2",
         sha256: Some("03e35fcba290454bb0ccf7ee57fb42d1e63108d10d593776a382c0a2fe355de0")
@@ -9172,6 +8401,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.15-linux32.tar.bz2",
         sha256: Some("c6209380977066c9e8b96e8258821c70f996004ce1bc8659ae83d4fd5a89ff5c")
@@ -9186,6 +8417,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.15-s390x.tar.bz2",
         sha256: Some("deeb5e54c36a0fd9cfefd16e63a0d5bed4f4a43e6bbc01c23f0ed8f7f1c0aaf3")
@@ -9200,6 +8433,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.15-linux64.tar.bz2",
         sha256: Some("f062be307200bde434817e1620cebc13f563d6ab25309442c5f4d0f0d68f0912")
@@ -9214,6 +8449,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.15-win64.zip",
         sha256: Some("a156dad8b58570597eaaabe05663f00f80c60bc11df4a9c46d0953b6c5eb9209")
@@ -9228,6 +8465,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.12-macos_arm64.tar.bz2",
         sha256: Some("0e8a1a3468b9790c734ac698f5b00cc03fc16899ccc6ce876465fac0b83980e3")
@@ -9242,6 +8481,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.12-macos_x86_64.tar.bz2",
         sha256: Some("64f008ffa070c407e5ef46c8256b2e014de7196ea5d858385861254e7959f4eb")
@@ -9256,6 +8497,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.12-aarch64.tar.bz2",
         sha256: Some("e9327fb9edaf2ad91935d5b8563ec5ff24193bddb175c1acaaf772c025af1824")
@@ -9270,6 +8513,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.12-linux32.tar.bz2",
         sha256: Some("aa04370d38f451683ccc817d76c2b3e0f471dbb879e0bd618d9affbdc9cd37a4")
@@ -9284,6 +8529,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.12-s390x.tar.bz2",
         sha256: Some("20d84658a6899bdd2ca35b00ead33a2f56cff2c40dce1af630466d27952f6d4f")
@@ -9298,6 +8545,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.12-linux64.tar.bz2",
         sha256: Some("84c89b966fab2b58f451a482ee30ca7fec3350435bd0b9614615c61dc6da2390")
@@ -9312,6 +8561,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.12-win64.zip",
         sha256: Some("0996054207b401aeacace1aa11bad82cfcb463838a1603c5f263626c47bbe0e6")
@@ -9326,6 +8577,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.11-macos_arm64.tar.bz2",
         sha256: Some("91ad7500f1a39531dbefa0b345a3dcff927ff9971654e8d2e9ef7c5ae311f57e")
@@ -9340,6 +8593,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.11-macos_x86_64.tar.bz2",
         sha256: Some("d33f40b207099872585afd71873575ca6ea638a27d823bc621238c5ae82542ed")
@@ -9354,6 +8609,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.11-aarch64.tar.bz2",
         sha256: Some("09175dc652ed895d98e9ad63d216812bf3ee7e398d900a9bf9eb2906ba8302b9")
@@ -9368,6 +8625,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.11-linux32.tar.bz2",
         sha256: Some("0099d72c2897b229057bff7e2c343624aeabdc60d6fb43ca882bff082f1ffa48")
@@ -9382,6 +8641,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.11-s390x.tar.bz2",
         sha256: Some("e1f30f2ddbe3f446ddacd79677b958d56c07463b20171fb2abf8f9a3178b79fc")
@@ -9396,6 +8657,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.11-linux64.tar.bz2",
         sha256: Some("d506172ca11071274175d74e9c581c3166432d0179b036470e3b9e8d20eae581")
@@ -9410,6 +8673,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.11-win64.zip",
         sha256: Some("57faad132d42d3e7a6406fcffafffe0b4f390cf0e2966abb8090d073c6edf405")
@@ -9424,6 +8689,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.10-macos_arm64.tar.bz2",
         sha256: Some("e2a6bec7408e6497c7de8165aa4a1b15e2416aec4a72f2578f793fb06859ccba")
@@ -9438,6 +8705,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.10-macos_x86_64.tar.bz2",
         sha256: Some("f90c8619b41e68ec9ffd7d5e913fe02e60843da43d3735b1c1bc75bcfe638d97")
@@ -9452,6 +8721,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.10-aarch64.tar.bz2",
         sha256: Some("657a04fd9a5a992a2f116a9e7e9132ea0c578721f59139c9fb2083775f71e514")
@@ -9466,6 +8737,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.10-linux32.tar.bz2",
         sha256: Some("b6db59613b9a1c0c1ab87bc103f52ee95193423882dc8a848b68850b8ba59cc5")
@@ -9480,6 +8753,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.10-s390x.tar.bz2",
         sha256: Some("ca6525a540cf0c682d1592ae35d3fbc97559a97260e4b789255cc76dde7a14f0")
@@ -9494,6 +8769,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.10-linux64.tar.bz2",
         sha256: Some("95cf99406179460d63ddbfe1ec870f889d05f7767ce81cef14b88a3a9e127266")
@@ -9508,6 +8785,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.10-win64.zip",
         sha256: Some("07e18b7b24c74af9730dfaab16e24b22ef94ea9a4b64cbb2c0d80610a381192a")
@@ -9522,6 +8801,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.9-osx64.tar.bz2",
         sha256: Some("59c8852168b2b1ba1f0211ff043c678760380d2f9faf2f95042a8878554dbc25")
@@ -9536,6 +8817,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.9-aarch64.tar.bz2",
         sha256: Some("2e1ae193d98bc51439642a7618d521ea019f45b8fb226940f7e334c548d2b4b9")
@@ -9550,6 +8833,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.9-linux32.tar.bz2",
         sha256: Some("0de4b9501cf28524cdedcff5052deee9ea4630176a512bdc408edfa30914bae7")
@@ -9564,6 +8849,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.9-s390x.tar.bz2",
         sha256: Some("774dca83bcb4403fb99b3d155e7bd572ef8c52b9fe87a657109f64e75ad71732")
@@ -9578,6 +8865,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.9-linux64.tar.bz2",
         sha256: Some("46818cb3d74b96b34787548343d266e2562b531ddbaf330383ba930ff1930ed5")
@@ -9592,6 +8881,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.9-win64.zip",
         sha256: Some("be48ab42f95c402543a7042c999c9433b17e55477c847612c8733a583ca6dff5")
@@ -9606,6 +8897,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.8-osx64.tar.bz2",
         sha256: Some("95bd88ac8d6372cd5b7b5393de7b7d5c615a0c6e42fdb1eb67f2d2d510965aee")
@@ -9620,6 +8913,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.8-aarch64-portable.tar.bz2",
         sha256: Some("b7282bc4484bceae5bc4cc04e05ee4faf51cb624c8fc7a69d92e5fdf0d0c96aa")
@@ -9634,6 +8929,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.8-linux32.tar.bz2",
         sha256: Some("a0d18e4e73cc655eb02354759178b8fb161d3e53b64297d05e2fff91f7cf862d")
@@ -9648,6 +8945,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.8-s390x.tar.bz2",
         sha256: Some("37b596bfe76707ead38ffb565629697e9b6fa24e722acc3c632b41ec624f5d95")
@@ -9662,6 +8961,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.8-linux64.tar.bz2",
         sha256: Some("129a055032bba700cd1d0acacab3659cf6b7180e25b1b2f730e792f06d5b3010")
@@ -9676,6 +8977,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.9-v7.3.8-win64.zip",
         sha256: Some("c1b2e4cde2dcd1208d41ef7b7df8e5c90564a521e7a5db431673da335a1ba697")
@@ -9690,6 +8993,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.11-macos_arm64.tar.bz2",
         sha256: Some("78cdc79ff964c4bfd13eb45a7d43a011cbe8d8b513323d204891f703fdc4fa1a")
@@ -9704,6 +9009,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.11-macos_x86_64.tar.bz2",
         sha256: Some("194ca0b4d91ae409a9cb1a59eb7572d7affa8a451ea3daf26539aa515443433a")
@@ -9718,6 +9025,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.11-aarch64.tar.bz2",
         sha256: Some("9a2fa0b8d92b7830aa31774a9a76129b0ff81afbd22cd5c41fbdd9119e859f55")
@@ -9732,6 +9041,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.11-linux32.tar.bz2",
         sha256: Some("a79b31fce8f5bc1f9940b6777134189a1d3d18bda4b1c830384cda90077c9176")
@@ -9746,6 +9057,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.11-s390x.tar.bz2",
         sha256: Some("eab7734d86d96549866f1cba67f4f9c73c989f6a802248beebc504080d4c3fcd")
@@ -9760,6 +9073,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.11-linux64.tar.bz2",
         sha256: Some("470330e58ac105c094041aa07bb05676b06292bc61409e26f5c5593ebb2292d9")
@@ -9774,6 +9089,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.11-win64.zip",
         sha256: Some("0f46fb6df32941ea016f77cfd7e9b426d5ac25a2af2453414df66103941c8435")
@@ -9788,6 +9105,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.10-macos_arm64.tar.bz2",
         sha256: Some("6cb1429371e4854b718148a509d80143f801e3abfc72fef58d88aeeee1e98f9e")
@@ -9802,6 +9121,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.10-macos_x86_64.tar.bz2",
         sha256: Some("399eb1ce4c65f62f6a096b7c273536601b7695e3c0dc0457393a659b95b7615b")
@@ -9816,6 +9137,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.10-aarch64.tar.bz2",
         sha256: Some("e4caa1a545f22cfee87d5b9aa6f8852347f223643ad7d2562e0b2a2f4663ad98")
@@ -9830,6 +9153,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.10-linux32.tar.bz2",
         sha256: Some("b70ed7fdc73a74ebdc04f07439f7bad1a849aaca95e26b4a74049d0e483f071c")
@@ -9844,6 +9169,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.10-s390x.tar.bz2",
         sha256: Some("c294f8e815158388628fe77ac5b8ad6cd93c8db1359091fa02d41cf6da4d61a1")
@@ -9858,6 +9185,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.10-linux64.tar.bz2",
         sha256: Some("ceef6496fd4ab1c99e3ec22ce657b8f10f8bb77a32427fadfb5e1dd943806011")
@@ -9872,6 +9201,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.10-win64.zip",
         sha256: Some("362dd624d95bd64743190ea2539b97452ecb3d53ea92ceb2fbe9f48dc60e6b8f")
@@ -9886,6 +9217,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.9-osx64.tar.bz2",
         sha256: Some("91a5c2c1facd5a4931a8682b7d792f7cf4f2ba25cd2e7e44e982139a6d5e4840")
@@ -9900,6 +9233,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.9-aarch64.tar.bz2",
         sha256: Some("5e124455e207425e80731dff317f0432fa0aba1f025845ffca813770e2447e32")
@@ -9914,6 +9249,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.9-linux32.tar.bz2",
         sha256: Some("4b261516c6c59078ab0c8bd7207327a1b97057b4ec1714ed5e79a026f9efd492")
@@ -9928,6 +9265,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.9-s390x.tar.bz2",
         sha256: Some("c6177a0016c9145c7b99fddb5d74cc2e518ccdb216a6deb51ef6a377510cc930")
@@ -9942,6 +9281,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.9-linux64.tar.bz2",
         sha256: Some("08be25ec82fc5d23b78563eda144923517daba481a90af0ace7a047c9c9a3c34")
@@ -9956,6 +9297,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.9-win64.zip",
         sha256: Some("05022baaa55db2b60880f2422312d9e4025e1267303ac57f33e8253559d0be88")
@@ -9970,6 +9313,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.8-osx64.tar.bz2",
         sha256: Some("de1b283ff112d76395c0162a1cf11528e192bdc230ee3f1b237f7694c7518dee")
@@ -9984,6 +9329,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.8-aarch64-portable.tar.bz2",
         sha256: Some("0210536e9f1841ba283c13b04783394050837bb3e6f4091c9f1bd9c7f2b94b55")
@@ -9998,6 +9345,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.8-linux32.tar.bz2",
         sha256: Some("bea4b275decd492af6462157d293dd6fcf08a949859f8aec0959537b40afd032")
@@ -10012,6 +9361,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.8-s390x.tar.bz2",
         sha256: Some("ad53d373d6e275a41ca64da7d88afb6a17e48e7bfb2a6fff92daafdc06da6b90")
@@ -10026,6 +9377,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.8-linux64.tar.bz2",
         sha256: Some("089f8e3e357d6130815964ddd3507c13bd53e4976ccf0a89b5c36a9a6775a188")
@@ -10040,6 +9393,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.8-v7.3.8-win64.zip",
         sha256: Some("0894c468e7de758c509a602a28ef0ba4fbf197ccdf946c7853a7283d9bb2a345")
@@ -10054,6 +9409,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.9-osx64.tar.bz2",
         sha256: Some("12d92f578a200d50959e55074b20f29f93c538943e9a6e6522df1a1cc9cef542")
@@ -10068,6 +9425,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.9-aarch64.tar.bz2",
         sha256: Some("dfc62f2c453fb851d10a1879c6e75c31ffebbf2a44d181bb06fcac4750d023fc")
@@ -10082,6 +9441,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.9-linux32.tar.bz2",
         sha256: Some("3398cece0167b81baa219c9cd54a549443d8c0a6b553ec8ec13236281e0d86cd")
@@ -10096,6 +9457,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.9-s390x.tar.bz2",
         sha256: Some("fcab3b9e110379948217cf592229542f53c33bfe881006f95ce30ac815a6df48")
@@ -10110,6 +9473,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.9-linux64.tar.bz2",
         sha256: Some("c58195124d807ecc527499ee19bc511ed753f4f2e418203ca51bc7e3b124d5d1")
@@ -10124,6 +9489,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.9-win64.zip",
         sha256: Some("8acb184b48fb3c854de0662e4d23a66b90e73b1ab73a86695022c12c745d8b00")
@@ -10138,6 +9505,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.8-osx64.tar.bz2",
         sha256: Some("76b8eef5b059a7e478f525615482d2a6e9feb83375e3f63c16381d80521a693f")
@@ -10152,6 +9521,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.8-aarch64-portable.tar.bz2",
         sha256: Some("639c76f128a856747aee23a34276fa101a7a157ea81e76394fbaf80b97dcf2f2")
@@ -10166,6 +9537,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.8-linux32.tar.bz2",
         sha256: Some("38429ec6ea1aca391821ee4fbda7358ae86de4600146643f2af2fe2c085af839")
@@ -10180,6 +9553,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.8-s390x.tar.bz2",
         sha256: Some("5c2cd3f7cf04cb96f6bcc6b02e271f5d7275867763978e66651b8d1605ef3141")
@@ -10194,6 +9569,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.8-linux64.tar.bz2",
         sha256: Some("409085db79a6d90bfcf4f576dca1538498e65937acfbe03bd4909bdc262ff378")
@@ -10208,6 +9585,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.8-win64.zip",
         sha256: Some("96df67492bc8d62b2e71dddf5f6c58965a26cac9799c5f4081401af0494b3bcc")
@@ -10222,6 +9601,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.5-osx64.tar.bz2",
         sha256: Some("b3a7d3099ad83de7c267bb79ae609d5ce73b01800578ffd91ba7e221b13f80db")
@@ -10236,6 +9617,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.5-aarch64.tar.bz2",
         sha256: Some("85d83093b3ef5b863f641bc4073d057cc98bb821e16aa9361a5ff4898e70e8ee")
@@ -10250,6 +9633,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.5-linux32.tar.bz2",
         sha256: Some("3dd8b565203d372829e53945c599296fa961895130342ea13791b17c84ed06c4")
@@ -10264,6 +9649,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.5-s390x.tar.bz2",
         sha256: Some("dffdf5d73613be2c6809dc1a3cf3ee6ac2f3af015180910247ff24270b532ed5")
@@ -10278,6 +9665,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.5-linux64.tar.bz2",
         sha256: Some("9000db3e87b54638e55177e68cbeb30a30fe5d17b6be48a9eb43d65b3ebcfc26")
@@ -10292,6 +9681,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.5-win64.zip",
         sha256: Some("072bd22427178dc4e65d961f50281bd2f56e11c4e4d9f16311c703f69f46ae24")
@@ -10306,6 +9697,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Darwin),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-osx64.tar.bz2",
         sha256: Some("d72b27d5bb60813273f14f07378a08822186a66e216c5d1a768ad295b582438d")
@@ -10320,6 +9713,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::Aarch64(target_lexicon::Aarch64Architecture::Aarch64)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-aarch64.tar.bz2",
         sha256: Some("ee4aa041558b58de6063dd6df93b3def221c4ca4c900d6a9db5b1b52135703a8")
@@ -10334,6 +9729,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-linux32.tar.bz2",
         sha256: Some("7d81b8e9fcd07c067cfe2f519ab770ec62928ee8787f952cadf2d2786246efc8")
@@ -10348,6 +9745,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::S390x),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-s390x.tar.bz2",
         sha256: Some("92000d90b9a37f2e9cb7885f2a872adfa9e48e74bf7f84a8b8185c8181f0502d")
@@ -10362,6 +9761,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_64),
             os: Os(target_lexicon::OperatingSystem::Linux),
             libc: Libc::Some(target_lexicon::Environment::Gnu),
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-linux64.tar.bz2",
         sha256: Some("37e2804c4661c86c857d709d28c7de716b000d31e89766599fdf5a98928b7096")
@@ -10376,6 +9777,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             arch: Arch(target_lexicon::Architecture::X86_32(target_lexicon::X86_32Architecture::I686)),
             os: Os(target_lexicon::OperatingSystem::Windows),
             libc: Libc::None,
+            variant: PythonVariant::Default
+
         },
         url: "https://downloads.python.org/pypy/pypy3.7-v7.3.3-win32.zip",
         sha256: Some("a282ce40aa4f853e877a5dbb38f0a586a29e563ae9ba82fd50c7e5dc465fb649")

--- a/crates/uv-python/src/downloads.inc.mustache
+++ b/crates/uv-python/src/downloads.inc.mustache
@@ -1,9 +1,8 @@
-// DO NOT EDIT
-//
 // Generated with `{{generated_with}}`
 // From template at `{{generated_from}}`
 
 use uv_pep440::{Prerelease, PrereleaseKind};
+use crate::PythonVariant;
 
 pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
     {{#versions}}
@@ -22,6 +21,8 @@ pub(crate) const PYTHON_DOWNLOADS: &[ManagedPythonDownload] = &[
             {{^value.libc}}
             libc: Libc::None,
             {{/value.libc}}
+            variant: {{value.variant}}
+
         },
         url: "{{value.url}}",
         {{#value.sha256}}

--- a/crates/uv-python/src/downloads.rs
+++ b/crates/uv-python/src/downloads.rs
@@ -273,9 +273,10 @@ impl PythonDownloadRequest {
             ) {
                 return false;
             }
-            if version.is_freethreaded() {
-                debug!("Installing managed free-threaded Python is not yet supported");
-                return false;
+            if let Some(variant) = version.variant() {
+                if variant != key.variant {
+                    return false;
+                }
             }
         }
         true

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -16,7 +16,7 @@ use crate::managed::{ManagedPythonInstallation, ManagedPythonInstallations};
 use crate::platform::{Arch, Libc, Os};
 use crate::{
     downloads, Error, ImplementationName, Interpreter, PythonDownloads, PythonPreference,
-    PythonSource, PythonVersion,
+    PythonSource, PythonVariant, PythonVersion,
 };
 
 /// A Python interpreter and accompanying tools.
@@ -227,6 +227,7 @@ pub struct PythonInstallationKey {
     pub(crate) os: Os,
     pub(crate) arch: Arch,
     pub(crate) libc: Libc,
+    pub(crate) variant: PythonVariant,
 }
 
 impl PythonInstallationKey {
@@ -239,6 +240,7 @@ impl PythonInstallationKey {
         os: Os,
         arch: Arch,
         libc: Libc,
+        variant: PythonVariant,
     ) -> Self {
         Self {
             implementation,
@@ -249,6 +251,7 @@ impl PythonInstallationKey {
             os,
             arch,
             libc,
+            variant,
         }
     }
 
@@ -258,6 +261,7 @@ impl PythonInstallationKey {
         os: Os,
         arch: Arch,
         libc: Libc,
+        variant: PythonVariant,
     ) -> Self {
         Self {
             implementation,
@@ -268,6 +272,7 @@ impl PythonInstallationKey {
             os,
             arch,
             libc,
+            variant,
         }
     }
 
@@ -303,9 +308,13 @@ impl PythonInstallationKey {
 
 impl fmt::Display for PythonInstallationKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let variant = match self.variant {
+            PythonVariant::Default => String::new(),
+            PythonVariant::Freethreaded => format!("+{}", self.variant),
+        };
         write!(
             f,
-            "{}-{}.{}.{}{}-{}-{}-{}",
+            "{}-{}.{}.{}{}{}-{}-{}-{}",
             self.implementation,
             self.major,
             self.minor,
@@ -313,6 +322,7 @@ impl fmt::Display for PythonInstallationKey {
             self.prerelease
                 .map(|pre| pre.to_string())
                 .unwrap_or_default(),
+            variant,
             self.os,
             self.arch,
             self.libc
@@ -349,6 +359,19 @@ impl FromStr for PythonInstallationKey {
             PythonInstallationKeyError::ParseError(key.to_string(), format!("invalid libc: {err}"))
         })?;
 
+        let (version, variant) = match version.split_once('+') {
+            Some((version, variant)) => {
+                let variant = PythonVariant::from_str(variant).map_err(|()| {
+                    PythonInstallationKeyError::ParseError(
+                        key.to_string(),
+                        format!("invalid Python variant: {variant}"),
+                    )
+                })?;
+                (version, variant)
+            }
+            None => (*version, PythonVariant::Default),
+        };
+
         let version = PythonVersion::from_str(version).map_err(|err| {
             PythonInstallationKeyError::ParseError(
                 key.to_string(),
@@ -362,6 +385,7 @@ impl FromStr for PythonInstallationKey {
             os,
             arch,
             libc,
+            variant,
         ))
     }
 }

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -26,7 +26,8 @@ use crate::implementation::LenientImplementationName;
 use crate::platform::{Arch, Libc, Os};
 use crate::pointer_size::PointerSize;
 use crate::{
-    Prefix, PythonInstallationKey, PythonVersion, Target, VersionRequest, VirtualEnvironment,
+    Prefix, PythonInstallationKey, PythonVariant, PythonVersion, Target, VersionRequest,
+    VirtualEnvironment,
 };
 
 /// A Python executable and its associated platform markers.
@@ -161,7 +162,16 @@ impl Interpreter {
             self.os(),
             self.arch(),
             self.libc(),
+            self.variant(),
         )
+    }
+
+    pub fn variant(&self) -> PythonVariant {
+        if self.gil_disabled() {
+            PythonVariant::Freethreaded
+        } else {
+            PythonVariant::default()
+        }
     }
 
     /// Return the [`Arch`] reported by the interpreter platform tags.

--- a/crates/uv-python/src/managed.rs
+++ b/crates/uv-python/src/managed.rs
@@ -20,7 +20,7 @@ use crate::libc::LibcDetectionError;
 use crate::platform::Error as PlatformError;
 use crate::platform::{Arch, Libc, Os};
 use crate::python_version::PythonVersion;
-use crate::PythonRequest;
+use crate::{PythonRequest, PythonVariant};
 use uv_fs::{LockedFile, Simplified};
 
 #[derive(Error, Debug)]
@@ -329,13 +329,17 @@ impl ManagedPythonInstallation {
         let stdlib = if matches!(self.key.os, Os(target_lexicon::OperatingSystem::Windows)) {
             self.python_dir().join("Lib")
         } else {
+            let lib_suffix = match self.key.variant {
+                PythonVariant::Default => "",
+                PythonVariant::Freethreaded => "t",
+            };
             let python = if matches!(
                 self.key.implementation,
                 LenientImplementationName::Known(ImplementationName::PyPy)
             ) {
                 format!("pypy{}", self.key.version().python_version())
             } else {
-                format!("python{}", self.key.version().python_version())
+                format!("python{}{lib_suffix}", self.key.version().python_version())
             };
             self.python_dir().join("lib").join(python)
         };

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -7,6 +7,7 @@ use owo_colors::OwoColorize;
 use std::collections::BTreeSet;
 use std::fmt::Write;
 use std::path::Path;
+use tracing::debug;
 
 use uv_client::Connectivity;
 use uv_python::downloads::{DownloadResult, ManagedPythonDownload, PythonDownloadRequest};
@@ -58,7 +59,10 @@ pub(crate) async fn install(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let installed_installations: Vec<_> = installations.find_all()?.collect();
+    let installed_installations: Vec<_> = installations
+        .find_all()?
+        .inspect(|installation| debug!("Found existing installation {}", installation.key()))
+        .collect();
     let mut unfilled_requests = Vec::new();
     let mut uninstalled = Vec::new();
     for (request, download_request) in requests.iter().zip(download_requests) {


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/7193

```

❯ cargo run -q -- python uninstall 3.13t
Searching for Python versions matching: Python 3.13t
Uninstalled Python 3.13.0 in 231ms
 - cpython-3.13.0+freethreaded-macos-aarch64-none
❯ cargo run -q -- python install 3.13t
Searching for Python versions matching: Python 3.13t
Installed Python 3.13.0 in 3.54s
 + cpython-3.13.0+freethreaded-macos-aarch64-none
❯ cargo run -q -- python install 3.12t
Searching for Python versions matching: Python 3.12t
error: No download found for request: cpython-3.12t-macos-aarch64-none
❯ cargo run -q -- python install 3.13rc3t
Searching for Python versions matching: Python 3.13rc3t
Found existing installation for Python 3.13rc3t: cpython-3.13.0+freethreaded-macos-aarch64-none
❯ cargo run -q -- run -p 3.13t python -c "import sys; print(sys.base_prefix)"
/Users/zb/.local/share/uv/python/cpython-3.13.0+freethreaded-macos-aarch64-none
```