### PR TITLE
Fix example pyproject.toml in project concept documentation

### DIFF
--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -7,7 +7,7 @@ field of the `pyproject.toml`.
 
 It is recommended to set a `requires-python` value:
 
-```toml title="pyproject.toml"
+```toml title="pyproject.toml" hl_lines="4"
 [project]
 name = "example"
 version = "0.1.0"

--- a/docs/concepts/projects/config.md
+++ b/docs/concepts/projects/config.md
@@ -9,6 +9,8 @@ It is recommended to set a `requires-python` value:
 
 ```toml title="pyproject.toml"
 [project]
+name = "example"
+version = "0.1.0"
 requires-python = ">=3.12"
 ```
 


### PR DESCRIPTION
The snippet out of context looks like a valid minimal pyproject.toml
which it is not without name and version. The line worked in layout.md
before when it was just under the minimal config.
