### PR TITLE
docs: fix `uv python install` docs to use an exisigin pypy version

### DIFF
--- a/docs/guides/install-python.md
+++ b/docs/guides/install-python.md
@@ -63,7 +63,7 @@ $ uv python install 3.11 3.12
 To install an alternative Python implementation, e.g. PyPy:
 
 ```console
-$ uv python install pypy@3.12
+$ uv python install pypy@3.10
 ```
 
 See the [`python install`](../concepts/python-versions.md#installing-a-python-version) documentation


### PR DESCRIPTION
The current docs call to install pypy@3.12 that does not exist yet. Change it to install pypy@3.10
