### PR TITLE
Revert "Using `--build-backend` in `uv init` implies `--package` (#8837)"

### DIFF
--- a/crates/uv/src/commands/project/init.rs
+++ b/crates/uv/src/commands/project/init.rs
@@ -643,7 +643,7 @@ impl InitProjectKind {
         let mut pyproject = pyproject_project(name, requires_python, author.as_ref(), no_readme);
 
         // Include additional project configuration for packaged applications
-        if package || build_backend.is_some() {
+        if package {
             // Since it'll be packaged, we can add a `[project.scripts]` entry
             pyproject.push('\n');
             pyproject.push_str(&pyproject_project_scripts(name, name.as_str(), "main"));


### PR DESCRIPTION
This reverts commit 515993c743fd7a8ad8636dde353676799ae1c542 from https://github.com/astral-sh/uv/pull/8837 as it was already implemented differently in https://github.com/astral-sh/uv/pull/8593 and I missed it
