### PR TITLE
Allow dashes and underscores in custom index names

### DIFF
--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -158,7 +158,7 @@ impl FromStr for Index {
                 return Err(IndexSourceError::EmptyName);
             }
 
-            if name.chars().all(char::is_alphanumeric) {
+            if name.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') {
                 let url = IndexUrl::from_str(url)?;
                 return Ok(Self {
                     name: Some(name.to_string()),

--- a/crates/uv-distribution-types/src/index.rs
+++ b/crates/uv-distribution-types/src/index.rs
@@ -158,7 +158,10 @@ impl FromStr for Index {
                 return Err(IndexSourceError::EmptyName);
             }
 
-            if name.chars().all(|c| c.is_alphanumeric() || c == '-' || c == '_') {
+            if name
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+            {
                 let url = IndexUrl::from_str(url)?;
                 return Ok(Self {
                     name: Some(name.to_string()),

--- a/docs/configuration/indexes.md
+++ b/docs/configuration/indexes.md
@@ -18,6 +18,8 @@ name = "pytorch"
 url = "https://download.pytorch.org/whl/cpu"
 ```
 
+Index names must only contain alphanumeric characters, dashes, or underscores.
+
 Indexes are prioritized in the order in which they’re defined, such that the first index listed in
 the configuration file is the first index consulted when resolving dependencies, with indexes
 provided via the command line taking precedence over those in the configuration file.


### PR DESCRIPTION
Previously, `uv add --index` command threw an error when the index name included characters like hyphens or underscores.

Closes #8315