### PR TITLE
Fix error leading to out-of-bound panic in `uv-pep508`

### DIFF
--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -933,7 +933,7 @@ fn parse_pep508_requirement<T: Pep508Url>(
     //
     // See: https://github.com/pypa/pip/blob/111eed14b6e9fba7c78a5ec2b7594812d17b5d2b/src/pip/_internal/utils/filetypes.py#L8
     if requirement_kind.is_none() {
-        if looks_like_archive(cursor.slice(name_start, name_end)) {
+        if looks_like_archive(cursor.slice(name_start, name_end - name_start)) {
             let clone = cursor.clone().at(start);
             return Err(Pep508Error {
                 message: Pep508ErrorSource::UnsupportedRequirement("URL requirement must be preceded by a package name. Add the name of the package before the URL (e.g., `package_name @ https://...`).".to_string()),

--- a/crates/uv-pep508/src/tests.rs
+++ b/crates/uv-pep508/src/tests.rs
@@ -117,6 +117,12 @@ fn basic_examples() {
 }
 
 #[test]
+fn leading_whitespace() {
+    let numpy = Requirement::<Url>::from_str(" numpy").unwrap();
+    assert_eq!(numpy.name.as_ref(), "numpy");
+}
+
+#[test]
 fn parenthesized_single() {
     let numpy = Requirement::<Url>::from_str("numpy ( >=1.19 )").unwrap();
     assert_eq!(numpy.name.as_ref(), "numpy");


### PR DESCRIPTION
Resolves #8281.

## Summary

[`Cursor.slice()`](https://github.com/astral-sh/uv/blob/d930367f8c5728b5c51a2bbf95d91354046f6efa/crates/uv-pep508/src/cursor.rs#L39) expects a start index and a length, but it is instead [given a start index and an end index](https://github.com/astral-sh/uv/blob/d930367f8c5728b5c51a2bbf95d91354046f6efa/crates/uv-pep508/src/lib.rs#L936).

## Test plan

A new "leading whitespace" test is added to `tests.rs`.
