### PR TITLE
Use XDG (i.e. `~/.local/bin`) instead of the Cargo home directory in the installer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -331,4 +331,4 @@ github-custom-job-permissions = { "build-docker" = { packages = "write", content
 # Whether to install an updater program
 install-updater = false
 # Path that installers should place binaries in
-install-path = "CARGO_HOME"
+install-path = ["$XDG_BIN_HOME/", "$XDG_DATA_HOME/../bin", "~/.local/bin"]

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -54,8 +54,8 @@ Request a specific version by including it in the URL:
 
 #### Configuring installation
 
-By default, uv is installed to `~/.cargo/bin`. To change the installation path, use
-`UV_INSTALL_DIR`:
+By default, uv is installed to `~/.local/bin`. uv's installer also respects the `XDG_BIN_HOME`
+environment variable. To use a custom installation path, use `UV_INSTALL_DIR`:
 
 === "macOS and Linux"
 
@@ -222,14 +222,14 @@ If you need to remove uv from your system, just remove the `uv` and `uvx` binari
 === "macOS and Linux"
 
     ```console
-    $ rm ~/.cargo/bin/uv ~/.cargo/bin/uvx
+    $ rm ~/.local/bin/uv ~/.local/bin/uvx
     ```
 
 === "Windows"
 
     ```powershell
-    $ rm $HOME\.cargo\bin\uv.exe
-    $ rm $HOME\.cargo\bin\uvx.exe
+    $ rm $HOME\.local\bin\uv.exe
+    $ rm $HOME\.local\bin\uvx.exe
     ```
 
 !!! tip


### PR DESCRIPTION
Reviving https://github.com/astral-sh/uv/pull/2236

Basically implements https://github.com/axodotdev/cargo-dist/issues/287