### PR TITLE
Improve Python discovery source messages

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -303,7 +303,7 @@ pub enum Commands {
     /// interpreters are found by searching for Python executables in the `PATH` environment
     /// variable.
     ///
-    /// On Windows, the `py` launcher is also invoked to find Python executables.
+    /// On Windows, the registry is also searched for Python executables.
     ///
     /// By default, uv will download Python if a version cannot be found. This behavior can be
     /// disabled with the `--no-python-downloads` flag or the `python-downloads` setting.

--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -147,11 +147,11 @@ impl TestContext {
     #[must_use]
     pub fn with_filtered_python_sources(mut self) -> Self {
         self.filters.push((
-            "managed installations or system path".to_string(),
+            "managed installations or search path".to_string(),
             "[PYTHON SOURCES]".to_string(),
         ));
         self.filters.push((
-            "managed installations, system path, or `py` launcher".to_string(),
+            "managed installations, search path, or registry".to_string(),
             "[PYTHON SOURCES]".to_string(),
         ));
         self

--- a/crates/uv/tests/it/help.rs
+++ b/crates/uv/tests/it/help.rs
@@ -223,7 +223,7 @@ fn help_subcommand() {
     interpreters are found by searching for Python executables in the `PATH` environment
     variable.
 
-    On Windows, the `py` launcher is also invoked to find Python executables.
+    On Windows, the registry is also searched for Python executables.
 
     By default, uv will download Python if a version cannot be found. This behavior can be
     disabled with the `--no-python-downloads` flag or the `python-downloads` setting.

--- a/crates/uv/tests/it/python_find.rs
+++ b/crates/uv/tests/it/python_find.rs
@@ -20,7 +20,7 @@ fn python_find() {
         ----- stdout -----
 
         ----- stderr -----
-        error: No interpreter found in virtual environments, managed installations, system path, or `py` launcher
+        error: No interpreter found in virtual environments, managed installations, search path, or registry
         "###);
     } else {
         uv_snapshot!(context.filters(), context.python_find().env(EnvVars::UV_TEST_PYTHON_PATH, ""), @r###"
@@ -29,7 +29,7 @@ fn python_find() {
         ----- stdout -----
 
         ----- stderr -----
-        error: No interpreter found in virtual environments, managed installations, or system path
+        error: No interpreter found in virtual environments, managed installations, or search path
         "###);
     }
 
@@ -116,7 +116,7 @@ fn python_find() {
         ----- stdout -----
 
         ----- stderr -----
-        error: No interpreter found for PyPy in virtual environments, managed installations, system path, or `py` launcher
+        error: No interpreter found for PyPy in virtual environments, managed installations, search path, or registry
         "###);
     } else {
         uv_snapshot!(context.filters(), context.python_find().arg("pypy"), @r###"
@@ -125,7 +125,7 @@ fn python_find() {
         ----- stdout -----
 
         ----- stderr -----
-        error: No interpreter found for PyPy in virtual environments, managed installations, or system path
+        error: No interpreter found for PyPy in virtual environments, managed installations, or search path
         "###);
     }
 
@@ -441,7 +441,7 @@ fn python_find_unsupported_version() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No interpreter found for Python 4.2 in virtual environments, managed installations, or system path
+    error: No interpreter found for Python 4.2 in virtual environments, managed installations, or search path
     "###);
 
     // Request a low version with a range
@@ -451,7 +451,7 @@ fn python_find_unsupported_version() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No interpreter found for Python <3.0 in virtual environments, managed installations, or system path
+    error: No interpreter found for Python <3.0 in virtual environments, managed installations, or search path
     "###);
 
     // Request free-threaded Python on unsupported version

--- a/crates/uv/tests/it/python_pin.rs
+++ b/crates/uv/tests/it/python_pin.rs
@@ -168,7 +168,7 @@ fn python_pin() {
         Updated `.python-version` from `[PYTHON-3.11]` -> `pypy`
 
         ----- stderr -----
-        warning: No interpreter found for PyPy in managed installations or system path
+        warning: No interpreter found for PyPy in managed installations or search path
         "###);
 
         let python_version = context.read(PYTHON_VERSION_FILENAME);
@@ -188,7 +188,7 @@ fn python_pin() {
         Updated `.python-version` from `pypy` -> `3.7`
 
         ----- stderr -----
-        warning: No interpreter found for Python 3.7 in managed installations or system path
+        warning: No interpreter found for Python 3.7 in managed installations or search path
         "###);
 
         let python_version = context.read(PYTHON_VERSION_FILENAME);
@@ -212,7 +212,7 @@ fn python_pin_no_python() {
     Pinned `.python-version` to `3.12`
 
     ----- stderr -----
-    warning: No interpreter found for Python 3.12 in managed installations or system path
+    warning: No interpreter found for Python 3.12 in managed installations or search path
     "###);
 }
 
@@ -411,7 +411,7 @@ fn warning_pinned_python_version_not_installed() -> anyhow::Result<()> {
         3.12
 
         ----- stderr -----
-        warning: Failed to resolve pinned Python version `3.12`: No interpreter found for Python 3.12 in managed installations, system path, or `py` launcher
+        warning: Failed to resolve pinned Python version `3.12`: No interpreter found for Python 3.12 in managed installations, search path, or registry
         "###);
     } else {
         uv_snapshot!(context.filters(), context.python_pin(), @r###"
@@ -421,7 +421,7 @@ fn warning_pinned_python_version_not_installed() -> anyhow::Result<()> {
         3.12
 
         ----- stderr -----
-        warning: Failed to resolve pinned Python version `3.12`: No interpreter found for Python 3.12 in managed installations or system path
+        warning: Failed to resolve pinned Python version `3.12`: No interpreter found for Python 3.12 in managed installations or search path
         "###);
     }
 
@@ -440,7 +440,7 @@ fn python_pin_resolve_no_python() {
         ----- stdout -----
 
         ----- stderr -----
-        error: No interpreter found for Python 3.12 in managed installations, system path, or `py` launcher
+        error: No interpreter found for Python 3.12 in managed installations, search path, or registry
         "###);
     } else {
         uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("3.12"), @r###"
@@ -449,7 +449,7 @@ fn python_pin_resolve_no_python() {
         ----- stdout -----
 
         ----- stderr -----
-        error: No interpreter found for Python 3.12 in managed installations or system path
+        error: No interpreter found for Python 3.12 in managed installations or search path
         "###);
     }
 }
@@ -605,7 +605,7 @@ fn python_pin_resolve() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No interpreter found for PyPy in managed installations or system path
+    error: No interpreter found for PyPy in managed installations or search path
     "###);
 
     let python_version = context.read(PYTHON_VERSION_FILENAME);
@@ -626,7 +626,7 @@ fn python_pin_resolve() {
     ----- stdout -----
 
     ----- stderr -----
-    error: No interpreter found for Python 3.7 in managed installations or system path
+    error: No interpreter found for Python 3.7 in managed installations or search path
     "###);
 
     let python_version = context.read(PYTHON_VERSION_FILENAME);

--- a/crates/uv/tests/it/venv.rs
+++ b/crates/uv/tests/it/venv.rs
@@ -605,7 +605,7 @@ fn create_venv_unknown_python_minor() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.100 in managed installations, system path, or `py` launcher
+          × No interpreter found for Python 3.100 in managed installations, search path, or registry
         "###
         );
     } else {
@@ -615,7 +615,7 @@ fn create_venv_unknown_python_minor() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.100 in managed installations or system path
+          × No interpreter found for Python 3.100 in managed installations or search path
         "###
         );
     }
@@ -643,7 +643,7 @@ fn create_venv_unknown_python_patch() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.12.100 in managed installations, system path, or `py` launcher
+          × No interpreter found for Python 3.12.100 in managed installations, search path, or registry
         "###
         );
     } else {
@@ -653,7 +653,7 @@ fn create_venv_unknown_python_patch() {
         ----- stdout -----
 
         ----- stderr -----
-          × No interpreter found for Python 3.12.100 in managed installations or system path
+          × No interpreter found for Python 3.12.100 in managed installations or search path
         "###
         );
     }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4142,7 +4142,7 @@ environment is not required, uv will then search for a Python interpreter. Pytho
 interpreters are found by searching for Python executables in the `PATH` environment
 variable.
 
-On Windows, the `py` launcher is also invoked to find Python executables.
+On Windows, the registry is also searched for Python executables.
 
 By default, uv will download Python if a version cannot be found. This behavior can be
 disabled with the `--no-python-downloads` flag or the `python-downloads` setting.


### PR DESCRIPTION
e.g.

```
❯ echo "anyio" |  cargo run -q -- pip compile - -v
DEBUG uv 0.4.30 (107ab3d71 2024-11-07)
DEBUG Starting Python discovery for a default Python
DEBUG Looking for exact match for request a default Python
DEBUG Searching for default Python interpreter in virtual environments, managed installations, or search path
DEBUG Found `cpython-3.12.7-macos-aarch64-none` at `/Users/zb/workspace/uv/.venv/bin/python3` (virtual environment)
```
```
❯ cargo run -q -- pip install anyio -v
DEBUG uv 0.4.30 (107ab3d71 2024-11-07)
DEBUG Searching for default Python interpreter in virtual environments
DEBUG Found `cpython-3.12.7-macos-aarch64-none` at `/Users/zb/workspace/uv/.venv/bin/python3` (virtual environment)
```

vs

```
❯ uv  pip install anyio -v
DEBUG uv 0.4.30 (61ed2a236 2024-11-04)
DEBUG Searching for default Python interpreter in system path
DEBUG Found `cpython-3.12.7-macos-aarch64-none` at `/Users/zb/workspace/uv/.venv/bin/python3` (virtual environment)
```

```
❯ echo "anyio" | uv pip compile - -v
DEBUG uv 0.4.30 (61ed2a236 2024-11-04)
DEBUG Starting Python discovery for a default Python
DEBUG Looking for exact match for request a default Python
DEBUG Searching for default Python interpreter in managed installations or system path
DEBUG Found `cpython-3.12.7-macos-aarch64-none` at `/Users/zb/workspace/uv/.venv/bin/python3` (virtual environment)
```