### PR TITLE
feat: add environment variable to disable progress output

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -232,7 +232,7 @@ pub struct GlobalArgs {
     /// Hide all progress outputs.
     ///
     /// For example, spinners or progress bars.
-    #[arg(global = true, long)]
+    #[arg(global = true, long, env = EnvVars::UV_NO_PROGRESS, value_parser = clap::builder::BoolishValueParser::new())]
     pub no_progress: bool,
 
     /// Change to the given directory prior to running the command.

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -277,6 +277,9 @@ impl EnvVars {
     /// Disables colored output (takes precedence over `FORCE_COLOR`).
     pub const NO_COLOR: &'static str = "NO_COLOR";
 
+    /// Disables all progress output. For example, spinners and progress bars.
+    pub const UV_NO_PROGRESS: &'static str = "UV_NO_PROGRESS";
+
     /// Forces colored output regardless of terminal support.
     pub const FORCE_COLOR: &'static str = "FORCE_COLOR";
 

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -54,7 +54,7 @@ fn help() {
           --native-tls                 Whether to load TLS certificates from the platform's native
                                        certificate store [env: UV_NATIVE_TLS=]
           --offline                    Disable network access
-          --no-progress                Hide all progress outputs
+          --no-progress                Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>      Change to the given directory prior to running the command
           --project <PROJECT>          Run the command within the given project directory
           --config-file <CONFIG_FILE>  The path to a `uv.toml` file to use for configuration [env:
@@ -123,7 +123,7 @@ fn help_flag() {
           --native-tls                 Whether to load TLS certificates from the platform's native
                                        certificate store [env: UV_NATIVE_TLS=]
           --offline                    Disable network access
-          --no-progress                Hide all progress outputs
+          --no-progress                Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>      Change to the given directory prior to running the command
           --project <PROJECT>          Run the command within the given project directory
           --config-file <CONFIG_FILE>  The path to a `uv.toml` file to use for configuration [env:
@@ -191,7 +191,7 @@ fn help_short_flag() {
           --native-tls                 Whether to load TLS certificates from the platform's native
                                        certificate store [env: UV_NATIVE_TLS=]
           --offline                    Disable network access
-          --no-progress                Hide all progress outputs
+          --no-progress                Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>      Change to the given directory prior to running the command
           --project <PROJECT>          Run the command within the given project directory
           --config-file <CONFIG_FILE>  The path to a `uv.toml` file to use for configuration [env:
@@ -211,7 +211,7 @@ fn help_short_flag() {
 fn help_subcommand() {
     let context = TestContext::new_with_versions(&[]);
 
-    uv_snapshot!(context.filters(), context.help().arg("python"), @r##"
+    uv_snapshot!(context.filters(), context.help().arg("python"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -344,6 +344,8 @@ fn help_subcommand() {
               Hide all progress outputs.
               
               For example, spinners or progress bars.
+              
+              [env: UV_NO_PROGRESS=]
 
           --directory <DIRECTORY>
               Change to the given directory prior to running the command.
@@ -392,14 +394,14 @@ fn help_subcommand() {
 
 
     ----- stderr -----
-    "##);
+    "###);
 }
 
 #[test]
 fn help_subsubcommand() {
     let context = TestContext::new_with_versions(&[]);
 
-    uv_snapshot!(context.filters(), context.help().arg("python").arg("install"), @r##"
+    uv_snapshot!(context.filters(), context.help().arg("python").arg("install"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -514,6 +516,8 @@ fn help_subsubcommand() {
               Hide all progress outputs.
               
               For example, spinners or progress bars.
+              
+              [env: UV_NO_PROGRESS=]
 
           --directory <DIRECTORY>
               Change to the given directory prior to running the command.
@@ -560,7 +564,7 @@ fn help_subsubcommand() {
 
 
     ----- stderr -----
-    "##);
+    "###);
 }
 
 #[test]
@@ -603,7 +607,7 @@ fn help_flag_subcommand() {
           --native-tls                 Whether to load TLS certificates from the platform's native
                                        certificate store [env: UV_NATIVE_TLS=]
           --offline                    Disable network access
-          --no-progress                Hide all progress outputs
+          --no-progress                Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>      Change to the given directory prior to running the command
           --project <PROJECT>          Run the command within the given project directory
           --config-file <CONFIG_FILE>  The path to a `uv.toml` file to use for configuration [env:
@@ -657,7 +661,7 @@ fn help_flag_subsubcommand() {
           --native-tls                 Whether to load TLS certificates from the platform's native
                                        certificate store [env: UV_NATIVE_TLS=]
           --offline                    Disable network access
-          --no-progress                Hide all progress outputs
+          --no-progress                Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>      Change to the given directory prior to running the command
           --project <PROJECT>          Run the command within the given project directory
           --config-file <CONFIG_FILE>  The path to a `uv.toml` file to use for configuration [env:
@@ -803,7 +807,7 @@ fn help_with_global_option() {
           --native-tls                 Whether to load TLS certificates from the platform's native
                                        certificate store [env: UV_NATIVE_TLS=]
           --offline                    Disable network access
-          --no-progress                Hide all progress outputs
+          --no-progress                Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>      Change to the given directory prior to running the command
           --project <PROJECT>          Run the command within the given project directory
           --config-file <CONFIG_FILE>  The path to a `uv.toml` file to use for configuration [env:
@@ -908,7 +912,7 @@ fn help_with_no_pager() {
           --native-tls                 Whether to load TLS certificates from the platform's native
                                        certificate store [env: UV_NATIVE_TLS=]
           --offline                    Disable network access
-          --no-progress                Hide all progress outputs
+          --no-progress                Hide all progress outputs [env: UV_NO_PROGRESS=]
           --directory <DIRECTORY>      Change to the given directory prior to running the command
           --project <PROJECT>          Run the command within the given project directory
           --config-file <CONFIG_FILE>  The path to a `uv.toml` file to use for configuration [env:

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -151,5 +151,6 @@ In addition, uv respects the following environment variables:
   least-recent non-EOL macOS version at time of writing.
 - `NO_COLOR`: Disable colors. Takes precedence over `FORCE_COLOR`. See
   [no-color.org](https://no-color.org).
+- `UV_NO_PROGRESS`: Disable progress indicators like spinners and progress bars.
 - `FORCE_COLOR`: Enforce colors regardless of TTY support. See
   [force-color.org](https://force-color.org).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -298,6 +298,7 @@ uv run [OPTIONS] [COMMAND]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-project</code></dt><dd><p>Avoid discovering the project or workspace.</p>
 
 <p>Instead of searching for projects in the current directory and parent directories, run in an isolated, ephemeral environment populated by the <code>--with</code> requirements.</p>
@@ -575,6 +576,7 @@ uv init [OPTIONS] [PATH]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-readme</code></dt><dd><p>Do not create a <code>README.md</code> file</p>
@@ -887,6 +889,7 @@ uv add [OPTIONS] <PACKAGES|--requirements <REQUIREMENTS>>
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -1225,6 +1228,7 @@ uv remove [OPTIONS] <PACKAGES>...
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -1577,6 +1581,7 @@ uv sync [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -1889,6 +1894,7 @@ uv lock [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -2227,6 +2233,7 @@ uv export [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -2548,6 +2555,7 @@ uv tree [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -2938,6 +2946,7 @@ uv tool run [OPTIONS] [COMMAND]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -3239,6 +3248,7 @@ uv tool install [OPTIONS] <PACKAGE>
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -3536,6 +3546,7 @@ uv tool upgrade [OPTIONS] <NAME>...
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -3686,6 +3697,7 @@ uv tool list [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
 
 <p>When disabled, uv will only use locally cached data and locally available files.</p>
@@ -3783,6 +3795,7 @@ uv tool uninstall [OPTIONS] <NAME>...
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -3892,6 +3905,7 @@ uv tool update-shell [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -4019,6 +4033,7 @@ uv tool dir [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -4202,6 +4217,7 @@ uv python list [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -4329,6 +4345,7 @@ uv python install [OPTIONS] [TARGETS]...
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -4448,6 +4465,7 @@ uv python find [OPTIONS] [REQUEST]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-project</code></dt><dd><p>Avoid discovering a project or workspace.</p>
 
 <p>Otherwise, when no request is provided, the Python requirement of a project in the current directory or parent directories will be used.</p>
@@ -4576,6 +4594,7 @@ uv python pin [OPTIONS] [REQUEST]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-project</code></dt><dd><p>Avoid validating the Python pin is compatible with the project or workspace.</p>
 
 <p>By default, a project or workspace is discovered in the current directory or any parent directory. If a workspace is found, the Python pin is validated against the workspace&#8217;s <code>requires-python</code> constraint.</p>
@@ -4693,6 +4712,7 @@ uv python dir [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -4806,6 +4826,7 @@ uv python uninstall [OPTIONS] <TARGETS>...
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -5122,6 +5143,7 @@ uv pip compile [OPTIONS] <SRC_FILE>...
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -5509,6 +5531,7 @@ uv pip sync [OPTIONS] <SRC_FILE>...
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -5881,6 +5904,7 @@ uv pip install [OPTIONS] <PACKAGE|--requirement <REQUIREMENT>|--editable <EDITAB
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -6168,6 +6192,7 @@ uv pip uninstall [OPTIONS] <PACKAGE|--requirement <REQUIREMENT>>
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -6293,6 +6318,7 @@ uv pip freeze [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -6430,6 +6456,7 @@ uv pip list [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -6557,6 +6584,7 @@ uv pip show [OPTIONS] [PACKAGE]...
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -6683,6 +6711,7 @@ uv pip tree [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-system</code></dt><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -6808,6 +6837,7 @@ uv pip check [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -7046,6 +7076,7 @@ uv venv [OPTIONS] [PATH]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-project</code></dt><dd><p>Avoid discovering a project or workspace.</p>
 
 <p>By default, uv searches for projects in the current directory or any parent directory to determine the default path of the virtual environment and check for Python version constraints, if any.</p>
@@ -7329,6 +7360,7 @@ uv build [OPTIONS] [SRC]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--no-sources</code></dt><dd><p>Ignore the <code>tool.uv.sources</code> table when resolving dependencies. Used to lock against the standards-compliant, publishable package metadata, as opposed to using any local or Git sources</p>
@@ -7542,6 +7574,7 @@ uv publish [OPTIONS] [FILES]...
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -7702,6 +7735,7 @@ uv cache clean [OPTIONS] [PACKAGE]...
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -7811,6 +7845,7 @@ uv cache prune [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -7922,6 +7957,7 @@ uv cache dir [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -8047,6 +8083,7 @@ uv self update [OPTIONS] [TARGET_VERSION]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -8153,6 +8190,7 @@ uv version [OPTIONS]
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>
@@ -8298,6 +8336,7 @@ uv help [OPTIONS] [COMMAND]...
 
 <p>For example, spinners or progress bars.</p>
 
+<p>May also be set with the <code>UV_NO_PROGRESS</code> environment variable.</p>
 </dd><dt><code>--no-python-downloads</code></dt><dd><p>Disable automatic downloads of Python.</p>
 
 </dd><dt><code>--offline</code></dt><dd><p>Disable network access.</p>


### PR DESCRIPTION
The changes in this commit introduce the `UV_NO_PROGRESS` environment variable as an alternative way to control progress output suppression in uv-cli, equivalent to using the `--no-progress` flag. This enhancement simplifies configuration in CI environments and automated scripts by eliminating the need to detect whether the script is running in a CI environment.

Previously, disabling progress output required either passing the `--no-progress` flag directly or implementing script logic to detect CI environments and conditionally add the flag. With this change, users can now simply set `UV_NO_PROGRESS=true` in their environment to achieve the same effect.

The changes include:

- Adding the `UV_NO_PROGRESS` environment variable to the `EnvVars` struct in `crates/uv-static/src/env_vars.rs`.
- Updating the `GlobalArgs` struct in `crates/uv-cli/src/lib.rs` to include a new `no_progress` field that is bound to the `UV_NO_PROGRESS` environment variable.
- Adding documentation for the new `UV_NO_PROGRESS` environment variable in `docs/configuration/environment.md`.
## Test Plan

After creating a uv project using `uv init` in a temp directory in this project:
```
cargo run cache clean && cargo run venv && UV_NO_PROGRESS=false cargo run sync 
cargo run cache clean && cargo run venv && cargo run sync  
```
produce the expected default behavior 

```
cargo run cache clean && cargo run venv && UV_NO_PROGRESS=false cargo run sync  
```
produces the same behavior as having the `--no-progress` flag. 