### PR TITLE
Remove end-of-line whitespace in snapshots

### DIFF
--- a/crates/uv/tests/it/common/mod.rs
+++ b/crates/uv/tests/it/common/mod.rs
@@ -67,6 +67,8 @@ pub const INSTA_FILTERS: &[(&str, &str)] = &[
         r"Caused by: .* \(os error 2\)",
         "Caused by: No such file or directory (os error 2)",
     ),
+    // Trim end-of-line whitespaces, to allow removing them on save.
+    (r"([^\s])[ \t]+(\r?\n)", "$1$2"),
 ];
 
 /// Create a context for tests which simplifies shared behavior across tests.

--- a/crates/uv/tests/it/pip_freeze.rs
+++ b/crates/uv/tests/it/pip_freeze.rs
@@ -80,7 +80,7 @@ fn freeze_duplicate() -> Result<()> {
     pip==22.1.1
 
     ----- stderr -----
-    warning: The package `pip` has multiple installed distributions: 
+    warning: The package `pip` has multiple installed distributions:
       - [SITE_PACKAGES]/pip-21.3.1.dist-info
       - [SITE_PACKAGES]/pip-22.1.1.dist-info
     "#

--- a/crates/uv/tests/it/pip_install.rs
+++ b/crates/uv/tests/it/pip_install.rs
@@ -7300,7 +7300,7 @@ fn sklearn() {
 
           [stderr]
           The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
-          rather than 'sklearn' for pip commands. 
+          rather than 'sklearn' for pip commands.
 
           Here is how to fix this error in the main use cases:
           - use 'pip install scikit-learn' rather than 'pip install sklearn'


### PR DESCRIPTION
I've configured my IDE to remove trailing end-of-line whitespace, and these snapshots were causing trouble.