### PR TITLE
Build backend: Include readme and license files

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -375,7 +375,7 @@ pub fn build_wheel(
         entry.path();
     }
 
-    if let Some(license_files) = &pyproject_toml.project().license_files {
+    if let Some(license_files) = &pyproject_toml.license_files() {
         let license_files_globs: Vec<_> = license_files
             .iter()
             .map(|license_files| {
@@ -556,8 +556,7 @@ pub fn build_source_dist(
 
     // Include the Readme
     if let Some(readme) = pyproject_toml
-        .project()
-        .readme
+        .readme()
         .as_ref()
         .and_then(|readme| readme.path())
     {
@@ -569,7 +568,7 @@ pub fn build_source_dist(
     }
 
     // Include the license files
-    for license_files in pyproject_toml.project().license_files.iter().flatten() {
+    for license_files in pyproject_toml.license_files().into_iter().flatten() {
         trace!("Including license files at: `{license_files}`");
         let glob = parse_portable_glob(license_files).map_err(|err| Error::PortableGlob {
             field: "project.license-files".to_string(),

--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -446,7 +446,11 @@ pub fn build_source_dist(
         extension: SourceDistExtension::TarGz,
     };
 
-    let top_level = format!("{}-{}", pyproject_toml.name(), pyproject_toml.version());
+    let top_level = format!(
+        "{}-{}",
+        pyproject_toml.name().as_dist_info_name(),
+        pyproject_toml.version()
+    );
 
     let source_dist_path = source_dist_directory.join(filename.to_string());
     let tar_gz = File::create(&source_dist_path)?;

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -76,8 +76,12 @@ impl PyProjectToml {
         Ok(toml::from_str(contents)?)
     }
 
-    pub(crate) fn project(&self) -> &Project {
-        &self.project
+    pub(crate) fn readme(&self) -> Option<&Readme> {
+        self.project.readme.as_ref()
+    }
+
+    pub(crate) fn license_files(&self) -> Option<&[String]> {
+        self.project.license_files.as_deref()
     }
 
     /// Warn if the `[build-system]` table looks suspicious.
@@ -534,61 +538,61 @@ impl PyProjectToml {
 /// should update the shared schema instead.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub(crate) struct Project {
+struct Project {
     /// The name of the project.
-    pub(crate) name: PackageName,
+    name: PackageName,
     /// The version of the project.
-    pub(crate) version: Version,
+    version: Version,
     /// The summary description of the project in one line.
-    pub(crate) description: Option<String>,
+    description: Option<String>,
     /// The full description of the project (i.e. the README).
-    pub(crate) readme: Option<Readme>,
+    readme: Option<Readme>,
     /// The Python version requirements of the project.
-    pub(crate) requires_python: Option<VersionSpecifiers>,
+    requires_python: Option<VersionSpecifiers>,
     /// The license under which the project is distributed.
     ///
     /// Supports both the current standard and the provisional PEP 639.
-    pub(crate) license: Option<License>,
+    license: Option<License>,
     /// The paths to files containing licenses and other legal notices to be distributed with the
     /// project.
     ///
     /// From the provisional PEP 639
-    pub(crate) license_files: Option<Vec<String>>,
+    license_files: Option<Vec<String>>,
     /// The people or organizations considered to be the "authors" of the project.
-    pub(crate) authors: Option<Vec<Contact>>,
+    authors: Option<Vec<Contact>>,
     /// The people or organizations considered to be the "maintainers" of the project.
-    pub(crate) maintainers: Option<Vec<Contact>>,
+    maintainers: Option<Vec<Contact>>,
     /// The keywords for the project.
-    pub(crate) keywords: Option<Vec<String>>,
+    keywords: Option<Vec<String>>,
     /// Trove classifiers which apply to the project.
-    pub(crate) classifiers: Option<Vec<String>>,
+    classifiers: Option<Vec<String>>,
     /// A table of URLs where the key is the URL label and the value is the URL itself.
     ///
     /// PyPI shows all URLs with their name. For some known patterns, they add favicons.
     /// main: <https://github.com/pypi/warehouse/blob/main/warehouse/templates/packaging/detail.html>
     /// archived: <https://github.com/pypi/warehouse/blob/e3bd3c3805ff47fff32b67a899c1ce11c16f3c31/warehouse/templates/packaging/detail.html>
-    pub(crate) urls: Option<BTreeMap<String, String>>,
+    urls: Option<BTreeMap<String, String>>,
     /// The console entrypoints of the project.
     ///
     /// The key of the table is the name of the entry point and the value is the object reference.
-    pub(crate) scripts: Option<BTreeMap<String, String>>,
+    scripts: Option<BTreeMap<String, String>>,
     /// The GUI entrypoints of the project.
     ///
     /// The key of the table is the name of the entry point and the value is the object reference.
-    pub(crate) gui_scripts: Option<BTreeMap<String, String>>,
+    gui_scripts: Option<BTreeMap<String, String>>,
     /// Entrypoints groups of the project.
     ///
     /// The key of the table is the name of the entry point and the value is the object reference.
-    pub(crate) entry_points: Option<BTreeMap<String, BTreeMap<String, String>>>,
+    entry_points: Option<BTreeMap<String, BTreeMap<String, String>>>,
     /// The dependencies of the project.
-    pub(crate) dependencies: Option<Vec<Requirement>>,
+    dependencies: Option<Vec<Requirement>>,
     /// The optional dependencies of the project.
-    pub(crate) optional_dependencies: Option<BTreeMap<ExtraName, Vec<Requirement>>>,
+    optional_dependencies: Option<BTreeMap<ExtraName, Vec<Requirement>>>,
     /// Specifies which fields listed by PEP 621 were intentionally unspecified so another tool
     /// can/will provide such metadata dynamically.
     ///
     /// Not supported, an error if anything but the default empty list.
-    pub(crate) dynamic: Option<Vec<String>>,
+    dynamic: Option<Vec<String>>,
 }
 
 /// The optional `project.readme` key in a pyproject.toml as specified in

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -76,6 +76,10 @@ impl PyProjectToml {
         Ok(toml::from_str(contents)?)
     }
 
+    pub(crate) fn project(&self) -> &Project {
+        &self.project
+    }
+
     /// Warn if the `[build-system]` table looks suspicious.
     ///
     /// Example of a valid table:
@@ -530,68 +534,68 @@ impl PyProjectToml {
 /// should update the shared schema instead.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
-struct Project {
+pub(crate) struct Project {
     /// The name of the project.
-    name: PackageName,
+    pub(crate) name: PackageName,
     /// The version of the project.
-    version: Version,
+    pub(crate) version: Version,
     /// The summary description of the project in one line.
-    description: Option<String>,
+    pub(crate) description: Option<String>,
     /// The full description of the project (i.e. the README).
-    readme: Option<Readme>,
+    pub(crate) readme: Option<Readme>,
     /// The Python version requirements of the project.
-    requires_python: Option<VersionSpecifiers>,
+    pub(crate) requires_python: Option<VersionSpecifiers>,
     /// The license under which the project is distributed.
     ///
     /// Supports both the current standard and the provisional PEP 639.
-    license: Option<License>,
+    pub(crate) license: Option<License>,
     /// The paths to files containing licenses and other legal notices to be distributed with the
     /// project.
     ///
     /// From the provisional PEP 639
-    license_files: Option<Vec<String>>,
+    pub(crate) license_files: Option<Vec<String>>,
     /// The people or organizations considered to be the "authors" of the project.
-    authors: Option<Vec<Contact>>,
+    pub(crate) authors: Option<Vec<Contact>>,
     /// The people or organizations considered to be the "maintainers" of the project.
-    maintainers: Option<Vec<Contact>>,
+    pub(crate) maintainers: Option<Vec<Contact>>,
     /// The keywords for the project.
-    keywords: Option<Vec<String>>,
+    pub(crate) keywords: Option<Vec<String>>,
     /// Trove classifiers which apply to the project.
-    classifiers: Option<Vec<String>>,
+    pub(crate) classifiers: Option<Vec<String>>,
     /// A table of URLs where the key is the URL label and the value is the URL itself.
     ///
     /// PyPI shows all URLs with their name. For some known patterns, they add favicons.
     /// main: <https://github.com/pypi/warehouse/blob/main/warehouse/templates/packaging/detail.html>
     /// archived: <https://github.com/pypi/warehouse/blob/e3bd3c3805ff47fff32b67a899c1ce11c16f3c31/warehouse/templates/packaging/detail.html>
-    urls: Option<BTreeMap<String, String>>,
+    pub(crate) urls: Option<BTreeMap<String, String>>,
     /// The console entrypoints of the project.
     ///
     /// The key of the table is the name of the entry point and the value is the object reference.
-    scripts: Option<BTreeMap<String, String>>,
+    pub(crate) scripts: Option<BTreeMap<String, String>>,
     /// The GUI entrypoints of the project.
     ///
     /// The key of the table is the name of the entry point and the value is the object reference.
-    gui_scripts: Option<BTreeMap<String, String>>,
+    pub(crate) gui_scripts: Option<BTreeMap<String, String>>,
     /// Entrypoints groups of the project.
     ///
     /// The key of the table is the name of the entry point and the value is the object reference.
-    entry_points: Option<BTreeMap<String, BTreeMap<String, String>>>,
+    pub(crate) entry_points: Option<BTreeMap<String, BTreeMap<String, String>>>,
     /// The dependencies of the project.
-    dependencies: Option<Vec<Requirement>>,
+    pub(crate) dependencies: Option<Vec<Requirement>>,
     /// The optional dependencies of the project.
-    optional_dependencies: Option<BTreeMap<ExtraName, Vec<Requirement>>>,
+    pub(crate) optional_dependencies: Option<BTreeMap<ExtraName, Vec<Requirement>>>,
     /// Specifies which fields listed by PEP 621 were intentionally unspecified so another tool
     /// can/will provide such metadata dynamically.
     ///
     /// Not supported, an error if anything but the default empty list.
-    dynamic: Option<Vec<String>>,
+    pub(crate) dynamic: Option<Vec<String>>,
 }
 
 /// The optional `project.readme` key in a pyproject.toml as specified in
 /// <https://packaging.python.org/en/latest/specifications/pyproject-toml/#readme>.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(untagged, rename_all = "kebab-case")]
-enum Readme {
+pub(crate) enum Readme {
     /// Relative path to the README.
     String(PathBuf),
     /// Relative path to the README.
@@ -608,11 +612,22 @@ enum Readme {
     },
 }
 
+impl Readme {
+    /// If the readme is a file, return the path to the file.
+    pub(crate) fn path(&self) -> Option<&Path> {
+        match self {
+            Readme::String(path) => Some(path),
+            Readme::File { file, .. } => Some(file),
+            Readme::Text { .. } => None,
+        }
+    }
+}
+
 /// The optional `project.license` key in a pyproject.toml as specified in
 /// <https://packaging.python.org/en/latest/specifications/pyproject-toml/#license>.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(untagged)]
-enum License {
+pub(crate) enum License {
     /// An SPDX Expression.
     ///
     /// From the provisional PEP 639.
@@ -639,7 +654,7 @@ enum License {
     deny_unknown_fields,
     expecting = "a table with 'name' and/or 'email' keys"
 )]
-enum Contact {
+pub(crate) enum Contact {
     /// TODO(konsti): RFC 822 validation.
     NameEmail { name: String, email: String },
     /// TODO(konsti): RFC 822 validation.

--- a/crates/uv-build-backend/src/tests.rs
+++ b/crates/uv-build-backend/src/tests.rs
@@ -131,6 +131,11 @@ fn test_prepare_metadata() {
     Summary: A package to be built with the uv build backend that uses all features exposed by the build backend
     Requires-Dist: anyio>=4,<5
     Requires-Python: >=3.12
+    Description-Content-Type: text/markdown
+
+    # built_by_uv
+
+    A package to be built with the uv build backend that uses all features exposed by the build backend.
     "###);
 
     let record_file = metadata_dir
@@ -138,7 +143,7 @@ fn test_prepare_metadata() {
         .join("built_by_uv-0.1.0.dist-info/RECORD");
     assert_snapshot!(fs_err::read_to_string(record_file).unwrap(), @r###"
     built_by_uv-0.1.0.dist-info/WHEEL,sha256=3da1bfa0e8fd1b6cc246aa0b2b44a35815596c600cb485c39a6f8c106c3d5a8d,83
-    built_by_uv-0.1.0.dist-info/METADATA,sha256=ec36b5ae8830bdd248e90aaf581483ffb057f9a2d0f41e19e585531e7d07c9dc,215
+    built_by_uv-0.1.0.dist-info/METADATA,sha256=dfa55ef756775bc493b878741bcdc848c4379812cee7656bc77d886e6ef71d39,372
     built_by_uv-0.1.0.dist-info/RECORD,,
     "###);
 

--- a/crates/uv-build-backend/src/tests.rs
+++ b/crates/uv-build-backend/src/tests.rs
@@ -195,7 +195,7 @@ fn built_by_uv_building() {
     );
 
     // Check the contained files and directories
-    assert_snapshot!(source_dist_contents.join("\n"), @r"
+    assert_snapshot!(source_dist_contents.iter().map(|path| path.replace('\\', "/")).join("\n"), @r"
         built_by_uv-0.1.0/LICENSE-APACHE
         built_by_uv-0.1.0/LICENSE-MIT
         built_by_uv-0.1.0/PKG-INFO
@@ -223,7 +223,7 @@ fn built_by_uv_building() {
     indirect_wheel_contents.sort_unstable();
     assert_eq!(indirect_wheel_contents, direct_wheel_contents);
 
-    assert_snapshot!(indirect_wheel_contents.join("\n"), @r"
+    assert_snapshot!(indirect_wheel_contents.iter().map(|path| path.replace('\\', "/")).join("\n"), @r"
         built_by_uv-0.1.0.dist-info/
         built_by_uv-0.1.0.dist-info/METADATA
         built_by_uv-0.1.0.dist-info/RECORD

--- a/crates/uv-build-backend/src/tests.rs
+++ b/crates/uv-build-backend/src/tests.rs
@@ -48,10 +48,16 @@ fn test_record() {
 fn test_determinism() {
     let built_by_uv = Path::new("../../scripts/packages/built-by-uv");
     let src = TempDir::new().unwrap();
-    for dir in ["src", "tests", "data-dir"] {
+    for dir in ["src", "tests", "data-dir", "third-party-licenses"] {
         copy_dir_all(built_by_uv.join(dir), src.path().join(dir)).unwrap();
     }
-    for dir in ["pyproject.toml", "README.md", "uv.lock"] {
+    for dir in [
+        "pyproject.toml",
+        "README.md",
+        "uv.lock",
+        "LICENSE-APACHE",
+        "LICENSE-MIT",
+    ] {
         fs_err::copy(built_by_uv.join(dir), src.path().join(dir)).unwrap();
     }
 
@@ -125,7 +131,7 @@ fn test_prepare_metadata() {
         .path()
         .join("built_by_uv-0.1.0.dist-info/METADATA");
     assert_snapshot!(fs_err::read_to_string(metadata_file).unwrap(), @r###"
-    Metadata-Version: 2.3
+    Metadata-Version: 2.4
     Name: built-by-uv
     Version: 0.1.0
     Summary: A package to be built with the uv build backend that uses all features exposed by the build backend
@@ -143,7 +149,7 @@ fn test_prepare_metadata() {
         .join("built_by_uv-0.1.0.dist-info/RECORD");
     assert_snapshot!(fs_err::read_to_string(record_file).unwrap(), @r###"
     built_by_uv-0.1.0.dist-info/WHEEL,sha256=3da1bfa0e8fd1b6cc246aa0b2b44a35815596c600cb485c39a6f8c106c3d5a8d,83
-    built_by_uv-0.1.0.dist-info/METADATA,sha256=dfa55ef756775bc493b878741bcdc848c4379812cee7656bc77d886e6ef71d39,372
+    built_by_uv-0.1.0.dist-info/METADATA,sha256=acb91f5a18cb53fa57b45eb4590ea13195a774c856a9dd8cf27cc5435d6451b6,372
     built_by_uv-0.1.0.dist-info/RECORD,,
     "###);
 

--- a/crates/uv/tests/it/build_backend.rs
+++ b/crates/uv/tests/it/build_backend.rs
@@ -105,7 +105,7 @@ fn built_by_uv_direct() -> Result<()> {
         .build_backend()
         .arg("build-wheel")
         .arg(wheel_dir.path())
-        .current_dir(sdist_tree.path().join("built-by-uv-0.1.0")), @r###"
+        .current_dir(sdist_tree.path().join("built_by_uv-0.1.0")), @r###"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/scripts/packages/built-by-uv/LICENSE-APACHE
+++ b/scripts/packages/built-by-uv/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/scripts/packages/built-by-uv/LICENSE-MIT
+++ b/scripts/packages/built-by-uv/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Astral Software Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/packages/built-by-uv/pyproject.toml
+++ b/scripts/packages/built-by-uv/pyproject.toml
@@ -5,6 +5,7 @@ description = "A package to be built with the uv build backend that uses all fea
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = ["anyio>=4,<5"]
+license-files = ["LICENSE*", "third-party-licenses/*"]
 
 [build-system]
 requires = ["uv>=0.4.15,<5"]

--- a/scripts/packages/built-by-uv/pyproject.toml
+++ b/scripts/packages/built-by-uv/pyproject.toml
@@ -2,7 +2,7 @@
 name = "built-by-uv"
 version = "0.1.0"
 description = "A package to be built with the uv build backend that uses all features exposed by the build backend"
-#rreadme = "README.md"
+readme = "README.md"
 requires-python = ">=3.12"
 dependencies = ["anyio>=4,<5"]
 

--- a/scripts/packages/built-by-uv/third-party-licenses/PEP-401.txt
+++ b/scripts/packages/built-by-uv/third-party-licenses/PEP-401.txt
@@ -1,0 +1,4 @@
+This document is the property of the Python Steering Union (not to
+be confused with the Python Secret Underground, which emphatically
+does not exist). We suppose it's okay for you to read this, but don't
+even think about quoting, copying, modifying, or distributing it.


### PR DESCRIPTION
When building source distributions, we need to include the readme, so it can become part the METADATA body when building the wheel. We also need to support the license files from PEP 639. When building the source distribution, we copy those file relative to their origin, when building the wheel, we copy them to `.dist-info/licenses`.

The test for idempotence in wheel building is merged into the file listing test, which also covers that source tree -> source dist -> wheel is equivalent to source tree -> wheel, though we do need to check for file inclusion stronger here.

Best reviewed commit-by-commit