### PR TITLE
Use `dev-dependencies` and `requires-dev` for lockfile compatibility

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2043,7 +2043,7 @@ impl Package {
                 }
             }
             if !dependency_groups.is_empty() {
-                table.insert("dependency-groups", Item::Table(dependency_groups));
+                table.insert("dev-dependencies", Item::Table(dependency_groups));
             }
         }
 
@@ -2108,7 +2108,7 @@ impl Package {
                     }
                 }
                 if !dependency_groups.is_empty() {
-                    metadata_table.insert("dependency-groups", Item::Table(dependency_groups));
+                    metadata_table.insert("requires-dev", Item::Table(dependency_groups));
                 }
             }
 
@@ -2218,7 +2218,7 @@ struct PackageWire {
     dependencies: Vec<DependencyWire>,
     #[serde(default)]
     optional_dependencies: BTreeMap<ExtraName, Vec<DependencyWire>>,
-    #[serde(default, alias = "dev-dependencies")]
+    #[serde(default, rename = "dev-dependencies")]
     dependency_groups: BTreeMap<GroupName, Vec<DependencyWire>>,
 }
 
@@ -2227,7 +2227,7 @@ struct PackageWire {
 struct PackageMetadata {
     #[serde(default)]
     requires_dist: BTreeSet<Requirement>,
-    #[serde(default, alias = "requires-dev")]
+    #[serde(default, rename = "requires-dev")]
     dependency_groups: BTreeMap<GroupName, BTreeSet<Requirement>>,
 }
 

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -1074,14 +1074,14 @@ fn add_remove_dev() -> Result<()> {
         version = "0.1.0"
         source = { editable = "." }
 
-        [package.dependency-groups]
+        [package.dev-dependencies]
         dev = [
             { name = "anyio" },
         ]
 
         [package.metadata]
 
-        [package.metadata.dependency-groups]
+        [package.metadata.requires-dev]
         dev = [{ name = "anyio", specifier = "==3.7.0" }]
 
         [[package]]

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -4541,7 +4541,7 @@ fn lock_dev() -> Result<()> {
             { name = "iniconfig" },
         ]
 
-        [package.dependency-groups]
+        [package.dev-dependencies]
         dev = [
             { name = "typing-extensions" },
         ]
@@ -4549,7 +4549,7 @@ fn lock_dev() -> Result<()> {
         [package.metadata]
         requires-dist = [{ name = "iniconfig" }]
 
-        [package.metadata.dependency-groups]
+        [package.metadata.requires-dev]
         dev = [{ name = "typing-extensions", url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl" }]
 
         [[package]]
@@ -6153,14 +6153,14 @@ fn lock_dev_transitive() -> Result<()> {
         version = "0.1.0"
         source = { editable = "baz" }
 
-        [package.dependency-groups]
+        [package.dev-dependencies]
         dev = [
             { name = "typing-extensions" },
         ]
 
         [package.metadata]
 
-        [package.metadata.dependency-groups]
+        [package.metadata.requires-dev]
         dev = [{ name = "typing-extensions", specifier = ">4" }]
 
         [[package]]
@@ -6170,7 +6170,7 @@ fn lock_dev_transitive() -> Result<()> {
 
         [package.metadata]
 
-        [package.metadata.dependency-groups]
+        [package.metadata.requires-dev]
         dev = [{ name = "anyio" }]
 
         [[package]]
@@ -7077,7 +7077,7 @@ fn lock_no_sources() -> Result<()> {
             { name = "anyio" },
         ]
 
-        [package.dependency-groups]
+        [package.dev-dependencies]
         dev = [
             { name = "typing-extensions" },
         ]
@@ -7085,7 +7085,7 @@ fn lock_no_sources() -> Result<()> {
         [package.metadata]
         requires-dist = [{ name = "anyio", directory = "anyio" }]
 
-        [package.metadata.dependency-groups]
+        [package.metadata.requires-dev]
         dev = [{ name = "typing-extensions", specifier = ">4" }]
 
         [[package]]
@@ -7167,7 +7167,7 @@ fn lock_no_sources() -> Result<()> {
             { name = "anyio" },
         ]
 
-        [package.dependency-groups]
+        [package.dev-dependencies]
         dev = [
             { name = "typing-extensions" },
         ]
@@ -7175,7 +7175,7 @@ fn lock_no_sources() -> Result<()> {
         [package.metadata]
         requires-dist = [{ name = "anyio" }]
 
-        [package.metadata.dependency-groups]
+        [package.metadata.requires-dev]
         dev = [{ name = "typing-extensions", specifier = ">4" }]
 
         [[package]]
@@ -11017,7 +11017,7 @@ fn lock_dev_dependencies_alias() -> Result<()> {
             { name = "typing-extensions" },
         ]
 
-        [package.dependency-groups]
+        [package.dev-dependencies]
         dev = [
             { name = "iniconfig" },
         ]
@@ -11025,7 +11025,7 @@ fn lock_dev_dependencies_alias() -> Result<()> {
         [package.metadata]
         requires-dist = [{ name = "typing-extensions" }]
 
-        [package.metadata.dependency-groups]
+        [package.metadata.requires-dev]
         dev = [{ name = "iniconfig" }]
 
         [[package]]
@@ -12412,14 +12412,14 @@ fn lock_dropped_dev_extra() -> Result<()> {
         version = "0.1.0"
         source = { editable = "." }
 
-        [package.dependency-groups]
+        [package.dev-dependencies]
         dev = [
             { name = "coverage" },
         ]
 
         [package.metadata]
 
-        [package.metadata.dependency-groups]
+        [package.metadata.requires-dev]
         dev = [{ name = "coverage", extras = ["toml"] }]
         "###
         );
@@ -13382,7 +13382,7 @@ fn lock_explicit_virtual_project() -> Result<()> {
             { name = "black" },
         ]
 
-        [package.dependency-groups]
+        [package.dev-dependencies]
         dev = [
             { name = "anyio" },
         ]
@@ -13390,7 +13390,7 @@ fn lock_explicit_virtual_project() -> Result<()> {
         [package.metadata]
         requires-dist = [{ name = "black" }]
 
-        [package.metadata.dependency-groups]
+        [package.metadata.requires-dev]
         dev = [{ name = "anyio" }]
 
         [[package]]
@@ -13599,7 +13599,7 @@ fn lock_implicit_virtual_project() -> Result<()> {
             { name = "black" },
         ]
 
-        [package.dependency-groups]
+        [package.dev-dependencies]
         dev = [
             { name = "anyio" },
         ]
@@ -13607,7 +13607,7 @@ fn lock_implicit_virtual_project() -> Result<()> {
         [package.metadata]
         requires-dist = [{ name = "black" }]
 
-        [package.metadata.dependency-groups]
+        [package.metadata.requires-dev]
         dev = [{ name = "anyio" }]
 
         [[package]]
@@ -16327,7 +16327,7 @@ fn lock_group_include() -> Result<()> {
             { name = "typing-extensions" },
         ]
 
-        [package.dependency-groups]
+        [package.dev-dependencies]
         bar = [
             { name = "trio" },
         ]
@@ -16339,7 +16339,7 @@ fn lock_group_include() -> Result<()> {
         [package.metadata]
         requires-dist = [{ name = "typing-extensions" }]
 
-        [package.metadata.dependency-groups]
+        [package.metadata.requires-dev]
         bar = [{ name = "trio" }]
         foo = [
             { name = "anyio" },

--- a/crates/uv/tests/it/snapshots/it__ecosystem__github-wikidata-bot-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__github-wikidata-bot-lock-file.snap
@@ -116,7 +116,7 @@ dependencies = [
     { name = "yarl" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "httpx" },
     { name = "pytest" },
@@ -135,7 +135,7 @@ requires-dist = [
     { name = "yarl", specifier = ">=1.9,<2" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.27.0,<0.28" },
     { name = "pytest", specifier = ">=8.0.0,<9" },

--- a/crates/uv/tests/it/snapshots/it__ecosystem__packse-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__packse-lock-file.snap
@@ -332,7 +332,7 @@ serve = [
     { name = "watchfiles" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "psutil" },
     { name = "pytest" },
@@ -352,7 +352,7 @@ requires-dist = [
     { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "psutil", specifier = ">=5.9.7" },
     { name = "pytest", specifier = ">=7.4.3" },

--- a/crates/uv/tests/it/snapshots/it__ecosystem__warehouse-lock-file.snap
+++ b/crates/uv/tests/it/snapshots/it__ecosystem__warehouse-lock-file.snap
@@ -3889,7 +3889,7 @@ deploy = [
     { name = "gunicorn" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "asyncudp" },
     { name = "black" },
@@ -4033,7 +4033,7 @@ requires-dist = [
     { name = "zxcvbn" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "asyncudp", specifier = ">=0.7" },
     { name = "black", specifier = "==24.4.2" },

--- a/crates/uv/tests/it/snapshots/it__workflow__packse_add_remove_existing_package_noop-2.snap
+++ b/crates/uv/tests/it/snapshots/it__workflow__packse_add_remove_existing_package_noop-2.snap
@@ -328,7 +328,7 @@ serve = [
     { name = "watchfiles" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "psutil" },
     { name = "pytest" },
@@ -348,7 +348,7 @@ requires-dist = [
     { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "psutil", specifier = ">=5.9.7" },
     { name = "pytest", specifier = ">=7.4.3" },

--- a/crates/uv/tests/it/snapshots/it__workflow__packse_add_remove_one_package-2.snap
+++ b/crates/uv/tests/it/snapshots/it__workflow__packse_add_remove_one_package-2.snap
@@ -328,7 +328,7 @@ serve = [
     { name = "watchfiles" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "psutil" },
     { name = "pytest" },
@@ -348,7 +348,7 @@ requires-dist = [
     { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "psutil", specifier = ">=5.9.7" },
     { name = "pytest", specifier = ">=7.4.3" },

--- a/crates/uv/tests/it/snapshots/it__workflow__packse_promote_transitive_to_direct_then_remove-2.snap
+++ b/crates/uv/tests/it/snapshots/it__workflow__packse_promote_transitive_to_direct_then_remove-2.snap
@@ -328,7 +328,7 @@ serve = [
     { name = "watchfiles" },
 ]
 
-[package.dependency-groups]
+[package.dev-dependencies]
 dev = [
     { name = "psutil" },
     { name = "pytest" },
@@ -348,7 +348,7 @@ requires-dist = [
     { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
 ]
 
-[package.metadata.dependency-groups]
+[package.metadata.requires-dev]
 dev = [
     { name = "psutil", specifier = ">=5.9.7" },
     { name = "pytest", specifier = ">=7.4.3" },

--- a/crates/uv/tests/it/workflow.rs
+++ b/crates/uv/tests/it/workflow.rs
@@ -72,7 +72,7 @@ fn packse_add_remove_one_package() {
              { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
          ]
 
-         [package.metadata.dependency-groups]
+         [package.metadata.requires-dev]
          dev = [
              { name = "psutil", specifier = ">=5.9.7" },
              { name = "pytest", specifier = ">=7.4.3" },
@@ -160,7 +160,7 @@ fn packse_add_remove_one_package() {
              { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
          ]
 
-         [package.metadata.dependency-groups]
+         [package.metadata.requires-dev]
          dev = [
              { name = "psutil", specifier = ">=5.9.7" },
              { name = "pytest", specifier = ">=7.4.3" },
@@ -315,7 +315,7 @@ fn packse_promote_transitive_to_direct_then_remove() {
              { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
          ]
 
-         [package.metadata.dependency-groups]
+         [package.metadata.requires-dev]
          dev = [
              { name = "psutil", specifier = ">=5.9.7" },
              { name = "pytest", specifier = ">=7.4.3" },
@@ -373,7 +373,7 @@ fn packse_promote_transitive_to_direct_then_remove() {
              { name = "watchfiles", marker = "extra == 'serve'", specifier = ">=0.21.0" },
          ]
 
-         [package.metadata.dependency-groups]
+         [package.metadata.requires-dev]
          dev = [
              { name = "psutil", specifier = ">=5.9.7" },
              { name = "pytest", specifier = ">=7.4.3" },


### PR DESCRIPTION
## Summary

Per discussion on Discord, we're going to keep these names for now (changed in #8391 but not yet released) for compatibility. They're just cosmetic, but with the changes as-is, if you ran an older uv version over a newer lockfile...

- For `uv sync`: the lockfile would be invalidated, and we'd re-resolve.
- For `uv sync --frozen`: we'd silently skip the development dependencies.

We'll change these names in the future once we've added better error handling around lockfile versions (#8465).