### PR TITLE
fix: usage of `a deprecated Node.js version` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1633,12 +1633,7 @@ jobs:
         run: chmod +x ./uv
 
       - name: "Print Python path"
-        run: |
-          echo "Python version: $(python --version)"
-          echo "Python path: $(which python)"
-          echo "Python3.9 path: $(which python3.9)"
-          echo "Pyenv path: $(which pyenv)"
-          echo "PATH: $PATH"
+        run: echo $(which python3.9)
 
       - name: "Validate global Python install"
         run: python3.9 scripts/check_system_python.py --uv ./uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1606,9 +1606,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Install pyenv"
-        uses: "gabrielfalcao/pyenv-action@v18"
-        with:
-          default: 3.9.7
+        run: |
+          curl https://pyenv.run | bash
+          echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> ~/.bashrc
+          echo 'eval "$(pyenv init --path)"' >> ~/.bashrc
+          echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+          echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc
+          source ~/.bashrc
 
       - name: "Download binary"
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1607,12 +1607,22 @@ jobs:
 
       - name: "Install pyenv"
         run: |
+          # Install pyenv
           curl https://pyenv.run | bash
-          echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> ~/.bashrc
-          echo 'eval "$(pyenv init --path)"' >> ~/.bashrc
-          echo 'eval "$(pyenv init -)"' >> ~/.bashrc
-          echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc
-          source ~/.bashrc
+
+          # Set up environment variables for current step
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init -)"
+
+          # Install Python 3.9
+          pyenv install 3.9
+          pyenv global 3.9
+
+          # Make environment variables persist across steps
+          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
+          echo "$HOME/.pyenv/bin" >> $GITHUB_PATH
+          echo "$HOME/.pyenv/shims" >> $GITHUB_PATH
 
       - name: "Download binary"
         uses: actions/download-artifact@v4
@@ -1623,7 +1633,12 @@ jobs:
         run: chmod +x ./uv
 
       - name: "Print Python path"
-        run: echo $(which python3.9)
+        run: |
+          echo "Python version: $(python --version)"
+          echo "Python path: $(which python)"
+          echo "Python3.9 path: $(which python3.9)"
+          echo "Pyenv path: $(which pyenv)"
+          echo "PATH: $PATH"
 
       - name: "Validate global Python install"
         run: python3.9 scripts/check_system_python.py --uv ./uv


### PR DESCRIPTION
fixes #8505.

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

[`ci.yml`](https://github.com/astral-sh/uv/blob/main/.github/workflows/ci.yml) uses [`gabrielfalcao/pyenv-action@v18`](https://github.com/gabrielfalcao/pyenv-action/), which [uses `a deprecated Node.js version`](https://github.com/astral-sh/uv/actions/runs/11483963555).

This pull request aims to remove any usage of `a deprecated Node.js version` from [`ci.yml`](https://github.com/astral-sh/uv/blob/main/.github/workflows/ci.yml).

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I attempted to test this but [canceled the run on my fork](https://github.com/hamirmahal/uv/actions/runs/11484989508/job/31964058415) after it waited for a runner for over 10 minutes with no result.

<!-- How was it tested? -->