### PR TITLE
Set `LC_ALL=C` in test commands

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -473,6 +473,11 @@ impl TestContext {
             command.env(EnvVars::VIRTUAL_ENV, self.venv.as_os_str());
         }
 
+        if cfg!(unix) {
+            // Avoid locale issues in tests
+            command.env("LC_ALL", "C");
+        }
+
         if cfg!(all(windows, debug_assertions)) {
             // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
             // default windows stack of 1MB


### PR DESCRIPTION
## Summary

The output of some programs used in uv tests depends on the OS language. In particular, git error messages are localized.

As a consequence, the following tests fail if run on a non-US environment:

```
pip_compile::git_source_missing_tag
pip_install::install_git_private_https_pat_not_authorized
pip_install::install_git_public_https_missing_branch_or_tag
pip_install::install_git_public_https_missing_commit
```

Example error:

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Snapshot: install_git_public_https_missing_branch_or_tag
Source: crates/uv/tests/it/pip_install.rs:1600
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Expression: snapshot
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    7     7 │   Caused by: failed to clone into: [CACHE_DIR]/git-v0/db/8dab139913c4b566
    8     8 │   Caused by: failed to fetch branch or tag `2.0.0`
    9     9 │   Caused by: process didn't exit successfully: `git fetch [...]` (exit code: 128)
   10    10 │ --- stderr
   11       │-fatal: couldn't find remote ref refs/tags/2.0.0
         11 │+fatal : impossible de trouver la référence distante refs/tags/2.0.0
────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

On Unix-like platforms, a simple workaround is to set the environment variable `LC_ALL=C` (there are variants e.g. `LANG=en_US.UTF-8`, but they are likely less robust).

My proposal here is to set this variable directly in tests, to avoid developers having to configure their environment before running tests.

## Test Plan

Tests listed above no longer fail with this workaround.
