### PR TITLE
Use shared resolver state between add and lock

### DIFF
--- a/crates/uv-once-map/src/lib.rs
+++ b/crates/uv-once-map/src/lib.rs
@@ -105,6 +105,18 @@ impl<K: Eq + Hash, V: Clone, H: BuildHasher + Clone> OnceMap<K, V, H> {
             Value::Waiting(_) => None,
         }
     }
+
+    /// Remove the result of a previous job, if any.
+    pub fn remove<Q: ?Sized + Hash + Eq>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+    {
+        let entry = self.items.remove(key)?;
+        match entry {
+            (_, Value::Filled(value)) => Some(value),
+            (_, Value::Waiting(_)) => None,
+        }
+    }
 }
 
 impl<K: Eq + Hash + Clone, V, H: Default + BuildHasher + Clone> Default for OnceMap<K, V, H> {

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -19,7 +19,7 @@ use uv_workspace::{DiscoveryOptions, MemberDiscovery, VirtualProject, Workspace}
 use crate::commands::pip::loggers::DefaultResolveLogger;
 use crate::commands::project::lock::do_safe_lock;
 use crate::commands::project::{ProjectError, ProjectInterpreter};
-use crate::commands::{diagnostics, pip, ExitStatus, OutputWriter};
+use crate::commands::{diagnostics, pip, ExitStatus, OutputWriter, SharedState};
 use crate::printer::Printer;
 use crate::settings::ResolverSettings;
 
@@ -88,6 +88,9 @@ pub(crate) async fn export(
     .await?
     .into_interpreter();
 
+    // Initialize any shared state.
+    let state = SharedState::default();
+
     // Lock the project.
     let lock = match do_safe_lock(
         locked,
@@ -95,6 +98,7 @@ pub(crate) async fn export(
         project.workspace(),
         &interpreter,
         settings.as_ref(),
+        &state,
         Box::new(DefaultResolveLogger),
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -166,6 +166,9 @@ pub(crate) async fn remove(
     )
     .await?;
 
+    // Initialize any shared state.
+    let state = SharedState::default();
+
     // Lock and sync the environment, if necessary.
     let lock = project::lock::do_safe_lock(
         locked,
@@ -173,6 +176,7 @@ pub(crate) async fn remove(
         project.workspace(),
         venv.interpreter(),
         settings.as_ref().into(),
+        &state,
         Box::new(DefaultResolveLogger),
         connectivity,
         concurrency,
@@ -193,9 +197,6 @@ pub(crate) async fn remove(
     let extras = ExtrasSpecification::All;
     let install_options = InstallOptions::default();
 
-    // Initialize any shared state.
-    let state = SharedState::default();
-
     project::sync::do_sync(
         InstallTarget::from(&project),
         &venv,
@@ -206,7 +207,6 @@ pub(crate) async fn remove(
         install_options,
         Modifications::Exact,
         settings.as_ref().into(),
-        &state,
         Box::new(DefaultInstallLogger),
         connectivity,
         concurrency,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -529,6 +529,7 @@ pub(crate) async fn run(
                     project.workspace(),
                     venv.interpreter(),
                     settings.as_ref().into(),
+                    &state,
                     if show_resolution {
                         Box::new(DefaultResolveLogger)
                     } else {
@@ -576,7 +577,6 @@ pub(crate) async fn run(
                     install_options,
                     Modifications::Sufficient,
                     settings.as_ref().into(),
-                    &state,
                     if show_resolution {
                         Box::new(DefaultInstallLogger)
                     } else {

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -13,7 +13,7 @@ use uv_workspace::{DiscoveryOptions, Workspace};
 use crate::commands::pip::loggers::DefaultResolveLogger;
 use crate::commands::pip::resolution_markers;
 use crate::commands::project::ProjectInterpreter;
-use crate::commands::{project, ExitStatus};
+use crate::commands::{project, ExitStatus, SharedState};
 use crate::printer::Printer;
 use crate::settings::ResolverSettings;
 
@@ -59,6 +59,9 @@ pub(crate) async fn tree(
     .await?
     .into_interpreter();
 
+    // Initialize any shared state.
+    let state = SharedState::default();
+
     // Update the lockfile, if necessary.
     let lock = project::lock::do_safe_lock(
         locked,
@@ -66,6 +69,7 @@ pub(crate) async fn tree(
         &workspace,
         &interpreter,
         settings.as_ref(),
+        &state,
         Box::new(DefaultResolveLogger),
         connectivity,
         concurrency,


### PR DESCRIPTION
## Summary

If you `uv add` a Git dependency, we resolve it twice:

![Screenshot 2024-10-12 at 2 17 27 PM](https://github.com/user-attachments/assets/342e2523-af06-4783-b836-93b6bd9f34bc)

While we need to avoid sharing state between `lock` and `sync` (see the large TODO that moved in this change), we should prioritize sharing state between different resolver operations.
