### PR TITLE
Avoid showing dependency group annotations on workspace members in tree

### DIFF
--- a/crates/uv/tests/it/pip_tree.rs
+++ b/crates/uv/tests/it/pip_tree.rs
@@ -1,4 +1,4 @@
-#![cfg(not(windows))]
+#![cfg(windows)]
 
 use std::process::Command;
 

--- a/crates/uv/tests/it/pip_tree.rs
+++ b/crates/uv/tests/it/pip_tree.rs
@@ -1,4 +1,4 @@
-#![cfg(windows)]
+#![cfg(not(windows))]
 
 use std::process::Command;
 


### PR DESCRIPTION
## Summary

By default, `uv tree` shows the full workspace, not _just_ the root. If the root depended on a workspace member as a dev dependency, then we'd still show it as `(group: dev)` in `uv tree` even if you passed `--no-dev`, because we weren't filtering the edges in the right place.

This is still somewhat confusing, because if `root` depends on workspace member `child` as a dev dependency, `uv tree --no-dev` still shows both.

Closes https://github.com/astral-sh/uv/issues/8719.
