### PR TITLE
Add further examples of git+https support

### DIFF
--- a/docs/guides/tools.md
+++ b/docs/guides/tools.md
@@ -103,6 +103,24 @@ For example, to pull from git:
 $ uvx --from git+https://github.com/httpie/cli httpie
 ```
 
+You can also pull the latest commit from a specific named branch:
+
+```console
+$ uvx --from git+https://github.com/httpie/cli@master httpie
+```
+
+Or pull a specific tag:
+
+```console
+$ uvx --from git+https://github.com/httpie/cli@3.2.4 httpie
+```
+
+Or even a specific commit:
+
+```console
+$ uvx --from git+https://github.com/httpie/cli@2843b87 httpie
+```
+
 ## Commands with plugins
 
 Additional dependencies can be included, e.g., to include `mkdocs-material` when running `mkdocs`:


### PR DESCRIPTION
This pull request includes updates to the `docs/guides/tools.md` file to provide more detailed instructions on how to pull from a git repository using different options, using the `git+https` scheme support.

It follows [asking a question in the Discord chat](https://discord.com/channels/1039017663004942429/1060247592765759518/1303270516588806214) and getting some useful guidance that was not in the docs, but makes some very useful features of `uv` easier to discover.

## Summary

Tweaks to documentation:

* Added instructions on how to pull the latest commit from a specific named branch.
* Added instructions on how to pull a specific tag.
* Added instructions on how to pull a specific commit.
