### PR TITLE
Rename `src` directory to `sdist`

### DIFF
--- a/crates/uv-distribution/src/source/mod.rs
+++ b/crates/uv-distribution/src/source/mod.rs
@@ -59,7 +59,7 @@ pub(crate) const LOCAL_REVISION: &str = "revision.rev";
 pub(crate) const METADATA: &str = "metadata.msgpack";
 
 /// The directory within each entry under which to store the unpacked source distribution.
-pub(crate) const SOURCE: &str = "src";
+pub(crate) const SOURCE: &str = "sdist";
 
 impl<'a, T: BuildContext> SourceDistributionBuilder<'a, T> {
     /// Initialize a [`SourceDistributionBuilder`] from a [`BuildContext`].


### PR DESCRIPTION
## Summary

It seems like XGBoost looks at `../src` and so it's causing problems for us to use that name as the build directory. We can't really dodge these problems in general -- it seems like it might be an XGBoost issue? -- but it's easy for us to change it to something that's less likely to collide.

Closes https://github.com/astral-sh/uv/issues/9068.
