### PR TITLE
Include trampolines in sdist on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ include = [
     # this one isn't discovered by maturin because it's behind a feature flag
     { path = "crates/uv-performance-memory-allocator/**/*", format = ["sdist", "wheel"] },
     { path = "crates/uv-performance-flate2-backend/**/*", format = ["sdist", "wheel"] },
+    { path = "crates/uv-trampoline/trampolines/*", format = "sdist" }, 
     { path = "LICENSE-APACHE", format = "sdist" },
     { path = "LICENSE-MIT", format = "sdist" },
 ]


### PR DESCRIPTION
Naive fix for

```
         Compiling uv-trampoline-builder v0.0.1 (C:\Users\...\AppData\Local\uv\cache\sdists-v6\pypi\uv\0.5.2\9xswF03fJ5dr3vH_iowkm\src\crates\uv-trampoline-builder)
      error: couldn't read `crates\uv-trampoline-builder\src\../../uv-trampoline/trampolines/uv-trampoline-x86_64-gui.exe`: The system cannot find the path specified. (os error 3)
        --> crates\uv-trampoline-builder\src\lib.rs:21:5
         |
      21 |     include_bytes!("../../uv-trampoline/trampolines/uv-trampoline-x86_64-gui.exe");
         |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Closes: https://github.com/astral-sh/uv/issues/9138.
