### PR TITLE
Avoid empty user display paths

### DIFF
--- a/crates/uv-fs/src/path.rs
+++ b/crates/uv-fs/src/path.rs
@@ -64,6 +64,11 @@ impl<T: AsRef<Path>> Simplified for T {
             return path.display();
         }
 
+        if path.as_os_str() == "" {
+            // Avoid printing an empty string for the current directory
+            return Path::new(".").display();
+        }
+
         // Attempt to strip the current working directory, then the canonicalized current working
         // directory, in case they differ.
         let path = path.strip_prefix(CWD.simplified()).unwrap_or(path);
@@ -84,6 +89,11 @@ impl<T: AsRef<Path>> Simplified for T {
         let path = path
             .strip_prefix(base.as_ref())
             .unwrap_or_else(|_| path.strip_prefix(CWD.simplified()).unwrap_or(path));
+
+        if path.as_os_str() == "" {
+            // Avoid printing an empty string for the current directory
+            return Path::new(".").display();
+        }
 
         path.display()
     }


### PR DESCRIPTION
Currently, user display returns an empty path if the current dir is the directory we are printing. This leads to odd messages such as

 > Including project.license-files at `` with `LICENSE*`

or

> Not a license files match: ``

Instead, we display the current path as a dot.
