### PR TITLE
Watch for changes to the template file during documentation serve

### DIFF
--- a/mkdocs.insiders.yml
+++ b/mkdocs.insiders.yml
@@ -1,1 +1,4 @@
 INHERIT: mkdocs.template.yml
+
+watch:
+  - mkdocs.template.yml

--- a/mkdocs.public.yml
+++ b/mkdocs.public.yml
@@ -4,3 +4,5 @@ plugins:
   - search
 validation:
   anchors: warn
+watch:
+  - mkdocs.template.yml


### PR DESCRIPTION
Fixes this really annoying behavior where the served documentation would not reflect changes to the mkdocs template file (where we store all of our actual configuration)

ref https://github.com/mkdocs/mkdocs/pull/2642