### PR TITLE
Rename `Fetch` to `Download` in build errors

### DIFF
--- a/crates/uv-installer/src/preparer.rs
+++ b/crates/uv-installer/src/preparer.rs
@@ -23,9 +23,9 @@ pub enum Error {
     #[error("Using pre-built wheels is disabled, but attempted to use `{0}`")]
     NoBinary(PackageName),
     #[error("Failed to download `{0}`")]
-    Fetch(Box<BuiltDist>, #[source] Box<uv_distribution::Error>),
+    Download(Box<BuiltDist>, #[source] Box<uv_distribution::Error>),
     #[error("Failed to download and build `{0}`")]
-    FetchAndBuild(Box<SourceDist>, #[source] Box<uv_distribution::Error>),
+    DownloadAndBuild(Box<SourceDist>, #[source] Box<uv_distribution::Error>),
     #[error("Failed to build `{0}`")]
     Build(Box<SourceDist>, #[source] Box<uv_distribution::Error>),
     #[error("Unzip failed in another thread: {0}")]
@@ -146,12 +146,12 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
                 .get_or_build_wheel(&dist, self.tags, policy)
                 .boxed_local()
                 .map_err(|err| match dist.clone() {
-                    Dist::Built(dist) => Error::Fetch(Box::new(dist), Box::new(err)),
+                    Dist::Built(dist) => Error::Download(Box::new(dist), Box::new(err)),
                     Dist::Source(dist) => {
                         if dist.is_local() {
                             Error::Build(Box::new(dist), Box::new(err))
                         } else {
-                            Error::FetchAndBuild(Box::new(dist), Box::new(err))
+                            Error::DownloadAndBuild(Box::new(dist), Box::new(err))
                         }
                     }
                 })
@@ -166,12 +166,12 @@ impl<'a, Context: BuildContext> Preparer<'a, Context> {
                             wheel.hashes(),
                         );
                         Err(match dist {
-                            Dist::Built(dist) => Error::Fetch(Box::new(dist), Box::new(err)),
+                            Dist::Built(dist) => Error::Download(Box::new(dist), Box::new(err)),
                             Dist::Source(dist) => {
                                 if dist.is_local() {
                                     Error::Build(Box::new(dist), Box::new(err))
                                 } else {
-                                    Error::FetchAndBuild(Box::new(dist), Box::new(err))
+                                    Error::DownloadAndBuild(Box::new(dist), Box::new(err))
                                 }
                             }
                         })

--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -87,10 +87,10 @@ pub enum ResolveError {
     ParsedUrl(#[from] uv_pypi_types::ParsedUrlError),
 
     #[error("Failed to download `{0}`")]
-    Fetch(Box<BuiltDist>, #[source] uv_distribution::Error),
+    Download(Box<BuiltDist>, #[source] uv_distribution::Error),
 
     #[error("Failed to download and build `{0}`")]
-    FetchAndBuild(Box<SourceDist>, #[source] uv_distribution::Error),
+    DownloadAndBuild(Box<SourceDist>, #[source] uv_distribution::Error),
 
     #[error("Failed to read `{0}`")]
     Read(Box<BuiltDist>, #[source] uv_distribution::Error),

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1783,12 +1783,14 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                         Dist::Source(source_dist @ SourceDist::Directory(_)) => {
                             ResolveError::Build(Box::new(source_dist), err)
                         }
-                        Dist::Built(built_dist) => ResolveError::Fetch(Box::new(built_dist), err),
+                        Dist::Built(built_dist) => {
+                            ResolveError::Download(Box::new(built_dist), err)
+                        }
                         Dist::Source(source_dist) => {
                             if source_dist.is_local() {
                                 ResolveError::Build(Box::new(source_dist), err)
                             } else {
-                                ResolveError::FetchAndBuild(Box::new(source_dist), err)
+                                ResolveError::DownloadAndBuild(Box::new(source_dist), err)
                             }
                         }
                     })?;
@@ -1919,13 +1921,16 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                         ResolveError::Build(Box::new(source_dist), err)
                                     }
                                     Dist::Built(built_dist) => {
-                                        ResolveError::Fetch(Box::new(built_dist), err)
+                                        ResolveError::Download(Box::new(built_dist), err)
                                     }
                                     Dist::Source(source_dist) => {
                                         if source_dist.is_local() {
                                             ResolveError::Build(Box::new(source_dist), err)
                                         } else {
-                                            ResolveError::FetchAndBuild(Box::new(source_dist), err)
+                                            ResolveError::DownloadAndBuild(
+                                                Box::new(source_dist),
+                                                err,
+                                            )
                                         }
                                     }
                                 })?;

--- a/crates/uv/src/commands/diagnostics.rs
+++ b/crates/uv/src/commands/diagnostics.rs
@@ -20,7 +20,7 @@ static SUGGESTIONS: LazyLock<FxHashMap<PackageName, PackageName>> = LazyLock::ne
         .collect()
 });
 
-/// Render a [`uv_resolver::ResolveError::FetchAndBuild`] with a help message.
+/// Render a [`uv_resolver::ResolveError::DownloadAndBuild`] with a help message.
 pub(crate) fn fetch_and_build(sdist: Box<SourceDist>, cause: uv_distribution::Error) {
     #[derive(Debug, miette::Diagnostic, thiserror::Error)]
     #[error("Failed to download and build `{sdist}`")]

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -410,7 +410,7 @@ pub(crate) async fn pip_compile(
             diagnostics::no_solution(&err);
             return Ok(ExitStatus::Failure);
         }
-        Err(operations::Error::Resolve(uv_resolver::ResolveError::FetchAndBuild(dist, err))) => {
+        Err(operations::Error::Resolve(uv_resolver::ResolveError::DownloadAndBuild(dist, err))) => {
             diagnostics::fetch_and_build(dist, err);
             return Ok(ExitStatus::Failure);
         }

--- a/crates/uv/src/commands/pip/install.rs
+++ b/crates/uv/src/commands/pip/install.rs
@@ -416,7 +416,7 @@ pub(crate) async fn pip_install(
             diagnostics::no_solution(&err);
             return Ok(ExitStatus::Failure);
         }
-        Err(operations::Error::Resolve(uv_resolver::ResolveError::FetchAndBuild(dist, err))) => {
+        Err(operations::Error::Resolve(uv_resolver::ResolveError::DownloadAndBuild(dist, err))) => {
             diagnostics::fetch_and_build(dist, err);
             return Ok(ExitStatus::Failure);
         }

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -360,7 +360,7 @@ pub(crate) async fn pip_sync(
             diagnostics::no_solution(&err);
             return Ok(ExitStatus::Failure);
         }
-        Err(operations::Error::Resolve(uv_resolver::ResolveError::FetchAndBuild(dist, err))) => {
+        Err(operations::Error::Resolve(uv_resolver::ResolveError::DownloadAndBuild(dist, err))) => {
             diagnostics::fetch_and_build(dist, err);
             return Ok(ExitStatus::Failure);
         }

--- a/crates/uv/src/commands/project/add.rs
+++ b/crates/uv/src/commands/project/add.rs
@@ -680,7 +680,7 @@ pub(crate) async fn add(
                     Ok(ExitStatus::Failure)
                 }
                 ProjectError::Operation(pip::operations::Error::Resolve(
-                    uv_resolver::ResolveError::FetchAndBuild(dist, err),
+                    uv_resolver::ResolveError::DownloadAndBuild(dist, err),
                 )) => {
                     diagnostics::fetch_and_build(dist, err);
                     Ok(ExitStatus::Failure)

--- a/crates/uv/src/commands/project/export.rs
+++ b/crates/uv/src/commands/project/export.rs
@@ -149,7 +149,7 @@ pub(crate) async fn export(
             return Ok(ExitStatus::Failure);
         }
         Err(ProjectError::Operation(pip::operations::Error::Resolve(
-            uv_resolver::ResolveError::FetchAndBuild(dist, err),
+            uv_resolver::ResolveError::DownloadAndBuild(dist, err),
         ))) => {
             diagnostics::fetch_and_build(dist, err);
             return Ok(ExitStatus::Failure);

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -170,7 +170,7 @@ pub(crate) async fn lock(
             Ok(ExitStatus::Failure)
         }
         Err(ProjectError::Operation(pip::operations::Error::Resolve(
-            uv_resolver::ResolveError::FetchAndBuild(dist, err),
+            uv_resolver::ResolveError::DownloadAndBuild(dist, err),
         ))) => {
             diagnostics::fetch_and_build(dist, err);
             Ok(ExitStatus::Failure)

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -306,7 +306,7 @@ pub(crate) async fn run(
                     return Ok(ExitStatus::Failure);
                 }
                 Err(ProjectError::Operation(operations::Error::Resolve(
-                    uv_resolver::ResolveError::FetchAndBuild(dist, err),
+                    uv_resolver::ResolveError::DownloadAndBuild(dist, err),
                 ))) => {
                     diagnostics::fetch_and_build(dist, err);
                     return Ok(ExitStatus::Failure);
@@ -635,7 +635,7 @@ pub(crate) async fn run(
                         return Ok(ExitStatus::Failure);
                     }
                     Err(ProjectError::Operation(operations::Error::Resolve(
-                        uv_resolver::ResolveError::FetchAndBuild(dist, err),
+                        uv_resolver::ResolveError::DownloadAndBuild(dist, err),
                     ))) => {
                         diagnostics::fetch_and_build(dist, err);
                         return Ok(ExitStatus::Failure);
@@ -838,7 +838,7 @@ pub(crate) async fn run(
                         return Ok(ExitStatus::Failure);
                     }
                     Err(ProjectError::Operation(operations::Error::Resolve(
-                        uv_resolver::ResolveError::FetchAndBuild(dist, err),
+                        uv_resolver::ResolveError::DownloadAndBuild(dist, err),
                     ))) => {
                         diagnostics::fetch_and_build(dist, err);
                         return Ok(ExitStatus::Failure);

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -161,7 +161,7 @@ pub(crate) async fn sync(
             return Ok(ExitStatus::Failure);
         }
         Err(ProjectError::Operation(operations::Error::Resolve(
-            uv_resolver::ResolveError::FetchAndBuild(dist, err),
+            uv_resolver::ResolveError::DownloadAndBuild(dist, err),
         ))) => {
             diagnostics::fetch_and_build(dist, err);
             return Ok(ExitStatus::Failure);


### PR DESCRIPTION
## Summary

We're inconsistent with these -- sometimes it's `Error::Fetch` and sometimes it's `Error::Download`. The message says download, so let's just use that?