### PR TITLE
Avoid showing lower-bound warning outside of explicit lock and sync

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -86,7 +86,8 @@ mod resolver {
     use uv_cache::Cache;
     use uv_client::RegistryClient;
     use uv_configuration::{
-        BuildOptions, Concurrency, ConfigSettings, Constraints, IndexStrategy, SourceStrategy,
+        BuildOptions, Concurrency, ConfigSettings, Constraints, IndexStrategy, LowerBound,
+        SourceStrategy,
     };
     use uv_dispatch::BuildDispatch;
     use uv_distribution::DistributionDatabase;
@@ -191,6 +192,7 @@ mod resolver {
             &build_options,
             &hashes,
             exclude_newer,
+            LowerBound::default(),
             sources,
             concurrency,
         );

--- a/crates/uv-build-frontend/src/lib.rs
+++ b/crates/uv-build-frontend/src/lib.rs
@@ -27,9 +27,8 @@ use tokio::process::Command;
 use tokio::sync::{Mutex, Semaphore};
 use tracing::{debug, info_span, instrument, Instrument};
 
-pub use crate::error::{Error, MissingHeaderCause};
-use uv_configuration::{BuildKind, BuildOutput, ConfigSettings, SourceStrategy};
-use uv_distribution::{LowerBound, RequiresDist};
+use uv_configuration::{BuildKind, BuildOutput, ConfigSettings, LowerBound, SourceStrategy};
+use uv_distribution::RequiresDist;
 use uv_distribution_types::{IndexLocations, Resolution};
 use uv_fs::{rename_with_retry, PythonExt, Simplified};
 use uv_pep440::Version;
@@ -38,6 +37,8 @@ use uv_pypi_types::{Requirement, VerbatimParsedUrl};
 use uv_python::{Interpreter, PythonEnvironment};
 use uv_static::EnvVars;
 use uv_types::{BuildContext, BuildIsolation, SourceBuildTrait};
+
+pub use crate::error::{Error, MissingHeaderCause};
 
 /// The default backend to use when PEP 517 is used without a `build-system` section.
 static DEFAULT_BACKEND: LazyLock<Pep517Backend> = LazyLock::new(|| Pep517Backend {

--- a/crates/uv-configuration/src/bounds.rs
+++ b/crates/uv-configuration/src/bounds.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, Default, Copy, Clone)]
+pub enum LowerBound {
+    /// Allow missing lower bounds.
+    #[default]
+    Allow,
+    /// Warn about missing lower bounds.
+    Warn,
+}

--- a/crates/uv-configuration/src/lib.rs
+++ b/crates/uv-configuration/src/lib.rs
@@ -1,4 +1,5 @@
 pub use authentication::*;
+pub use bounds::*;
 pub use build_options::*;
 pub use concurrency::*;
 pub use config_settings::*;
@@ -20,6 +21,7 @@ pub use trusted_publishing::*;
 pub use vcs::*;
 
 mod authentication;
+mod bounds;
 mod build_options;
 mod concurrency;
 mod config_settings;

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -15,7 +15,8 @@ use uv_build_frontend::{SourceBuild, SourceBuildContext};
 use uv_cache::Cache;
 use uv_client::RegistryClient;
 use uv_configuration::{
-    BuildKind, BuildOptions, ConfigSettings, Constraints, IndexStrategy, Reinstall, SourceStrategy,
+    BuildKind, BuildOptions, ConfigSettings, Constraints, IndexStrategy, LowerBound, Reinstall,
+    SourceStrategy,
 };
 use uv_configuration::{BuildOutput, Concurrency};
 use uv_distribution::DistributionDatabase;
@@ -56,6 +57,7 @@ pub struct BuildDispatch<'a> {
     exclude_newer: Option<ExcludeNewer>,
     source_build_context: SourceBuildContext,
     build_extra_env_vars: FxHashMap<OsString, OsString>,
+    bounds: LowerBound,
     sources: SourceStrategy,
     concurrency: Concurrency,
 }
