### PR TITLE
Update indexes.md: ch UV_INDEX_ to UV_HTTP_BASIC_

### DIFF
--- a/docs/configuration/indexes.md
+++ b/docs/configuration/indexes.md
@@ -134,12 +134,12 @@ name = "internal"
 url = "https://example.com/simple"
 ```
 
-From there, you can set the `UV_INDEX_INTERNAL_USERNAME` and `UV_INDEX_INTERNAL_PASSWORD`
+From there, you can set the `UV_HTTP_BASIC_INTERNAL_USERNAME` and `UV_HTTP_BASIC_INTERNAL_PASSWORD`
 environment variables, where `INTERNAL` is the uppercase version of the index name:
 
 ```sh
-export UV_INDEX_INTERNAL_USERNAME=public
-export UV_INDEX_INTERNAL_PASSWORD=koala
+export UV_HTTP_BASIC_INTERNAL_USERNAME=public
+export UV_HTTP_BASIC_INTERNAL_PASSWORD=koala
 ```
 
 By providing credentials via environment variables, you can avoid storing sensitive information in


### PR DESCRIPTION
The code actually uses UV_HTTP_BASIC_ as the prefix for environment variable credentials

See PR #7741 for code: https://github.com/astral-sh/uv/pull/7741/files#diff-ae78c09a4ee5f2a80c0e91c05e0ec13b5a87bfa1b0ff86b94bd04d885e1afaee

```rust
    pub fn from_env(name: &str) -> Option<Self> {
        let name = name.to_uppercase();
        let username = std::env::var(format!("UV_HTTP_BASIC_{name}_USERNAME")).ok();
        let password = std::env::var(format!("UV_HTTP_BASIC_{name}_PASSWORD")).ok();
        if username.is_none() && password.is_none() {
            None
        } else {
            Some(Self::new(username, password))
        }
    }
```