### PR TITLE
Handle sigterm calls, fixes #6724

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,7 @@ version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "windows-sys 0.59.0",
 ]
 
@@ -1419,7 +1419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bdbbd5bc8c5749697ccaa352fa45aff8730cf21c68029c0eef1ffed7c3d6ba2"
 dependencies = [
  "cfg-if",
- "nix",
+ "nix 0.29.0",
  "widestring",
  "windows 0.57.0",
 ]
@@ -1940,6 +1940,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miette"
 version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,6 +2060,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -4183,6 +4205,7 @@ dependencies = [
  "axoupdater",
  "base64 0.22.1",
  "byteorder",
+ "cfg-if",
  "clap",
  "console",
  "ctrlc",
@@ -4200,6 +4223,7 @@ dependencies = [
  "itertools 0.13.0",
  "jiff",
  "miette",
+ "nix 0.23.2",
  "owo-colors",
  "petgraph",
  "predicates",
@@ -5623,7 +5647,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,7 @@ version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
 dependencies = [
- "nix 0.29.0",
+ "nix",
  "windows-sys 0.59.0",
 ]
 
@@ -1419,7 +1419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bdbbd5bc8c5749697ccaa352fa45aff8730cf21c68029c0eef1ffed7c3d6ba2"
 dependencies = [
  "cfg-if",
- "nix 0.29.0",
+ "nix",
  "widestring",
  "windows 0.57.0",
 ]
@@ -1940,15 +1940,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miette"
 version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,19 +2051,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -4205,7 +4183,6 @@ dependencies = [
  "axoupdater",
  "base64 0.22.1",
  "byteorder",
- "cfg-if",
  "clap",
  "console",
  "ctrlc",
@@ -4223,7 +4200,7 @@ dependencies = [
  "itertools 0.13.0",
  "jiff",
  "miette",
- "nix 0.23.2",
+ "nix",
  "owo-colors",
  "petgraph",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,15 +120,15 @@ md-5 = { version = "0.10.6" }
 memchr = { version = "2.7.4" }
 miette = { version = "7.2.0" }
 nanoid = { version = "0.4.0" }
+nix = { version = "0.29.0" }
 owo-colors = { version = "4.1.0" }
 path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 petgraph = { version = "0.6.5" }
 platform-info = { version = "2.0.3" }
-procfs = { version = "0.17.0", default-features = false, features = ["flate2"] }
 proc-macro2 = { version = "1.0.86" }
+procfs = { version = "0.17.0", default-features = false, features = ["flate2"] }
 pubgrub = { git = "https://github.com/astral-sh/pubgrub", rev = "95e1390399cdddee986b658be19587eb1fdb2d79" }
-version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "95e1390399cdddee986b658be19587eb1fdb2d79" }
 quote = { version = "1.0.37" }
 rayon = { version = "1.10.0" }
 reflink-copy = { version = "0.1.19" }
@@ -172,6 +172,7 @@ unicode-width = { version = "0.1.13" }
 unscanny = { version = "0.1.0" }
 url = { version = "2.5.2" }
 urlencoding = { version = "2.1.3" }
+version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "95e1390399cdddee986b658be19587eb1fdb2d79" }
 walkdir = { version = "2.5.0" }
 which = { version = "7.0.0", features = ["regex"] }
 windows-registry = { version = "0.3.0" }

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -97,6 +97,7 @@ url = { workspace = true }
 walkdir = { workspace = true }
 which = { workspace = true }
 zip = { workspace = true }
+cfg-if = "1.0"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.16" }
@@ -114,6 +115,9 @@ reqwest = { workspace = true, features = ["blocking"], default-features = false 
 similar = { version = "2.6.0" }
 tempfile = { workspace = true }
 zip = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+nix = "0.23"
 
 [package.metadata.cargo-shear]
 ignored = [

--- a/crates/uv/Cargo.toml
+++ b/crates/uv/Cargo.toml
@@ -97,7 +97,6 @@ url = { workspace = true }
 walkdir = { workspace = true }
 which = { workspace = true }
 zip = { workspace = true }
-cfg-if = "1.0"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.16" }
@@ -117,7 +116,7 @@ tempfile = { workspace = true }
 zip = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.23"
+nix = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = [

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 
 use anstream::eprint;
 use anyhow::{anyhow, bail, Context};
-use cfg_if::cfg_if;
 use futures::StreamExt;
 use itertools::Itertools;
 use owo_colors::OwoColorize;
@@ -1001,6 +1000,7 @@ pub(crate) async fn run(
     {
         use tokio::select;
         use tokio::signal::unix::{signal, SignalKind};
+
         let mut term_signal = signal(SignalKind::terminate())?;
         loop {
             select! {
@@ -1036,20 +1036,13 @@ pub(crate) async fn run(
     }
 }
 
-#[allow(clippy::items_after_statements, dead_code)]
-fn terminate_process(_child: &mut Child) -> Result<(), anyhow::Error> {
-    cfg_if! {
-        if #[cfg(unix)] {
-            let pid = _child.id().context("Failed to get child process ID")?;
-            use nix::sys::signal::{self, Signal};
-            use nix::unistd::Pid;
-            signal::kill(Pid::from_raw(pid.try_into().unwrap()), Signal::SIGTERM)
-                .context("Failed to send SIGTERM")
-        } else if #[cfg(windows)] {
-            // On Windows, use winapi to terminate the process gracefully
-            todo!("Implement graceful termination on Windows");
-        }
-    }
+#[cfg(unix)]
+fn terminate_process(child: &mut Child) -> anyhow::Result<()> {
+    use nix::sys::signal::{self, Signal};
+    use nix::unistd::Pid;
+
+    let pid = child.id().context("Failed to get child process ID")?;
+    signal::kill(Pid::from_raw(pid.try_into()?), Signal::SIGTERM).context("Failed to send SIGTERM")
 }
 
 /// Returns `true` if we can skip creating an additional ephemeral environment in `uv run`.

--- a/crates/uv/src/commands/tool/run.rs
+++ b/crates/uv/src/commands/tool/run.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use std::fmt::Display;
 use std::fmt::Write;
 use std::path::PathBuf;
@@ -7,9 +8,8 @@ use anstream::eprint;
 use anyhow::{bail, Context};
 use itertools::Itertools;
 use owo_colors::OwoColorize;
+use tokio::process::Child;
 use tokio::process::Command;
-use tokio::select;
-use tokio::signal::unix::{signal, SignalKind};
 use tracing::{debug, warn};
 
 use uv_cache::{Cache, Refresh};
@@ -238,30 +238,27 @@ pub(crate) async fn run(
     // signal handlers after the command completes.
     let _handler = tokio::spawn(async { while tokio::signal::ctrl_c().await.is_ok() {} });
 
-    let mut term_signal = signal(SignalKind::terminate())?;
-    let mut int_signal = signal(SignalKind::interrupt())?;
+    #[cfg(unix)]
+    {
+        use tokio::select;
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut term_signal = signal(SignalKind::terminate())?;
+        loop {
+            select! {
+                _ = handle.wait() => {
+                    break
+                },
 
-    let status = select! {
-        status = handle.wait() => status,
-
-        // `SIGTERM`
-        _ = term_signal.recv() => {
-            handle.kill().await?;
-            handle.wait().await.context("Child process disappeared")?;
-            return Ok(ExitStatus::Failure);
+                // `SIGTERM`
+                _ = term_signal.recv() => {
+                    let _ = terminate_process(&mut handle);
+                }
+            };
         }
-
-        // `SIGINT`
-        _ = int_signal.recv() => {
-            handle.kill().await?;
-            handle.wait().await.context("Child process disappeared")?;
-            return Ok(ExitStatus::Failure);
-        }
-    };
-
-    let status = status.context("Child process disappeared")?;
+    }
 
     // Exit based on the result of the command
+    let status = handle.wait().await?;
     if let Some(code) = status.code() {
         debug!("Command exited with code: {code}");
         if let Ok(code) = u8::try_from(code) {
@@ -277,6 +274,23 @@ pub(crate) async fn run(
             debug!("Command exited with signal: {:?}", status.signal());
         }
         Ok(ExitStatus::Failure)
+    }
+}
+
+#[allow(clippy::items_after_statements, dead_code)]
+fn terminate_process(_child: &mut Child) -> Result<(), anyhow::Error> {
+    cfg_if! {
+        if #[cfg(unix)] {
+            let pid = _child.id().context("Failed to get child process ID")?;
+            // On Unix, send SIGTERM for a graceful shutdown
+            use nix::sys::signal::{self, Signal};
+            use nix::unistd::Pid;
+            signal::kill(Pid::from_raw(pid.try_into().unwrap()), Signal::SIGTERM)
+                .context("Failed to send SIGTERM")
+        } else if #[cfg(windows)] {
+            // On Windows, use winapi to terminate the process gracefully
+            todo!("Implement graceful termination on Windows");
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR builds off of https://github.com/astral-sh/uv/pull/6738 to fix #6724 (sorry for the new PR @charliermarsh I didn't want to push to your branch, not even sure if I could). The reason the original PR doesn't fix the issue described in #6724 is because the fastapi is ran in the project context (as I assume a lot of use cases are). This PR adds an extra commit to handle the signals in the project/run.rs file

~It also addresses the comment [here](https://github.com/astral-sh/uv/pull/6738/files#r1734757548) to not use the tokio ctrl-c method since we are now handling SIGINT ourselves~ update, tokio handles SIGINT in a platform agnostic way, intercepting this ouselves makes the logic more complicated with windows, decided to leave the tokio ctrl-c handler

~[This comment](https://github.com/astral-sh/uv/pull/6738/files#r1743510140) remains unaddressed, however, the Child process does not have any other methods besides kill() so I don't see how we can "preserve" the interrupt call :/  I tried looking around but no luck.~ updated, this PR is reduced to only handling SIGTERM propagation on unix machines, and the sigterm call to the child is preserved by making use of the nix package, instead of relying on tokio which only allowed for `kill()` on a child process

## Test Plan

I tested this by building the docker container locally with these changes and tagging it "myuv", and then using that as the base image in uv-docker-example, (and ofc following the rest of the repro issues in #6724. In my tests I see that ctrl-c in the docker-compose up command exits the process almost immediately 👍 
