### PR TITLE
uv-client: switch to RFC 9110 compatible format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,9 +1710,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jiff"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb"
+checksum = "b9d9d414fc817d3e3d62b2598616733f76c4cc74fbac96069674739b881295c8"
 dependencies = [
  "jiff-tzdb-platform",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ indexmap = { version = "2.5.0" }
 indicatif = { version = "0.17.8" }
 indoc = { version = "2.0.5" }
 itertools = { version = "0.13.0" }
-jiff = { version = "0.1.13", features = ["serde"] }
+jiff = { version = "0.1.14", features = ["serde"] }
 junction = { version = "1.2.0" }
 krata-tokio-tar = { version = "0.4.2" }
 mailparse = { version = "0.15.0" }

--- a/crates/uv-client/src/httpcache/mod.rs
+++ b/crates/uv-client/src/httpcache/mod.rs
@@ -1381,11 +1381,9 @@ fn unix_timestamp_to_rfc2822(seconds: u64) -> Option<String> {
     use jiff::fmt::rfc2822::DateTimePrinter;
 
     unix_timestamp_to_datetime(seconds).and_then(|timestamp| {
-        let mut buf = String::new();
         DateTimePrinter::new()
-            .print_timestamp(&timestamp, &mut buf)
-            .ok()?;
-        Some(buf)
+            .timestamp_to_rfc9110_string(&timestamp)
+            .ok()
     })
 }
 


### PR DESCRIPTION
This still utilizes the RFC 2822 datetime formatter, but utilizes new
methods [added in jiff 0.1.14] to emit timestamps in a format strictly
compatible with RFC 9110.

It seems like most HTTP servers were pretty flexible and supported RFC
2822 datetime formats, but #8747 shows at least one case where that
isn't true. Given that the [MDN docs prescribe RFC 9110], we defer to
them.

Fixes #8747

[added in jiff 0.1.14]: https://github.com/BurntSushi/jiff/pull/154
[MDN docs prescribe RFC 9110]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since
