### PR TITLE
Remove duplicate word in error message

### DIFF
--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -439,7 +439,7 @@ impl ProjectInterpreter {
                         if fs_err::read_dir(&venv).is_ok_and(|mut dir| dir.next().is_some()) {
                             return Err(ProjectError::InvalidProjectEnvironmentDir(
                                 venv,
-                                "because it is not a valid Python environment (no Python executable was found)"
+                                "it is not a valid Python environment (no Python executable was found)"
                                     .to_string(),
                             ));
                         }

--- a/crates/uv/tests/it/sync.rs
+++ b/crates/uv/tests/it/sync.rs
@@ -2385,7 +2385,7 @@ fn sync_custom_environment_path() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Project virtual environment directory `[TEMP_DIR]/foo` cannot be used because because it is not a valid Python environment (no Python executable was found)
+    error: Project virtual environment directory `[TEMP_DIR]/foo` cannot be used because it is not a valid Python environment (no Python executable was found)
     "###);
 
     // But if it's just an incompatible virtual environment...
@@ -3554,7 +3554,7 @@ fn sync_invalid_environment() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Project virtual environment directory `[VENV]/` cannot be used because because it is not a valid Python environment (no Python executable was found)
+    error: Project virtual environment directory `[VENV]/` cannot be used because it is not a valid Python environment (no Python executable was found)
     "###);
 
     // But if it's just an incompatible virtual environment...
@@ -3620,7 +3620,7 @@ fn sync_invalid_environment() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: Project virtual environment directory `[VENV]/` cannot be used because because it is not a valid Python environment (no Python executable was found)
+    error: Project virtual environment directory `[VENV]/` cannot be used because it is not a valid Python environment (no Python executable was found)
     "###);
 
     // But if it's not a virtual environment...


### PR DESCRIPTION
## Summary

Remove duplicate word ("because" ) in error message.

## Test Plan

I ran all the tests locally.
