### PR TITLE
Add reference to `uv build` and `uv publish` in the landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ An extremely fast Python package and project manager, written in Rust.
 
 ## Highlights
 
-- 🚀 A single tool to replace `pip`, `pip-tools`, `pipx`, `poetry`, `pyenv`, `virtualenv`, and more.
+- 🚀 A single tool to replace `pip`, `pip-tools`, `pipx`, `poetry`, `pyenv`, `twine`, `virtualenv`,
+  and more.
 - ⚡️ [10-100x faster](https://github.com/astral-sh/uv/blob/main/BENCHMARKS.md) than `pip`.
 - 🐍 [Installs and manages](#python-management) Python versions.
 - 🛠️ [Runs and installs](#tool-management) Python applications.
@@ -100,6 +101,9 @@ All checks passed!
 ```
 
 See the [project documentation](https://docs.astral.sh/uv/guides/projects/) to get started.
+
+uv also supports building and publishing projects, even if they're not managed with uv. See the
+[publish guide](./guides/publish.md) to learn more.
 
 ### Tool management
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,8 @@ An extremely fast Python package and project manager, written in Rust.
 
 ## Highlights
 
-- 🚀 A single tool to replace `pip`, `pip-tools`, `pipx`, `poetry`, `pyenv`, `virtualenv`, and more.
+- 🚀 A single tool to replace `pip`, `pip-tools`, `pipx`, `poetry`, `pyenv`, `twine`, `virtualenv`,
+  and more.
 - ⚡️ [10-100x faster](https://github.com/astral-sh/uv/blob/main/BENCHMARKS.md) than `pip`.
 - 🐍 [Installs and manages](#python-management) Python versions.
 - 🛠️ [Runs and installs](#tool-management) Python applications.
@@ -82,6 +83,9 @@ All checks passed!
 ```
 
 See the [project guide](./guides/projects.md) to get started.
+
+uv also supports building and publishing projects, even if they're not managed with uv. See the
+[publish guide](./guides/publish.md) to learn more.
 
 ## Tool management
 


### PR DESCRIPTION
I don't include the `uv build` and `uv publish` commands in the `uv init` project because they're not distributable by default :/