### PR TITLE
Remove `--upgrade`, `--no-upgrade`, and `--upgrade-package` from `uv tool upgrade`

### DIFF
--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -9,7 +9,8 @@ use uv_cache::{CacheArgs, Refresh};
 use uv_cli::comma::CommaSeparatedRequirements;
 use uv_cli::{
     options::{flag, resolver_installer_options, resolver_options},
-    AuthorFrom, BuildArgs, ExportArgs, PublishArgs, PythonDirArgs, ToolUpgradeArgs,
+    AuthorFrom, BuildArgs, ExportArgs, PublishArgs, PythonDirArgs, ResolverInstallerArgs,
+    ToolUpgradeArgs,
 };
 use uv_cli::{
     AddArgs, ColorChoice, ExternalCommand, GlobalArgs, InitArgs, ListFormat, LockArgs, Maybe,
@@ -544,18 +545,58 @@ impl ToolUpgradeSettings {
         let ToolUpgradeArgs {
             name,
             python,
+            upgrade,
+            upgrade_package,
+            index_args,
             all,
-            mut installer,
+            reinstall,
+            no_reinstall,
+            reinstall_package,
+            index_strategy,
+            keyring_provider,
+            resolution,
+            prerelease,
+            pre,
+            config_setting,
+            no_build_isolation,
+            no_build_isolation_package,
+            build_isolation,
+            exclude_newer,
+            link_mode,
+            compile_bytecode,
+            no_compile_bytecode,
+            no_sources,
             build,
         } = args;
 
-        if installer.upgrade {
-            // If `--upgrade` was passed explicitly, warn.
+        if upgrade {
             warn_user_once!("`--upgrade` is enabled by default on `uv tool upgrade`");
-        } else if installer.upgrade_package.is_empty() {
-            // If neither `--upgrade` nor `--upgrade-package` were passed in, assume `--upgrade`.
-            installer.upgrade = true;
         }
+
+        // Enable `--upgrade` by default.
+        let installer = ResolverInstallerArgs {
+            index_args,
+            upgrade: upgrade_package.is_empty(),
+            no_upgrade: false,
+            upgrade_package,
+            reinstall,
+            no_reinstall,
+            reinstall_package,
+            index_strategy,
+            keyring_provider,
+            resolution,
+            prerelease,
+            pre,
+            config_setting,
+            no_build_isolation,
+            no_build_isolation_package,
+            build_isolation,
+            exclude_newer,
+            link_mode,
+            compile_bytecode,
+            no_compile_bytecode,
+            no_sources,
+        };
 
         let args = resolver_installer_options(installer, build);
         let filesystem = filesystem.map(FilesystemOptions::into_options);

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3741,10 +3741,6 @@ uv tool upgrade [OPTIONS] <NAME>...
 
 <li><code>lowest-direct</code>:  Resolve the lowest compatible version of any direct dependencies, and the highest compatible version of any transitive dependencies</li>
 </ul>
-</dd><dt><code>--upgrade</code>, <code>-U</code></dt><dd><p>Allow package upgrades, ignoring pinned versions in any existing output file. Implies <code>--refresh</code></p>
-
-</dd><dt><code>--upgrade-package</code>, <code>-P</code> <i>upgrade-package</i></dt><dd><p>Allow upgrades for a specific package, ignoring pinned versions in any existing output file. Implies <code>--refresh-package</code></p>
-
 </dd><dt><code>--verbose</code>, <code>-v</code></dt><dd><p>Use verbose output.</p>
 
 <p>You can configure fine-grained logging using the <code>RUST_LOG</code> environment variable. (&lt;https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives&gt;)</p>


### PR DESCRIPTION
## Summary

`--upgrade` isn't useful, since it's the default. So it's now hidden, but continues to warn if you enable it.

`--no-upgrade` isn't useful, since it panics. So it's now removed entirely. This isn't breaking, since it already didn't work.

`--upgrade-package` actually _is_ useful, because it turns out it allows things like: `uv tool upgrade babel --upgrade-package "babel<0.2.14"` to constrain the upgrade.

I left this in place but hid it... I think we should provide a better workflow for this, like `uv tool upgrade "babel<0.2.14"`? It's strange to specify the package twice, and that `uv tool upgrade` has an `--upgrade-package` flag.

Closes https://github.com/astral-sh/uv/issues/9317.
