### PR TITLE
Set `UV_LINK_MODE=copy` for Windows test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,10 @@ jobs:
 
       - name: "Cargo test"
         working-directory: ${{ env.UV_WORKSPACE }}
+        env:
+          # Avoid permission errors during concurrent tests
+          # See https://github.com/astral-sh/uv/issues/6940
+          UV_LINK_MODE: copy
         run: |
           cargo nextest run --no-default-features --features python,pypi --workspace --status-level skip --failure-output immediate-final --no-fail-fast -j 20 --final-status-level slow
 

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -299,6 +299,12 @@ impl TestContext {
 
         let mut filters = Vec::new();
 
+        // Exclude `link-mode` on Windows since we set it in the remote test suite
+        if cfg!(windows) {
+            filters.push(("--link-mode <LINK_MODE> ".to_string(), String::new()));
+            filters.push(((r#"link-mode = "copy"\n"#).to_string(), String::new()));
+        }
+
         filters.extend(
             Self::path_patterns(&cache_dir)
                 .into_iter()

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -3217,7 +3217,7 @@ fn add_reject_multiple_git_ref_flags() {
     let context = TestContext::new("3.12");
 
     // --tag and --branch
-    uv_snapshot!(context
+    uv_snapshot!(context.filters(), context
         .add()
         .arg("foo")
         .arg("--tag")
@@ -3238,7 +3238,7 @@ fn add_reject_multiple_git_ref_flags() {
     );
 
     // --tag and --rev
-    uv_snapshot!(context
+    uv_snapshot!(context.filters(), context
         .add()
         .arg("foo")
         .arg("--tag")
@@ -3259,7 +3259,7 @@ fn add_reject_multiple_git_ref_flags() {
     );
 
     // --tag and --tag
-    uv_snapshot!(context
+    uv_snapshot!(context.filters(), context
         .add()
         .arg("foo")
         .arg("--tag")


### PR DESCRIPTION
Cherry-picked from #8347 

Might fix https://github.com/astral-sh/uv/issues/6940 — I'm not seeing a failure over there after this change. I think there may be some problem with concurrent reads of junctioned files on the DevDrive? It's really hard to say.

We might lose some important test coverage with this change. I'm not sure what to do about that either.