### PR TITLE
Publish: Warn about unnormalized filenames

### DIFF
--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -230,6 +230,12 @@ pub fn files_for_publishing(
             }
             let dist_filename = DistFilename::try_from_normalized_filename(&filename)
                 .ok_or_else(|| PublishError::InvalidFilename(dist.clone()))?;
+            if dist_filename.to_string() != filename {
+                warn_user!(
+                    "Invalid filename: Expected `{dist_filename}`, found `{filename}`. \
+                    This is a problem with the build backend."
+                );
+            }
             files.push((dist, filename, dist_filename));
         }
     }

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -63,8 +63,10 @@ fn invalid_validation_error() {
     dist.child("aviary.gsm8k-0.7.6-py3-none-any.whl")
         .touch()
         .unwrap();
-    // Unescaped dot
     dist.child("aviary.gsm8k-0.7.6.tar.gz").touch().unwrap();
+    // Not lowercase
+    dist.child("Foo-0.7.6-py3-none-any.whl").touch().unwrap();
+    dist.child("Foo-0.7.6.tar.gz").touch().unwrap();
     // Complex but valid
     dist.child("maturin-1.7.4-py3.py2-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl").touch().unwrap();
 
@@ -80,11 +82,13 @@ fn invalid_validation_error() {
 
     ----- stderr -----
     warning: `uv publish` is experimental and may change without warning
+    warning: Invalid filename: Expected `foo-0.7.6-py3-none-any.whl`, found `Foo-0.7.6-py3-none-any.whl`. This is a problem with the build backend.
+    warning: Invalid filename: Expected `foo-0.7.6.tar.gz`, found `Foo-0.7.6.tar.gz`. This is a problem with the build backend.
     warning: Invalid filename: Expected `aviary_gsm8k-0.7.6-py3-none-any.whl`, found `aviary.gsm8k-0.7.6-py3-none-any.whl`. This is a problem with the build backend.
     warning: Invalid filename: Expected `aviary_gsm8k-0.7.6.tar.gz`, found `aviary.gsm8k-0.7.6.tar.gz`. This is a problem with the build backend.
-    Publishing 3 files https://test.pypi.org/legacy/
-    Uploading aviary_gsm8k-0.7.6-py3-none-any.whl ([SIZE])
-    error: Failed to publish: `dist/aviary.gsm8k-0.7.6-py3-none-any.whl`
+    Publishing 5 files https://test.pypi.org/legacy/
+    Uploading foo-0.7.6-py3-none-any.whl ([SIZE])
+    error: Failed to publish: `dist/Foo-0.7.6-py3-none-any.whl`
       Caused by: Failed to read metadata
       Caused by: Failed to read from zip file
       Caused by: unable to locate the end of central directory record

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -1,4 +1,5 @@
 use crate::common::{uv_snapshot, TestContext};
+use assert_fs::fixture::{FileTouch, PathChild};
 
 #[test]
 fn username_password_no_longer_supported() {
@@ -48,6 +49,45 @@ fn invalid_token() {
     Uploading ok-1.0.0-py3-none-any.whl ([SIZE])
     error: Failed to publish `../../scripts/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/
       Caused by: Permission denied (status code 403 Forbidden): 403 Invalid or non-existent authentication information. See https://test.pypi.org/help/#invalid-auth for more information.
+    "###
+    );
+}
+
+/// Check that we warn about unnormalized filenames.
+#[test]
+fn invalid_validation_error() {
+    let context = TestContext::new("3.12");
+
+    let dist = context.temp_dir.child("dist");
+    // Unescaped dot
+    dist.child("aviary.gsm8k-0.7.6-py3-none-any.whl")
+        .touch()
+        .unwrap();
+    // Unescaped dot
+    dist.child("aviary.gsm8k-0.7.6.tar.gz").touch().unwrap();
+    // Complex but valid
+    dist.child("maturin-1.7.4-py3.py2-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl").touch().unwrap();
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--token")
+        .arg("dummy")
+        .arg("--publish-url")
+        .arg("https://test.pypi.org/legacy/")
+        .current_dir(&context.temp_dir), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv publish` is experimental and may change without warning
+    warning: Invalid filename: Expected `aviary_gsm8k-0.7.6-py3-none-any.whl`, found `aviary.gsm8k-0.7.6-py3-none-any.whl`. This is a problem with the build backend.
+    warning: Invalid filename: Expected `aviary_gsm8k-0.7.6.tar.gz`, found `aviary.gsm8k-0.7.6.tar.gz`. This is a problem with the build backend.
+    Publishing 3 files https://test.pypi.org/legacy/
+    Uploading aviary_gsm8k-0.7.6-py3-none-any.whl ([SIZE])
+    error: Failed to publish: `dist/aviary.gsm8k-0.7.6-py3-none-any.whl`
+      Caused by: Failed to read metadata
+      Caused by: Failed to read from zip file
+      Caused by: unable to locate the end of central directory record
     "###
     );
 }


### PR DESCRIPTION
The spec requires normalizing the name and the version in distribution filenames (https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode). Missing normalization caused #8030, so we warn about it. Ideally, we would error, but this would break setuptools (https://github.com/pypa/setuptools/issues/3777)