### PR TITLE
Actually perform checks on alternate trampoline platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,12 +359,10 @@ jobs:
 
       - name: "Clippy"
         working-directory: ${{ env.UV_WORKSPACE }}/crates/uv-trampoline
-        if: matrix.target-arch == 'x86_64'
         run: cargo clippy --all-features --locked --target x86_64-pc-windows-msvc --tests -- -D warnings
 
       - name: "Bloat Check"
         working-directory: ${{ env.UV_WORKSPACE }}/crates/uv-trampoline
-        if: matrix.target-arch == 'x86_64'
         run: |
           $output = cargo bloat --release --target x86_64-pc-windows-msvc
           $filteredOutput = $output | Select-String -Pattern 'core::fmt::write|core::fmt::getcount' -NotMatch


### PR DESCRIPTION
It seems unintentional that we basically did nothing on these alternative platforms? It seems like an artifact from some previous change.

I'm not sure it's worth running Clippy multiple times. We could also just reduce the matrix here.