### PR TITLE
Better error message when `git` is not found

### DIFF
--- a/crates/uv-git/src/git.rs
+++ b/crates/uv-git/src/git.rs
@@ -26,14 +26,14 @@ const CHECKOUT_READY_LOCK: &str = ".ok";
 pub enum GitError {
     #[error("Git executable not found. Ensure that Git is installed and available.")]
     GitNotFound,
-    #[error("Unexpected error: {0}")]
-    Other(String),
+    #[error(transparent)]
+    Other(#[from] which::Error),
 }
 /// A global cache of the result of `which git`.
 pub static GIT: LazyLock<Result<PathBuf, GitError>> = LazyLock::new(|| {
     which::which("git").map_err(|e| match e {
         which::Error::CannotFindBinaryPath => GitError::GitNotFound,
-        e => GitError::Other(e.to_string()),
+        e => GitError::Other(e),
     })
 });
 


### PR DESCRIPTION
## Summary

Closes https://github.com/astral-sh/uv/issues/9200


## Test Plan

Using the following Dockerfile:
```Dockerfile
FROM debian:latest

RUN apt-get update && apt-get install -y python3

WORKDIR /app
COPY target/debug/uv .
RUN chmod +x uv

RUN /app/uv venv && /app/uv pip install git@github.com:pallets/flask.git
```

```
❯ cargo build -q -p uv && docker build .
...
 => ERROR [6/6] RUN /app/uv venv && /app/uv pip install git@github.com:pallets/flask.git                    0.4s
------
 > [6/6] RUN /app/uv venv && /app/uv pip install git@github.com:pallets/flask.git:
0.275 Using CPython 3.11.2 interpreter at: /usr/bin/python3
0.275 Creating virtual environment at: .venv
0.318   × Failed to download and build `git @
0.318   │ file:///app/github.com:pallets/flask.git`
0.318   ├─▶ Git operation failed
0.318   ╰─▶ Git executable not found. Ensure that Git is installed and available.
------
Dockerfile:9
--------------------
   7 |     RUN chmod +x uv
   8 |
   9 | >>> RUN /app/uv venv && /app/uv pip install git@github.com:pallets/flask.git
  10 |
--------------------
ERROR: failed to solve: process "/bin/sh -c /
```


