### PR TITLE
Compute superset of existing and required hashes when healing cache

### DIFF
--- a/crates/uv-distribution/src/error.rs
+++ b/crates/uv-distribution/src/error.rs
@@ -11,7 +11,7 @@ use uv_distribution_filename::WheelFilenameError;
 use uv_fs::Simplified;
 use uv_normalize::PackageName;
 use uv_pep440::{Version, VersionSpecifiers};
-use uv_pypi_types::{HashDigest, ParsedUrlError};
+use uv_pypi_types::{HashAlgorithm, HashDigest, ParsedUrlError};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -94,8 +94,8 @@ pub enum Error {
     MetadataLowering(#[from] MetadataError),
     #[error("Distribution not found at: {0}")]
     NotFound(Url),
-    #[error("Attempted to re-extract the source distribution for `{0}`, but the hashes didn't match. Run `{}` to clear the cache.", "uv cache clean".green())]
-    CacheHeal(String),
+    #[error("Attempted to re-extract the source distribution for `{0}`, but the {1} hash didn't match. Run `{}` to clear the cache.", "uv cache clean".green())]
+    CacheHeal(String, HashAlgorithm),
     #[error("The source distribution requires Python {0}, but {1} is installed")]
     RequiresPython(VersionSpecifiers, Version),
 


### PR DESCRIPTION
## Summary

The basic issue here is that `uv add` will compute and store a hash for each package. But if you later run `uv pip install` _after_ `uv cache prune --ci`, we need to re-download the source distribution. After re-downloading, we compare the hashes before and after. But `uv pip install` doesn't compute any hashes by default. So the hashes "differ" and we error.

Instead, we need to compute a superset of the already-existing and newly-requested hashes when performing this re-download. (In practice, this will always be SHA-256.)

Closes https://github.com/astral-sh/uv/issues/8929.

## Test Plan

```shell
export UV_CACHE_DIR="$PWD/cache"

rm -rf "$UV_CACHE_DIR" .venv .venv-2 pyproject.toml uv.lock

echo $(uv --version)

uv init --name uv-cache-issue
cargo run add --python 3.13 "pycairo"

uv cache prune --ci

rm -rf .venv .venv-2

uv venv --python python3.11 .venv-2
. .venv-2/bin/activate
cargo run pip install "pycairo"
```
