### PR TITLE
Fix Python interpreter discovery on non-glibc hosts

### DIFF
--- a/crates/uv-platform-tags/src/platform.rs
+++ b/crates/uv-platform-tags/src/platform.rs
@@ -50,6 +50,7 @@ pub enum Os {
     Dragonfly { release: String },
     Illumos { release: String, arch: String },
     Haiku { release: String },
+    Android { api_level: u16 },
 }
 
 impl fmt::Display for Os {
@@ -65,6 +66,7 @@ impl fmt::Display for Os {
             Self::Dragonfly { .. } => write!(f, "DragonFly"),
             Self::Illumos { .. } => write!(f, "Illumos"),
             Self::Haiku { .. } => write!(f, "Haiku"),
+            Self::Android { .. } => write!(f, "Android"),
         }
     }
 }

--- a/crates/uv-platform-tags/src/tags.rs
+++ b/crates/uv-platform-tags/src/tags.rs
@@ -543,6 +543,14 @@ fn compatible_tags(platform: &Platform) -> Result<Vec<String>, PlatformError> {
             let os = os.to_string().to_lowercase();
             vec![format!("{}_{}_{}", os, release, arch)]
         }
+        (Os::Android { api_level }, _) => {
+            vec![format!(
+                "{}_{}_{}",
+                os.to_string().to_lowercase(),
+                api_level,
+                arch
+            )]
+        }
         _ => {
             return Err(PlatformError::OsVersionDetectionError(format!(
                 "Unsupported operating system and architecture combination: {os} {arch}"

--- a/crates/uv-python/python/packaging/_manylinux.py
+++ b/crates/uv-python/python/packaging/_manylinux.py
@@ -173,7 +173,7 @@ def _parse_glibc_version(version_str: str) -> tuple[int, int]:
 def _get_glibc_version() -> tuple[int, int]:
     version_str = _glibc_version_string()
     if version_str is None:
-        return (-1, -1)
+        return (0, 0)
     return _parse_glibc_version(version_str)
 
 

--- a/crates/uv-python/src/platform.rs
+++ b/crates/uv-python/src/platform.rs
@@ -203,9 +203,9 @@ impl From<&uv_platform_tags::Os> for Os {
             uv_platform_tags::Os::Haiku { .. } => Self(target_lexicon::OperatingSystem::Haiku),
             uv_platform_tags::Os::Illumos { .. } => Self(target_lexicon::OperatingSystem::Illumos),
             uv_platform_tags::Os::Macos { .. } => Self(target_lexicon::OperatingSystem::Darwin),
-            uv_platform_tags::Os::Manylinux { .. } | uv_platform_tags::Os::Musllinux { .. } => {
-                Self(target_lexicon::OperatingSystem::Linux)
-            }
+            uv_platform_tags::Os::Manylinux { .. }
+            | uv_platform_tags::Os::Musllinux { .. }
+            | uv_platform_tags::Os::Android { .. } => Self(target_lexicon::OperatingSystem::Linux),
             uv_platform_tags::Os::NetBsd { .. } => Self(target_lexicon::OperatingSystem::Netbsd),
             uv_platform_tags::Os::OpenBsd { .. } => Self(target_lexicon::OperatingSystem::Openbsd),
             uv_platform_tags::Os::Windows => Self(target_lexicon::OperatingSystem::Windows),


### PR DESCRIPTION
## Summary

On Termux, uv currently fails to find any interpreter because it can't find a glibc version, because there isn't one. But the Python interpreter is still functional nonetheless.

So, when glibc cannot be found, simply return 0 for the version numbers and mark the interpreter as being incompatible with manylinux

I really don't know if this is the right way to address this, but I can attest that manual testing shows uv appears to be fully functional, at least for pip and virtualenvs.

Fixes #7373

## Test Plan

I tried running the test suite, and after some tweaks, a good portion of the test suite passes as well. A significant number of tests fail, but this appears to be due to minor differences in output, like warnings about hard links not working (hard links are completely disallowed on Android), differences in the number of files removed, etc. The test suite seems to be very sensitive to minor variations in output.