### PR TITLE
Add `--no-group` support to CLI

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2617,6 +2617,12 @@ pub struct RunArgs {
     #[arg(long, conflicts_with("only_group"))]
     pub group: Vec<GroupName>,
 
+    /// Exclude dependencies from the specified local dependency group.
+    ///
+    /// May be provided multiple times.
+    #[arg(long)]
+    pub no_group: Vec<GroupName>,
+
     /// Only include dependencies from the specified local dependency group.
     ///
     /// May be provided multiple times.
@@ -2807,6 +2813,12 @@ pub struct SyncArgs {
     /// May be provided multiple times.
     #[arg(long, conflicts_with("only_group"))]
     pub group: Vec<GroupName>,
+
+    /// Exclude dependencies from the specified local dependency group.
+    ///
+    /// May be provided multiple times.
+    #[arg(long)]
+    pub no_group: Vec<GroupName>,
 
     /// Only include dependencies from the specified local dependency group.
     ///
@@ -3198,6 +3210,12 @@ pub struct TreeArgs {
     #[arg(long, conflicts_with("only_group"))]
     pub group: Vec<GroupName>,
 
+    /// Exclude dependencies from the specified local dependency group.
+    ///
+    /// May be provided multiple times.
+    #[arg(long)]
+    pub no_group: Vec<GroupName>,
+
     /// Only include dependencies from the specified local dependency group.
     ///
     /// May be provided multiple times.
@@ -3312,6 +3330,12 @@ pub struct ExportArgs {
     /// May be provided multiple times.
     #[arg(long, conflicts_with("only_group"))]
     pub group: Vec<GroupName>,
+
+    /// Exclude dependencies from the specified local dependency group.
+    ///
+    /// May be provided multiple times.
+    #[arg(long)]
+    pub no_group: Vec<GroupName>,
 
     /// Only include dependencies from the specified local dependency group.
     ///

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -823,9 +823,7 @@ async fn lock_and_sync(
         DependencyType::Group(ref group_name) => {
             let extras = ExtrasSpecification::None;
             let dev =
-                DevGroupsSpecification::from(GroupsSpecification::Include(
-                    vec![group_name.clone()],
-                ));
+                DevGroupsSpecification::from(GroupsSpecification::from_group(group_name.clone()));
             (extras, dev)
         }
     };

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -8,8 +8,8 @@ use tracing::debug;
 use uv_cache::Cache;
 use uv_client::{BaseClientBuilder, Connectivity, FlatIndexClient, RegistryClientBuilder};
 use uv_configuration::{
-    Concurrency, Constraints, DevGroupsSpecification, ExtrasSpecification, LowerBound, Reinstall,
-    Upgrade,
+    Concurrency, Constraints, DevGroupsSpecification, ExtrasSpecification, GroupsSpecification,
+    LowerBound, Reinstall, Upgrade,
 };
 use uv_dispatch::BuildDispatch;
 use uv_distribution::DistributionDatabase;
@@ -1361,7 +1361,11 @@ pub(crate) fn validate_dependency_groups(
     pyproject_toml: &PyProjectToml,
     dev: &DevGroupsSpecification,
 ) -> Result<(), ProjectError> {
-    for group in dev.groups().into_iter().flatten() {
+    for group in dev
+        .groups()
+        .into_iter()
+        .flat_map(GroupsSpecification::names)
+    {
         if !pyproject_toml
             .dependency_groups
             .as_ref()

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -253,6 +253,7 @@ impl RunSettings {
             dev,
             no_dev,
             group,
+            no_group,
             only_group,
             module: _,
             only_dev,
@@ -282,7 +283,9 @@ impl RunSettings {
                 flag(all_extras, no_all_extras).unwrap_or_default(),
                 extra.unwrap_or_default(),
             ),
-            dev: DevGroupsSpecification::from_args(dev, no_dev, only_dev, group, only_group),
+            dev: DevGroupsSpecification::from_args(
+                dev, no_dev, only_dev, group, no_group, only_group,
+            ),
             editable: EditableMode::from_args(no_editable),
             with,
             with_editable,
@@ -715,6 +718,7 @@ impl SyncSettings {
             only_dev,
             group,
             only_group,
+            no_group,
             no_editable,
             inexact,
             exact,
@@ -742,7 +746,9 @@ impl SyncSettings {
                 flag(all_extras, no_all_extras).unwrap_or_default(),
                 extra.unwrap_or_default(),
             ),
-            dev: DevGroupsSpecification::from_args(dev, no_dev, only_dev, group, only_group),
+            dev: DevGroupsSpecification::from_args(
+                dev, no_dev, only_dev, group, no_group, only_group,
+            ),
             editable: EditableMode::from_args(no_editable),
             install_options: InstallOptions::new(
                 no_install_project,
@@ -1022,6 +1028,7 @@ impl TreeSettings {
             only_dev,
             no_dev,
             group,
+            no_group,
             only_group,
             locked,
             frozen,
@@ -1033,7 +1040,9 @@ impl TreeSettings {
         } = args;
 
         Self {
-            dev: DevGroupsSpecification::from_args(dev, no_dev, only_dev, group, only_group),
+            dev: DevGroupsSpecification::from_args(
+                dev, no_dev, only_dev, group, no_group, only_group,
+            ),
             locked,
             frozen,
             universal,
@@ -1084,6 +1093,7 @@ impl ExportSettings {
             no_dev,
             only_dev,
             group,
+            no_group,
             only_group,
             header,
             no_header,
@@ -1109,7 +1119,9 @@ impl ExportSettings {
                 flag(all_extras, no_all_extras).unwrap_or_default(),
                 extra.unwrap_or_default(),
             ),
-            dev: DevGroupsSpecification::from_args(dev, no_dev, only_dev, group, only_group),
+            dev: DevGroupsSpecification::from_args(
+                dev, no_dev, only_dev, group, no_group, only_group,
+            ),
             editable: EditableMode::from_args(no_editable),
             hashes: flag(hashes, no_hashes).unwrap_or(true),
             install_options: InstallOptions::new(

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -286,6 +286,10 @@ uv run [OPTIONS] [COMMAND]
 
 </dd><dt><code>--no-editable</code></dt><dd><p>Install any editable dependencies, including the project and any workspace members, as non-editable</p>
 
+</dd><dt><code>--no-group</code> <i>no-group</i></dt><dd><p>Exclude dependencies from the specified local dependency group.</p>
+
+<p>May be provided multiple times.</p>
+
 </dd><dt><code>--no-index</code></dt><dd><p>Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those provided via <code>--find-links</code></p>
 
 </dd><dt><code>--no-progress</code></dt><dd><p>Hide all progress outputs.</p>
@@ -1539,6 +1543,10 @@ uv sync [OPTIONS]
 
 </dd><dt><code>--no-editable</code></dt><dd><p>Install any editable dependencies, including the project and any workspace members, as non-editable</p>
 
+</dd><dt><code>--no-group</code> <i>no-group</i></dt><dd><p>Exclude dependencies from the specified local dependency group.</p>
+
+<p>May be provided multiple times.</p>
+
 </dd><dt><code>--no-index</code></dt><dd><p>Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those provided via <code>--find-links</code></p>
 
 </dd><dt><code>--no-install-package</code> <i>no-install-package</i></dt><dd><p>Do not install the given package(s).</p>
@@ -2185,6 +2193,10 @@ uv export [OPTIONS]
 
 <p>By default, all workspace members and their dependencies are included in the exported requirements file, with all of their dependencies. The <code>--no-emit-workspace</code> option allows exclusion of all the workspace members while retaining their dependencies.</p>
 
+</dd><dt><code>--no-group</code> <i>no-group</i></dt><dd><p>Exclude dependencies from the specified local dependency group.</p>
+
+<p>May be provided multiple times.</p>
+
 </dd><dt><code>--no-hashes</code></dt><dd><p>Omit hashes in the generated output</p>
 
 </dd><dt><code>--no-header</code></dt><dd><p>Exclude the comment header at the top of the generated output file</p>
@@ -2501,6 +2513,10 @@ uv tree [OPTIONS]
 </dd><dt><code>--no-dedupe</code></dt><dd><p>Do not de-duplicate repeated dependencies. Usually, when a package has already displayed its dependencies, further occurrences will not re-display its dependencies, and will include a (*) to indicate it has already been shown. This flag will cause those duplicates to be repeated</p>
 
 </dd><dt><code>--no-dev</code></dt><dd><p>Omit development dependencies</p>
+
+</dd><dt><code>--no-group</code> <i>no-group</i></dt><dd><p>Exclude dependencies from the specified local dependency group.</p>
+
+<p>May be provided multiple times.</p>
 
 </dd><dt><code>--no-index</code></dt><dd><p>Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and those provided via <code>--find-links</code></p>
 


### PR DESCRIPTION
## Summary

Now that `default-groups` can include more than just `"dev"`, it makes sense to allow users to remove groups with `--no-group`.
