### PR TITLE
Add support for `.env` and custom env files in `uv run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4130,6 +4136,7 @@ dependencies = [
  "clap",
  "console",
  "ctrlc",
+ "dotenvy",
  "etcetera",
  "filetime",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ csv = { version = "1.3.0" }
 ctrlc = { version = "3.4.5" }
 dashmap = { version = "6.1.0" }
 data-encoding = { version = "2.6.0" }
+dotenvy = { version = "0.15.7" }
 dunce = { version = "1.0.5" }
 either = { version = "1.13.0" }
 encoding_rs_io = { version = "0.1.7" }

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -618,6 +618,9 @@ pub enum ProjectCommand {
     /// arguments to uv. All options to uv must be provided before the command,
     /// e.g., `uv run --verbose foo`. A `--` can be used to separate the command
     /// from uv options for clarity, e.g., `uv run --python 3.12 -- python`.
+    ///
+    /// Respects `.env` files in the current directory unless `--no-env-file` is
+    /// provided.
     #[command(
         after_help = "Use `uv help run` for more details.",
         after_long_help = ""

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2628,11 +2628,13 @@ pub struct RunArgs {
     #[arg(long)]
     pub no_editable: bool,
 
-    /// Load environment variables from a file. The default is to use `.env`.
+    /// Load environment variables from a `.env` file.
+    ///
+    /// Defaults to reading `.env` in the current working directory.
     #[arg(long, value_parser = parse_file_path, env = EnvVars::UV_ENV_FILE)]
     pub env_file: Option<PathBuf>,
 
-    /// Skip loading of the environment variables file
+    /// Avoid reading environment variables from a `.env` file.
     #[arg(long, conflicts_with = "env_file", value_parser = clap::builder::BoolishValueParser::new(), env = EnvVars::UV_NO_ENV_FILE)]
     pub no_env_file: bool,
 

--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2628,6 +2628,14 @@ pub struct RunArgs {
     #[arg(long)]
     pub no_editable: bool,
 
+    /// Load environment variables from a file. The default is to use `.env`.
+    #[arg(long, value_parser = parse_file_path, env = EnvVars::UV_ENV_FILE)]
+    pub env_file: Option<PathBuf>,
+
+    /// Skip loading of the environment variables file
+    #[arg(long, conflicts_with = "env_file", value_parser = clap::builder::BoolishValueParser::new(), env = EnvVars::UV_NO_ENV_FILE)]
+    pub no_env_file: bool,
+
     /// The command to run.
     ///
     /// If the path to a Python script (i.e., ending in `.py`), it will be

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -386,4 +386,10 @@ impl EnvVars {
 
     /// Used to set test credentials for keyring tests.
     pub const KEYRING_TEST_CREDENTIALS: &'static str = "KEYRING_TEST_CREDENTIALS";
+
+    /// Used to overwrite path for loading env file when executing `uv run`.
+    pub const UV_ENV_FILE: &'static str = "UV_ENV_FILE";
+
+    /// Used to ignore .env file when executing `uv run`.
+    pub const UV_NO_ENV_FILE: &'static str = "UV_NO_ENV_FILE";
 }

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -387,9 +387,9 @@ impl EnvVars {
     /// Used to set test credentials for keyring tests.
     pub const KEYRING_TEST_CREDENTIALS: &'static str = "KEYRING_TEST_CREDENTIALS";
 
-    /// Used to overwrite path for loading env file when executing `uv run`.
+    /// Used to overwrite path for loading `.env` files when executing `uv run` commands.
     pub const UV_ENV_FILE: &'static str = "UV_ENV_FILE";
 
-    /// Used to ignore .env file when executing `uv run`.
+    /// Used to ignore `.env` files when executing `uv run` commands.
     pub const UV_NO_ENV_FILE: &'static str = "UV_NO_ENV_FILE";
 }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -93,6 +93,7 @@ unicode-width = { workspace = true }
 url = { workspace = true }
 which = { workspace = true }
 zip = { workspace = true }
+dotenvy = "0.15.7"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.16" }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -63,6 +63,7 @@ axoupdater = { workspace = true, features = [
 clap = { workspace = true, features = ["derive", "string", "wrap_help"] }
 console = { workspace = true }
 ctrlc = { workspace = true }
+dotenvy = { workspace = true }
 flate2 = { workspace = true, default-features = false }
 fs-err = { workspace = true, features = ["tokio"] }
 futures = { workspace = true }
@@ -93,7 +94,6 @@ unicode-width = { workspace = true }
 url = { workspace = true }
 which = { workspace = true }
 zip = { workspace = true }
-dotenvy = "0.15.7"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.16" }

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -109,7 +109,9 @@ pub(crate) async fn run(
 
     // Initialize env file, if necessary.
     if !no_env_file {
-        let env_file_path = env_file.clone().unwrap_or(Path::new(".env").to_path_buf());
+        let env_file_path = env_file
+            .clone()
+            .unwrap_or_else(|| Path::new(".env").to_path_buf());
 
         let loaded = dotenvy::from_path_override(&env_file_path);
 

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -127,7 +127,7 @@ pub(crate) async fn run(
             }
             Err(dotenvy::Error::LineParse(line_content, line_num)) => {
                 warn_user!(
-                    "Failed to parse environment file `{}` (line {}): {}",
+                    "Failed to parse line in environment file `{}` at position {}: {}",
                     env_file_path.display(),
                     line_num,
                     line_content

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::env;
 use std::ffi::OsString;
 use std::fmt::Write;
 use std::io::stdout;
@@ -1295,6 +1296,8 @@ async fn run_project(
                 globals.native_tls,
                 &cache,
                 printer,
+                args.env_file,
+                args.no_env_file,
             ))
             .await
         }

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -244,6 +244,8 @@ pub(crate) struct RunSettings {
     pub(crate) python: Option<String>,
     pub(crate) refresh: Refresh,
     pub(crate) settings: ResolverInstallerSettings,
+    pub(crate) env_file: Option<PathBuf>,
+    pub(crate) no_env_file: bool,
 }
 
 impl RunSettings {
@@ -275,6 +277,8 @@ impl RunSettings {
             no_project,
             python,
             show_resolution,
+            env_file,
+            no_env_file,
         } = args;
 
         Self {
@@ -303,6 +307,8 @@ impl RunSettings {
                 resolver_installer_options(installer, build),
                 filesystem,
             ),
+            env_file,
+            no_env_file,
         }
     }
 }

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2391,3 +2391,179 @@ fn run_stdin_with_pep723() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn run_with_env() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let test_script = context.temp_dir.child("test.py");
+    test_script.write_str(indoc! { r#"
+        import os
+        print(os.environ.get('THE_EMPIRE_VARIABLE'))
+        print(os.environ.get('REBEL_1'))
+        print(os.environ.get('REBEL_2'))
+        print(os.environ.get('REBEL_3'))
+       "#
+    })?;
+
+    let env_file = context.temp_dir.child(".env");
+    env_file.write_str(indoc! { r#"
+        THE_EMPIRE_VARIABLE=palpatine
+        REBEL_1=leia_organa
+        REBEL_2=obi_wan_kenobi
+        REBEL_3=C3PO
+       "#
+    })?;
+
+    let mut command = context.run();
+    let command_with_args = command.arg("test.py");
+
+    uv_snapshot!(context.filters(), command_with_args,@r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    palpatine
+    leia_organa
+    obi_wan_kenobi
+    C3PO
+
+    ----- stderr -----
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn run_with_env_omitted() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let test_script = context.temp_dir.child("test.py");
+    test_script.write_str(indoc! { r#"
+        import os
+        print(os.environ.get('THE_EMPIRE_VARIABLE'))
+       "#
+    })?;
+
+    let env_file = context.temp_dir.child(".env");
+    env_file.write_str(indoc! { r#"
+        THE_EMPIRE_VARIABLE=palpatine
+       "#
+    })?;
+
+    let mut command = context.run();
+    let command_with_args = command.arg("--no-env-file").arg("test.py");
+
+    uv_snapshot!(context.filters(), command_with_args,@r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    None
+
+    ----- stderr -----
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn run_with_malformed_env() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let test_script = context.temp_dir.child("test.py");
+    test_script.write_str(indoc! { r#"
+        import os
+        print(os.environ.get('THE_EMPIRE_VARIABLE'))
+       "#
+    })?;
+
+    let env_file = context.temp_dir.child(".env");
+    env_file.write_str(indoc! { r#"
+        THE_^EMPIRE_VARIABLE=darth_vader
+       "#
+    })?;
+
+    let mut command = context.run();
+    let command_with_args = command.arg("test.py");
+
+    uv_snapshot!(context.filters(), command_with_args,@r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    None
+
+    ----- stderr -----
+    warning: Failed to parse line in environment file `.env` at position 4: THE_^EMPIRE_VARIABLE=darth_vader
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn run_with_specific_env_file() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let test_script = context.temp_dir.child("test.py");
+    test_script.write_str(indoc! { r#"
+        import os
+        print(os.environ.get('THE_EMPIRE_VARIABLE'))
+       "#
+    })?;
+
+    let env_file = context.temp_dir.child(".env.development");
+    env_file.write_str(indoc! { r#"
+        THE_EMPIRE_VARIABLE=sidious
+       "#
+    })?;
+
+    let mut command = context.run();
+    let command_with_args = command
+        .arg("--env-file")
+        .arg(".env.development")
+        .arg("test.py");
+
+    uv_snapshot!(context.filters(), command_with_args,@r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    sidious
+
+    ----- stderr -----
+    "###);
+
+    Ok(())
+}
+
+#[test]
+fn run_with_not_existing_env_file() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let test_script = context.temp_dir.child("test.py");
+    test_script.write_str(indoc! { r#"
+        import os
+        print(os.environ.get('THE_EMPIRE_VARIABLE'))
+       "#
+    })?;
+
+    let mut command = context.run();
+    let command_with_args = command
+        .arg("--env-file")
+        .arg(".env.development")
+        .arg("test.py");
+
+    let mut filters = context.filters();
+    filters.push((
+        r"(?m)^error: Failed to read environment file `.env.development`: .*$",
+        "error: Failed to read environment file `.env.development`: [ERR]",
+    ));
+
+    uv_snapshot!(filters, command_with_args,@r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Failed to read environment file `.env.development`: [ERR]
+    "###);
+
+    Ok(())
+}

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2397,22 +2397,22 @@ fn run_with_env() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let test_script = context.temp_dir.child("test.py");
-    test_script.write_str(indoc! { r#"
+    test_script.write_str(indoc! { "
         import os
         print(os.environ.get('THE_EMPIRE_VARIABLE'))
         print(os.environ.get('REBEL_1'))
         print(os.environ.get('REBEL_2'))
         print(os.environ.get('REBEL_3'))
-       "#
+       "
     })?;
 
     let env_file = context.temp_dir.child(".env");
-    env_file.write_str(indoc! { r#"
+    env_file.write_str(indoc! { "
         THE_EMPIRE_VARIABLE=palpatine
         REBEL_1=leia_organa
         REBEL_2=obi_wan_kenobi
         REBEL_3=C3PO
-       "#
+       "
     })?;
 
     let mut command = context.run();
@@ -2438,16 +2438,16 @@ fn run_with_env_omitted() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let test_script = context.temp_dir.child("test.py");
-    test_script.write_str(indoc! { r#"
+    test_script.write_str(indoc! { "
         import os
         print(os.environ.get('THE_EMPIRE_VARIABLE'))
-       "#
+       "
     })?;
 
     let env_file = context.temp_dir.child(".env");
-    env_file.write_str(indoc! { r#"
+    env_file.write_str(indoc! { "
         THE_EMPIRE_VARIABLE=palpatine
-       "#
+       "
     })?;
 
     let mut command = context.run();
@@ -2470,16 +2470,16 @@ fn run_with_malformed_env() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let test_script = context.temp_dir.child("test.py");
-    test_script.write_str(indoc! { r#"
+    test_script.write_str(indoc! { "
         import os
         print(os.environ.get('THE_EMPIRE_VARIABLE'))
-       "#
+       "
     })?;
 
     let env_file = context.temp_dir.child(".env");
-    env_file.write_str(indoc! { r#"
+    env_file.write_str(indoc! { "
         THE_^EMPIRE_VARIABLE=darth_vader
-       "#
+       "
     })?;
 
     let mut command = context.run();
@@ -2503,16 +2503,16 @@ fn run_with_specific_env_file() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let test_script = context.temp_dir.child("test.py");
-    test_script.write_str(indoc! { r#"
+    test_script.write_str(indoc! { "
         import os
         print(os.environ.get('THE_EMPIRE_VARIABLE'))
-       "#
+       "
     })?;
 
     let env_file = context.temp_dir.child(".env.development");
-    env_file.write_str(indoc! { r#"
+    env_file.write_str(indoc! { "
         THE_EMPIRE_VARIABLE=sidious
-       "#
+       "
     })?;
 
     let mut command = context.run();
@@ -2538,10 +2538,10 @@ fn run_with_not_existing_env_file() -> Result<()> {
     let context = TestContext::new("3.12");
 
     let test_script = context.temp_dir.child("test.py");
-    test_script.write_str(indoc! { r#"
+    test_script.write_str(indoc! { "
         import os
         print(os.environ.get('THE_EMPIRE_VARIABLE'))
-       "#
+       "
     })?;
 
     let mut command = context.run();

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2434,6 +2434,49 @@ fn run_with_env() -> Result<()> {
 }
 
 #[test]
+fn run_with_parent_env() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let test_script = context.temp_dir.child("test").child("test.py");
+    test_script.write_str(indoc! { "
+        import os
+        print(os.environ.get('THE_EMPIRE_VARIABLE'))
+        print(os.environ.get('REBEL_1'))
+        print(os.environ.get('REBEL_2'))
+        print(os.environ.get('REBEL_3'))
+       "
+    })?;
+
+    let env_file = context.temp_dir.child(".env");
+    env_file.write_str(indoc! { "
+        THE_EMPIRE_VARIABLE=palpatine
+        REBEL_1=leia_organa
+        REBEL_2=obi_wan_kenobi
+        REBEL_3=C3PO
+       "
+    })?;
+
+    let mut command = context.run();
+    let command_with_args = command
+        .arg("test.py")
+        .current_dir(context.temp_dir.child("test"));
+
+    uv_snapshot!(context.filters(), command_with_args,@r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    None
+    None
+    None
+    None
+
+    ----- stderr -----
+    "###);
+
+    Ok(())
+}
+
+#[test]
 fn run_with_env_omitted() -> Result<()> {
     let context = TestContext::new("3.12");
 
@@ -2492,7 +2535,7 @@ fn run_with_malformed_env() -> Result<()> {
     None
 
     ----- stderr -----
-    warning: Failed to parse line in environment file `.env` at position 4: THE_^EMPIRE_VARIABLE=darth_vader
+    warning: Failed to parse environment file `.env` at position 4: THE_^EMPIRE_VARIABLE=darth_vader
     "###);
 
     Ok(())
@@ -2562,7 +2605,7 @@ fn run_with_not_existing_env_file() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to read environment file `.env.development`: [ERR]
+    error: No environment file found at: `.env.development`
     "###);
 
     Ok(())

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -86,9 +86,9 @@ uv accepts the following command-line arguments as environment variables:
 - `UV_FROZEN`: Equivalent to the `--frozen` command-line argument. If set, uv will run without
   updating the `uv.lock` file.
 - `UV_ENV_FILE`: Equivalent to the `--env-file` command-line argument in `uv run`. If set, uv will
-  use this file as the environment file.
+  read environment variables from this `.env` file.
 - `UV_NO_ENV_FILE`: Equivalent to the `--no-env-file` command-line argument in `uv run`. If set, uv
-  will not use an environment file.
+  will not read environment variables from a `.env` file.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -85,8 +85,10 @@ uv accepts the following command-line arguments as environment variables:
   `uv.lock` remains unchanged.
 - `UV_FROZEN`: Equivalent to the `--frozen` command-line argument. If set, uv will run without
   updating the `uv.lock` file.
-- `UV_ENV_FILE`: Equivalent to the `--env-file` command-line argument in `uv run`. If set, uv will use this file as the environment file.
-- `UV_NO_ENV_FILE`: Equivalent to the `--no-env-file` command-line argument in `uv run`. If set, uv will not use an environment file.
+- `UV_ENV_FILE`: Equivalent to the `--env-file` command-line argument in `uv run`. If set, uv will
+  use this file as the environment file.
+- `UV_NO_ENV_FILE`: Equivalent to the `--no-env-file` command-line argument in `uv run`. If set, uv
+  will not use an environment file.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -85,6 +85,8 @@ uv accepts the following command-line arguments as environment variables:
   `uv.lock` remains unchanged.
 - `UV_FROZEN`: Equivalent to the `--frozen` command-line argument. If set, uv will run without
   updating the `uv.lock` file.
+- `UV_ENV_FILE`: Equivalent to the `--env-file` command-line argument in `uv run`. If set, uv will use this file as the environment file.
+- `UV_NO_ENV_FILE`: Equivalent to the `--no-env-file` command-line argument in `uv run`. If set, uv will not use an environment file.
 
 In each case, the corresponding command-line argument takes precedence over an environment variable.
 

--- a/docs/configuration/files.md
+++ b/docs/configuration/files.md
@@ -72,6 +72,18 @@ configuration files (e.g., user-level configuration will be ignored).
 
 See the [settings reference](../reference/settings.md) for an enumeration of the available settings.
 
+## `.env`
+
+By default, `uv run` will load environment variables from a `.env` file in the current working
+directory, following the discovery and parsing rules of the
+[`dotenvy`](https://github.com/allan2/dotenvy) crate.
+
+If the same variable is defined in the environment and in the file, the value from the environment
+will take precedence.
+
+To disable this behavior, set `UV_NO_ENV_FILE=1` in the environment, or pass the `--no-env-file`
+flag to `uv run`.
+
 ## Configuring the pip interface
 
 A dedicated [`[tool.uv.pip]`](../reference/settings.md#pip) section is provided for configuring

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -64,6 +64,8 @@ When used outside a project, if a virtual environment can be found in the curren
 
 Arguments following the command (or script) are not interpreted as arguments to uv. All options to uv must be provided before the command, e.g., `uv run --verbose foo`. A `--` can be used to separate the command from uv options for clarity, e.g., `uv run --python 3.12 -- python`.
 
+Respects `.env` files in the current directory unless `--no-env-file` is provided.
+
 <h3 class="cli-reference">Usage</h3>
 
 ```
