### PR TITLE
Add `From` for `FlatDistributions` struct

### DIFF
--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -226,3 +226,9 @@ impl From<FlatDistributions> for BTreeMap<Version, PrioritizedDist> {
         distributions.0
     }
 }
+
+impl From<BTreeMap<Version, PrioritizedDist>> for FlatDistributions {
+    fn from(distributions: BTreeMap<Version, PrioritizedDist>) -> Self {
+        Self(distributions)
+    }
+}

--- a/crates/uv-resolver/src/flat_index.rs
+++ b/crates/uv-resolver/src/flat_index.rs
@@ -227,6 +227,7 @@ impl From<FlatDistributions> for BTreeMap<Version, PrioritizedDist> {
     }
 }
 
+/// For external users.
 impl From<BTreeMap<Version, PrioritizedDist>> for FlatDistributions {
     fn from(distributions: BTreeMap<Version, PrioritizedDist>) -> Self {
         Self(distributions)


### PR DESCRIPTION
I'm using a override `ResolverProvider` and want to make use of the eager version of the `VersionMap`. This way I can construct that variant :)
