### PR TITLE
Sort distributions when computing hash

### DIFF
--- a/crates/uv/src/commands/project/environment.rs
+++ b/crates/uv/src/commands/project/environment.rs
@@ -11,7 +11,7 @@ use uv_cache::{Cache, CacheBucket};
 use uv_cache_key::{cache_digest, hash_digest};
 use uv_client::Connectivity;
 use uv_configuration::{Concurrency, TrustedHost};
-use uv_distribution_types::Resolution;
+use uv_distribution_types::{Name, Resolution};
 use uv_python::{Interpreter, PythonEnvironment};
 
 /// A [`PythonEnvironment`] stored in the cache.
@@ -79,7 +79,8 @@ impl CachedEnvironment {
         // TODO(charlie): If the resolution contains any mutable metadata (like a path or URL
         // dependency), skip this step.
         let resolution_hash = {
-            let distributions = resolution.distributions().collect::<Vec<_>>();
+            let mut distributions = resolution.distributions().collect::<Vec<_>>();
+            distributions.sort_unstable_by_key(|dist| dist.name());
             hash_digest(&distributions)
         };
 


### PR DESCRIPTION
## Summary

The distributions used to be stored in a `BTreeMap`, keyed by name. They're now stored in a graph... so iteration isn't guaranteed to produce a deterministic hash!

This fixes a "flaky" test, though it's actually a real bug. The test was right!

Closes #9137.
