### PR TITLE
Add a dedicated error for `include = "dev"` with `tool.uv.dev-dependencies`

### DIFF
--- a/crates/uv-distribution/src/metadata/requires_dist.rs
+++ b/crates/uv-distribution/src/metadata/requires_dist.rs
@@ -132,7 +132,8 @@ impl RequiresDist {
 
             // Resolve any `include-group` entries in `dependency-groups`.
             let dependency_groups =
-                FlatDependencyGroups::from_dependency_groups(&dependency_groups)?
+                FlatDependencyGroups::from_dependency_groups(&dependency_groups)
+                    .map_err(|err| err.with_dev_dependencies(dev_dependencies))?
                     .into_iter()
                     .chain(
                         // Only add the `dev` group if `dev-dependencies` is defined.

--- a/crates/uv-resolver/src/lock/target.rs
+++ b/crates/uv-resolver/src/lock/target.rs
@@ -114,7 +114,8 @@ impl<'env> InstallTarget<'env> {
                 // Merge any overlapping groups.
                 let mut map = BTreeMap::new();
                 for (name, dependencies) in
-                    FlatDependencyGroups::from_dependency_groups(&dependency_groups)?
+                    FlatDependencyGroups::from_dependency_groups(&dependency_groups)
+                        .map_err(|err| err.with_dev_dependencies(dev_dependencies))?
                         .into_iter()
                         .chain(
                             // Only add the `dev` group if `dev-dependencies` is defined.

--- a/crates/uv-workspace/src/workspace.rs
+++ b/crates/uv-workspace/src/workspace.rs
@@ -343,7 +343,8 @@ impl Workspace {
 
             // Resolve any `include-group` entries in `dependency-groups`.
             let dependency_groups =
-                FlatDependencyGroups::from_dependency_groups(&dependency_groups)?;
+                FlatDependencyGroups::from_dependency_groups(&dependency_groups)
+                    .map_err(|err| err.with_dev_dependencies(dev_dependencies))?;
 
             // Concatenate the two sets of requirements.
             let dev_dependencies = dependency_groups


### PR DESCRIPTION
## Summary

This isn't really spec-compliant, so we already don't allow it -- this just adds a better error message and an explicit test for it.