### PR TITLE
Remove unneeded `return` from Maturin project template

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -975,7 +975,7 @@ fn generate_package_scripts(
 
                     #[pyfunction]
                     fn hello_from_bin() -> String {{
-                        return "Hello from {package}!".to_string();
+                        "Hello from {package}!".to_string()
                     }}
 
                     /// A Python module implemented in Rust. The name of this function must match

--- a/crates/uv/tests/it/init.rs
+++ b/crates/uv/tests/it/init.rs
@@ -2665,7 +2665,7 @@ fn init_app_build_backend_maturin() -> Result<()> {
 
         #[pyfunction]
         fn hello_from_bin() -> String {
-            return "Hello from foo!".to_string();
+            "Hello from foo!".to_string()
         }
 
         /// A Python module implemented in Rust. The name of this function must match
@@ -2918,7 +2918,7 @@ fn init_lib_build_backend_maturin() -> Result<()> {
 
         #[pyfunction]
         fn hello_from_bin() -> String {
-            return "Hello from foo!".to_string();
+            "Hello from foo!".to_string()
         }
 
         /// A Python module implemented in Rust. The name of this function must match


### PR DESCRIPTION
## Summary

This PR removes an unnecessary `return` statement from Rust code in the Maturin template. This makes the generated code more idiomatic and prevents a Clippy warning.

## Test Plan

This change was tested both in unit tests and by manually creating a Maturin project.
