### PR TITLE
Prefer Python executable names that match the request over default names

### DIFF
--- a/crates/uv-python/src/discovery/tests.rs
+++ b/crates/uv-python/src/discovery/tests.rs
@@ -477,49 +477,52 @@ fn executable_names_from_request() {
     case(
         "any",
         &[
-            "python", "python3", "cpython", "pypy", "graalpy", "cpython3", "pypy3", "graalpy3",
+            "python", "python3", "cpython", "cpython3", "pypy", "pypy3", "graalpy", "graalpy3",
         ],
     );
 
     case("default", &["python", "python3"]);
 
-    case("3", &["python", "python3"]);
+    case("3", &["python3", "python"]);
 
-    case("4", &["python", "python4"]);
+    case("4", &["python4", "python"]);
 
-    case("3.13", &["python", "python3", "python3.13"]);
+    case("3.13", &["python3.13", "python3", "python"]);
+
+    case("pypy", &["pypy", "pypy3", "python", "python3"]);
 
     case(
         "pypy@3.10",
         &[
-            "python",
-            "python3",
-            "python3.10",
-            "pypy",
-            "pypy3",
             "pypy3.10",
+            "pypy3",
+            "pypy",
+            "python3.10",
+            "python3",
+            "python",
         ],
     );
 
     case(
         "3.13t",
         &[
-            "python",
-            "python3",
-            "python3.13",
-            "pythont",
-            "python3t",
             "python3.13t",
+            "python3.13",
+            "python3t",
+            "python3",
+            "pythont",
+            "python",
         ],
     );
+    case("3t", &["python3t", "python3", "pythont", "python"]);
 
     case(
         "3.13.2",
-        &["python", "python3", "python3.13", "python3.13.2"],
+        &["python3.13.2", "python3.13", "python3", "python"],
     );
 
     case(
         "3.13rc2",
-        &["python", "python3", "python3.13", "python3.13rc2"],
+        &["python3.13rc2", "python3.13", "python3", "python"],
     );
 }

--- a/crates/uv-python/src/implementation.rs
+++ b/crates/uv-python/src/implementation.rs
@@ -33,6 +33,10 @@ impl ImplementationName {
         ["cpython", "pypy", "graalpy"].into_iter()
     }
 
