### PR TITLE
Publish: Warn when keyring has no password

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1164,7 +1164,7 @@ jobs:
       - name: "Add password to keyring"
         run: |
           # `keyrings.alt` contains the plaintext keyring
-          ./uv tool install --with keyrings.alt "keyring<25.4.0" # TODO(konsti): Remove upper bound once fix is released
+          ./uv tool install --with keyrings.alt keyring
           echo $UV_TEST_PUBLISH_KEYRING | keyring set https://test.pypi.org/legacy/?astral-test-keyring __token__
         env:
           UV_TEST_PUBLISH_KEYRING: ${{ secrets.UV_TEST_PUBLISH_KEYRING }}

--- a/crates/uv-auth/src/credentials.rs
+++ b/crates/uv-auth/src/credentials.rs
@@ -76,7 +76,7 @@ impl Credentials {
         }
     }
 
-    pub(crate) fn username(&self) -> Option<&str> {
+    pub fn username(&self) -> Option<&str> {
         self.username.as_deref()
     }
 
@@ -84,7 +84,7 @@ impl Credentials {
         self.username.clone()
     }
 
-    pub(crate) fn password(&self) -> Option<&str> {
+    pub fn password(&self) -> Option<&str> {
         self.password.as_deref()
     }
 

--- a/crates/uv-auth/src/keyring.rs
+++ b/crates/uv-auth/src/keyring.rs
@@ -35,7 +35,7 @@ impl KeyringProvider {
     /// Returns [`None`] if no password was found for the username or if any errors
     /// are encountered in the keyring backend.
     #[instrument(skip_all, fields(url = % url.to_string(), username))]
-    pub(crate) async fn fetch(&self, url: &Url, username: &str) -> Option<Credentials> {
+    pub async fn fetch(&self, url: &Url, username: &str) -> Option<Credentials> {
         // Validate the request
         debug_assert!(
             url.host_str().is_some(),

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -230,7 +230,8 @@ fn check_keyring_behaviours() {
         .arg("https://test.pypi.org/simple/")
         .arg("--publish-url")
         .arg("https://test.pypi.org/legacy/?ok")
-        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl"), @r###"
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl")
+        .env(EnvVars::PATH, venv_bin_path(&context.venv)), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -253,7 +254,8 @@ fn check_keyring_behaviours() {
         .arg("subprocess")
         .arg("--publish-url")
         .arg("https://test.pypi.org/legacy/?ok")
-        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl"),  @r###"
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl")
+        .env(EnvVars::PATH, venv_bin_path(&context.venv)),  @r###"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -279,7 +281,8 @@ fn check_keyring_behaviours() {
         .arg("https://test.pypi.org/simple/")
         .arg("--publish-url")
         .arg("https://test.pypi.org/legacy/?ok")
-        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl"),  @r###"
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl")
+        .env(EnvVars::PATH, venv_bin_path(&context.venv)), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -287,6 +290,8 @@ fn check_keyring_behaviours() {
     ----- stderr -----
     warning: `uv publish` is experimental and may change without warning
     Publishing 1 file to https://test.pypi.org/legacy/?ok
+    Request for dummy@https://test.pypi.org/legacy/?ok
+    Request for dummy@test.pypi.org
     warning: Keyring has no password for URL `https://test.pypi.org/legacy/?ok` and username `dummy`
     error: Failed to query check URL
       Caused by: Package `ok` was not found in the registry

--- a/crates/uv/tests/it/publish.rs
+++ b/crates/uv/tests/it/publish.rs
@@ -1,5 +1,9 @@
 use crate::common::{uv_snapshot, TestContext};
+use assert_cmd::assert::OutputAssertExt;
 use assert_fs::fixture::{FileTouch, PathChild};
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::{env, iter};
 use uv_static::EnvVars;
 
 #[test]
@@ -194,6 +198,178 @@ fn dubious_filenames() {
     warning: Skipping file that looks like a distribution, but is not a valid distribution filename: `[TEMP_DIR]/not-a-wheel.whl`
     warning: Skipping file that looks like a distribution, but is not a valid distribution filename: `[TEMP_DIR]/not-sdist-1-2-3-asdf.zip`
     error: No files found to publish
+    "###
+    );
+}
+
+/// Check that we (don't) use the keyring and warn for missing keyring behaviors correctly.
+#[test]
+fn check_keyring_behaviours() {
+    let context = TestContext::new("3.12");
+
+    // No upper bound, since we are recommending `uv tool install keyring` without upper bound to
+    // users. The keyring package had a bad release in the past, but so it hits us before it hits
+    // users.
+    context
+        .pip_install()
+        .arg("keyring")
+        // Contains the plaintext keyring
+        .arg("keyrings.alt")
+        .env_remove(EnvVars::UV_EXCLUDE_NEWER)
+        .assert()
+        .success();
+
+    // Ok: The keyring may be used for the index page.
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("-u")
+        .arg("dummy")
+        .arg("-p")
+        .arg("dummy")
+        .arg("--keyring-provider")
+        .arg("subprocess")
+        .arg("--check-url")
+        .arg("https://test.pypi.org/simple/")
+        .arg("--publish-url")
+        .arg("https://test.pypi.org/legacy/?ok")
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl")
+        // Avoid `gi.repository.GLib.GError`
+        .env(
+            "PYTHON_KEYRING_BACKEND",
+            "keyrings.alt.file.PlaintextKeyring",
+        ), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv publish` is experimental and may change without warning
+    Publishing 1 file to https://test.pypi.org/legacy/?ok
+    error: Failed to query check URL
+      Caused by: Package `ok` was not found in the registry
+    "###
+    );
+
+    // Warn: The keyring is unused.
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("-u")
+        .arg("dummy")
+        .arg("-p")
+        .arg("dummy")
+        .arg("--keyring-provider")
+        .arg("subprocess")
+        .arg("--publish-url")
+        .arg("https://test.pypi.org/legacy/?ok")
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl")
+        // Avoid `gi.repository.GLib.GError`
+        .env(
+            "PYTHON_KEYRING_BACKEND",
+            "keyrings.alt.file.PlaintextKeyring",
+        ),  @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv publish` is experimental and may change without warning
+    Publishing 1 file to https://test.pypi.org/legacy/?ok
+    warning: Using `--keyring-provider` with a password or token and no check url has no effect
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE])
+    error: Failed to publish `../../scripts/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/?ok
+      Caused by: Upload failed with status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
+    "###
+    );
+
+    // Warn: There is no keyring entry for the user dummy.
+    // https://github.com/astral-sh/uv/issues/7963#issuecomment-2453558043
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("-u")
+        .arg("dummy")
+        .arg("--keyring-provider")
+        .arg("subprocess")
+        .arg("--check-url")
+        .arg("https://test.pypi.org/simple/")
+        .arg("--publish-url")
+        .arg("https://test.pypi.org/legacy/?ok")
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl")
+        // Avoid `gi.repository.GLib.GError`
+        .env(
+            "PYTHON_KEYRING_BACKEND",
+            "keyrings.alt.file.PlaintextKeyring",
+        ),  @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv publish` is experimental and may change without warning
+    Publishing 1 file to https://test.pypi.org/legacy/?ok
+    warning: Keyring has no password for URL `https://test.pypi.org/legacy/?ok` and username `dummy`
+    error: Failed to query check URL
+      Caused by: Package `ok` was not found in the registry
+    "###
+    );
+
+    let mut child = Command::new(context.interpreter())
+        .arg("-m")
+        .arg("keyring")
+        .arg("set")
+        .arg("https://test.pypi.org/legacy/?ok")
+        .arg("dummy")
+        // Don't save the dummy to the host's actual keyring!
+        .env(
+            "PYTHON_KEYRING_BACKEND",
+            "keyrings.alt.file.PlaintextKeyring",
+        )
+        // Configure keyring file location
+        .env("XDG_DATA_HOME", context.temp_dir.path())
+        .env("LOCALAPPDATA", context.temp_dir.path())
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().expect("Failed to open stdin");
+    std::thread::spawn(move || {
+        stdin
+            .write_all("dummy\n".as_bytes())
+            .expect("Failed to write to stdin");
+        stdin.flush().expect("Failed to flush stdin");
+    });
+    let status = child.wait().expect("Failed to wait on child");
+    assert!(status.success(), "Setting password in keyring failed");
+
+    // Ok: There is a keyring entry for the user dummy.
+    // https://github.com/astral-sh/uv/issues/7963#issuecomment-2453558043
+    let path_with_venv = env::join_paths(
+        iter::once(context.interpreter().parent().unwrap().to_path_buf())
+            .chain(env::split_paths(&env::var_os("PATH").unwrap())),
+    )
+    .unwrap();
+    uv_snapshot!(context.filters(), context.publish()
+        .arg("-u")
+        .arg("dummy")
+        .arg("--keyring-provider")
+        .arg("subprocess")
+        .arg("--publish-url")
+        .arg("https://test.pypi.org/legacy/?ok")
+        .arg("../../scripts/links/ok-1.0.0-py3-none-any.whl")
+        // Don't save the dummy to the host's actual keyring!
+        .env(
+            "PYTHON_KEYRING_BACKEND",
+            "keyrings.alt.file.PlaintextKeyring",
+        )
+        // Configure keyring file location
+        .env("XDG_DATA_HOME", context.temp_dir.path())
+        .env("LOCALAPPDATA", context.temp_dir.path())
+        .env("PATH", path_with_venv), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    warning: `uv publish` is experimental and may change without warning
+    Publishing 1 file to https://test.pypi.org/legacy/?ok
+    Uploading ok-1.0.0-py3-none-any.whl ([SIZE])
+    error: Failed to publish `../../scripts/links/ok-1.0.0-py3-none-any.whl` to https://test.pypi.org/legacy/?ok
+      Caused by: Upload failed with status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://test.pypi.org/help/#apitoken and https://test.pypi.org/help/#trusted-publishers
     "###
     );
 }

--- a/scripts/packages/keyring_test_plugin/keyrings/test_keyring.py
+++ b/scripts/packages/keyring_test_plugin/keyrings/test_keyring.py
@@ -10,7 +10,7 @@ class KeyringTest(backend.KeyringBackend):
 
     def get_password(self, service, username):
         print(f"Request for {username}@{service}", file=sys.stderr)
-        credentials = json.loads(os.environ.get("KEYRING_TEST_CREDENTIALS") or {})
+        credentials = json.loads(os.environ.get("KEYRING_TEST_CREDENTIALS", "{}"))
         return credentials.get(service, {}).get(username)
 
     def set_password(self, service, username, password):


### PR DESCRIPTION
When trying to upload without a password but with the keyring, check that the keyring has a password for the upload URL and username and warn if it doesn't.

Fixes #8781