### PR TITLE
Revert `uv.lock` changes when `uv add` fails

### DIFF
--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -1009,6 +1009,17 @@ pub(crate) async fn read(workspace: &Workspace) -> Result<Option<Lock>, ProjectE
     }
 }
 
+/// Read the lockfile from the workspace as bytes.
+///
+/// Returns `Ok(None)` if the lockfile does not exist.
+pub(crate) async fn read_bytes(workspace: &Workspace) -> Result<Option<Vec<u8>>, ProjectError> {
+    match fs_err::tokio::read(&workspace.install_path().join("uv.lock")).await {
+        Ok(encoded) => Ok(Some(encoded)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
 /// Reports on the versions that were upgraded in the new lockfile.
 ///
 /// Returns `true` if any upgrades were reported.

--- a/crates/uv/tests/it/edit.rs
+++ b/crates/uv/tests/it/edit.rs
@@ -5506,57 +5506,77 @@ fn add_git_to_script() -> Result<()> {
     Ok(())
 }
 
-/// Revert changes to a `pyproject.toml` the `add` fails.
+/// Revert changes to the `pyproject.toml` and `uv.lock` when the `add` operation fails.
 #[test]
 fn fail_to_add_revert_project() -> Result<()> {
     let context = TestContext::new("3.12");
 
-    let pyproject_toml = context.temp_dir.child("pyproject.toml");
-    pyproject_toml.write_str(indoc! {r#"
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
         [project]
-        name = "project"
+        name = "parent"
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = []
+    "#})?;
+
+    // Add a dependency on a package that declares static metadata (so can always resolve), but
+    // can't be installed.
+    let pyproject_toml = context.temp_dir.child("child/pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
 
         [build-system]
         requires = ["setuptools>=42"]
         build-backend = "setuptools.build_meta"
     "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("child")
+        .child("__init__.py")
+        .touch()?;
+    context
+        .temp_dir
+        .child("child")
+        .child("setup.py")
+        .write_str("1/0")?;
 
-    // Adding `pytorch==1.0.2` should produce an error
     let filters = std::iter::once((r"exit code: 1", "exit status: 1"))
         .chain(context.filters())
         .collect::<Vec<_>>();
-    uv_snapshot!(filters, context.add().arg("pytorch==1.0.2"), @r###"
+    uv_snapshot!(filters, context.add().arg("./child"), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Resolved 2 packages in [TIME]
+    Resolved 3 packages in [TIME]
     error: Failed to prepare distributions
-      Caused by: Failed to download and build `pytorch==1.0.2`
-      Caused by: Build backend failed to build wheel through `build_wheel` (exit status: 1)
+      Caused by: Failed to build `child @ file://[TEMP_DIR]/child`
+      Caused by: Build backend failed to determine requirements with `build_wheel()` (exit status: 1)
 
     [stderr]
     Traceback (most recent call last):
-      File "<string>", line 11, in <module>
-      File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 410, in build_wheel
-        return self._build_with_temp_dir(
-               ^^^^^^^^^^^^^^^^^^^^^^^^^^
-      File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 395, in _build_with_temp_dir
+      File "<string>", line 14, in <module>
+      File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 325, in get_requires_for_build_wheel
+        return self._get_build_requires(config_settings, requirements=['wheel'])
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 295, in _get_build_requires
         self.run_setup()
-      File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 487, in run_setup
-        super().run_setup(setup_script=setup_script)
       File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 311, in run_setup
         exec(code, locals())
-      File "<string>", line 15, in <module>
-    Exception: You tried to install "pytorch". The package named for PyTorch is "torch"
-
+      File "<string>", line 1, in <module>
+    ZeroDivisionError: division by zero
     "###);
 
-    let pyproject_toml = context.read("pyproject.toml");
+    let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
 
     insta::with_settings!({
         filters => context.filters(),
@@ -5564,17 +5584,127 @@ fn fail_to_add_revert_project() -> Result<()> {
         assert_snapshot!(
             pyproject_toml, @r###"
         [project]
-        name = "project"
+        name = "parent"
         version = "0.1.0"
         requires-python = ">=3.12"
         dependencies = []
+        "###
+        );
+    });
+
+    // The lockfile should not exist, even though resolution succeeded.
+    assert!(!context.temp_dir.join("uv.lock").exists());
+
+    Ok(())
+}
+
+/// Revert changes to the `pyproject.toml` and `uv.lock` when the `add` operation fails.
+///
+/// In this case, the project has an existing lockfile.
+#[test]
+fn fail_to_edit_revert_project() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    context
+        .temp_dir
+        .child("pyproject.toml")
+        .write_str(indoc! {r#"
+        [project]
+        name = "parent"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = []
+    "#})?;
+
+    uv_snapshot!(context.filters(), context.add().arg("iniconfig"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 2 packages in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + iniconfig==2.0.0
+    "###);
+
+    let before = fs_err::read_to_string(context.temp_dir.join("uv.lock"))?;
+
+    // Add a dependency on a package that declares static metadata (so can always resolve), but
+    // can't be installed.
+    let pyproject_toml = context.temp_dir.child("child/pyproject.toml");
+    pyproject_toml.write_str(indoc! {r#"
+        [project]
+        name = "child"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = ["iniconfig"]
 
         [build-system]
         requires = ["setuptools>=42"]
         build-backend = "setuptools.build_meta"
+    "#})?;
+    context
+        .temp_dir
+        .child("src")
+        .child("child")
+        .child("__init__.py")
+        .touch()?;
+    context
+        .temp_dir
+        .child("child")
+        .child("setup.py")
+        .write_str("1/0")?;
+
+    let filters = std::iter::once((r"exit code: 1", "exit status: 1"))
+        .chain(context.filters())
+        .collect::<Vec<_>>();
+    uv_snapshot!(filters, context.add().arg("./child"), @r###"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    Resolved 3 packages in [TIME]
+    error: Failed to prepare distributions
+      Caused by: Failed to build `child @ file://[TEMP_DIR]/child`
+      Caused by: Build backend failed to determine requirements with `build_wheel()` (exit status: 1)
+
+    [stderr]
+    Traceback (most recent call last):
+      File "<string>", line 14, in <module>
+      File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 325, in get_requires_for_build_wheel
+        return self._get_build_requires(config_settings, requirements=['wheel'])
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 295, in _get_build_requires
+        self.run_setup()
+      File "[CACHE_DIR]/builds-v0/[TMP]/build_meta.py", line 311, in run_setup
+        exec(code, locals())
+      File "<string>", line 1, in <module>
+    ZeroDivisionError: division by zero
+    "###);
+
+    let pyproject_toml = fs_err::read_to_string(context.temp_dir.join("pyproject.toml"))?;
+
+    insta::with_settings!({
+        filters => context.filters(),
+    }, {
+        assert_snapshot!(
+            pyproject_toml, @r###"
+        [project]
+        name = "parent"
+        version = "0.1.0"
+        requires-python = ">=3.12"
+        dependencies = [
+            "iniconfig>=2.0.0",
+        ]
         "###
         );
     });
+
+    // The lockfile should exist, but be unchanged.
+    let after = fs_err::read_to_string(context.temp_dir.join("uv.lock"))?;
+    assert_eq!(before, after);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

If a `uv add` fails at the sync stage, we need to clean up the changes to the `uv.lock`, since it might've been edited during in the lock stage (which, by necessity, succeeded). As-is, we revert the `pyproject.toml` but not the `uv.lock`, so the two are out-of-sync.

Closes https://github.com/astral-sh/uv/issues/9028.
Closes https://github.com/astral-sh/uv/issues/7992.
