### PR TITLE
Fix typos in --no-... option names in no-op warnings

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -115,7 +115,7 @@ pub(crate) async fn add(
         }
         if no_sync {
             warn_user_once!(
-                "`--no_sync` is a no-op for Python scripts with inline metadata, which always run in isolation"
+                "`--no-sync` is a no-op for Python scripts with inline metadata, which always run in isolation"
             );
         }
 

--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -176,10 +176,10 @@ async fn init_script(
     native_tls: bool,
 ) -> Result<()> {
     if no_workspace {
-        warn_user_once!("`--no_workspace` is a no-op for Python scripts, which are standalone");
+        warn_user_once!("`--no-workspace` is a no-op for Python scripts, which are standalone");
     }
     if no_readme {
-        warn_user_once!("`--no_readme` is a no-op for Python scripts, which are standalone");
+        warn_user_once!("`--no-readme` is a no-op for Python scripts, which are standalone");
     }
     if author_from.is_some() {
         warn_user_once!("`--author-from` is a no-op for Python scripts, which are standalone");

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -61,7 +61,7 @@ pub(crate) async fn remove(
         }
         if no_sync {
             warn_user_once!(
-                "`--no_sync` is a no-op for Python scripts with inline metadata, which always run in isolation"
+                "`--no-sync` is a no-op for Python scripts with inline metadata, which always run in isolation"
             );
         }
         Target::Script(script)


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

When trying out standalone scripts I noticed a warning that said `--no_readme` is a no-op when I provided `--no-readme`.

I searched for this "--\w+_" pattern in the codebase and found a similar typo in warnings in other places, so I fixed them here.

## Test Plan


no plan, since these commands are mainly for interactive use I would assume nobody parses out warnings about unnecessary options?