### PR TITLE
Rename `ResolutionGraph` to `ResolverOutput`

### DIFF
--- a/crates/uv-bench/benches/uv.rs
+++ b/crates/uv-bench/benches/uv.rs
@@ -101,7 +101,7 @@ mod resolver {
     use uv_python::Interpreter;
     use uv_resolver::{
         FlatIndex, InMemoryIndex, Manifest, OptionsBuilder, PythonRequirement, RequiresPython,
-        ResolutionGraph, Resolver, ResolverEnvironment,
+        Resolver, ResolverEnvironment, ResolverOutput,
     };
     use uv_types::{BuildIsolation, EmptyInstalledPackages, HashStrategy, InFlight};
 
@@ -139,7 +139,7 @@ mod resolver {
         client: &RegistryClient,
         interpreter: &Interpreter,
         universal: bool,
-    ) -> Result<ResolutionGraph> {
+    ) -> Result<ResolverOutput> {
         let build_isolation = BuildIsolation::default();
         let build_options = BuildOptions::default();
         let concurrency = Concurrency::default();

--- a/crates/uv-dispatch/src/lib.rs
+++ b/crates/uv-dispatch/src/lib.rs
@@ -197,7 +197,7 @@ impl<'a> BuildContext for BuildDispatch<'a> {
             EmptyInstalledPackages,
             DistributionDatabase::new(self.client, self, self.concurrency.downloads),
         )?;
-        let graph = resolver.resolve().await.with_context(|| {
+        let resolution = Resolution::from(resolver.resolve().await.with_context(|| {
             format!(
                 "No solution found when resolving: {}",
                 requirements
@@ -205,8 +205,8 @@ impl<'a> BuildContext for BuildDispatch<'a> {
                     .map(|requirement| format!("`{requirement}`"))
                     .join(", ")
             )
-        })?;
-        Ok(Resolution::from(graph))
+        })?);
+        Ok(resolution)
     }
 
     #[instrument(

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -14,7 +14,7 @@ pub use prerelease::PrereleaseMode;
 pub use python_requirement::PythonRequirement;
 pub use requires_python::{RequiresPython, RequiresPythonRange};
 pub use resolution::{
-    AnnotationStyle, ConflictingDistributionError, DisplayResolutionGraph, ResolutionGraph,
+    AnnotationStyle, ConflictingDistributionError, DisplayResolutionGraph, ResolverOutput,
 };
 pub use resolution_mode::ResolutionMode;
 pub use resolver::{

--- a/crates/uv-resolver/src/resolution/mod.rs
+++ b/crates/uv-resolver/src/resolution/mod.rs
@@ -11,12 +11,12 @@ use uv_pep508::MarkerTree;
 use uv_pypi_types::HashDigest;
 
 pub use crate::resolution::display::{AnnotationStyle, DisplayResolutionGraph};
-pub(crate) use crate::resolution::graph::ResolutionGraphNode;
-pub use crate::resolution::graph::{ConflictingDistributionError, ResolutionGraph};
+pub(crate) use crate::resolution::output::ResolutionGraphNode;
+pub use crate::resolution::output::{ConflictingDistributionError, ResolverOutput};
 pub(crate) use crate::resolution::requirements_txt::RequirementsTxtDist;
 
 mod display;
-mod graph;
+mod output;
 mod requirements_txt;
 
 /// A pinned package with its resolved distribution and metadata. The [`ResolvedDist`] refers to a

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -56,7 +56,7 @@ use crate::pubgrub::{
     PubGrubPython,
 };
 use crate::python_requirement::PythonRequirement;
-use crate::resolution::ResolutionGraph;
+use crate::resolution::ResolverOutput;
 use crate::resolution_mode::ResolutionStrategy;
 pub(crate) use crate::resolver::availability::{
     IncompletePackage, ResolverVersion, UnavailablePackage, UnavailableReason, UnavailableVersion,
@@ -251,7 +251,7 @@ impl<Provider: ResolverProvider, InstalledPackages: InstalledPackagesProvider>
     }
 
     /// Resolve a set of requirements into a set of pinned versions.
-    pub async fn resolve(self) -> Result<ResolutionGraph, ResolveError> {
+    pub async fn resolve(self) -> Result<ResolverOutput, ResolveError> {
         let state = Arc::new(self.state);
         let provider = Arc::new(self.provider);
 
@@ -291,7 +291,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
     fn solve(
         self: Arc<Self>,
         request_sink: Sender<Request>,
-    ) -> Result<ResolutionGraph, ResolveError> {
+    ) -> Result<ResolverOutput, ResolveError> {
         debug!(
             "Solving with installed Python version: {}",
             self.python_requirement.exact()
@@ -598,7 +598,7 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
         for resolution in &resolutions {
             Self::trace_resolution(resolution);
         }
-        ResolutionGraph::from_state(
+        ResolverOutput::from_state(
             &resolutions,
             &self.requirements,
             &self.constraints,

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -37,7 +37,7 @@ use uv_requirements::{
 };
 use uv_resolver::{
     DependencyMode, Exclusions, FlatIndex, InMemoryIndex, Manifest, Options, Preference,
-    Preferences, PythonRequirement, ResolutionGraph, Resolver, ResolverEnvironment,
+    Preferences, PythonRequirement, Resolver, ResolverEnvironment, ResolverOutput,
 };
 use uv_types::{HashStrategy, InFlight, InstalledPackagesProvider};
 use uv_warnings::warn_user;
@@ -113,7 +113,7 @@ pub(crate) async fn resolve<InstalledPackages: InstalledPackagesProvider>(
     options: Options,
     logger: Box<dyn ResolveLogger>,
     printer: Printer,
-) -> Result<ResolutionGraph, Error> {
+) -> Result<ResolverOutput, Error> {
     let start = std::time::Instant::now();
 
     // Resolve the requirements from the provided sources.

--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -58,21 +58,22 @@ impl CachedEnvironment {
         };
 
         // Resolve the requirements with the interpreter.
-        let graph = resolve_environment(
-            spec,
-            &interpreter,
-            settings.as_ref().into(),
-            state,
-            resolve,
-            connectivity,
-            concurrency,
-            native_tls,
-            allow_insecure_host,
-            cache,
-            printer,
-        )
-        .await?;
-        let resolution = Resolution::from(graph);
+        let resolution = Resolution::from(
+            resolve_environment(
+                spec,
+                &interpreter,
+                settings.as_ref().into(),
+                state,
+                resolve,
+                connectivity,
+                concurrency,
+                native_tls,
+                allow_insecure_host,
+                cache,
+                printer,
+            )
+            .await?,
+        );
 
         // Hash the resolution by hashing the generated lockfile.
         // TODO(charlie): If the resolution contains any mutable metadata (like a path or URL

--- a/crates/uv/src/commands/project/lock.rs
+++ b/crates/uv/src/commands/project/lock.rs
@@ -659,7 +659,7 @@ async fn do_lock(
             .relative_to(workspace)?;
 
             let previous = existing_lock.map(ValidatedLock::into_lock);
-            let lock = Lock::from_resolution_graph(&resolution, workspace.install_path())?
+            let lock = Lock::from_resolution(&resolution, workspace.install_path())?
                 .with_manifest(manifest)
                 .with_conflicts(workspace.conflicts())
                 .with_supported_environments(

--- a/crates/uv/src/commands/project/mod.rs
+++ b/crates/uv/src/commands/project/mod.rs
@@ -31,8 +31,8 @@ use uv_python::{
 use uv_requirements::upgrade::{read_lock_requirements, LockedRequirements};
 use uv_requirements::{NamedRequirementsResolver, RequirementsSpecification};
 use uv_resolver::{
-    FlatIndex, Lock, OptionsBuilder, PythonRequirement, RequiresPython, ResolutionGraph,
-    ResolverEnvironment,
+    FlatIndex, Lock, OptionsBuilder, PythonRequirement, RequiresPython, ResolverEnvironment,
+    ResolverOutput,
 };
 use uv_scripts::Pep723Item;
 use uv_settings::PythonInstallMirrors;
@@ -955,7 +955,7 @@ impl<'lock> EnvironmentSpecification<'lock> {
     }
 }
 
-/// Run dependency resolution for an interpreter, returning the [`ResolutionGraph`].
+/// Run dependency resolution for an interpreter, returning the [`ResolverOutput`].
 pub(crate) async fn resolve_environment<'a>(
     spec: EnvironmentSpecification<'_>,
     interpreter: &Interpreter,
@@ -968,7 +968,7 @@ pub(crate) async fn resolve_environment<'a>(
     allow_insecure_host: &[TrustedHost],
     cache: &Cache,
     printer: Printer,
-) -> Result<ResolutionGraph, ProjectError> {
+) -> Result<ResolverOutput, ProjectError> {
     warn_on_requirements_txt_setting(&spec.requirements, settings);
 
     let ResolverSettingsRef {


### PR DESCRIPTION
## Summary

As discussed in Discord... This struct has evolved to include a lot of information apart from the `petgraph::Graph`. And I want to add a graph to the simplified `Resolution` type. So I think this name makes more sense.
