### PR TITLE
Refactor `Resolution` type to retain dependency graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4884,6 +4884,7 @@ dependencies = [
  "fs-err",
  "itertools 0.13.0",
  "jiff",
+ "petgraph",
  "rkyv",
  "rustc-hash",
  "schemars",

--- a/crates/uv-distribution-types/Cargo.toml
+++ b/crates/uv-distribution-types/Cargo.toml
@@ -33,6 +33,7 @@ bitflags = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
 jiff = { workspace = true }
+petgraph = { workspace = true }
 rkyv = { workspace = true }
 rustc-hash = { workspace = true }
 schemars = { workspace = true, optional = true }

--- a/crates/uv-distribution-types/src/resolution.rs
+++ b/crates/uv-distribution-types/src/resolution.rs
@@ -1,5 +1,3 @@
-use petgraph::{Directed, Graph};
-
 use uv_distribution_filename::DistExtension;
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep508::MarkerTree;
@@ -8,15 +6,19 @@ use uv_pypi_types::{HashDigest, RequirementSource};
 use crate::{BuiltDist, Diagnostic, Dist, Name, ResolvedDist, SourceDist};
 
 /// A set of packages pinned at specific versions.
+///
+/// This is similar to [`ResolverOutput`], but represents a resolution for a subset of all
+/// marker environments. For example, the resolution is guaranteed to contain at most one version
+/// for a given package.
 #[derive(Debug, Default, Clone)]
 pub struct Resolution {
-    graph: Graph<Node, Edge, Directed>,
+    graph: petgraph::graph::DiGraph<Node, Edge>,
     diagnostics: Vec<ResolutionDiagnostic>,
 }
 
 impl Resolution {
     /// Create a new resolution from the given pinned packages.
-    pub fn new(graph: Graph<Node, Edge, Directed>) -> Self {
+    pub fn new(graph: petgraph::graph::DiGraph<Node, Edge>) -> Self {
         Self {
             graph,
             diagnostics: Vec::new(),
@@ -24,7 +26,7 @@ impl Resolution {
     }
 
     /// Return the underlying graph of the resolution.
-    pub fn graph(&self) -> &Graph<Node, Edge, Directed> {
+    pub fn graph(&self) -> &petgraph::graph::DiGraph<Node, Edge> {
         &self.graph
     }
 
@@ -174,10 +176,8 @@ impl Diagnostic for ResolutionDiagnostic {
 
 /// A node in the resolution, along with whether its been filtered out.
 ///
-/// This is similar to [`ResolutionGraph`], but represents a resolution for a single platform.
-///
 /// We retain filtered nodes as we still need to be able to trace dependencies through the graph
-/// (e.g., to determine why a package was install in the resolution).
+/// (e.g., to determine why a package was included in the resolution).
 #[derive(Debug, Clone)]
 pub enum Node {
     Root,

--- a/crates/uv-resolver/src/lock/requirements_txt.rs
+++ b/crates/uv-resolver/src/lock/requirements_txt.rs
@@ -6,7 +6,7 @@ use std::path::{Component, Path, PathBuf};
 
 use either::Either;
 use petgraph::visit::IntoNodeReferences;
-use petgraph::{Directed, Graph};
+use petgraph::Graph;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use url::Url;
 
@@ -21,8 +21,6 @@ use uv_pypi_types::{ParsedArchiveUrl, ParsedGitUrl};
 use crate::graph_ops::marker_reachability;
 use crate::lock::{Package, PackageId, Source};
 use crate::{InstallTarget, LockError};
-
-type LockGraph<'lock> = Graph<Node<'lock>, Edge, Directed>;
 
 /// An export of a [`Lock`] that renders in `requirements.txt` format.
 #[derive(Debug)]
@@ -42,7 +40,7 @@ impl<'lock> RequirementsTxtExport<'lock> {
         install_options: &'lock InstallOptions,
     ) -> Result<Self, LockError> {
         let size_guess = target.lock().packages.len();
-        let mut petgraph = LockGraph::with_capacity(size_guess, size_guess);
+        let mut petgraph = Graph::with_capacity(size_guess, size_guess);
         let mut inverse = FxHashMap::with_capacity_and_hasher(size_guess, FxBuildHasher);
 
         let mut queue: VecDeque<(&Package, Option<&ExtraName>)> = VecDeque::new();
@@ -282,15 +280,12 @@ impl std::fmt::Display for RequirementsTxtExport<'_> {
     }
 }
 
-/// A node in the [`LockGraph`].
+/// A node in the graph.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Node<'lock> {
     Root,
     Package(&'lock Package),
 }
-
-/// The edges of the [`LockGraph`].
-type Edge = MarkerTree;
 
 /// A flat requirement, with its associated marker.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/uv-types/src/hash.rs
+++ b/crates/uv-types/src/hash.rs
@@ -274,8 +274,7 @@ impl HashStrategy {
     ) -> Result<Self, HashStrategyError> {
         let mut hashes = FxHashMap::<VersionId, Vec<HashDigest>>::default();
 
-        for dist in resolution.distributions() {
-            let digests = resolution.get_hashes(dist.name());
+        for (dist, digests) in resolution.hashes() {
             if digests.is_empty() {
                 // Under `--require-hashes`, every requirement must include a hash.
                 if mode.is_require() {

--- a/crates/uv/src/commands/pip/operations.rs
+++ b/crates/uv/src/commands/pip/operations.rs
@@ -733,8 +733,8 @@ pub(crate) fn diagnose_environment(
     for diagnostic in site_packages.diagnostics(markers)? {
         // Only surface diagnostics that are "relevant" to the current resolution.
         if resolution
-            .packages()
-            .any(|package| diagnostic.includes(package))
+            .distributions()
+            .any(|dist| diagnostic.includes(dist.name()))
         {
             writeln!(
                 printer.stderr(),

--- a/crates/uv/src/commands/project/sync.rs
+++ b/crates/uv/src/commands/project/sync.rs
@@ -510,19 +510,19 @@ fn apply_editable_mode(
                 version,
             } = dist
             else {
-                return dist;
+                return None;
             };
 
-            ResolvedDist::Installable {
+            Some(ResolvedDist::Installable {
                 dist: Dist::Source(SourceDist::Directory(DirectorySourceDist {
-                    name,
-                    install_path,
+                    name: name.clone(),
+                    install_path: install_path.clone(),
                     editable: false,
                     r#virtual: false,
-                    url,
+                    url: url.clone(),
                 })),
-                version,
-            }
+                version: version.clone(),
+            })
         }),
     }
 }


### PR DESCRIPTION
## Summary

This PR should not contain any user-visible changes, but the goal is to refactor the `Resolution` type to retain a dependency graph. We want to be able to explain _why_ a given package was excluded on error (see: https://github.com/astral-sh/uv/issues/8962), which in turn requires that at install time, we can go back and figure out the dependency chain. At present, `Resolution` is just a map from package name to distribution; this PR remodels it as a graph in which each node is a package, and the edges contain markers plus extras or dependency groups.