### PR TITLE
Improve documentation of manually adding branch, rev, and tag

### DIFF
--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -154,7 +154,7 @@ Git dependencies can also be manually added or edited in the `pyproject.toml` wi
     dependencies = [
         "httpx",
     ]
-    
+
     [tool.uv.sources]
     httpx = { git = "https://github.com/encode/httpx", tag = "0.27.0" }
     ```
@@ -166,7 +166,7 @@ Git dependencies can also be manually added or edited in the `pyproject.toml` wi
     dependencies = [
         "httpx",
     ]
-    
+
     [tool.uv.sources]
     httpx = { git = "https://github.com/encode/httpx", branch = "main" }
     ```
@@ -178,7 +178,7 @@ Git dependencies can also be manually added or edited in the `pyproject.toml` wi
     dependencies = [
         "httpx",
     ]
-    
+
     [tool.uv.sources]
     httpx = { git = "https://github.com/encode/httpx", rev = "326b943" }
     ```

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -145,7 +145,7 @@ $ uv add git+https://github.com/encode/httpx --rev 326b943
 ```
 
 Git dependencies can also be manually added or edited in the `pyproject.toml` with the
-`{ git = <url> }` syntax. A target revision may be specified with one of: `rev`, `tag`, or `branch`.
+`{ git = <url> }` syntax. A target revision may be specified with one of: `tag`, `branch`, or `rev` (i.e., commmit).
 
 === "tag"
 
@@ -173,7 +173,7 @@ Git dependencies can also be manually added or edited in the `pyproject.toml` wi
 
 === "rev"
 
-   ```toml title="pyproject.toml"
+    ```toml title="pyproject.toml"
     [project]
     dependencies = [
         "httpx",

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -136,7 +136,7 @@ dependencies = [
 httpx = { git = "https://github.com/encode/httpx" }
 ```
 
-A revision, tag, or branch may also be included:
+A revision (i.e., commit), tag, or branch may also be included:
 
 ```console
 $ uv add git+https://github.com/encode/httpx --tag 0.27.0
@@ -146,6 +146,43 @@ $ uv add git+https://github.com/encode/httpx --rev 326b943
 
 Git dependencies can also be manually added or edited in the `pyproject.toml` with the
 `{ git = <url> }` syntax. A target revision may be specified with one of: `rev`, `tag`, or `branch`.
+
+=== "tag"
+
+    ```toml title="pyproject.toml"
+    [project]
+    dependencies = [
+        "httpx",
+    ]
+    
+    [tool.uv.sources]
+    httpx = { git = "https://github.com/encode/httpx", tag = "0.27.0" }
+    ```
+
+=== "branch"
+
+    ```toml title="pyproject.toml"
+    [project]
+    dependencies = [
+        "httpx",
+    ]
+    
+    [tool.uv.sources]
+    httpx = { git = "https://github.com/encode/httpx", branch = "main" }
+    ```
+
+=== "rev"
+
+   ```toml title="pyproject.toml"
+    [project]
+    dependencies = [
+        "httpx",
+    ]
+    
+    [tool.uv.sources]
+    httpx = { git = "https://github.com/encode/httpx", rev = "326b943" }
+    ```
+
 A `subdirectory` may be specified if the package isn't in the repository root.
 
 ### URL

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -141,12 +141,12 @@ A revision (i.e., commit), tag, or branch may also be included:
 ```console
 $ uv add git+https://github.com/encode/httpx --tag 0.27.0
 $ uv add git+https://github.com/encode/httpx --branch main
-$ uv add git+https://github.com/encode/httpx --rev 326b943
+$ uv add git+https://github.com/encode/httpx --rev 326b9431c761e1ef1e00b9f760d1f654c8db48c6
 ```
 
 Git dependencies can also be manually added or edited in the `pyproject.toml` with the
-`{ git = <url> }` syntax. A target revision may be specified with one of: `tag`, `branch`, or `rev`
-(i.e., commit).
+`{ git = <url> }` syntax. A target revision may be specified with one of: `rev` (i.e., commit),
+`tag`, or `branch`.
 
 === "tag"
 
@@ -181,7 +181,7 @@ Git dependencies can also be manually added or edited in the `pyproject.toml` wi
     ]
 
     [tool.uv.sources]
-    httpx = { git = "https://github.com/encode/httpx", rev = "326b943" }
+    httpx = { git = "https://github.com/encode/httpx", rev = "326b9431c761e1ef1e00b9f760d1f654c8db48c6" }
     ```
 
 A `subdirectory` may be specified if the package isn't in the repository root.

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -145,7 +145,8 @@ $ uv add git+https://github.com/encode/httpx --rev 326b943
 ```
 
 Git dependencies can also be manually added or edited in the `pyproject.toml` with the
-`{ git = <url> }` syntax. A target revision may be specified with one of: `tag`, `branch`, or `rev` (i.e., commit).
+`{ git = <url> }` syntax. A target revision may be specified with one of: `tag`, `branch`, or `rev`
+(i.e., commit).
 
 === "tag"
 

--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -145,7 +145,7 @@ $ uv add git+https://github.com/encode/httpx --rev 326b943
 ```
 
 Git dependencies can also be manually added or edited in the `pyproject.toml` with the
-`{ git = <url> }` syntax. A target revision may be specified with one of: `tag`, `branch`, or `rev` (i.e., commmit).
+`{ git = <url> }` syntax. A target revision may be specified with one of: `tag`, `branch`, or `rev` (i.e., commit).
 
 === "tag"
 


### PR DESCRIPTION
Closes #8490 by improving the documentation to make it more obvious how to manually edit the `pyproject.toml` if you want to explicitly set the branch, rev (commit), or tag.