### PR TITLE
Support PEP 723 metadata with `uv run -`

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -380,7 +380,7 @@ pub(crate) async fn add(
             }
             Target::Script(ref script, _) => {
                 let uv_scripts::Source::File(path) = &script.source else {
-                    bail!("Cannot resolve requirement from stdin")
+                    unreachable!("script source is not a file");
                 };
                 let script_path = std::path::absolute(path)?;
                 let script_dir = script_path.parent().expect("script path has no parent");

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -379,7 +379,10 @@ pub(crate) async fn add(
                 (uv_pep508::Requirement::from(requirement), None)
             }
             Target::Script(ref script, _) => {
-                let script_path = std::path::absolute(&script.path)?;
+                let uv_scripts::Source::File(path) = &script.source else {
+                    bail!("Cannot resolve requirement from stdin")
+                };
+                let script_path = std::path::absolute(path)?;
                 let script_dir = script_path.parent().expect("script path has no parent");
                 resolve_requirement(
                     requirement,
@@ -508,11 +511,9 @@ pub(crate) async fn add(
         Target::Project(project, venv) => (project, venv),
         // If `--script`, exit early. There's no reason to lock and sync.
         Target::Script(script, _) => {
-            writeln!(
-                printer.stderr(),
-                "Updated `{}`",
-                script.path.user_display().cyan()
-            )?;
+            if let uv_scripts::Source::File(path) = &script.source {
+                writeln!(printer.stderr(), "Updated `{}`", path.user_display().cyan())?;
+            }
             return Ok(ExitStatus::Success);
         }
     };

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -144,11 +144,9 @@ pub(crate) async fn remove(
         Target::Project(project) => project,
         // If `--script`, exit early. There's no reason to lock and sync.
         Target::Script(script) => {
-            writeln!(
-                printer.stderr(),
-                "Updated `{}`",
-                script.path.user_display().cyan()
-            )?;
+            if let uv_scripts::Source::File(path) = &script.source {
+                writeln!(printer.stderr(), "Updated `{}`", path.user_display().cyan())?;
+            }
             return Ok(ExitStatus::Success);
         }
     };

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -116,8 +116,8 @@ pub(crate) async fn run(
         } else {
             writeln!(
                 printer.stderr(),
-                "Reading inline script metadata from: {}",
-                "<stdin>".cyan()
+                "Reading inline script metadata from: `{}`",
+                "stdin".cyan()
             )?;
         }
 

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -107,11 +107,19 @@ pub(crate) async fn run(
     // Determine whether the command to execute is a PEP 723 script.
     let temp_dir;
     let script_interpreter = if let Some(script) = script {
-        writeln!(
-            printer.stderr(),
-            "Reading inline script metadata from: {}",
-            script.path.user_display().cyan()
-        )?;
+        if let uv_scripts::Source::File(path) = &script.source {
+            writeln!(
+                printer.stderr(),
+                "Reading inline script metadata from: {}",
+                path.user_display().cyan()
+            )?;
+        } else {
+            writeln!(
+                printer.stderr(),
+                "Reading inline script metadata from: {}",
+                "<stdin>".cyan()
+            )?;
+        }
 
         let (source, python_request) = if let Some(request) = python.as_deref() {
             // (1) Explicit request from user
@@ -196,15 +204,23 @@ pub(crate) async fn run(
                     .unwrap_or(&empty),
                 SourceStrategy::Disabled => &empty,
             };
-            let script_path = std::path::absolute(script.path)?;
-            let script_dir = script_path.parent().expect("script path has no parent");
+            let script_dir = match &script.source {
+                uv_scripts::Source::File(path) => {
+                    let script_path = std::path::absolute(path)?;
+                    script_path
+                        .parent()
+                        .expect("script path has no parent")
+                        .to_owned()
+                }
+                uv_scripts::Source::Stdin => std::env::current_dir()?,
+            };
 
             let requirements = dependencies
                 .into_iter()
                 .flat_map(|requirement| {
                     LoweredRequirement::from_non_workspace_requirement(
                         requirement,
-                        script_dir,
+                        script_dir.as_ref(),
                         script_sources,
                     )
                     .map_ok(LoweredRequirement::into_inner)

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -214,13 +214,12 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
     // If the target is a PEP 723 script, parse it.
     let script = if let Commands::Project(command) = &*cli.command {
         if let ProjectCommand::Run(uv_cli::RunArgs { .. }) = &**command {
-            if let Some(
-                RunCommand::PythonScript(script, _) | RunCommand::PythonGuiScript(script, _),
-            ) = run_command.as_ref()
-            {
-                Pep723Script::read(&script).await?
-            } else {
-                None
+            match run_command.as_ref() {
+                Some(
+                    RunCommand::PythonScript(script, _) | RunCommand::PythonGuiScript(script, _),
+                ) => Pep723Script::read(&script).await?,
+                Some(RunCommand::PythonStdin(contents)) => Pep723Script::parse_stdin(contents)?,
+                _ => None,
             }
         } else if let ProjectCommand::Remove(uv_cli::RemoveArgs {
             script: Some(script),

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -2359,3 +2359,39 @@ fn run_url_like_with_local_file_priority() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn run_stdin_with_pep723() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let test_script = context.temp_dir.child("main.py");
+    test_script.write_str(indoc! { r#"
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = [
+        #   "iniconfig",
+        # ]
+        # ///
+        import iniconfig
+        print("Hello, world!")
+       "#
+    })?;
+
+    let mut command = context.run();
+    let command_with_args = command.stdin(std::fs::File::open(test_script)?).arg("-");
+    uv_snapshot!(context.filters(), command_with_args, @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Hello, world!
+
+    ----- stderr -----
+    Reading inline script metadata from: <stdin>
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    "###);
+
+    Ok(())
+}

--- a/crates/uv/tests/run.rs
+++ b/crates/uv/tests/run.rs
@@ -2386,7 +2386,7 @@ fn run_stdin_with_pep723() -> Result<()> {
     Hello, world!
 
     ----- stderr -----
-    Reading inline script metadata from: <stdin>
+    Reading inline script metadata from: `stdin`
     Resolved 1 package in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #8097. One challenge is that the `Pep723Script` is used for both reading
and writing the metadata, so I wasn't sure about how to handle `script.write`
when stdin (currently just ignoring it, but maybe we should raise an error?).

## Test Plan

Added a test case copying the `test_stdin` with PEP 723 metadata.
