### PR TITLE
In uv-globfilter, use the workspace fs-err in dev-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5007,7 +5007,7 @@ dependencies = [
 name = "uv-globfilter"
 version = "0.1.0"
 dependencies = [
- "fs-err 2.11.0",
+ "fs-err 3.0.0",
  "globset",
  "insta",
  "regex",

--- a/crates/uv-globfilter/Cargo.toml
+++ b/crates/uv-globfilter/Cargo.toml
@@ -19,7 +19,7 @@ tracing = { workspace = true }
 walkdir = { workspace = true }
 
 [dev-dependencies]
-fs-err = "2.11.0"
+fs-err = { workspace = true }
 insta = "1.41.1"
 tempfile = "3.14.0"
 


### PR DESCRIPTION
<!--
Thank you for contributing to uv! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

In uv-globfilter, use the workspace `fs-err` in `dev-dependencies`.

This fixes an unnecessary dev-dependency on `fs-err` 2.x even after the workspace fs-err was updated to 3.x in https://github.com/astral-sh/uv/pull/8625.

The `Cargo.lock` file still has `fs-err v2.11.0` after this PR, but it is via `tracing-durations-export v0.3.0` rather than directly required by any `uv` crate.

## Test Plan

<!-- How was it tested? -->

```
$ cd crates/uv-globfilter/
$ cargo test
```