### PR TITLE
ci: validate project metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
       - name: "Python type check"
         run: uvx mypy
 
+      - name: "Validate project metadata"
+        run: uvx --from 'validate-pyproject[all,store]' validate-pyproject pyproject.toml
+
       - name: "Lint shell scripts"
         uses: ludeeus/action-shellcheck@2.0.0
         env:


### PR DESCRIPTION
## Summary

As per https://github.com/astral-sh/uv/pull/8943#discussion_r1835065562, adding a CI step to validate project metadata. Documentation for the tool: https://validate-pyproject.readthedocs.io/en/stable/readme.html. `store` is an extra that uses [this package](https://github.com/henryiii/validate-pyproject-schema-store) to get a weekly update of the schema in SchemaStore.

## Test Plan

Step passes on CI, and testing the same command locally while voluntarily using a wrong classifier fails:
```console
$ uvx --from 'validate-pyproject[all,store]' validate-pyproject pyproject.toml
Invalid file: pyproject.toml
[ERROR] `project.classifiers[5]` must be trove-classifier
```