### PR TITLE
Add `version` to `ResolvedDist`

### DIFF
--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -442,7 +442,7 @@ impl<'a> CompatibleDist<'a> {
     /// Return the [`ResolvedDistRef`] to use during resolution.
     pub fn for_resolution(&self) -> ResolvedDistRef<'a> {
         match *self {
-            CompatibleDist::InstalledDist(dist) => ResolvedDistRef::Installed(dist),
+            CompatibleDist::InstalledDist(dist) => ResolvedDistRef::Installed { dist },
             CompatibleDist::SourceDist { sdist, prioritized } => {
                 ResolvedDistRef::InstallableRegistrySourceDist { sdist, prioritized }
             }
@@ -458,7 +458,7 @@ impl<'a> CompatibleDist<'a> {
     /// Return the [`ResolvedDistRef`] to use during installation.
     pub fn for_installation(&self) -> ResolvedDistRef<'a> {
         match *self {
-            CompatibleDist::InstalledDist(dist) => ResolvedDistRef::Installed(dist),
+            CompatibleDist::InstalledDist(dist) => ResolvedDistRef::Installed { dist },
             CompatibleDist::SourceDist { sdist, prioritized } => {
                 ResolvedDistRef::InstallableRegistrySourceDist { sdist, prioritized }
             }

--- a/crates/uv-distribution-types/src/resolution.rs
+++ b/crates/uv-distribution-types/src/resolution.rs
@@ -170,7 +170,7 @@ impl Diagnostic for ResolutionDiagnostic {
 impl From<&ResolvedDist> for Requirement {
     fn from(resolved_dist: &ResolvedDist) -> Self {
         let source = match resolved_dist {
-            ResolvedDist::Installable(dist) => match dist {
+            ResolvedDist::Installable { dist, .. } => match dist {
                 Dist::Built(BuiltDist::Registry(wheels)) => RequirementSource::Registry {
                     specifier: uv_pep440::VersionSpecifiers::from(
                         uv_pep440::VersionSpecifier::equals_version(
@@ -229,7 +229,7 @@ impl From<&ResolvedDist> for Requirement {
                     r#virtual: sdist.r#virtual,
                 },
             },
-            ResolvedDist::Installed(dist) => RequirementSource::Registry {
+            ResolvedDist::Installed { dist } => RequirementSource::Registry {
                 specifier: uv_pep440::VersionSpecifiers::from(
                     uv_pep440::VersionSpecifier::equals_version(dist.version().clone()),
                 ),

--- a/crates/uv-installer/src/plan.rs
+++ b/crates/uv-installer/src/plan.rs
@@ -107,18 +107,18 @@ impl<'a> Planner<'a> {
                 }
             }
 
-            let ResolvedDist::Installable(installable) = dist else {
+            let ResolvedDist::Installable { dist, .. } = dist else {
                 unreachable!("Installed distribution could not be found in site-packages: {dist}");
             };
 
             if cache.must_revalidate(dist.name()) {
                 debug!("Must revalidate requirement: {}", dist.name());
-                remote.push(installable.clone());
+                remote.push(dist.clone());
                 continue;
             }
 
             // Identify any cached distributions that satisfy the requirement.
-            match installable {
+            match dist {
                 Dist::Built(BuiltDist::Registry(wheel)) => {
                     if let Some(distribution) = registry_index.get(wheel.name()).find_map(|entry| {
                         if *entry.index.url() != wheel.best_wheel().index {
@@ -309,8 +309,8 @@ impl<'a> Planner<'a> {
                 }
             }
 
-            debug!("Identified uncached distribution: {installable}");
-            remote.push(installable.clone());
+            debug!("Identified uncached distribution: {dist}");
+            remote.push(dist.clone());
         }
 
         // Remove any unnecessary packages.

--- a/crates/uv-resolver/src/lock/mod.rs
+++ b/crates/uv-resolver/src/lock/mod.rs
@@ -2360,8 +2360,8 @@ impl Source {
     fn from_resolved_dist(resolved_dist: &ResolvedDist, root: &Path) -> Result<Source, LockError> {
         match *resolved_dist {
             // We pass empty installed packages for locking.
-            ResolvedDist::Installed(_) => unreachable!(),
-            ResolvedDist::Installable(ref dist) => Source::from_dist(dist, root),
+            ResolvedDist::Installed { .. } => unreachable!(),
+            ResolvedDist::Installable { ref dist, .. } => Source::from_dist(dist, root),
         }
     }
 
@@ -2892,8 +2892,8 @@ impl SourceDist {
     ) -> Result<Option<SourceDist>, LockError> {
         match annotated_dist.dist {
             // We pass empty installed packages for locking.
-            ResolvedDist::Installed(_) => unreachable!(),
-            ResolvedDist::Installable(ref dist) => {
+            ResolvedDist::Installed { .. } => unreachable!(),
+            ResolvedDist::Installable { ref dist, .. } => {
                 SourceDist::from_dist(id, dist, &annotated_dist.hashes, annotated_dist.index())
             }
         }
@@ -3174,8 +3174,8 @@ impl Wheel {
     fn from_annotated_dist(annotated_dist: &AnnotatedDist) -> Result<Vec<Wheel>, LockError> {
         match annotated_dist.dist {
             // We pass empty installed packages for locking.
-            ResolvedDist::Installed(_) => unreachable!(),
-            ResolvedDist::Installable(ref dist) => {
+            ResolvedDist::Installed { .. } => unreachable!(),
+            ResolvedDist::Installable { ref dist, .. } => {
                 Wheel::from_dist(dist, &annotated_dist.hashes, annotated_dist.index())
             }
         }

--- a/crates/uv-resolver/src/lock/target.rs
+++ b/crates/uv-resolver/src/lock/target.rs
@@ -266,11 +266,14 @@ impl<'env> InstallTarget<'env> {
             ) {
                 map.insert(
                     dist.id.name.clone(),
-                    ResolvedDist::Installable(dist.to_dist(
-                        self.workspace().install_path(),
-                        TagPolicy::Required(tags),
-                        build_options,
-                    )?),
+                    ResolvedDist::Installable {
+                        dist: dist.to_dist(
+                            self.workspace().install_path(),
+                            TagPolicy::Required(tags),
+                            build_options,
+                        )?,
+                        version: dist.id.version.clone(),
+                    },
                 );
                 hashes.insert(dist.id.name.clone(), dist.hashes());
             }

--- a/crates/uv-resolver/src/resolution/graph.rs
+++ b/crates/uv-resolver/src/resolution/graph.rs
@@ -444,7 +444,14 @@ impl ResolutionGraph {
                 archive.metadata.clone()
             };
 
-            (dist.into(), hashes, Some(metadata))
+            (
+                ResolvedDist::Installable {
+                    dist,
+                    version: version.clone(),
+                },
+                hashes,
+                Some(metadata),
+            )
         } else {
             let dist = pins
                 .get(name, version)

--- a/crates/uv-resolver/src/resolution/mod.rs
+++ b/crates/uv-resolver/src/resolution/mod.rs
@@ -49,8 +49,8 @@ impl AnnotatedDist {
     /// Returns the [`IndexUrl`] of the distribution, if it is from a registry.
     pub(crate) fn index(&self) -> Option<&IndexUrl> {
         match &self.dist {
-            ResolvedDist::Installed(_) => None,
-            ResolvedDist::Installable(dist) => match dist {
+            ResolvedDist::Installed { .. } => None,
+            ResolvedDist::Installable { dist, .. } => match dist {
                 Dist::Built(dist) => match dist {
                     BuiltDist::Registry(dist) => Some(&dist.best_wheel().index),
                     BuiltDist::DirectUrl(_) => None,

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -1151,7 +1151,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
             ResolvedDistRef::InstallableRegistryBuiltDist { wheel, .. } => wheel
                 .filename()
                 .unwrap_or(Cow::Borrowed("unknown filename")),
-            ResolvedDistRef::Installed(_) => Cow::Borrowed("installed"),
+            ResolvedDistRef::Installed { .. } => Cow::Borrowed("installed"),
         };
 
         debug!(
@@ -1958,7 +1958,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                     let dist = dist.for_resolution().to_owned();
 
                     let response = match dist {
-                        ResolvedDist::Installable(dist) => {
+                        ResolvedDist::Installable { dist, .. } => {
                             let metadata = provider
                                 .get_or_build_wheel_metadata(&dist)
                                 .boxed_local()
@@ -1966,7 +1966,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
 
                             Response::Dist { dist, metadata }
                         }
-                        ResolvedDist::Installed(dist) => {
+                        ResolvedDist::Installed { dist } => {
                             let metadata = dist.metadata().map_err(|err| {
                                 ResolveError::ReadInstalled(Box::new(dist.clone()), err)
                             })?;
@@ -2621,7 +2621,7 @@ impl<'a> From<ResolvedDistRef<'a>> for Request {
                 let built = prioritized.built_dist().expect("at least one wheel");
                 Request::Dist(Dist::Built(BuiltDist::Registry(built)))
             }
-            ResolvedDistRef::Installed(dist) => Request::Installed(dist.clone()),
+            ResolvedDistRef::Installed { dist } => Request::Installed(dist.clone()),
         }
     }
 }

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -454,7 +454,7 @@ fn apply_no_virtual_project(
     resolution: uv_distribution_types::Resolution,
 ) -> uv_distribution_types::Resolution {
     resolution.filter(|dist| {
-        let ResolvedDist::Installable(dist) = dist else {
+        let ResolvedDist::Installable { dist, .. } = dist else {
             return true;
         };
 
@@ -481,26 +481,31 @@ fn apply_editable_mode(
 
         // Filter out any editable distributions.
         EditableMode::NonEditable => resolution.map(|dist| {
-            let ResolvedDist::Installable(Dist::Source(SourceDist::Directory(
-                DirectorySourceDist {
-                    name,
-                    install_path,
-                    editable: true,
-                    r#virtual: false,
-                    url,
-                },
-            ))) = dist
+            let ResolvedDist::Installable {
+                dist:
+                    Dist::Source(SourceDist::Directory(DirectorySourceDist {
+                        name,
+                        install_path,
+                        editable: true,
+                        r#virtual: false,
+                        url,
+                    })),
+                version,
+            } = dist
             else {
                 return dist;
             };
 
-            ResolvedDist::Installable(Dist::Source(SourceDist::Directory(DirectorySourceDist {
-                name,
-                install_path,
-                editable: false,
-                r#virtual: false,
-                url,
-            })))
+            ResolvedDist::Installable {
+                dist: Dist::Source(SourceDist::Directory(DirectorySourceDist {
+                    name,
+                    install_path,
+                    editable: false,
+                    r#virtual: false,
+                    url,
+                })),
+                version,
+            }
         }),
     }
 }


### PR DESCRIPTION
## Summary

I need this for the derivation chain work (https://github.com/astral-sh/uv/issues/8962), but it just seems generally useful. You can't always get a version from a `Dist` (it could be URL-based!), but when we create a `ResolvedDist`, we _do_ know the version (and not just the URL). This PR preserves it.
