### PR TITLE
uv-resolver: simplify case analysis in ForkMap::get

### DIFF
--- a/crates/uv-resolver/src/resolver/fork_map.rs
+++ b/crates/uv-resolver/src/resolver/fork_map.rs
@@ -62,11 +62,11 @@ impl<T> ForkMap<T> {
         match markers {
             // If we are solving for a specific environment we already filtered
             // compatible requirements `from_manifest`.
-            ResolverMarkers::SpecificEnvironment(_) => values
-                .first()
-                .map(|entry| &entry.value)
-                .into_iter()
-                .collect(),
+            //
+            // Or, if we haven't forked yet, all values are potentially compatible.
+            ResolverMarkers::SpecificEnvironment(_) | ResolverMarkers::Universal { .. } => {
+                values.iter().map(|entry| &entry.value).collect()
+            }
 
             // Return all values that were requested with markers that are compatible
             // with the current fork, i.e. the markers are not disjoint.
@@ -75,9 +75,6 @@ impl<T> ForkMap<T> {
                 .filter(|entry| !fork.is_disjoint(&entry.marker))
                 .map(|entry| &entry.value)
                 .collect(),
-
-            // If we haven't forked yet, all values are potentially compatible.
-            ResolverMarkers::Universal { .. } => values.iter().map(|entry| &entry.value).collect(),
         }
     }
 }


### PR DESCRIPTION
Previously, when doing a `uv pip` resolution, we would only return the
first entry in the map. But there should only ever be one entry, or else
we would have incompatible dependencies. So we can collapse the case
with the "one universal fork" case.

(I found this while doing some refactoring of how we handle forking, and
collapsing these cases simplifies some of that refactoring work.)
