### PR TITLE
Add armv8l alias for armv7l to support arm 32-bit compatibility mode

### DIFF
--- a/crates/uv-platform-tags/src/platform.rs
+++ b/crates/uv-platform-tags/src/platform.rs
@@ -76,6 +76,7 @@ pub enum Arch {
     #[serde(alias = "arm64")]
     Aarch64,
     Armv6L,
+    #[serde(alias = "armv8l")]
     Armv7L,
     #[serde(alias = "ppc64le")]
     Powerpc64Le,


### PR DESCRIPTION
## Summary

`uv` commands like `uv venv` and `uv tool` throw this error when running on arm64 in 32-bit [compatibility mode](https://elixir.bootlin.com/linux/v6.11.6/source/arch/arm64/include/asm/compat.h#L32):
```
unknown variant `armv8l`, expected one of `aarch64`, `arm64`, `armv6l`, `armv7l`, `powerpc64le`, `ppc64le`, `powerpc64`, `ppc64`, `i386`, `i686`, `x86`, `amd64`, `x86_64`, `s390x`, `riscv64`
--- stdout:
{"result": "success", "markers": {"implementation_name": "cpython", "implementation_version": "3.11.10", "os_name": "posix", "platform_machine": "armv8l", "platform_python_implementation": "CPython", "platform_release": "6.8.0-1015-azure", "platform_system": "Linux", "platform_version": "#17-Ubuntu SMP Mon Sep  2 15:50:42 UTC 2024", "python_full_version": "3.11.10", "python_version": "3.11", "sys_platform": "linux"}, "sys_base_prefix": "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf", "sys_base_exec_prefix": "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf", "sys_prefix": "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf", "sys_base_executable": "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf/bin/python3.11", "sys_executable": "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf/bin/python3.11", "sys_path": ["/home/pi/.cache/uv/.tmpvXy34S", "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf/lib/python311.zip", "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf/lib/python3.11", "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf/lib/python3.11/lib-dynload", "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf/lib/python3.11/site-packages"], "stdlib": "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf/lib/python3.11", "scheme": {"platlib": "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf/lib/python3.11/site-packages", "purelib": "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf/lib/python3.11/site-packages", "include": "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf/include/python3.11", "scripts": "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf/bin", "data": "/home/pi/.local/share/uv/python/cpython-3.11.10-linux-armv7-gnueabihf"}, "virtualenv": {"purelib": "lib/python3.11/site-packages", "platlib": "lib/python3.11/site-packages", "include": "include/site/python3.11", "scripts": "bin", "data": ""}, "platform": {"os": {"name": "manylinux", "major": 2, "minor": 31}, "arch": "armv8l"}, "manylinux_compatible": true, "gil_disabled": false, "pointer_size": "32"}
--- stderr:

---
```

This is needed when building for 32-bit arm on a arm64 runner.

The `platform.machine()` function in python (which uses the `uname` syscall) outputs`armv8l` when running in 32-bit [compatibility mode](https://elixir.bootlin.com/linux/v6.11.6/source/arch/arm64/include/asm/compat.h#L32), which means that the system supports armv7l binaries.

## Test Plan

Not tested :) 
