### PR TITLE
Always attach URL to network errors

### DIFF
--- a/crates/uv-client/src/error.rs
+++ b/crates/uv-client/src/error.rs
@@ -180,7 +180,7 @@ pub enum ErrorKind {
     MetadataNotFound(WheelFilename, String),
 
     /// An error that happened while making a request or in a reqwest middleware.
-    #[error("Failed to fetch {0}")]
+    #[error("Failed to fetch: `{0}`")]
     WrappedReqwestError(Url, #[source] WrappedReqwestError),
 
     #[error("Received some unexpected JSON from {url}")]

--- a/crates/uv-client/src/flat_index.rs
+++ b/crates/uv-client/src/flat_index.rs
@@ -160,14 +160,17 @@ impl<'a> FlatIndexClient<'a> {
             .header("Accept-Encoding", "gzip")
             .header("Accept", "text/html")
             .build()
-            .map_err(ErrorKind::from)?;
+            .map_err(|err| ErrorKind::from_reqwest(url.clone(), err))?;
         let parse_simple_response = |response: Response| {
             async {
                 // Use the response URL, rather than the request URL, as the base for relative URLs.
                 // This ensures that we handle redirects and other URL transformations correctly.
                 let url = response.url().clone();
 
-                let text = response.text().await.map_err(ErrorKind::from)?;
+                let text = response
+                    .text()
+                    .await
+                    .map_err(|err| ErrorKind::from_reqwest(url.clone(), err))?;
                 let SimpleHtml { base, files } = SimpleHtml::parse(&text, &url)
                     .map_err(|err| Error::from_html_err(err, url.clone()))?;
 

--- a/crates/uv-client/src/tls.rs
+++ b/crates/uv-client/src/tls.rs
@@ -7,12 +7,15 @@ pub(crate) enum CertificateError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error(transparent)]
-    Reqwest(#[from] reqwest::Error),
+    Reqwest(reqwest::Error),
 }
 
 /// Return the `Identity` from the provided file.
 pub(crate) fn read_identity(ssl_client_cert: &OsStr) -> Result<Identity, CertificateError> {
     let mut buf = Vec::new();
     fs_err::File::open(ssl_client_cert)?.read_to_end(&mut buf)?;
-    Ok(Identity::from_pem(&buf)?)
+    Identity::from_pem(&buf).map_err(|tls_err| {
+        debug_assert!(tls_err.is_builder(), "must be a rustls::Error internally");
+        CertificateError::Reqwest(tls_err)
+    })
 }

--- a/crates/uv-distribution/src/distribution_database.rs
+++ b/crates/uv-distribution/src/distribution_database.rs
@@ -87,7 +87,8 @@ impl<'a, Context: BuildContext> DistributionDatabase<'a, Context> {
             io::Error::new(
                 io::ErrorKind::TimedOut,
                 format!(
-                    "Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: {}s).", self.client.unmanaged.timeout().as_secs()
+                    "Failed to download distribution due to network timeout. Try increasing UV_HTTP_TIMEOUT (current value: {}s).",
+                    self.client.unmanaged.timeout().as_secs()
                 ),
             )
         } else {

--- a/crates/uv-publish/src/lib.rs
+++ b/crates/uv-publish/src/lib.rs
@@ -79,7 +79,7 @@ pub enum PublishPrepareError {
 #[derive(Error, Debug)]
 pub enum PublishSendError {
     #[error("Failed to send POST request")]
-    ReqwestMiddleware(#[from] reqwest_middleware::Error),
+    ReqwestMiddleware(#[source] reqwest_middleware::Error),
     #[error("Upload failed with status {0}")]
     StatusNoBody(StatusCode, #[source] reqwest::Error),
     #[error("Upload failed with status code {0}. Server says: {1}")]
@@ -336,7 +336,11 @@ pub async fn upload(
         }
 
         let response = result.map_err(|err| {
-            PublishError::PublishSend(file.to_path_buf(), registry.clone(), err.into())
+            PublishError::PublishSend(
+                file.to_path_buf(),
+                registry.clone(),
+                PublishSendError::ReqwestMiddleware(err),
+            )
         })?;
 
         return handle_response(registry, response)

--- a/crates/uv-publish/src/trusted_publishing.rs
+++ b/crates/uv-publish/src/trusted_publishing.rs
@@ -17,9 +17,9 @@ pub enum TrustedPublishingError {
     Var(#[from] VarError),
     #[error(transparent)]
     Url(#[from] url::ParseError),
-    #[error("Failed to fetch {0}")]
+    #[error("Failed to fetch: `{0}`")]
     Reqwest(Url, #[source] reqwest::Error),
-    #[error("Failed to fetch {0}")]
+    #[error("Failed to fetch: `{0}`")]
     ReqwestMiddleware(Url, #[source] reqwest_middleware::Error),
     #[error(transparent)]
     SerdeJson(#[from] serde_json::error::Error),

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -6304,6 +6304,7 @@ fn lock_redact_https() -> Result<()> {
     ----- stderr -----
     error: Failed to prepare distributions
       Caused by: Failed to download `iniconfig==2.0.0`
+      Caused by: Failed to fetch https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
     "###);
 
@@ -6316,6 +6317,7 @@ fn lock_redact_https() -> Result<()> {
     ----- stderr -----
     error: Failed to prepare distributions
       Caused by: Failed to download `iniconfig==2.0.0`
+      Caused by: Failed to fetch https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
     "###);
 
@@ -6355,6 +6357,7 @@ fn lock_redact_https() -> Result<()> {
     ----- stderr -----
     error: Failed to prepare distributions
       Caused by: Failed to download `iniconfig==2.0.0`
+      Caused by: Failed to fetch https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
     "###);
 

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -6304,7 +6304,7 @@ fn lock_redact_https() -> Result<()> {
     ----- stderr -----
     error: Failed to prepare distributions
       Caused by: Failed to download `iniconfig==2.0.0`
-      Caused by: Failed to fetch https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
+      Caused by: Failed to fetch: `https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
     "###);
 

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -6317,7 +6317,7 @@ fn lock_redact_https() -> Result<()> {
     ----- stderr -----
     error: Failed to prepare distributions
       Caused by: Failed to download `iniconfig==2.0.0`
-      Caused by: Failed to fetch https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
+      Caused by: Failed to fetch: `https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
     "###);
 
@@ -6357,7 +6357,7 @@ fn lock_redact_https() -> Result<()> {
     ----- stderr -----
     error: Failed to prepare distributions
       Caused by: Failed to download `iniconfig==2.0.0`
-      Caused by: Failed to fetch https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl
+      Caused by: Failed to fetch: `https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl`
       Caused by: HTTP status client error (401 Unauthorized) for url (https://pypi-proxy.fly.dev/basic-auth/files/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl)
     "###);
 

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -9365,6 +9365,7 @@ fn not_found_direct_url() -> Result<()> {
 
     ----- stderr -----
     error: Failed to download: `iniconfig @ https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl`
+      Caused by: Failed to fetch https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl
       Caused by: HTTP status client error (404 Not Found) for url (https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl)
     "###
     );

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -9365,7 +9365,7 @@ fn not_found_direct_url() -> Result<()> {
 
     ----- stderr -----
     error: Failed to download: `iniconfig @ https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl`
-      Caused by: Failed to fetch https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl
+      Caused by: Failed to fetch: `https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl`
       Caused by: HTTP status client error (404 Not Found) for url (https://files.pythonhosted.org/packages/ef/a6/fake/iniconfig-2.0.0-py3-none-any.whl)
     "###
     );


### PR DESCRIPTION
Due to the enduring problems with #8144 and related issues, I've opted for a more systemic approach and switched all reqwest errors to not use the implicit-try-fallthrough `#[from]`, but an explicit `#[source]` with a URL attached (except for when there is only one or no URL). This guarantees that we get the URL that failed, and helps identifying the responsible code path.

