### PR TITLE
docs: fix typo

### DIFF
--- a/docs/configuration/indexes.md
+++ b/docs/configuration/indexes.md
@@ -36,7 +36,7 @@ default = true
 The default index is always treated as lowest priority, regardless of its position in the list of
 indexes.
 
-Index names many only contain alphanumeric characters, dashes, underscores, and periods, and must be
+Index names may only contain alphanumeric characters, dashes, underscores, and periods, and must be
 valid ASCII.
 
 ## Pinning a package to an index


### PR DESCRIPTION
## Summary

Fix of a typo `many` -> `may` in documentation.

## Test Plan

Building the documentation locally using the instructions in contribution guideline: https://github.com/lukany/uv/blob/docs/fix-typo-in-defining-index/CONTRIBUTING.md#documentation
