### PR TITLE
Fix Python install path in tests

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -646,25 +646,32 @@ impl TestContext {
     pub fn python_install(&self) -> Command {
         let mut command = Command::new(get_bin());
         let managed = self.temp_dir.join("managed");
+        self.add_shared_args(&mut command, true);
         command
             .arg("python")
             .arg("install")
-            .env(EnvVars::UV_PREVIEW, "1")
             .env(EnvVars::UV_PYTHON_INSTALL_DIR, managed)
             .current_dir(&self.temp_dir);
+        command
+    }
+
+    /// Create a `uv python uninstall` command with options shared across scenarios.
+    pub fn python_uninstall(&self) -> Command {
+        let mut command = Command::new(get_bin());
+        let managed = self.temp_dir.join("managed");
         self.add_shared_args(&mut command, true);
+        command
+            .arg("python")
+            .arg("uninstall")
+            .env(EnvVars::UV_PYTHON_INSTALL_DIR, managed)
+            .current_dir(&self.temp_dir);
         command
     }
 
     /// Create a `uv python pin` command with options shared across scenarios.
     pub fn python_pin(&self) -> Command {
         let mut command = Command::new(get_bin());
-        command
-            .arg("python")
-            .arg("pin")
-            .env(EnvVars::UV_PREVIEW, "1")
-            .env(EnvVars::UV_PYTHON_INSTALL_DIR, "")
-            .current_dir(&self.temp_dir);
+        command.arg("python").arg("pin");
         self.add_shared_args(&mut command, true);
         command
     }

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -38,6 +38,32 @@ fn python_install() {
     Searching for Python versions matching: Python 3.13
     Found existing installation for Python 3.13: cpython-3.13.0-[PLATFORM]
     "###);
+
+    // Uninstallation requires an argument
+    uv_snapshot!(context.filters(), context.python_uninstall(), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the following required arguments were not provided:
+      <TARGETS>...
+
+    Usage: uv python uninstall <TARGETS>...
+
+    For more information, try '--help'.
+    "###);
+
+    uv_snapshot!(context.filters(), context.python_uninstall().arg("3.13"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Searching for Python versions matching: Python 3.13
+    Uninstalled Python 3.13.0 in [TIME]
+     - cpython-3.13.0-[PLATFORM]
+    "###);
 }
 
 #[test]
@@ -77,5 +103,17 @@ fn python_install_freethreaded() {
     ----- stderr -----
     Searching for Python versions matching: Python 3.12t
     error: No download found for request: cpython-3.12t-[PLATFORM]
+    "###);
+
+    uv_snapshot!(context.filters(), context.python_uninstall().arg("--all"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Searching for Python installations
+    Uninstalled 2 versions in [TIME]
+     - cpython-3.13.0-[PLATFORM]
+     - cpython-3.13.0+freethreaded-[PLATFORM]
     "###);
 }

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -24,8 +24,8 @@ fn python_install() {
 
     ----- stderr -----
     Searching for Python installations
-    Installed Python 3.13.0 in [TIME]
-     + cpython-3.13.0-[PLATFORM]
+    Found: cpython-3.13.0-[PLATFORM]
+    Python is already available. Use `uv python install <request>` to install a specific version.
     "###);
 
     // Similarly, when a requested version is already installed
@@ -36,8 +36,7 @@ fn python_install() {
 
     ----- stderr -----
     Searching for Python versions matching: Python 3.13
-    Installed Python 3.13.0 in [TIME]
-     + cpython-3.13.0-[PLATFORM]
+    Found existing installation for Python 3.13: cpython-3.13.0-[PLATFORM]
     "###);
 }
 


### PR DESCRIPTION
The shared arguments were resetting the `UV_PYTHON_INSTALL_DIR`, breaking the intent of the test.

Added some uninstall tests too, needed later for #8571 