### PR TITLE
Separate use cases from non-use cases of workspaces in docs

### DIFF
--- a/docs/concepts/workspaces.md
+++ b/docs/concepts/workspaces.md
@@ -147,7 +147,7 @@ albatross
 Since `seeds` was excluded in the `pyproject.toml`, the workspace has two members total: `albatross`
 (the root) and `bird-feeder`.
 
-## When (not) to use workspaces
+## Summary of use cases
 
 Workspaces are intended to facilitate the development of multiple interconnected packages within a
 single repository. As a codebase grows in complexity, it can be helpful to split it into smaller,
@@ -163,6 +163,8 @@ Other common use cases for workspaces include:
   etc.).
 - A library with a plugin system, where each plugin is a separate workspace package with a
   dependency on the root.
+
+## When _not_ to use workspaces
 
 Workspaces are _not_ suited for cases in which members have conflicting requirements, or desire a
 separate virtual environment for each member. In this case, path dependencies are often preferable.


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Partially address https://github.com/astral-sh/uv/issues/5605#issuecomment-2447089161

It puts the use cases in its own section, so the _non_ use cases are easier to find.

I still think more could be done to describe the usage of uv in non-workspace settings but I don't have specific examples at the moment, still exploring it.

## Test Plan

<!-- How was it tested? -->
