### PR TITLE
Ignore empty groups when validating lock

### DIFF
--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1242,6 +1242,7 @@ impl Lock {
                 let expected: BTreeMap<GroupName, BTreeSet<Requirement>> = metadata
                     .dependency_groups
                     .into_iter()
+                    .filter(|(_, requirements)| !requirements.is_empty())
                     .map(|(group, requirements)| {
                         Ok::<_, LockError>((
                             group,
@@ -1256,6 +1257,7 @@ impl Lock {
                     .metadata
                     .dependency_groups
                     .iter()
+                    .filter(|(_, requirements)| !requirements.is_empty())
                     .map(|(group, requirements)| {
                         Ok::<_, LockError>((
                             group.clone(),
@@ -2126,9 +2128,7 @@ impl Package {
                         [requirement] => Array::from_iter([requirement]),
                         deps => each_element_on_its_line_array(deps.iter()),
                     };
-                    if !deps.is_empty() {
-                        dependency_groups.insert(extra.as_ref(), value(deps));
-                    }
+                    dependency_groups.insert(extra.as_ref(), value(deps));
                 }
                 if !dependency_groups.is_empty() {
                     metadata_table.insert("dependency-groups", Item::Table(dependency_groups));

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -1174,6 +1174,11 @@ fn add_remove_dev() -> Result<()> {
         name = "project"
         version = "0.1.0"
         source = { editable = "." }
+
+        [package.metadata]
+
+        [package.metadata.dependency-groups]
+        dev = []
         "###
         );
     });


### PR DESCRIPTION
## Summary

It turns out we were omitting empty dependency groups from the lockfile metadata, which was then causing us to reject locks when empty groups were defined.

We now include them (that section of the lock is meant to be a true representation of the metadata, and an empty-but-defined group is different from an absent group), though we can ignore them for validation, since it doesn't affect any behavior.

Closes https://github.com/astral-sh/uv/issues/8581.
