### PR TITLE
Publish: Workaround using raw filename

### DIFF
--- a/crates/uv-publish/src/tests.rs
+++ b/crates/uv-publish/src/tests.rs
@@ -21,9 +21,9 @@ impl Reporter for DummyReporter {
 /// Snapshot the data we send for an upload request for a source distribution.
 #[tokio::test]
 async fn upload_request_source_dist() {
-    let filename = "tqdm-999.0.0.tar.gz";
-    let file = PathBuf::from("../../scripts/links/").join(filename);
-    let filename = DistFilename::try_from_normalized_filename(filename).unwrap();
+    let raw_filename = "tqdm-999.0.0.tar.gz";
+    let file = PathBuf::from("../../scripts/links/").join(raw_filename);
+    let filename = DistFilename::try_from_normalized_filename(raw_filename).unwrap();
 
     let form_metadata = form_metadata(&file, &filename).await.unwrap();
 
@@ -81,6 +81,7 @@ async fn upload_request_source_dist() {
 
     let (request, _) = build_request(
         &file,
+        raw_filename,
         &filename,
         &Url::parse("https://example.org/upload").unwrap(),
         &BaseClientBuilder::new().build().client(),
@@ -129,10 +130,10 @@ async fn upload_request_source_dist() {
 /// Snapshot the data we send for an upload request for a wheel.
 #[tokio::test]
 async fn upload_request_wheel() {
-    let filename =
+    let raw_filename =
         "tqdm-4.66.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl";
-    let file = PathBuf::from("../../scripts/links/").join(filename);
-    let filename = DistFilename::try_from_normalized_filename(filename).unwrap();
+    let file = PathBuf::from("../../scripts/links/").join(raw_filename);
+    let filename = DistFilename::try_from_normalized_filename(raw_filename).unwrap();
 
     let form_metadata = form_metadata(&file, &filename).await.unwrap();
 
@@ -225,6 +226,7 @@ async fn upload_request_wheel() {
 
     let (request, _) = build_request(
         &file,
+        raw_filename,
         &filename,
         &Url::parse("https://example.org/upload").unwrap(),
         &BaseClientBuilder::new().build().client(),

--- a/crates/uv/src/commands/publish.rs
+++ b/crates/uv/src/commands/publish.rs
@@ -85,7 +85,7 @@ pub(crate) async fn publish(
         bail!("You need to provide a username with a password, use `--token` for tokens");
     }
 
-    for (file, filename) in files {
+    for (file, raw_filename, filename) in files {
         let size = fs_err::metadata(&file)?.len();
         let (bytes, unit) = human_readable_bytes(size);
         writeln!(
@@ -97,6 +97,7 @@ pub(crate) async fn publish(
         let reporter = PublishReporter::single(printer);
         let uploaded = upload(
             &file,
+            &raw_filename,
             &filename,
             &publish_url,
             &upload_client.client(),


### PR DESCRIPTION
Since setuptools violates the wheel filenames spec (https://github.com/pypa/setuptools/issues/3777), we have to use the raw filename when publishing to get through https://github.com/pypi/warehouse/blob/50a58f3081e693a3772c0283050a275e350004bf/warehouse/forklift/legacy.py#L1133-L1155.

Tested with

```
cargo run publish aviary.gsm8k-0.7.6-py3-none-any.whl --publish-url https://test.pypi.org/legacy/
```

Fixes #8030