### PR TITLE
`uv python install`: remove the existing version only after the new installation is downloaded successfully

### DIFF
--- a/crates/uv-python/src/installation.rs
+++ b/crates/uv-python/src/installation.rs
@@ -132,7 +132,7 @@ impl PythonInstallation {
 
         info!("Fetching requested Python...");
         let result = download
-            .fetch(&client, installations_dir, &cache_dir, reporter)
+            .fetch(&client, installations_dir, &cache_dir, false, reporter)
             .await?;
 
         let path = match result {

--- a/crates/uv/src/commands/python/install.rs
+++ b/crates/uv/src/commands/python/install.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use fs_err as fs;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use itertools::Itertools;
@@ -90,7 +89,6 @@ pub(crate) async fn install(
                 )?;
             }
             if reinstall {
-                fs::remove_dir_all(installation.path())?;
                 uninstalled.push(installation.key().clone());
                 unfilled_requests.push(download_request);
             }
@@ -145,7 +143,13 @@ pub(crate) async fn install(
             (
                 download.key(),
                 download
-                    .fetch(&client, installations_dir, &cache_dir, Some(&reporter))
+                    .fetch(
+                        &client,
+                        installations_dir,
+                        &cache_dir,
+                        reinstall,
+                        Some(&reporter),
+                    )
                     .await,
             )
         });


### PR DESCRIPTION
## Summary

This PR delays the removal of an existing version after downloading the new version when running `uv python install --reinstall`.

If the download fails, we can keep the existing version working.

## Test Plan

```console
$ cargo run -- python install 3.13
$ cargo run -- python install --reinstall 3.13 # when downloading, `ctrl-c` to interrupt
$ cargo run -- python list
```

