### PR TITLE
Fix test context filtering of Python platform keys with elided patch versions

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -215,8 +215,9 @@ impl TestContext {
 
     /// Adds a filter that ignores platform information in a Python installation key.
     pub fn with_filtered_python_keys(mut self) -> Self {
+        // Filter platform keys
         self.filters.push((
-            r"((?:cpython|pypy)-\d+\.\d+(:?\.\d+)?[a-z]?(:?\+[a-z]+)?)-.*".to_string(),
+            r"((?:cpython|pypy)-\d+\.\d+(?:\.(?:\[X\]|\d+))?[a-z]?(?:\+[a-z]+)?)-.*".to_string(),
             "$1-[PLATFORM]".to_string(),
         ));
         self


### PR DESCRIPTION
Cherry-picked from #8650