### PR TITLE
Add dedicated warning for empty stdin

### DIFF
--- a/crates/uv-requirements-txt/src/lib.rs
+++ b/crates/uv-requirements-txt/src/lib.rs
@@ -220,10 +220,14 @@ impl RequirementsTxt {
             error: err,
         })?;
         if data == Self::default() {
-            warn_user!(
-                "Requirements file {} does not contain any dependencies",
-                requirements_txt.user_display()
-            );
+            if requirements_txt == Path::new("-") {
+                warn_user!("No dependencies found in stdin");
+            } else {
+                warn_user!(
+                    "Requirements file {} does not contain any dependencies",
+                    requirements_txt.user_display()
+                );
+            }
         }
 
         Ok(data)


### PR DESCRIPTION
## Summary

I ran into this in practice:

![Screenshot 2024-11-19 at 4 20 37 PM](https://github.com/user-attachments/assets/d89aa9f1-828a-492e-af5a-3434e277580e)

