### PR TITLE
Keep the instructions for the Windows standalone installer consistent across the README and the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Install uv with our standalone installers, or from [PyPI](https://pypi.org/proje
 $ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # On Windows.
-$ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+$ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 
 # With pip.
 $ pip install uv


### PR DESCRIPTION
## Summary
This PR aims to align the instructions for installing the Windows standalone installer in the README with the current documentation.
https://github.com/astral-sh/uv/blob/7bd0d97ce573e9fa428d2b0076d83976e772b3b7/docs/getting-started/installation.md?plain=1#L17-L21
## Test Plan
Only README is modified and identical to the doc, so not tested.
