### PR TITLE
Upgrade to cargo-dist `0.25.2-prerelease.3`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.25.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.25.2-prerelease.3/cargo-dist-installer.sh | sh"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,10 +282,10 @@ strip = "debuginfo"
 [profile.dist]
 inherits = "release"
 
-# Config for 'cargo dist'
+# Config for 'dist'
 [workspace.metadata.dist]
-# The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.25.1"
+# The preferred dist version to use in CI (Cargo.toml SemVer syntax)
+cargo-dist-version = "0.25.2-prerelease.3"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -315,13 +315,13 @@ targets = [
 ]
 # Whether to auto-include files like READMEs, LICENSEs, and CHANGELOGs (default true)
 auto-includes = false
-# Whether cargo-dist should create a Github Release or use an existing draft
+# Whether dist should create a Github Release or use an existing draft
 create-release = true
 # Which actions to run on pull requests
 pr-run-mode = "skip"
 # Whether CI should trigger releases with dispatches instead of tag pushes
 dispatch-releases = true
-# Which phase cargo-dist should use to create the GitHub release
+# Which phase dist should use to create the GitHub release
 github-release = "announce"
 # Whether CI should include auto-generated code to build local artifacts
 build-local-artifacts = false


### PR DESCRIPTION
Gets us the upstream fix (https://github.com/axodotdev/cargo-dist/pull/1538Z) for https://github.com/axodotdev/axoupdater/issues/210 so we don't need to patch releases manually for self update to work.

Includes a few other changes, i.e., they validate checksums now.