### PR TITLE
uv-resolver: use disjointness checks instead of marker equality

### DIFF
--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -178,11 +178,15 @@ impl CandidateSelector {
                 let preferences_match =
                     preferences.get(package_name).filter(|(marker, _version)| {
                         // `.unwrap_or(true)` because the universal marker is considered matching.
-                        marker.map(|marker| marker == fork_markers).unwrap_or(true)
+                        marker
+                            .map(|marker| !marker.is_disjoint(fork_markers))
+                            .unwrap_or(true)
                     });
                 let preferences_mismatch =
                     preferences.get(package_name).filter(|(marker, _version)| {
-                        marker.map(|marker| marker != fork_markers).unwrap_or(false)
+                        marker
+                            .map(|marker| marker.is_disjoint(fork_markers))
+                            .unwrap_or(false)
                     });
                 self.get_preferred_from_iter(
                     preferences_match.chain(preferences_mismatch),

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -2936,15 +2936,11 @@ fn add_update_marker() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 8 packages in [TIME]
-    Prepared 3 packages in [TIME]
-    Uninstalled 3 packages in [TIME]
-    Installed 3 packages in [TIME]
-     - idna==3.6
-     + idna==2.7
+    Resolved 10 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Uninstalled 1 package in [TIME]
+    Installed 1 package in [TIME]
      ~ project==0.1.0 (from file://[TEMP_DIR]/)
-     - urllib3==2.2.1
-     + urllib3==1.23
     "###);
 
     let pyproject_toml = context.read("pyproject.toml");
@@ -2979,7 +2975,7 @@ fn add_update_marker() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 8 packages in [TIME]
+    Resolved 10 packages in [TIME]
     Prepared 1 package in [TIME]
     Uninstalled 1 package in [TIME]
     Installed 1 package in [TIME]
@@ -3026,10 +3022,10 @@ fn add_update_marker() -> Result<()> {
     Installed 1 package in [TIME]
      - certifi==2024.2.2
      - charset-normalizer==3.3.2
-     - idna==2.7
+     - idna==3.6
      ~ project==0.1.0 (from file://[TEMP_DIR]/)
      - requests==2.31.0
-     - urllib3==1.23
+     - urllib3==2.2.1
     "###);
 
     let pyproject_toml = context.read("pyproject.toml");


### PR DESCRIPTION
When this code was written, we didn't have "proper" disjointness checks,
and so simple equality was used instead. Arguably disjointness checks are
more correct, and this would also simplify some case analysis in an ongoing
refactor.