@@ -131,7 +133,9 @@ uv run [OPTIONS] [COMMAND]
 
 <p>See <code>--project</code> to only change the project root directory.</p>
 
-</dd><dt><code>--env-file</code> <i>env-file</i></dt><dd><p>Load environment variables from a file. The default is to use <code>.env</code></p>
+</dd><dt><code>--env-file</code> <i>env-file</i></dt><dd><p>Load environment variables from a <code>.env</code> file.</p>
+
+<p>Defaults to reading <code>.env</code> in the current working directory.</p>
 
 <p>May also be set with the <code>UV_ENV_FILE</code> environment variable.</p>
 </dd><dt><code>--exclude-newer</code> <i>exclude-newer</i></dt><dd><p>Limit candidate packages to those that were uploaded prior to the given date.</p>
@@ -285,7 +289,7 @@ uv run [OPTIONS] [COMMAND]
 
 </dd><dt><code>--no-editable</code></dt><dd><p>Install any editable dependencies, including the project and any workspace members, as non-editable</p>
 
-</dd><dt><code>--no-env-file</code></dt><dd><p>Skip loading of the environment variables file</p>
+</dd><dt><code>--no-env-file</code></dt><dd><p>Avoid reading environment variables from a <code>.env</code> file</p>
 
 <p>May also be set with the <code>UV_NO_ENV_FILE</code> environment variable.</p>
 </dd><dt><code>--no-index</code></dt><dd><p>Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those provided via <code>--find-links</code></p>

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -131,6 +131,9 @@ uv run [OPTIONS] [COMMAND]
 
 <p>See <code>--project</code> to only change the project root directory.</p>
 
