### PR TITLE
Improve build backend excludes

### DIFF
--- a/crates/uv-build-backend/src/lib.rs
+++ b/crates/uv-build-backend/src/lib.rs
@@ -484,7 +484,12 @@ fn wheel_subdir_from_globs(
     let license_files_globs: Vec<_> = globs
         .iter()
         .map(|license_files| {
-            trace!("Including license files at: `{license_files}`");
+            trace!(
+                "Including {} at `{}` with `{}`",
+                globs_field,
+                src.user_display(),
+                license_files
+            );
             parse_portable_glob(license_files)
         })
         .collect::<Result<_, _>>()
@@ -521,7 +526,7 @@ fn wheel_subdir_from_globs(
             .expect("walkdir starts with root");
 
         if !license_files_matcher.match_path(relative) {
-            trace!("Excluding {}", relative.user_display());
+            trace!("Excluding: `{}`", relative.user_display());
             continue;
         };
 
@@ -735,7 +740,7 @@ pub fn build_source_dist(
             .expect("walkdir starts with root");
 
         if !include_matcher.match_path(relative) || exclude_matcher.is_match(relative) {
-            trace!("Excluding {}", relative.user_display());
+            trace!("Excluding: `{}`", relative.user_display());
             continue;
         };
 
@@ -1159,13 +1164,6 @@ mod tests {
         )
         .unwrap();
 
-        // Check that we write deterministic wheels.
-        let wheel_filename = "built_by_uv-0.1.0-py3-none-any.whl";
-        assert_eq!(
-            fs_err::read(direct_output_dir.path().join(wheel_filename)).unwrap(),
-            fs_err::read(indirect_output_dir.path().join(wheel_filename)).unwrap()
-        );
-
         // Check the contained files and directories
         assert_snapshot!(source_dist_contents.iter().map(|path| path.replace('\\', "/")).join("\n"), @r"
             built_by_uv-0.1.0/LICENSE-APACHE
@@ -1220,5 +1218,12 @@ mod tests {
             built_by_uv/arithmetic/circle.py
             built_by_uv/arithmetic/pi.txt
         ");
+
+        // Check that we write deterministic wheels.
+        let wheel_filename = "built_by_uv-0.1.0-py3-none-any.whl";
+        assert_eq!(
+            fs_err::read(direct_output_dir.path().join(wheel_filename)).unwrap(),
+            fs_err::read(indirect_output_dir.path().join(wheel_filename)).unwrap()
+        );
     }
 }

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -1,5 +1,5 @@
 use crate::Error;
-use globset::{Glob, GlobSetBuilder};
+use globset::Glob;
 use itertools::Itertools;
 use serde::Deserialize;
 use std::collections::{BTreeMap, Bound};
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use tracing::{debug, trace};
 use uv_fs::Simplified;
-use uv_globfilter::parse_portable_glob;
+use uv_globfilter::{parse_portable_glob, GlobDirFilter};
 use uv_normalize::{ExtraName, PackageName};
 use uv_pep440::{Version, VersionSpecifiers};
 use uv_pep508::{Requirement, VersionOrUrl};
@@ -328,7 +328,7 @@ impl PyProjectToml {
                 };
 
                 let mut license_files = Vec::new();
-                let mut license_glob_builder = GlobSetBuilder::new();
+                let mut license_globs_parsed = Vec::new();
                 for license_glob in license_globs {
                     let pep639_glob =
                         parse_portable_glob(license_glob).map_err(|err| Error::PortableGlob {
@@ -341,28 +341,38 @@ impl PyProjectToml {
                     .join(pep639_glob.to_string())
                     .to_string_lossy()
                     .to_string();
-                    license_glob_builder.add(Glob::new(&absolute_glob).map_err(|err| {
+                    license_globs_parsed.push(Glob::new(&absolute_glob).map_err(|err| {
                         Error::GlobSet {
                             field: "project.license-files".to_string(),
                             err,
                         }
                     })?);
                 }
-                let license_globs = license_glob_builder.build().map_err(|err| Error::GlobSet {
-                    field: "project.license-files".to_string(),
-                    err,
-                })?;
+                let license_globs =
+                    GlobDirFilter::from_globs(&license_globs_parsed).map_err(|err| {
+                        Error::GlobSetTooLarge {
+                            field: "tool.uv.source-dist.include".to_string(),
+                            source: err,
+                        }
+                    })?;
 
-                for entry in WalkDir::new(".") {
+                for entry in WalkDir::new(root).into_iter().filter_entry(|entry| {
+                    license_globs.match_directory(
+                        entry
+                            .path()
+                            .strip_prefix(root)
+                            .expect("walkdir starts with root"),
+                    )
+                }) {
                     let entry = entry.map_err(|err| Error::WalkDir {
                         root: PathBuf::from("."),
                         err,
                     })?;
                     let relative = entry
                         .path()
-                        .strip_prefix("./")
+                        .strip_prefix(root)
                         .expect("walkdir starts with root");
-                    if !license_globs.is_match(relative) {
+                    if !license_globs.match_path(relative) {
                         trace!("Not a license files match: `{}`", relative.user_display());
                         continue;
                     }

--- a/crates/uv-build-backend/src/metadata.rs
+++ b/crates/uv-build-backend/src/metadata.rs
@@ -721,6 +721,17 @@ pub(crate) struct WheelSettings {
     /// The directory that contains the module directory, usually `src`, or an empty path when
     /// using the flat layout over the src layout.
     pub(crate) module_root: Option<PathBuf>,
+
+    /// Glob expressions which files and directories to exclude from the previous source
+    /// distribution includes.
+    ///
+    /// Excludes are not anchored, which means that `__pycache__` excludes all directories named
+    /// `__pycache__` and it's children anywhere. To anchor a directory, use a `/` prefix, e.g.,
+    /// `/dist` will exclude only `<project root>/dist`.
+    ///
+    /// The glob syntax is the reduced portable glob from
+    /// [PEP 639](https://peps.python.org/pep-0639/#add-license-FILES-key).
+    pub(crate) exclude: Option<Vec<String>>,
     /// Data includes for wheels.
     pub(crate) data: Option<WheelDataIncludes>,
 }

--- a/crates/uv-globfilter/src/main.rs
+++ b/crates/uv-globfilter/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
             .to_path_buf();
 
         if !include_matcher.match_path(&relative) || exclude_matcher.is_match(&relative) {
-            trace!("Excluding: {}", relative.display());
+            trace!("Excluding: `{}`", relative.display());
             continue;
         };
         println!("{}", relative.display());


### PR DESCRIPTION
This PR contains three smaller improvements:
* Improve the include/exclude logging. We're still showing the current directory as empty backticks, not sure what to do about that
* Add early stopping to license file globbing, so we don't traverse the whole directory recursively when license files can only be in few places
* Support explicit wheel excludes. These are still not entirely right, but at least we're correctly excluding compiled python files now. The next step is to make sure that the wheel excludes contain all pattern from source dist excludes, to make sure source tree -> wheel can't have more files than source tree -> source dist -> wheel.