### PR TITLE
Extend BaseClient to accept extra middleware

### DIFF
--- a/crates/uv-client/src/base_client.rs
+++ b/crates/uv-client/src/base_client.rs
@@ -336,7 +336,7 @@ impl<'a> BaseClientBuilder<'a> {
 
                 // When supplied add the extra middleware
                 if let Some(extra_middleware) = &self.extra_middleware {
-                    for middleware in extra_middleware.0.iter() {
+                    for middleware in &extra_middleware.0 {
                         client = client.with_arc(middleware.clone());
                     }
                 }

--- a/crates/uv-client/src/registry_client.rs
+++ b/crates/uv-client/src/registry_client.rs
@@ -26,7 +26,7 @@ use uv_pep508::MarkerEnvironment;
 use uv_platform_tags::Platform;
 use uv_pypi_types::{ResolutionMetadata, SimpleJson};
 
-use crate::base_client::BaseClientBuilder;
+use crate::base_client::{BaseClientBuilder, ExtraMiddleware};
 use crate::cached_client::CacheControl;
 use crate::html::SimpleHtml;
 use crate::remote_metadata::wheel_metadata_from_remote_zip;
@@ -107,6 +107,12 @@ impl<'a> RegistryClientBuilder<'a> {
     #[must_use]
     pub fn client(mut self, client: Client) -> Self {
         self.base_client_builder = self.base_client_builder.client(client);
+        self
+    }
+
+    #[must_use]
+    pub fn extra_middleware(mut self, middleware: ExtraMiddleware) -> Self {
+        self.base_client_builder = self.base_client_builder.extra_middleware(middleware);
         self
     }
 


### PR DESCRIPTION
This PR is a revival of #3502, albeit in a much simpler form.

This would allow for different middlewares like authentication and such, useful for if you want to deviate from the keychain authentication methods when using uv as a library.

@zanieb I hope I made the changes as you noted you wanted to see them :)

Happy to add/change anything you need.

