### PR TITLE
Don't prefetch unreachable packages

### DIFF
--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -475,6 +475,10 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         index,
                         &version,
                         term_intersection.unwrap_positive(),
+                        state
+                            .pubgrub
+                            .partial_solution
+                            .unchanging_term_for_package(&state.next),
                         &state.python_requirement,
                         &request_sink,
                         &self.index,


### PR DESCRIPTION
When batch prefetching we can fetch versions we know that are incompatible. In the following example, we were prefetching sentry-kafka-schemas below version 1.50.0.

```
python-rapidjson<=1.20,>=1.4
sentry-kafka-schemas<=0.1.113,>=0.1.50
```

Using a new pubgrub interface from https://github.com/astral-sh/pubgrub/pull/32, we can avoid those prefetches by asking for incompatibilities that won't change anymore (those with root).

main:

![image](https://github.com/user-attachments/assets/c8475069-856e-4072-a688-0bb426e32160)

branch:

![image](https://github.com/user-attachments/assets/0b0da8e0-2f09-4137-a2c9-2af0cd706be5)

For the tested case, the performance impact was negligible.

Draft since it depends on #8245 and then another pubgrub update.