### PR TITLE
Split after specifiers in `--with` requirements

### DIFF
--- a/crates/uv-cli/src/comma.rs
+++ b/crates/uv-cli/src/comma.rs
@@ -31,6 +31,17 @@ impl FromStr for CommaSeparatedRequirements {
                     depth = depth.saturating_sub(1);
                 }
                 ',' if depth == 0 => {
+                    // If the next character is a version identifier, skip the comma, as in:
+                    // `requests>=2.1,<3`.
+                    if let Some(c) = input
+                        .get(i + ','.len_utf8()..)
+                        .and_then(|s| s.chars().find(|c| !c.is_whitespace()))
+                    {
+                        if matches!(c, '!' | '=' | '<' | '>' | '~') {
+                            continue;
+                        }
+                    }
+
                     let requirement = input[start..i].trim().to_string();
                     if !requirement.is_empty() {
                         requirements.push(requirement);

--- a/crates/uv-cli/src/comma/tests.rs
+++ b/crates/uv-cli/src/comma/tests.rs
@@ -43,3 +43,19 @@ fn double_extras() {
         ])
     );
 }
+
+#[test]
+fn single_specifiers() {
+    assert_eq!(
+        CommaSeparatedRequirements::from_str("requests>=2.1,<3").unwrap(),
+        CommaSeparatedRequirements(vec!["requests>=2.1,<3".to_string(),])
+    );
+}
+
+#[test]
+fn double_specifiers() {
+    assert_eq!(
+        CommaSeparatedRequirements::from_str("requests>=2.1,<3, flask").unwrap(),
+        CommaSeparatedRequirements(vec!["requests>=2.1,<3".to_string(), "flask".to_string()])
+    );
+}


### PR DESCRIPTION
## Summary

Part of me wants to revert support for `--with "flask, requests"`, but the multiple specifiers case actually isn't ambiguous, and handling it is better than shipping a breaking change in a patch release.

Closes https://github.com/astral-sh/uv/issues/9081.
