### PR TITLE
Invalidate clippy-xwin cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+          # For manual cache invalidation
+          key: v2
+
       - name: "Install Rust toolchain"
         run: rustup target add x86_64-pc-windows-msvc
       - name: "Install cargo-xwin"


### PR DESCRIPTION
Closes https://github.com/astral-sh/uv/issues/8430

The theory is that we're getting a bad cached build because GitHub upgraded then rolled back the runners.