### PR TITLE
Allow apostrophe in venv name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5575,6 +5575,7 @@ dependencies = [
  "uv-platform-tags",
  "uv-pypi-types",
  "uv-python",
+ "uv-shell",
  "uv-version",
 ]
 

--- a/crates/uv-virtualenv/Cargo.toml
+++ b/crates/uv-virtualenv/Cargo.toml
@@ -25,6 +25,7 @@ uv-platform-tags = { workspace = true }
 uv-pypi-types = { workspace = true }
 uv-python = { workspace = true }
 uv-version = { workspace = true }
+uv-shell = { workspace = true }
 
 fs-err = { workspace = true }
 itertools = { workspace = true }


### PR DESCRIPTION
Escape an apostrophe in the venv path name.

Fixes #8947