### PR TITLE
Avoid rewriting `[[tool.uv.index]]` entries when credentials are provided

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5341,6 +5341,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "url",
+ "uv-cache-key",
  "uv-distribution-types",
  "uv-fs",
  "uv-git",

--- a/crates/uv-workspace/Cargo.toml
+++ b/crates/uv-workspace/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 workspace = true
 
 [dependencies]
+uv-cache-key = { workspace = true }
 uv-distribution-types = { workspace = true }
 uv-fs = { workspace = true, features = ["tokio", "schemars"] }
 uv-git = { workspace = true }


### PR DESCRIPTION
## Summary

Instead of creating a new entry, we should reuse the existing entry (to preserve decor); similarly, we should avoid overwriting fields that are already "correct".

Closes https://github.com/astral-sh/uv/issues/8483.
