### PR TITLE
Add reference to correct issue for conflicting dependency groups 

### DIFF
--- a/docs/concepts/dependencies.md
+++ b/docs/concepts/dependencies.md
@@ -456,7 +456,7 @@ to resolve the requirements of the project with an error.
 !!! note
 
     There is currently no way to declare conflicting dependency groups. See
-    [astral.sh/uv#6981](https://github.com/astral-sh/uv/issues/6981) to track support.
+    [astral.sh/uv#8814](https://github.com/astral-sh/uv/issues/8814) to track support.
 
 ### Default groups
 


### PR DESCRIPTION
In the [Dependency Groups section of the Dependencies documentation](https://docs.astral.sh/uv/concepts/dependencies/#dependency-groups), the issue mentioned concerns optional dependencies and not dependency groups.

I think it'd help newcomers know what is currently allowed (maybe conflicting optional dependencies will be allowed before conflicting dependency groups or vice-versa etc.). 

I have opened an issue for the conflicting dependency groups here https://github.com/astral-sh/uv/issues/8814

PS:
I haven't found another issue that mentions that but please do edit or even remove this PR / the issue if you have a better way.