### PR TITLE
Docs(GitLab): add entrypoint for distroless image

### DIFF
--- a/docs/guides/integration/gitlab.md
+++ b/docs/guides/integration/gitlab.md
@@ -21,6 +21,17 @@ uv:
     # your `uv` commands
 ```
 
+!!! note
+
+    If you are using a distroless image, you have to specify the entrypoint:
+    ```yaml
+    uv:
+      image:
+        name: ghcr.io/astral-sh/uv:$UV_VERSION
+        entrypoint: [""]
+      # ...
+    ```
+
 ## Caching
 
 Persisting the uv cache between workflow runs can improve performance.


### PR DESCRIPTION
## Summary

Update the docs for the GitLab integration, to make it clear that an entrypoint has to be specified, when a distroless image is being used.

## Test Plan

Without specifying an entrypoint when using a distroless image:

<img src=https://github.com/user-attachments/assets/35499bd5-51d8-4016-b1d0-2d56956f82e6 width=500>

_It works if you either specify the entrypoint or if the image used in not a distroless one._