### PR TITLE
Invalid cache when adding lower bound to lockfile

### DIFF
--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -740,7 +740,8 @@ async fn lock_and_sync(
                 let url = Url::from_file_path(project.project_root())
                     .expect("project root is a valid URL");
                 let version_id = VersionId::from_url(&url);
-                debug_assert!(state.index.distributions().remove(&version_id).is_some());
+                let existing = state.index.distributions().remove(&version_id);
+                debug_assert!(existing.is_some(), "distribution should exist");
             }
 
             // If the file was modified, we have to lock again, though the only expected change is


### PR DESCRIPTION
## Summary

This was already properly handled, but the operation itself was in a `debug_assert!`, so it wasn't running at all in production builds...

Closes https://github.com/astral-sh/uv/issues/8208.
