### PR TITLE
docs: document how to mimic --verbose with environment variable RUST_LOG

### DIFF
--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -481,7 +481,10 @@ impl EnvVars {
 
     /// If set, uv will use this value as the log level for its `--verbose` output. Accepts
     /// any filter compatible with the `tracing_subscriber` crate.
-    /// For example, `RUST_LOG=trace` will enable trace-level logging.
+    /// For example:
+    /// * `RUST_LOG=uv=debug` is the equivalent of adding `--verbose` to the command line
+    /// * `RUST_LOG=trace` will enable trace-level logging.
+    ///
     /// See the [tracing documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax)
     /// for more.
     pub const RUST_LOG: &'static str = "RUST_LOG";

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -171,7 +171,10 @@ uv respects the following environment variables:
 - <a id="TRACING_DURATIONS_FILE"></a> [`TRACING_DURATIONS_FILE`](#TRACING_DURATIONS_FILE): Use to create the tracing durations file via the `tracing-durations-export` feature.
 - <a id="RUST_LOG"></a> [`RUST_LOG`](#RUST_LOG): If set, uv will use this value as the log level for its `--verbose` output. Accepts
   any filter compatible with the `tracing_subscriber` crate.
-  For example, `RUST_LOG=trace` will enable trace-level logging.
+  For example:
+  * `RUST_LOG=uv=debug` is the equivalent of adding `--verbose` to the command line
+  * `RUST_LOG=trace` will enable trace-level logging.
+
   See the [tracing documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax)
   for more.
 - <a id="UV_ENV_FILE"></a> [`UV_ENV_FILE`](#UV_ENV_FILE): `.env` files from which to load environment variables when executing `uv run` commands.

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -174,7 +174,6 @@ uv respects the following environment variables:
   For example:
   * `RUST_LOG=uv=debug` is the equivalent of adding `--verbose` to the command line
   * `RUST_LOG=trace` will enable trace-level logging.
-
   See the [tracing documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax)
   for more.
 - <a id="UV_ENV_FILE"></a> [`UV_ENV_FILE`](#UV_ENV_FILE): `.env` files from which to load environment variables when executing `uv run` commands.


### PR DESCRIPTION
The doc was unclear to me and I had to dig in the code to understand that RUST_LOG could do the same as adding `--verbose`