### PR TITLE
Allow installation of manylinux wheels on riscv64

### DIFF
--- a/crates/uv-platform-tags/src/platform.rs
+++ b/crates/uv-platform-tags/src/platform.rs
@@ -117,8 +117,10 @@ impl Arch {
             }
             // manylinux 1
             Self::X86 | Self::X86_64 => Some(5),
+            // manylinux_2_31
+            Self::Riscv64 => Some(31),
             // unsupported
-            Self::Armv6L | Self::Riscv64 => None,
+            Self::Armv6L => None,
         }
     }
 }


### PR DESCRIPTION

<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

auditwheel is capable of generating riscv64 wheels for manylinux_2_31 and above.  Here we modify uv-platform-tags so that those wheels can be installed using uv.

Fixes: #8889

## Test Plan

- ran `cargo nextest run` locally on an x86 machine
- also ran `cargo nextest run` locally on a riscv64 VM but there were a fair few failures (with and without this patch)
- built a riscv64 uv wheel, installed it on a riscv64 VM and checked that I could use the newly built version of uv to install manylinux_2_35_riscv64 wheels.