### PR TITLE
Fix feature scoping for pep508 wasm32 support for ruff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4922,7 +4922,6 @@ dependencies = [
  "indexmap",
  "insta",
  "itertools 0.13.0",
- "log",
  "regex",
  "rustc-hash",
  "schemars",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,15 +3633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "testing_logger"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d92b727cb45d33ae956f7f46b966b25f1bc712092aeef9dba5ac798fc89f720"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3965,6 +3956,27 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4917,9 +4929,9 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "testing_logger",
  "thiserror",
  "tracing",
+ "tracing-test",
  "unicode-width",
  "url",
  "uv-fs",

--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -41,7 +41,6 @@ version-ranges = { workspace = true }
 
 [dev-dependencies]
 insta = { version = "1.40.0" }
-log = { version = "0.4.22" }
 serde_json = { version = "1.0.128" }
 tracing-test = { version = "0.2.5" }
 

--- a/crates/uv-pep508/Cargo.toml
+++ b/crates/uv-pep508/Cargo.toml
@@ -43,7 +43,7 @@ version-ranges = { workspace = true }
 insta = { version = "1.40.0" }
 log = { version = "0.4.22" }
 serde_json = { version = "1.0.128" }
-testing_logger = { version = "0.1.1" }
+tracing-test = { version = "0.2.5" }
 
 [features]
 tracing = ["dep:tracing", "uv-pep440/tracing"]

--- a/crates/uv-pep508/src/lib.rs
+++ b/crates/uv-pep508/src/lib.rs
@@ -26,13 +26,12 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 use url::Url;
 
-use crate::marker::MarkerValueExtra;
 use cursor::Cursor;
 pub use marker::{
     ContainsMarkerTree, ExtraMarkerTree, ExtraOperator, InMarkerTree, MarkerEnvironment,
     MarkerEnvironmentBuilder, MarkerExpression, MarkerOperator, MarkerTree, MarkerTreeContents,
-    MarkerTreeKind, MarkerValue, MarkerValueString, MarkerValueVersion, MarkerWarningKind,
-    StringMarkerTree, StringVersion, VersionMarkerTree,
+    MarkerTreeKind, MarkerValue, MarkerValueExtra, MarkerValueString, MarkerValueVersion,
+    MarkerWarningKind, StringMarkerTree, StringVersion, VersionMarkerTree,
 };
 pub use origin::RequirementOrigin;
 #[cfg(feature = "non-pep508-extensions")]

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1995,7 +1995,7 @@ mod test {
             if lines == expected {
                 Ok(())
             } else {
-                Err(format!("{:?}", lines))
+                Err(format!("{lines:?}"))
             }
         });
     }

