### PR TITLE
Use base executable to set virtualenv Python path

### DIFF
--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -250,24 +250,6 @@ pub fn canonicalize_executable(path: impl AsRef<Path>) -> std::io::Result<PathBu
     }
 }
 
-/// Resolve a symlink for an executable. Unlike `fs_err::canonicalize`, this does not resolve
-/// symlinks recursively.
-pub fn read_executable_link(executable: &Path) -> Result<Option<PathBuf>, std::io::Error> {
-    let Ok(link) = executable.read_link() else {
-        return Ok(None);
-    };
-    if link.is_absolute() {
-        Ok(Some(link))
-    } else {
-        executable
-            .parent()
-            .map(|parent| parent.join(link))
-            .as_deref()
-            .map(normalize_absolute_path)
-            .transpose()
-    }
-}
-
 /// Compute a path describing `path` relative to `base`.
 ///
 /// `lib/python/site-packages/foo/__init__.py` and `lib/python/site-packages` -> `foo/__init__.py`

--- a/crates/uv-python/python/get_interpreter_info.py
+++ b/crates/uv-python/python/get_interpreter_info.py
@@ -563,6 +563,7 @@ def main() -> None:
         "sys_executable": sys.executable,
         "sys_path": sys.path,
         "stdlib": sysconfig.get_path("stdlib"),
