### PR TITLE
Add note about trampoline tests on aarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-arch: ["x86_64", "i686"]
+        target-arch: ["x86_64", "i686", "aarch64"]
     steps:
       - uses: actions/checkout@v4
       - name: "Install Rust toolchain"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-arch: ["x86_64", "i686", "aarch64"]
+        # Note, we exclude `aarch64` because it's not supported by the GitHub runner
+        target-arch: ["x86_64", "i686"]
     steps:
       - uses: actions/checkout@v4
       - name: "Install Rust toolchain"


### PR DESCRIPTION
Similar to https://github.com/astral-sh/uv/pull/8642, not sure why this is incomplete.

We'll see if it works.