### PR TITLE
Add `--group`, `--only-group`, and `--only-dev` support to `uv tree`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3170,9 +3170,29 @@ pub struct TreeArgs {
     #[arg(long, overrides_with("no_dev"), hide = true)]
     pub dev: bool,
 
+    /// Omit non-development dependencies.
+    ///
+    /// The project itself will also be omitted.
+    #[arg(long, conflicts_with("no_dev"))]
+    pub only_dev: bool,
+
     /// Omit development dependencies.
     #[arg(long, overrides_with("dev"), conflicts_with = "invert")]
     pub no_dev: bool,
+
+    /// Include dependencies from the specified local dependency group.
+    ///
+    /// May be provided multiple times.
+    #[arg(long, conflicts_with("only_group"))]
+    pub group: Vec<GroupName>,
+
+    /// Only include dependencies from the specified local dependency group.
+    ///
+    /// May be provided multiple times.
+    ///
+    /// The project itself will also be omitted.
+    #[arg(long, conflicts_with("group"))]
+    pub only_group: Vec<GroupName>,
 
     /// Assert that the `uv.lock` will remain unchanged.
     ///

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1018,7 +1018,10 @@ impl TreeSettings {
             tree,
             universal,
             dev,
+            only_dev,
             no_dev,
+            group,
+            only_group,
             locked,
             frozen,
             build,
@@ -1029,8 +1032,7 @@ impl TreeSettings {
         } = args;
 
         Self {
-            // TODO(zanieb): Support `--group` here
-            dev: DevGroupsSpecification::from_args(dev, no_dev, false, vec![], vec![]),
+            dev: DevGroupsSpecification::from_args(dev, no_dev, only_dev, group, only_group),
             locked,
             frozen,
             universal,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2354,6 +2354,10 @@ uv tree [OPTIONS]
 
 <p>If the lockfile is missing, uv will exit with an error.</p>
 
+</dd><dt><code>--group</code> <i>group</i></dt><dd><p>Include dependencies from the specified local dependency group.</p>
+
+<p>May be provided multiple times.</p>
+
 </dd><dt><code>--help</code>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 
 </dd><dt><code>--index</code> <i>index</i></dt><dd><p>The URLs to use when resolving dependencies, in addition to the default index.</p>
@@ -2475,6 +2479,16 @@ uv tree [OPTIONS]
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
 <p>When disabled, uv will only use locally cached data and locally available files.</p>
+
+</dd><dt><code>--only-dev</code></dt><dd><p>Omit non-development dependencies.</p>
+
+<p>The project itself will also be omitted.</p>
+
+</dd><dt><code>--only-group</code> <i>only-group</i></dt><dd><p>Only include dependencies from the specified local dependency group.</p>
+
+<p>May be provided multiple times.</p>
+
+<p>The project itself will also be omitted.</p>
 
 </dd><dt><code>--package</code> <i>package</i></dt><dd><p>Display only the specified packages</p>
 


### PR DESCRIPTION
Part of #8090 

Most of the heavy lifting is done in #8309 

Includes `--only-dev` which appears to be missing as an oversight.