--- a/crates/uv-pep508/src/marker/tree.rs
+++ b/crates/uv-pep508/src/marker/tree.rs
@@ -1937,59 +1937,66 @@ mod test {
 
     #[test]
     #[cfg(feature = "tracing")]
-    fn warnings() {
+    #[tracing_test::traced_test]
+    fn warnings1() {
         let env37 = env37();
-        testing_logger::setup();
         let compare_keys = MarkerTree::from_str("platform_version == sys_platform").unwrap();
         compare_keys.evaluate(&env37, &[]);
-        testing_logger::validate(|captured_logs| {
-            assert_eq!(
-                captured_logs[0].body,
-                "Comparing two markers with each other doesn't make any sense, will evaluate to false"
-            );
-            assert_eq!(captured_logs[0].level, log::Level::Warn);
-            assert_eq!(captured_logs.len(), 1);
-        });
+        logs_contain(
+            "Comparing two markers with each other doesn't make any sense, will evaluate to false",
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tracing")]
+    #[tracing_test::traced_test]
+    fn warnings2() {
+        let env37 = env37();
         let non_pep440 = MarkerTree::from_str("python_version >= '3.9.'").unwrap();
         non_pep440.evaluate(&env37, &[]);
-        testing_logger::validate(|captured_logs| {
-            assert_eq!(
-                captured_logs[0].body,
-                "Expected PEP 440 version to compare with python_version, found `3.9.`, \
-                 will evaluate to false: after parsing `3.9`, found `.`, which is \
-                 not part of a valid version"
-            );
-            assert_eq!(captured_logs[0].level, log::Level::Warn);
-            assert_eq!(captured_logs.len(), 1);
-        });
+        logs_contain(
+            "Expected PEP 440 version to compare with python_version, found `3.9.`, \
+             will evaluate to false: after parsing `3.9`, found `.`, which is \
+             not part of a valid version",
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tracing")]
+    #[tracing_test::traced_test]
+    fn warnings3() {
+        let env37 = env37();
         let string_string = MarkerTree::from_str("'b' >= 'a'").unwrap();
         string_string.evaluate(&env37, &[]);
-        testing_logger::validate(|captured_logs| {
-            assert_eq!(
-                captured_logs[0].body,
-                "Comparing two quoted strings with each other doesn't make sense: 'b' >= 'a', will evaluate to false"
-            );
-            assert_eq!(captured_logs[0].level, log::Level::Warn);
-            assert_eq!(captured_logs.len(), 1);
-        });
+        logs_contain(
+            "Comparing two quoted strings with each other doesn't make sense: 'b' >= 'a', will evaluate to false"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "tracing")]
+    #[tracing_test::traced_test]
+    fn warnings4() {
+        let env37 = env37();
         let string_string = MarkerTree::from_str(r"os.name == 'posix' and platform.machine == 'x86_64' and platform.python_implementation == 'CPython' and 'Ubuntu' in platform.version and sys.platform == 'linux'").unwrap();
         string_string.evaluate(&env37, &[]);
-        testing_logger::validate(|captured_logs| {
-            let messages: Vec<_> = captured_logs
+        logs_assert(|lines: &[&str]| {
+            let lines: Vec<_> = lines
                 .iter()
-                .map(|message| {
-                    assert_eq!(message.level, log::Level::Warn);
-                    &message.body
-                })
+                .map(|s| s.split_once("  ").unwrap().1)
                 .collect();
-            let expected = [
-                "os.name is deprecated in favor of os_name",
-                "platform.machine is deprecated in favor of platform_machine",
-                "platform.python_implementation is deprecated in favor of platform_python_implementation",
-                "platform.version is deprecated in favor of platform_version",
-                "sys.platform  is deprecated in favor of sys_platform"
+            let expected =  [
+                "WARN warnings4: uv_pep508: os.name is deprecated in favor of os_name",
+                "WARN warnings4: uv_pep508: platform.machine is deprecated in favor of platform_machine",
+                "WARN warnings4: uv_pep508: platform.python_implementation is deprecated in favor of",
+                "WARN warnings4: uv_pep508: sys.platform  is deprecated in favor of sys_platform",
+                "WARN warnings4: uv_pep508: Comparing linux and posix lexicographically"
             ];
-            assert_eq!(messages, &expected);
+            if lines == expected {
+                Ok(())
+            } else {
+                Err(format!("{:?}", lines))
+            }
         });
     }
 

--- a/crates/uv-pep508/src/tests.rs
+++ b/crates/uv-pep508/src/tests.rs
@@ -712,6 +712,7 @@ fn error_invalid_extra_unnamed_url() {
 
 /// Check that the relative path support feature toggle works.
 #[test]
+#[cfg(feature = "non-pep508-extensions")]
 fn non_pep508_paths() {
     let requirements = &[
         "foo @ file://./foo",
@@ -748,6 +749,7 @@ fn no_space_after_operator() {
 }
 
 #[test]
+#[cfg(feature = "non-pep508-extensions")]
 fn path_with_fragment() {
     let requirements = if cfg!(windows) {
         &[

--- a/crates/uv-pypi-types/src/metadata/requires_txt.rs
+++ b/crates/uv-pypi-types/src/metadata/requires_txt.rs
@@ -3,8 +3,7 @@ use serde::Deserialize;
 use std::io::BufRead;
 use std::str::FromStr;
 use uv_normalize::ExtraName;
-use uv_pep508::marker::MarkerValueExtra;
-use uv_pep508::{ExtraOperator, MarkerExpression, MarkerTree, Requirement};
+use uv_pep508::{ExtraOperator, MarkerExpression, MarkerTree, MarkerValueExtra, Requirement};
 
 /// `requires.txt` metadata as defined in <https://setuptools.pypa.io/en/latest/deprecated/python_eggs.html#dependency-metadata>.
 ///


### PR DESCRIPTION
Use the `non-pep508-extensions` feature so that ruff can compile to the wasm32-unknown-unknown target, when only using the default features without `non-pep508-extensions`. Since uv always uses the `non-pep508-extensions` feature, it is a cosmetic change for uv.