+</dd><dt><code>--env-file</code> <i>env-file</i></dt><dd><p>Load environment variables from a file. The default is to use <code>.env</code></p>
+
+<p>May also be set with the <code>UV_ENV_FILE</code> environment variable.</p>
 </dd><dt><code>--exclude-newer</code> <i>exclude-newer</i></dt><dd><p>Limit candidate packages to those that were uploaded prior to the given date.</p>
 
 <p>Accepts both RFC 3339 timestamps (e.g., <code>2006-12-02T02:07:43Z</code>) and local dates in the same format (e.g., <code>2006-12-02</code>) in your system&#8217;s configured time zone.</p>
@@ -282,6 +285,9 @@ uv run [OPTIONS] [COMMAND]
 
 </dd><dt><code>--no-editable</code></dt><dd><p>Install any editable dependencies, including the project and any workspace members, as non-editable</p>
 
+</dd><dt><code>--no-env-file</code></dt><dd><p>Skip loading of the environment variables file</p>
+
+<p>May also be set with the <code>UV_NO_ENV_FILE</code> environment variable.</p>
 </dd><dt><code>--no-index</code></dt><dd><p>Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those provided via <code>--find-links</code></p>
 
 </dd><dt><code>--no-progress</code></dt><dd><p>Hide all progress outputs.</p>


### PR DESCRIPTION
## Summary

I have been reading discussion #1384 about .env and how to include it in the `uv run` command.

I have always wanted to include this possibility in `uv`, so I was interested in the latest changes. Following @charliermarsh's [advice ](https://github.com/astral-sh/uv/issues/1384#issuecomment-2381434225) I have tried to respect the philosophy that `uv run` uses the default `.env` and this can be discarded or changed via terminal or environment variables.

The behaviour is as follows:
- `uv run file.py` executes file.py using the `.env` (if it exists).
- `uv run --env-file .env.development file.py` uses the `.env.development` file to load the variables and then runs file.py. In this case the program fails if the file does not exist.
- `uv run --no-env-file file.py` skips reading the `.env` file.

Equivalently, I have included the `UV_ENV_FILE` and `UV_NO_ENV_FILE` environment variables.

## Test Plan

I haven't got into including automated tests, I would need help with this.

I have tried the above commands, with a python script that prints environment variables.