@@ -80,6 +82,7 @@ impl<'a> BuildDispatch<'a> {
         build_options: &'a BuildOptions,
         hasher: &'a HashStrategy,
         exclude_newer: Option<ExcludeNewer>,
+        bounds: LowerBound,
         sources: SourceStrategy,
         concurrency: Concurrency,
     ) -> Self {
@@ -104,6 +107,7 @@ impl<'a> BuildDispatch<'a> {
             exclude_newer,
             source_build_context: SourceBuildContext::default(),
             build_extra_env_vars: FxHashMap::default(),
+            bounds,
             sources,
             concurrency,
         }
@@ -150,6 +154,10 @@ impl<'a> BuildContext for BuildDispatch<'a> {
 
     fn config_settings(&self) -> &ConfigSettings {
         self.config_settings
+    }
+
+    fn bounds(&self) -> LowerBound {
+        self.bounds
     }
 
     fn sources(&self) -> SourceStrategy {

--- a/crates/uv-distribution/src/lib.rs
+++ b/crates/uv-distribution/src/lib.rs
@@ -2,9 +2,7 @@ pub use distribution_database::{DistributionDatabase, HttpArchivePointer, LocalA
 pub use download::LocalWheel;
 pub use error::Error;
 pub use index::{BuiltWheelIndex, RegistryWheelIndex};
-pub use metadata::{
-    ArchiveMetadata, LowerBound, LoweredRequirement, Metadata, MetadataError, RequiresDist,
-};
+pub use metadata::{ArchiveMetadata, LoweredRequirement, Metadata, MetadataError, RequiresDist};
 pub use reporter::Reporter;
 pub use source::prune;
 

--- a/crates/uv-distribution/src/metadata/mod.rs
+++ b/crates/uv-distribution/src/metadata/mod.rs
@@ -3,15 +3,15 @@ use std::path::Path;
 
 use thiserror::Error;
 
-use uv_configuration::SourceStrategy;
+use uv_configuration::{LowerBound, SourceStrategy};
 use uv_distribution_types::IndexLocations;
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_pypi_types::{HashDigest, ResolutionMetadata};
 use uv_workspace::WorkspaceError;
 
+pub use crate::metadata::lowering::LoweredRequirement;
 use crate::metadata::lowering::LoweringError;
-pub use crate::metadata::lowering::{LowerBound, LoweredRequirement};
 pub use crate::metadata::requires_dist::RequiresDist;
 
 mod lowering;
@@ -64,6 +64,7 @@ impl Metadata {
         install_path: &Path,
         locations: &IndexLocations,
         sources: SourceStrategy,
+        bounds: LowerBound,
     ) -> Result<Self, MetadataError> {
         // Lower the requirements.
         let RequiresDist {
@@ -80,7 +81,7 @@ impl Metadata {
             install_path,
             locations,
             sources,
-            LowerBound::Warn,
+            bounds,
         )
         .await?;
 

--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -1,10 +1,9 @@
-use crate::metadata::lowering::LowerBound;
 use crate::metadata::{LoweredRequirement, MetadataError};
 use crate::Metadata;
 
 use std::collections::BTreeMap;
 use std::path::Path;
-use uv_configuration::SourceStrategy;
+use uv_configuration::{LowerBound, SourceStrategy};
 use uv_distribution_types::IndexLocations;
 use uv_normalize::{ExtraName, GroupName, PackageName, DEV_DEPENDENCIES};
 use uv_workspace::pyproject::ToolUvSources;
@@ -198,12 +197,11 @@ mod test {
     use anyhow::Context;
     use indoc::indoc;
     use insta::assert_snapshot;
-    use uv_configuration::SourceStrategy;
+    use uv_configuration::{LowerBound, SourceStrategy};
     use uv_distribution_types::IndexLocations;
     use uv_workspace::pyproject::PyProjectToml;
     use uv_workspace::{DiscoveryOptions, ProjectWorkspace};
 
-    use crate::metadata::lowering::LowerBound;
     use crate::RequiresDist;
 
     async fn requires_dist_from_pyproject_toml(contents: &str) -> anyhow::Result<RequiresDist> {
@@ -228,7 +226,7 @@ mod test {
             &project_workspace,
             &IndexLocations::default(),
             SourceStrategy::default(),
-            LowerBound::Warn,
+            LowerBound::default(),
         )?)
     }
 

--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -5,13 +5,6 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
-use crate::distribution_database::ManagedClient;
-use crate::error::Error;
-use crate::metadata::{ArchiveMetadata, Metadata};
-use crate::reporter::Facade;
-use crate::source::built_wheel_metadata::BuiltWheelMetadata;
-use crate::source::revision::Revision;
-use crate::{LowerBound, Reporter, RequiresDist};
 use fs_err::tokio as fs;
 use futures::{FutureExt, TryStreamExt};
 use reqwest::Response;
@@ -37,6 +30,14 @@ use uv_platform_tags::Tags;
 use uv_pypi_types::{HashDigest, Metadata12, RequiresTxt, ResolutionMetadata};
 use uv_types::{BuildContext, SourceBuildTrait};
 use zip::ZipArchive;
+
+use crate::distribution_database::ManagedClient;
+use crate::error::Error;
+use crate::metadata::{ArchiveMetadata, Metadata};
+use crate::reporter::Facade;
+use crate::source::built_wheel_metadata::BuiltWheelMetadata;
+use crate::source::revision::Revision;
+use crate::{Reporter, RequiresDist};
 
 mod built_wheel_metadata;
 mod revision;
@@ -390,7 +391,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
             project_root,
             self.build_context.locations(),
             self.build_context.sources(),
-            LowerBound::Warn,
+            self.build_context.bounds(),
         )
         .await?;
         Ok(requires_dist)
@@ -1089,6 +1090,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     resource.install_path.as_ref(),
                     self.build_context.locations(),
                     self.build_context.sources(),
+                    self.build_context.bounds(),
                 )
                 .await?,
             ));
@@ -1124,6 +1126,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     resource.install_path.as_ref(),
                     self.build_context.locations(),
                     self.build_context.sources(),
+                    self.build_context.bounds(),
                 )
                 .await?,
             ));
