### PR TITLE
Fix grammar in missing platform marker error message

### DIFF
--- a/crates/uv-workspace/src/pyproject.rs
+++ b/crates/uv-workspace/src/pyproject.rs
@@ -1278,7 +1278,7 @@ pub enum SourceError {
     NonUtf8Path(PathBuf),
     #[error("Source markers must be disjoint, but the following markers overlap: `{0}` and `{1}`.\n\n{hint}{colon} replace `{1}` with `{2}`.", hint = "hint".bold().cyan(), colon = ":".bold())]
     OverlappingMarkers(String, String, String),
-    #[error("When multiple sources are provided, each source must include a platform markers (e.g., `marker = \"sys_platform == 'linux'\"`)")]
+    #[error("When multiple sources are provided, each source must include a platform marker (e.g., `marker = \"sys_platform == 'linux'\"`)")]
     MissingMarkers,
     #[error("Must provide at least one source")]
     EmptySources,

--- a/crates/uv/tests/it/lock.rs
+++ b/crates/uv/tests/it/lock.rs
@@ -18068,7 +18068,7 @@ fn lock_multiple_sources_no_marker() -> Result<()> {
       |
     9 |         iniconfig = [
       |                     ^
-    When multiple sources are provided, each source must include a platform markers (e.g., `marker = "sys_platform == 'linux'"`)
+    When multiple sources are provided, each source must include a platform marker (e.g., `marker = "sys_platform == 'linux'"`)
     "###);
 
     Ok(())


### PR DESCRIPTION
`s/a platform markers/a platform marker/`
