### PR TITLE
DOC - Fix syntax for local directory installation

### DIFF
--- a/docs/pip/packages.md
+++ b/docs/pip/packages.md
@@ -73,7 +73,7 @@ $ uv pip install -e .
 To install a project in another directory as an editable package:
 
 ```console
-$ uv pip install -e ruff @ ./project/ruff
+$ uv pip install -e "ruff @ ./project/ruff"
 ```
 
 ## Installing packages from files


### PR DESCRIPTION
## Summary

This is a minor fix as the command in https://docs.astral.sh/uv/pip/packages/#installing-a-package to install projects in editable mode from local directories results in the following error:

```
error: Failed to parse: `@`
  Caused by: Expected package name starting with an alphanumeric character, found `@`
```

This PR adds the missing `"`

## Test Plan

<!-- How was it tested? -->
Using the fixed syntax here does not result in the above error, and packages are correctly installed ✨ 
