### PR TITLE
Modify pip list and tree to print to stdout regardless of the --quiet flag

### DIFF
--- a/crates/uv/src/commands/pip/list.rs
+++ b/crates/uv/src/commands/pip/list.rs
@@ -53,12 +53,11 @@ pub(crate) fn pip_list(
         .collect_vec();
 
     // We force output to stdout specifically for `pip list` command (#8379)
-    let mut forced_stdout = Stdout::Enabled;
     match format {
         ListFormat::Json => {
             let rows = results.iter().copied().map(Entry::from).collect_vec();
             let output = serde_json::to_string(&rows)?;
-            writeln!(forced_stdout, "{output}")?;
+            writeln!(Stdout::Enabled, "{output}")?;
         }
         ListFormat::Columns if results.is_empty() => {}
         ListFormat::Columns => {
@@ -99,13 +98,18 @@ pub(crate) fn pip_list(
             }
 
             for elems in MultiZip(columns.iter().map(Column::fmt).collect_vec()) {
-                writeln!(forced_stdout, "{}", elems.join(" ").trim_end())?;
+                writeln!(Stdout::Enabled, "{}", elems.join(" ").trim_end())?;
             }
         }
         ListFormat::Freeze if results.is_empty() => {}
         ListFormat::Freeze => {
             for dist in &results {
-                writeln!(forced_stdout, "{}=={}", dist.name().bold(), dist.version())?;
+                writeln!(
+                    Stdout::Enabled,
+                    "{}=={}",
+                    dist.name().bold(),
+                    dist.version()
+                )?;
             }
         }
     }

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -14,7 +14,7 @@ use crate::commands::pip::loggers::DefaultResolveLogger;
 use crate::commands::pip::resolution_markers;
 use crate::commands::project::ProjectInterpreter;
 use crate::commands::{project, ExitStatus, SharedState};
-use crate::printer::Printer;
+use crate::printer::{Printer, Stdout};
 use crate::settings::ResolverSettings;
 
 /// Run a command.
@@ -100,7 +100,8 @@ pub(crate) async fn tree(
         invert,
     );
 
-    write!(printer.stdout(), "{tree}")?;
+    // Making an exclusion specifically for tree subcommand (#8379)
+    write!(Stdout::Enabled, "{tree}")?;
 
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/src/commands/project/tree.rs
+++ b/crates/uv/src/commands/project/tree.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anstream::println;
+use anstream::print;
 use anyhow::Result;
 
 use uv_cache::Cache;
@@ -101,7 +101,7 @@ pub(crate) async fn tree(
         invert,
     );
 
-    println!("{tree}");
+    print!("{tree}");
 
     Ok(ExitStatus::Success)
 }

--- a/crates/uv/tests/it/pip_tree.rs
+++ b/crates/uv/tests/it/pip_tree.rs
@@ -1744,3 +1744,42 @@ fn show_version_specifiers_with_package() {
     "###
     );
 }
+
+#[test]
+fn print_output_even_with_quite_flag() {
+    let context = TestContext::new("3.12");
+
+    let requirements_txt = context.temp_dir.child("requirements.txt");
+    requirements_txt.write_str("requests==2.31.0").unwrap();
+
+    uv_snapshot!(context
+        .pip_install()
+        .arg("-r")
+        .arg("requirements.txt")
+        .arg("--strict"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 5 packages in [TIME]
+    Prepared 5 packages in [TIME]
+    Installed 5 packages in [TIME]
+     + certifi==2024.2.2
+     + charset-normalizer==3.3.2
+     + idna==3.6
+     + requests==2.31.0
+     + urllib3==2.2.1
+    "###
+    );
+
+    context.assert_command("import requests").success();
+    uv_snapshot!(context.filters(), context.pip_tree().arg("--quiet"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    "###
+    );
+}


### PR DESCRIPTION
## Summary

The desired behavior for `uv tree` and `uv pip list` with `-q | --quiet` flag is https://github.com/astral-sh/uv/issues/8379#issuecomment-2425093709 to still produce output. This is implemented here.

Closes https://github.com/astral-sh/uv/issues/8379

## Test Plan

Use `uv tree -q` or `uv pip list -q` on any uv project setup and expect the corresponding output.
Added tests for that as well.
