### PR TITLE
Allow semicolons directly after direct URLs

### DIFF
--- a/crates/uv-pep508/src/tests.rs
+++ b/crates/uv-pep508/src/tests.rs
@@ -546,42 +546,6 @@ fn error_extras_not_closed() {
 }
 
 #[test]
-fn error_no_space_after_url() {
-    assert_snapshot!(
-        parse_pep508_err(r"name @ https://example.com/; extra == 'example'"),
-        @r#"
-    Missing space before ';', the end of the URL is ambiguous
-    name @ https://example.com/; extra == 'example'
-                               ^
-    "#
-    );
-}
-
-#[test]
-fn error_no_space_after_file_url() {
-    assert_snapshot!(
-        parse_pep508_err(r"name @ file:///test.whl; extra == 'example'"),
-        @r###"
-    Missing space before ';', the end of the URL is ambiguous
-    name @ file:///test.whl; extra == 'example'
-                           ^
-    "###
-    );
-}
-
-#[test]
-fn error_no_space_after_file_path() {
-    assert_snapshot!(
-        parse_pep508_err(r"name @ ./test.whl; extra == 'example'"),
-        @r###"
-    Missing space before ';', the end of the URL is ambiguous
-    name @ ./test.whl; extra == 'example'
-                     ^
-    "###
-    );
-}
-
-#[test]
 fn error_name_at_nothing() {
     assert_snapshot!(
         parse_pep508_err(r"name @"),

--- a/crates/uv-pep508/src/unnamed.rs
+++ b/crates/uv-pep508/src/unnamed.rs
@@ -174,7 +174,11 @@ fn parse_unnamed_requirement<Url: UnnamedRequirementUrl>(
     // wsp*
     cursor.eat_whitespace();
     if let Some((pos, char)) = cursor.next() {
-        let message = if marker.is_none() {
+        let message = if char == '#' {
+            format!(
+                r#"Expected end of input or `;`, found `{char}`; comments must be preceded by a leading space"#
+            )
+        } else if marker.is_none() {
             format!(r#"Expected end of input or `;`, found `{char}`"#)
         } else {
             format!(r#"Expected end of input, found `{char}`"#)
@@ -388,15 +392,11 @@ fn parse_unnamed_url<Url: UnnamedRequirementUrl>(
             len += c.len_utf8();
 
             // If we see a top-level semicolon or hash followed by whitespace, we're done.
-            if depth == 0 {
-                match c {
-                    ';' if cursor.peek_char().is_some_and(char::is_whitespace) => {
-                        break;
-                    }
-                    '#' if cursor.peek_char().is_some_and(char::is_whitespace) => {
-                        break;
-                    }
-                    _ => {}
+            if depth == 0 && cursor.peek_char().is_some_and(|c| matches!(c, ';' | '#')) {
+                let mut cursor = cursor.clone();
+                cursor.next();
+                if cursor.peek_char().is_some_and(char::is_whitespace) {
+                    break;
                 }
             }
         }
@@ -411,19 +411,6 @@ fn parse_unnamed_url<Url: UnnamedRequirementUrl>(
             len,
             input: cursor.to_string(),
         });
-    }
-
-    for c in [';', '#'] {
-        if url.ends_with(c) {
-            return Err(Pep508Error {
-                message: Pep508ErrorSource::String(format!(
-                    "Missing space before '{c}', the end of the URL is ambiguous"
-                )),
-                start: start + len - 1,
-                len: 1,
-                input: cursor.to_string(),
-            });
-        }
     }
 
     let url = preprocess_unnamed_url(url, working_dir, cursor, start, len)?;

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-unix-editable.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-unix-editable.txt.snap
@@ -334,6 +334,106 @@ RequirementsTxt {
             ),
             hashes: [],
         },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Directory(
+                            ParsedDirectoryUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                install_path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
+                                virtual: false,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: true,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Directory(
+                            ParsedDirectoryUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                install_path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
+                                virtual: false,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: true,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
     ],
     index_url: None,
     extra_index_urls: [],

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-unix-hash.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-unix-hash.txt.snap
@@ -7,7 +7,7 @@ RequirementsTxtFileError {
     error: Pep508 {
         source: Pep508Error {
             message: String(
-                "Missing space before '#', the end of the URL is ambiguous",
+                "Expected end of input or `;`, found `#`; comments must be preceded by a leading space",
             ),
             start: 10,
             len: 1,

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-unix-semicolon.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-unix-semicolon.txt.snap
@@ -6,14 +6,17 @@ RequirementsTxtFileError {
     file: "<REQUIREMENTS_DIR>/semicolon.txt",
     error: Pep508 {
         source: Pep508Error {
-            message: String(
-                "Missing space before ';', the end of the URL is ambiguous",
+            message: UrlError(
+                MissingExtensionPath(
+                    "./editable;python_version >= \"3.9\" and os_name == \"posix\"",
+                    Dist,
+                ),
             ),
-            start: 10,
-            len: 1,
-            input: "./editable; python_version >= \"3.9\" and os_name == \"posix\"",
+            start: 0,
+            len: 57,
+            input: "./editable;python_version >= \"3.9\" and os_name == \"posix\"",
         },
         start: 50,
-        end: 108,
+        end: 107,
     },
 }

--- a/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-windows-editable.txt.snap
+++ b/crates/uv-requirements-txt/src/snapshots/uv_requirements_txt__test__parse-windows-editable.txt.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/requirements-txt/src/lib.rs
+source: crates/uv-requirements-txt/src/lib.rs
 expression: actual
 ---
 RequirementsTxt {
@@ -320,6 +320,106 @@ RequirementsTxt {
                             },
                             given: Some(
                                 "./editable[d",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: true,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Directory(
+                            ParsedDirectoryUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "/<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                install_path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
+                                virtual: false,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./editable",
+                            ),
+                        },
+                    },
+                    extras: [],
+                    marker: true,
+                    origin: Some(
+                        File(
+                            "<REQUIREMENTS_DIR>/editable.txt",
+                        ),
+                    ),
+                },
+            ),
+            hashes: [],
+        },
+        RequirementEntry {
+            requirement: Unnamed(
+                UnnamedRequirement {
+                    url: VerbatimParsedUrl {
+                        parsed_url: Directory(
+                            ParsedDirectoryUrl {
+                                url: Url {
+                                    scheme: "file",
+                                    cannot_be_a_base: false,
+                                    username: "",
+                                    password: None,
+                                    host: None,
+                                    port: None,
+                                    path: "/<REQUIREMENTS_DIR>/editable",
+                                    query: None,
+                                    fragment: None,
+                                },
+                                install_path: "<REQUIREMENTS_DIR>/editable",
+                                editable: true,
+                                virtual: false,
+                            },
+                        ),
+                        verbatim: VerbatimUrl {
+                            url: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/<REQUIREMENTS_DIR>/editable",
+                                query: None,
+                                fragment: None,
+                            },
+                            given: Some(
+                                "./editable",
                             ),
                         },
                     },

--- a/crates/uv-requirements-txt/test-data/requirements-txt/editable.txt
+++ b/crates/uv-requirements-txt/test-data/requirements-txt/editable.txt
@@ -15,3 +15,9 @@
 
 # OK (unterminated)
 -e ./editable[d
+
+# OK
+-e ./editable # comment
+
+# OK
+-e ./editable #comment

--- a/crates/uv-requirements-txt/test-data/requirements-txt/semicolon.txt
+++ b/crates/uv-requirements-txt/test-data/requirements-txt/semicolon.txt
@@ -1,2 +1,2 @@
 # Disallowed (missing whitespace before colon)
--e ./editable; python_version >= "3.9" and os_name == "posix"
+-e ./editable;python_version >= "3.9" and os_name == "posix"

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -296,31 +296,6 @@ dependencies = ["flask==1.0.x"]
 }
 
 #[test]
-fn trailing_semicolon() -> Result<()> {
-    let context = TestContext::new("3.12");
-    let requirements_txt = context.temp_dir.child("requirements.txt");
-    requirements_txt.write_str("./flask.whl; sys_platform == 'win32'")?;
-
-    uv_snapshot!(context.pip_install()
-        .arg("-r")
-        .arg("requirements.txt")
-        .arg("--strict"), @r###"
-    success: false
-    exit_code: 2
-    ----- stdout -----
-
-    ----- stderr -----
-    error: Couldn't parse requirement in `requirements.txt` at position 0
-      Caused by: Missing space before ';', the end of the URL is ambiguous
-    ./flask.whl; sys_platform == 'win32'
-               ^
-    "###
-    );
-
-    Ok(())
-}
-
-#[test]
 fn missing_pip() {
     uv_snapshot!(Command::new(get_bin()).arg("install"), @r###"
     success: false


### PR DESCRIPTION
## Summary

Like pip, we now allow the semicolon to directly proceed the URL (but require that it's either preceded or followed by a space):

```
# OK
./test.whl; sys_platform == 'darwin'

# OK
./test.whl ;sys_platform == 'darwin'

# Error
./test.whl;sys_platform == 'darwin'
```

Closes https://github.com/astral-sh/uv/issues/8831.
