### PR TITLE
Better trusted publishing error story

### DIFF
--- a/crates/uv-publish/src/trusted_publishing.rs
+++ b/crates/uv-publish/src/trusted_publishing.rs
@@ -45,12 +45,6 @@ impl TrustedPublishingError {
 #[serde(transparent)]
 pub struct TrustedPublishingToken(String);
 
-impl From<TrustedPublishingToken> for String {
-    fn from(token: TrustedPublishingToken) -> Self {
-        token.0
-    }
-}
-
 impl Display for TrustedPublishingToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -53,15 +53,43 @@ fn invalid_token() {
     );
 }
 
+/// Emulate a missing `permission` `id-token: write` situation.
+#[test]
+fn mixed_credentials() {
+    let context = TestContext::new("3.12");
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--username")
+        .arg("ferris")
+        .arg("--password")
+        .arg("ZmVycmlz")
+        .arg("--publish-url")
+        .arg("https://test.pypi.org/legacy/")
+        .arg("--trusted-publishing")
+        .arg("always")
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl")
+        // Emulate CI
+        .env(EnvVars::GITHUB_ACTIONS, "true")
+        // Just to make sure
+        .env_remove(EnvVars::ACTIONS_ID_TOKEN_REQUEST_TOKEN), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv publish` is experimental and may change without warning
+    Publishing 1 file to https://test.pypi.org/legacy/
+    error: When using trusted publishing, also using a username is not allowed
+    "###
+    );
+}
+
+/// Emulate a missing `permission` `id-token: write` situation.
 #[test]
 fn missing_trusted_publishing_permission() {
     let context = TestContext::new("3.12");
 
     uv_snapshot!(context.filters(), context.publish()
-        .arg("-u")
-        .arg("__token__")
-        .arg("-p")
-        .arg("dummy")
         .arg("--publish-url")
         .arg("https://test.pypi.org/legacy/")
         .arg("--trusted-publishing")
@@ -80,6 +108,37 @@ fn missing_trusted_publishing_permission() {
     Publishing 1 file to https://test.pypi.org/legacy/
     error: Failed to obtain token for trusted publishing
       Caused by: Environment variable ACTIONS_ID_TOKEN_REQUEST_TOKEN not set, is the `id-token: write` permission missing?
+    "###
+    );
+}
+
+/// Check the error when there are no credentials provided on GitHub Actions. Is it an incorrect
+/// trusted publishing configuration?
+#[test]
+fn no_credentials() {
+    let context = TestContext::new("3.12");
+
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("--publish-url")
+        .arg("https://test.pypi.org/legacy/")
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl")
+        // Emulate CI
+        .env(EnvVars::GITHUB_ACTIONS, "true")
+        // Just to make sure
+        .env_remove(EnvVars::ACTIONS_ID_TOKEN_REQUEST_TOKEN), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv publish` is experimental and may change without warning
+    Publishing 1 file to https://test.pypi.org/legacy/
+    Note: Neither credentials nor keyring are configured, and there was an error fetching the trusted publishing token. If you don't want to use trusted publishing, you can ignore this error, but you need to provide credentials.
+    Trusted publishing error: Environment variable ACTIONS_ID_TOKEN_REQUEST_TOKEN not set, is the `id-token: write` permission missing?
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE])
+    error: Failed to publish `../../scripts/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/
+      Caused by: Failed to send POST request
+      Caused by: Missing credentials for https://test.pypi.org/legacy/
     "###
     );
 }


### PR DESCRIPTION
Trusted publishing errors are a tough problem because for security reason, PyPI won't tell use the trusted publishing configuration for a repo and GitHub Actions doesn't let us see arbitrary secrets either.

These changes handle using trusted publishing while other credentials are also set (an error) and adds a hint and an error trace when it looks like the user wanted trusted publishing, but it wasn't configured.

Most of #8223, only missing a live test repo.

I'm currently threading this into the live test repo, so we can see this in action.