+    pub(crate) fn iter_all() -> impl Iterator<Item = Self> {
+        [Self::CPython, Self::PyPy, Self::GraalPy].into_iter()
+    }
+
     pub fn pretty(self) -> &'static str {
         match self {
             Self::CPython => "CPython",

--- a/crates/uv-python/src/tests.rs
+++ b/crates/uv-python/src/tests.rs
@@ -2087,83 +2087,7 @@ fn find_python_graalpy_request_ignores_cpython() -> Result<()> {
 }
 
 #[test]
-fn find_python_prefers_generic_executable_over_implementation_name() -> Result<()> {
-    let mut context = TestContext::new()?;
-
-    // We prefer `python` executables over `graalpy` executables in the same directory
-    // if they are both GraalPy
-    TestContext::create_mock_interpreter(
-        &context.tempdir.join("python"),
-        &PythonVersion::from_str("3.10.0").unwrap(),
-        ImplementationName::GraalPy,
-        true,
-        false,
-    )?;
-    TestContext::create_mock_interpreter(
-        &context.tempdir.join("graalpy"),
-        &PythonVersion::from_str("3.10.1").unwrap(),
-        ImplementationName::GraalPy,
-        true,
-        false,
-    )?;
-    context.add_to_search_path(context.tempdir.to_path_buf());
-
-    let python = context.run(|| {
-        find_python_installation(
-            &PythonRequest::parse("graalpy@3.10"),
-            EnvironmentPreference::Any,
-            PythonPreference::OnlySystem,
-            &context.cache,
-        )
-    })??;
-    assert_eq!(
-        python.interpreter().python_full_version().to_string(),
-        "3.10.0",
-    );
-
-    // And `python` executables earlier in the search path will take precedence
-    context.reset_search_path();
-    context.add_python_interpreters(&[
-        (true, ImplementationName::GraalPy, "python", "3.10.2"),
-        (true, ImplementationName::GraalPy, "graalpy", "3.10.3"),
-    ])?;
-    let python = context.run(|| {
-        find_python_installation(
-            &PythonRequest::parse("graalpy@3.10"),
-            EnvironmentPreference::Any,
-            PythonPreference::OnlySystem,
-            &context.cache,
-        )
-    })??;
-    assert_eq!(
-        python.interpreter().python_full_version().to_string(),
-        "3.10.2",
-    );
-
-    // But `graalpy` executables earlier in the search path will take precedence
-    context.reset_search_path();
-    context.add_python_interpreters(&[
-        (true, ImplementationName::GraalPy, "graalpy", "3.10.3"),
-        (true, ImplementationName::GraalPy, "python", "3.10.2"),
-    ])?;
-    let python = context.run(|| {
-        find_python_installation(
-            &PythonRequest::parse("graalpy@3.10"),
-            EnvironmentPreference::Any,
-            PythonPreference::OnlySystem,
-            &context.cache,
-        )
-    })??;
-    assert_eq!(
-        python.interpreter().python_full_version().to_string(),
-        "3.10.3",
-    );
-
-    Ok(())
-}
-
-#[test]
-fn find_python_prefers_generic_executable_over_one_with_version() -> Result<()> {
+fn find_python_executable_name_preference() -> Result<()> {
     let mut context = TestContext::new()?;
     TestContext::create_mock_interpreter(
         &context.tempdir.join("pypy3.10"),
@@ -2181,18 +2105,38 @@ fn find_python_prefers_generic_executable_over_one_with_version() -> Result<()> 
     )?;
     context.add_to_search_path(context.tempdir.to_path_buf());
 
-    let python = context.run(|| {
-        find_python_installation(
-            &PythonRequest::parse("pypy@3.10"),
-            EnvironmentPreference::Any,
-            PythonPreference::OnlySystem,
-            &context.cache,
-        )
-    })??;
+    let python = context
+        .run(|| {
+            find_python_installation(
+                &PythonRequest::parse("pypy@3.10"),
+                EnvironmentPreference::Any,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        })
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        python.interpreter().python_full_version().to_string(),
+        "3.10.0",
+        "We should prefer the versioned one when a version is requested"
+    );
+
+    let python = context
+        .run(|| {
+            find_python_installation(
+                &PythonRequest::parse("pypy"),
+                EnvironmentPreference::Any,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        })
+        .unwrap()
+        .unwrap();
     assert_eq!(
         python.interpreter().python_full_version().to_string(),
         "3.10.1",
-        "We should prefer the generic executable over one with the version number"
+        "We should prefer the generic one when no version is requested"
     );
 
     let mut context = TestContext::new()?;
@@ -2210,20 +2154,126 @@ fn find_python_prefers_generic_executable_over_one_with_version() -> Result<()> 
         true,
         false,
     )?;
+    TestContext::create_mock_interpreter(
+        &context.tempdir.join("python"),
+        &PythonVersion::from_str("3.10.2").unwrap(),
+        ImplementationName::PyPy,
+        true,
+        false,
+    )?;
     context.add_to_search_path(context.tempdir.to_path_buf());
 
-    let python = context.run(|| {
-        find_python_installation(
-            &PythonRequest::parse("pypy@3.10"),
-            EnvironmentPreference::Any,
-            PythonPreference::OnlySystem,
-            &context.cache,
-        )
-    })??;
+    let python = context
+        .run(|| {
+            find_python_installation(
+                &PythonRequest::parse("pypy@3.10"),
+                EnvironmentPreference::Any,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        })
+        .unwrap()
+        .unwrap();
     assert_eq!(
         python.interpreter().python_full_version().to_string(),
-        "3.10.0",
-        "We should prefer the generic name with a version over one the implementation name"
+        "3.10.1",
+        "We should prefer the implementation name over the generic name"
+    );
+
+    let python = context
+        .run(|| {
+            find_python_installation(
+                &PythonRequest::parse("default"),
+                EnvironmentPreference::Any,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        })
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        python.interpreter().python_full_version().to_string(),
+        "3.10.2",
+        "We should prefer the generic name over the implementation name, but not the versioned name"
+    );
+
+    // We prefer `python` executables over `graalpy` executables in the same directory
+    // if they are both GraalPy
+    let mut context = TestContext::new()?;
+    TestContext::create_mock_interpreter(
+        &context.tempdir.join("python"),
+        &PythonVersion::from_str("3.10.0").unwrap(),
+        ImplementationName::GraalPy,
+        true,
+        false,
+    )?;
+    TestContext::create_mock_interpreter(
+        &context.tempdir.join("graalpy"),
+        &PythonVersion::from_str("3.10.1").unwrap(),
+        ImplementationName::GraalPy,
+        true,
+        false,
+    )?;
+    context.add_to_search_path(context.tempdir.to_path_buf());
+
+    let python = context
+        .run(|| {
+            find_python_installation(
+                &PythonRequest::parse("graalpy@3.10"),
+                EnvironmentPreference::Any,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        })
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        python.interpreter().python_full_version().to_string(),
+        "3.10.1",
+    );
+
+    // And `python` executables earlier in the search path will take precedence
+    context.reset_search_path();
+    context.add_python_interpreters(&[
+        (true, ImplementationName::GraalPy, "python", "3.10.2"),
+        (true, ImplementationName::GraalPy, "graalpy", "3.10.3"),
+    ])?;
+    let python = context
+        .run(|| {
+            find_python_installation(
+                &PythonRequest::parse("graalpy@3.10"),
+                EnvironmentPreference::Any,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        })
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        python.interpreter().python_full_version().to_string(),
+        "3.10.2",
+    );
+
+    // And `graalpy` executables earlier in the search path will take precedence
+    context.reset_search_path();
+    context.add_python_interpreters(&[
+        (true, ImplementationName::GraalPy, "graalpy", "3.10.3"),
+        (true, ImplementationName::GraalPy, "python", "3.10.2"),
+    ])?;
+    let python = context
+        .run(|| {
+            find_python_installation(
+                &PythonRequest::parse("graalpy@3.10"),
+                EnvironmentPreference::Any,
+                PythonPreference::OnlySystem,
+                &context.cache,
+            )
+        })
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        python.interpreter().python_full_version().to_string(),
+        "3.10.3",
     );
 
     Ok(())

--- a/crates/uv/tests/it/python_pin.rs
+++ b/crates/uv/tests/it/python_pin.rs
@@ -456,14 +456,14 @@ fn python_pin_resolve_no_python() {
 
 #[test]
 fn python_pin_resolve() {
-    let context: TestContext = TestContext::new_with_versions(&["3.11", "3.12"]);
+    let context: TestContext = TestContext::new_with_versions(&["3.12", "3.13"]);
 
     // We pin the first interpreter on the path
     uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("any"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    Pinned `.python-version` to `[PYTHON-3.11]`
+    Pinned `.python-version` to `[PYTHON-3.12]`
 
     ----- stderr -----
     "###);
@@ -472,17 +472,15 @@ fn python_pin_resolve() {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(python_version, @r###"
-        [PYTHON-3.11]
-        "###);
+        assert_snapshot!(python_version, @"[PYTHON-3.12]");
     });
 
-    // Request Python 3.12
-    uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("3.12"), @r###"
+    // Request Python 3.13
+    uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("3.13"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    Updated `.python-version` from `[PYTHON-3.11]` -> `[PYTHON-3.12]`
+    Updated `.python-version` from `[PYTHON-3.12]` -> `[PYTHON-3.13]`
 
     ----- stderr -----
     "###);
@@ -491,17 +489,15 @@ fn python_pin_resolve() {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(python_version, @r###"
-        [PYTHON-3.12]
-        "###);
+        assert_snapshot!(python_version, @"[PYTHON-3.13]");
     });
 
-    // Request Python 3.11
-    uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("3.11"), @r###"
+    // Request Python 3.13
+    uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("3.13"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    Updated `.python-version` from `[PYTHON-3.12]` -> `[PYTHON-3.11]`
+    Pinned `.python-version` to `[PYTHON-3.13]`
 
     ----- stderr -----
     "###);
@@ -510,9 +506,7 @@ fn python_pin_resolve() {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(python_version, @r###"
-        [PYTHON-3.11]
-        "###);
+        assert_snapshot!(python_version, @"[PYTHON-3.13]");
     });
 
     // Request CPython
@@ -520,7 +514,7 @@ fn python_pin_resolve() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Pinned `.python-version` to `[PYTHON-3.11]`
+    Updated `.python-version` from `[PYTHON-3.13]` -> `[PYTHON-3.12]`
 
     ----- stderr -----
     "###);
@@ -529,17 +523,15 @@ fn python_pin_resolve() {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(python_version, @r###"
-        [PYTHON-3.11]
-        "###);
+        assert_snapshot!(python_version, @"[PYTHON-3.12]");
     });
 
-    // Request CPython 3.12
-    uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("cpython@3.12"), @r###"
+    // Request CPython 3.13
+    uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("cpython@3.13"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    Updated `.python-version` from `[PYTHON-3.11]` -> `[PYTHON-3.12]`
+    Updated `.python-version` from `[PYTHON-3.12]` -> `[PYTHON-3.13]`
 
     ----- stderr -----
     "###);
@@ -548,17 +540,15 @@ fn python_pin_resolve() {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(python_version, @r###"
-        [PYTHON-3.12]
-        "###);
+        assert_snapshot!(python_version, @"[PYTHON-3.13]");
     });
 
-    // Request CPython 3.12 via partial key syntax
-    uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("cpython-3.12"), @r###"
+    // Request CPython 3.13 via partial key syntax
+    uv_snapshot!(context.filters(), context.python_pin().arg("--resolved").arg("cpython-3.13"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    Pinned `.python-version` to `[PYTHON-3.12]`
+    Pinned `.python-version` to `[PYTHON-3.13]`
 
     ----- stderr -----
     "###);
@@ -567,22 +557,20 @@ fn python_pin_resolve() {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(python_version, @r###"
-        [PYTHON-3.12]
-        "###);
+        assert_snapshot!(python_version, @"[PYTHON-3.13]");
     });
 
-    // Request CPython 3.12 for the current platform
+    // Request CPython 3.13 for the current platform
     let os = Os::from_env();
     let arch = Arch::from_env();
 
     uv_snapshot!(context.filters(), context.python_pin().arg("--resolved")
-    .arg(format!("cpython-3.12-{os}-{arch}"))
+    .arg(format!("cpython-3.13-{os}-{arch}"))
     , @r###"
     success: true
     exit_code: 0
     ----- stdout -----
-    Pinned `.python-version` to `[PYTHON-3.12]`
+    Pinned `.python-version` to `[PYTHON-3.13]`
 
     ----- stderr -----
     "###);
@@ -591,9 +579,7 @@ fn python_pin_resolve() {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(python_version, @r###"
-        [PYTHON-3.12]
-        "###);
+        assert_snapshot!(python_version, @"[PYTHON-3.13]");
     });
 
     // Request an implementation that is not installed
@@ -612,9 +598,7 @@ fn python_pin_resolve() {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(python_version, @r###"
-        [PYTHON-3.12]
-        "###);
+        assert_snapshot!(python_version, @"[PYTHON-3.13]");
     });
 
     // Request a version that is not installed
@@ -633,9 +617,7 @@ fn python_pin_resolve() {
     insta::with_settings!({
         filters => context.filters(),
     }, {
-        assert_snapshot!(python_version, @r###"
-        [PYTHON-3.12]
-        "###);
+        assert_snapshot!(python_version, @"[PYTHON-3.13]");
     });
 }
 


### PR DESCRIPTION
This restores behavior previously removed in https://github.com/astral-sh/uv/pull/7649.

I thought it'd be clearer (and simpler) to have a consistent Python executable name ordering. However, we've seen some cases where this can be surprising and, in combination with #8481, can result in incorrect behavior. For example, see https://github.com/astral-sh/uv/issues/9046 where we prefer `python3` over `python3.12` in the same directory even though `python3.12` was requested. While `python3` and `python3.12` both point to valid Python 3.12 environments there, the expectation is that when `python3.12` is requested that the `python3.12` executable is preferred. This expectation may be less obvious if the user requests `python@3.12`, but uv does not distinguish between these request forms. Similarly, this may be surprising as by default uv prefers `python` over `python3` but when requesting `python3.12` the preference will be swapped.