### PR TITLE
Fix link to publish guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ All checks passed!
 See the [project documentation](https://docs.astral.sh/uv/guides/projects/) to get started.
 
 uv also supports building and publishing projects, even if they're not managed with uv. See the
-[publish guide](https://docs.astral.sh/uv/guides/publish.md) to learn more.
+[publish guide](https://docs.astral.sh/uv/guides/publish/) to learn more.
 
 ### Tool management
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The README contains a link to the publish guide (https://docs.astral.sh/uv/guides/publish.md) that gives an error 404. When navigating to that page via the side menu, the correct link seems to be (https://docs.astral.sh/uv/guides/publish/).

## Test Plan

<!-- How was it tested? -->

Documentation change, therefore manual testing by clicking on the link.