@@ -1154,6 +1157,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     resource.install_path.as_ref(),
                     self.build_context.locations(),
                     self.build_context.sources(),
+                    self.build_context.bounds(),
                 )
                 .await?,
             ));
@@ -1200,6 +1204,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 resource.install_path.as_ref(),
                 self.build_context.locations(),
                 self.build_context.sources(),
+                self.build_context.bounds(),
             )
             .await?,
         ))
@@ -1384,6 +1389,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     &path,
                     self.build_context.locations(),
                     self.build_context.sources(),
+                    self.build_context.bounds(),
                 )
                 .await?,
             ));
@@ -1411,6 +1417,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                         &path,
                         self.build_context.locations(),
                         self.build_context.sources(),
+                        self.build_context.bounds(),
                     )
                     .await?,
                 ));
@@ -1442,6 +1449,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                     &path,
                     self.build_context.locations(),
                     self.build_context.sources(),
+                    self.build_context.bounds(),
                 )
                 .await?,
             ));
@@ -1488,6 +1496,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 fetch.path(),
                 self.build_context.locations(),
                 self.build_context.sources(),
+                self.build_context.bounds(),
             )
             .await?,
         ))

--- a/crates/uv-types/src/traits.rs
+++ b/crates/uv-types/src/traits.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 
 use uv_cache::Cache;
