### PR TITLE
Ignore sources in build requirements for non-source trees

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -472,7 +472,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 source_dist_entry.path(),
                 subdirectory,
                 &cache_shard,
-                self.build_context.sources(),
+                SourceStrategy::Disabled,
             )
             .await?;
 
@@ -585,7 +585,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 source,
                 source_dist_entry.path(),
                 subdirectory,
-                self.build_context.sources(),
+                SourceStrategy::Disabled,
             )
             .boxed_local()
             .await?
@@ -616,7 +616,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 source_dist_entry.path(),
                 subdirectory,
                 &cache_shard,
-                self.build_context.sources(),
+                SourceStrategy::Disabled,
             )
             .await?;
 
@@ -774,7 +774,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 source_entry.path(),
                 None,
                 &cache_shard,
-                self.build_context.sources(),
+                SourceStrategy::Disabled,
             )
             .await?;
 
@@ -861,12 +861,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
 
         // If the backend supports `prepare_metadata_for_build_wheel`, use it.
         if let Some(metadata) = self
-            .build_metadata(
-                source,
-                source_entry.path(),
-                None,
-                self.build_context.sources(),
-            )
+            .build_metadata(source, source_entry.path(), None, SourceStrategy::Disabled)
             .boxed_local()
             .await?
         {
@@ -904,7 +899,7 @@ impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
                 source_entry.path(),
                 None,
                 &cache_shard,
-                self.build_context.sources(),
+                SourceStrategy::Disabled,
             )
             .await?;
 


### PR DESCRIPTION
## Summary

We shouldn't enforce sources when, e.g., you provide a `.tar.gz` file.

Closes https://github.com/astral-sh/uv/issues/8236.
