### PR TITLE
Remove trailing newlines in error messages

### DIFF
--- a/crates/uv-dev/src/main.rs
+++ b/crates/uv-dev/src/main.rs
@@ -129,7 +129,7 @@ async fn main() -> ExitCode {
     if let Err(err) = result {
         eprintln!("{}", "uv-dev failed".red().bold());
         for err in err.chain() {
-            eprintln!("  {}: {}", "Caused by".red().bold(), err);
+            eprintln!("  {}: {}", "Caused by".red().bold(), err.to_string().trim());
         }
         ExitCode::FAILURE
     } else {

--- a/crates/uv/src/commands/build_frontend.rs
+++ b/crates/uv/src/commands/build_frontend.rs
@@ -299,11 +299,20 @@ async fn build_impl(
             Err(err) => {
                 let mut causes = err.chain();
 
-                let message = format!("{}: {}", "error".red().bold(), causes.next().unwrap());
+                let message = format!(
+                    "{}: {}",
+                    "error".red().bold(),
+                    causes.next().unwrap().to_string().trim()
+                );
                 writeln!(printer.stderr(), "{}", source.annotate(&message))?;
 
                 for err in causes {
-                    writeln!(printer.stderr(), "  {}: {}", "Caused by".red().bold(), err)?;
+                    writeln!(
+                        printer.stderr(),
+                        "  {}: {}",
+                        "Caused by".red().bold(),
+                        err.to_string().trim()
+                    )?;
                 }
             }
         }

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -235,7 +235,12 @@ pub(crate) async fn install(
                 key.green()
             )?;
             for err in anyhow::Error::new(err).chain() {
-                writeln!(printer.stderr(), "  {}: {}", "Caused by".red().bold(), err)?;
+                writeln!(
+                    printer.stderr(),
+                    "  {}: {}",
+                    "Caused by".red().bold(),
+                    err.to_string().trim()
+                )?;
             }
         }
         return Ok(ExitStatus::Failure);

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -195,7 +195,7 @@ async fn do_uninstall(
                 printer.stderr(),
                 "Failed to uninstall {}: {}",
                 key.green(),
-                err
+                err.to_string().trim()
             )?;
         }
         return Ok(ExitStatus::Failure);

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1629,9 +1629,13 @@ where
         Ok(code) => code.into(),
         Err(err) => {
             let mut causes = err.chain();
-            eprintln!("{}: {}", "error".red().bold(), causes.next().unwrap());
+            eprintln!(
+                "{}: {}",
+                "error".red().bold(),
+                causes.next().unwrap().to_string().trim()
+            );
             for err in causes {
-                eprintln!("  {}: {}", "Caused by".red().bold(), err);
+                eprintln!("  {}: {}", "Caused by".red().bold(), err.to_string().trim());
             }
             ExitStatus::Error.into()
         }


### PR DESCRIPTION
Sometimes, multiline errors bring their own trailing newlines, which double with our trailing newlines. We need to trim those.

Before:

![image](https://github.com/user-attachments/assets/3ae41dcf-475d-4b9d-8833-2de3ea1c4911)

After:

![image](https://github.com/user-attachments/assets/e7497990-053b-4b91-8ab5-a893d4e8a7fd)