-use uv_configuration::{BuildKind, BuildOptions, BuildOutput, ConfigSettings, SourceStrategy};
+use uv_configuration::{
+    BuildKind, BuildOptions, BuildOutput, ConfigSettings, LowerBound, SourceStrategy,
+};
 use uv_distribution_types::{
     CachedDist, DependencyMetadata, IndexCapabilities, IndexLocations, InstalledDist, Resolution,
     SourceDist,
@@ -74,6 +76,9 @@ pub trait BuildContext {
 
     /// The [`ConfigSettings`] used to build distributions.
     fn config_settings(&self) -> &ConfigSettings;
+
+    /// Whether to warn on missing lower bounds.
+    fn bounds(&self) -> LowerBound;
 
     /// Whether to incorporate `tool.uv.sources` when resolving requirements.
     fn sources(&self) -> SourceStrategy;

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -16,7 +16,7 @@ use uv_cache::{Cache, CacheBucket};
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildKind, BuildOptions, BuildOutput, Concurrency, ConfigSettings, Constraints,
-    HashCheckingMode, IndexStrategy, KeyringProviderType, SourceStrategy, TrustedHost,
+    HashCheckingMode, IndexStrategy, KeyringProviderType, LowerBound, SourceStrategy, TrustedHost,
 };
 use uv_dispatch::BuildDispatch;
 use uv_fs::Simplified;
@@ -486,6 +486,7 @@ async fn build_package(
         build_options,
         &hasher,
         exclude_newer,
+        LowerBound::Allow,
         sources,
         concurrency,
     );

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -10,7 +10,7 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, Constraints, ExtrasSpecification, IndexStrategy,
-    NoBinary, NoBuild, Reinstall, SourceStrategy, TrustedHost, Upgrade,
+    LowerBound, NoBinary, NoBuild, Reinstall, SourceStrategy, TrustedHost, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::BuildDispatch;
@@ -362,6 +362,7 @@ pub(crate) async fn pip_compile(
         &build_options,
         &build_hashes,
         exclude_newer,
+        LowerBound::Warn,
         sources,
         concurrency,
     );

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -8,7 +8,7 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, Constraints, ExtrasSpecification, HashCheckingMode,
-    IndexStrategy, Reinstall, SourceStrategy, TrustedHost, Upgrade,
+    IndexStrategy, LowerBound, Reinstall, SourceStrategy, TrustedHost, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::BuildDispatch;
@@ -369,6 +369,7 @@ pub(crate) async fn pip_install(
         &build_options,
         &build_hasher,
         exclude_newer,
+        LowerBound::Warn,
         sources,
         concurrency,
     );

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -8,7 +8,7 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, Constraints, ExtrasSpecification, HashCheckingMode,
-    IndexStrategy, Reinstall, SourceStrategy, TrustedHost, Upgrade,
+    IndexStrategy, LowerBound, Reinstall, SourceStrategy, TrustedHost, Upgrade,
 };
 use uv_configuration::{KeyringProviderType, TargetTriple};
 use uv_dispatch::BuildDispatch;
