### PR TITLE
Improve styling of `requires-python` warnings

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -334,9 +334,9 @@ async fn do_lock(
         if requires_python.is_unbounded() {
             let default =
                 RequiresPython::greater_than_equal_version(&interpreter.python_minor_version());
-            warn_user_once!("The workspace `requires-python` value does not contain a lower bound: `{requires_python}`. Set a lower bound to indicate the minimum compatible Python version (e.g., `{default}`).");
+            warn_user_once!("The workspace `requires-python` value (`{requires_python}`) does not contain a lower bound. Add a lower bound to indicate the minimum compatible Python version (e.g., `{default}`).");
         } else if requires_python.is_exact_without_patch() {
-            warn_user_once!("The workspace `requires-python` value contains an exact match without a patch version: `{requires_python}`. When omitted, the patch version is implicitly `0`, e.g., `{requires_python}.0`. Did you mean `{requires_python}.*`?");
+            warn_user_once!("The workspace `requires-python` value (`{requires_python}`) contains an exact match without a patch version. When omitted, the patch version is implicitly `0` (e.g., `{requires_python}.0`). Did you mean `{requires_python}.*`?");
         }
         requires_python
     } else {

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -3530,7 +3530,7 @@ fn lock_requires_python_exact() -> Result<()> {
 
     ----- stderr -----
     Using CPython 3.12.[X]
-    warning: The workspace `requires-python` value contains an exact match without a patch version: `==3.12`. When omitted, the patch version is implicitly `0`, e.g., `==3.12.[X]`. Did you mean `==3.12.*`?
+    warning: The workspace `requires-python` value (`==3.12`) contains an exact match without a patch version. When omitted, the patch version is implicitly `0` (e.g., `==3.12.[X]`). Did you mean `==3.12.*`?
     Resolved 2 packages in [TIME]
     "###);
 
@@ -3587,7 +3587,7 @@ fn lock_requires_python_exact() -> Result<()> {
 
     ----- stderr -----
     Using CPython 3.12.[X]
-    warning: The workspace `requires-python` value contains an exact match without a patch version: `==3.12`. When omitted, the patch version is implicitly `0`, e.g., `==3.12.[X]`. Did you mean `==3.12.*`?
+    warning: The workspace `requires-python` value (`==3.12`) contains an exact match without a patch version. When omitted, the patch version is implicitly `0` (e.g., `==3.12.[X]`). Did you mean `==3.12.*`?
     Resolved 2 packages in [TIME]
     "###);
 
@@ -4139,7 +4139,7 @@ fn lock_requires_python_unbounded() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: The workspace `requires-python` value does not contain a lower bound: `<=3.12`. Set a lower bound to indicate the minimum compatible Python version (e.g., `>=3.11`).
+    warning: The workspace `requires-python` value (`<=3.12`) does not contain a lower bound. Add a lower bound to indicate the minimum compatible Python version (e.g., `>=3.11`).
     Resolved 2 packages in [TIME]
     "###);
 
@@ -4186,7 +4186,7 @@ fn lock_requires_python_unbounded() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    warning: The workspace `requires-python` value does not contain a lower bound: `<=3.12`. Set a lower bound to indicate the minimum compatible Python version (e.g., `>=3.11`).
+    warning: The workspace `requires-python` value (`<=3.12`) does not contain a lower bound. Add a lower bound to indicate the minimum compatible Python version (e.g., `>=3.11`).
     Resolved 2 packages in [TIME]
     "###);
 


### PR DESCRIPTION
Extends #7959

While I was looking at that message, I noticed I didn't love the readability of the existing message and opted to follow-up with a change to them both.