### PR TITLE
Fix mkdocs workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,7 @@ jobs:
       MKDOCS_INSIDERS_SSH_KEY_EXISTS: ${{ secrets.MKDOCS_INSIDERS_SSH_KEY != '' }}
     steps:
       - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
       - uses: actions/setup-python@v5
       - name: "Add SSH key"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
@@ -434,17 +435,12 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.MKDOCS_INSIDERS_SSH_KEY }}
 
-      - name: "Install dependencies (public)"
-        run: pip install -r docs/requirements.txt
       - name: "Build docs (public)"
-        run: mkdocs build --strict -f mkdocs.public.yml
+        run: uvx --with-requirements docs/requirements.txt mkdocs build --strict -f mkdocs.public.yml
 
-      - name: "Install dependencies (insiders)"
-        if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
-        run: pip install -r docs/requirements-insiders.txt
       - name: "Build docs (insiders)"
         if: ${{ env.MKDOCS_INSIDERS_SSH_KEY_EXISTS == 'true' }}
-        run: mkdocs build --strict -f mkdocs.insiders.yml
+        run: uvx --with-requirements docs/requirements.txt mkdocs build --strict -f mkdocs.insiders.yml
 
   build-binary-linux:
     timeout-minutes: 10


### PR DESCRIPTION
GitHub changed these environments to "externally managed" (or something changed with the setup-python action?)