### PR TITLE
DRY up diagnostic reporting for resolution failures

### DIFF
--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -406,30 +406,11 @@ pub(crate) async fn pip_compile(
     .await
     {
         Ok(resolution) => resolution,
-        Err(operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(err))) => {
-            diagnostics::no_solution(&err);
-            return Ok(ExitStatus::Failure);
+        Err(err) => {
+            return diagnostics::OperationDiagnostic::default()
+                .report(err)
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
         }
-        Err(operations::Error::Resolve(uv_resolver::ResolveError::DownloadAndBuild(dist, err))) => {
-            diagnostics::download_and_build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(operations::Error::Resolve(uv_resolver::ResolveError::Build(dist, err))) => {
-            diagnostics::build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(operations::Error::Requirements(uv_requirements::Error::DownloadAndBuild(
-            dist,
-            err,
-        ))) => {
-            diagnostics::download_and_build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(operations::Error::Requirements(uv_requirements::Error::Build(dist, err))) => {
-            diagnostics::build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(err) => return Err(err.into()),
     };
 
     // Write the resolved dependencies to the output channel.

--- a/crates/uv/src/commands/pip/sync.rs
+++ b/crates/uv/src/commands/pip/sync.rs
@@ -356,30 +356,11 @@ pub(crate) async fn pip_sync(
     .await
     {
         Ok(resolution) => Resolution::from(resolution),
-        Err(operations::Error::Resolve(uv_resolver::ResolveError::NoSolution(err))) => {
-            diagnostics::no_solution(&err);
-            return Ok(ExitStatus::Failure);
+        Err(err) => {
+            return diagnostics::OperationDiagnostic::default()
+                .report(err)
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
         }
-        Err(operations::Error::Resolve(uv_resolver::ResolveError::DownloadAndBuild(dist, err))) => {
-            diagnostics::download_and_build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(operations::Error::Resolve(uv_resolver::ResolveError::Build(dist, err))) => {
-            diagnostics::build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(operations::Error::Requirements(uv_requirements::Error::DownloadAndBuild(
-            dist,
-            err,
-        ))) => {
-            diagnostics::download_and_build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(operations::Error::Requirements(uv_requirements::Error::Build(dist, err))) => {
-            diagnostics::build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(err) => return Err(err.into()),
     };
 
     // Sync the environment.
@@ -408,22 +389,11 @@ pub(crate) async fn pip_sync(
     .await
     {
         Ok(_) => {}
-        Err(operations::Error::Prepare(uv_installer::PrepareError::Build(dist, err))) => {
-            diagnostics::build(dist, err);
-            return Ok(ExitStatus::Failure);
+        Err(err) => {
+            return diagnostics::OperationDiagnostic::default()
+                .report(err)
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
         }
-        Err(operations::Error::Prepare(uv_installer::PrepareError::DownloadAndBuild(
-            dist,
-            err,
-        ))) => {
-            diagnostics::download_and_build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(operations::Error::Prepare(uv_installer::PrepareError::Download(dist, err))) => {
-            diagnostics::download(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(err) => return Err(err.into()),
     }
 
     // Notify the user of any resolution diagnostics.

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -1116,7 +1116,7 @@ pub(crate) async fn sync_environment(
     allow_insecure_host: &[TrustedHost],
     cache: &Cache,
     printer: Printer,
-) -> anyhow::Result<PythonEnvironment> {
+) -> Result<PythonEnvironment, ProjectError> {
     let InstallerSettingsRef {
         index_locations,
         index_strategy,
@@ -1269,7 +1269,7 @@ pub(crate) async fn update_environment(
     allow_insecure_host: &[TrustedHost],
     cache: &Cache,
     printer: Printer,
-) -> anyhow::Result<EnvironmentUpdate> {
+) -> Result<EnvironmentUpdate, ProjectError> {
     warn_on_requirements_txt_setting(&spec, settings.as_ref().into());
 
     let ResolverInstallerSettings {

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -154,35 +154,10 @@ pub(crate) async fn sync(
     .await
     {
         Ok(result) => result.into_lock(),
-        Err(ProjectError::Operation(operations::Error::Resolve(
-            uv_resolver::ResolveError::NoSolution(err),
-        ))) => {
-            diagnostics::no_solution(&err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(ProjectError::Operation(operations::Error::Resolve(
-            uv_resolver::ResolveError::DownloadAndBuild(dist, err),
-        ))) => {
-            diagnostics::download_and_build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(ProjectError::Operation(operations::Error::Resolve(
-            uv_resolver::ResolveError::Build(dist, err),
-        ))) => {
-            diagnostics::build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(ProjectError::Operation(operations::Error::Requirements(
-            uv_requirements::Error::DownloadAndBuild(dist, err),
-        ))) => {
-            diagnostics::download_and_build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(ProjectError::Operation(operations::Error::Requirements(
-            uv_requirements::Error::Build(dist, err),
-        ))) => {
-            diagnostics::build(dist, err);
-            return Ok(ExitStatus::Failure);
+        Err(ProjectError::Operation(err)) => {
+            return diagnostics::OperationDiagnostic::default()
+                .report(err)
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
         }
         Err(err) => return Err(err.into()),
     };
@@ -233,23 +208,10 @@ pub(crate) async fn sync(
     .await
     {
         Ok(()) => {}
-        Err(ProjectError::Operation(operations::Error::Prepare(
-            uv_installer::PrepareError::Build(dist, err),
-        ))) => {
-            diagnostics::build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(ProjectError::Operation(operations::Error::Prepare(
-            uv_installer::PrepareError::DownloadAndBuild(dist, err),
-        ))) => {
-            diagnostics::download_and_build(dist, err);
-            return Ok(ExitStatus::Failure);
-        }
-        Err(ProjectError::Operation(operations::Error::Prepare(
-            uv_installer::PrepareError::Download(dist, err),
-        ))) => {
-            diagnostics::download(dist, err);
-            return Ok(ExitStatus::Failure);
+        Err(ProjectError::Operation(err)) => {
+            return diagnostics::OperationDiagnostic::default()
+                .report(err)
+                .map_or(Ok(ExitStatus::Failure), |err| Err(err.into()))
         }
         Err(err) => return Err(err.into()),
     }

--- a/crates/uv/tests/it/export.rs
+++ b/crates/uv/tests/it/export.rs
@@ -620,13 +620,13 @@ fn frozen() -> Result<()> {
 
     uv_snapshot!(context.filters(), context.export().arg("--all-packages"), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to build `project @ file://[TEMP_DIR]/`
-      Caused by: Failed to parse entry: `child`
-      Caused by: Package is not included as workspace package in `tool.uv.workspace`
+      × Failed to build `project @ file://[TEMP_DIR]/`
+      ├─▶ Failed to parse entry: `child`
+      ╰─▶ Package is not included as workspace package in `tool.uv.workspace`
     "###);
 
     uv_snapshot!(context.filters(), context.export().arg("--all-packages").arg("--frozen"), @r###"

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -9431,13 +9431,13 @@ fn lock_mismatched_sources() -> Result<()> {
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to build `project @ file://[TEMP_DIR]/`
-      Caused by: Failed to parse entry: `uv-public-pypackage`
-      Caused by: Can't combine URLs from both `project.dependencies` and `tool.uv.sources`
+      × Failed to build `project @ file://[TEMP_DIR]/`
+      ├─▶ Failed to parse entry: `uv-public-pypackage`
+      ╰─▶ Can't combine URLs from both `project.dependencies` and `tool.uv.sources`
     "###);
 
     Ok(())
@@ -13597,13 +13597,13 @@ fn lock_named_index_cli() -> Result<()> {
     // The package references a non-existent index.
     uv_snapshot!(context.filters(), context.lock().env_remove(EnvVars::UV_EXCLUDE_NEWER), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to build `project @ file://[TEMP_DIR]/`
-      Caused by: Failed to parse entry: `jinja2`
-      Caused by: Package `jinja2` references an undeclared index: `pytorch`
+      × Failed to build `project @ file://[TEMP_DIR]/`
+      ├─▶ Failed to parse entry: `jinja2`
+      ╰─▶ Package `jinja2` references an undeclared index: `pytorch`
     "###);
 
     // But it's fine if it comes from the CLI.
@@ -17286,12 +17286,12 @@ fn lock_group_include_cycle() -> Result<()> {
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to build `project @ file://[TEMP_DIR]/`
-      Caused by: Detected a cycle in `dependency-groups`: `bar` -> `foobar` -> `foo` -> `bar`
+      × Failed to build `project @ file://[TEMP_DIR]/`
+      ╰─▶ Detected a cycle in `dependency-groups`: `bar` -> `foobar` -> `foo` -> `bar`
     "###);
 
     Ok(())
@@ -17317,12 +17317,12 @@ fn lock_group_include_missing() -> Result<()> {
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to build `project @ file://[TEMP_DIR]/`
-      Caused by: Failed to find group `bar` included by `foo`
+      × Failed to build `project @ file://[TEMP_DIR]/`
+      ╰─▶ Failed to find group `bar` included by `foo`
     "###);
 
     Ok(())
@@ -17348,28 +17348,28 @@ fn lock_group_invalid_entry_package() -> Result<()> {
 
     uv_snapshot!(context.filters(), context.lock(), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to build `project @ file://[TEMP_DIR]/`
-      Caused by: Failed to parse entry in group `foo`: `invalid!`
-      Caused by: no such comparison operator "!", must be one of ~= == != <= >= < > ===
-    invalid!
-           ^
+      × Failed to build `project @ file://[TEMP_DIR]/`
+      ├─▶ Failed to parse entry in group `foo`: `invalid!`
+      ╰─▶ no such comparison operator "!", must be one of ~= == != <= >= < > ===
+          invalid!
+                 ^
     "###);
 
     uv_snapshot!(context.filters(), context.sync().arg("--group").arg("foo"), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Failed to build `project @ file://[TEMP_DIR]/`
-      Caused by: Failed to parse entry in group `foo`: `invalid!`
-      Caused by: no such comparison operator "!", must be one of ~= == != <= >= < > ===
-    invalid!
-           ^
+      × Failed to build `project @ file://[TEMP_DIR]/`
+      ├─▶ Failed to parse entry in group `foo`: `invalid!`
+      ╰─▶ no such comparison operator "!", must be one of ~= == != <= >= < > ===
+          invalid!
+                 ^
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -1105,7 +1105,7 @@ fn run_with_editable() -> Result<()> {
     ----- stderr -----
     Resolved 3 packages in [TIME]
     Audited 3 packages in [TIME]
-      × Invalid `--with` requirement
+      × Failed to resolve `--with` requirement
       ╰─▶ Distribution not found at: file://[TEMP_DIR]/foo
     "###);
 

--- a/crates/uv/tests/it/tool_install.rs
+++ b/crates/uv/tests/it/tool_install.rs
@@ -1460,31 +1460,28 @@ fn tool_install_uninstallable() {
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .env(EnvVars::PATH, bin_dir.as_os_str()), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Resolved 1 package in [TIME]
-    error: Failed to prepare distributions
-      Caused by: Failed to download and build `pyenv==0.0.1`
-      Caused by: Build backend failed to build wheel through `build_wheel` (exit status: 1)
+      × Failed to download and build `pyenv==0.0.1`
+      ╰─▶ Build backend failed to build wheel through `build_wheel` (exit status: 1)
 
-    [stdout]
-    running bdist_wheel
-    running build
-    installing to build/bdist.linux-x86_64/wheel
-    running install
+          [stdout]
+          running bdist_wheel
+          running build
+          installing to build/bdist.linux-x86_64/wheel
+          running install
 
-    [stderr]
-    # NOTE #
-    We are sorry, but this package is not installable with pip.
+          [stderr]
+          # NOTE #
+          We are sorry, but this package is not installable with pip.
 
-    Please read the installation instructions at:
+          Please read the installation instructions at:
      
-    https://github.com/pyenv/pyenv#installation
-    #
-
-
+          https://github.com/pyenv/pyenv#installation
+          #
     "###);
 
     // Ensure the tool environment is not created.
@@ -2439,12 +2436,13 @@ fn tool_install_preserve_environment() {
         .env(EnvVars::XDG_BIN_HOME, bin_dir.as_os_str())
         .env(EnvVars::PATH, bin_dir.as_os_str()), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
-    error: Because black==24.1.1 depends on packaging>=22.0 and you require black==24.1.1, we can conclude that you require packaging>=22.0.
-    And because you require packaging==0.0.1, we can conclude that your requirements are unsatisfiable.
+      × No solution found when resolving dependencies:
+      ╰─▶ Because black==24.1.1 depends on packaging>=22.0 and you require black==24.1.1, we can conclude that you require packaging>=22.0.
+          And because you require packaging==0.0.1, we can conclude that your requirements are unsatisfiable.
     "###);
 
     // Install `black`. The tool should already be installed, since we didn't remove the environment.

--- a/crates/uv/tests/it/tool_run.rs
+++ b/crates/uv/tests/it/tool_run.rs
@@ -1277,7 +1277,7 @@ fn tool_run_with_editable() -> anyhow::Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-      × Invalid `--with` requirement
+      × Failed to resolve `--with` requirement
       ╰─▶ Distribution not found at: file://[TEMP_DIR]/foo
     "###);
 

--- a/crates/uv/tests/it/workspace.rs
+++ b/crates/uv/tests/it/workspace.rs
@@ -1690,14 +1690,14 @@ fn workspace_member_name_shadows_dependencies() -> Result<()> {
     // TODO(zanieb): This error message is bad?
     uv_snapshot!(context.filters(), context.lock().current_dir(&workspace), @r###"
     success: false
-    exit_code: 2
+    exit_code: 1
     ----- stdout -----
 
     ----- stderr -----
     Using CPython 3.12.[X] interpreter at: [PYTHON-3.12]
-    error: Failed to build `foo @ file://[TEMP_DIR]/workspace/packages/foo`
-      Caused by: Failed to parse entry: `anyio`
-      Caused by: Package is not included as workspace package in `tool.uv.workspace`
+      × Failed to build `foo @ file://[TEMP_DIR]/workspace/packages/foo`
+      ├─▶ Failed to parse entry: `anyio`
+      ╰─▶ Package is not included as workspace package in `tool.uv.workspace`
     "###
     );
 


### PR DESCRIPTION
## Summary

Not thrilled with this but helps for now. I feel like this error-handling should happen at the top-level, rather than on all these individual commands. But we don't have a unified result type at the top-level of the CLI -- all these commands return `anyhow::Result`.
