### PR TITLE
Fix selection of free-threaded interpreters during default Python discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,7 +653,7 @@ jobs:
 
       - name: "Check install"
         run: |
-          ./uv pip install anyio
+          ./uv pip install -v anyio
 
       - name: "Install free-threaded Python via uv"
         run: |
@@ -670,7 +670,7 @@ jobs:
 
       - name: "Check install"
         run: |
-          ./uv pip install anyio
+          ./uv pip install -v anyio
 
   integration-test-pypy-linux:
     timeout-minutes: 10


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/8228

e.g., on this branch

```
❯ uv python install 3.13t 3.13
❯ cargo build
❯ cargo run -q --bin uvx -- --from build python -c "import sys; print(sys.base_prefix)"
/Users/zb/.local/share/uv/python/cpython-3.13.0-macos-aarch64-none
❯ cargo run -q --bin uvx -- -p 3.13 --from build python -c "import sys; print(sys.base_prefix)"
/Users/zb/.local/share/uv/python/cpython-3.13.0-macos-aarch64-none
❯ cargo run -q --bin uvx -- -p 3.13t --from build python -c "import sys; print(sys.base_prefix)"
/Users/zb/.local/share/uv/python/cpython-3.13.0+freethreaded-macos-aarch64-none
```

and on main

```
❯ cargo build
❯ cargo run -q --bin uvx -- --from build python -c "import sys; print(sys.base_prefix)"
Installed 3 packages in 12ms
/Users/zb/.local/share/uv/python/cpython-3.13.0+freethreaded-macos-aarch64-none
```

I want to add more test coverage around this, but I've noticed the free-threaded discovery tests are a bit off as-is and it'll be a bigger task. I think the recent bugs around discovery indicate we should invest more into that test framework.

