### PR TITLE
Support dates for `exclude-newer` tool setting

### DIFF
--- a/crates/uv-resolver/src/exclude_newer.rs
+++ b/crates/uv-resolver/src/exclude_newer.rs
@@ -4,6 +4,7 @@ use jiff::{tz::TimeZone, Timestamp, ToSpan};
 
 /// A timestamp that excludes files newer than it.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(try_from = "String")]
 pub struct ExcludeNewer(Timestamp);
 
 impl ExcludeNewer {
@@ -16,6 +17,14 @@ impl ExcludeNewer {
 impl From<Timestamp> for ExcludeNewer {
     fn from(timestamp: Timestamp) -> Self {
         Self(timestamp)
+    }
+}
+
+impl TryFrom<String> for ExcludeNewer {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(&value)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

hey! I was poking around with the tool support for exclude newer in juv (think this would be awesome to use to make Jupyter notebooks more standalone/reproducible) and ran into an issue.

The settings documentation for [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) says that it supports both dates and timestamp. 

However, with uv v0.4.26:

```sh
uv init foo
cd foo
echo "[tool.uv]\nexclude-newer = '2022-01-01'" >> pyproject.toml
uv run hello.py
#  warning: Failed to parse `pyproject.toml` during settings discovery:
#   TOML parse error at line 9, column 17
#     |
#   9 | exclude-newer = "2022-01-01"
#     |                 ^^^^^^^^^^^^
#   failed to find time component in "2022-01-01", which is required for parsing a timestamp
```

I believe this is because the derive'd Deserialize from jiff only supports timestamps and doesn't use the more flexible FromStr implemention implemented for `ExlcudeNewer`

## Test Plan

Added a test with a date string
