### PR TITLE
Use a + for the visual max local

### DIFF
--- a/crates/uv-pep440/src/version.rs
+++ b/crates/uv-pep440/src/version.rs
@@ -734,7 +734,7 @@ impl std::fmt::Display for Version {
                 LocalVersionSlice::Segments(_) => {
                     format!("+{}", self.local())
                 }
-                LocalVersionSlice::Max => String::new(),
+                LocalVersionSlice::Max => "+".to_string(),
             }
         };
         write!(f, "{epoch}{release}{pre}{post}{dev}{local}")


### PR DESCRIPTION
## Summary

We don't actually want users to see this, but we should be stripping it anyway. Without this change, we show ranges in the debug logs that look like `>=1.0.0, <1.0.0`, which is more confusing than helpful. (We may want to post-process those debug ranges to remove these.)