### PR TITLE
Add --gui-script flag for running Python scripts with pythonw.exe on …

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -2636,7 +2636,7 @@ pub struct RunArgs {
     /// Run a Python module.
     ///
     /// Equivalent to `python -m <module>`.
-    #[arg(short, long, conflicts_with = "script")]
+    #[arg(short, long, conflicts_with_all = ["script", "gui_script"])]
     pub module: bool,
 
     /// Only include the development dependency group.
@@ -2735,8 +2735,15 @@ pub struct RunArgs {
     ///
     /// Using `--script` will attempt to parse the path as a PEP 723 script,
     /// irrespective of its extension.
-    #[arg(long, short, conflicts_with = "module")]
+    #[arg(long, short, conflicts_with_all = ["module", "gui_script"])]
     pub script: bool,
+
+    /// Run the given path as a Python GUI script.
+    ///
+    /// Using `--gui-script` will attempt to parse the path as a PEP 723 script and run it with pythonw.exe,
+    /// irrespective of its extension. Only available on Windows.
+    #[arg(long, conflicts_with_all = ["script", "module"])]
+    pub gui_script: bool,
 
     #[command(flatten)]
     pub installer: ResolverInstallerArgs,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1251,6 +1251,7 @@ impl RunCommand {
         command: &ExternalCommand,
         module: bool,
         script: bool,
+        gui_script: bool,
         connectivity: Connectivity,
         native_tls: bool,
         allow_insecure_host: &[TrustedHost],
@@ -1304,6 +1305,11 @@ impl RunCommand {
             return Ok(Self::PythonModule(target.clone(), args.to_vec()));
         } else if script {
             return Ok(Self::PythonScript(target.clone().into(), args.to_vec()));
+        } else if gui_script {
+            #[cfg(windows)] // @reviewer less sure about this part, but seems likea good check
+            return Ok(Self::PythonGuiScript(target.clone().into(), args.to_vec()));
+            #[cfg(not(windows))]
+            anyhow::bail!("`--gui-script` is only supported on Windows");
         }
 
         let metadata = target_path.metadata();

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1247,6 +1247,7 @@ impl std::fmt::Display for RunCommand {
 
 impl RunCommand {
     /// Determine the [`RunCommand`] for a given set of arguments.
+    #[allow(clippy::fn_params_excessive_bools)]
     pub(crate) async fn from_args(
         command: &ExternalCommand,
         module: bool,

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -1307,10 +1307,10 @@ impl RunCommand {
         } else if script {
             return Ok(Self::PythonScript(target.clone().into(), args.to_vec()));
         } else if gui_script {
-            #[cfg(windows)] // @reviewer less sure about this part, but seems likea good check
-            return Ok(Self::PythonGuiScript(target.clone().into(), args.to_vec()));
-            #[cfg(not(windows))]
-            anyhow::bail!("`--gui-script` is only supported on Windows");
+            if cfg!(windows) {
+                return Ok(Self::PythonGuiScript(target.clone().into(), args.to_vec()));
+            }
+            anyhow::bail!("`--gui-script` is only supported on Windows. Did you mean `--script`?");
         }
 
         let metadata = target_path.metadata();

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -140,6 +140,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
             command: Some(command),
             module,
             script,
+            gui_script,
             ..
         }) = &mut **command
         {
@@ -149,6 +150,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                     command,
                     *module,
                     *script,
+                    *gui_script,
                     settings.connectivity,
                     settings.native_tls,
                     &settings.allow_insecure_host,

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -291,6 +291,7 @@ impl RunSettings {
             only_dev,
             no_editable,
             script: _,
+            gui_script: _,
             command: _,
             with,
             with_editable,

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2795,7 +2795,7 @@ fn run_gui_script_not_supported() -> Result<()> {
     ----- stderr -----
     error: `--gui-script` is only supported on Windows. Did you mean `--script`?
     "###);
-    
+
     Ok(())
 }
 

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2793,7 +2793,7 @@ fn run_gui_script_explicit() -> Result<()> {
 
 #[test]
 #[cfg(not(windows))]
-fn run_gui_script_not_supported() -> Result<()> {  // Add Result return type
+fn run_gui_script_not_supported() -> Result<()> { 
     let context = TestContext::new("3.12");
 
     let test_script = context.temp_dir.child("script");
@@ -2814,7 +2814,7 @@ fn run_gui_script_not_supported() -> Result<()> {  // Add Result return type
     error: `--gui-script` is only supported on Windows
     "###);
 
-    Ok(())  // Add Ok(()) at the end
+    Ok(())
 }
 
 #[test]

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2804,7 +2804,7 @@ fn run_gui_script_not_supported() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
-    error: `--gui-script` is only supported on Windows
+    error: `--gui-script` is only supported on Windows. Did you mean `--script`?
     "###);
 
     Ok(())

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2742,7 +2742,7 @@ fn run_script_explicit_directory() -> Result<()> {
 fn run_gui_script_explicit() -> Result<()> {
     let context = TestContext::new("3.12");
 
-    let test_script = context.temp_dir.child("script.pyw");
+    let test_script = context.temp_dir.child("script");
     test_script.write_str(indoc! { r#"
         # /// script
         # requires-python = ">=3.11"
@@ -2759,7 +2759,7 @@ fn run_gui_script_explicit() -> Result<()> {
         print(f"Using executable: {executable}", file=sys.stderr)
     "#})?;
 
-    uv_snapshot!(context.filters(), context.run().arg("--gui-script").arg("script.pyw"), @r###"
+    uv_snapshot!(context.filters(), context.run().arg("--gui-script").arg("script"), @r###"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2785,14 +2785,17 @@ fn run_gui_script_not_supported() -> Result<()> {
     "#})?;
 
     uv_snapshot!(context.filters(), context.run().arg("--gui-script").arg("script"), @r###"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
 
     ----- stderr -----
-    error: `--gui-script` is only supported on Windows. Did you mean `--script`?
+    Reading inline script metadata from `script`
+    Resolved in [TIME]
+    Audited in [TIME]
+    Using executable: pythonw.exe
     "###);
-
+    
     Ok(())
 }
 

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2787,14 +2787,14 @@ fn run_gui_script_not_supported() -> Result<()> {
         print("Hello")
     "#})?;
 
-    uv_snapshot!(context.filters(), context.run().arg("--gui-script").arg("script"), @r"
+    uv_snapshot!(context.filters(), context.run().arg("--gui-script").arg("script"), @r###"
     success: false
     exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
     error: `--gui-script` is only supported on Windows. Did you mean `--script`?
-    ");
+    "###);
     
     Ok(())
 }

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2742,7 +2742,6 @@ fn run_script_explicit_directory() -> Result<()> {
 fn run_gui_script_explicit() -> Result<()> {
     let context = TestContext::new("3.12");
 
-    // Create a script that shows a GUI window
     let test_script = context.temp_dir.child("script");
     test_script.write_str(indoc! { r#"
         # /// script
@@ -2752,6 +2751,7 @@ fn run_gui_script_explicit() -> Result<()> {
         # ]
         # ///
         import sys
+        import os
         from PyQt5.QtWidgets import QApplication, QMainWindow
         from PyQt5.QtCore import QTimer
         

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2765,8 +2765,12 @@ fn run_gui_script_explicit() -> Result<()> {
     ----- stdout -----
 
     ----- stderr -----
+    Reading inline script metadata from `script`
+    Resolved in [TIME]
+    Audited in [TIME]
     Using executable: pythonw.exe
     "###);
+
 
     Ok(())
 }

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2793,7 +2793,7 @@ fn run_gui_script_explicit() -> Result<()> {
 
 #[test]
 #[cfg(not(windows))]
-fn run_gui_script_not_supported() -> Result<()> { 
+fn run_gui_script_not_supported() -> Result<()> {
     let context = TestContext::new("3.12");
     let test_script = context.temp_dir.child("script");
     test_script.write_str(indoc! { r#"

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2771,7 +2771,6 @@ fn run_gui_script_explicit() -> Result<()> {
     Using executable: pythonw.exe
     "###);
 
-
     Ok(())
 }
 

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2784,17 +2784,14 @@ fn run_gui_script_not_supported() -> Result<()> {
         print("Hello")
     "#})?;
 
-    uv_snapshot!(context.filters(), context.run().arg("--gui-script").arg("script"), @r###"
-    success: true
-    exit_code: 0
+    uv_snapshot!(context.filters(), context.run().arg("--gui-script").arg("script"), @r"
+    success: false
+    exit_code: 2
     ----- stdout -----
 
     ----- stderr -----
-    Reading inline script metadata from `script`
-    Resolved in [TIME]
-    Audited in [TIME]
-    Using executable: pythonw.exe
-    "###);
+    error: `--gui-script` is only supported on Windows. Did you mean `--script`?
+    ");
     
     Ok(())
 }

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2768,10 +2768,7 @@ fn run_gui_script_explicit() -> Result<()> {
     "#})?;
 
     // Run with --gui-script flag
-    let output = context.run()
-        .arg("--gui-script")
-        .arg("script")
-        .output()?;
+    let output = context.run().arg("--gui-script").arg("script").output()?;
 
     // In GUI mode (pythonw.exe):
     // 1. The process should succeed
@@ -2780,23 +2777,23 @@ fn run_gui_script_explicit() -> Result<()> {
     assert!(output.stdout.is_empty());
 
     // Run with regular --script flag (python.exe)
-    let output = context.run()
-        .arg("--script")
-        .arg("script")
-        .output()?;
+    let output = context.run().arg("--script").arg("script").output()?;
 
     // In regular mode:
     // 1. The process should succeed
     // 2. stdout should contain our print message
     assert!(output.status.success());
-    assert!(String::from_utf8_lossy(&output.stdout).contains("This should not be visible in GUI mode"));
+
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("This should not be visible in GUI mode")
+    );
 
     Ok(())
 }
 
 #[test]
 #[cfg(not(windows))]
-fn run_gui_script_not_supported() {
+fn run_gui_script_not_supported() -> Result<()> {  // Add Result return type
     let context = TestContext::new("3.12");
 
     let test_script = context.temp_dir.child("script");
@@ -2816,6 +2813,8 @@ fn run_gui_script_not_supported() {
     ----- stderr -----
     error: `--gui-script` is only supported on Windows
     "###);
+
+    Ok(())  // Add Ok(()) at the end
 }
 
 #[test]

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -2795,7 +2795,6 @@ fn run_gui_script_explicit() -> Result<()> {
 #[cfg(not(windows))]
 fn run_gui_script_not_supported() -> Result<()> { 
     let context = TestContext::new("3.12");
-
     let test_script = context.temp_dir.child("script");
     test_script.write_str(indoc! { r#"
         # /// script

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -180,6 +180,10 @@ uv run [OPTIONS] [COMMAND]
 
 <p>May be provided multiple times.</p>
 
+</dd><dt><code>--gui-script</code></dt><dd><p>Run the given path as a Python GUI script.</p>
+
+<p>Using <code>--gui-script</code> will attempt to parse the path as a PEP 723 script and run it with pythonw.exe, irrespective of its extension. Only available on Windows.</p>
+
 </dd><dt><code>--help</code>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 
 </dd><dt><code>--index</code> <i>index</i></dt><dd><p>The URLs to use when resolving dependencies, in addition to the default index.</p>
@@ -428,13 +432,6 @@ uv run [OPTIONS] [COMMAND]
 </dd><dt><code>--script</code>, <code>-s</code></dt><dd><p>Run the given path as a Python script.</p>
 
 <p>Using <code>--script</code> will attempt to parse the path as a PEP 723 script, irrespective of its extension.</p>
-
-</dd><dt><code>--gui-script</code></dt><dd><p>Run the given path as a Python GUI script (Windows only).</p>
-
-<p>Using <code>--gui-script</code> will attempt to parse the path as a PEP 723 script and run it with <code>pythonw.exe</code>, 
-irrespective of its extension. This is useful for GUI applications where you don't want a console window to appear.</p>
-
-<p>This flag is only available on Windows. On other platforms, using this flag will result in an error.</p>
 
 </dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -429,6 +429,13 @@ uv run [OPTIONS] [COMMAND]
 
 <p>Using <code>--script</code> will attempt to parse the path as a PEP 723 script, irrespective of its extension.</p>
 
+</dd><dt><code>--gui-script</code></dt><dd><p>Run the given path as a Python GUI script (Windows only).</p>
+
+<p>Using <code>--gui-script</code> will attempt to parse the path as a PEP 723 script and run it with <code>pythonw.exe</code>, 
+irrespective of its extension. This is useful for GUI applications where you don't want a console window to appear.</p>
+
+<p>This flag is only available on Windows. On other platforms, using this flag will result in an error.</p>
+
 </dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
 
 </dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>


### PR DESCRIPTION
Addresses #6805

## Summary

This PR adds a `--gui-script` flag to `uv run` that allows running Python scripts with `pythonw.exe` on Windows, regardless of file extension. This solves the issue where users need to maintain duplicate `.py` and `.pyw` files to run the same script with and without a console window.

The implementation follows the pattern established by the existing `--script` flag, but uses `pythonw.exe` instead of `python.exe` on Windows. On non-Windows platforms, the flag is present but returns an error indicating it's Windows-only functionality.

Changes:
- Added `--gui-script` flag (Windows-only)
- Added Windows test to verify GUI script behavior
- Added non-Windows test to verify proper error message
- Updated CLI documentation


## Test Plan

The changes are tested through:

1. New Windows-specific test that verifies:
   - Script runs successfully with `pythonw.exe` when using `--gui-script`
   - Console output is suppressed in GUI mode but visible in regular mode
   - Same script can be run both ways without modification

2. New non-Windows test that verifies:
   - Appropriate error message when `--gui-script` is used on non-Windows platforms

3. Documentation updates to clearly indicate Windows-only functionality
