### PR TITLE
uv/tests: try harder to isolate tests from parent git repositories

### DIFF
--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -316,6 +316,16 @@ impl EnvVars {
     /// Alternate locations for git objects. Ignored by `uv` when performing fetch.
     pub const GIT_ALTERNATE_OBJECT_DIRECTORIES: &'static str = "GIT_ALTERNATE_OBJECT_DIRECTORIES";
 
+    /// Used in tests for better git isolation.
+    ///
+    /// For example, we run some tests in ~/.local/share/uv/tests.
+    /// And if the user's `$HOME` directory is a git repository,
+    /// this will change the behavior of some tests. Setting
+    /// `GIT_CEILING_DIRECTORIES=/home/andrew/.local/share/uv/tests` will
+    /// prevent git from crawling up the directory tree past that point to find
+    /// parent git repositories.
+    pub const GIT_CEILING_DIRECTORIES: &'static str = "GIT_CEILING_DIRECTORIES";
+
     /// Used for trusted publishing via `uv publish`.
     pub const GITHUB_ACTIONS: &'static str = "GITHUB_ACTIONS";
 


### PR DESCRIPTION
Previously, when tests were run in `~/.local/share/uv`, the behavior of
some tests could be impacted by a git repository in `~` (as on my
system). To avoid this, we set `GIT_CEILING_DIRECTORIES` to forcefully
prevent git from climbing out of its test directory to look for parent
git repositories.
