### PR TITLE
Don't allow non-string email in authors

### DIFF
--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -605,14 +605,19 @@ enum License {
 /// The entry is derived from the email format of `John Doe <john.doe@example.net>`. You need to
 /// provide at least name or email.
 #[derive(Deserialize, Debug, Clone)]
-#[serde(untagged, expecting = "a table with 'name' and/or 'email' keys")]
+// deny_unknown_fields prevents using the name field when the email is not a string.
+#[serde(
+    untagged,
+    deny_unknown_fields,
+    expecting = "a table with 'name' and/or 'email' keys"
+)]
 enum Contact {
+    /// TODO(konsti): RFC 822 validation.
+    NameEmail { name: String, email: String },
     /// TODO(konsti): RFC 822 validation.
     Name { name: String },
     /// TODO(konsti): RFC 822 validation.
     Email { email: String },
-    /// TODO(konsti): RFC 822 validation.
-    NameEmail { name: String, email: String },
 }
 
 /// The `[build-system]` section of a pyproject.toml as specified in PEP 517.


### PR DESCRIPTION
Previously, the case below would pass by matching the name variant, ignoring the invalid email address.

```toml
[project]
name = "hello-world"
version = "0.1.0"
authors = [
    { name = "John Doe", email = 1 }
]
```

Usually, we don't use `deny_unknown_fields` for blocking too much, but here it's needed to prevent fallthrough (it avoids writing a custom deserializer).

This affects the build backend (preview) only.