### PR TITLE
uv-resolver: add new `UniversalMarker` type

### DIFF
--- a/crates/uv-resolver/src/candidate_selector.rs
+++ b/crates/uv-resolver/src/candidate_selector.rs
@@ -8,12 +8,12 @@ use uv_distribution_types::{CompatibleDist, IncompatibleDist, IncompatibleSource
 use uv_distribution_types::{DistributionMetadata, IncompatibleWheel, Name, PrioritizedDist};
 use uv_normalize::PackageName;
 use uv_pep440::Version;
-use uv_pep508::MarkerTree;
 use uv_types::InstalledPackagesProvider;
 
 use crate::preferences::Preferences;
 use crate::prerelease::{AllowPrerelease, PrereleaseStrategy};
 use crate::resolution_mode::ResolutionStrategy;
+use crate::universal_marker::UniversalMarker;
 use crate::version_map::{VersionMap, VersionMapDistHandle};
 use crate::{Exclusions, Manifest, Options, ResolverEnvironment};
 
@@ -140,10 +140,10 @@ impl CandidateSelector {
         // first has the matching half and then the mismatching half.
         let preferences_match = preferences
             .get(package_name)
-            .filter(|(marker, _index, _version)| env.included_by_marker(marker));
+            .filter(|(marker, _index, _version)| env.included_by_marker(marker.pep508()));
         let preferences_mismatch = preferences
             .get(package_name)
-            .filter(|(marker, _index, _version)| !env.included_by_marker(marker));
+            .filter(|(marker, _index, _version)| !env.included_by_marker(marker.pep508()));
         let preferences = preferences_match.chain(preferences_mismatch).filter_map(
             |(marker, source, version)| {
                 // If the package is mapped to an explicit index, only consider preferences that
@@ -167,7 +167,7 @@ impl CandidateSelector {
     /// Return the first preference that satisfies the current range and is allowed.
     fn get_preferred_from_iter<'a, InstalledPackages: InstalledPackagesProvider>(
         &'a self,
-        preferences: impl Iterator<Item = (&'a MarkerTree, &'a Version)>,
+        preferences: impl Iterator<Item = (&'a UniversalMarker, &'a Version)>,
         package_name: &'a PackageName,
         range: &Range<Version>,
         version_maps: &'a [VersionMap],

--- a/crates/uv-resolver/src/lib.rs
+++ b/crates/uv-resolver/src/lib.rs
@@ -22,6 +22,7 @@ pub use resolver::{
     PackageVersionsResult, Reporter as ResolverReporter, Resolver, ResolverEnvironment,
     ResolverProvider, VersionsResponse, WheelMetadataResult,
 };
+pub use universal_marker::UniversalMarker;
 pub use version_map::VersionMap;
 pub use yanks::AllowedYanks;
 
@@ -56,5 +57,6 @@ mod requires_python;
 mod resolution;
 mod resolution_mode;
 mod resolver;
+mod universal_marker;
 mod version_map;
 mod yanks;

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_unambiguous.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/uv-resolver/src/lock/tests.rs
+source: crates/uv-resolver/src/lock/mod.rs
 expression: result
 ---
 Ok(
@@ -135,7 +135,10 @@ Ok(
                         simplified_marker: SimplifiedMarkerTree(
                             true,
                         ),
-                        complexified_marker: python_full_version >= '3.12',
+                        complexified_marker: UniversalMarker {
+                            pep508_marker: python_full_version >= '3.12',
+                            conflict_marker: true,
+                        },
                     },
                 ],
                 optional_dependencies: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_source_version_unambiguous.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/uv-resolver/src/lock/tests.rs
+source: crates/uv-resolver/src/lock/mod.rs
 expression: result
 ---
 Ok(
@@ -135,7 +135,10 @@ Ok(
                         simplified_marker: SimplifiedMarkerTree(
                             true,
                         ),
-                        complexified_marker: python_full_version >= '3.12',
+                        complexified_marker: UniversalMarker {
+                            pep508_marker: python_full_version >= '3.12',
+                            conflict_marker: true,
+                        },
                     },
                 ],
                 optional_dependencies: {},

--- a/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
+++ b/crates/uv-resolver/src/lock/snapshots/uv_resolver__lock__tests__missing_dependency_version_unambiguous.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/uv-resolver/src/lock/tests.rs
+source: crates/uv-resolver/src/lock/mod.rs
 expression: result
 ---
 Ok(
@@ -135,7 +135,10 @@ Ok(
                         simplified_marker: SimplifiedMarkerTree(
                             true,
                         ),
-                        complexified_marker: python_full_version >= '3.12',
+                        complexified_marker: UniversalMarker {
+                            pep508_marker: python_full_version >= '3.12',
+                            conflict_marker: true,
+                        },
                     },
                 ],
                 optional_dependencies: {},

--- a/crates/uv-resolver/src/lock/target.rs
+++ b/crates/uv-resolver/src/lock/target.rs
@@ -248,7 +248,14 @@ impl<'env> InstallTarget<'env> {
                 petgraph.add_edge(
                     index,
                     dep_index,
-                    Edge::Dev(group.clone(), dep.complexified_marker.clone()),
+                    // This is OK because we are resolving to a resolution for
+                    // a specific marker environment and set of extras/groups.
+                    // So at this point, we know the extras/groups have been
+                    // satisfied, so we can safely drop the conflict marker.
+                    //
+                    // FIXME: Make the above true. We aren't actually checking
+                    // the conflict marker yet.
+                    Edge::Dev(group.clone(), dep.complexified_marker.pep508().clone()),
                 );
 
                 // Push its dependencies on the queue.
@@ -373,9 +380,9 @@ impl<'env> InstallTarget<'env> {
                     index,
                     dep_index,
                     if let Some(extra) = extra {
-                        Edge::Optional(extra.clone(), dep.complexified_marker.clone())
+                        Edge::Optional(extra.clone(), dep.complexified_marker.pep508().clone())
                     } else {
-                        Edge::Prod(dep.complexified_marker.clone())
+                        Edge::Prod(dep.complexified_marker.pep508().clone())
                     },
                 );
 

--- a/crates/uv-resolver/src/preferences.rs
+++ b/crates/uv-resolver/src/preferences.rs
@@ -11,6 +11,7 @@ use uv_pep508::{MarkerTree, VersionOrUrl};
 use uv_pypi_types::{HashDigest, HashError};
 use uv_requirements_txt::{RequirementEntry, RequirementsTxtRequirement};
 
+use crate::universal_marker::UniversalMarker;
 use crate::{LockError, ResolverEnvironment};
 
 #[derive(thiserror::Error, Debug)]
@@ -30,7 +31,7 @@ pub struct Preference {
     index: Option<IndexUrl>,
     /// If coming from a package with diverging versions, the markers of the forks this preference
     /// is part of, otherwise `None`.
-    fork_markers: Vec<MarkerTree>,
+    fork_markers: Vec<UniversalMarker>,
     hashes: Vec<HashDigest>,
 }
 
@@ -118,7 +119,7 @@ impl Preference {
 
 #[derive(Debug, Clone)]
 struct Entry {
-    marker: MarkerTree,
+    marker: UniversalMarker,
     index: Option<IndexUrl>,
     pin: Pin,
 }
@@ -169,7 +170,7 @@ impl Preferences {
                 slf.insert(
                     preference.name,
                     preference.index,
-                    MarkerTree::TRUE,
+                    UniversalMarker::TRUE,
                     Pin {
                         version: preference.version,
                         hashes: preference.hashes,
@@ -198,7 +199,7 @@ impl Preferences {
         &mut self,
         package_name: PackageName,
         index: Option<IndexUrl>,
-        markers: MarkerTree,
+        markers: UniversalMarker,
         pin: impl Into<Pin>,
     ) {
         self.0.entry(package_name).or_default().push(Entry {
@@ -214,7 +215,7 @@ impl Preferences {
     ) -> impl Iterator<
         Item = (
             &PackageName,
-            impl Iterator<Item = (&MarkerTree, Option<&IndexUrl>, &Version)>,
+            impl Iterator<Item = (&UniversalMarker, Option<&IndexUrl>, &Version)>,
         ),
     > {
         self.0.iter().map(|(name, preferences)| {
@@ -231,7 +232,7 @@ impl Preferences {
     pub(crate) fn get(
         &self,
         package_name: &PackageName,
-    ) -> impl Iterator<Item = (&MarkerTree, Option<&IndexUrl>, &Version)> {
+    ) -> impl Iterator<Item = (&UniversalMarker, Option<&IndexUrl>, &Version)> {
         self.0
             .get(package_name)
             .into_iter()

--- a/crates/uv-resolver/src/resolution/mod.rs
+++ b/crates/uv-resolver/src/resolution/mod.rs
@@ -7,13 +7,13 @@ use uv_distribution_types::{
 };
 use uv_normalize::{ExtraName, GroupName, PackageName};
 use uv_pep440::Version;
-use uv_pep508::MarkerTree;
 use uv_pypi_types::HashDigest;
 
 pub use crate::resolution::display::{AnnotationStyle, DisplayResolutionGraph};
 pub(crate) use crate::resolution::output::ResolutionGraphNode;
 pub use crate::resolution::output::{ConflictingDistributionError, ResolverOutput};
 pub(crate) use crate::resolution::requirements_txt::RequirementsTxtDist;
+use crate::universal_marker::UniversalMarker;
 
 mod display;
 mod output;
@@ -36,7 +36,7 @@ pub(crate) struct AnnotatedDist {
     /// That is, when doing a traversal over all of the distributions in a
     /// resolution, this marker corresponds to the disjunction of all paths to
     /// this distribution in the resolution graph.
-    pub(crate) marker: MarkerTree,
+    pub(crate) marker: UniversalMarker,
 }
 
 impl AnnotatedDist {

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -33,8 +33,6 @@ use crate::{
     VersionsResponse,
 };
 
-pub(crate) type MarkersForDistribution = Vec<MarkerTree>;
-
 /// The output of a successful resolution.
 ///
 /// Includes a complete resolution graph in which every node represents a pinned package and every
@@ -119,24 +117,10 @@ impl ResolverOutput {
         // Add the root node.
         let root_index = graph.add_node(ResolutionGraphNode::Root);
 
-        let mut package_markers: FxHashMap<PackageName, MarkersForDistribution> =
-            FxHashMap::default();
-
         let mut seen = FxHashSet::default();
         for resolution in resolutions {
             // Add every package to the graph.
             for (package, version) in &resolution.nodes {
-                if package.is_base() {
-                    // For packages with diverging versions, store which version comes from which
-                    // fork.
-                    if let Some(markers) = resolution.env.try_markers() {
-                        package_markers
-                            .entry(package.name.clone())
-                            .or_default()
-                            .push(markers.clone());
-                    }
-                }
-
                 if !seen.insert((package, version)) {
                     // Insert each node only once.
                     continue;

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -188,8 +188,6 @@ impl ResolverOutput {
                                 .expect("A non-forking resolution exists in forking mode")
                                 .clone()
                         })
-                        // Any unsatisfiable forks were skipped.
-                        .filter(|fork| !fork.is_false())
                         .collect()
                 })
                 .unwrap_or_else(Vec::new)
@@ -203,8 +201,6 @@ impl ResolverOutput {
                         .cloned()
                         .unwrap_or(MarkerTree::TRUE)
                 })
-                // Any unsatisfiable forks were skipped.
-                .filter(|fork| !fork.is_false())
                 .collect()
         };
 

--- a/crates/uv-resolver/src/resolution/output.rs
+++ b/crates/uv-resolver/src/resolution/output.rs
@@ -174,33 +174,12 @@ impl ResolverOutput {
         // Extract the `Requires-Python` range, if provided.
         let requires_python = python.target().clone();
 
-        let fork_markers = if let [resolution] = resolutions {
-            resolution
-                .env
-                .try_markers()
-                .map(|_| {
-                    resolutions
-                        .iter()
-                        .map(|resolution| {
-                            resolution
-                                .env
-                                .try_markers()
-                                .expect("A non-forking resolution exists in forking mode")
-                                .clone()
-                        })
-                        .collect()
-                })
-                .unwrap_or_else(Vec::new)
+        let fork_markers: Vec<MarkerTree> = if let [resolution] = resolutions {
+            resolution.env.try_markers().cloned().into_iter().collect()
         } else {
             resolutions
                 .iter()
-                .map(|resolution| {
-                    resolution
-                        .env
-                        .try_markers()
-                        .cloned()
-                        .unwrap_or(MarkerTree::TRUE)
-                })
+                .map(|resolution| resolution.env.try_markers().cloned().unwrap_or_default())
                 .collect()
         };
 

--- a/crates/uv-resolver/src/resolution/requirements_txt.rs
+++ b/crates/uv-resolver/src/resolution/requirements_txt.rs
@@ -167,11 +167,20 @@ impl<'dist> RequirementsTxtDist<'dist> {
     }
 
     pub(crate) fn from_annotated_dist(annotated: &'dist AnnotatedDist) -> Self {
+        assert!(
+            annotated.marker.conflict().is_true(),
+            "found dist {annotated} with non-trivial conflicting marker {marker}, \
+             which cannot be represented in a `requirements.txt` format",
+            marker = annotated.marker,
+        );
         Self {
             dist: &annotated.dist,
             version: &annotated.version,
             hashes: &annotated.hashes,
-            markers: &annotated.marker,
+            // OK because we've asserted above that this dist
+            // does not have a non-trivial conflicting marker
+            // that we would otherwise need to care about.
+            markers: annotated.marker.pep508(),
             extras: if let Some(extra) = annotated.extra.clone() {
                 vec![extra]
             } else {

--- a/crates/uv-resolver/src/resolver/environment.rs
+++ b/crates/uv-resolver/src/resolver/environment.rs
@@ -6,6 +6,7 @@ use uv_pypi_types::{ConflictItem, ConflictItemRef, ResolverMarkerEnvironment};
 use crate::pubgrub::{PubGrubDependency, PubGrubPackage};
 use crate::requires_python::RequiresPythonRange;
 use crate::resolver::ForkState;
+use crate::universal_marker::UniversalMarker;
 use crate::PythonRequirement;
 
 /// Represents one or more marker environments for a resolution.
@@ -328,6 +329,26 @@ impl ResolverEnvironment {
                     None
                 } else {
                     Some(markers)
+                }
+            }
+        }
+    }
+
+    /// Creates a universal marker expression corresponding to the fork that is
+    /// represented by this resolver environment. A universal marker includes
+    /// not just the standard PEP 508 marker, but also a marker based on
+    /// conflicting extras/groups.
+    ///
+    /// This returns `None` when this does not correspond to a fork.
+    pub(crate) fn try_universal_markers(&self) -> Option<UniversalMarker> {
+        match self.kind {
+            Kind::Specific { .. } => None,
+            Kind::Universal { ref markers, .. } => {
+                if markers.is_true() {
+                    None
+                } else {
+                    // FIXME: Support conflicts.
+                    Some(UniversalMarker::new(markers.clone(), MarkerTree::TRUE))
                 }
             }
         }

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -2612,12 +2612,6 @@ pub(crate) struct ResolutionDependencyEdge {
     pub(crate) marker: MarkerTree,
 }
 
-impl ResolutionPackage {
-    pub(crate) fn is_base(&self) -> bool {
-        self.extra.is_none() && self.dev.is_none()
-    }
-}
-
 /// Fetch the metadata for an item
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]

--- a/crates/uv-resolver/src/resolver/mod.rs
+++ b/crates/uv-resolver/src/resolver/mod.rs
@@ -63,6 +63,7 @@ pub(crate) use crate::resolver::availability::{
 };
 use crate::resolver::batch_prefetch::BatchPrefetcher;
 pub use crate::resolver::derivation::DerivationChainBuilder;
+use crate::universal_marker::UniversalMarker;
 
 use crate::resolver::groups::Groups;
 pub use crate::resolver::index::InMemoryIndex;
@@ -384,9 +385,8 @@ impl<InstalledPackages: InstalledPackagesProvider> ResolverState<InstalledPackag
                                 package.index.clone(),
                                 resolution
                                     .env
-                                    .try_markers()
-                                    .cloned()
-                                    .unwrap_or(MarkerTree::TRUE),
+                                    .try_universal_markers()
+                                    .unwrap_or(UniversalMarker::TRUE),
                                 version.clone(),
                             );
                         }
@@ -2610,6 +2610,13 @@ pub(crate) struct ResolutionDependencyEdge {
     pub(crate) to_extra: Option<ExtraName>,
     pub(crate) to_dev: Option<GroupName>,
     pub(crate) marker: MarkerTree,
+}
+
+impl ResolutionDependencyEdge {
+    pub(crate) fn universal_marker(&self) -> UniversalMarker {
+        // FIXME: Account for extras and groups here.
+        UniversalMarker::new(self.marker.clone(), MarkerTree::TRUE)
+    }
 }
 
 /// Fetch the metadata for an item

--- a/crates/uv-resolver/src/universal_marker.rs
+++ b/crates/uv-resolver/src/universal_marker.rs
@@ -1,0 +1,131 @@
+use uv_normalize::ExtraName;
+use uv_pep508::{MarkerEnvironment, MarkerTree};
+
+/// A representation of a marker for use in universal resolution.
+///
+/// (This also degrades gracefully to a standard PEP 508 marker in the case of
+/// non-universal resolution.)
+///
+/// This universal marker is meant to combine both a PEP 508 marker and a
+/// marker for conflicting extras/groups. The latter specifically expresses
+/// whether a particular edge in a dependency graph should be followed
+/// depending on the activated extras and groups.
+///
+/// A universal marker evaluates to true only when *both* its PEP 508 marker
+/// and its conflict marker evaluate to true.
+#[derive(Debug, Default, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct UniversalMarker {
+    pep508_marker: MarkerTree,
+    conflict_marker: MarkerTree,
+}
+
+impl UniversalMarker {
+    /// A constant universal marker that always evaluates to `true`.
+    pub(crate) const TRUE: UniversalMarker = UniversalMarker {
+        pep508_marker: MarkerTree::TRUE,
+        conflict_marker: MarkerTree::TRUE,
+    };
+
+    /// A constant universal marker that always evaluates to `false`.
+    pub(crate) const FALSE: UniversalMarker = UniversalMarker {
+        pep508_marker: MarkerTree::FALSE,
+        conflict_marker: MarkerTree::FALSE,
+    };
+
+    /// Creates a new universal marker from its constituent pieces.
+    pub(crate) fn new(pep508_marker: MarkerTree, conflict_marker: MarkerTree) -> UniversalMarker {
+        UniversalMarker {
+            pep508_marker,
+            conflict_marker,
+        }
+    }
+
+    /// Combine this universal marker with the one given in a way that unions
+    /// them. That is, the updated marker will evaluate to `true` if `self` or
+    /// `other` evaluate to `true`.
+    pub(crate) fn or(&mut self, other: UniversalMarker) {
+        self.pep508_marker.or(other.pep508_marker);
+        self.conflict_marker.or(other.conflict_marker);
+    }
+
+    /// Combine this universal marker with the one given in a way that
+    /// intersects them. That is, the updated marker will evaluate to `true` if
+    /// `self` and `other` evaluate to `true`.
+    pub(crate) fn and(&mut self, other: UniversalMarker) {
+        self.pep508_marker.and(other.pep508_marker);
+        self.conflict_marker.and(other.conflict_marker);
+    }
+
+    /// Returns true if this universal marker will always evaluate to `true`.
+    pub(crate) fn is_true(&self) -> bool {
+        self.pep508_marker.is_true() && self.conflict_marker.is_true()
+    }
+
+    /// Returns true if this universal marker will always evaluate to `false`.
+    pub(crate) fn is_false(&self) -> bool {
+        self.pep508_marker.is_false() || self.conflict_marker.is_false()
+    }
+
+    /// Returns true if this universal marker is disjoint with the one given.
+    ///
+    /// Two universal markers are disjoint when it is impossible for them both
+    /// to evaluate to `true` simultaneously.
+    pub(crate) fn is_disjoint(&self, other: &UniversalMarker) -> bool {
+        self.pep508_marker.is_disjoint(&other.pep508_marker)
+            || self.conflict_marker.is_disjoint(&other.conflict_marker)
+    }
+
+    /// Returns true if this universal marker is satisfied by the given
+    /// marker environment and list of activated extras.
+    ///
+    /// FIXME: This also needs to accept a list of groups.
+    pub(crate) fn evaluate(&self, env: &MarkerEnvironment, extras: &[ExtraName]) -> bool {
+        self.pep508_marker.evaluate(env, extras) && self.conflict_marker.evaluate(env, extras)
+    }
+
+    /// Returns the PEP 508 marker for this universal marker.
+    ///
+    /// One should be cautious using this. Generally speaking, it should only
+    /// be used when one knows universal resolution isn't in effect. When
+    /// universal resolution is enabled (i.e., there may be multiple forks
+    /// producing different versions of the same package), then one should
+    /// always use a universal marker since it accounts for all possible ways
+    /// for a package to be installed.
+    pub fn pep508(&self) -> &MarkerTree {
+        &self.pep508_marker
+    }
+
+    /// Returns the non-PEP 508 marker expression that represents conflicting
+    /// extras/groups.
+    ///
+    /// Like with `UniversalMarker::pep508`, one should be cautious when using
+    /// this. It is generally always wrong to consider conflicts in isolation
+    /// from PEP 508 markers. But this can be useful for detecting failure
+    /// cases. For example, the code for emitting a `ResolverOutput` (even a
+    /// universal one) in a `requirements.txt` format checks for the existence
+    /// of non-trivial conflict markers and fails if any are found. (Because
+    /// conflict markers cannot be represented in the `requirements.txt`
+    /// format.)
+    pub fn conflict(&self) -> &MarkerTree {
+        &self.conflict_marker
+    }
+}
+
+impl std::fmt::Display for UniversalMarker {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if self.pep508_marker.is_false() || self.conflict_marker.is_false() {
+            return write!(f, "`false`");
+        }
+        match (
+            self.pep508_marker.contents(),
+            self.conflict_marker.contents(),
+        ) {
+            (None, None) => write!(f, "`true`"),
+            (Some(pep508), None) => write!(f, "`{pep508}`"),
+            (None, Some(conflict)) => write!(f, "`true` (conflict marker: `{conflict}`"),
+            (Some(pep508), Some(conflict)) => {
+                write!(f, "`{pep508}` (conflict marker: `{conflict}`")
+            }
+        }
+    }
+}

--- a/crates/uv/src/commands/pip/compile.rs
+++ b/crates/uv/src/commands/pip/compile.rs
@@ -54,7 +54,6 @@ pub(crate) async fn pip_compile(
     constraints_from_workspace: Vec<Requirement>,
     overrides_from_workspace: Vec<Requirement>,
     environments: SupportedEnvironments,
-    conflicts: Conflicts,
     extras: ExtrasSpecification,
     output_file: Option<&Path>,
     resolution_mode: ResolutionMode,
@@ -252,20 +251,15 @@ pub(crate) async fn pip_compile(
     };
 
     // Determine the environment for the resolution.
-    let (tags, resolver_env, conflicting_groups) = if universal {
+    let (tags, resolver_env) = if universal {
         (
             None,
             ResolverEnvironment::universal(environments.into_markers()),
-            conflicts,
         )
     } else {
         let (tags, marker_env) =
             resolution_environment(python_version, python_platform, &interpreter)?;
-        (
-            Some(tags),
-            ResolverEnvironment::specific(marker_env),
-            Conflicts::empty(),
-        )
+        (Some(tags), ResolverEnvironment::specific(marker_env))
     };
 
     // Generate, but don't enforce hashes for the requirements.
@@ -400,7 +394,7 @@ pub(crate) async fn pip_compile(
         tags.as_deref(),
         resolver_env.clone(),
         python_requirement,
-        conflicting_groups,
+        Conflicts::empty(),
         &client,
         &flat_index,
         &top_level_index,

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -24,7 +24,6 @@ use uv_cli::{PythonCommand, PythonNamespace, ToolCommand, ToolNamespace, TopLeve
 #[cfg(feature = "self-update")]
 use uv_cli::{SelfCommand, SelfNamespace, SelfUpdateArgs};
 use uv_fs::CWD;
-use uv_pypi_types::Conflicts;
 use uv_requirements::RequirementsSource;
 use uv_scripts::{Pep723Item, Pep723Metadata, Pep723Script};
 use uv_settings::{Combine, FilesystemOptions, Options};
@@ -333,7 +332,6 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.constraints_from_workspace,
                 args.overrides_from_workspace,
                 args.environments,
-                Conflicts::empty(),
                 args.settings.extras,
                 args.settings.output_file.as_deref(),
                 args.settings.resolution,


### PR DESCRIPTION
This effectively combines a PEP 508 marker and an as-yet-specified
marker for expressing conflicts among extras and groups.

This just defines the type and threads it through most of the various
points in the code that previously used `MarkerTree` only. Some parts
do still continue to use `MarkerTree` specifically, e.g., when dealing
with non-universal resolution or exporting to `requirements.txt`.

This doesn't change any behavior.

There are some other smaller commits in this PR will smaller changes,
so I'd recommend reviewing commit-by-commit.

Ref #9289
