### PR TITLE
Respect `[[tool.uv.index]]` in PEP 723 scripts

### DIFF
--- a/crates/uv-scripts/src/lib.rs
+++ b/crates/uv-scripts/src/lib.rs
@@ -275,7 +275,7 @@ pub struct ToolUv {
     pub override_dependencies: Option<Vec<uv_pep508::Requirement<VerbatimParsedUrl>>>,
     pub constraint_dependencies: Option<Vec<uv_pep508::Requirement<VerbatimParsedUrl>>>,
     pub sources: Option<BTreeMap<PackageName, Sources>>,
-    pub indexes: Option<Vec<Index>>,
+    pub index: Option<Vec<Index>>,
 }
 
 #[derive(Debug, Error)]

--- a/crates/uv/src/commands/project/run.rs
+++ b/crates/uv/src/commands/project/run.rs
@@ -243,7 +243,7 @@ pub(crate) async fn run(
                     .tool
                     .as_ref()
                     .and_then(|tool| tool.uv.as_ref())
-                    .and_then(|uv| uv.indexes.as_deref())
+                    .and_then(|uv| uv.index.as_deref())
                     .unwrap_or(&empty),
                 SourceStrategy::Disabled => &empty,
             };

--- a/crates/uv/tests/it/run.rs
+++ b/crates/uv/tests/it/run.rs
@@ -654,6 +654,48 @@ fn run_pep723_script_metadata() -> Result<()> {
     Ok(())
 }
 
+/// Run a PEP 723-compatible script with a `[[tool.uv.index]]`.
+#[test]
+fn run_pep723_script_index() -> Result<()> {
+    let context = TestContext::new("3.12");
+
+    let test_script = context.temp_dir.child("main.py");
+    test_script.write_str(indoc! { r#"
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = [
+        #   "idna>=2",
+        # ]
+        #
+        # [[tool.uv.index]]
+        # name = "test"
+        # url = "https://test.pypi.org/simple"
+        # explicit = true
+        #
+        # [tool.uv.sources]
+        # idna = { index = "test" }
+        # ///
+
+        import idna
+       "#
+    })?;
+
+    uv_snapshot!(context.filters(), context.run().arg("main.py"), @r###"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Reading inline script metadata from `main.py`
+    Resolved 1 package in [TIME]
+    Prepared 1 package in [TIME]
+    Installed 1 package in [TIME]
+     + idna==2.7
+    "###);
+
+    Ok(())
+}
+
 /// Run a PEP 723-compatible script with `tool.uv` constraints.
 #[test]
 fn run_pep723_script_constraints() -> Result<()> {


### PR DESCRIPTION
## Summary

There was a typo here, combined with a lack of test coverage.

Closes https://github.com/astral-sh/uv/issues/9201.
