### PR TITLE
Add to `dependency-groups.dev` in `uv add --dev`

### DIFF
--- a/crates/uv-workspace/src/pyproject_mut.rs
+++ b/crates/uv-workspace/src/pyproject_mut.rs
@@ -782,6 +782,26 @@ impl PyProjectTomlMut {
         Ok(())
     }
 
+    /// Returns `true` if the `tool.uv.dev-dependencies` table is present.
+    pub fn has_dev_dependencies(&self) -> bool {
+        self.doc
+            .get("tool")
+            .and_then(Item::as_table)
+            .and_then(|tool| tool.get("uv"))
+            .and_then(Item::as_table)
+            .and_then(|uv| uv.get("dev-dependencies"))
+            .is_some()
+    }
+
+    /// Returns `true` if the `dependency-groups` table is present and contains the given group.
+    pub fn has_dependency_group(&self, group: &GroupName) -> bool {
+        self.doc
+            .get("dependency-groups")
+            .and_then(Item::as_table)
+            .and_then(|groups| groups.get(group.as_ref()))
+            .is_some()
+    }
+
     /// Returns all the places in this `pyproject.toml` that contain a dependency with the given
     /// name.
     ///


### PR DESCRIPTION
## Summary

`uv add --dev` now updates the `dependency-groups.dev` section, rather than `tool.uv.dev-dependencies` -- unless the dependency is already present in `tool.uv.dev-dependencies`.

`uv remove --dev` now removes from both `dependency-groups.dev` and `tool.uv.dev-dependencies`.

`--dev` and `--group dev` are now treated equivalently in `uv add` and `uv remove`.