### PR TITLE
Add support for anchor redirects with client-side js

### DIFF
--- a/docs/js/extra.js
+++ b/docs/js/extra.js
@@ -8,8 +8,8 @@ function cleanupClipboardText(targetSelector) {
     .filter(
       (node) =>
         !excludedClasses.some((className) =>
-          node?.classList?.contains(className),
-        ),
+          node?.classList?.contains(className)
+        )
     )
     .map((node) => node.textContent)
     .filter((s) => s != "");
@@ -23,7 +23,7 @@ function setCopyText() {
   const attr = "clipboardText";
   // all "copy" buttons whose target selector is a <code> element
   const elements = document.querySelectorAll(
-    'button[data-clipboard-target$="code"]',
+    'button[data-clipboard-target$="code"]'
   );
   const observer = new IntersectionObserver((entries) => {
     entries.forEach((entry) => {
@@ -33,7 +33,7 @@ function setCopyText() {
         entry.target.dataset[attr] === undefined
       ) {
         entry.target.dataset[attr] = cleanupClipboardText(
-          entry.target.dataset.clipboardTarget,
+          entry.target.dataset.clipboardTarget
         );
       }
     });
@@ -51,3 +51,62 @@ function setCopyText() {
 document$.subscribe(function () {
   setCopyText();
 });
+
+// Use client-side redirects for anchors that have moved.
+// Other redirects should use `redirect_maps` in the `mkdocs.yml` file instead.
+(function () {
+  let redirect_maps = {
+    "concepts/projects/#managing-dependencies":
+      "concepts/projects/dependencies/",
+    "concepts/projects/#project-metadata": "concepts/projects/layout/",
+    "concepts/projects/#defining-entry-points":
+      "concepts/projects/config/#entry-points",
+    "concepts/projects/#build-systems":
+      "concepts/projects/config/#build-systems",
+    "concepts/projects/#configuring-project-packaging":
+      "concepts/projects/config/#project-packaging",
+    "concepts/projects/#creating-projects": "concepts/projects/init/",
+    "concepts/projects/#project-environments":
+      "concepts/projects/layout/#the-project-environment",
+    "concepts/projects/#configuring-the-project-environment-path":
+      "concepts/projects/config/#project-environment-path",
+    "concepts/projects/#project-lockfile":
+      "concepts/projects/layout/#the-lockfile",
+    "concepts/projects/#platform-specific-dependencies":
+      "concepts/projects/dependenices/#platform-specific-dependencies",
+    "concepts/projects/#running-commands": "concepts/projects/run/",
+    "concepts/projects/#building-projects": "concepts/projects/build/",
+    "concepts/projects/#build-isolation":
+      "concepts/projects/config/#build-isolation",
+  };
+
+  // The prefix for the site, see `site_dir` in `mkdocs.yml`
+  let site_dir = "uv";
+
+  function get_path() {
+    var path = window.location.pathname;
+
+    // Trim the site prefix
+    if (path.startsWith("/" + site_dir + "/")) {
+      path = path.slice(site_dir.length + 2);
+    }
+
+    // Always include a trailing `/`
+    if (!path.endsWith("/")) {
+      path = path + "/";
+    }
+
+    // Check for an anchor
+    var anchor = window.location.hash.substring(1);
+    if (!anchor) {
+      return path;
+    }
+
+    return path + "#" + anchor;
+  }
+
+  let path = get_path();
+  if (path && redirect_maps.hasOwnProperty(path)) {
+    window.location.replace("/" + site_dir + "/" + redirect_maps[path]);
+  }
+})();

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -62,6 +62,8 @@ markdown_extensions:
 plugins:
   - search
   - redirects:
+      # Note that redirecting an anchor, e.g., `concepts/projects/#managing-dependencies` must be done
+      # client-side and is implemented in `extra.js` instead.
       redirect_maps:
         "concepts/workspaces.md": "concepts/projects/workspaces.md"
         "concepts/dependencies.md": "concepts/projects/dependencies.md"


### PR DESCRIPTION
The redirect plugin doesn't support this, and it's not feasible to do server-side so we need to do the redirect client-side with some javascript.