### PR TITLE
Add basic testing of managed Python installs

### DIFF
--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -119,7 +119,7 @@ ignored = [
 ]
 
 [features]
-default = ["python", "pypi", "git", "performance", "crates-io"]
+default = ["python", "python-managed", "pypi", "git", "performance", "crates-io"]
 # Use better memory allocators, etc. — also turns-on self-update.
 performance = [
     "performance-memory-allocator",
@@ -133,6 +133,8 @@ performance-flate2-backend = ["dep:uv-performance-flate2-backend"]
 python = []
 # Introduces a dependency on a local Python installation with specific patch versions.
 python-patch = []
+# Introduces a dependency on managed Python installations.
+python-managed = []
 # Introduces a dependency on PyPI.
 pypi = []
 # Introduces a dependency on Git.

--- a/crates/uv/tests/it/main.rs
+++ b/crates/uv/tests/it/main.rs
@@ -66,10 +66,13 @@ mod publish;
 
 mod python_dir;
 
-#[cfg(all(feature = "python", feature = "pypi"))]
+#[cfg(feature = "python")]
 mod python_find;
 
-#[cfg(all(feature = "python", feature = "pypi"))]
+#[cfg(feature = "python-managed")]
+mod python_install;
+
+#[cfg(feature = "python")]
 mod python_pin;
 
 #[cfg(all(feature = "python", feature = "pypi"))]

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -1,0 +1,82 @@
+use crate::common::{uv_snapshot, TestContext};
+
+#[test]
+fn python_install() {
+    let context: TestContext = TestContext::new_with_versions(&[]).with_filtered_python_keys();
+
+    // Install the latest version
+    uv_snapshot!(context.filters(), context.python_install(), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Searching for Python installations
+    Installed Python 3.13.0 in [TIME]
+     + cpython-3.13.0-[PLATFORM]
+    "###);
+
+    // Should be a no-op when already installed
+    uv_snapshot!(context.filters(), context.python_install(), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Searching for Python installations
+    Installed Python 3.13.0 in [TIME]
+     + cpython-3.13.0-[PLATFORM]
+    "###);
+
+    // Similarly, when a requested version is already installed
+    uv_snapshot!(context.filters(), context.python_install().arg("3.13"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Searching for Python versions matching: Python 3.13
+    Installed Python 3.13.0 in [TIME]
+     + cpython-3.13.0-[PLATFORM]
+    "###);
+}
+
+#[test]
+fn python_install_freethreaded() {
+    let context: TestContext = TestContext::new_with_versions(&[]).with_filtered_python_keys();
+
+    // Install the latest version
+    uv_snapshot!(context.filters(), context.python_install().arg("3.13t"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Searching for Python versions matching: Python 3.13t
+    Installed Python 3.13.0 in [TIME]
+     + cpython-3.13.0+freethreaded-[PLATFORM]
+    "###);
+
+    // Should be distinct from 3.13
+    uv_snapshot!(context.filters(), context.python_install().arg("3.13"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Searching for Python versions matching: Python 3.13
+    Installed Python 3.13.0 in [TIME]
+     + cpython-3.13.0-[PLATFORM]
+    "###);
+
+    // Should not work with older Python versions
+    uv_snapshot!(context.filters(), context.python_install().arg("3.12t"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Searching for Python versions matching: Python 3.12t
+    error: No download found for request: cpython-3.12t-[PLATFORM]
+    "###);
+}


### PR DESCRIPTION
With a change like https://github.com/astral-sh/uv/pull/8458, we really need tests for these.

I'm just going to take the possible performance hit of these slow tests and deal with optimizing them separately.