### PR TITLE
Apply narrowing with upper bounds

### DIFF
--- a/crates/uv-resolver/src/requires_python.rs
+++ b/crates/uv-resolver/src/requires_python.rs
@@ -105,18 +105,32 @@ impl RequiresPython {
         }))
     }
 
-    /// Narrow the [`RequiresPython`] to the given version, if it's stricter (i.e., greater) than
-    /// the current target.
+    /// Narrow the [`RequiresPython`] to the given version, if it's stricter than the current target.
     pub fn narrow(&self, range: &RequiresPythonRange) -> Option<Self> {
-        if *range == self.range {
-            None
-        } else if range.0 >= self.range.0 && range.1 <= self.range.1 {
-            Some(Self {
-                specifiers: self.specifiers.clone(),
-                range: range.clone(),
-            })
+        let lower = if range.0 >= self.range.0 {
+            Some(&range.0)
         } else {
             None
+        };
+        let upper = if range.1 <= self.range.1 {
+            Some(&range.1)
+        } else {
+            None
+        };
+        match (lower, upper) {
+            (Some(lower), Some(upper)) => Some(Self {
+                specifiers: self.specifiers.clone(),
+                range: RequiresPythonRange(lower.clone(), upper.clone()),
+            }),
+            (Some(lower), None) => Some(Self {
+                specifiers: self.specifiers.clone(),
+                range: RequiresPythonRange(lower.clone(), self.range.1.clone()),
+            }),
+            (None, Some(upper)) => Some(Self {
+                specifiers: self.specifiers.clone(),
+                range: RequiresPythonRange(self.range.0.clone(), upper.clone()),
+            }),
+            (None, None) => None,
         }
     }
 

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -11039,6 +11039,120 @@ fn lock_reorder() -> Result<()> {
     Ok(())
 }
 
+/// Ensure that `requires-python` bounds are correctly narrowed in the presence of upper-bound caps.
+#[test]
+fn lock_narrowed_python_version_upper() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let dependency = context.temp_dir.child("dependency");
+    dependency.child("pyproject.toml").write_str(
+        r#"
+        [project]
+        name = "dependency"
+        version = "0.1.0"
+        requires-python = ">=3.10"
+        dependencies = ["iniconfig"]
+
+        [build-system]
+        requires = ["setuptools>=42"]
+        build-backend = "setuptools.build_meta"
+        "#,
+    )?;
+
+    let pyproject_toml = context.temp_dir.child("pyproject.toml");
+    pyproject_toml.write_str(
+        r#"
+        [project]
+        name = "project"
+        version = "0.1.0"
+        requires-python = ">=3.7, <4"
+        dependencies = ["dependency ; python_version >= '3.10'"]
+
+        [tool.uv.sources]
+        dependency = { path = "./dependency" }
+
+        [tool.uv]
+        environments = ["python_version >= '3.10'"]
+        "#,
+    )?;
+
+    let lockfile = context.temp_dir.join("uv.lock");
+
+    uv_snapshot!(context.filters(), context.lock(), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    "###);
+
+    let lock = fs_err::read_to_string(&lockfile).unwrap();
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            lock, @r###"
+        version = 1
+        requires-python = ">=3.7, <4"
+        resolution-markers = [
+            "python_full_version >= '3.10'",
+        ]
+        supported-markers = [
+            "python_full_version >= '3.10'",
+        ]
+
+        [options]
+        exclude-newer = "2024-03-25T00:00:00Z"
+
+        [[package]]
+        name = "dependency"
+        version = "0.1.0"
+        source = { directory = "dependency" }
+        dependencies = [
+            { name = "iniconfig", marker = "python_full_version >= '3.10'" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "iniconfig" }]
+
+        [[package]]
+        name = "iniconfig"
+        version = "2.0.0"
+        source = { registry = "https://pypi.org/simple" }
+        sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+        wheels = [
+            { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+        ]
+
+        [[package]]
+        name = "project"
+        version = "0.1.0"
+        source = { virtual = "." }
+        dependencies = [
+            { name = "dependency", marker = "python_full_version >= '3.10'" },
+        ]
+
+        [package.metadata]
+        requires-dist = [{ name = "dependency", marker = "python_full_version >= '3.10'", directory = "dependency" }]
+        "###
+        );
+    });
+
+    // Re-run with `--locked`.
+    uv_snapshot!(context.filters(), context.lock().arg("--locked"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    "###);
+
+    Ok(())
+}
+
 #[test]
 fn lock_narrowed_python_version() -> Result<()> {
     let context = TestContext::new("3.12");


### PR DESCRIPTION
## Summary

If the user has an upper-bound in a `requires-python`, we don't correctly narrow it during resolution. We should be narrowing based on the intersection.

Closes #8297.
