### PR TITLE
Add support for `uv python dir --bin`

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -3836,7 +3836,9 @@ pub enum PythonCommand {
     /// `%APPDATA%\uv\data\python` on Windows.
     ///
     /// The Python installation directory may be overridden with `$UV_PYTHON_INSTALL_DIR`.
-    Dir,
+    ///
+    /// To instead view the directory uv installs Python executables into, use the `--bin` flag.
+    Dir(PythonDirArgs),
 
     /// Uninstall Python versions.
     Uninstall(PythonUninstallArgs),
@@ -3862,6 +3864,25 @@ pub struct PythonListArgs {
     /// By default, available downloads for the current platform are shown.
     #[arg(long)]
     pub only_installed: bool,
+}
+
+#[derive(Args)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct PythonDirArgs {
+    /// Show the directory into which `uv python` will install Python executables.
+    ///
+    /// By default, `uv python dir` shows the directory into which the Python distributions
+    /// themselves are installed, rather than the directory containing the linked executables.
+    ///
+    /// The Python executable directory is determined according to the XDG standard and is derived
+    /// from the following environment variables, in order of preference:
+    ///
+    /// - `$UV_PYTHON_BIN_DIR`
+    /// - `$XDG_BIN_HOME`
+    /// - `$XDG_DATA_HOME/../bin`
+    /// - `$HOME/.local/bin`
+    #[arg(long, verbatim_doc_comment)]
+    pub bin: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/python/dir.rs
+++ b/crates/uv/src/commands/python/dir.rs
@@ -3,15 +3,21 @@ use anyhow::Context;
 use owo_colors::OwoColorize;
 
 use uv_fs::Simplified;
-use uv_python::managed::ManagedPythonInstallations;
+use uv_python::managed::{python_executable_dir, ManagedPythonInstallations};
 
-/// Show the toolchain directory.
-pub(crate) fn dir() -> anyhow::Result<()> {
-    let installed_toolchains = ManagedPythonInstallations::from_settings()
-        .context("Failed to initialize toolchain settings")?;
-    println!(
-        "{}",
-        installed_toolchains.root().simplified_display().cyan()
-    );
+/// Show the Python installation directory.
+pub(crate) fn dir(bin: bool) -> anyhow::Result<()> {
+    if bin {
+        let bin = python_executable_dir()?;
+        println!("{}", bin.simplified_display().cyan());
+    } else {
+        let installed_toolchains = ManagedPythonInstallations::from_settings()
+            .context("Failed to initialize toolchain settings")?;
+        println!(
+            "{}",
+            installed_toolchains.root().simplified_display().cyan()
+        );
+    }
+
     Ok(())
 }

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1118,9 +1118,13 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             .await
         }
         Commands::Python(PythonNamespace {
-            command: PythonCommand::Dir,
+            command: PythonCommand::Dir(args),
         }) => {
-            commands::python_dir()?;
+            // Resolve the settings from the command-line arguments and workspace configuration.
+            let args = settings::PythonDirSettings::resolve(args, filesystem);
+            show_settings!(args);
+
+            commands::python_dir(args.bin)?;
             Ok(ExitStatus::Success)
         }
         Commands::Publish(args) => {

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -8,7 +8,7 @@ use url::Url;
 use uv_cache::{CacheArgs, Refresh};
 use uv_cli::{
     options::{flag, resolver_installer_options, resolver_options},
-    AuthorFrom, BuildArgs, ExportArgs, PublishArgs, ToolUpgradeArgs,
+    AuthorFrom, BuildArgs, ExportArgs, PublishArgs, PythonDirArgs, ToolUpgradeArgs,
 };
 use uv_cli::{
     AddArgs, ColorChoice, ExternalCommand, GlobalArgs, InitArgs, ListFormat, LockArgs, Maybe,
@@ -620,6 +620,23 @@ impl PythonListSettings {
             all_platforms,
             all_versions,
         }
+    }
+}
+
+/// The resolved settings to use for a `python dir` invocation.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone)]
+pub(crate) struct PythonDirSettings {
+    pub(crate) bin: bool,
+}
+
+impl PythonDirSettings {
+    /// Resolve the [`PythonDirSettings`] from the CLI and filesystem configuration.
+    #[allow(clippy::needless_pass_by_value)]
+    pub(crate) fn resolve(args: PythonDirArgs, _filesystem: Option<FilesystemOptions>) -> Self {
+        let PythonDirArgs { bin } = args;
+
+        Self { bin }
     }
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4786,6 +4786,8 @@ By default, Python installations are stored in the uv data directory at `$XDG_DA
 
 The Python installation directory may be overridden with `$UV_PYTHON_INSTALL_DIR`.
 
+To instead view the directory uv installs Python executables into, use the `--bin` flag.
+
 <h3 class="cli-reference">Usage</h3>
 
 ```
@@ -4803,6 +4805,22 @@ uv python dir [OPTIONS]
 <p>WARNING: Hosts included in this list will not be verified against the system&#8217;s certificate store. Only use <code>--allow-insecure-host</code> in a secure network with verified sources, as it bypasses SSL verification and could expose you to MITM attacks.</p>
 
 <p>May also be set with the <code>UV_INSECURE_HOST</code> environment variable.</p>
+</dd><dt><code>--bin</code></dt><dd><p>Show the directory into which <code>uv python</code> will install Python executables.</p>
+
+<p>By default, <code>uv python dir</code> shows the directory into which the Python distributions themselves are installed, rather than the directory containing the linked executables.</p>
+
+<p>The Python executable directory is determined according to the XDG standard and is derived from the following environment variables, in order of preference:</p>
+
+<ul>
+<li><code>$UV_PYTHON_BIN_DIR</code></li>
+
+<li><code>$XDG_BIN_HOME</code></li>
+
+<li><code>$XDG_DATA_HOME/../bin</code></li>
+
+<li><code>$HOME/.local/bin</code></li>
+</ul>
+
 </dd><dt><code>--cache-dir</code> <i>cache-dir</i></dt><dd><p>Path to the cache directory.</p>
 
 <p>Defaults to <code>$XDG_CACHE_HOME/uv</code> or <code>$HOME/.cache/uv</code> on macOS and Linux, and <code>%LOCALAPPDATA%\uv\cache</code> on Windows.</p>


### PR DESCRIPTION
Following #8458 we want to support showing the target directory in the CLI