@@ -311,6 +311,7 @@ pub(crate) async fn pip_sync(
         &build_options,
         &build_hasher,
         exclude_newer,
+        LowerBound::Warn,
         sources,
         concurrency,
     );

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -14,7 +14,7 @@ use uv_cache_key::RepositoryUrl;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     Concurrency, Constraints, DevMode, EditableMode, ExtrasSpecification, InstallOptions,
-    SourceStrategy,
+    LowerBound, SourceStrategy,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution::DistributionDatabase;
@@ -234,6 +234,7 @@ pub(crate) async fn add(
 
     // TODO(charlie): These are all default values. We should consider whether we want to make them
     // optional on the downstream APIs.
+    let bounds = LowerBound::default();
     let build_constraints = Constraints::default();
     let build_hasher = HashStrategy::default();
     let hasher = HashStrategy::default();
@@ -304,6 +305,7 @@ pub(crate) async fn add(
         &settings.build_options,
         &build_hasher,
         settings.exclude_newer,
+        bounds,
         sources,
         concurrency,
     );
@@ -588,6 +590,7 @@ pub(crate) async fn add(
         &dependency_type,
         raw_sources,
         settings.as_ref(),
+        bounds,
         connectivity,
         concurrency,
         native_tls,
@@ -648,6 +651,7 @@ async fn lock_and_sync(
     dependency_type: &DependencyType,
     raw_sources: bool,
     settings: ResolverInstallerSettingsRef<'_>,
+    bounds: LowerBound,
     connectivity: Connectivity,
     concurrency: Concurrency,
     native_tls: bool,
@@ -660,6 +664,7 @@ async fn lock_and_sync(
         project.workspace(),
         venv.interpreter(),
         settings.into(),
+        bounds,
         &state,
         Box::new(DefaultResolveLogger),
         connectivity,
@@ -773,6 +778,7 @@ async fn lock_and_sync(
                 project.workspace(),
                 venv.interpreter(),
                 settings.into(),
+                bounds,
                 &state,
                 Box::new(SummaryResolveLogger),
                 connectivity,

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -9,7 +9,7 @@ use uv_cache::Cache;
 use uv_client::Connectivity;
 use uv_configuration::{
     Concurrency, DevMode, DevSpecification, EditableMode, ExportFormat, ExtrasSpecification,
-    InstallOptions,
+    InstallOptions, LowerBound,
 };
 use uv_normalize::{PackageName, DEV_DEPENDENCIES};
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest};
@@ -98,6 +98,7 @@ pub(crate) async fn export(
         project.workspace(),
         &interpreter,
         settings.as_ref(),
+        LowerBound::Warn,
         &state,
         Box::new(DefaultResolveLogger),
         connectivity,

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
-    BuildOptions, Concurrency, Constraints, ExtrasSpecification, Reinstall, Upgrade,
+    BuildOptions, Concurrency, Constraints, ExtrasSpecification, LowerBound, Reinstall, Upgrade,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution::DistributionDatabase;
@@ -111,6 +111,7 @@ pub(crate) async fn lock(
         &workspace,
         &interpreter,
         settings.as_ref(),
+        LowerBound::Warn,
         &state,
         Box::new(DefaultResolveLogger),
         connectivity,
@@ -157,6 +158,7 @@ pub(super) async fn do_safe_lock(
     workspace: &Workspace,
     interpreter: &Interpreter,
     settings: ResolverSettingsRef<'_>,
+    bounds: LowerBound,
     state: &SharedState,
     logger: Box<dyn ResolveLogger>,
     connectivity: Connectivity,
@@ -183,6 +185,7 @@ pub(super) async fn do_safe_lock(
             interpreter,
             Some(existing),
             settings,
+            bounds,
             state,
             logger,
             connectivity,
@@ -209,6 +212,7 @@ pub(super) async fn do_safe_lock(
             interpreter,
             existing,
             settings,
+            bounds,
             state,
             logger,
             connectivity,
@@ -234,6 +238,7 @@ async fn do_lock(
     interpreter: &Interpreter,
     existing_lock: Option<Lock>,
     settings: ResolverSettingsRef<'_>,
+    bounds: LowerBound,
     state: &SharedState,
     logger: Box<dyn ResolveLogger>,
     connectivity: Connectivity,
@@ -437,6 +442,7 @@ async fn do_lock(
         build_options,
         &build_hasher,
         exclude_newer,
+        bounds,
         sources,
         concurrency,
     );

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -7,7 +7,9 @@ use tracing::debug;
 
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
-use uv_configuration::{Concurrency, Constraints, ExtrasSpecification, Reinstall, Upgrade};
+use uv_configuration::{
+    Concurrency, Constraints, ExtrasSpecification, LowerBound, Reinstall, Upgrade,
+};
 use uv_dispatch::BuildDispatch;
 use uv_distribution::DistributionDatabase;
 use uv_distribution_types::{
@@ -703,6 +705,7 @@ pub(crate) async fn resolve_names(
         build_options,
         &build_hasher,
         *exclude_newer,
+        LowerBound::Allow,
         *sources,
         concurrency,
     );
@@ -886,6 +889,7 @@ pub(crate) async fn resolve_environment<'a>(
         build_options,
         &build_hasher,
         exclude_newer,
+        LowerBound::Allow,
         sources,
         concurrency,
     );
@@ -1020,6 +1024,7 @@ pub(crate) async fn sync_environment(
         build_options,
         &build_hasher,
         exclude_newer,
+        LowerBound::Allow,
         sources,
         concurrency,
     );
@@ -1226,6 +1231,7 @@ pub(crate) async fn update_environment(
         build_options,
         &build_hasher,
         *exclude_newer,
+        LowerBound::Allow,
         *sources,
         concurrency,
     );

--- a/crates/uv/src/commands/project/remove.rs
+++ b/crates/uv/src/commands/project/remove.rs
@@ -5,7 +5,9 @@ use std::path::Path;
 use owo_colors::OwoColorize;
 use uv_cache::Cache;
 use uv_client::Connectivity;
-use uv_configuration::{Concurrency, DevMode, EditableMode, ExtrasSpecification, InstallOptions};
+use uv_configuration::{
+    Concurrency, DevMode, EditableMode, ExtrasSpecification, InstallOptions, LowerBound,
+};
 use uv_fs::Simplified;
 use uv_pep508::PackageName;
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest};
@@ -176,6 +178,7 @@ pub(crate) async fn remove(
         project.workspace(),
         venv.interpreter(),
         settings.as_ref().into(),
+        LowerBound::Allow,
         &state,
         Box::new(DefaultResolveLogger),
         connectivity,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -17,7 +17,8 @@ use uv_cache::Cache;
 use uv_cli::ExternalCommand;
 use uv_client::{BaseClientBuilder, Connectivity};
 use uv_configuration::{
-    Concurrency, DevMode, EditableMode, ExtrasSpecification, InstallOptions, SourceStrategy,
+    Concurrency, DevMode, EditableMode, ExtrasSpecification, InstallOptions, LowerBound,
+    SourceStrategy,
 };
 use uv_distribution::LoweredRequirement;
 use uv_fs::which::is_executable;
@@ -248,6 +249,7 @@ pub(crate) async fn run(
                         script_sources,
                         script_indexes,
                         &settings.index_locations,
+                        LowerBound::Allow,
                     )
                     .map_ok(LoweredRequirement::into_inner)
                 })
@@ -544,6 +546,7 @@ pub(crate) async fn run(
                     project.workspace(),
                     venv.interpreter(),
                     settings.as_ref().into(),
+                    LowerBound::Allow,
                     &state,
                     if show_resolution {
                         Box::new(DefaultResolveLogger)

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -9,7 +9,7 @@ use uv_cache::Cache;
 use uv_client::{Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     Concurrency, Constraints, DevMode, DevSpecification, EditableMode, ExtrasSpecification,
-    HashCheckingMode, InstallOptions,
+    HashCheckingMode, InstallOptions, LowerBound,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution_types::{DirectorySourceDist, Dist, Index, ResolvedDist, SourceDist};
@@ -115,6 +115,7 @@ pub(crate) async fn sync(
         target.workspace(),
         venv.interpreter(),
         settings.as_ref().into(),
+        LowerBound::Warn,
         &state,
         Box::new(DefaultResolveLogger),
         connectivity,
@@ -311,6 +312,7 @@ pub(super) async fn do_sync(
 
     // TODO(charlie): These are all default values. We should consider whether we want to make them
     // optional on the downstream APIs.
+    let bounds = LowerBound::default();
     let build_constraints = Constraints::default();
     let build_hasher = HashStrategy::default();
     let dry_run = false;
@@ -347,6 +349,7 @@ pub(super) async fn do_sync(
         build_options,
         &build_hasher,
         exclude_newer,
+        bounds,
         sources,
         concurrency,
     );

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use uv_cache::Cache;
 use uv_client::Connectivity;
-use uv_configuration::{Concurrency, DevMode, TargetTriple};
+use uv_configuration::{Concurrency, DevMode, LowerBound, TargetTriple};
 use uv_pep508::PackageName;
 use uv_python::{PythonDownloads, PythonPreference, PythonRequest, PythonVersion};
 use uv_resolver::TreeDisplay;
@@ -69,6 +69,7 @@ pub(crate) async fn tree(
         &workspace,
         &interpreter,
         settings.as_ref(),
+        LowerBound::Allow,
         &state,
         Box::new(DefaultResolveLogger),
         connectivity,

--- a/crates/uv/src/commands/venv.rs
+++ b/crates/uv/src/commands/venv.rs
@@ -13,7 +13,7 @@ use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
     BuildOptions, Concurrency, ConfigSettings, Constraints, IndexStrategy, KeyringProviderType,
-    NoBinary, NoBuild, SourceStrategy, TrustedHost,
+    LowerBound, NoBinary, NoBuild, SourceStrategy, TrustedHost,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution_types::{DependencyMetadata, Index, IndexLocations};
@@ -345,6 +345,7 @@ async fn venv_impl(
             &build_options,
             &build_hasher,
             exclude_newer,
+            LowerBound::Allow,
             sources,
             concurrency,
         );

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -5214,7 +5214,6 @@ fn add_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Missing version constraint (e.g., a lower bound) for `jinja2`
     Resolved 4 packages in [TIME]
     Prepared 2 packages in [TIME]
     Installed 2 packages in [TIME]
@@ -5426,7 +5425,6 @@ fn add_index() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: Missing version constraint (e.g., a lower bound) for `typing-extensions`
     Resolved 5 packages in [TIME]
     Prepared 1 package in [TIME]
     Installed 1 package in [TIME]


### PR DESCRIPTION
## Summary

We shouldn't show these in `uv add`, especially when the thing we're adding is about to have a lower-bound put on it. Now, we only show these when the user runs `uv lock` or `uv sync`.
