### PR TITLE
Fix reference to `--resolution` in docs

### DIFF
--- a/docs/concepts/resolution.md
+++ b/docs/concepts/resolution.md
@@ -355,9 +355,10 @@ code.
 
 Lower bounds are particularly critical when writing a library. It's important to declare the lowest
 version for each dependency that your library works with, and to validate that the bounds are
-correct — testing with [`--resolution lowest` or `--resolution lowest-direct`](#resolution-strategy).
-Otherwise, a user may receive an old, incompatible version of one of your library's dependencies and
-the library will fail with an unexpected error.
+correct — testing with
+[`--resolution lowest` or `--resolution lowest-direct`](#resolution-strategy). Otherwise, a user may
+receive an old, incompatible version of one of your library's dependencies and the library will fail
+with an unexpected error.
 
 ## Reproducible resolutions
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Update `resolution` to `--resolution`, so it's aligned with the rest of the resolution documentation, and copy-pastable for usage.