+        "sysconfig_prefix": sysconfig.get_config_var("prefix"),
         "scheme": get_scheme(),
         "virtualenv": get_virtualenv(),
         "platform": os_and_arch,

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -438,7 +438,7 @@ impl Interpreter {
     /// `python-build-standalone`; if it returns `false`, the interpreter is definitely _not_ from
     /// `python-build-standalone`.
     ///
-    /// See: https://github.com/indygreg/python-build-standalone/issues/382
+    /// See: <https://github.com/indygreg/python-build-standalone/issues/382>
     pub fn is_standalone(&self) -> bool {
         self.sysconfig_prefix()
             .is_some_and(|prefix| prefix == Path::new("/install"))

--- a/crates/uv-python/src/interpreter.rs
+++ b/crates/uv-python/src/interpreter.rs
@@ -45,6 +45,7 @@ pub struct Interpreter {
     sys_executable: PathBuf,
     sys_path: Vec<PathBuf>,
     stdlib: PathBuf,
+    sysconfig_prefix: Option<PathBuf>,
     tags: OnceLock<Tags>,
     target: Option<Target>,
     prefix: Option<Prefix>,
@@ -78,6 +79,7 @@ impl Interpreter {
             sys_executable: info.sys_executable,
             sys_path: info.sys_path,
             stdlib: info.stdlib,
+            sysconfig_prefix: info.sysconfig_prefix,
             tags: OnceLock::new(),
             target: None,
             prefix: None,
@@ -365,6 +367,11 @@ impl Interpreter {
         &self.stdlib
     }
 
+    /// Return the `prefix` path for this Python interpreter, as returned by `sysconfig.get_config_var("prefix")`.
+    pub fn sysconfig_prefix(&self) -> Option<&Path> {
+        self.sysconfig_prefix.as_deref()
+    }
+
     /// Return the `purelib` path for this Python interpreter, as returned by `sysconfig.get_paths()`.
     pub fn purelib(&self) -> &Path {
         &self.scheme.purelib
@@ -422,6 +429,19 @@ impl Interpreter {
     /// Return the `--prefix` directory for this interpreter, if any.
     pub fn prefix(&self) -> Option<&Prefix> {
         self.prefix.as_ref()
+    }
+
+    /// Returns `true` if an [`Interpreter`] may be a `python-build-standalone` interpreter.
+    ///
+    /// This method may return false positives, but it should not return false negatives. In other
+    /// words, if this method returns `true`, the interpreter _may_ be from
+    /// `python-build-standalone`; if it returns `false`, the interpreter is definitely _not_ from
+    /// `python-build-standalone`.
+    ///
+    /// See: https://github.com/indygreg/python-build-standalone/issues/382
+    pub fn is_standalone(&self) -> bool {
+        self.sysconfig_prefix()
+            .is_some_and(|prefix| prefix == Path::new("/install"))
     }
 
     /// Return the [`Layout`] environment used to install wheels into this interpreter.
@@ -605,6 +625,7 @@ struct InterpreterInfo {
     sys_executable: PathBuf,
     sys_path: Vec<PathBuf>,
     stdlib: PathBuf,
+    sysconfig_prefix: Option<PathBuf>,
     pointer_size: PointerSize,
     gil_disabled: bool,
 }

--- a/crates/uv-virtualenv/src/virtualenv.rs
+++ b/crates/uv-virtualenv/src/virtualenv.rs
@@ -57,31 +57,20 @@ pub(crate) fn create(
     // considered the "base" for the virtual environment. This is typically the Python executable
     // from the [`Interpreter`]; however, if the interpreter is a virtual environment itself, then
     // the base Python executable is the Python executable of the interpreter's base interpreter.
-    let base_python = if cfg!(unix) {
-        // On Unix, follow symlinks to resolve the base interpreter, since the Python executable in
-        // a virtual environment is a symlink to the base interpreter.
-        uv_fs::canonicalize_executable(interpreter.sys_executable())?
-    } else if cfg!(windows) {
-        // On Windows, follow `virtualenv`. If we're in a virtual environment, use
-        // `sys._base_executable` if it exists; if not, use `sys.base_prefix`. For example, with
-        // Python installed from the Windows Store, `sys.base_prefix` is slightly "incorrect".
+    let base_python = if cfg!(unix) && interpreter.is_standalone() {
+        // In `python-build-standalone`, a symlinked interpreter will return its own executable path
+        // as `sys._base_executable`. Using the symlinked path as the base Python executable is
+        // incorrect,  since it will cause `home` to point to something that is _not_ a Python
+        // installation.
         //
-        // If we're _not_ in a virtual environment, use the interpreter's executable, since it's
-        // already a "system Python". We canonicalize the path to ensure that it's real and
-        // consistent, though we don't expect any symlinks on Windows.
-        if interpreter.is_virtualenv() {
-            if let Some(base_executable) = interpreter.sys_base_executable() {
-                base_executable.to_path_buf()
-            } else {
-                // Assume `python.exe`, though the exact executable name is never used (below) on
-                // Windows, only its parent directory.
-                interpreter.sys_base_prefix().join("python.exe")
-            }
-        } else {
-            interpreter.sys_executable().to_path_buf()
-        }
+        // Instead, we want to fully resolve the symlink to the actual Python executable.
+        uv_fs::canonicalize_executable(interpreter.sys_executable())?
     } else {
-        unimplemented!("Only Windows and Unix are supported")
+        std::path::absolute(
+            interpreter
+                .sys_base_executable()
+                .unwrap_or(interpreter.sys_executable()),
+        )?
     };
 
     // Validate the existing location.


### PR DESCRIPTION
## Summary

See extensive discussion in https://github.com/astral-sh/uv/pull/8433#issuecomment-2430472849.

This PR brings us into alignment with the standard library by using `sys._base_executable` rather than canonicalizing the executable path.

The benefits are primarily for Homebrew, where we'll now resolve to paths like `/opt/homebrew/opt/python@3.12/bin` instead of the undesirable `/opt/homebrew/Cellar/python@3.9/3.9.19_1/Frameworks/Python.framework/Versions/3.9/bin`.

Most other users should see no change, though in some cases, nested virtual environments now have slightly different behavior -- namely, they _sometimes_ resolve to the virtual environment Python (at least for Homebrew; not for rtx or uv Pythons though). See [here](https://docs.google.com/spreadsheets/d/1Vw5ClYEjgrBJJhQiwa3cCenIA1GbcRyudYN9NwQaEcM/edit?gid=0#gid=0) for a breakdown.

Closes https://github.com/astral-sh/uv/issues/1640.
Closes https://github.com/astral-sh/uv/issues/1795.
