### PR TITLE
Defer reporting of build failures in resolver

### DIFF
--- a/crates/uv-resolver/src/error.rs
+++ b/crates/uv-resolver/src/error.rs
@@ -32,6 +32,9 @@ pub enum ResolveError {
     #[error(transparent)]
     Client(#[from] uv_client::Error),
 
+    #[error(transparent)]
+    Distribution(#[from] uv_distribution::Error),
+
     #[error("The channel closed unexpectedly")]
     ChannelClosed,
 
@@ -94,20 +97,20 @@ pub enum ResolveError {
     ParsedUrl(#[from] uv_pypi_types::ParsedUrlError),
 
     #[error("Failed to download `{0}`")]
-    Download(Box<BuiltDist>, #[source] uv_distribution::Error),
+    Download(Box<BuiltDist>, #[source] Arc<uv_distribution::Error>),
 
     #[error("Failed to download and build `{0}`")]
-    DownloadAndBuild(Box<SourceDist>, #[source] uv_distribution::Error),
+    DownloadAndBuild(Box<SourceDist>, #[source] Arc<uv_distribution::Error>),
 
     #[error("Failed to read `{0}`")]
-    Read(Box<BuiltDist>, #[source] uv_distribution::Error),
+    Read(Box<BuiltDist>, #[source] Arc<uv_distribution::Error>),
 
     // TODO(zanieb): Use `thiserror` in `InstalledDist` so we can avoid chaining `anyhow`
     #[error("Failed to read metadata from installed package `{0}`")]
     ReadInstalled(Box<InstalledDist>, #[source] anyhow::Error),
 
     #[error("Failed to build `{0}`")]
-    Build(Box<SourceDist>, #[source] uv_distribution::Error),
+    Build(Box<SourceDist>, #[source] Arc<uv_distribution::Error>),
 
     #[error(transparent)]
     NoSolution(#[from] NoSolutionError),

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -1241,7 +1241,7 @@ enum TagPolicy<'tags> {
     /// Exclusively consider wheels that match the specified platform tags.
     Required(&'tags Tags),
     /// Prefer wheels that match the specified platform tags, but fall back to incompatible wheels
-    /// if  necessary.
+    /// if necessary.
     Preferred(&'tags Tags),
 }
 


### PR DESCRIPTION
## Summary

In https://github.com/astral-sh/uv/issues/9078, resolution fails because we fail to build `jsmin`. However... if you look at what's actually happening, `jsmin` fails to build during _prefetching_. And we never actually attempt to access its metadata later on.

This PR modifies the metadata result handling such that we don't raise these errors until the resolver actually asks for the metadata, so https://github.com/astral-sh/uv/issues/9078 now succeeds.

I actually had to make this change anyway in pursuing https://github.com/astral-sh/uv/issues/8962, so I've decided to carve it out here.

Closes https://github.com/astral-sh/uv/issues/9078.
