### PR TITLE
Patch Python executable name for Windows free-threaded builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,6 +718,46 @@ jobs:
         run: |
           ./uv pip install -v anyio
 
+  integration-test-free-threaded-windows:
+    timeout-minutes: 10
+    needs: build-binary-windows
+    name: "integration test | free-threaded on windows"
+    runs-on: windows-latest
+    env:
+      # Avoid debug build stack overflows.
+      UV_STACK_SIZE: 2000000
+
+    steps:
+      - name: "Download binary"
+        uses: actions/download-artifact@v4
+        with:
+          name: uv-windows-${{ github.sha }}
+
+      - name: "Install free-threaded Python via uv"
+        run: |
+          ./uv python install -v 3.13t
+
+      - name: "Create a virtual environment"
+        run: |
+          ./uv venv -p 3.13t --python-preference only-managed
+
+      - name: "Check version"
+        run: |
+          .venv/Scripts/python --version
+
+      - name: "Check is free-threaded"
+        run: |
+          .venv/Scripts/python -c "import sys; exit(1) if sys._is_gil_enabled() else exit(0)"
+
+      - name: "Check install"
+        run: |
+          ./uv pip install -v anyio
+
+      - name: "Check uv run"
+        run: |
+          ./uv run python -c ""
+          ./uv run -p 3.13t python -c ""
+
   integration-test-pypy-linux:
     timeout-minutes: 10
     needs: build-binary-linux

--- a/crates/uv-fs/src/lib.rs
+++ b/crates/uv-fs/src/lib.rs
@@ -104,6 +104,26 @@ pub fn remove_symlink(path: impl AsRef<Path>) -> std::io::Result<()> {
     fs_err::remove_file(path.as_ref())
 }
 
+/// Create a symlink at `dst` pointing to `src` or, on Windows, copy `src` to `dst`.
+///
+/// This function should only be used for files. If targeting a directory, use [`replace_symlink`]
+/// instead; it will use a junction on Windows, which is more performant.
+pub fn symlink_copy_fallback_file(
+    src: impl AsRef<Path>,
+    dst: impl AsRef<Path>,
+) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        fs_err::copy(src.as_ref(), dst.as_ref())?;
+    }
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(src.as_ref(), dst.as_ref())?;
+    }
+
+    Ok(())
+}
+
 #[cfg(windows)]
 pub fn remove_symlink(path: impl AsRef<Path>) -> std::io::Result<()> {
     match junction::delete(dunce::simplified(path.as_ref())) {

--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -142,6 +142,7 @@ impl PythonInstallation {
 
         let installed = ManagedPythonInstallation::new(path)?;
         installed.ensure_externally_managed()?;
+        installed.ensure_canonical_executables()?;
 
         Ok(Self {
             source: PythonSource::Managed,

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -167,6 +167,7 @@ pub(crate) async fn install(
                 // Ensure the installations have externally managed markers
                 let managed = ManagedPythonInstallation::new(path.clone())?;
                 managed.ensure_externally_managed()?;
+                managed.ensure_canonical_executables()?;
             }
             Err(err) => {
                 errors.push((key, err));


### PR DESCRIPTION
A temporary fix for https://github.com/astral-sh/uv/issues/8298 while we wait for my slower upstream fix at https://github.com/indygreg/python-build-standalone/pull/373

I think we'll want this machinery anyway to ensure that the various executable names are available? Otherwise we need to special-case all the `python` names in `uv run`?

We don't have unit test coverage of managed downloads, so I added an [integration test](https://github.com/astral-sh/uv/actions/runs/11394150653/job/31703956805?pr=8310) similar to what we have for Linux.