### PR TITLE
Increase UV_STACK_SIZE to 3MB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
         working-directory: ${{ env.UV_WORKSPACE }}
         env:
           # Avoid debug build stack overflows.
-          UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
+          UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
         run: |
           Set-Alias -Name uv -Value ./target/debug/uv
           uv venv -v
@@ -321,7 +321,7 @@ jobs:
         shell: powershell
         env:
           # Avoid debug build stack overflows.
-          UV_STACK_SIZE: 2000000
+          UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
         run: |
           Set-Alias -Name uv -Value ./target/debug/uv
           Set-Alias -Name uvx -Value ./target/debug/uvx
@@ -754,7 +754,7 @@ jobs:
     runs-on: windows-latest
     env:
       # Avoid debug build stack overflows.
-      UV_STACK_SIZE: 2000000
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
 
     steps:
       - name: "Download binary"
@@ -910,7 +910,7 @@ jobs:
       - name: "Check install"
         env:
           # Avoid debug build stack overflows.
-          UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
+          UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
         run: |
           .\uv.exe pip install anyio
 
@@ -1042,7 +1042,7 @@ jobs:
       - name: "Check install"
         env:
           # Avoid debug build stack overflows.
-          UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
+          UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
         run: |
           .\uv.exe pip install anyio
 
@@ -1536,7 +1536,7 @@ jobs:
     runs-on: windows-latest
     env:
       # Avoid debug build stack overflows.
-      UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
     steps:
       - uses: actions/checkout@v4
 
@@ -1562,7 +1562,7 @@ jobs:
     runs-on: windows-latest
     env:
       # Avoid debug build stack overflows.
-      UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
     steps:
       - uses: actions/checkout@v4
 
@@ -1589,7 +1589,7 @@ jobs:
     runs-on: windows-latest
     env:
       # Avoid debug build stack overflows.
-      UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
     steps:
       - uses: actions/checkout@v4
 
@@ -1617,7 +1617,7 @@ jobs:
     runs-on: windows-latest
     env:
       # Avoid debug build stack overflows.
-      UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
     steps:
       - uses: actions/checkout@v4
 
@@ -1752,7 +1752,7 @@ jobs:
         shell: bash -el {0}
         env:
           # Avoid debug build stack overflows.
-          UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
+          UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
         run: python ./scripts/check_system_python.py --uv ./uv
 
   system-test-amazonlinux:
@@ -1791,7 +1791,7 @@ jobs:
     runs-on: windows-latest
     env:
       # Avoid debug build stack overflows.
-      UV_STACK_SIZE: 2000000 # 2 megabyte, double the default on windows
+      UV_STACK_SIZE: 3000000 # 3 megabyte, triple the default on windows
     steps:
       - uses: actions/checkout@v4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ When testing debug builds on Windows, the stack can overflow resulting in a `STA
 error code. This is due to a small stack size limit on Windows that we encounter when running
 unoptimized builds — the release builds do not have this problem. We
 [added a `UV_STACK_SIZE` variable](https://github.com/astral-sh/uv/pull/941) to bypass this problem
-during testing. We recommend bumping the stack size from the default of 1MB to 2MB, for example:
+during testing. We recommend bumping the stack size from the default of 1MB to 3MB, for example:
 
 ```powershell
 $Env:UV_STACK_SIZE = '3000000'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ unoptimized builds — the release builds do not have this problem. We
 during testing. We recommend bumping the stack size from the default of 1MB to 2MB, for example:
 
 ```powershell
-$Env:UV_STACK_SIZE = '2000000'
+$Env:UV_STACK_SIZE = '3000000'
 ```
 
 ## Running inside a Docker container

--- a/crates/uv-static/src/env_vars.rs
+++ b/crates/uv-static/src/env_vars.rs
@@ -237,7 +237,7 @@ impl EnvVars {
     /// Use to disable line wrapping for diagnostics.
     pub const UV_NO_WRAP: &'static str = "UV_NO_WRAP";
 
-    /// Use to control the stack size used by uv. Typically more relevant for Windows in debug mode.
+    /// Use to increase the stack size used by uv in debug builds on Windows.
     pub const UV_STACK_SIZE: &'static str = "UV_STACK_SIZE";
 
     /// Generates the environment variable key for the HTTP Basic authentication username.

--- a/crates/uv/tests/it/ecosystem.rs
+++ b/crates/uv/tests/it/ecosystem.rs
@@ -113,7 +113,7 @@ fn lock_ecosystem_package(python_version: &str, name: &str) -> Result<()> {
     if cfg!(all(windows, debug_assertions)) {
         // TODO(konstin): Reduce stack usage in debug mode enough that the tests pass with the
         // default windows stack of 1MB
-        command.env(EnvVars::UV_STACK_SIZE, (2 * 1024 * 1024).to_string());
+        command.env(EnvVars::UV_STACK_SIZE, (4 * 1024 * 1024).to_string());
     }
     let (snapshot, _) = common::run_and_format(
         &mut command,

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -299,7 +299,7 @@ Equivalent to the `--resolution` command-line argument. For example, if set to
 
 ### `UV_STACK_SIZE`
 
-Use to control the stack size used by uv. Typically more relevant for Windows in debug mode.
+Use to increase the stack size used by uv in debug builds on Windows.
 
 ### `UV_SYSTEM_PYTHON`
 


### PR DESCRIPTION
We're seeing CI failures on windows