### PR TITLE
Fix reflow of index on image load: benchmark image - #6264

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -85,6 +85,32 @@
   display: inline; /* Show dark images in dark mode */
 }
 
+[data-md-color-scheme="astral-light"] img[src$="#only-light"],
+[data-md-color-scheme="astral-light"] img[src$="#gh-light-mode-only"] {
+  display: inline; /* Show light images in light mode */
+  height: 300px; /* Add size constraints here */
+  width: 600px;
+}
+
+[data-md-color-scheme="astral-dark"] img[src$="#only-light"],
+[data-md-color-scheme="astral-dark"] img[src$="#gh-light-mode-only"] {
+  display: none; /* Hide light images in dark mode */
+}
+
+[data-md-color-scheme="astral-dark"] img[src$="#only-dark"],
+[data-md-color-scheme="astral-dark"] img[src$="#gh-dark-mode-only"] {
+  display: inline; /* Show dark images in dark mode */
+  height: 300px; /* Add size constraints here */
+  width: 600px;
+}
+
+/* Just keep minimal container styling */
+p[align="center"] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* See: https://github.com/squidfunk/mkdocs-material/issues/175#issuecomment-616694465 */
 .md-typeset__table {
   min-width: 100%;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -88,8 +88,8 @@
 [data-md-color-scheme="astral-light"] img[src$="#only-light"],
 [data-md-color-scheme="astral-light"] img[src$="#gh-light-mode-only"] {
   display: inline; /* Show light images in light mode */
-  height: 300px; /* Add size constraints here */
-  width: 600px;
+  height: 250px; /* Add size constraints here */
+  width: 500px;
 }
 
 [data-md-color-scheme="astral-dark"] img[src$="#only-light"],
@@ -100,15 +100,14 @@
 [data-md-color-scheme="astral-dark"] img[src$="#only-dark"],
 [data-md-color-scheme="astral-dark"] img[src$="#gh-dark-mode-only"] {
   display: inline; /* Show dark images in dark mode */
-  height: 300px; /* Add size constraints here */
-  width: 600px;
+  height: 250px; 
+  width: 500px;
+  margin-top: -3rem;
 }
 
-/* Just keep minimal container styling */
-p[align="center"] {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+p[align="center"] i {
+  display: block;
+  margin-top: -3rem;
 }
 
 /* See: https://github.com/squidfunk/mkdocs-material/issues/175#issuecomment-616694465 */


### PR DESCRIPTION
This PR sets a fixed height and width for the benchmark image and description text underneath it. 

The purpose of the change is to prevent page reflow and layout shifts on the docs page.

Both light mode and dark mode were tested. The benchmark image is slightly larger with the change. I thought this increase in size helps draw attention to the bolded uv result shown in the benchmark diagram. I'll draw the size back down to the original if reviewers don't like it. 

![aaaaaScreenshot 2024-11-11 151909](https://github.com/user-attachments/assets/506c2aa4-5c6f-489a-b831-8ad3d13a96bd)


