### PR TITLE
Remove Python executables on uninstall

### DIFF
--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -110,6 +110,9 @@ fn python_install() {
     Uninstalled Python 3.13.0 in [TIME]
      - cpython-3.13.0-[PLATFORM]
     "###);
+
+    // The executable should be removed
+    bin_python.assert(predicate::path::missing());
 }
 
 #[test]


### PR DESCRIPTION
Following #8458, we need to remove the installed Python executables on `uv python uninstall`.

Needs Windows support still, but that approach will be different since there won't be links.