### PR TITLE
Add support for async unzipping with ZIP64 archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 [[package]]
 name = "async_zip"
 version = "0.0.17"
-source = "git+https://github.com/charliermarsh/rs-async-zip?rev=011b24604fa7bc223daaad7712c0694bac8f0a87#011b24604fa7bc223daaad7712c0694bac8f0a87"
+source = "git+https://github.com/charliermarsh/rs-async-zip?rev=c909fda63fcafe4af496a07bfda28a5aae97e58d#c909fda63fcafe4af496a07bfda28a5aae97e58d"
 dependencies = [
  "async-compression",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ async-channel = { version = "2.3.1" }
 async-compression = { version = "0.4.12" }
 async-trait = { version = "0.1.82" }
 async_http_range_reader = { version = "0.9.1" }
-async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "011b24604fa7bc223daaad7712c0694bac8f0a87", features = ["deflate", "tokio"] }
+async_zip = { git = "https://github.com/charliermarsh/rs-async-zip", rev = "c909fda63fcafe4af496a07bfda28a5aae97e58d", features = ["deflate", "tokio"] }
 axoupdater = { version = "0.8.0", default-features = false }
 backoff = { version = "0.4.0" }
 base64 = { version = "0.22.1" }


### PR DESCRIPTION
## Summary

See: https://github.com/charliermarsh/rs-async-zip/pull/4.

Closes https://github.com/astral-sh/uv/issues/8031.

## Test Plan

I created a wheel with 100,000 files in it.

I verified that `uv pip install https://github.com/astral-sh/uv/raw/refs/heads/charlie/sixtyfour/sixtyfour/dist/sixtyfour-0.1.0-py3-none-any.whl` fails, while `cargo run pip install https://github.com/astral-sh/uv/raw/refs/heads/charlie/sixtyfour/sixtyfour/dist/sixtyfour-0.1.0-py3-none-any.whl` succeeds, and I can then `import sixtyfour`, `import sixtyfour.file_20557`, etc.
