### PR TITLE
Link to Dependency specifiers instead of PEP 508

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -33,7 +33,9 @@ Utilities for interacting with Python version numbers and specifiers.
 
 ## [uv-pep508-rs](./uv-pep508)
 
-Utilities for interacting with [PEP 508](https://peps.python.org/pep-0508/) dependency specifiers.
+Utilities for parsing and evaluating
+[dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/),
+previously known as [PEP 508](https://peps.python.org/pep-0508/).
 
 ## [uv-platform-tags](./uv-platform-tags)
 

--- a/crates/uv-pep508/Readme.md
+++ b/crates/uv-pep508/Readme.md
@@ -3,9 +3,9 @@
 [![Crates.io](https://img.shields.io/crates/v/pep508_rs.svg?logo=rust&style=flat-square)](https://crates.io/crates/pep508_rs)
 [![PyPI](https://img.shields.io/pypi/v/pep508_rs.svg?logo=python&style=flat-square)](https://pypi.org/project/pep508_rs)
 
-A library for python
+A library for
 [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/),
-better known as [PEP 508](https://peps.python.org/pep-0508/).
+previously known as [PEP 508](https://peps.python.org/pep-0508/).
 
 ## Usage
 

--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -1,5 +1,5 @@
-//! A library for python [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/)
-//! better known as [PEP 508](https://peps.python.org/pep-0508/)
+//! A library for [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/)
+//! previously known as [PEP 508](https://peps.python.org/pep-0508/)
 //!
 //! ## Usage
 //!

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -28,9 +28,10 @@ bird-feeder = { path = "./packages/bird-feeder" }
 ## Project dependencies
 
 The `project.dependencies` table represents the dependencies that are used when uploading to PyPI or
-building a wheel. Individual dependencies are specified using [PEP 508](#pep-508) syntax, and the
-table follows the [PEP 621](https://packaging.python.org/en/latest/specifications/pyproject-toml/)
-standard.
+building a wheel. Individual dependencies are specified using
+[dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/)
+syntax, and the table follows the
+[PEP 621](https://packaging.python.org/en/latest/specifications/pyproject-toml/) standard.
 
 `project.dependencies` defines the list of packages that are required for the project, along with
 the version constraints that should be used when installing them. Each entry includes a dependency
@@ -248,8 +249,8 @@ members = [
 ### Platform-specific sources
 
 You can limit a source to a given platform or Python version by providing
-[PEP 508](https://peps.python.org/pep-0508/#environment-markers)-compatible environment markers for
-the source.
+[dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/)-compatible
+environment markers for the source.
 
 For example, to pull `httpx` from GitHub, but only on macOS, use the following:
 
@@ -437,10 +438,12 @@ Or, to opt-out of using an editable dependency in a workspace:
 $ uv add --no-editable ./path/foo
 ```
 
-## PEP 508
+## Dependency specifiers (PEP 508)
 
-[PEP 508](https://peps.python.org/pep-0508/) defines a syntax for dependency specification. It is
-composed of, in order:
+uv uses
+[dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/),
+previously known as [PEP 508](https://peps.python.org/pep-0508/). A dependency specifier is composed
+of, in order:
 
 - The dependency name
 - The extras you want (optional)


### PR DESCRIPTION
The canonical source is https://packaging.python.org/en/latest/specifications/dependency-specifiers/, not PEP 508 anymore, so we should link there and use the new name.