### PR TITLE
Use a dedicated message for incompatible Python versions in wheel ABI tags

### DIFF
--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -139,6 +139,9 @@ impl Display for IncompatibleDist {
                         f.write_str("no wheels with a matching Python implementation tag")
                     }
                     IncompatibleTag::Abi => f.write_str("no wheels with a matching Python ABI tag"),
+                    IncompatibleTag::AbiPythonVersion => {
+                        f.write_str("no wheels with a matching Python version tag")
+                    }
                     IncompatibleTag::Platform => {
                         f.write_str("no wheels with a matching platform tag")
                     }

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -23,9 +23,15 @@ pub enum TagsError {
 
 #[derive(Debug, Eq, Ord, PartialEq, PartialOrd, Clone)]
 pub enum IncompatibleTag {
+    /// The tag is invalid and cannot be used.
     Invalid,
+    /// The Python implementation tag is incompatible.
     Python,
+    /// The ABI tag is incompatible.
     Abi,
+    /// The Python version component of the ABI tag is incompatible with `requires-python`.
+    AbiPythonVersion,
+    /// The platform tag is incompatible.
     Platform,
 }
 

--- a/crates/uv-resolver/src/version_map.rs
+++ b/crates/uv-resolver/src/version_map.rs
@@ -563,7 +563,9 @@ impl VersionMapLazy {
         // Check if the wheel is compatible with the `requires-python` (i.e., the Python ABI tag
         // is not less than the `requires-python` minimum version).
         if !self.requires_python.matches_wheel_tag(filename) {
-            return WheelCompatibility::Incompatible(IncompatibleWheel::Tag(IncompatibleTag::Abi));
+            return WheelCompatibility::Incompatible(IncompatibleWheel::Tag(
+                IncompatibleTag::AbiPythonVersion,
+            ));
         }
 
         // Break ties with the build tag.

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -5521,7 +5521,7 @@ fn lock_requires_python_no_wheels() -> Result<()> {
 
     ----- stderr -----
       × No solution found when resolving dependencies:
-      ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python ABI tag and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
+      ╰─▶ Because dearpygui==1.9.1 has no wheels with a matching Python version tag and your project depends on dearpygui==1.9.1, we can conclude that your project's requirements are unsatisfiable.
     "###);
 
     Ok(())


### PR DESCRIPTION
Part of https://github.com/astral-sh/uv/issues/2777

I noticed we're seeing "Python ABI" _a lot_ in error messages which I did not expect. This improves a common case by being a little more specific.