### PR TITLE
Remove commands available in the top-level from the suggested subcommand error

### DIFF
--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1530,25 +1530,19 @@ where
             if let Some(ContextValue::String(subcommand)) = err.get(ContextKind::InvalidSubcommand)
             {
                 match subcommand.as_str() {
-                    "compile" | "lock" => {
+                    "compile" => {
                         err.insert(
                             ContextKind::SuggestedSubcommand,
                             ContextValue::String("uv pip compile".to_string()),
                         );
                     }
-                    "sync" => {
-                        err.insert(
-                            ContextKind::SuggestedSubcommand,
-                            ContextValue::String("uv pip sync".to_string()),
-                        );
-                    }
-                    "install" | "add" => {
+                    "install" => {
                         err.insert(
                             ContextKind::SuggestedSubcommand,
                             ContextValue::String("uv pip install".to_string()),
                         );
                     }
-                    "uninstall" | "remove" => {
+                    "uninstall" => {
                         err.insert(
                             ContextKind::SuggestedSubcommand,
                             ContextValue::String("uv pip uninstall".to_string()),
@@ -1570,12 +1564,6 @@ where
                         err.insert(
                             ContextKind::SuggestedSubcommand,
                             ContextValue::String("uv pip show".to_string()),
-                        );
-                    }
-                    "tree" => {
-                        err.insert(
-                            ContextKind::SuggestedSubcommand,
-                            ContextValue::String("uv pip tree".to_string()),
                         );
                     }
                     _ => {}


### PR DESCRIPTION
Part of https://github.com/astral-sh/uv/issues/8313

I think we'll need to open an issue upstream to add more context to the error here, because there's not sufficient information about the parent command to provide a good error message. As a first step, let's avoid giving these suggestions for subcommands that overlap with our top-level commands.. because that's just confusing.

Here's all the information we have here

```rust
[crates/uv/src/lib.rs:1530:13] &err = ErrorInner {
    kind: InvalidSubcommand,
    context: FlatMap {
        keys: [
            InvalidSubcommand,
            Usage,
        ],
        values: [
            String(
                "remove",
            ),
            StyledStr(
                StyledStr(
                    "\u{1b}[1m\u{1b}[32mUsage:\u{1b}[0m \u{1b}[1m\u{1b}[36muv python\u{1b}[0m \u{1b}[36m[OPTIONS]\u{1b}[0m \u{1b}[36m<COMMAND>\u{1b}[0m",
                ),
            ),
        ],
    },
    message: None,
    source: None,
    help_flag: Some(
        "--help",
    ),
    styles: Styles {
        header: Style {
            fg: Some(
                Ansi(
                    Green,
                ),
            ),
            bg: None,
            underline: None,
            effects: Effects(BOLD),
        },
        error: Style {
            fg: Some(
                Ansi(
                    Red,
                ),
            ),
            bg: None,
            underline: None,
            effects: Effects(BOLD),
        },
        usage: Style {
            fg: Some(
                Ansi(
                    Green,
                ),
            ),
            bg: None,
            underline: None,
            effects: Effects(BOLD),
        },
        literal: Style {
            fg: Some(
                Ansi(
                    Cyan,
                ),
            ),
            bg: None,
            underline: None,
            effects: Effects(BOLD),
        },
        placeholder: Style {
            fg: Some(
                Ansi(
                    Cyan,
                ),
            ),
            bg: None,
            underline: None,
            effects: Effects(),
        },
        valid: Style {
            fg: Some(
                Ansi(
                    Green,
                ),
            ),
            bg: None,
            underline: None,
            effects: Effects(),
        },
        invalid: Style {
            fg: Some(
                Ansi(
                    Yellow,
                ),
            ),
            bg: None,
            underline: None,
            effects: Effects(),
        },
    },
    color_when: Auto,
    color_help_when: Auto,
    backtrace: None,
}
```