### PR TITLE
Treat invalid platform as more compatible than invalid Python

### DIFF
--- a/crates/uv-distribution-types/src/prioritized_distribution.rs
+++ b/crates/uv-distribution-types/src/prioritized_distribution.rs
@@ -572,7 +572,7 @@ impl IncompatibleWheel {
             },
             Self::Tag(tag_self) => match other {
                 Self::ExcludeNewer(_) => false,
-                Self::Tag(tag_other) => tag_other > tag_self,
+                Self::Tag(tag_other) => tag_self > tag_other,
                 Self::NoBinary | Self::RequiresPython(_, _) | Self::Yanked(_) => true,
             },
             Self::RequiresPython(_, _) => match other {

--- a/crates/uv/tests/it/pip_compile.rs
+++ b/crates/uv/tests/it/pip_compile.rs
@@ -13638,3 +13638,45 @@ fn compile_derivation_chain() -> Result<()> {
 
     Ok(())
 }
+
+/// See: <https://github.com/astral-sh/uv/issues/7553>
+#[test]
+fn invalid_platform() -> Result<()> {
+    let context = TestContext::new("3.10");
+    let requirements_in = context.temp_dir.child("requirements.in");
+    requirements_in.write_str("open3d")?;
+
+    uv_snapshot!(context
+        .pip_compile()
+        .arg("--python-platform")
+        .arg("linux")
+        .arg("requirements.in"), @r###"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+      × No solution found when resolving dependencies:
+      ╰─▶ Because only the following versions of open3d are available:
+              open3d==0.8.0.0
+              open3d==0.9.0.0
+              open3d==0.10.0.0
+              open3d==0.10.0.1
+              open3d==0.11.0
+              open3d==0.11.1
+              open3d==0.11.2
+              open3d==0.12.0
+              open3d==0.13.0
+              open3d==0.14.1
+              open3d==0.15.1
+              open3d==0.15.2
+              open3d==0.16.0
+              open3d==0.16.1
+              open3d==0.17.0
+              open3d==0.18.0
+          and open3d<=0.15.2 has no wheels with a matching Python ABI tag, we can conclude that open3d<0.9.0.0 cannot be used.
+          And because open3d>=0.16.0 has no wheels with a matching platform tag and you require open3d, we can conclude that your requirements are unsatisfiable.
+    "###);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

This is a second pass at https://github.com/astral-sh/uv/pull/7556, which was reverted in https://github.com/astral-sh/uv/pull/7608 due to a regression in https://github.com/astral-sh/uv/issues/7606. The behavior is actually correct, but a package (`nmslib`) publishes inconsistent metadata, and the change here happened to cause us to select a wheel with "wrong" metadata. It's arbitrary, but it did cause a regression for folks.

Since we're now seeing other issues caused by the wrongness here (and since the reporter in https://github.com/astral-sh/uv/issues/7606 has since removed the dependency), I'm inclined to ship this fix.

Closes https://github.com/astral-sh/uv/issues/7553.
Closes https://github.com/astral-sh/uv/issues/9283.
