### PR TITLE
Move "from PyPI" install message to above the relevant code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv is backed by [Astral](https://astral.sh), the creators of
 
 ## Installation
 
-Install uv with our standalone installers, or from [PyPI](https://pypi.org/project/uv/):
+Install uv with our standalone installers:
 
 ```bash
 # On macOS and Linux.
@@ -58,9 +58,16 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
+Or, from [PyPI](https://pypi.org/project/uv/):
+
 ```bash
 # With pip.
 pip install uv
+```
+
+```bash
+# Or pipx.
+pipx install uv
 ```
 
 If installed via the standalone installer, uv can update itself to the latest version:


### PR DESCRIPTION
A minor follow-up to https://github.com/astral-sh/uv/pull/8853

I also included `pipx`, if anyone is opposed I'm happy to drop it.