### PR TITLE
Replace `cargo xwin clippy` with native clippy run on Windows again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,37 +108,30 @@ jobs:
       - name: "Clippy"
         run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
-  cargo-clippy-xwin:
-    # Do not set timeout below 15 minutes as uncached xwin Windows SDK download can take 10+ minutes
-    timeout-minutes: 20
+  cargo-clippy-windows:
+    timeout-minutes: 15
     needs: determine_changes
     if: ${{ github.repository == 'astral-sh/uv' && (needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main') }}
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: "windows-latest-xlarge"
     name: "cargo clippy | windows"
     steps:
       - uses: actions/checkout@v4
-      - name: Load xwin cache
-        uses: actions/cache@v4
-        with:
-          path: "${{ github.workspace}}/.xwin"
-          key: cargo-xwin-x86_64
-      - name: Load rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Create Dev Drive using ReFS
+        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
+
+      # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
+      - name: Copy Git Repo to Dev Drive
+        run: |
+          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
+
       - name: "Install Rust toolchain"
-        run: rustup target add x86_64-pc-windows-msvc
-      - name: "Install cargo-xwin"
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-xwin
-      - name: Install xwin dependencies
-        run: sudo apt-get install --no-install-recommends -y lld llvm clang cmake ninja-build
+        run: rustup component add clippy
+
       - name: "Clippy"
-        run: cargo xwin clippy --target x86_64-pc-windows-msvc --workspace --all-targets --all-features --locked --profile fast-build -- -D warnings
-        env:
-          XWIN_ARCH: "x86_64"
-          XWIN_CACHE_DIR: "${{ github.workspace}}/.xwin"
+        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
   cargo-dev-generate-all:
     timeout-minutes: 10


### PR DESCRIPTION
Adds #8181 again

This failure is taking up way too much time and cache misses are feeling frequent.